### PR TITLE
(feat): corrected translations and improved translate skill

### DIFF
--- a/.ai/plans/2026-08-27-translation-consistency-runbook.md
+++ b/.ai/plans/2026-08-27-translation-consistency-runbook.md
@@ -1,0 +1,234 @@
+# Runbook — repair translation terminology, one language at a time
+
+**Paste this whole file to an agent as its instructions.** It is written to be
+resumable: every phase records what it did before moving on, so a lost
+connection costs you one phase, never the run.
+
+---
+
+## What you are fixing
+
+Carbon's UI is translated into 12 languages. Those translations were produced by
+a cheap model with no domain context, so the same English term came out
+differently depending on which chunk translated it — Chinese rendered "Job" six
+ways across 165 strings, and often chose the wrong ERP word entirely (工作,
+"employment", instead of the shop-floor work-order term).
+
+`packages/locale/locales/glossary.json` now holds **448 approved domain terms in
+all 12 languages**. The repair is: find every translated string that disagrees
+with the approved term, blank it, and re-translate it with the glossary attached.
+
+**Do not delete whole catalogs and start over.** Blanking everything produces an
+88,000-line diff nobody can review and re-spends on strings that are already
+fine. The tooling is built around fixing only what is wrong.
+
+---
+
+## The tools (do not write your own)
+
+All paths are relative to the repo root. Run everything from the repo root.
+
+| What you need | Command |
+|---|---|
+| Is this a domain term, and what is its approved translation? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --term Job --locale zh` |
+| Which terms appear in this English string? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --scan "Delete this job?" --locale zh` |
+| How much of the glossary is filled per language? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage` |
+| Which translations disagree with the glossary? | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh` |
+| The same, machine-readable | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh --json` |
+| Preview what would be cleared | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh --dry-run` |
+| Clear the disagreeing translations | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh` |
+| Refill every empty translation | the **`/translate` skill** (not a script — it fans out to cheap subagents) |
+| Strip catalog churn before committing | `pnpm run lingui:clean` |
+| Confirm nothing is left empty | `pnpm exec linguito check` |
+
+Two rules about these:
+
+- **Never edit `packages/locale/locales/glossary.json`.** It is the source of
+  truth and it is already filled and reviewed. If a term looks wrong, record it
+  in the ledger and tell the user — do not change it yourself.
+- **Never hand-edit a `.po` file.** Blanking is `reset-violations.mjs`; filling
+  is `/translate`. Both are deterministic; a hand edit is not.
+
+---
+
+## Enforced vs advisory
+
+`check-glossary.mjs` reports two kinds of disagreement:
+
+- **Enforced** — the term has one meaning, so a mismatch is a real defect. These
+  are what you fix.
+- **Advisory** — the term also has a non-domain English sense (`Part` inside
+  "part of", `Make`/`Buy` as ordinary verbs, `Line` as an address line). A
+  mismatch here is often correct. `reset-violations.mjs` skips these by default
+  and you should leave that default alone.
+
+The checker matches on the word's stem, so a correctly inflected form passes
+(German `Auftrag` → `Aufträge`, Russian `заказ` → `заказа`). A translation is
+supposed to inflect the approved term, not paste it in.
+
+---
+
+## Do one language per run
+
+Current backlog of enforced violations (measured 2026-08-27):
+
+```
+ja 2837   ru 2569   ko 2204   de 2091   zh 2069   pl 1869
+hi 1871   fr 1797   tr 1680   pt 1558   it 1485   es 1282
+```
+
+**Start with `zh`** — there is a real Chinese customer who reported this, so it
+is the one language where you will get feedback on whether the fix worked.
+
+Finish a language end to end, commit it, and stop. Do not begin a second
+language in the same run. One language is ~1,500–2,800 strings, which is already
+a large diff; two is unreviewable, and a failure halfway through leaves both in
+an unknown state.
+
+---
+
+## The ledger — write this BEFORE you start
+
+Create `.ai/runs/translation-consistency/<locale>.md` as your first action and
+update it **after every phase**, not at the end. If the connection drops, this
+file is the only thing that says where you were.
+
+```markdown
+# Translation consistency — <locale>
+
+Started: <date>
+Status: in-progress | blocked | done
+
+## Phase log
+- [ ] Phase 1 — baseline measured
+- [ ] Phase 2 — violations cleared
+- [ ] Phase 3 — re-translated
+- [ ] Phase 4 — verified
+- [ ] Phase 5 — committed
+
+## Notes
+(append findings, counts, and anything that looked wrong)
+```
+
+Tick a box only after that phase's command has actually run and you have read
+its output. Never tick ahead.
+
+---
+
+## Phase 1 — Baseline
+
+```bash
+node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage
+node .claude/skills/translate/scripts/check-glossary.mjs --locale <locale> --max 15
+git status --short packages/locale/
+```
+
+Record in the ledger: the approved-term count for this locale, the enforced and
+advisory violation counts, and whether the working tree was clean.
+
+**Stop and ask the user if:** the locale has 0 approved terms (nothing to check
+against), or the working tree already has uncommitted `.po` changes (you would
+mix someone else's work into your diff).
+
+Read a few of the sample violations before continuing. If the *approved* term
+looks wrong rather than the translations, stop — say so, and do not clear
+thousands of strings against a bad term.
+
+---
+
+## Phase 2 — Clear the disagreeing translations
+
+```bash
+node .claude/skills/translate/scripts/reset-violations.mjs --locale <locale> --dry-run
+```
+
+Read the sample. Confirm the flagged strings really are using the wrong word.
+Then run it for real:
+
+```bash
+node .claude/skills/translate/scripts/reset-violations.mjs --locale <locale>
+```
+
+This writes `.ai/runs/translation-consistency/reset-<locale>.json` containing
+**every old value it cleared**. That file is your undo — do not delete it until
+the language is committed and verified.
+
+Record in the ledger: how many were cleared, per catalog, and the record path.
+
+---
+
+## Phase 3 — Re-translate
+
+Invoke the **`/translate` skill**. Do not call the scripts by hand and do not
+write your own translation loop — the skill handles chunking, attaching the
+right glossary terms per chunk, dispatching cheap subagents, merging
+deterministically, and retrying.
+
+It fills only empty entries, so it will pick up exactly what Phase 2 cleared
+(plus any that were already missing).
+
+The skill has its own progress watcher and its own retry cap. Let it finish.
+
+Record in the ledger: how many it filled, and any residual it reported.
+
+---
+
+## Phase 4 — Verify
+
+```bash
+pnpm run lingui:clean
+pnpm exec linguito check
+node .claude/skills/translate/scripts/check-glossary.mjs --locale <locale>
+```
+
+What each proves: `linguito check` proves nothing is **empty**; the glossary
+check proves the filled ones **agree**. You need both — the original bug shipped
+through a green `linguito check`.
+
+Also confirm you changed only what you meant to:
+
+```bash
+git diff --no-color packages/locale/locales | grep -E '^\+' | grep -vE '^\+msgstr|^\+\+\+'
+git diff --quiet packages/locale/locales/glossary.json && echo "glossary untouched"
+```
+
+The first must print nothing (only `msgstr` lines changed, no `msgid` touched).
+The second must print `glossary untouched`.
+
+**If enforced violations remain:** run Phase 2 and 3 once more for just those.
+If a second pass does not clear them, stop and report — repeating a third time
+means the approved term or the checker is wrong, not the translation.
+
+Record in the ledger: final counts from all three commands.
+
+---
+
+## Phase 5 — Commit
+
+Only when Phase 4 is green. Use the `/check-and-commit` skill, or commit the
+`.po` files for this locale with a message like:
+
+```
+fix(i18n): apply approved glossary terminology to <locale>
+```
+
+Commit **only** `packages/locale/locales/<locale>/*.po`. Do not commit
+`.ai/runs/`, and do not commit the glossary.
+
+Then update the ledger to `Status: done` and **stop**. Do not start another
+language. Tell the user which language is finished, how many strings changed,
+and what the remaining backlog is.
+
+---
+
+## Honest limits — tell the user these, do not paper over them
+
+- This fixes **terminology only**. A translation that is wrong for some other
+  reason is invisible to the checker, which only knows the 448 glossary terms.
+- Roughly **71% of strings** contain a glossary term. The other 29% are
+  unconstrained and can still drift.
+- The approved terms were chosen by a model, not a native speaker. They are
+  consistent and domain-aware, but unverified by a human. Chinese is the one
+  language where a real customer can confirm them — ask.
+- `nl` is excluded everywhere: it is not in `supportedLanguages` and its catalog
+  is stale.

--- a/.ai/plans/2026-08-27-translation-consistency-runbook.md
+++ b/.ai/plans/2026-08-27-translation-consistency-runbook.md
@@ -1,12 +1,7 @@
 # Runbook — repair translation terminology, one language at a time
-
-**Paste this whole file to an agent as its instructions.** It is written to be
-resumable: every phase records what it did before moving on, so a lost
-connection costs you one phase, never the run.
-
 ---
 
-## What you are fixing
+## What we are fixing
 
 Carbon's UI is translated into 12 languages. Those translations were produced by
 a cheap model with no domain context, so the same English term came out
@@ -28,18 +23,18 @@ fine. The tooling is built around fixing only what is wrong.
 
 All paths are relative to the repo root. Run everything from the repo root.
 
-| What you need | Command |
-|---|---|
-| Is this a domain term, and what is its approved translation? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --term Job --locale zh` |
-| Which terms appear in this English string? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --scan "Delete this job?" --locale zh` |
-| How much of the glossary is filled per language? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage` |
-| Which translations disagree with the glossary? | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh` |
-| The same, machine-readable | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh --json` |
-| Preview what would be cleared | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh --dry-run` |
-| Clear the disagreeing translations | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh` |
-| Refill every empty translation | the **`/translate` skill** (not a script — it fans out to cheap subagents) |
-| Strip catalog churn before committing | `pnpm run lingui:clean` |
-| Confirm nothing is left empty | `pnpm exec linguito check` |
+| What you need                                                | Command                                                                                           |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Is this a domain term, and what is its approved translation? | `node .claude/skills/translate/scripts/glossary-lookup.mjs --term Job --locale zh`                |
+| Which terms appear in this English string?                   | `node .claude/skills/translate/scripts/glossary-lookup.mjs --scan "Delete this job?" --locale zh` |
+| How much of the glossary is filled per language?             | `node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage`                            |
+| Which translations disagree with the glossary?               | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh`                            |
+| The same, machine-readable                                   | `node .claude/skills/translate/scripts/check-glossary.mjs --locale zh --json`                     |
+| Preview what would be cleared                                | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh --dry-run`                |
+| Clear the disagreeing translations                           | `node .claude/skills/translate/scripts/reset-violations.mjs --locale zh`                          |
+| Refill every empty translation                               | the **`/translate` skill** (not a script — it fans out to cheap subagents)                        |
+| Strip catalog churn before committing                        | `pnpm run lingui:clean`                                                                           |
+| Confirm nothing is left empty                                | `pnpm exec linguito check`                                                                        |
 
 Two rules about these:
 

--- a/.ai/plans/2026-08-27-translation-consistency-runbook.md
+++ b/.ai/plans/2026-08-27-translation-consistency-runbook.md
@@ -43,9 +43,12 @@ All paths are relative to the repo root. Run everything from the repo root.
 
 Two rules about these:
 
-- **Never edit `packages/locale/locales/glossary.json`.** It is the source of
-  truth and it is already filled and reviewed. If a term looks wrong, record it
-  in the ledger and tell the user — do not change it yourself.
+- **Never edit `packages/locale/locales/glossary.json` mid-run.** It is the
+  source of truth for every language at once, so changing it while a language is
+  in flight silently changes what the checker measured five minutes ago. Term
+  changes happen in Phase 0, as their own reviewed decision, before any language
+  starts. If a term looks wrong once you are past Phase 0, record it in the
+  ledger and stop — do not change it yourself.
 - **Never hand-edit a `.po` file.** Blanking is `reset-violations.mjs`; filling
   is `/translate`. Both are deterministic; a hand edit is not.
 
@@ -66,16 +69,70 @@ The checker matches on the word's stem, so a correctly inflected form passes
 (German `Auftrag` → `Aufträge`, Russian `заказ` → `заказа`). A translation is
 supposed to inflect the approved term, not paste it in.
 
+**Only 30 of the 448 terms carry an `ambiguity` note today**, so "enforced" is
+currently far wider than "unambiguous". That is what Phase 0 exists to fix, and
+until it is done the enforced counts below overstate the real defect count.
+
+---
+
+## Phase 0 — fix the glossary BEFORE any language (do this once)
+
+Learned the hard way on the zh run: the checker matches a bare English word with
+no sense of context, and the SAME matcher builds the word list the Haiku
+subagent is ordered to obey. So a term missing its `ambiguity` note does not
+merely produce a noisy report — it tells a small model to write the wrong word.
+The small model cannot push back; that is the whole reason the glossary exists.
+
+Concrete misses from the zh run, all reported as hard defects when the Chinese
+was right: `Pick another field` (ordinary verb, not warehouse 拣货),
+`inventory transactions` (the plain noun, not the module title 库存管理),
+`bill of materials` (items, not raw stock 原材料), `Setup Map`
+(onboarding, not machine changeover 换型), `a traceable standard`
+(not the AQL level 正常检验), `the right person`, `maintenance schedule`,
+`open the document`, `Closed at`.
+
+**These false positives are identical in every language** — they come from the
+English side of the matcher, so `de`, `ja`, `ru` and the rest will hit exactly
+the same ones. Fixing the glossary once removes them from all twelve runs;
+skipping it means paying to blank and re-translate correct strings twelve times,
+and shipping worse text each time.
+
+Drafted wording for the 16 worst terms is in
+`.ai/runs/translation-consistency/glossary-ambiguity-draft.md`. Adding a note is
+a reviewed decision — get the user's sign-off, apply, then re-measure the
+backlog before choosing a language.
+
+**Status: done on 2026-08-27.** 16 notes added (`Inventory`, `Open`, `Pick`,
+`Material`, `Total`, `Standard`, `Posted`, `View`, `Setup`, `Planned`, `Closed`,
+`Picked`, `Move`, `Schedule`, `Person`, `Items`), taking the glossary from 30
+notes to 46. Effect: zh enforced 401 → **168**, de 2081 → **1712**. Re-measure
+before starting any language; the pre-Phase-0 table below is now stale.
+
+One divergence fixed at the same time: `Item` had an `ambiguity` note and `Items`
+did not, so the same sentence passed or failed depending on which form the
+English used. `Items` got a mirroring note. Do NOT "simplify" this by folding
+`Items` into `Item` as an `englishVariants` — their translations genuinely differ
+in six locales (`fr` Article/Articles, `pt` Item/Itens, `tr` Stok kartı/Stok
+kartları, and `es`/`it`/`pl`), because `Items` is the plural module name.
+
+Not solvable with a note, and still open: **negation**. `{0} problems — not
+published` is translated 未发布 ("not published") and rejected for lacking
+已发布 ("published"). That needs checker logic, and it is easy to get wrong.
+
 ---
 
 ## Do one language per run
 
-Current backlog of enforced violations (measured 2026-08-27):
+Backlog of enforced violations as first measured on 2026-08-27, BEFORE Phase 0:
 
 ```
 ja 2837   ru 2569   ko 2204   de 2091   zh 2069   pl 1869
 hi 1871   fr 1797   tr 1680   pt 1558   it 1485   es 1282
 ```
+
+Treat these as an upper bound, not a defect count — a large share are the
+false positives Phase 0 removes. Re-measure after Phase 0 and pick from the new
+numbers.
 
 **Start with `zh`** — there is a real Chinese customer who reported this, so it
 is the one language where you will get feedback on whether the fix worked.
@@ -100,6 +157,7 @@ Started: <date>
 Status: in-progress | blocked | done
 
 ## Phase log
+- [ ] Phase 0 — glossary ambiguity notes applied (once, repo-wide)
 - [ ] Phase 1 — baseline measured
 - [ ] Phase 2 — violations cleared
 - [ ] Phase 3 — re-translated
@@ -153,6 +211,11 @@ This writes `.ai/runs/translation-consistency/reset-<locale>.json` containing
 **every old value it cleared**. That file is your undo — do not delete it until
 the language is committed and verified.
 
+**It is overwritten on every run**, so a second pass over the same locale
+destroys the first pass's record. The reliable undo for a whole run is
+`git checkout packages/locale/locales/<locale>/` — nothing is committed until
+Phase 5. Do not rely on the JSON alone.
+
 Record in the ledger: how many were cleared, per catalog, and the record path.
 
 ---
@@ -168,6 +231,22 @@ It fills only empty entries, so it will pick up exactly what Phase 2 cleared
 (plus any that were already missing).
 
 The skill has its own progress watcher and its own retry cap. Let it finish.
+
+Three things the zh run hit that the skill's own docs do not warn you about:
+
+- **`extract-missing.mjs` has no `--locale` flag** — it always chunks all twelve
+  locales. To honour one-language-per-run, read
+  `.ai/scratch/translate/manifest.json` and dispatch only the entries whose
+  `locale` matches yours. The other locales' chunks stay unwritten, which is
+  fine: the merge skips them.
+- **Skip `pnpm run lingui:extract`** unless source strings actually changed. You
+  are refilling existing entries, and on this branch it dumps a large unrelated
+  catalog diff that breaks Phase 4's "only `msgstr` changed" check.
+- **Read the merge output's `Missing/invalid chunk outputs` list.** A subagent
+  that writes unparseable JSON has its whole chunk dropped in silence — 3 of 44
+  chunks failed this way on the zh run, 120 strings, all of it from bare ASCII
+  `"` inside a value. The retry round catches them; not reading the list means
+  you never learn they were dropped.
 
 Record in the ledger: how many it filled, and any residual it reported.
 
@@ -185,6 +264,15 @@ What each proves: `linguito check` proves nothing is **empty**; the glossary
 check proves the filled ones **agree**. You need both — the original bug shipped
 through a green `linguito check`.
 
+`linguito check` is repo-wide and was **already red before this work started**
+(~52 pre-existing empty strings per locale, ~572 across the eleven you are not
+touching), so it cannot pass on a single-language run and is not a gate here.
+Check your own locale directly instead — one hit per file is the PO header:
+
+```bash
+grep -c '^msgstr ""$' packages/locale/locales/<locale>/erp.po packages/locale/locales/<locale>/mes.po
+```
+
 Also confirm you changed only what you meant to:
 
 ```bash
@@ -198,6 +286,16 @@ The second must print `glossary untouched`.
 **If enforced violations remain:** run Phase 2 and 3 once more for just those.
 If a second pass does not clear them, stop and report — repeating a third time
 means the approved term or the checker is wrong, not the translation.
+
+The zh run proved this out: 2069 → 513 after one pass, → 406 after two, and
+sampling the residual showed it was almost entirely Phase 0 material rather than
+bad Chinese. A third pass would have blanked correct translations and paid a
+model to make them worse. **Read a dozen residuals before you decide** — if they
+are ordinary English words used in a non-ERP sense, the answer is a glossary
+note, not another pass.
+
+Expect to land with a residual, not a zero, until Phase 0 is done. Say so
+plainly rather than letting the count read as remaining defects.
 
 Record in the ledger: final counts from all three commands.
 
@@ -225,6 +323,10 @@ and what the remaining backlog is.
 
 - This fixes **terminology only**. A translation that is wrong for some other
   reason is invisible to the checker, which only knows the 448 glossary terms.
+- The checker reads the ENGLISH with no sense of context, so a term without an
+  `ambiguity` note flags correct translations as defects — and pushes the
+  subagent to write the wrong word. Until Phase 0 lands, "enforced" does not
+  mean "defect". Never quote an enforced count as a defect count.
 - Roughly **71% of strings** contain a glossary term. The other 29% are
   unconstrained and can still drift.
 - The approved terms were chosen by a model, not a native speaker. They are

--- a/.ai/plans/2026-08-27-translation-consistency-runbook.md
+++ b/.ai/plans/2026-08-27-translation-consistency-runbook.md
@@ -102,11 +102,25 @@ Drafted wording for the 16 worst terms is in
 a reviewed decision — get the user's sign-off, apply, then re-measure the
 backlog before choosing a language.
 
-**Status: done on 2026-08-27.** 16 notes added (`Inventory`, `Open`, `Pick`,
-`Material`, `Total`, `Standard`, `Posted`, `View`, `Setup`, `Planned`, `Closed`,
-`Picked`, `Move`, `Schedule`, `Person`, `Items`), taking the glossary from 30
-notes to 46. Effect: zh enforced 401 → **168**, de 2081 → **1712**. Re-measure
-before starting any language; the pre-Phase-0 table below is now stale.
+**Status: done on 2026-08-27.** 31 notes added across two rounds, taking the
+glossary from 30 noted terms to **61**:
+
+- Round 1 (`8426a12e6`) — `Inventory`, `Open`, `Pick`, `Material`, `Total`,
+  `Standard`, `Posted`, `View`, `Setup`, `Planned`, `Closed`, `Picked`, `Move`,
+  `Schedule`, `Person`, `Items`, plus the placeholder-masking fix.
+- Round 2 (`afac560b9`) — statuses and actions that double as ordinary verbs:
+  `Close`, `Active`, `Assigned`, `Released`, `Disposed`, `Team`, `Credit`,
+  `Consumed`, `Rejected`, `Pass`, `Split`, `Ordered`, `Role`, `Monthly`, `Buy`.
+
+Backlog after Phase 0, with NO translation work in between — measure from these,
+not from the pre-Phase-0 table below:
+
+```
+ja 2296   ru 2155   ko 1727   de 1623   fr 1348   zh 103
+```
+
+(zh also had its catalogs repaired, `3c9315ce3`; the others are untouched, so
+their drop is purely the checker no longer crying wolf.)
 
 One divergence fixed at the same time: `Item` had an `ambiguity` note and `Items`
 did not, so the same sentence passed or failed depending on which form the
@@ -123,16 +137,18 @@ published` is translated 未发布 ("not published") and rejected for lacking
 
 ## Do one language per run
 
-Backlog of enforced violations as first measured on 2026-08-27, BEFORE Phase 0:
+Backlog of enforced violations as first measured on 2026-08-27, BEFORE Phase 0.
+**Historical only — do not plan against these.** Use the post-Phase-0 numbers in
+the section above.
 
 ```
 ja 2837   ru 2569   ko 2204   de 2091   zh 2069   pl 1869
 hi 1871   fr 1797   tr 1680   pt 1558   it 1485   es 1282
 ```
 
-Treat these as an upper bound, not a defect count — a large share are the
-false positives Phase 0 removes. Re-measure after Phase 0 and pick from the new
-numbers.
+They are kept as the record of how much of an "enforced violation" count can be
+the checker rather than the translation: `zh` went 2069 → 103, and roughly half
+of that came from Phase 0 alone.
 
 **Start with `zh`** — there is a real Chinese customer who reported this, so it
 is the one language where you will get feedback on whether the fix worked.

--- a/.ai/plans/2026-08-27-translation-consistency-runbook.md
+++ b/.ai/plans/2026-08-27-translation-consistency-runbook.md
@@ -150,13 +150,42 @@ They are kept as the record of how much of an "enforced violation" count can be
 the checker rather than the translation: `zh` went 2069 → 103, and roughly half
 of that came from Phase 0 alone.
 
-**Start with `zh`** — there is a real Chinese customer who reported this, so it
-is the one language where you will get feedback on whether the fix worked.
+Finish a language end to end, commit it, and **stop and ask the user before
+starting the next one**. This is a hard gate, not a courtesy: one language is
+~1,000–2,300 strings, which is already a large diff; two is unreviewable, and a
+failure halfway through leaves both in an unknown state. It is also the only
+point where a human sees what the terminology actually produced before the next
+language repeats it.
 
-Finish a language end to end, commit it, and stop. Do not begin a second
-language in the same run. One language is ~1,500–2,800 strings, which is already
-a large diff; two is unreviewable, and a failure halfway through leaves both in
-an unknown state.
+At that gate, report: the before/after enforced count, how many strings changed,
+the commit hash, what the residual is made of, and the remaining backlog. Then
+wait. Do not start the next language on your own initiative, even if the user
+previously said "do them all" — that is the instruction to work through the
+list, not permission to skip the gate.
+
+## The order
+
+`zh` went first because a real Chinese customer reported the bug, so it is the
+one language where feedback on the fix is available. It is **done**
+(`3c9315ce3`).
+
+Remaining, and the order to take them in:
+
+```
+de 1623   ja 2296   ru 2155   ko 1727   pl 1538   hi 1509
+fr 1348   tr 1292   pt 1257   it 1177   es 990
+```
+
+`de` is deliberately NOT the biggest. It goes next because it is the first
+Latin-script language through this pipeline, and Latin-script languages take a
+completely different code path in the checker: CJK matches the approved term
+whole, everything else matches on a ~60% stem prefix (`stemOf` in
+`lib-glossary.mjs`) so an inflected form still passes. German is the most
+inflection-heavy and compound-heavy of the large backlogs, so it is the best
+stress test of a path `zh` never touched. Find the stem bugs on the language
+most likely to expose them, before spending five more languages on them.
+
+After `de`, work down by size.
 
 ---
 
@@ -331,7 +360,7 @@ Commit **only** `packages/locale/locales/<locale>/*.po`. Do not commit
 
 Then update the ledger to `Status: done` and **stop**. Do not start another
 language. Tell the user which language is finished, how many strings changed,
-and what the remaining backlog is.
+and what the remaining backlog is — then wait for them to say go.
 
 ---
 

--- a/.claude/skills/translate/SKILL.md
+++ b/.claude/skills/translate/SKILL.md
@@ -1,22 +1,83 @@
 ---
 name: translate
-description: Fill missing i18n translations in the Lingui .po catalogs cheaply — extract every empty msgstr, fan out chunked jobs to Haiku subagents (model override, not the main model), merge results back deterministically, and verify zero remain. Produces filled packages/locale/locales/*/*.po. Use when the user asks to translate/fill missing translations, run "pnpm translate" cheaply, or after adding new UI strings. Do not use to add or mark new strings (that is lingui:extract in code) or to change the locale list — use the i18n-lingui-system rule.
+description: Fill missing i18n translations in the Lingui .po catalogs cheaply and CONSISTENTLY — extract every empty msgstr, attach the approved domain terminology from packages/locale/locales/glossary.json, fan out chunked jobs to Haiku subagents (model override, not the main model), merge results back deterministically, then verify none are missing AND none disagree on terminology. Produces filled packages/locale/locales/*/*.po. Use when the user asks to translate/fill missing translations, run "pnpm translate" cheaply, or after adding new UI strings. Do not use to add or mark new strings (that is lingui:extract in code) or to change the locale list — use the i18n-lingui-system rule.
 ---
 
 # translate — fill missing .po translations with a cheap model
 
 Replaces `pnpm translate` (which would run every string through the main model).
-Instead: a deterministic script finds every empty `msgstr`, chunks them into
-jobs, **Haiku subagents** translate the chunks (invoked with `model: "haiku"` so
-the expensive main model only orchestrates), and a deterministic merge script
-writes them back — no model in the write path. Input → output: empty `msgstr` in
+Instead: a deterministic script finds every empty `msgstr`, **attaches the
+approved domain terms for that chunk**, chunks them into jobs, **Haiku
+subagents** translate the chunks (invoked with `model: "haiku"` so the expensive
+main model only orchestrates), and a deterministic merge script writes them back
+— no model in the write path. Input → output: empty `msgstr` in
 `packages/locale/locales/{locale}/{erp,mes}.po` → filled `msgstr`.
 
-**Announce at start:** "Using the translate skill — filling missing .po translations via Haiku subagents."
+**Announce at start:** "Using the translate skill — filling missing .po translations via Haiku subagents, with the approved glossary attached."
 
 Scope: all target locales at once (supportedLanguages minus source `en`; orphaned
 `nl` is excluded automatically). Never overwrites an existing translation — only
 empty `msgstr` are touched.
+
+## What this product is (the domain context every subagent gets)
+
+Carbon is a manufacturing **ERP/MES/QMS** — it runs a machine shop end to end:
+quoting, sales orders, purchasing, inventory and lot traceability, jobs on the
+shop floor, quality records, and accounting. Its users are manufacturing
+professionals, not general software users.
+
+That matters because the everyday English word is usually the WRONG word. A
+"Job" is a shop-floor work order, not employment. A "Receipt" is goods arriving
+from a supplier, not a payment slip. An "Operation" is a routing step, not an
+action. Translating these literally produces text that reads as machine output
+to the customer who has to work in it all day. **Translate the way an ERP is
+translated in that market, not the way a dictionary would.**
+
+## The glossary is the thing that makes this consistent
+
+`packages/locale/locales/glossary.json` — **448 domain terms**, each with its
+English meaning and an approved translation per locale.
+
+The variance problem this exists to fix: the fan-out translates chunks in
+parallel, and every chunk used to decide terminology independently. That is how
+Chinese ended up rendering "Job" six different ways across 165 strings. The
+glossary removes the decision — subagents are handed the word, so they cannot
+disagree.
+
+Three rules that are easy to get wrong:
+
+- **Blank means NOT YET APPROVED, never "translate freely."** A blank slot is
+  passed to the subagent as `approved: null` alongside the English meaning, so
+  it still gets domain context without being fed a wrong word.
+- **`ambiguity` narrows a term to its domain sense only.** `Part` must not be
+  fixed inside "part of"; `Make`/`Buy` are replenishment settings AND ordinary
+  verbs; `Line` is a document row, never an address line. Violations on these
+  are reported as *advisory* and never fail the gate.
+- **`englishVariants` are the same word spelled differently** (`Cancelled`/
+  `Canceled`, the three spellings of `Nonconformance`) and MUST share one
+  translation. `seeAlso` is different — it links an abbreviation to its
+  spelled-out form, and those are translated **independently**, because a
+  language may keep `BOM` in Latin while translating "Bill of Materials".
+
+## Glossary helper — do not write your own script
+
+`glossary-lookup.mjs` answers terminology questions without pulling the 448-term
+file into context:
+
+```bash
+node .claude/skills/translate/scripts/glossary-lookup.mjs --term Job --locale zh
+node .claude/skills/translate/scripts/glossary-lookup.mjs --scan "Delete this job material?" --locale zh
+node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage
+node .claude/skills/translate/scripts/glossary-lookup.mjs --list --locale zh --missing
+```
+
+Exit 0 = it is a domain term, 1 = it is not (so it can gate a shell step).
+`--coverage` is the first thing to run when the user asks "how consistent are
+we?" — it prints approved-term counts per locale.
+
+Editing the glossary is NOT part of this skill. Filling a language's column is a
+separate, reviewed decision — an unreviewed term list just makes a wrong word
+consistent everywhere. If terms are missing, say so and stop.
 
 ## Step 1 — Extract missing translations into chunked jobs
 
@@ -25,12 +86,18 @@ pnpm run lingui:extract                                   # refresh catalogs fro
 node .claude/skills/translate/scripts/extract-missing.mjs     # scan → chunk jobs
 ```
 
-Read the printed summary. It prints total missing, chunk count, and per-locale
-counts, then writes `.ai/scratch/translate/manifest.json` plus one input file per
-chunk under `.ai/scratch/translate/in/`.
+Read the printed summary. It prints total missing, chunk count, per-locale
+counts, **and the glossary coverage for each locale**, then writes
+`.ai/scratch/translate/manifest.json` plus one input file per chunk under
+`.ai/scratch/translate/in/`. Each chunk file now carries `domain`, `glossary`
+(only the terms appearing in that chunk's strings) and `doNotTranslate`.
 
 - If the output contains `NOTHING_TO_TRANSLATE` → **STOP**, report "no missing
   translations", skip to nothing. Do not run later steps.
+- If it prints `NO APPROVED TERMS YET` for a locale, that locale will be
+  translated with domain context but no fixed vocabulary. That is allowed, but
+  **tell the user** — those results will not be consistent, and the fix is to
+  fill the glossary, not to re-run this skill.
 
 ## Step 2 — Start the live progress watcher, then fan out subagents
 
@@ -64,13 +131,42 @@ Then send the next batch. Use this exact prompt, substituting the entry's `in`
 and `out` absolute paths:
 
 ````text
-You are a professional software-localization translator for a manufacturing ERP.
+You are a professional software-localization translator specializing in
+MANUFACTURING ERP/MES software. Your translations are read all day by machine
+shop staff — planners, buyers, quality engineers, shop-floor operators.
 
 Read the input file (JSON) at this absolute path:
 <manifest entry `in`>
 
-It is: { "locale", "langLabel", "catalog", "items": [ { "msgid", "note?" } ] }.
+It is: { "locale", "langLabel", "catalog", "domain", "glossary", "doNotTranslate",
+"items": [ { "msgid", "note?" } ] }.
 Translate every item's `msgid` from English into the language named by `langLabel`.
+
+Read `domain` first — it tells you what this product is. Translate the way an ERP
+is translated in that market, using the terminology a manufacturing professional
+there expects. A literal dictionary rendering is usually WRONG here: a "Job" is a
+shop-floor work order (not employment), a "Receipt" is goods arriving from a
+supplier (not a payment slip), an "Operation" is a routing step (not an action).
+
+GLOSSARY — this overrides your own judgement:
+G1. `glossary` lists the domain terms that appear in THIS chunk. Each entry is
+    { term, approved, meaning, onlyAppliesTo?, sameWordAs? }.
+G2. If `approved` is a string, use THAT WORD wherever the term appears — do not
+    substitute a synonym you prefer.
+G2a. `approved` is the BASE (dictionary) form, not text to paste in. Inflect it
+    so the sentence is grammatical: decline it, pluralise it, agree its gender,
+    add the case ending, apply vowel harmony — whatever the language requires.
+    A translation that reads as pasted-in is a FAILURE, not compliance. What
+    must stay constant is the WORD CHOICE, never the exact characters.
+G3. If `approved` is null, the term is NOT YET APPROVED. Use `meaning` to
+    translate it correctly for the domain, and use the SAME rendering for every
+    occurrence within this chunk. Null does not mean "translate freely".
+G4. `onlyAppliesTo` means the English word has a non-domain sense too. Apply the
+    approved rendering ONLY to the domain sense described. Example: "Part" as a
+    component, never inside "part of".
+G5. `sameWordAs` lists alternate English spellings of the same term — they all
+    take one identical translation.
+G6. Never translate anything in `doNotTranslate`.
 
 RULES — follow exactly:
 1. Preserve every placeholder EXACTLY: `{0}`, `{name}`, `{count}`, etc. Never
@@ -141,10 +237,31 @@ LLM step — do NOT run `pnpm translate` itself here (it would re-invoke an LLM)
 | Exit 0 / "no missing" | Verified clean → Step 7. |
 | Non-zero, lists entries | Those `msgstr` are still empty. If under the 3-round cap, go back to Step 4 (re-run `extract-missing.mjs` → dispatch → merge). Otherwise report the residual and STOP. |
 
-Report: total filled, per-locale counts, any residual, and that the changed files
-are `packages/locale/locales/*/*.po`.
+## Step 7 — Verify terminology AGREES
 
-## Step 7 — Clean up scratch (always, even on partial/failed runs)
+Step 6 proves nothing is missing. It does not prove anything is consistent — the
+original defect shipped through a green `linguito check`.
+
+```bash
+node .claude/skills/translate/scripts/check-glossary.mjs
+```
+
+It reads every translated string whose English contains a glossary term and
+confirms the approved rendering is present. Exit 0 = clean, 1 = violations.
+
+| Result | Action |
+|--------|--------|
+| `No approved translations yet` | The glossary has no filled column for these locales, so there is nothing to check against. Report that plainly — do NOT report the run as "consistent". |
+| Exit 0 with approved terms | Verified consistent → Step 8. |
+| Violations listed | These are strings the subagent translated against the approved word. Re-run the offending locale with a smaller chunk (`TRANSLATE_CHUNK_SIZE=15`), or report them for review. Advisory hits on `ambiguity` terms are judgement calls — read before acting. |
+
+Use `--locale zh --max 40` to focus, `--json` for the full machine-readable list.
+
+Report: total filled, per-locale counts, glossary coverage per locale, any
+residual, any violations, and that the changed files are
+`packages/locale/locales/*/*.po`.
+
+## Step 8 — Clean up scratch (always, even on partial/failed runs)
 
 ```bash
 rm -rf .ai/scratch/translate
@@ -165,14 +282,21 @@ only if the user asks, via `/check-and-commit` (the `.po` files are the artifact
       `Remaining empty msgstr ... : 0` (or the residual is reported after 3 rounds).
 - [ ] `pnpm run lingui:clean` has run.
 - [ ] `pnpm exec linguito check` exits 0 (or the residual is reported after 3 rounds).
+- [ ] `node .claude/skills/translate/scripts/check-glossary.mjs` exits 0, OR its
+      "no approved translations yet" state was reported honestly to the user.
 - [ ] Only `msgstr` lines changed in the `.po` diff (no `msgid` touched):
       `git diff --no-color packages/locale/locales | grep -E '^\+' | grep -vE '^\+msgstr|^\+\+\+'` is empty.
+- [ ] `glossary.json` is UNCHANGED — this skill reads it, never writes it:
+      `git diff --quiet packages/locale/locales/glossary.json`
 - [ ] `.ai/scratch/translate` has been removed.
 
 ## Failure → action
 | Symptom | Action |
 |---------|--------|
 | `extract-missing.mjs` errors reading config | Confirm `packages/locale/src/config.ts` still defines `supportedLanguages` + `languageNativeLabels`; the parser reads them by regex. |
+| `Cannot find ... glossary.json` | The glossary moved or was deleted. It is the source of terminology — STOP and tell the user; do not translate without it. |
 | Merge shows many `unmatched` | The model rewrote keys. Re-run the round with smaller `TRANSLATE_CHUNK_SIZE`; unmatched entries stay empty and are retried next round. |
 | A subagent dies / returns no file | That chunk's `out` is listed as missing; the next retry round re-dispatches only the still-empty entries. |
 | `lingui:extract` produces huge unrelated diff | Expected on this branch; `lingui:clean` strips the date/origin churn. Real content changes are legitimate. |
+| `check-glossary.mjs` reports many violations in ONE locale | That locale's approved terms are probably wrong for the domain rather than the translations being wrong. Do not mass-rewrite — surface it for native-speaker review. |
+| A term is missing from the glossary | Report it. Adding terms is a reviewed decision outside this skill. |

--- a/.claude/skills/translate/SKILL.md
+++ b/.claude/skills/translate/SKILL.md
@@ -177,6 +177,11 @@ RULES — follow exactly:
 3. Preserve leading/trailing spaces, capitalization intent, and punctuation.
 4. Do NOT translate brand names, code identifiers, or placeholder variable names.
 5. Use `note` only as context for a placeholder; never include it in the output.
+6. Every ASCII `"` INSIDE a key or value must be escaped as `\"`, or the whole
+   chunk is unparseable and every string in it is silently dropped. Many msgids
+   quote a word (`Pick another "field"`); prefer the target language's own
+   quotation marks (`“ ”`, `« »`, `„ “`) over a bare ASCII `"`. Re-read your
+   output and confirm it parses as JSON before writing.
 
 OUTPUT — write ONLY a JSON object (create/overwrite) to this absolute path:
 <manifest entry `out`>

--- a/.claude/skills/translate/SKILL.md
+++ b/.claude/skills/translate/SKILL.md
@@ -19,6 +19,15 @@ Scope: all target locales at once (supportedLanguages minus source `en`; orphane
 `nl` is excluded automatically). Never overwrites an existing translation — only
 empty `msgstr` are touched.
 
+**One exception, and it overrides the scope above.** Repairing a locale whose
+existing translations disagree with the glossary is a DIFFERENT job: it is
+one locale per run, it skips `lingui:extract`, and repo-wide `linguito check` is
+not a gate for it. That procedure is
+`.ai/plans/2026-08-27-translation-consistency-runbook.md`, and it is
+authoritative wherever it contradicts this file. Follow it end to end rather
+than mixing the two — it calls back into this skill for the refill step only
+(its Phase 3), after `reset-violations.mjs` has emptied the wrong entries.
+
 ## What this product is (the domain context every subagent gets)
 
 Carbon is a manufacturing **ERP/MES/QMS** — it runs a machine shop end to end:
@@ -258,7 +267,7 @@ confirms the approved rendering is present. Exit 0 = clean, 1 = violations.
 |--------|--------|
 | `No approved translations yet` | The glossary has no filled column for these locales, so there is nothing to check against. Report that plainly — do NOT report the run as "consistent". |
 | Exit 0 with approved terms | Verified consistent → Step 8. |
-| Violations listed | These are strings the subagent translated against the approved word. Re-run the offending locale with a smaller chunk (`TRANSLATE_CHUNK_SIZE=15`), or report them for review. Advisory hits on `ambiguity` terms are judgement calls — read before acting. |
+| Violations listed | Report them for review — do NOT just re-run this skill. A violation has a NON-EMPTY `msgstr`, and every step above only fills empty ones, so a retry cannot touch it. Clearing it first is what makes it re-translatable: `node .claude/skills/translate/scripts/reset-violations.mjs --locale <locale> --dry-run`, then without `--dry-run`, then re-run this skill. That is a terminology repair, not a fill — follow `.ai/plans/2026-08-27-translation-consistency-runbook.md`. Advisory hits on `ambiguity` terms are judgement calls — read before acting. |
 
 Use `--locale zh --max 40` to focus, `--json` for the full machine-readable list.
 

--- a/.claude/skills/translate/scripts/check-glossary.mjs
+++ b/.claude/skills/translate/scripts/check-glossary.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+// Consistency gate for /translate. `merge-translations.mjs` proves nothing is
+// EMPTY; this proves the filled ones AGREE.
+//
+//   node .claude/skills/translate/scripts/check-glossary.mjs
+//   node .claude/skills/translate/scripts/check-glossary.mjs --locale zh --max 40
+//   node .claude/skills/translate/scripts/check-glossary.mjs --json > violations.json
+//
+// Exit 0 = clean (or nothing approved yet to check against), 1 = violations.
+// Only as strong as the glossary is filled, so coverage is printed up front
+// rather than showing a green tick over an empty rulebook.
+import { existsSync, readFileSync } from "node:fs";
+import {
+  buildMatcher,
+  loadGlossary,
+  localeCoverage,
+  localesOf,
+  termsInString,
+  usesApprovedTerm,
+} from "./lib-glossary.mjs";
+import { parsePo, readLocaleConfig } from "./lib-po.mjs";
+
+const REPO = process.cwd();
+const LOCALES_DIR = `${REPO}/packages/locale/locales`;
+const CATALOGS = ["erp", "mes"];
+
+const argv = process.argv.slice(2);
+const flag = (n) => {
+  const i = argv.indexOf(`--${n}`);
+  return i === -1 ? undefined : argv[i + 1];
+};
+const asJson = argv.includes("--json");
+const strict = argv.includes("--strict");
+const maxShown = Number(flag("max") || 25);
+
+const doc = loadGlossary();
+const matcher = buildMatcher(doc);
+const { codes } = readLocaleConfig(`${REPO}/packages/locale/src/config.ts`, readFileSync);
+const only = flag("locale");
+const targets = (only ? [only] : codes.filter((c) => c !== "en")).filter((c) => localesOf(doc).includes(c));
+
+const violations = [];
+let checkedStrings = 0;
+
+for (const locale of targets) {
+  const approved = new Map();
+  for (const e of doc.terms) {
+    const t = (e.translations?.[locale] || "").trim();
+    if (t) approved.set(e.term, { approved: t, entry: e });
+  }
+  if (approved.size === 0) continue;
+
+  for (const catalog of CATALOGS) {
+    const po = `${LOCALES_DIR}/${locale}/${catalog}.po`;
+    if (!existsSync(po)) continue;
+    const { entries } = parsePo(readFileSync(po, "utf8"));
+    for (const entry of entries) {
+      if (!entry.msgid || !entry.msgstr) continue;
+      const hits = termsInString(entry.msgid, matcher);
+      if (!hits.length) continue;
+      checkedStrings++;
+      for (const hit of hits) {
+        const rule = approved.get(hit.term);
+        if (!rule) continue;
+        // Base form + inflection: "Aufträge" for approved "Auftrag" is not a violation.
+        if (usesApprovedTerm(entry.msgstr, rule.approved)) continue;
+        // An `ambiguity` note means a miss isn't reliably a defect — flag, don't fail.
+        violations.push({
+          locale,
+          catalog,
+          term: hit.term,
+          expected: rule.approved,
+          msgid: entry.msgid,
+          msgstr: entry.msgstr,
+          advisory: Boolean(hit.ambiguity),
+        });
+      }
+    }
+  }
+}
+
+const hard = violations.filter((v) => !v.advisory);
+const advisory = violations.filter((v) => v.advisory);
+
+if (asJson) {
+  console.log(JSON.stringify({ checkedStrings, violations }, null, 2));
+  process.exit((strict ? violations.length : hard.length) ? 1 : 0);
+}
+
+console.log(`Glossary: ${doc.terms.length} terms`);
+for (const l of targets) {
+  const c = localeCoverage(doc, l);
+  console.log(`  ${c.locale}: ${c.filled}/${c.total} terms approved (${c.pct}%)`);
+}
+const noRules = targets.filter((l) => localeCoverage(doc, l).filled === 0);
+if (noRules.length === targets.length) {
+  console.log(`\nNo approved translations yet — nothing to check against. Fill packages/locale/locales/glossary.json first.`);
+  process.exit(0);
+}
+if (noRules.length) console.log(`\nSkipped (no approved terms): ${noRules.join(", ")}`);
+
+console.log(`\nChecked ${checkedStrings} translated strings containing a glossary term.`);
+console.log(`Violations: ${hard.length} enforced, ${advisory.length} advisory`);
+
+// Per-term breakdown first: a term with hundreds of advisory hits is the real
+// story of a run, and printing only the enforced list would hide it.
+const byTerm = new Map();
+for (const v of violations) {
+  const k = `${v.locale}  ${v.term}`;
+  const row = byTerm.get(k) || { locale: v.locale, term: v.term, expected: v.expected, hard: 0, advisory: 0 };
+  row[v.advisory ? "advisory" : "hard"]++;
+  byTerm.set(k, row);
+}
+if (byTerm.size) {
+  console.log(`\nBy term:`);
+  for (const r of [...byTerm.values()].sort((a, b) => b.hard + b.advisory - (a.hard + a.advisory))) {
+    const tag = r.advisory ? `${r.hard} enforced + ${r.advisory} advisory` : `${r.hard} enforced`;
+    console.log(`  [${r.locale}] ${r.term} → "${r.expected}": ${tag}`);
+  }
+}
+
+const sample = (rows, heading) => {
+  if (!rows.length) return;
+  console.log(`\n--- ${heading} ---`);
+  for (const v of rows.slice(0, maxShown)) {
+    console.log(`\n[${v.locale}/${v.catalog}] "${v.term}" should render as "${v.expected}"`);
+    console.log(`   en: ${v.msgid}`);
+    console.log(`   ${v.locale}: ${v.msgstr}`);
+  }
+  if (rows.length > maxShown) console.log(`\n… ${rows.length - maxShown} more (use --json for the full list).`);
+};
+sample(hard, "ENFORCED (unambiguous terms — these are defects)");
+sample(advisory, "ADVISORY (term has a non-domain sense too — read before acting)");
+
+if (advisory.length && !strict) {
+  console.log(`\nAdvisory hits do not fail this check. Re-run with --strict to fail on them too.`);
+}
+process.exit((strict ? violations.length : hard.length) ? 1 : 0);

--- a/.claude/skills/translate/scripts/extract-missing.mjs
+++ b/.claude/skills/translate/scripts/extract-missing.mjs
@@ -8,11 +8,18 @@
 //   manifest.json      list of {in,out,locale,catalog,langLabel,count}
 //   (subagents write out/{n}.json — this script only creates in/ + manifest)
 //
+// Each chunk carries its OWN slice of the glossary — only the terms that
+// actually appear in that chunk's strings. Injecting all 448 terms into every
+// chunk would cost more tokens than the strings themselves and bury the few
+// that matter. This is what stops parallel subagents from each inventing their
+// own word for "Job": they are no longer deciding.
+//
 // Locale scope: supportedLanguages from packages/locale/src/config.ts, minus
 // the source locale "en". Orphaned locales on disk (e.g. nl) are excluded
 // because they're not in supportedLanguages.
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { existsSync } from "node:fs";
+import { buildMatcher, doNotTranslate, glossaryForItems, loadGlossary, localeCoverage } from "./lib-glossary.mjs";
 import { parsePo, readLocaleConfig } from "./lib-po.mjs";
 
 const REPO = process.cwd();
@@ -25,6 +32,10 @@ const CHUNK_SIZE = Number(process.env.TRANSLATE_CHUNK_SIZE || 40);
 const { codes, labels } = readLocaleConfig(CONFIG, readFileSync);
 const targets = codes.filter((c) => c !== "en");
 
+const glossary = loadGlossary(REPO);
+const matcher = buildMatcher(glossary);
+const keepAsIs = doNotTranslate(glossary);
+
 // Fresh scratch each run so stale chunks never merge.
 rmSync(OUT_DIR, { recursive: true, force: true });
 mkdirSync(`${OUT_DIR}/in`, { recursive: true });
@@ -33,6 +44,7 @@ mkdirSync(`${OUT_DIR}/out`, { recursive: true });
 const manifest = [];
 let chunkNo = 0;
 let totalMissing = 0;
+let totalTermRefs = 0;
 
 for (const locale of targets) {
   const langLabel = labels[locale] || locale;
@@ -47,6 +59,8 @@ for (const locale of targets) {
       const slice = missing.slice(i, i + CHUNK_SIZE);
       const inPath = `${OUT_DIR}/in/${chunkNo}.json`;
       const outPath = `${OUT_DIR}/out/${chunkNo}.json`;
+      const terms = glossaryForItems(slice.map((e) => e.msgid), locale, glossary, matcher);
+      totalTermRefs += terms.length;
       writeFileSync(
         inPath,
         JSON.stringify(
@@ -54,6 +68,10 @@ for (const locale of targets) {
             locale,
             langLabel,
             catalog,
+            domain:
+              "Carbon is a manufacturing ERP/MES/QMS: it runs a machine shop's quotes, orders, purchasing, inventory, jobs on the shop floor, quality records and accounting. Translate as an ERP product would be translated in this language — use the terminology a manufacturing professional in that market expects, not a literal dictionary rendering.",
+            glossary: terms,
+            doNotTranslate: keepAsIs,
             items: slice.map((e) => ({
               msgid: e.msgid,
               // translator notes (#. lines) carry placeholder context
@@ -64,7 +82,17 @@ for (const locale of targets) {
           2,
         ),
       );
-      manifest.push({ chunk: chunkNo, in: inPath, out: outPath, locale, catalog, langLabel, count: slice.length });
+      manifest.push({
+        chunk: chunkNo,
+        in: inPath,
+        out: outPath,
+        locale,
+        catalog,
+        langLabel,
+        count: slice.length,
+        glossaryTerms: terms.length,
+        approvedTerms: terms.filter((t) => t.approved).length,
+      });
       chunkNo++;
     }
   }
@@ -77,4 +105,17 @@ for (const m of manifest) byLocale[m.locale] = (byLocale[m.locale] || 0) + m.cou
 console.log(`Missing translations: ${totalMissing} across ${targets.length} locales`);
 console.log(`Chunks: ${manifest.length} (size ${CHUNK_SIZE}) → ${OUT_DIR}/manifest.json`);
 for (const [loc, n] of Object.entries(byLocale)) console.log(`  ${loc}: ${n}`);
+
+console.log(`\nGlossary: ${glossary.terms.length} terms · ${totalTermRefs} term references injected across chunks`);
+const bare = [];
+for (const loc of new Set(manifest.map((m) => m.locale))) {
+  const c = localeCoverage(glossary, loc);
+  if (c.filled === 0) bare.push(loc);
+  else console.log(`  ${loc}: ${c.filled}/${c.total} approved (${c.pct}%)`);
+}
+if (bare.length) {
+  console.log(`  NO APPROVED TERMS YET: ${bare.join(", ")}`);
+  console.log(`  → those locales get domain context and English meanings, but no fixed vocabulary.`);
+  console.log(`  → fill packages/locale/locales/glossary.json to make them consistent.`);
+}
 if (totalMissing === 0) console.log("NOTHING_TO_TRANSLATE");

--- a/.claude/skills/translate/scripts/glossary-lookup.mjs
+++ b/.claude/skills/translate/scripts/glossary-lookup.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Glossary lookup for /translate — "is this a domain term, and what is its
+// approved translation?" without reading the whole file into context.
+//
+//   node .claude/skills/translate/scripts/glossary-lookup.mjs --term Job --locale zh
+//   node .claude/skills/translate/scripts/glossary-lookup.mjs --scan "Delete this job material?" --locale zh
+//   node .claude/skills/translate/scripts/glossary-lookup.mjs --coverage
+//   node .claude/skills/translate/scripts/glossary-lookup.mjs --list --locale zh --missing
+//
+// Exit codes: 0 found / 1 not found (so it can gate a shell step).
+import {
+  buildMatcher,
+  glossaryForItems,
+  loadGlossary,
+  localeCoverage,
+  localesOf,
+  surfaceForms,
+  termsInString,
+} from "./lib-glossary.mjs";
+
+const argv = process.argv.slice(2);
+const flag = (name) => {
+  const i = argv.indexOf(`--${name}`);
+  return i === -1 ? undefined : argv[i + 1]?.startsWith("--") ? true : argv[i + 1];
+};
+const has = (name) => argv.includes(`--${name}`);
+
+const doc = loadGlossary();
+const locales = localesOf(doc);
+const locale = flag("locale");
+if (locale && !locales.includes(locale)) {
+  console.error(`Unknown locale "${locale}". Known: ${locales.join(", ")}`);
+  process.exit(1);
+}
+
+const show = (entry) => {
+  const line = [`${entry.term}  [${entry.category}]`];
+  if (locale) {
+    const t = (entry.translations?.[locale] || "").trim();
+    line.push(t ? `→ ${locale}: ${t}` : `→ ${locale}: (NOT YET APPROVED — leave to translator judgement)`);
+  }
+  console.log(line.join("  "));
+  console.log(`    meaning: ${entry.context}`);
+  if (entry.ambiguity) console.log(`    ONLY applies to: ${entry.ambiguity}`);
+  if (entry.englishVariants) console.log(`    same word as: ${entry.englishVariants.join(", ")}`);
+  if (entry.seeAlso) console.log(`    see also: ${entry.seeAlso} (related, translated independently)`);
+};
+
+if (has("coverage")) {
+  console.log(`Glossary: ${doc.terms.length} terms · ${locales.length} locales`);
+  for (const l of locales) {
+    const c = localeCoverage(doc, l);
+    console.log(`  ${c.locale}: ${c.filled}/${c.total} approved (${c.pct}%)`);
+  }
+  process.exit(0);
+}
+
+if (has("list")) {
+  const wantMissing = has("missing");
+  const rows = doc.terms.filter((t) => {
+    if (!locale || !wantMissing) return true;
+    return (t.translations?.[locale] || "").trim() === "";
+  });
+  for (const e of rows.sort((a, b) => a.category.localeCompare(b.category) || a.term.localeCompare(b.term))) {
+    console.log(`${e.category.padEnd(12)} ${e.term}${locale ? `  ${(e.translations?.[locale] || "").trim() || "—"}` : ""}`);
+  }
+  console.log(`\n${rows.length} term(s)${wantMissing && locale ? ` with no approved ${locale} translation` : ""}`);
+  process.exit(0);
+}
+
+const term = flag("term");
+if (term) {
+  const key = String(term).toLowerCase();
+  const hits = doc.terms.filter((e) => surfaceForms(e).some((f) => f.toLowerCase() === key));
+  if (!hits.length) {
+    console.log(`"${term}" is not a glossary term — translate it normally.`);
+    process.exit(1);
+  }
+  hits.forEach(show);
+  process.exit(0);
+}
+
+const scan = flag("scan");
+if (scan) {
+  const hits = termsInString(String(scan), buildMatcher(doc));
+  if (!hits.length) {
+    console.log("No glossary terms in that string — translate it normally.");
+    process.exit(1);
+  }
+  hits.forEach(show);
+  if (locale) {
+    console.log(`\nJSON block for a subagent prompt:`);
+    console.log(JSON.stringify(glossaryForItems([String(scan)], locale, doc, buildMatcher(doc)), null, 2));
+  }
+  process.exit(0);
+}
+
+console.error(`Usage:
+  --term <English term> [--locale <code>]   look up one term
+  --scan "<English string>" [--locale ...]  find every glossary term in a string
+  --list [--locale <code>] [--missing]      list terms, optionally only unapproved ones
+  --coverage                                approved-term counts per locale`);
+process.exit(1);

--- a/.claude/skills/translate/scripts/lib-glossary.mjs
+++ b/.claude/skills/translate/scripts/lib-glossary.mjs
@@ -1,0 +1,115 @@
+// Shared glossary helpers for the /translate skill.
+// A blank translation means NOT YET APPROVED — callers must surface that
+// explicitly, so a subagent can't read silence as permission to pick its own word.
+
+import { readFileSync } from "node:fs";
+
+export const GLOSSARY_PATH = "packages/locale/locales/glossary.json";
+
+export function loadGlossary(repo = process.cwd()) {
+  const doc = JSON.parse(readFileSync(`${repo}/${GLOSSARY_PATH}`, "utf8"));
+  if (!Array.isArray(doc.terms)) throw new Error(`${GLOSSARY_PATH}: no terms[]`);
+  return doc;
+}
+
+// The term plus its spelling variants — every English form resolving to this entry.
+export function surfaceForms(entry) {
+  return [entry.term, ...(entry.englishVariants || [])];
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Abbreviations match case-SENSITIVELY: lowercase "eco" is inside "record" and
+// "rma" inside "format", so a loose match there produces confident nonsense.
+function formRegex(form) {
+  const caseSensitive = form === form.toUpperCase() && /[A-Z]/.test(form);
+  return new RegExp(`(?<![\\w-])${escapeRe(form)}(s|es)?(?![\\w-])`, caseSensitive ? "" : "i");
+}
+
+// Build a matcher once, reuse across thousands of strings.
+export function buildMatcher(doc) {
+  const forms = [];
+  for (const entry of doc.terms) {
+    for (const form of surfaceForms(entry)) forms.push({ form, entry, re: formRegex(form) });
+  }
+  forms.sort((a, b) => b.form.length - a.form.length);
+  return forms;
+}
+
+// Longest-match-wins: "Sales Order Line" consumes the "Line" inside it, so a
+// compound doesn't drag in its own parts and bury the terms that matter.
+export function termsInString(str, matcher) {
+  const hits = [];
+  let masked = str;
+  for (const { form, entry, re } of matcher) {
+    const m = masked.match(re);
+    if (!m) continue;
+    if (!hits.includes(entry)) hits.push(entry);
+    masked = masked.slice(0, m.index) + " ".repeat(m[0].length) + masked.slice(m.index + m[0].length);
+  }
+  return hits;
+}
+
+// The per-chunk term list for a subagent. Blank translations pass through as
+// `approved: null` with their meaning — context without a wrong word to copy.
+export function glossaryForItems(msgids, locale, doc, matcher) {
+  const seen = new Map();
+  for (const msgid of msgids) {
+    for (const entry of termsInString(msgid, matcher)) {
+      if (seen.has(entry.term)) continue;
+      seen.set(entry.term, {
+        term: entry.term,
+        approved: entry.translations?.[locale] || null,
+        meaning: entry.context,
+        ...(entry.ambiguity ? { onlyAppliesTo: entry.ambiguity } : {}),
+        ...(entry.englishVariants ? { sameWordAs: entry.englishVariants } : {}),
+      });
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.term.localeCompare(b.term));
+}
+
+// An approved term is the BASE form and translators inflect it (Auftrag →
+// Aufträge, заказ → заказа), so matching is on the STEM, not the whole word.
+// Errs toward accepting: a false violation costs trust in the whole gate.
+
+const CJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿가-힯]/;
+
+function normalize(s) {
+  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+}
+
+// CJK doesn't inflect, so the term must appear whole; else keep ~60% as stem.
+function stemOf(approved) {
+  if (CJK.test(approved)) return approved;
+  const n = normalize(approved);
+  if (n.length <= 4) return n;
+  return n.slice(0, Math.max(4, Math.ceil(n.length * 0.6)));
+}
+
+// Multi-word terms are checked word by word, since a language may reorder them.
+export function usesApprovedTerm(msgstr, approved) {
+  if (!approved) return true;
+  if (CJK.test(approved)) return msgstr.includes(approved);
+  const haystack = normalize(msgstr);
+  return approved
+    .split(/\s+/)
+    .filter((w) => normalize(w).length > 2)
+    .every((w) => haystack.includes(stemOf(w)));
+}
+
+export function localesOf(doc) {
+  return doc._readme?.locales || Object.keys(doc.terms[0]?.translations || {});
+}
+
+export function doNotTranslate(doc) {
+  return doc._readme?.doNotTranslate || [];
+}
+
+export function localeCoverage(doc, locale) {
+  const total = doc.terms.length;
+  const filled = doc.terms.filter((t) => (t.translations?.[locale] || "").trim() !== "").length;
+  return { locale, filled, total, pct: total ? Math.round((filled / total) * 100) : 0 };
+}

--- a/.claude/skills/translate/scripts/lib-glossary.mjs
+++ b/.claude/skills/translate/scripts/lib-glossary.mjs
@@ -51,8 +51,15 @@ export function buildMatcher(doc) {
 // holds real human text and MUST stay visible to the matcher.
 const PLACEHOLDER = /\{[A-Za-z0-9_]+\}/g;
 
+// `{variances, plural, …}` — the argument name and the ICU keyword are code too,
+// but the trailing comma keeps them out of PLACEHOLDER. Mask the header ONLY,
+// so the branches after it stay visible.
+const ICU_HEADER = /\{\s*[A-Za-z0-9_]+\s*,\s*(plural|select|selectordinal)\s*,/g;
+
 export function maskPlaceholders(str) {
-  return str.replace(PLACEHOLDER, (m) => " ".repeat(m.length));
+  return str
+    .replace(ICU_HEADER, (m) => " ".repeat(m.length))
+    .replace(PLACEHOLDER, (m) => " ".repeat(m.length));
 }
 
 // Longest-match-wins: "Sales Order Line" consumes the "Line" inside it, so a

--- a/.claude/skills/translate/scripts/lib-glossary.mjs
+++ b/.claude/skills/translate/scripts/lib-glossary.mjs
@@ -8,7 +8,8 @@ export const GLOSSARY_PATH = "packages/locale/locales/glossary.json";
 
 export function loadGlossary(repo = process.cwd()) {
   const doc = JSON.parse(readFileSync(`${repo}/${GLOSSARY_PATH}`, "utf8"));
-  if (!Array.isArray(doc.terms)) throw new Error(`${GLOSSARY_PATH}: no terms[]`);
+  if (!Array.isArray(doc.terms))
+    throw new Error(`${GLOSSARY_PATH}: no terms[]`);
   return doc;
 }
 
@@ -25,29 +26,48 @@ function escapeRe(s) {
 // "rma" inside "format", so a loose match there produces confident nonsense.
 function formRegex(form) {
   const caseSensitive = form === form.toUpperCase() && /[A-Z]/.test(form);
-  return new RegExp(`(?<![\\w-])${escapeRe(form)}(s|es)?(?![\\w-])`, caseSensitive ? "" : "i");
+  return new RegExp(
+    `(?<![\\w-])${escapeRe(form)}(s|es)?(?![\\w-])`,
+    caseSensitive ? "" : "i"
+  );
 }
 
 // Build a matcher once, reuse across thousands of strings.
 export function buildMatcher(doc) {
   const forms = [];
   for (const entry of doc.terms) {
-    for (const form of surfaceForms(entry)) forms.push({ form, entry, re: formRegex(form) });
+    for (const form of surfaceForms(entry))
+      forms.push({ form, entry, re: formRegex(form) });
   }
   forms.sort((a, b) => b.form.length - a.form.length);
   return forms;
+}
+
+// A placeholder is CODE, not prose: `{total}` is a variable name the translator
+// must copy verbatim, so scanning it for terms both mis-reports a violation and
+// — worse — orders the subagent to translate an identifier. Masked to spaces so
+// match offsets still line up with the original.
+// Only `{identifier}` is masked. An ICU plural branch (`{# lines differ …}`)
+// holds real human text and MUST stay visible to the matcher.
+const PLACEHOLDER = /\{[A-Za-z0-9_]+\}/g;
+
+export function maskPlaceholders(str) {
+  return str.replace(PLACEHOLDER, (m) => " ".repeat(m.length));
 }
 
 // Longest-match-wins: "Sales Order Line" consumes the "Line" inside it, so a
 // compound doesn't drag in its own parts and bury the terms that matter.
 export function termsInString(str, matcher) {
   const hits = [];
-  let masked = str;
+  let masked = maskPlaceholders(str);
   for (const { form, entry, re } of matcher) {
     const m = masked.match(re);
     if (!m) continue;
     if (!hits.includes(entry)) hits.push(entry);
-    masked = masked.slice(0, m.index) + " ".repeat(m[0].length) + masked.slice(m.index + m[0].length);
+    masked =
+      masked.slice(0, m.index) +
+      " ".repeat(m[0].length) +
+      masked.slice(m.index + m[0].length);
   }
   return hits;
 }
@@ -78,7 +98,10 @@ export function glossaryForItems(msgids, locale, doc, matcher) {
 const CJK = /[぀-ヿ㐀-䶿一-鿿豈-﫿가-힯]/;
 
 function normalize(s) {
-  return s.normalize("NFD").replace(/\p{Diacritic}/gu, "").toLowerCase();
+  return s
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
 }
 
 // CJK doesn't inflect, so the term must appear whole; else keep ~60% as stem.
@@ -110,6 +133,13 @@ export function doNotTranslate(doc) {
 
 export function localeCoverage(doc, locale) {
   const total = doc.terms.length;
-  const filled = doc.terms.filter((t) => (t.translations?.[locale] || "").trim() !== "").length;
-  return { locale, filled, total, pct: total ? Math.round((filled / total) * 100) : 0 };
+  const filled = doc.terms.filter(
+    (t) => (t.translations?.[locale] || "").trim() !== ""
+  ).length;
+  return {
+    locale,
+    filled,
+    total,
+    pct: total ? Math.round((filled / total) * 100) : 0,
+  };
 }

--- a/.claude/skills/translate/scripts/lib-po.mjs
+++ b/.claude/skills/translate/scripts/lib-po.mjs
@@ -41,11 +41,25 @@ export function parsePo(text) {
     const msgidQ = [lines[i].slice("msgid ".length)];
     i++;
     while (i < lines.length && lines[i].startsWith('"')) msgidQ.push(lines[i++]);
+    // Plural entries carry msgstr[n], not msgstr. Lingui does not emit them, but
+    // consume them rather than leaving the msgstr[n] lines to be re-scanned.
+    if (i < lines.length && lines[i].startsWith("msgid_plural ")) {
+      i++;
+      while (i < lines.length && (lines[i].startsWith('"') || lines[i].startsWith("msgstr["))) i++;
+      continue;
+    }
     if (i >= lines.length || !lines[i].startsWith("msgstr ")) continue;
     const msgstrLineIndex = i;
     const msgstrQ = [lines[i].slice("msgstr ".length)];
     i++;
     while (i < lines.length && lines[i].startsWith('"')) msgstrQ.push(lines[i++]);
+    // A second msgstr on one msgid is a corrupt catalog (a bad .po merge keeps
+    // both sides). Refuse rather than silently translating against one of them.
+    if (i < lines.length && lines[i].startsWith("msgstr ")) {
+      throw new Error(
+        `Corrupt .po: duplicate msgstr on line ${i + 1} for msgid ${msgidQ.join("")}. Keep one translation per entry.`,
+      );
+    }
     entries.push({
       comments,
       msgid: msgidQ.map((q) => unescapePo(stripQuotes(q))).join(""),

--- a/.claude/skills/translate/scripts/merge-translations.mjs
+++ b/.claude/skills/translate/scripts/merge-translations.mjs
@@ -18,6 +18,59 @@ if (!existsSync(MANIFEST)) {
 }
 const manifest = JSON.parse(readFileSync(MANIFEST, "utf8"));
 
+// The one failure mode a cheap model hits over and over: a bare ASCII `"` inside
+// a value, because so many msgids quote a word. Left alone it costs the WHOLE
+// chunk — 6 of 37 on the de run, ~230 strings — so repair it here rather than
+// re-spending on a retry that fails the same way. A closing quote is one whose
+// next non-space character is `:`, `,` or `}`; anything else is text.
+//
+// BEST EFFORT, not a guarantee — 5 of those 6 chunks. It cannot save a mismatched
+// pair like German `„Wort"`, where the closing ASCII quote sits before a comma and
+// is genuinely indistinguishable from the end of the value. The retry round is the
+// backstop for those; this just stops the common case costing a whole chunk.
+function repairBareQuotes(src) {
+  let out = "";
+  let inStr = false;
+  for (let i = 0; i < src.length; i++) {
+    const c = src[i];
+    if (inStr && c === "\\") {
+      out += c + src[++i];
+      continue;
+    }
+    if (c === '"') {
+      if (!inStr) {
+        inStr = true;
+        out += c;
+        continue;
+      }
+      let j = i + 1;
+      while (j < src.length && /\s/.test(src[j])) j++;
+      if (":,}".includes(src[j])) {
+        inStr = false;
+        out += c;
+        continue;
+      }
+      out += '\\"';
+      continue;
+    }
+    out += c;
+  }
+  return out;
+}
+
+let repairedChunks = 0;
+
+function readChunk(path) {
+  const raw = readFileSync(path, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const parsed = JSON.parse(repairBareQuotes(raw)); // throws on anything else
+    repairedChunks++;
+    return parsed;
+  }
+}
+
 // Merge all chunk outputs for a given (locale,catalog) against its .po once.
 const byPo = {};
 for (const m of manifest) {
@@ -37,7 +90,7 @@ for (const { locale, catalog, outs } of Object.values(byPo)) {
       continue;
     }
     try {
-      Object.assign(translations, JSON.parse(readFileSync(out, "utf8")));
+      Object.assign(translations, readChunk(out));
     } catch {
       missingChunks.push(`${out} (invalid JSON)`);
     }
@@ -69,6 +122,7 @@ for (const { locale, catalog } of Object.values(byPo)) {
 }
 
 console.log(`Merged: ${matched} filled, ${unmatched} unmatched (key mismatch)`);
+if (repairedChunks) console.log(`Repaired ${repairedChunks} chunk(s) with unescaped quotes`);
 console.log(`Remaining empty msgstr in targeted catalogs: ${remaining}`);
 if (missingChunks.length) {
   console.log(`Missing/invalid chunk outputs (${missingChunks.length}):`);

--- a/.claude/skills/translate/scripts/reset-violations.mjs
+++ b/.claude/skills/translate/scripts/reset-violations.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Blanks the msgstr of translations that disagree with the approved glossary.
+// /translate only ever fills EMPTY msgstr, so a wrong one must be cleared first.
+//
+//   node .claude/skills/translate/scripts/reset-violations.mjs --locale zh --dry-run
+//   node .claude/skills/translate/scripts/reset-violations.mjs --locale zh
+//   node .claude/skills/translate/scripts/reset-violations.mjs --locale zh --include-advisory
+//
+// Enforced-only by default: blanking advisory hits would re-translate strings
+// that were probably right. Always records what it cleared (and the old values)
+// under .ai/runs/translation-consistency/ so a lost connection loses nothing.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  buildMatcher,
+  loadGlossary,
+  localeCoverage,
+  localesOf,
+  termsInString,
+  usesApprovedTerm,
+} from "./lib-glossary.mjs";
+import { escapePo, parsePo } from "./lib-po.mjs";
+
+const REPO = process.cwd();
+const LOCALES_DIR = `${REPO}/packages/locale/locales`;
+const RECORD_DIR = `${REPO}/.ai/runs/translation-consistency`;
+const CATALOGS = ["erp", "mes"];
+
+const argv = process.argv.slice(2);
+const flag = (n) => {
+  const i = argv.indexOf(`--${n}`);
+  return i === -1 ? undefined : argv[i + 1];
+};
+const dryRun = argv.includes("--dry-run");
+const includeAdvisory = argv.includes("--include-advisory");
+const locale = flag("locale");
+
+const doc = loadGlossary();
+if (!locale) {
+  console.error(`--locale is required. Known: ${localesOf(doc).join(", ")}`);
+  process.exit(1);
+}
+if (!localesOf(doc).includes(locale)) {
+  console.error(`Unknown locale "${locale}". Known: ${localesOf(doc).join(", ")}`);
+  process.exit(1);
+}
+
+const coverage = localeCoverage(doc, locale);
+if (coverage.filled === 0) {
+  console.error(
+    `${locale} has no approved terms in the glossary — there is nothing to reset against. Fill packages/locale/locales/glossary.json first.`,
+  );
+  process.exit(1);
+}
+
+const matcher = buildMatcher(doc);
+const approved = new Map();
+for (const e of doc.terms) {
+  const t = (e.translations?.[locale] || "").trim();
+  if (t) approved.set(e.term, t);
+}
+
+let totalCleared = 0;
+const summary = [];
+
+for (const catalog of CATALOGS) {
+  const po = `${LOCALES_DIR}/${locale}/${catalog}.po`;
+  if (!existsSync(po)) continue;
+  const text = readFileSync(po, "utf8");
+  const { lines, entries } = parsePo(text);
+  const cleared = [];
+
+  for (const entry of entries) {
+    if (!entry.msgid || !entry.msgstr) continue;
+    const hits = termsInString(entry.msgid, matcher);
+    const bad = [];
+    for (const hit of hits) {
+      const want = approved.get(hit.term);
+      if (!want) continue;
+      if (usesApprovedTerm(entry.msgstr, want)) continue;
+      if (hit.ambiguity && !includeAdvisory) continue;
+      bad.push({ term: hit.term, expected: want });
+    }
+    if (!bad.length) continue;
+    cleared.push({ msgid: entry.msgid, was: entry.msgstr, terms: bad });
+    // A msgstr can span continuation lines; blanking only the first would leave
+    // the rest as orphan strings and corrupt the catalog.
+    lines[entry.msgstrLineIndex] = `msgstr "${escapePo("")}"`;
+    for (let i = 1; i < entry.msgstrLineCount; i++) lines[entry.msgstrLineIndex + i] = null;
+  }
+
+  if (cleared.length && !dryRun) {
+    writeFileSync(po, lines.filter((l) => l !== null).join("\n"));
+  }
+  totalCleared += cleared.length;
+  summary.push({ catalog, cleared: cleared.length, entries: cleared });
+}
+
+console.log(`${locale}: ${coverage.filled}/${coverage.total} approved terms`);
+for (const s of summary) console.log(`  ${s.catalog}: ${s.cleared} translation(s) ${dryRun ? "would be" : ""} cleared`);
+console.log(`Total: ${totalCleared}${includeAdvisory ? " (including advisory)" : " (enforced only)"}`);
+
+if (dryRun) {
+  console.log(`\nDRY RUN — nothing written. Sample:`);
+  for (const s of summary) {
+    for (const e of s.entries.slice(0, 5)) {
+      console.log(`  [${s.catalog}] ${e.terms.map((t) => `${t.term}→${t.expected}`).join(", ")}`);
+      console.log(`     en: ${e.msgid}`);
+      console.log(`     ${locale}: ${e.was}`);
+    }
+  }
+  process.exit(0);
+}
+
+if (totalCleared) {
+  mkdirSync(RECORD_DIR, { recursive: true });
+  const path = `${RECORD_DIR}/reset-${locale}.json`;
+  writeFileSync(path, JSON.stringify({ locale, includeAdvisory, coverage, summary }, null, 2));
+  console.log(`\nRecord written: ${path}`);
+  console.log(`The old values are in that file — recoverable if a re-translation goes wrong.`);
+  console.log(`Next: run the /translate skill to refill the ${totalCleared} now-empty entries.`);
+} else {
+  console.log(`\nNothing to reset — ${locale} already agrees with every approved term.`);
+}

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -1087,7 +1087,7 @@ msgid "Add Affected Item"
 msgstr "Betroffenes Element hinzufügen"
 
 msgid "Add an extra layer of security by requiring a code from an authenticator app when signing in."
-msgstr "Erhöhen Sie die Sicherheit, indem Sie beim Anmelden einen Code aus einer Authentifizierungs-App anfordern."
+msgstr "Fügen Sie eine zusätzliche Sicherheitsebene hinzu, indem Sie beim Anmelden einen Code aus einer Authentifizierungs-App verlangen."
 
 msgid "Add any notes about your decision..."
 msgstr "Notizen zu Ihrer Entscheidung hinzufügen..."
@@ -8932,7 +8932,7 @@ msgid "Map Lines Now"
 msgstr "Zeilen jetzt zuordnen"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Ordnen Sie Ihren Kontenplan den Konten des Anbieters zu. Posting-Standard- und Ausgabenkonten sind als erforderlich gekennzeichnet; gebuchte Journale werden mit dem zugeordneten Anbieter-Kontokencode übertragen."
+msgstr "Ordnen Sie Ihren Kontenplan dem des Anbieters zu. Buchungs-Standardkonten und Aufwandkonten sind als erforderlich gekennzeichnet. Gebuchte Buchungssätze werden mit dem zugeordneten Anbieterkontokode übertragen."
 
 msgid "Map your current process, systems, and data"
 msgstr "Ordnen Sie Ihren aktuellen Prozess, Ihre Systeme und Daten"
@@ -14349,11 +14349,11 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adresse erforderlich. Dies wird auch im Kontakt in Carbon gespeichert."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Die Buchung erstellt einen auf Ihrem verbundenen Konto."
+msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Beim Buchen wird einer auf Ihrem verbundenen Konto erstellt."
 msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adresse erforderlich. Dies wird auch als Kontakt in Carbon gespeichert."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Das Buchen erstellt einen auf Ihrem verbundenen Konto."
+msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Beim Buchen wird einer auf Ihrem verbundenen Konto erstellt."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Stil der Kanban-Ausgabe, die in der Kanban-Tabelle angezeigt werden soll"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -304,7 +304,6 @@ msgstr "4h"
 
 msgid "5 user minimum"
 msgstr "Minimum 5 Benutzer"
-msgstr "Mindestens 5 Benutzer"
 
 msgid "5-8 weeks"
 msgstr "5-8 Wochen"
@@ -362,7 +361,6 @@ msgstr "Ein Externer Mitarbeiter ist ein Lieferantenkontakt mit bestimmten Quali
 
 msgid "A custom solution to meet your needs"
 msgstr "Eine maßgeschneiderte Lösung für Ihre Anforderungen."
-msgstr "Eine maßgeschneiderte Lösung für Ihre Anforderungen"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Ein Kunde ist ein Unternehmen oder eine Person, die Ihre Teile oder Dienstleistungen kauft."
@@ -479,7 +477,6 @@ msgstr "Eine verwaltete, cloud-gehostete Version von Carbon."
 
 msgid "A managed version with all the advanced features"
 msgstr "Eine verwaltete Version mit allen erweiterten Funktionen."
-msgstr "Eine verwaltete Cloud-gehostete Version von Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Eine verwaltete Version mit allen erweiterten Funktionen"
@@ -507,7 +504,6 @@ msgstr "Eine neue Größe wird erstellt, indem eine Kopie der aktuellen Größe 
 
 msgid "A new Stripe customer will be created"
 msgstr "Ein neuer Stripe-Kunde wird erstellt."
-msgstr "Ein neuer Stripe-Kunde wird erstellt"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Ein bargeldloses Dokument, das eine Rechnung gegen ein Verrechnungskonto ausgleicht: ein Haben senkt die Schuld, ein Soll erhöht sie."
@@ -2310,7 +2306,6 @@ msgstr "Änderungsprotokoll"
 
 msgid "Audit logging"
 msgstr "Änderungsprotokollierung"
-msgstr "Audit-Protokollierung"
 
 msgid "Audit Logging"
 msgstr "Audit-Protokollierung"
@@ -2383,7 +2378,6 @@ msgstr "Automatische Aktualisierungen"
 
 msgid "Automatic updates and backups"
 msgstr "Automatische Aktualisierungen und Sicherungen"
-msgstr "Automatische Updates und Sicherungen"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatischer, anteiliger Verbrauch der ungespurten Materialien eines Auftrags, wenn die Leistung gemeldet wird — verfolgte Materialien werden manuell ausgegeben."
@@ -2624,7 +2618,6 @@ msgstr "Bibliothek durchsuchen"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Durchsuchen Sie die veröffentlichte Version schreibgeschützt. Sie können die Schritte weiterhin neu anordnen, um das Layout zu ordnen."
-msgstr "Durchsuchen Sie die veröffentlichte Version schreibgeschützt. Sie können Schritte immer noch neu anordnen, um das Layout aufzuräumen."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2832,7 +2825,6 @@ msgstr "RFQ kann nicht gesendet werden"
 
 msgid "Cannot send through Stripe"
 msgstr "Kann nicht über Stripe senden"
-msgstr "Kann nicht über Stripe gesendet werden"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Hochladen nicht möglich — Lieferanteninteraktion noch nicht erstellt"
@@ -3041,7 +3033,6 @@ msgstr "Überprüfen Sie Ihre E-Mail"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Überprüfung von Stripe für diesen Kunden…"
-msgstr "Stripe für diesen Kunden wird überprüft …"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3246,7 +3237,6 @@ msgstr "Bestätigung eines Wareneingangs, einer Lieferung oder einer Rechnung: M
 
 msgid "Community support"
 msgstr "Community-Unterstützung"
-msgstr "Community-Support"
 
 msgid "Companies"
 msgstr "Unternehmen"
@@ -4424,7 +4414,6 @@ msgstr "Kunden"
 
 msgid "Customizations, training, and integrations"
 msgstr "Anpassungen, Schulung und Integrationen"
-msgstr "Anpassungen, Schulungen und Integrationen"
 
 msgid "Customize"
 msgstr "Anpassen"
@@ -6271,7 +6260,6 @@ msgstr "Vorhandene Zuordnungen. Wählen Sie eine andere Provider-Option zum Neu-
 
 msgid "Existing Stripe customer"
 msgstr "Bestehender Stripe-Kunde"
-msgstr "Vorhandener Stripe-Kunde"
 
 msgid "Expand"
 msgstr "Erweitern"
@@ -6993,7 +6981,6 @@ msgstr "Format"
 
 msgid "Forward deployed engineer"
 msgstr "Techniker vor Ort"
-msgstr "Ingenieur vor Ort"
 
 msgid "Foundation"
 msgstr "Grundlagen"
@@ -7050,7 +7037,6 @@ msgstr "Vollständiger Name"
 
 msgid "Full setup and migrations"
 msgstr "Vollständiges Setup und Migrationen"
-msgstr "Vollständige Einrichtung und Migrationen"
 
 msgid "Fully Depreciated"
 msgstr "Vollständig abgeschrieben"
@@ -8600,7 +8586,6 @@ msgstr "Linear-Problem verknüpfen"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Verknüpfen Sie diesen Carbon-Kunden mit einem davon, oder erstellen Sie einen separaten Stripe-Kunden."
-msgstr "Verknüpfen Sie diesen Carbon-Kunden mit einem von ihnen, oder erstellen Sie einen separaten Stripe-Kunden."
 
 msgid "Link to sales order line"
 msgstr "Mit Kundenauftragsposition verknüpfen"
@@ -12674,7 +12659,6 @@ msgstr "Alle Artikelledgereinträge aus dieser Rechnung stornieren"
 
 msgid "Reverse charge"
 msgstr "Stornierungsgebühr"
-msgstr "Umkehrung der Steuerschuld"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Reverse-Charge-Verfahren Umsatzsteuer"
@@ -13496,7 +13480,6 @@ msgstr "Selbstgehostet oder verwaltet"
 
 msgid "Self-onboarding"
 msgstr "Selbstgesteuertes Onboarding"
-msgstr "Selbst gehostet oder verwaltet"
 
 msgid "Self-onboarding"
 msgstr "Selbst-Onboarding"
@@ -14350,7 +14333,6 @@ msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adre
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Beim Buchen wird einer auf Ihrem verbundenen Konto erstellt."
-msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adresse erforderlich. Dies wird auch als Kontakt in Carbon gespeichert."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Beim Buchen wird einer auf Ihrem verbundenen Konto erstellt."
@@ -15663,7 +15645,6 @@ msgstr "Diese Rechnung hat kein nutzbares Fälligkeitsdatum – wählen Sie eine
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Diese Rechnung wird dem Stripe-Kunden in Rechnung gestellt, der bereits mit diesem Carbon-Kunden verknüpft ist. Um die Details zu ändern, bearbeiten Sie diese im Stripe Dashboard."
-msgstr "Diese Rechnung hat kein verwendbares Fälligkeitsdatum — wählen Sie eines für Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Diese Rechnung wird dem Stripe-Kunden in Rechnung gestellt, der bereits mit diesem Carbon-Kunden verknüpft ist. Um die Details zu ändern, bearbeiten Sie sie im Stripe-Dashboard."
@@ -15807,7 +15788,6 @@ msgstr "Diese Version ist veröffentlicht"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Diese Version ist veröffentlicht. Erstellen Sie eine neue Version, um sie zu bearbeiten."
-msgstr "Diese Version ist veröffentlicht. Erstellen Sie eine neue Version zum Bearbeiten."
 
 msgid "This version's definition could not be read."
 msgstr "Die Definition dieser Version konnte nicht gelesen werden."
@@ -17648,7 +17628,6 @@ msgstr "Du bist live auf Carbon"
 
 msgid "You're one step away from your workspace."
 msgstr "Sie sind einen Schritt entfernt von Ihrem Arbeitsbereich."
-msgstr "Sie sind nur noch einen Schritt von Ihrem Arbeitsbereich entfernt."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Du richtest Carbon selbst ein, in deinem eigenen Tempo"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -30,10 +30,10 @@ msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
 msgstr "„{0}\" ist auf der/den ausgewählten Oberfläche(n) nicht verfügbar. Wählen Sie ein anderes Feld."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "„${storageUnitName}\" hat ${childCount} direkt verschachtelte Speichereinheiten. Das Löschen führt auch zum Löschen dieser und aller darunter liegenden Einheiten. Dies kann nicht rückgängig gemacht werden."
+msgstr "„{storageUnitName}\" hat {childCount} direkt verschachtelte Lagereinheiten. Wenn Sie diese löschen, werden auch diese und alles darunter gelöscht. Dies kann nicht rückgängig gemacht werden."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "„${storageUnitName}\" hat 1 direkt verschachtelte Speichereinheit. Das Löschen wird auch diese Einheit und alles darunter löschen. Dies kann nicht rückgängig gemacht werden."
+msgstr "„{storageUnitName}\" hat 1 direkt verschachtelte Lagereinheit. Wenn Sie diese löschen, wird auch diese Einheit und alles darunter gelöscht. Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -79,11 +79,11 @@ msgstr "{0} erfolgreich gelöscht"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} Entwurfs-Journaleinträge"
+msgstr "{0} Entwurfs-Buchungszeilen"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} Aufträge erstellt"
+msgstr "{0} Fertigungsaufträge erstellt"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} Werte fehlen"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} Teile übersprungen — sie haben bereits offene Aufträge"
+msgstr "{alreadyPlannedItemCount} übersprungene Teile — sie haben bereits offene Fertigungsaufträge"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% der Verbindlichkeiten"
@@ -166,10 +166,10 @@ msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} von {count}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}–{to} von {count} Operationen"
+msgstr "{from}–{to} von {count} Arbeitsgängen"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} weitere: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} Monate mit abweichenden Summen"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} Journale fehlen im Provider"
+msgstr "{missingCount} fehlende Buchungssätze beim Anbieter"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} fehlende Journale und {mismatchCount} Monate mit Abweichungen"
+msgstr "{missingCount} fehlende Buchungssätze und {mismatchCount} nicht übereinstimmende Monate"
 
 msgid "{name} deleted"
 msgstr "{name} gelöscht"
@@ -199,7 +199,7 @@ msgstr "{noDemandItemCount} Teile übersprungen — es gibt nichts zu produziere
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel} wird zur Bearbeitung als Überarbeitung {0} erneut geöffnet. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
+msgstr "{orderLabel} wird zur Bearbeitung erneut geöffnet als Revision {0}. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# Phase verbleibend} other {# Phasen verbleibend}}"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} Aufträge aktualisiert"
+msgstr "{updatedJobCount} Fertigungsaufträge aktualisiert"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} hochgeladen — Felder wurden aus dem Dokument ausgefüllt."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "{variances, plural, one {# Zeile weicht von der erwarteten Menge ab} other {# Zeilen weichen von der erwarteten Menge ab}}"
+msgstr "{variances, plural, one {# Position unterscheidet sich von der erwarteten Menge} other {# Positionen unterscheiden sich von der erwarteten Menge}}"
 
 msgid "{years}yr"
 msgstr "{years}J."
@@ -246,10 +246,10 @@ msgid "↩ {0} redirected from superseded {1}"
 msgstr "↩ {0} umgeleitet von veralteten {1}"
 
 msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
-msgstr "<0>Fügen Sie eine Lieferantenkomponente hinzu</0> für diesen Artikel, um einen bevorzugten Lieferanten festzulegen."
+msgstr "<0>Lieferantenteil hinzufügen</0> für diesen Artikel, um einen bevorzugten Lieferanten festzulegen."
 
 msgid "0 operations"
-msgstr "0 Operationen"
+msgstr "0 Arbeitsgänge"
 
 msgid "0-4 weeks"
 msgstr "0-4 Wochen"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 Tag"
 
 msgid "1 draft journal entry"
-msgstr "1 Entwurfs-Journaleintrag"
+msgstr "1 Entwurfs-Buchungszeile"
 
 msgid "1 job created"
 msgstr "1 Auftrag erstellt"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimum 5 Benutzer"
 
 msgid "5-8 weeks"
 msgstr "5-8 Wochen"
 
 msgid "52-week demand"
-msgstr "52-Wochen-Nachfrage"
+msgstr "52-Wochen-Bedarf"
 
 msgid "5MB file limit"
 msgstr "5MB Dateigrößenlimit"
@@ -354,13 +354,13 @@ msgid "A completed job's output, received into inventory at the job's actual acc
 msgstr "Die Ausgabe eines abgeschlossenen Auftrags, der in Bestand zu den tatsächlichen kumulierten WIP-Kosten des Auftrags empfangen wird."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Ein Verbrauchsmaterial ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird, das über mehrere Aufträge hinweg verwendet werden kann"
+msgstr "Ein Verbrauchsmaterial ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und der über mehrere Fertigungsaufträge hinweg verwendet werden kann."
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Ein Auftragnehmer ist ein Lieferantenkontakt mit besonderen Fähigkeiten und verfügbaren Stunden"
+msgstr "Ein Externer Mitarbeiter ist ein Lieferantenkontakt mit bestimmten Qualifikationen und verfügbaren Stunden."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Eine maßgeschneiderte Lösung für Ihre Anforderungen."
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Ein Kunde ist ein Unternehmen oder eine Person, die Ihre Teile oder Dienstleistungen kauft."
@@ -375,7 +375,7 @@ msgid "A customer's account manager changes"
 msgstr "Der Kontoführer eines Kunden ändert sich"
 
 msgid "A customer's assignee changes"
-msgstr "Der Verantwortliche eines Kunden ändert sich"
+msgstr "Der Bearbeiter eines Kunden ändert sich."
 
 msgid "A customer's currency changes"
 msgstr "Die Währung eines Kunden ändert sich"
@@ -393,7 +393,7 @@ msgid "A customer's type changes"
 msgstr "Der Typ eines Kunden ändert sich"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "Ein datierter Datensatz, der nachweist, dass ein Messinstrument gegen einen nachvollziehbaren Standard überprüft wurde; es besteht, solange keine Kennzeichnung für Maßnahmen, Anpassung oder Reparatur aktiviert ist, und setzt das nächste Fälligkeitsdatum des Messinstruments zurück."
+msgstr "Ein datierter Beleg, der beweist, dass ein Prüfmittel gegen einen nachvollziehbaren Standard überprüft wurde; es besteht die Prüfung, es sei denn, es ist ein Flag für erforderliche Maßnahme, Anpassung oder Reparatur markiert, und setzt das nächste Fälligkeitsdatum des Prüfmittels zurück."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
 msgstr "Ein datiertes Zeitfenster, in das Buchungen fallen; sein Schließungsstatus wechselt von Offen → Gesperrt → Geschlossen, und eine geschlossene Periode ist gegen neue Buchungen eingefroren."
@@ -414,7 +414,7 @@ msgid "A formal acceptance / sign-off phase"
 msgstr "Eine formale Akzeptanz- / Abzeichnungsphase"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "Ein Messinstrument, dessen Rolle Meister ist — der Referenzstandard, gegen den andere Messinstrumente kalibriert werden, anstatt eines, das für Routinekontrollen verwendet wird."
+msgstr "Ein Prüfmittel, dessen Rolle „Normal\" ist — der Referenzstandard, gegen den andere Prüfmittel kalibriert werden, anstatt eines für Routineprüfungen verwendeten."
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "Ein Fehlerdatensatz verfolgt Qualitätsprobleme und deren Lösungsprozess."
@@ -426,16 +426,16 @@ msgid "A job is deleted"
 msgstr "Ein Auftrag wird gelöscht"
 
 msgid "A job is put on hold"
-msgstr "Ein Auftrag wird zurückgestellt"
+msgstr "Ein Fertigungsauftrag wird angehalten."
 
 msgid "A job is released"
 msgstr "Ein Auftrag wird freigegeben"
 
 msgid "A job operation is completed"
-msgstr "Eine Auftragsoperation wird abgeschlossen"
+msgstr "Ein Auftragsvorgang wird fertiggestellt."
 
 msgid "A job's assignee changes"
-msgstr "Der Verantwortliche eines Auftrags ändert sich"
+msgstr "Der Bearbeiter eines Fertigungsauftrags ändert sich."
 
 msgid "A job's deadline type changes"
 msgstr "Der Fälligkeitstyp eines Auftrags ändert sich"
@@ -467,31 +467,31 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Eine Liste ist mit {0} verbunden, sodass dieser Schritt für jedes Element darin einmal ausgeführt wird – bis zu {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Eine Make-to-Order-Komponente, die seinen eigenen Job und Routing in den Build des Elternteils erhält."
+msgstr "Eine Auftragfertigungskomponente, die bei der Fertigung des übergeordneten Fertigungsauftrags einen eigenen Fertigungsauftrag und Arbeitsplan erhält."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Eine Make-to-Order-Komponente, deren Teile zusammen in den übergeordneten Job ausgegeben werden — kein separater Build."
+msgstr "Eine Auftragfertigungskomponente, deren Teile zusammen in den übergeordneten Fertigungsauftrag bereitgestellt werden — kein separater Aufbau."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Eine verwaltete, cloud-gehostete Version von Carbon."
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Eine verwaltete Version mit allen erweiterten Funktionen."
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Ein Material ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und über mehrere Aufträge hinweg verwendet werden kann"
+msgstr "Ein Werkstoff ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und der über mehrere Fertigungsaufträge hinweg verwendet werden kann."
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "Ein Messinstrument (Schieblehre, Schraublehre, Lehrdorn, KMG) verfolgt als Datensatz und unterliegt einem wiederkehrenden Kalibrierplan."
+msgstr "Ein Messinstrument (Schieblehre, Micrometer, Prüfstift, CMM), das als Datensatz verwaltet und einem regelmäßigen Kalibrierplan unterworfen wird."
 
 msgid "A name is required to save a view"
 msgstr "Ein Name ist erforderlich, um eine Ansicht zu speichern"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Ein ausgehandelter Preis, der für einen bestimmten Artikel festgelegt ist — nach Kunde, Kundentyp oder allen Kunden — der den Basispreis vollständig ersetzt, optional mit Mengenrabatten."
+msgstr "Ein verhandelter, für einen bestimmten Artikel festgelegter Preis — pro Kunde, Kundentyp oder alle Kunden — der den Basispreis vollständig ersetzt, optional mit Mengenstaffeln."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "Eine neue Bestellung wird für jeden Lieferanten erstellt. Alternativ können Sie eine vorhandene Entwurfsbestellung für den Lieferanten auswählen, um die externen Vorgänge hinzuzufügen."
+msgstr "Für jeden Lieferanten wird eine neue Bestellung erstellt. Alternativ können Sie eine vorhandene Entwurfs-Bestellung für den Lieferanten auswählen, um die externen Arbeitsgänge hinzuzufügen."
 
 msgid "A new revision will be created using a copy of the current revision"
 msgstr "Eine neue Revision wird erstellt, indem eine Kopie der aktuellen Revision verwendet wird"
@@ -500,49 +500,49 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Eine neue Größe wird erstellt, indem eine Kopie der aktuellen Größe verwendet wird"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Ein neuer Stripe-Kunde wird erstellt."
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "Ein nicht-liquiditätswirksames Dokument, das eine Rechnung gegen ein Begründungskonto abrechnet: eine Gutschrift reduziert die Schuld, eine Belastung erhöht sie."
+msgstr "Ein bargeldloses Dokument, das eine Rechnung gegen ein Verrechnungskonto ausgleicht: ein Haben senkt die Schuld, ein Soll erhöht sie."
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
 msgstr "Eine Nichtkonformität, die mit einem Lieferanten über einen passwortfreien Link /share/scar geteilt wird, damit dieser auf das Problem reagieren und seine Aufgaben von außerhalb von Carbon aktualisieren kann."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Ein nicht steuerbarer Zuschlag (z.B. rückzahlbare Kosten wie Genehmigungsgebühren), der zur Position hinzugefügt wird und von der Steuerbasis ausgeschlossen ist."
+msgstr "Ein nicht besteuerbarer Zuschlag (z. B. erstattungsfähige Kosten wie Genehmigungsgebühren), der zur Position hinzugefügt wird; von der Steuerbasis ausgenommen."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Eine Nichtkonformitätsaufgabe, die eine bestätigte Grundursache behebt — im Gegensatz zu einer vorbeugenden oder unmittelbaren Eindämmungsmaßnahme."
+msgstr "Eine Nichtkonformitätsaufgabe, die eine bestätigte Grundursache behebt — im Gegensatz zu einer vorbeugenden oder unmittelbaren Containment-Maßnahme."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "Eine Nichtkonformitätsaufgabe, die verhindert, dass das Problem anderswo erneut auftritt — unterscheidet sich von der Korrekturmaßnahme und Eindämmung."
+msgstr "Eine Nichtkonformitätsaufgabe, die verhindert, dass das Problem anderswo erneut auftritt — unterschiedlich von der korrigierenden Maßnahme und dem Containment."
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "Ein Teil enthält die Informationen über einen bestimmten Artikel, der gekauft oder hergestellt werden kann."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "Ein physisches Abrufsignal — eine gedruckte Karte oder ein QR-Code neben dem Bestand — das eine Bestellung oder einen Auftrag auslöst, sobald er eingescannt wird, um einen Behälter nachzufüllen."
+msgstr "Ein physisches Pull-Signal — eine gedruckte Karte oder ein QR-Code, der sich beim Bestand befindet — das eine Bestellung oder einen Fertigungsauftrag erstellt, sobald es gescannt wird, um einen Lagerplatz nachzufüllen."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "Ein Punkt in einem der eigenen Prozesse von Carbon, den ein Workflow überwachen kann – ein freigegebener Auftrag, ein akzeptiertes Angebot, eine gebuchte Sendung – im Gegensatz zu einer reinen Feldänderung; er übergibt dem Workflow die beteiligten Datensätze nach ID."
+msgstr "Ein Punkt in einem der eigenen Prozesse von Carbon, den ein Workflow überwachen kann — ein freigegebener Fertigungsauftrag, ein angenommenes Angebot, eine gebuchte Lieferung — im Gegensatz zu einer rohen Feldänderung; es übergibt dem Workflow die beteiligten Datensätze nach ID."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Ein gebuchter Buchhaltungseintrag: ein Header plus ausgeglichene Debit- und Kreditzeilen gegen GL-Konten."
+msgstr "Ein gebuchter Buchhaltungseintrag: ein Header plus ausgeglichene Soll- und Haben-Zeilen gegen Sachkonten."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Eine gebuchte Bargeldtransaktion — eine Quittung von einem Kunden oder eine Auszahlung an einen Lieferanten — angewendet auf Rechnungen durch Ausgleiche, wechselt von Entwurf → Gebucht → Annulliert."
+msgstr "Eine gebuchte Kassatransaktion — ein Zahlungseingang von einem Kunden oder eine Auszahlung an einen Lieferant — auf Rechnungen durch Abrechnungen angewendet, Bewegung Entwurf → Gebucht → Storniert."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Eine vorgeschriebene Beschreibung, die bei jedem Problem mit diesem Workflow eingefügt wird; Platzhalter wie {itemId} und {location} werden bei der Erstellung ersetzt."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "Ein bewertetes Verkaufsangebot; Entwurf → Gesendet → Bestellt, oder endet verloren, abgelaufen oder storniert."
+msgstr "Ein Angebot; Entwurf → Versendet → Bestellt, oder endet mit Verloren, Abgelaufen oder Storniert."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
-msgstr "Eine Kaufrechnung ist ein Dokument, das die von einem Kunden gekauften Produkte oder Dienstleistungen und die entsprechenden Kosten angibt."
+msgstr "Eine Eingangsrechnung ist ein Dokument, das die von einem Kunden gekauften Produkte oder Dienstleistungen und die entsprechenden Kosten spezifiziert."
 
 msgid "A purchase invoice is posted"
-msgstr "Eine Kaufrechnung wird gebucht"
+msgstr "Eine Eingangsrechnung wird gebucht"
 
 msgid "A purchase order is created"
 msgstr "Eine Bestellung wird erstellt"
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "Eine Bestellung wird gelöscht"
 
 msgid "A purchase order's assignee changes"
-msgstr "Der Verantwortliche einer Bestellung ändert sich"
+msgstr "Der Bearbeiter einer Bestellung ändert sich"
 
 msgid "A purchase order's order date changes"
 msgstr "Das Bestelldatum einer Bestellung ändert sich"
@@ -575,7 +575,7 @@ msgid "A purchase order's type changes"
 msgstr "Der Typ einer Bestellung ändert sich"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Ein Qualitätsproblem – eine protokollierte Abweichung oder ein Mangel mit einem konfigurierbaren Workflow von Untersuchungs- und Maßnahmenaufgaben."
+msgstr "Ein Qualitätsproblem — eine protokollierte Abweichung oder ein Mangel mit einem konfigurierbaren Workflow von Untersuchungs- und Maßnahmenaufgaben."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Eine Menge identischer Einheiten teilt sich eine verfolgte Entität und Chargennummer — eine Entität, viele Einheiten."
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "Ein Angebot wird versendet"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Eine Angebotszeile enthält Preise und Lieferzeiten für ein bestimmtes Teil"
+msgstr "Eine Angebotsposition enthält Preise und Beschaffungszeiten für einen bestimmten Teil"
 
 msgid "A quote's assignee changes"
-msgstr "Der Beauftragte eines Angebots ändert sich"
+msgstr "Der Bearbeiter eines Angebots ändert sich"
 
 msgid "A quote's completed date changes"
 msgstr "Das Abschlussdatum eines Angebots ändert sich"
@@ -614,7 +614,7 @@ msgid "A quote's estimator changes"
 msgstr "Der Schätzer eines Angebots ändert sich"
 
 msgid "A quote's expiration date changes"
-msgstr "Das Ablaufdatum eines Angebots ändert sich"
+msgstr "Das Verfallsdatum eines Angebots ändert sich"
 
 msgid "A quote's salesperson changes"
 msgstr "Der Verkäufer eines Angebots ändert sich"
@@ -632,10 +632,10 @@ msgid "A receipt is posted"
 msgstr "Ein Wareneingang wird verbucht"
 
 msgid "A receipt's assignee changes"
-msgstr "Der Beauftragte eines Wareneingangs ändert sich"
+msgstr "Der Bearbeiter eines Wareneingangs ändert sich"
 
 msgid "A receipt's invoiced changes"
-msgstr "Der Rechnungsstatus eines Wareneingangs ändert sich"
+msgstr "Die Rechnungsgestellung eines Wareneingangs ändert sich"
 
 msgid "A receipt's location changes"
 msgstr "Der Lagerort eines Wareneingangs ändert sich"
@@ -644,7 +644,7 @@ msgid "A receipt's posting date changes"
 msgstr "Das Verbuchungsdatum eines Wareneingangs ändert sich"
 
 msgid "A receipt's source document changes"
-msgstr "Das Quelldokument eines Wareneingangs ändert sich"
+msgstr "Der Ursprungsbeleg eines Wareneingangs ändert sich"
 
 msgid "A receipt's status changes"
 msgstr "Der Status eines Wareneingangs ändert sich"
@@ -656,109 +656,109 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Ein wiederverwendbarer, versionierter Satz von Arbeitsanweisungen, die an einen Prozess angehängt sind und einem Vorgang seine geordneten Schritte zum Aufzeichnen und Überprüfen sowie die Parameter, mit denen er ausgeführt wird, geben."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Ein Routingschritt auf einem freigegebenen Job, die eigene Kopie eines Vorgangs des Jobs, mit einem Status, den die Fertigung von \"Zu erledigen\" bis \"Fertig\" steuert."
+msgstr "Ein Arbeitsplanschritt eines freigegebenen Fertigungsauftrags, die eigene Kopie eines Arbeitsgangs, mit einem Status, den die Etage von Todo bis Erledigt steuert."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Eine Verkaufsrechnung (Sie berechnen einem Kunden) oder Einkaufsrechnung (ein Lieferant berechnet Ihnen), gezahlt durch Anwendung von Zahlungen und Gut- oder Lastschriften."
+msgstr "Eine Ausgangsrechnung (Sie stellen einem Kunden eine Rechnung) oder eine Eingangsrechnung (ein Lieferant stellt Ihnen eine Rechnung), beglichen durch Anwendung von Zahlungen und Gutschriften oder Lastschriften."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
-msgstr "Eine Verkaufsrechnung ist ein Dokument, das die an einen Kunden verkauften Produkte oder Dienstleistungen und die entsprechenden Kosten angibt."
+msgstr "Eine Ausgangsrechnung ist ein Dokument, das die an einen Kunden verkauften Produkte oder Dienstleistungen und die entsprechenden Kosten spezifiziert."
 
 msgid "A sales invoice is posted"
-msgstr "Eine Verkaufsrechnung wird verbucht"
+msgstr "Eine Ausgangsrechnung wird gebucht"
 
 msgid "A sales invoice line contains invoice details for a particular item"
-msgstr "Eine Verkaufsrechnungsposition enthält Rechnungsdetails für einen bestimmten Artikel"
+msgstr "Eine Ausgangsrechnungsposition enthält Details für einen bestimmten Artikel"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Eine Bestellung enthält Informationen über die Vereinbarung zwischen dem Unternehmen und einem bestimmten Kunden für Teile und Dienstleistungen."
+msgstr "Ein Kundenauftrag enthält Informationen über die Vereinbarung zwischen dem Unternehmen und einem bestimmten Kunden für Teile und Dienstleistungen."
 
 msgid "A sales order is created"
-msgstr "Eine Verkaufsbestellung wird erstellt"
+msgstr "Ein Kundenauftrag wird erstellt"
 
 msgid "A sales order is deleted"
-msgstr "Eine Verkaufsbestellung wird gelöscht"
+msgstr "Ein Kundenauftrag wird gelöscht"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "Eine Auftragszeile enthält Bestelldetails für einen bestimmten Artikel"
+msgstr "Eine Kundenauftragsposition enthält Bestelldetails für einen bestimmten Artikel"
 
 msgid "A sales order's assignee changes"
-msgstr "Der Beauftragte einer Verkaufsbestellung ändert sich"
+msgstr "Der Bearbeiter eines Kundenauftrags ändert sich"
 
 msgid "A sales order's completed date changes"
-msgstr "Das Abschlussdatum einer Verkaufsbestellung ändert sich"
+msgstr "Das Fertigstellungsdatum eines Kundenauftrags ändert sich"
 
 msgid "A sales order's customer changes"
-msgstr "Der Kunde einer Verkaufsbestellung ändert sich"
+msgstr "Der Kunde eines Kundenauftrags ändert sich"
 
 msgid "A sales order's customer reference changes"
-msgstr "Die Kundenreferenz einer Verkaufsbestellung ändert sich"
+msgstr "Die Kundenreferenz eines Kundenauftrags ändert sich"
 
 msgid "A sales order's location changes"
-msgstr "Der Lagerort einer Verkaufsbestellung ändert sich"
+msgstr "Der Standort eines Kundenauftrags ändert sich"
 
 msgid "A sales order's order date changes"
-msgstr "Das Bestelldatum einer Verkaufsbestellung ändert sich"
+msgstr "Das Bestelldatum eines Kundenauftrags ändert sich"
 
 msgid "A sales order's salesperson changes"
-msgstr "Der Verkäufer einer Verkaufsbestellung ändert sich"
+msgstr "Der Verkäufer eines Kundenauftrags ändert sich"
 
 msgid "A sales order's status changes"
-msgstr "Der Status einer Verkaufsbestellung ändert sich"
+msgstr "Der Status eines Kundenauftrags ändert sich"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Eine Verkaufsanfrage (RFQ) ist eine Kundenanfrage zur Preisgestaltung für eine Reihe von Teilen und Mengen. Sie kann zu einem Angebot führen."
+msgstr "Eine Anfrage (RFQ) ist eine Kundenanfrage für Preise für eine Reihe von Teilen und Mengen. Sie kann zu einem Angebot führen."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
-msgstr "Ein Verkaufs-RFQ (ein Kunde bittet Sie zu zitieren) oder ein Einkaufs-RFQ (Sie fragen Lieferanten); beide speisen den Gelegenheitsfaden."
+msgstr "Ein Verkaufs-Anfrage (ein Kunde bittet Sie um ein Angebot) oder eine Einkaufs-Anfrage (Sie bitten Lieferanten um ein Angebot); beide nähren die Verkaufschance."
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
 msgstr "Ein bereichsbegrenztes Geheimnis, das im carbon-key-Anfrage-Header gesendet wird und programmgesteuerte Aufrufe an Carbon authentifiziert, mit eigenen Berechtigungen und Ratenlimit statt einer Benutzersitzung."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "Ein separater Zeitplan für die Steuererklärung, wenn die Steuervorschriften eine andere Methode als die Buchabschreibung erfordern."
+msgstr "Ein separater Plan für die Steuermeldung, wenn Steuerregeln eine Methode erfordern, die sich von der buchhalterischen Abschreibung unterscheidet."
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "Eine Dienstleistung ist eine abrechenbare Tätigkeit, die gekauft oder erbracht wird – sie wird nie versandt, empfangen oder gelagert"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Eine Gruppe von Unternehmen unter einem Eigentümer, die gruppenweite Konfigurationen teilen – den Kontenplan, Währungen und Dimensionen –, sodass dieselbe Buchhaltungseinrichtung für jedes Unternehmen der Gruppe gilt."
+msgstr "Eine Reihe von Unternehmen unter einem Eigentümer, die eine Gruppenkonfiguration teilen — der Kontenplan, Währungen und Dimensionen — so dass die gleiche Buchhaltungseinrichtung alle Unternehmen in der Gruppe umfasst."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Ein Satz von Anweisungen zum Abholen der ausstehenden Materialien eines Auftrags aus dem Lager und deren Bereitstellung am Einsatzort; ein Kommissioniervorgang verschiebt den Bestand zum Einsatzort, anstatt ihn zu verbrauchen."
+msgstr "Ein Satz von Anweisungen, um die ausstehenden Materialien eines Fertigungsauftrags aus dem Lager zu kommissionieren und sie im Linienlager bereitzustellen; Kommissionieren bewegt den Bestand zum Einsatzort statt ihn zu verbrauchen."
 
 msgid "A shipment is created"
-msgstr "Ein Versand wird erstellt"
+msgstr "Eine Lieferung wird erstellt"
 
 msgid "A shipment is deleted"
-msgstr "Ein Versand wird gelöscht"
+msgstr "Eine Lieferung wird gelöscht"
 
 msgid "A shipment is posted"
-msgstr "Ein Versand wird verbucht"
+msgstr "Eine Lieferung wird gebucht"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "Eine Versandzeile, die direkt vom Lieferanten zum Kunden gesendet wird und Ihr Lager umgeht — pro Zeile eingestellt, nicht im Header."
+msgstr "Eine Lieferposition wird direkt vom Lieferanten zum Kunden versendet, ohne Ihr Lager zu durchlaufen — pro Position eingestellt, nicht im Kopf."
 
 msgid "A shipment's assignee changes"
-msgstr "Der Beauftragte eines Versands ändert sich"
+msgstr "Der Bearbeiter einer Lieferung ändert sich"
 
 msgid "A shipment's customer changes"
-msgstr "Der Kunde eines Versands ändert sich"
+msgstr "Der Kunde einer Lieferung ändert sich"
 
 msgid "A shipment's location changes"
-msgstr "Der Lagerort eines Versands ändert sich"
+msgstr "Der Standort einer Lieferung ändert sich"
 
 msgid "A shipment's posting date changes"
-msgstr "Das Verbuchungsdatum eines Versands ändert sich"
+msgstr "Das Buchungsdatum einer Lieferung ändert sich"
 
 msgid "A shipment's shipping method changes"
-msgstr "Die Versandart eines Versands ändert sich"
+msgstr "Die Versandart einer Lieferung ändert sich"
 
 msgid "A shipment's status changes"
-msgstr "Der Status eines Versands ändert sich"
+msgstr "Der Status einer Lieferung ändert sich"
 
 msgid "A shipment's tracking number changes"
-msgstr "Die Verfolgungsnummer einer Sendung ändert sich"
+msgstr "Die Verfolgungsnummer einer Lieferung ändert sich"
 
 msgid "A step needs a name."
 msgstr "Ein Schritt benötigt einen Namen."
@@ -773,7 +773,7 @@ msgid "A supplier's account manager changes"
 msgstr "Der Kundenbetreuer eines Lieferanten ändert sich"
 
 msgid "A supplier's assignee changes"
-msgstr "Der Verantwortliche eines Lieferanten ändert sich"
+msgstr "Der Bearbeiter eines Lieferanten ändert sich"
 
 msgid "A supplier's currency changes"
 msgstr "Die Währung eines Lieferanten ändert sich"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "Der Name eines Lieferanten ändert sich"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "Die Preisreaktion eines Lieferanten auf eine Einkaufs-RFQ — einer pro Lieferant; Entwurf → Aktiv, wenn sie absenden, oder Abgelehnt."
+msgstr "Die Antwort eines Lieferanten auf eine Anfrage im Einkauf mit Preis — eine pro Lieferant; Entwurf → Aktiv, wenn eingereicht, oder Abgelehnt."
 
 msgid "A supplier's status changes"
 msgstr "Der Status eines Lieferanten ändert sich"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "Ein steuerbarer Zuschlag (Bearbeitung, Setup, Treibstoff), der zur Position hinzugefügt wird und in die Steuerbasis fließt."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Ein zeitgestempelter Datensatz für Setup-, Arbeits- oder Maschinenarbeit, die gegen einen Jobvorgang protokolliert wird und dessen Dauer in die tatsächlichen Kosten des Vorgangs einfließt."
+msgstr "Eine zeitgestempelte Aufzeichnung von Rüsten, Personal- oder Maschinenarbeit, die gegen einen Auftragsvorgang protokolliert wird und deren Dauer in die tatsächlichen Kosten des Auftragsvorgang einfließt."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Ein Werkzeug ist ein physischer Gegenstand, der zur Herstellung eines Teils verwendet wird und über mehrere Aufträge hinweg eingesetzt werden kann"
+msgstr "Ein Werkzeug ist ein physischer Artikel, der zur Herstellung eines Teils verwendet wird und über mehrere Fertigungsaufträge hinweg eingesetzt werden kann"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
 msgstr "Ein Benutzer erfasst das Verfallsdatum für jede Charge oder Seriennummer, wenn die Waren eingehen. Verwenden Sie dies, wenn Lieferanten Chargen mit unterschiedlichen Verfallsdaten versenden."
 
 msgid "abilities"
-msgstr "Fähigkeiten"
+msgstr "qualifikationen"
 
 msgid "Abilities"
-msgstr "Fähigkeiten"
+msgstr "Qualifikationen"
 
 msgid "ability"
-msgstr "Fähigkeit"
+msgstr "qualifikation"
 
 msgid "About"
 msgstr "Über"
@@ -827,13 +827,13 @@ msgid "Academy"
 msgstr "Academy"
 
 msgid "Accept Lot"
-msgstr "Lot akzeptieren"
+msgstr "Charge annehmen"
 
 msgid "Accept lot?"
-msgstr "Lot akzeptieren?"
+msgstr "charge annehmen?"
 
 msgid "Accept Quote"
-msgstr "Angebot akzeptieren"
+msgstr "Angebot annehmen"
 
 msgid "Acceptable Quality Level — the highest defect rate that's still considered passable under the Z1.4 / ISO 2859-1 tables."
 msgstr "Acceptable Quality Level – die höchste Fehlerquote, die nach den Z1.4 / ISO 2859-1 Tabellen noch als zulässig gilt."
@@ -846,7 +846,7 @@ msgstr "Akzeptanz bestanden"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
-msgstr "Akzeptiert am {0}"
+msgstr "Angenommen {0}"
 
 msgid "Account"
 msgstr "Konto"
@@ -855,7 +855,7 @@ msgid "Account & Details"
 msgstr "Konto & Details"
 
 msgid "Account balances with debits and credits"
-msgstr "Kontostand mit Soll- und Habenseite"
+msgstr "Kontosalden mit Soll und Haben"
 
 msgid "Account for advance payments made before goods or services are received"
 msgstr "Konten Sie für Vorschusszahlungen, die vor Lieferung von Waren oder Dienstleistungen getätigt werden."
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "Buchhaltung"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "Die Buchhaltung befindet sich derzeit in der Beta-Phase. Fordern Sie Zugriff an, um Berichte, Journaleinträge, Buchhaltungsperioden, Anlagevermögen und mehr zu aktivieren."
+msgstr "Buchhaltung befindet sich derzeit in der Beta-Phase. Fordern Sie Zugriff an, um Berichte, Buchungssätze, Buchungsperioden, Anlagegüter und mehr zu aktivieren."
 
 msgid "Accounting is disabled"
 msgstr "Buchhaltung ist deaktiviert"
@@ -912,10 +912,10 @@ msgid "Accounting is enabled"
 msgstr "Buchhaltung ist aktiviert"
 
 msgid "Accounting period"
-msgstr "Abrechnungsperiode"
+msgstr "buchungsperiode"
 
 msgid "Accounting Periods"
-msgstr "Abrechnungsperioden"
+msgstr "Buchungsperioden"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
 msgstr "Buchhaltung: Hauptbuch, Debitorenbuchhaltung, Kreditorenbuchhaltung und Monatsabschluss"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Kontenkonto für kumulierte Abschreibung"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Kumulierte Abschreibung bei Entsorgung"
+msgstr "Kumulierte Abschreibung bei Abgang"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Kumulierte Abschreibung bei Entsorgung (Standard)"
+msgstr "Kumulierte Abschreibung bei Abgang (Standard)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Akkumulationszeitraum (Wochen)"
@@ -1002,7 +1002,7 @@ msgid "Activate Process"
 msgstr "Prozess aktivieren"
 
 msgid "Activate Work Center"
-msgstr "Arbeitszentrum aktivieren"
+msgstr "Arbeitsplatz aktivieren"
 
 msgid "Activation fee · we advise"
 msgstr "Aktivierungsgebühr · wir beraten"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "Aktiv"
 
 msgid "Active Jobs"
-msgstr "Aktive Aufträge"
+msgstr "Aktive Fertigungsaufträge"
 
 msgid "Active Statuses"
 msgstr "Aktive Status"
@@ -1047,19 +1047,19 @@ msgid "Add & Issue"
 msgstr "Hinzufügen & Ausgeben"
 
 msgid "Add a column below to sort the view"
-msgstr "Fügen Sie unten eine Spalte hinzu, um die Ansicht zu sortieren"
+msgstr "Spalte unten hinzufügen, um die Anzeige zu sortieren"
 
 msgid "Add a comment..."
 msgstr "Einen Kommentar hinzufügen..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Fügen Sie eine benutzerdefinierte Preiszeile hinzu, um Menge, Preis, Versand, Lieferzeit und Steuer zu überschreiben"
+msgstr "Benutzerdefinierten Preiszeile hinzufügen, um Menge, Preis, Versand, Beschaffungszeit und Steuer zu übersteuern"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
-msgstr "Fügen Sie einen Materialkatalogabschnitt hinzu, der jedes Element der Stückliste mit seiner Menge auflistet."
+msgstr "Materialien-Abschnitt hinzufügen, der jeden Artikel auf der Stückliste mit seiner Menge auflistet."
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Fügen Sie einen Drucker in den Druckeinstellungen hinzu, um Etiketten direkt zu drucken."
+msgstr "Drucker in den Druckeinstellungen hinzufügen, um Etiketten direkt zu drucken."
 
 msgid "Add a requirement"
 msgstr "Anforderung hinzufügen"
@@ -1077,13 +1077,13 @@ msgid "Add Actions"
 msgstr "Aktionen hinzufügen"
 
 msgid "Add Adjustment"
-msgstr "Anpassung hinzufügen"
+msgstr "Korrektur hinzufügen"
 
 msgid "Add Affected Item"
 msgstr "Betroffenes Element hinzufügen"
 
 msgid "Add any notes about your decision..."
-msgstr "Fügen Sie Notizen zu Ihrer Entscheidung hinzu..."
+msgstr "Notizen zu Ihrer Entscheidung hinzufügen..."
 
 msgid "Add Approval Requirement"
 msgstr "Genehmigungsanforderung hinzufügen"
@@ -1092,10 +1092,10 @@ msgid "Add Authenticator App"
 msgstr "Authentifikator-App hinzufügen"
 
 msgid "Add Calibration Record"
-msgstr "Kalibrierungsdatensatz hinzufügen"
+msgstr "Kalibrierprotokoll hinzufügen"
 
 msgid "Add Child Storage Unit"
-msgstr "Untergeordnete Speichereinheit hinzufügen"
+msgstr "Untergeordnete Lagereinheit hinzufügen"
 
 msgid "Add clause"
 msgstr "Klausel hinzufügen"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "Bedingung hinzufügen"
 
 msgid "Add Contractor"
-msgstr "Auftragnehmer hinzufügen"
+msgstr "Externen Mitarbeiter hinzufügen"
 
 msgid "Add cost center"
 msgstr "Kostenstelle hinzufügen"
@@ -1146,13 +1146,13 @@ msgid "Add Note"
 msgstr "Notiz hinzufügen"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Notizen und Dokumentation für diesen Wartungseinsatz hinzufügen"
+msgstr "Notizen und Dokumentation für diesen Instandhaltungsauftrag hinzufügen"
 
 msgid "Add Operation"
 msgstr "Operation hinzufügen"
 
 msgid "Add options above first"
-msgstr "Fügen Sie zuerst Optionen hinzu"
+msgstr "Optionen oben zuerst hinzufügen"
 
 msgid "Add otherwise"
 msgstr "Alternativ hinzufügen"
@@ -1206,7 +1206,7 @@ msgid "Add Selector"
 msgstr "Selektor hinzufügen"
 
 msgid "Add Shipment"
-msgstr "Sendung hinzufügen"
+msgstr "Lieferung hinzufügen"
 
 msgid "Add Shipping"
 msgstr "Versand hinzufügen"
@@ -1221,7 +1221,7 @@ msgid "Add Step"
 msgstr "Schritt hinzufügen"
 
 msgid "Add steps to preview the operator view."
-msgstr "Schritte hinzufügen, um die Bedieneransicht in der Vorschau anzuzeigen."
+msgstr "Schritte hinzufügen, um die Werker-Ansicht vorab anzusehen."
 
 msgid "Add Stock Transfer"
 msgstr "Bestandsübertrag hinzufügen"
@@ -1230,13 +1230,13 @@ msgid "Add Supplier"
 msgstr "Lieferant hinzufügen"
 
 msgid "Add the next capability on the same system instead of buying another tool."
-msgstr "Fügen Sie die nächste Funktion im selben System hinzu, anstatt ein anderes Tool zu kaufen."
+msgstr "Füge die nächste Fähigkeit auf demselben System hinzu, anstatt ein anderes Werkzeug zu kaufen."
 
 msgid "Add Timecard"
 msgstr "Zeitkarte hinzufügen"
 
 msgid "Add to stock for future use"
-msgstr "Zum zukünftigen Gebrauch in den Bestand aufnehmen"
+msgstr "Zum Bestand hinzufügen zur zukünftigen Verwendung"
 
 msgid "Add tools"
 msgstr "Werkzeuge hinzufügen"
@@ -1279,7 +1279,7 @@ msgid "Address line2"
 msgstr "Adresszeile 2"
 
 msgid "Adjustment Type"
-msgstr "Anpassungstyp"
+msgstr "Korrekturtyp"
 
 msgid "Admin"
 msgstr "Admin"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Alle {0} Zellen gleichen sich ab"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Alle {total} Phasen sind abgeschlossen. Großartig — Ihr Team ist einsatzbereit."
+msgstr "Alle {total} Phasen sind erledigt. Gute Arbeit – Ihr Team ist einsatzbereit."
 
 msgid "All accounts"
 msgstr "Alle Konten"
@@ -1334,10 +1334,10 @@ msgid "All actions selected"
 msgstr "Alle Aktionen ausgewählt"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Alle erweiterten Funktionen verfügbar"
 
 msgid "All Audit Logs"
-msgstr "Alle Audit-Protokolle"
+msgstr "Alle Änderungsprotokolle"
 
 msgid "All changes to auditable entities are being recorded."
 msgstr "Alle Änderungen an prüfbaren Entitäten werden aufgezeichnet."
@@ -1388,7 +1388,7 @@ msgid "All users"
 msgstr "Alle Benutzer"
 
 msgid "All Work Centers"
-msgstr "Alle Arbeitszentren"
+msgstr "Alle Arbeitsplätze"
 
 msgid "Allows acknowledge & continue"
 msgstr "Ermöglicht Bestätigung & Fortfahren"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Betrag"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Ein Betrag, der Vermögenswerte/Ausgaben erhöht oder Verbindlichkeiten/Eigenkapital/Einnahmen bei dieser Position verringert."
+msgstr "Betrag, der Vermögen/Aufwendungen in dieser Position erhöht oder Verbindlichkeiten/Eigenkapital/Umsatzerlöse verringert."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Ein Betrag, der Verbindlichkeiten/Eigenkapital/Einnahmen erhöht oder Vermögenswerte/Ausgaben bei dieser Position verringert."
+msgstr "Betrag, der Verbindlichkeiten/Eigenkapital/Umsatzerlöse in dieser Position erhöht oder Vermögen/Aufwendungen verringert."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "Betragtyp"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Ein Rechnungsfach, das Ausgaben nach Abteilung oder Funktion gruppiert, damit die Bilanz die Ausgaben nach Gruppe, nicht nur nach Konto, berichten kann."
+msgstr "Ein Buchhaltungs-Sammelkonto, das Aufwendungen nach Abteilung oder Funktion gruppiert, damit das Hauptbuch die Ausgaben nach Gruppe anstelle nach Konto berichten kann."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Ein Buchhaltungsdatensatz für einen aktivierten Gegenstand, den Sie abschreiben, anstatt zu verbuchen; Entwurf → Aktiv → Vollständig abgeschrieben → Entsorgt."
+msgstr "Ein Buchhaltungsdatensatz für einen aktivierten Vermögenswert, den Sie abschreiben anstatt ihn als Aufwand zu buchen; Entwurf → Aktiv → Vollständig abgeschrieben → Abgegangen."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Eine Benachrichtigung, dass etwas die Aufmerksamkeit einer Person benötigt, verteilt von einem carbon/notify-Ereignis zum In-App-Posteingang plus optionale E-Mail und Slack, stummschaltbar pro Thema pro Benutzer."
@@ -1449,7 +1449,7 @@ msgid "An integration or a custom change — the small slice that's actually cus
 msgstr "Eine Integration oder eine benutzerdefinierte Änderung — der kleine Teil, der tatsächlich benutzerdefiniert ist."
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "Eine Einladung steht aus. Sie werden aktiv, sobald sie sie akzeptieren."
+msgstr "Eine Einladung steht aus. Sie werden aktiv, sobald sie diese annehmen."
 
 msgid "An issue is created"
 msgstr "Ein Problem wird erstellt"
@@ -1458,7 +1458,7 @@ msgid "An issue is deleted"
 msgstr "Ein Problem wird gelöscht"
 
 msgid "An issue's assignee changes"
-msgstr "Der Verantwortliche eines Problems ändert sich"
+msgstr "Der Bearbeiter eines Problems ändert sich"
 
 msgid "An issue's close date changes"
 msgstr "Das Abschlussdatum eines Problems ändert sich"
@@ -1497,16 +1497,16 @@ msgid "An item's active changes"
 msgstr "Der aktive Status eines Artikels ändert sich"
 
 msgid "An item's assignee changes"
-msgstr "Die Zuordnung eines Elements ändert sich"
+msgstr "Der Bearbeiter eines Artikels ändert sich"
 
 msgid "An item's default method type changes"
-msgstr "Der Standard-Methodentyp eines Elements ändert sich"
+msgstr "Die Standardbereitstellungsart eines Artikels ändert sich"
 
 msgid "An item's name changes"
 msgstr "Der Name eines Elements ändert sich"
 
 msgid "An item's replenishment system changes"
-msgstr "Das Auffüllungssystem eines Elements ändert sich"
+msgstr "Die Beschaffungsart eines Artikels ändert sich"
 
 msgid "An item's revision status changes"
 msgstr "Der Revisionsstatus eines Elements ändert sich"
@@ -1515,13 +1515,13 @@ msgid "An item's tracking type changes"
 msgstr "Der Nachverfolgungstyp eines Elements ändert sich"
 
 msgid "An item's unit of measure changes"
-msgstr "Die Maßeinheit eines Elements ändert sich"
+msgstr "Die Mengeneinheit eines Artikels ändert sich"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Eine Operation, die von einem externen Lieferanten anstelle eines internen Arbeitszentrums durchgeführt wird und durch eine Fremdvergabe-Kauforder abgedeckt wird."
+msgstr "Ein Arbeitsgang, der von einem externen Lieferanten anstelle eines internen Arbeitsplatzes durchgeführt wird und durch eine Unterauftrags-Bestellung gedeckt ist."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "Die Position einer Operation in der Warteschlange seines Arbeitszentrums — die Reihenfolge, in der die Werkstatt die Arbeiten aufnimmt — festgelegt durch Neuanordnung von Karten auf dem Board der Arbeitszentren, ohne Daten zu ändern."
+msgstr "Die Position eines Arbeitsgangs in der Warteschlange seines Arbeitsplatzes – die Reihenfolge, in der die Produktion die Arbeit aufgreift – wird durch Neuordnung von Karten auf der Arbeitsplätze-Tafel festgelegt, ohne Daten zu ändern."
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Bei der Verbindung mit Onshape ist ein unerwarteter Fehler aufgetreten. Versuchen Sie die Verbindung erneut."
@@ -1564,7 +1564,7 @@ msgid "Another cost center this one rolls up into, letting you nest a sub-depart
 msgstr "Ein anderes Kostenzentrum, dem dieses untergeordnet ist, was es ermöglicht, eine Unterkostenstelle unter ihrer Muttergesellschaft für hierarchische Kostenberichterstattung zu verschachteln."
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "Eine andere Lagereinheit, in der diese verschachtelt ist (z. B. ein Behälter in einem Gestell); muss sich am gleichen Ort befinden."
+msgstr "Eine weitere Lagereinheit, in die diese Einheit verschachtelt ist (z. B. ein Lagerplatz innerhalb eines Regals); muss sich am gleichen Standort befinden."
 
 msgid "Any item group"
 msgstr "Beliebige Artikelgruppe"
@@ -1576,19 +1576,19 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "Alles, was oben nicht explizit im Umfang aufgeführt ist"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Kreditoren"
 
 msgid "AP Aging"
 msgstr "Kreditorenalterung"
 
 msgid "AP Clerk"
-msgstr "AP-Sachbearbeiter"
+msgstr "Kreditoren-Sachbearbeiter"
 
 msgid "AP Outstanding"
-msgstr "AP ausstehend"
+msgstr "Ausstehende Kreditoren"
 
 msgid "AP Overdue"
-msgstr "AP Überfällig"
+msgstr "Überfällige Kreditoren"
 
 msgid "API Docs"
 msgstr "API-Dokumentation"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "API-Schlüssel für programmgesteuerten Zugriff auf Ihre Carbon-Daten."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, Webhooks und Integrationen"
 
 msgid "Applied"
 msgstr "Angewendet"
@@ -1631,10 +1631,10 @@ msgid "Applies to all"
 msgstr "Gilt für alle"
 
 msgid "Applies to all work centers"
-msgstr "Gilt für alle Arbeitszentren"
+msgstr "Gilt für alle Arbeitsplätze"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
-msgstr "Gilt für Funktionen ohne eigene Regel und für die Charge, wenn dieser Plan eine Inspektion auslöst."
+msgstr "Gilt für Funktionen ohne eigene Regel und für die Charge, wenn dieser Plan eine Prüfung durchführt."
 
 msgid "Apply"
 msgstr "Anwenden"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Debitoren"
 
 msgid "AR / AP representation"
-msgstr "AR / AP Darstellung"
+msgstr "Debitoren / Kreditoren-Darstellung"
 
 msgid "AR Aging"
 msgstr "Debitorenalterung"
 
 msgid "AR Clerk"
-msgstr "AR-Sachbearbeiter"
+msgstr "Debitoren-Sachbearbeiter"
 
 msgid "AR Outstanding"
-msgstr "Forderungen ausstehend"
+msgstr "Ausstehende Debitoren"
 
 msgid "AR Overdue"
-msgstr "AR Überfällig"
+msgstr "Überfällige Debitoren"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Debitoren/Kreditoren"
 
 msgid "Archive"
 msgstr "Archiv"
@@ -1744,17 +1744,17 @@ msgstr "Archivierte Protokolle"
 #. placeholder {0}: getQuoteDisplayId(quote)
 #. placeholder {1}: formatter.format(total)
 msgid "Are you sure you want to accept quote {0} for {1}?"
-msgstr "Sind Sie sicher, dass Sie das Angebot {0} für {1} akzeptieren möchten?"
+msgstr "Möchten Sie das Angebot {0} für {1} wirklich annehmen?"
 
 msgid "Are you sure you want to activate the process: {name}? It will appear in dropdowns again."
 msgstr "Sind Sie sicher, dass Sie den Prozess aktivieren möchten: {name}? Er wird wieder in Dropdown-Listen angezeigt."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Sind Sie sicher, dass Sie dieses Messinstrument aktivieren möchten?."
+msgstr "Möchten Sie dieses Prüfmittel wirklich aktivieren?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "Sind Sie sicher, dass Sie {0} stornieren möchten? Es wird geschlossen und schreibgeschützt, bis Sie es erneut öffnen."
+msgstr "Möchten Sie {0} wirklich stornieren? Es wird geschlossen und schreibgeschützt, bis Sie es wieder öffnen."
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Sind Sie sicher, dass Sie diese Bestandsübertragung abschließen möchten?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Sind Sie sicher, dass Sie diese Bestellung bestätigen möchten? Die Bestätigung der Bestellung wirkt sich auf die Bestellmengen aus, die zur Berechnung von Angebot und Nachfrage verwendet werden."
+msgstr "Möchten Sie diesen Kundenauftrag wirklich bestätigen? Die Bestätigung des Auftrags wirkt sich auf die Auftragsmengen aus, die zur Berechnung von Deckung und Bedarf verwendet werden."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "Sind Sie sicher, dass Sie die Anfrage in ein Angebot umwandeln möchten?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Sind Sie sicher, dass Sie Aufträge für diese Bestellung erstellen möchten? Dies erstellt Aufträge für alle Positionen, die noch keine Aufträge haben."
+msgstr "Möchten Sie Fertigungsaufträge für diesen Kundenauftrag wirklich erstellen? Dies erstellt Fertigungsaufträge für alle Positionen, die noch keinen Fertigungsauftrag haben."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Sind Sie sicher, dass Sie diese Benutzer deaktivieren möchten?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Sind Sie sicher, dass Sie dieses Messinstrument deaktivieren möchten?."
+msgstr "Möchten Sie dieses Prüfmittel wirklich deaktivieren?."
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Sind Sie sicher, dass Sie diesen Benutzer deaktivieren möchten?"
@@ -1859,7 +1859,7 @@ msgstr "Sind Sie sicher, dass Sie den API-Schlüssel: {0}? löschen möchten? Di
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Möchten Sie die Anlageklasse wirklich löschen: {0}? Dies kann nicht rückgängig gemacht werden."
+msgstr "Möchten Sie die Anlagenklasse {0} wirklich löschen? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
@@ -1870,7 +1870,7 @@ msgid "Are you sure you want to delete the change notice category: {0}? This can
 msgstr "Sind Sie sicher, dass Sie die Änderungsmitteilung-Kategorie löschen möchten: {0}? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie den Auftragnehmer: {name} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie den externen Mitarbeiter: {name} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "Sind Sie sicher, dass Sie den Fehlermodus: {name} löschen möchten? Die
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie den Messtyp: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Prüfmittelart: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1937,7 +1937,7 @@ msgstr "Sind Sie sicher, dass Sie die Materialdimension: {0} löschen möchten? 
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Materialoberfläche {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Oberflächenbehandlung: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
@@ -1945,11 +1945,11 @@ msgstr "Sind Sie sicher, dass Sie das Materialformular {0} löschen möchten? Di
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Materialgüte {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Werkstoffgüte: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Materialsubstanz: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie den Grundwerkstoff: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1977,24 +1977,24 @@ msgstr "Sind Sie sicher, dass Sie den Drucker \"{0}\" löschen möchten? Alle Zu
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Rechnungszeile für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Eingangsrechnungsposition für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Verkaufsrechnungsposition für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Ausgangsrechnungsposition für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Verkaufsauftragsposition für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Kundenauftragsposition für {0} {1} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie den Verschrottungsgrund: {0}? löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie den Ausschussgrund: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Seriennummernfolge für {itemLabel} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie den Seriennummernkreis für {itemLabel} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "Sind Sie sicher, dass Sie die Schicht: {name} von {locationName} löschen möchten? Dies kann nicht rückgängig gemacht werden."
@@ -2009,7 +2009,7 @@ msgstr "Sind Sie sicher, dass Sie den Speichertyp: {0} löschen möchten? Dies k
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Speichereinheit löschen möchten: {0}? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Lagereinheit: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
@@ -2017,7 +2017,7 @@ msgstr "Sind Sie sicher, dass Sie den Lieferantentyp: {0} löschen möchten? Die
 
 #. placeholder {0}: unitOfMeasure.name
 msgid "Are you sure you want to delete the unit of measure: {0}? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie die Maßeinheit: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie die Mengeneinheit: {0} löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 #. placeholder {0}: selectedView.name
 msgid "Are you sure you want to delete the view \"{0}\"?"
@@ -2034,13 +2034,13 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "Sind Sie sicher, dass Sie diese Änderungsmitteilung löschen möchten?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Sind Sie sicher, dass Sie dieses Messinstrument löschen möchten?"
+msgstr "Sind Sie sicher, dass Sie dieses Prüfmittel löschen möchten?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "Sind Sie sicher, dass Sie diesen Inspektionsplan löschen möchten?"
+msgstr "Sind Sie sicher, dass Sie diesen Prüfplan löschen möchten?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie diesen Inspektionsplan löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie diesen Prüfplan löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Sind Sie sicher, dass Sie diesen Issue-Workflow löschen möchten?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Sind Sie sicher, dass Sie diese Kanban-Karte löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Sind Sie sicher, dass Sie diesen Wartungseinsatz löschen möchten? Dies kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie diesen Instandhaltungsauftrag löschen möchten? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "Sind Sie sicher, dass Sie diesen Passkey löschen möchten? Sie können sich damit nicht mehr anmelden."
@@ -2100,13 +2100,13 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "Sind Sie sicher, dass Sie {0} dauerhaft löschen möchten?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "Sind Sie sicher, dass Sie den Lieferantenprozess dauerhaft löschen möchten?"
+msgstr "Sind Sie sicher, dass Sie das Lieferantenverfahren dauerhaft löschen möchten?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "Sind Sie sicher, dass Sie diesen Beleg buchen möchten?"
 
 msgid "Are you sure you want to post this shipment?"
-msgstr "Sind Sie sicher, dass Sie diese Sendung buchen möchten?"
+msgstr "Sind Sie sicher, dass Sie diese Lieferung buchen möchten?"
 
 msgid "Are you sure you want to reject this quote?"
 msgstr "Sind Sie sicher, dass Sie dieses Angebot ablehnen möchten?"
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Sind Sie sicher, dass Sie eine Einladung an diesen Benutzer senden möchten?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Sind Sie sicher, dass Sie diese Kaufrechnung stornieren möchten? Diese Aktion kehrt alle Finanztransaktionen um und kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie diese Eingangsrechnung stornieren möchten? Diese Aktion kehrt alle Finanztransaktionen um und kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
 msgstr "Sind Sie sicher, dass Sie diesen Beleg stornieren möchten? Diese Aktion kehrt alle Bestandstransaktionen um und kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Sind Sie sicher, dass Sie diese Verkaufsrechnung stornieren möchten? Diese Aktion kehrt alle Finanztransaktionen um und kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie diese Ausgangsrechnung stornieren möchten? Diese Aktion kehrt alle Finanztransaktionen um und kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Sind Sie sicher, dass Sie diese Sendung stornieren möchten? Diese Aktion kehrt alle Bestandstransaktionen um und kann nicht rückgängig gemacht werden."
+msgstr "Sind Sie sicher, dass Sie diese Lieferung stornieren möchten? Diese Aktion kehrt alle Bestandstransaktionen um und kann nicht rückgängig gemacht werden."
 
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "Zum Stand von:"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "Als Unternehmenseigentümer können Sie das Eigentum an einen anderen Mitarbeiter übertragen. Dies gibt ihm vollständigen Zugriff auf Abrechnungs- und Verwaltungseinstellungen."
+msgstr "Als Unternehmenseigner können Sie das Eigentum an einen anderen Mitarbeiter übertragen. Dies gibt ihm vollen Zugriff auf Abrechnungs- und Verwaltungseinstellungen."
 
 msgid "Ascending"
 msgstr "Aufsteigend"
@@ -2173,7 +2173,7 @@ msgstr "Aufsteigend"
 #. placeholder {0}: copy.moduleLabel
 #. placeholder {1}: copy.noun
 msgid "Ask an admin with {0} permission to add the first {1}."
-msgstr "Bitten Sie einen Admin mit {0}-Berechtigung, das erste {1} hinzuzufügen."
+msgstr "Bitten Sie einen Administrator mit {0}-Berechtigung, den ersten {1} hinzuzufügen."
 
 msgid "Assemblies"
 msgstr "Montagen"
@@ -2206,25 +2206,25 @@ msgid "Asset Acquisition Cost (default)"
 msgstr "Vermögensanschaffungskosten (Standard)"
 
 msgid "asset class"
-msgstr "Anlageklasse"
+msgstr "anlagenklasse"
 
 msgid "Asset class"
-msgstr "Anlageklasse"
+msgstr "Anlagenklasse"
 
 msgid "Asset Class"
-msgstr "Anlageklasse"
+msgstr "Anlagenklasse"
 
 msgid "asset classes"
-msgstr "Anlageklassen"
+msgstr "anlagenklassen"
 
 msgid "Asset Classes"
-msgstr "Anlageklassen"
+msgstr "Anlagenklassen"
 
 msgid "Asset Cost on Disposal"
-msgstr "Vermögenskosten bei Entsorgung"
+msgstr "Anlagenwert bei Abgang"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Vermögenskosten bei Entsorgung (Standard)"
+msgstr "Anlagenwert bei Abgang (Standard)"
 
 msgid "Asset ID"
 msgstr "Anlagen-ID"
@@ -2236,7 +2236,7 @@ msgid "Assets, liabilities and equity as of a date"
 msgstr "Vermögenswerte, Verbindlichkeiten und Eigenkapital an einem bestimmten Stichtag"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
-msgstr "Drucker Standorten zuweisen. Versand, Empfang und Arbeitszentren erben die Standortvorgabe, sofern nicht überschrieben."
+msgstr "Drucker den Standorten zuweisen. Versand, Empfang und Arbeitplätze erben den Standort-Standard, wenn nicht anders vorgegeben."
 
 msgid "Assign To"
 msgstr "Zuweisen an"
@@ -2251,7 +2251,7 @@ msgid "Assigned to Me"
 msgstr "Mir zugewiesen"
 
 msgid "Assignee"
-msgstr "Beauftragter"
+msgstr "Bearbeiter"
 
 msgid "Assignment"
 msgstr "Aufgabe"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Zuweisungen"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Weist diese Lagereinheit einem Arbeitszentrum zu (Linienseite)"
+msgstr "Weist diese Lagereinheit einem Arbeitsplatz (Linienlager) zu"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Weist diese Einheit einem Arbeitsplatz für Linienside-Material zu, damit Operatoren sie in der Produktionsansicht sehen; wird vom übergeordneten Gerät geerbt, wenn dort eingestellt."
+msgstr "Weist diese Lagereinheit einem Arbeitsplatz für Linienmaterial zu, damit Werker sie in der Produktionsansicht sehen; wird von der übergeordneten Lagereinheit geerbt, wenn dort festgelegt."
 
 msgid "At each gate"
 msgstr "Bei jedem Gate"
@@ -2281,7 +2281,7 @@ msgid "Attach File"
 msgstr "Datei anhängen"
 
 msgid "Attachment"
-msgstr "Anlage"
+msgstr "Anhang"
 
 msgid "Attachments"
 msgstr "Anhänge"
@@ -2293,19 +2293,19 @@ msgid "Attribute"
 msgstr "Attribut"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Attribut-Stichprobenstandard zur Berechnung von Losgrößen und Annahme-/Ablehnungszahlen bei Wareneingangsprüfungen."
+msgstr "Attribut-Stichprobenstandard zur Berechnung von Stichprobenumfängen und Annahme-/Ablehnungszahlen bei Wareneingangsprüfungen."
 
 msgid "Attributes"
 msgstr "Attribute"
 
 msgid "Attributes are inherited from the procedure."
-msgstr "Attribute werden von der Prozedur geerbt."
+msgstr "Attribute werden von der Verfahrensanweisung geerbt."
 
 msgid "Audit Log"
-msgstr "Audit-Protokoll"
+msgstr "Änderungsprotokoll"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Änderungsprotokollierung"
 
 msgid "Audit Logging"
 msgstr "Audit-Protokollierung"
@@ -2320,7 +2320,7 @@ msgid "Audit logging is not enabled"
 msgstr "Audit-Protokollierung ist nicht aktiviert"
 
 msgid "Audit Logs"
-msgstr "Audit-Protokolle"
+msgstr "Änderungsprotokolle"
 
 msgid "Authentication Error"
 msgstr "Authentifizierungsfehler"
@@ -2341,7 +2341,7 @@ msgid "Auto Release"
 msgstr "Automatische Freigabe"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "Automatische Freigabe muss aktiviert sein, um einen Job automatisch zu starten"
+msgstr "Die automatische Freigabe muss aktiviert werden, um einen Fertigungsauftrag automatisch zu starten"
 
 msgid "Auto Start Job"
 msgstr "Auftrag automatisch starten"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Automatisch generierter QR-Code"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Automatische Nummerierungsformate für Bestellungen, Aufträge, Teile und mehr"
+msgstr "Automatische Nummerierungsformate für Aufträge, Fertigungsaufträge, Teile und mehr"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Käufe automatisch basierend auf Bedarf und Bestellpunkten vorschlagen"
+msgstr "Automatische Kaufvorschläge aus Bedarf und Meldebestand"
 
 msgid "Automate"
 msgstr "Automatisieren"
@@ -2371,13 +2371,13 @@ msgid "Automatic Cost Updates"
 msgstr "Automatische Kostenaktualisierungen"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Automatische Aktualisierung der Lieferzeiten"
+msgstr "Automatische Aktualisierungen der Beschaffungszeit"
 
 msgid "Automatic Updates"
 msgstr "Automatische Aktualisierungen"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Automatische Aktualisierungen und Sicherungen"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatischer, anteiliger Verbrauch der ungespurten Materialien eines Auftrags, wenn die Leistung gemeldet wird — verfolgte Materialien werden manuell ausgegeben."
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "Zurück zur Rückverfolgbarkeit"
 
 msgid "Backflush"
-msgstr "Rücklauf"
+msgstr "Retrograde Entnahme"
 
 msgid "Backups"
 msgstr "Sicherungen"
@@ -2435,10 +2435,10 @@ msgid "Balloon"
 msgstr "Ballon"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "Aufgeblähte Zeichnungen mit Inspektionsmerkmalen."
+msgstr "Zeichnungen mit Prüfungsmerkmalen."
 
 msgid "Bank - Cash"
-msgstr "Bank - Bargeld"
+msgstr "Bank – Kasse"
 
 msgid "Bank - Foreign Currency"
 msgstr "Bank - Fremdwährung"
@@ -2447,7 +2447,7 @@ msgid "Bank - Local Currency"
 msgstr "Bank - Landeswährung"
 
 msgid "Bank — Cash (default)"
-msgstr "Bank — Bargeld (Standard)"
+msgstr "Bank — Kasse (Standard)"
 
 msgid "Bank — Foreign Currency (default)"
 msgstr "Bank — Fremdwährung (Standard)"
@@ -2456,7 +2456,7 @@ msgid "Bank — Local Currency (default)"
 msgstr "Bank — Landeswährung (Standard)"
 
 msgid "Bank / Cash Account"
-msgstr "Bank-/Bargeldkonto"
+msgstr "Bank-/Kassenkonto"
 
 msgid "Bank account denominated in a foreign currency"
 msgstr "Bankkonto, das auf eine Fremdwährung lautet."
@@ -2465,10 +2465,10 @@ msgid "Bank account denominated in the local currency"
 msgstr "Bankkonto in Landeswährung lautet."
 
 msgid "Bank and financial service charge expenses"
-msgstr "Bank- und Finanzdienstleistungsgebührenausgaben."
+msgstr "Aufwendungen für Bank- und Finanzservicegebühren"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Balken zeigen wöchentliche Strömungen: &lt;0&gt;Angebot&lt;/0&gt; drückt Inventar nach oben, &lt;1&gt;Nachfrage&lt;/1&gt; zieht es nach unten. Die &lt;2&gt;Linie&lt;/2&gt; ist deine projizierte verfügbare Menge — wenn sie unter &lt;3&gt;Sicherheitsbestand&lt;/3&gt; fällt, sind Sie gefährdet, und unter Null ist ein &lt;4&gt;Stockout&lt;/4&gt;."
+msgstr "Balken zeigen den wöchentlichen Fluss: <0>Deckung</0> erhöht den Bestand, <1>Bedarf</1> senkt ihn. Die <2>Linie</2> ist Ihr geplanter verfügbarer Bestand — wenn er unter <3>Sicherheitsbestand</3> fällt, sind Sie gefährdet, und unter Null ist ein <4>Fehlbestand</4>."
 
 msgid "Base Currency"
 msgstr "Basiswährung"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Basispreis"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Grundlegende ERP-, MES- und QMS-Funktionalität"
 
 msgid "Basic Information"
 msgstr "Grundinformationen"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "Charge / Seriennummer"
 
 msgid "Batch items require a sales order"
-msgstr "Chargennummern-Artikel erfordern einen Verkaufsauftrag"
+msgstr "Los-Artikel erfordern einen Kundenauftrag"
 
 msgid "Batch number"
 msgstr "Chargennummer"
@@ -2523,19 +2523,19 @@ msgid "Beta"
 msgstr "Beta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Hauptursachen für Ausschuss nach Grund, Artikel oder Arbeitszentrum"
+msgstr "Größte Ursachen für Ausschuss nach Grund, Artikel oder Arbeitsplatz"
 
 msgid "Bill of Material"
 msgstr "Stückliste"
 
 msgid "Bill of materials"
-msgstr "Bill of materials"
+msgstr "Stückliste"
 
 msgid "Bill of Materials"
 msgstr "Stückliste"
 
 msgid "Bill of Process"
-msgstr "Fertigungsprozess"
+msgstr "Arbeitsgangliste"
 
 msgid "Bill To"
 msgstr "Rechnung an"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Mit Fehler blockieren"
 
 msgid "Block, allow override"
-msgstr "Blockieren, Überschreibung zulassen"
+msgstr "Sperren, Übersteuerung zulassen"
 
 msgid "Blocked"
 msgstr "Blockiert"
@@ -2581,13 +2581,13 @@ msgid "BOM synced successfully"
 msgstr "BOM erfolgreich synchronisiert"
 
 msgid "BOMs"
-msgstr "Stücklisten"
+msgstr "BOMs"
 
 msgid "Bonus Depreciation %"
 msgstr "Bonus-Abschreibung %"
 
 msgid "Book a call to discuss guided implementation"
-msgstr "Buchen Sie einen Anruf, um die geführte Implementierung zu besprechen"
+msgstr "Ein Gespräch vereinbaren, um eine geführte Umsetzung zu besprechen"
 
 msgid "Book a call with Carbon"
 msgstr "Buchen Sie einen Anruf mit Carbon"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Breadcrumb-Navigation"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Importieren Sie Ihre Teile, Stücklisten, Fertigungsprozesse und Kostenkalkulationen – mit Carbons Importwerkzeugen, CSV oder KI-Unterstützung."
+msgstr "Importieren Sie Ihre Teile, BOMs, Arbeitsgangliste und Kalkulation — mit Carbons Importwerkzeugen, CSV oder LLM-Hilfe."
 
 msgid "Browse library"
 msgstr "Bibliothek durchsuchen"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Durchsuchen Sie die veröffentlichte Version schreibgeschützt. Sie können die Schritte weiterhin neu anordnen, um das Layout zu ordnen."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Integrationen und Anpassungen erstellen"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Angebote erstellen, die Live-Teildaten, Kosten und Bill-of-Process-Daten abrufen"
+msgstr "Erstellen Sie Angebote durch Abrufen von Live-Teil-, Kosten- und Arbeitsgangliste-Daten"
 
 msgid "Build role-based training materials"
 msgstr "Erstellen Sie rollenbasierte Schulungsmaterialien"
@@ -2662,10 +2662,10 @@ msgid "Buy"
 msgstr "Kaufen"
 
 msgid "Buy and Make"
-msgstr "Kaufen und Herstellen"
+msgstr "Fremdbeschaffung und Eigenfertigung"
 
 msgid "Buyer"
-msgstr "Käufer"
+msgstr "Einkäufer"
 
 msgid "Buyer, Planner"
 msgstr "Einkäufer, Planer"
@@ -2701,7 +2701,7 @@ msgid "CAD Model"
 msgstr "CAD-Modell"
 
 msgid "Calculate from BOM"
-msgstr "Aus Stückliste berechnen"
+msgstr "Aus BOM berechnen"
 
 msgid "Calculated finished-good expiry"
 msgstr "Berechnete Verfallsdatum für Fertigprodukte"
@@ -2719,13 +2719,13 @@ msgid "Calibration Expiration Notifications"
 msgstr "Benachrichtigungen zur Kalibrierungsablauf"
 
 msgid "Calibration Interval (Months)"
-msgstr "Kalibrierungsintervall (Monate)"
+msgstr "Kalibrierintervall (Monate)"
 
 msgid "Calibration Record"
-msgstr "Kalibrierregister"
+msgstr "Kalibrierprotokoll"
 
 msgid "Calibration Records"
-msgstr "Kalibrierungsdatensätze"
+msgstr "Kalibrierprotokolle"
 
 msgid "Calibration Status"
 msgstr "Kalibrierungsstatus"
@@ -2740,13 +2740,13 @@ msgid "Call an outside URL"
 msgstr "Externe URL aufrufen"
 
 msgid "Called a method in Carbon — the components plus operations that produce a part."
-msgstr "Eine Methode genannt in Carbon — die Komponenten plus Operationen, die einen Teil produzieren."
+msgstr "Eine Methode in Carbon genannt — die Komponenten plus Arbeitsgänge, die einen Teil produzieren."
 
 msgid "Can't delete this period"
 msgstr "Diese Periode kann nicht gelöscht werden"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "Der einzige aktive Break kann nicht deaktiviert werden. Fügen Sie einen weiteren Break hinzu oder schalten Sie stattdessen die Aktivierung der Überschreibung um."
+msgstr "Die einzige aktive Pause kann nicht deaktiviert werden. Fügen Sie eine weitere Pause hinzu oder schalten Sie stattdessen den Status Aktiv der Übersteuerung um."
 
 msgid "Can't download this file"
 msgstr "Diese Datei kann nicht heruntergeladen werden"
@@ -2770,7 +2770,7 @@ msgid "Cancel Purchase Order"
 msgstr "Bestellung stornieren"
 
 msgid "Cancel Sales Order"
-msgstr "Verkaufsauftrag stornieren"
+msgstr "Kundenauftrag abbrechen"
 
 msgid "Cancel SO"
 msgstr "SO stornieren"
@@ -2788,25 +2788,25 @@ msgid "Cancel SO only"
 msgstr "Nur SO stornieren"
 
 msgid "Canceled"
-msgstr "Abgebrochen"
+msgstr "Storniert"
 
 msgid "Cancelled"
-msgstr "Abgebrochen"
+msgstr "Storniert"
 
 msgid "Cannot add parameters to unsaved operation"
 msgstr "Kann keine Parameter zu nicht gespeichertem Vorgang hinzufügen"
 
 msgid "Cannot add steps to unsaved operation"
-msgstr "Schritte können nicht zu nicht gespeichertem Vorgang hinzugefügt werden"
+msgstr "Schritte können nicht zu unspeichertem Arbeitsgang hinzugefügt werden"
 
 msgid "Cannot add tools to unsaved operation"
-msgstr "Werkzeuge können nicht zu nicht gespeicherten Vorgängen hinzugefügt werden"
+msgstr "Werkzeuge können nicht zu unspeichertem Arbeitsgang hinzugefügt werden"
 
 msgid "Cannot close yet"
 msgstr "Kann noch nicht geschlossen werden"
 
 msgid "Cannot convert RFQ to quote"
-msgstr "RFQ kann nicht in Angebot umgewandelt werden"
+msgstr "Anfrage kann nicht in Angebot umgewandelt werden"
 
 msgid "Cannot move to parts bucket without item ID"
 msgstr "Kann nicht in den Teile-Bucket ohne Element-ID verschoben werden"
@@ -2815,19 +2815,19 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "Bestellung kann nicht aufgegeben werden - kein Lieferant mit diesem Artikel verknüpft"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "Kann nicht gebucht werden – Sendung enthält abgelaufene nachverfölgte Entitäten."
+msgstr "Kann nicht buchen – Lieferung enthält abgelaufene verfolgte Entitäten."
 
 msgid "Cannot send RFQ"
 msgstr "RFQ kann nicht gesendet werden"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Kann nicht über Stripe senden"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Hochladen nicht möglich — Lieferanteninteraktion noch nicht erstellt"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "Kann nicht in den Teile-Bucket ohne Element-ID hochgeladen werden"
+msgstr "Kann ohne Artikel-ID nicht in den Teile-Bucket hochladen"
 
 msgid "Caption"
 msgstr "Beschriftung"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Nur für Carbon · der Kunde sieht diesen Text, gesperrt."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Carbons Name für eine Stückliste und Betriebsstückliste (Routing): die Komponenten plus die Vorgänge, die eine Teile herstellen."
+msgstr "Carbons Name für eine Stückliste und Arbeitsgangliste (Arbeitsplan): die Komponenten plus die Arbeitsgänge, die einen Teil ausmachen."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Carbons Planungslauf netzt Angebot gegen Nachfrage auf und erweitert Methoden, zeigt Engpässe — aber es selbst erzeugt keine Aufträge."
+msgstr "Carbons Planungslauf stellt die Deckung gegen den Bedarf gegenüber, explodiert Methoden und bringt Engpässe ans Licht – erstellt aber selbst keine Bestellungen."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Produktionsauftrag von Carbon – ein Auftrag fertigt eine Menge eines Elements mit seiner kopierten Methode und seinem Routing."
+msgstr "Carbons Fertigungsauftrag – ein Fertigungsauftrag baut eine Menge eines Artikels aus seiner eigenen kopierten Methode und seinem Arbeitsplan."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "Carbons Shop-Floor-App, in der Bediener Operationen durchführen, Mengen melden, Material ausgeben und Zeit gegen freigegebene Aufträge in Echtzeit protokollieren."
+msgstr "Carbons Werkstatt-App, auf der Werker Arbeitsgänge durchführen, Mengen erfassen, Material entnehmen und Zeit gegen freigegebene Fertigungsaufträge in Echtzeit protokollieren."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Carbons einziger Datensatz für alles mit einer Teilenummer — Teil, Material, Werkzeug, Dienstleistung, Verbrauchsmaterial oder Vorrichtung — auf das Jobs, Methoden, Bestellungen und Inventar verweisen."
+msgstr "Carbons einzelner Datensatz für alles mit einer Teilenummer – Teil, Werkstoff, Werkzeug, Dienstleistung, Verbrauchsmaterial oder Vorrichtung – auf den alle Fertigungsaufträge, Methoden, Bestellungen und Bestände verweisen."
 
 msgid "Cards"
 msgstr "Karten"
@@ -2912,7 +2912,7 @@ msgid "Carrier Account"
 msgstr "Spediteurkonto"
 
 msgid "Cash & Banking"
-msgstr "Bargeld und Bankwesen"
+msgstr "Kasse & Banken"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Kategorien, die klassifizieren, wie Bestände gelagert werden"
@@ -2948,7 +2948,7 @@ msgid "Chain"
 msgstr "Kette"
 
 msgid "Champion users are available for training and data validation"
-msgstr "Champion-Benutzer sind für Training und Datenvalidierung verfügbar"
+msgstr "Champion-Benutzer sind für Schulung und Datenvalidierung verfügbar"
 
 msgid "Champion(s)"
 msgstr "Champion(s)"
@@ -2963,7 +2963,7 @@ msgid "Change Document"
 msgstr "Dokument ändern"
 
 msgid "Change Inspection Plan"
-msgstr "Inspektionsplan ändern"
+msgstr "Prüfplan ändern"
 
 msgid "Change notice"
 msgstr "Änderungsmitteilung"
@@ -2981,16 +2981,16 @@ msgid "Change Notices"
 msgstr "Änderungsmitteilungen"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "Änderungsmitteilungen konnten nicht geladen werden, daher sind neue Versionen und Überarbeitungen blockiert. Laden Sie neu, um es erneut zu versuchen."
+msgstr "Änderungsmitteilungen konnten nicht geladen werden, sodass neue Versionen und Revisionen blockiert sind. Zum erneuten Versuch neu laden."
 
 msgid "Change order"
-msgstr "Änderungsbestellung"
+msgstr "Änderungsauftrag"
 
 msgid "Change status"
 msgstr "Status ändern"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "Ändern Sie den Elementtyp (z. B. Teil, Material, Werkzeug usw.)"
+msgstr "Ändern Sie die Artikelart (z. B. Teil, Werkstoff, Werkzeug usw.)"
 
 msgid "Change type"
 msgstr "Typ ändern"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Überprüfen Sie das Artikelhauptbuch auf Artikel mit negativem Bestand am Ende der Periode — normalerweise eine fehlende Rechnung oder eine falsch angeordnete Buchung, die den Bestandswert und die Herstellungskosten verfälscht. Markieren Sie es als erledigt, nachdem Sie es überprüft haben, oder überspringen Sie es mit einem Grund."
+msgstr "Überprüfen Sie das Artikelledger auf Artikel mit negativer Bestandsmenge am Periodenende – normalerweise ein fehlender Wareneingang oder eine fehlerhafte Buchung, die den Bestandswert und die Umsatzkosten verzerrt. Markieren Sie es als erledigt, nachdem es überprüft wurde, oder überspringen Sie es mit einem Grund."
 
 msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Überprüfung von Stripe für diesen Kunden…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Wählen Sie eine andere Datei"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Wählen Sie aus, was auf dem gedruckten Arbeitsbegleitzettel angezeigt wird."
+msgstr "Wählen Sie, was auf der gedruckten Laufkarte erscheint."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Wählen Sie Ihre bevorzugte Sprache für die Benutzeroberfläche."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Klasse (geerbt)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Klassifiziert eine Routingoperation: Prozess-, Montage- und Inspektionsoperationen laufen auf Ihrer eigenen Werkstattebene in der MES – Montage erhält die geführte Montageansicht und Inspektion eine Qualitätsprüfung – während eine Fremdfertigungsoperation an einen Lieferanten vergeben wird und eine Bestellung erstellt; der Prozess trägt den gleichen Typ und nimmt ihn als Standard bei neuen Operationen an."
+msgstr "Klassifiziert einen Arbeitsgang: Verfahrens-, Montage- und Prüfarbeitsgänge werden auf Ihrer Werkstatt in der MES durchgeführt – die Montage erhält die geführte Montageansicht und die Prüfung eine Qualitätsprüfung – während ein Fremdbearbeitungs-Arbeitsgang an einen Lieferanten vergeben wird und eine Bestellung erstellt; das Verfahren trägt den gleichen Typ und setzt ihn standardmäßig bei neuen Arbeitsgängen."
 
 msgid "Clean and approve the migrated data"
 msgstr "Bereinigen und genehmigen Sie die migrierten Daten"
@@ -3095,13 +3095,13 @@ msgid "Clear selection"
 msgstr "Auswahl löschen"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Begleichen Sie diese Rechnung mit den gebuchten Gutschriften der Partei sowie mit Bargeld. Gutschriften werden direkt angewendet — keine Buchung erforderlich."
+msgstr "Begleichen Sie diese Rechnung mit den gebuchten Gutschriften des Geschäftspartners sowie Kasse. Gutschriften werden direkt angewendet – keine Buchung erforderlich."
 
 msgid "Clear value"
 msgstr "Wert löschen"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Verrechnungskonto zwischen Wareneingang und Lieferantenrechnung; wird ausgeglichen, wenn beide gebucht wurden."
+msgstr "Clearing-Konto zwischen Wareneingang und Lieferantenrechnung; wird ausgeglichen, wenn beide gebucht wurden."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Verrechnungskonto für Wareneingang / Rechnungseingang Abgleich"
@@ -3122,7 +3122,7 @@ msgid "Clock In"
 msgstr "Einstempeln"
 
 msgid "Clock Out"
-msgstr "Uhr aus"
+msgstr "Ausstempeln"
 
 msgid "Clocked in since <0/>"
 msgstr "Angemeldet seit <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud oder Ihre selbst gehostete Umgebung."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC-konform"
 
 msgid "Code"
 msgstr "Code"
@@ -3188,7 +3188,7 @@ msgid "Collapse features table"
 msgstr "Features-Tabelle ausblenden"
 
 msgid "Collapse Labor"
-msgstr "Arbeit einklappen"
+msgstr "Personal ausblenden"
 
 msgid "Collapse Machine"
 msgstr "Maschine einklappen"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "Verpflichten Sie einen Champion-Benutzer für jeden Bereich"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Commit einer Quittung, eines Versands oder einer Rechnung: Mengen bewegen sich, Journal-Einträge treffen das Ledger, und der Status wird Posted."
+msgstr "Bestätigung eines Wareneingangs, einer Lieferung oder einer Rechnung: Mengen bewegen sich, Buchungszeilen treffen das Ledger, und der Status wird Gebucht."
 
 msgid "Community support"
-msgstr ""
+msgstr "Community-Unterstützung"
 
 msgid "Companies"
 msgstr "Unternehmen"
@@ -3339,7 +3339,7 @@ msgid "Configure Carbon"
 msgstr "Carbon konfigurieren"
 
 msgid "Configure default accounts for cash and bank transactions"
-msgstr "Standardkonten für Bargeld- und Banktransaktionen konfigurieren"
+msgstr "Standardkonten für Kasse- und Banktransaktionen konfigurieren"
 
 msgid "Configure default accounts for inventory management"
 msgstr "Standardkonten für Bestandsverwaltung konfigurieren"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Standardkonten für Anbieter- und Lieferantentransaktionen konfigurieren"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Konfigurieren Sie die Standard-Eigenkapital- und Gewinnrücklagenkonten"
+msgstr "Standardkonten für Eigenkapital und Gewinnvortrag konfigurieren"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Konfigurieren Sie die Standardeinstellungen für das Qualitätsdashboard."
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "Artikel konfigurieren"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Konfigurieren Sie Benachrichtigungen für den Fall, dass Messinstrumente außer Kalibrierung gehen."
+msgstr "Benachrichtigungen konfigurieren, wenn Prüfmittel außer Kalibrierung gehen."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Konfigurieren Sie Benachrichtigungen für den Abschluss von Aufträgen."
+msgstr "Benachrichtigungen konfigurieren, wenn Fertigungsaufträge fertiggestellt sind."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Konfigurieren Sie Benachrichtigungen für den Fall, dass Wartungseinsätze vom Shopfloor erstellt werden. Benachrichtigungen werden basierend auf dem Fehlermodtyp weitergeleitet."
+msgstr "Benachrichtigungen konfigurieren, wenn Instandhaltungsaufträge von der Werkstatt aus erstellt werden. Benachrichtigungen werden basierend auf dem Fehlermodus-Typ verwaltet."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Konfigurieren Sie Benachrichtigungen für neue eingereichte Vorschläge."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Konfigurieren Sie Standorte, Arbeitszentren, Bill of Process, Stücklisten, Kostenrechnung, Rollen"
+msgstr "Standorte, Arbeitsplätze, Arbeitsgangliste, BOMs, Kalkulation, Rollen konfigurieren"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Konfigurieren Sie die Standardkonten, die für verschiedene Transaktionstypen in Ihrem System verwendet werden"
@@ -3430,7 +3430,7 @@ msgid "Confirm ID Change"
 msgstr "ID-Änderung bestätigen"
 
 msgid "Confirm Import"
-msgstr "Import bestätigen"
+msgstr "Importieren bestätigen"
 
 msgid "Confirm Inventory Count"
 msgstr "Bestandszählung bestätigen"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Bestätigter eingehender Bestand — Kauf- und Produktionsaufträge (Balken über Null)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Bestätigter ausgehender Bestand — Verkaufsaufträge & Auftragsmaterial (Balken unter Null)."
+msgstr "Bestätigter ausgehender Bestand – Kundenaufträge & Auftragsmaterialien (Balken unter Null)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Bestätigt, dass jeder gebuchte Journaleintrag in der Periode gleiche Belastungen und Gutschriften hat. Wenn ein Eintrag nicht ausgeglichen ist, stimmt die Probebilanz nicht überein, daher muss er korrigiert werden, bevor die Periode geschlossen werden kann."
+msgstr "Bestätigt, dass jede gebuchte Buchungszeile in der Periode gleiche Soll- und Haben-Beträge hat. Falls ein Eintrag nicht ausgeglichen ist, wird die Rohbilanz nicht abgestimmt, daher muss sie korrigiert werden, bevor die Periode abgeschlossen werden kann."
 
 msgid "Conflict reason"
 msgstr "Konfliktgrund"
@@ -3490,7 +3490,7 @@ msgid "Console mode is enabled"
 msgstr "Konsolenmodus ist aktiviert"
 
 msgid "Console Operator"
-msgstr "Konsolenoperator"
+msgstr "Konsolenbediener"
 
 msgid "consumable"
 msgstr "Verbrauchsmaterial"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Kontakt (optional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Kontaktieren Sie uns"
 
 msgid "contacts"
 msgstr "Kontakte"
@@ -3538,10 +3538,10 @@ msgid "Contained"
 msgstr "Enthalten"
 
 msgid "Containment"
-msgstr "Eindämmung"
+msgstr "Containment"
 
 msgid "Containment action"
-msgstr "Eindämmungsmaßnahme"
+msgstr "Containment-Maßnahme"
 
 msgid "Content"
 msgstr "Inhalt"
@@ -3553,31 +3553,31 @@ msgid "Contra-asset account for total depreciation of fixed assets"
 msgstr "Gegenkonto für die gesamte Abschreibung von Anlagevermögen"
 
 msgid "Contra-revenue account for discounts given on sales"
-msgstr "Gegenkonto für gewährte Verkaufsrabatte"
+msgstr "Gegenkonto für Rabatte auf Verkäufe"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
 msgstr "Kontra-Umsatz-GL-Konto für Rabatte auf Kundenrechnungen."
 
 msgid "Contractor"
-msgstr "Auftragnehmer"
+msgstr "Externer Mitarbeiter"
 
 msgid "Contractors"
-msgstr "Auftragnehmer"
+msgstr "Externe Mitarbeiter"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "Designänderungen mit Revisionen / ECOs steuern"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "Kontrollieren Sie, wie Bediener Material auswählen und Zeit auf dem Shopfloor nachverfolgen."
+msgstr "Steuern Sie, wie Werker Material kommissionieren und Zeit in der Werkstatt verfolgen."
 
 msgid "Controller, Accountant"
 msgstr "Controller, Buchhalter"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "Steuert, wie die Planung ein eingestelltes Artikel handhabt: Consume First erschöpft den Bestand, bevor zur Nachfolgeposition gewechselt wird, Prefer New leitet neue Nachfrage sofort zur Nachfolgeposition um, Stock Only behält nur einen minimalen Servicebestand, und No Stock entfernt den Artikel vollständig aus der Planung."
+msgstr "Steuert, wie die Planung einen auslaufenden Artikel handhabt: Zuerst verbrauchen erschöpft den Bestand vor dem Wechsel zum Nachfolger, Neue bevorzugen leitet neue Nachfrage sofort zum Nachfolger um, Nur Bestand behält nur eine minimale Serviceresserve, und Kein Bestand entfernt den Artikel vollständig aus der Planung."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Steuert, ob die Stückliste und die Prozeßliste einer freigegebenen (Produktions-)Version außerhalb einer Änderungsanweisung bearbeitet werden können."
+msgstr "Steuert, ob die Stückliste und Arbeitsgangliste einer aktivierten (Produktion) Revision außerhalb eines Änderungsauftrags bearbeitet werden können."
 
 msgid "Convention"
 msgstr "Konvention"
@@ -3595,19 +3595,19 @@ msgid "Conversion:"
 msgstr "Umrechnung:"
 
 msgid "Convert"
-msgstr "Konvertieren"
+msgstr "Umwandeln"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "Konvertieren Sie ein Angebot in einen Auftrag ohne erneute Eingabe"
+msgstr "Wandeln Sie ein Angebot in einen Kundenauftrag um, ohne die Daten erneut einzugeben"
 
 msgid "Convert Line to Job"
 msgstr "Zeile in Auftrag umwandeln"
 
 msgid "Convert Lines to Jobs"
-msgstr "Zeilen in Aufträge konvertieren"
+msgstr "Positionen in Fertigungsaufträge umwandeln"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Konvertieren Sie MRP-Vorschläge in Bestellungen und Aufträge."
+msgstr "Konvertieren Sie MRP-Vorschläge in Bestellungen und Fertigungsaufträge."
 
 msgid "Convert to Quote"
 msgstr "In Angebot umwandeln"
@@ -3616,7 +3616,7 @@ msgid "Converting…"
 msgstr "Wird konvertiert …"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "Konvertiert die Kaufeinheit eines Lieferanten in Ihre Bestandseinheit in einer Bestellung, Quittung oder Rechnungszeile — kaufen in Kartons von 12, lagern in Stücken."
+msgstr "Konvertiert die Einkaufseinheit eines Lieferanten in Ihre Bestandseinheit auf einer Bestellung, im Wareneingang oder einer Rechnungsposition — Sie kaufen in Kartons à 12, lagern in Einzelstücken."
 
 msgid "Copied link to clipboard"
 msgstr "Link in die Zwischenablage kopiert"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "Kopieren"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Kopieren Sie alle Artikel und Preise auf einen anderen Kunden oder Typ."
+msgstr "Kopieren Sie alle Artikel und Preise zu einem anderen Kunden oder Typ."
 
 msgid "Copy API Key"
 msgstr "API-Schlüssel kopieren"
@@ -3637,10 +3637,10 @@ msgid "Copy consumable number"
 msgstr "Verbrauchsmaterialnummer kopieren"
 
 msgid "Copy dispatch ID"
-msgstr "Dispatch-ID kopieren"
+msgstr "Instandhaltungsauftrags-ID kopieren"
 
 msgid "Copy dispatch number"
-msgstr "Versandnummer kopieren"
+msgstr "Instandhaltungsauftragsnummer kopieren"
 
 msgid "Copy document name"
 msgstr "Dokumentnamen kopieren"
@@ -3670,7 +3670,7 @@ msgid "Copy link to consumable"
 msgstr "Link zum Verbrauchsmaterial kopieren"
 
 msgid "Copy link to dispatch"
-msgstr "Link zum Dispatch kopieren"
+msgstr "Link zum Instandhaltungsauftrag kopieren"
 
 msgid "Copy link to document"
 msgstr "Dokumentlink kopieren"
@@ -3688,7 +3688,7 @@ msgid "Copy link to part"
 msgstr "Link zum Teil kopieren"
 
 msgid "Copy link to procedure"
-msgstr "Link zum Verfahren kopieren"
+msgstr "Link zur Verfahrensanweisung kopieren"
 
 msgid "Copy link to service"
 msgstr "Link zur Dienstleistung kopieren"
@@ -3697,7 +3697,7 @@ msgid "Copy link to tool"
 msgstr "Link zum Werkzeug kopieren"
 
 msgid "Copy link to training"
-msgstr "Trainingslink kopieren"
+msgstr "Link zur Schulung kopieren"
 
 msgid "Copy material number"
 msgstr "Materialnummer kopieren"
@@ -3718,19 +3718,19 @@ msgid "Copy PIN"
 msgstr "PIN kopieren"
 
 msgid "Copy pricing to a single customer"
-msgstr "Preise für einen einzelnen Kunden kopieren"
+msgstr "Preise zu einem einzelnen Kunden kopieren"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Preise für alle Kunden eines Typs kopieren"
+msgstr "Preise zu allen Kunden eines Typs kopieren"
 
 msgid "Copy Procedure"
-msgstr "Verfahren kopieren"
+msgstr "Verfahrensanweisung kopieren"
 
 msgid "Copy procedure name"
-msgstr "Verfahrensnamen kopieren"
+msgstr "Name der Verfahrensanweisung kopieren"
 
 msgid "Copy procedure unique identifier"
-msgstr "Eindeutige Kennung des Verfahrens kopieren"
+msgstr "Eindeutige Kennung der Verfahrensanweisung kopieren"
 
 msgid "Copy Quality Document"
 msgstr "Qualitätsdokument kopieren"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "Eindeutige Kennung der Dienstleistung kopieren"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Kopieren Sie die Preisgestaltung dieses Artikels in einen anderen Bereich."
+msgstr "Kopieren Sie die Preise dieses Artikels auf einen anderen Geltungsbereich."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "Kopieren Sie diesen Link, um das Angebot mit einem Kunden zu teilen"
@@ -3817,22 +3817,22 @@ msgid "Cost Centers"
 msgstr "Kostenstellen"
 
 msgid "Cost History"
-msgstr "Kostenhistorie"
+msgstr "Kostenverlauf"
 
 msgid "Cost of Goods Sold"
-msgstr "Kosten der verkauften Waren"
+msgstr "Umsatzkosten"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Kosten der verkauften Waren (COGS)"
+msgstr "Umsatzkosten (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Kosten der verkauften Waren (Standard)"
+msgstr "Umsatzkosten (Standard)"
 
 msgid "Cost of Sales"
-msgstr "Kosten der verkauften Waren"
+msgstr "Umsatzkosten"
 
 msgid "Costing"
-msgstr "Kostenberechnung"
+msgstr "Kalkulation"
 
 msgid "Costing & Posting"
 msgstr "Kalkulation & Buchung"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "Dokumente konnten nicht geladen werden"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "Verwandte Dokumente konnten nicht geladen werden. Aktualisieren Sie die Seite, bevor Sie ein neues erstellen, um Duplikate zu vermeiden."
+msgstr "Konnte zugehörige Dokumente nicht laden. Aktualisieren Sie den Bereich, bevor Sie ein neues Dokument erstellen, um Duplikate zu vermeiden."
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "Die Dimensionsziele des Providers konnten nicht geladen werden — überprüfen Sie die Verbindung und laden Sie neu."
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "Erstellen & Snapshot"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "Erstellen Sie eine Änderungsmitteilung für die neue Überarbeitung und öffnen Sie sie"
+msgstr "Erstellen Sie eine Änderungsmitteilung für die neue Revision und öffnen Sie sie"
 
 msgid "Create a job"
 msgstr "Auftrag erstellen"
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Erstellen Sie eine neue Kanban-Karte für scan-basierte Nachschubversorgung."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Erstellen Sie eine neue Wartungsmitteilung, um Gerätereparaturen und Wartungsaktivitäten zu verfolgen"
+msgstr "Erstellen Sie einen neuen Instandhaltungsauftrag zur Verfolgung von Anlagenreparaturen und Instandhaltungsaktivitäten"
 
 msgid "Create a new production job to fulfill the sales order"
-msgstr "Erstellen Sie einen neuen Produktionsauftrag, um die Bestellung zu erfüllen"
+msgstr "Erstellen Sie einen neuen Fertigungsauftrag zur Erfüllung des Kundenauftrags"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Erstellen Sie stattdessen einen neuen Stripe-Kunden"
 
 msgid "Create a new version"
 msgstr "Neue Version erstellen"
@@ -3948,7 +3948,7 @@ msgid "Create a quote with a new quote ID"
 msgstr "Erstellen Sie ein Angebot mit einer neuen Angebots-ID"
 
 msgid "Create a sales order"
-msgstr "Verkaufsauftrag erstellen"
+msgstr "Erstellen Sie einen Kundenauftrag"
 
 msgid "Create Account"
 msgstr "Konto erstellen"
@@ -3975,7 +3975,7 @@ msgid "Create Issue"
 msgstr "Problem erstellen"
 
 msgid "Create Jobs"
-msgstr "Aufträge erstellen"
+msgstr "Fertigungsaufträge erstellen"
 
 msgid "Create Kanban"
 msgstr "Kanban erstellen"
@@ -4014,7 +4014,7 @@ msgid "Create Version"
 msgstr "Version erstellen"
 
 msgid "Create Work Center"
-msgstr "Arbeitszentrum erstellen"
+msgstr "Arbeitsplatz erstellen"
 
 msgid "Created"
 msgstr "Erstellt"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "Konto erstellt"
 
 msgid "Created asset class"
-msgstr "Anlageklasse erstellt"
+msgstr "Anlagenklasse erstellt"
 
 msgid "Created at"
 msgstr "Erstellt am"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Fehlermodus erstellt"
 
 msgid "Created gauge type"
-msgstr "Messgaugetyp erstellt"
+msgstr "Prüfmittelart erstellt"
 
 msgid "Created item group"
 msgstr "Artikelgruppe erstellt"
@@ -4078,7 +4078,7 @@ msgid "Created location"
 msgstr "Standort erstellt"
 
 msgid "Created maintenance schedule"
-msgstr "Wartungsplan erstellt"
+msgstr "Instandhaltungsplan erstellt"
 
 msgid "Created material"
 msgstr "Material erstellt"
@@ -4087,22 +4087,22 @@ msgid "Created material dimension"
 msgstr "Materialdimension erstellt"
 
 msgid "Created material finish"
-msgstr "Material-Finish erstellt"
+msgstr "Oberflächenbehandlung erstellt"
 
 msgid "Created material form"
 msgstr "Materialformular erstellt"
 
 msgid "Created material grade"
-msgstr "Materialklasse erstellt"
+msgstr "Werkstoffgüte erstellt"
 
 msgid "Created material substance"
-msgstr "Materialsubstanz erstellt"
+msgstr "Grundwerkstoff erstellt"
 
 msgid "Created material type"
 msgstr "Materialtyp erstellt"
 
 msgid "Created no quote reason"
-msgstr "Ablehnungsgrund erstellt"
+msgstr "Grund für Kein Angebot erstellt"
 
 msgid "Created non conformance type"
 msgstr "Nichtkonformitätstyp erstellt"
@@ -4120,7 +4120,7 @@ msgid "Created required action"
 msgstr "Erforderliche Aktion erstellt"
 
 msgid "Created scrap reason"
-msgstr "Verschrottungsgrund erstellt"
+msgstr "Ausschussgrund erstellt"
 
 msgid "Created service"
 msgstr "Dienstleistung erstellt"
@@ -4129,7 +4129,7 @@ msgid "Created shipping method"
 msgstr "Versandmethode erstellt"
 
 msgid "Created stock transfer line"
-msgstr "Bestandsübergabezeile erstellt"
+msgstr "Umlagerungsposition erstellt"
 
 msgid "Created storage type"
 msgstr "Speichertyp erstellt"
@@ -4142,13 +4142,13 @@ msgid "Created tool"
 msgstr "Werkzeug erstellt"
 
 msgid "Created unit of measure"
-msgstr "Maßeinheit erstellt"
+msgstr "Mengeneinheit erstellt"
 
 msgid "Created webhook"
 msgstr "Webhook erstellt"
 
 msgid "Created work center"
-msgstr "Arbeitszentrum erstellt"
+msgstr "Arbeitsplatz erstellt"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
 msgstr "Erstellt die 12 monatlichen Perioden für ein Geschäftsjahr. Bereits vorhandene Perioden werden beibehalten."
@@ -4164,22 +4164,22 @@ msgid "Credit ({0})"
 msgstr "Kredit ({0})"
 
 msgid "Credit / debit memo"
-msgstr "Gut-/Lastschrift"
+msgstr "Gutschrift / Sollschrift"
 
 msgid "Credit / Debit Memos"
-msgstr "Gutschrift- / Lastschriftmemos"
+msgstr "Gutschriften / Sollschriften"
 
 msgid "Credit Account"
 msgstr "Gutschriftkonto"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Gutschriftkonto, wenn Arbeits- / Maschinenzeit in WIP aufgenommen wird"
+msgstr "Habenkonto bei der Absorption von Personal- und Maschinenzeit in WIP"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Aktivkonto, wenn Gemeinkosten in laufende Arbeiten aufgenommen werden"
+msgstr "Habenkonto bei der Absorption von Gemeinkosten in WIP"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Aktienkonten, die verwendet werden, wenn Herstellungskosten in laufende Arbeiten aufgenommen werden"
+msgstr "Habenkonten bei der Absorption von Fertigungskosten in WIP"
 
 msgid "Credit Memo"
 msgstr "Gutschrift"
@@ -4188,7 +4188,7 @@ msgid "Credits"
 msgstr "Guthaben"
 
 msgid "Credits & Debits"
-msgstr "Gutschriften & Belastungen"
+msgstr "Haben & Soll"
 
 msgid "Credits applied"
 msgstr "Angewendete Gutschriften"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "Aktuell"
 
 msgid "Current Net Book Value:"
-msgstr "Aktueller Netto-Buchwert:"
+msgstr "Aktueller Restbuchwert:"
 
 msgid "Current Password"
 msgstr "Aktuelles Passwort"
@@ -4239,7 +4239,7 @@ msgid "Current quantity"
 msgstr "Aktuelle Menge"
 
 msgid "Currently training for"
-msgstr "Derzeit in Ausbildung für"
+msgstr "Schulung für"
 
 msgid "Custom"
 msgstr "Benutzerdefiniert"
@@ -4251,7 +4251,7 @@ msgid "Custom {label}"
 msgstr "Benutzerdefiniert {label}"
 
 msgid "Custom attributes you track against your people"
-msgstr "Benutzerdefinierte Attribute, die Sie für Ihre Mitarbeiter nachverfolgen"
+msgstr "Benutzerdefinierte Attribute für Ihr Personal"
 
 msgid "Custom development beyond what's listed"
 msgstr "Benutzerdefinierte Entwicklung über das Aufgelistete hinaus"
@@ -4326,13 +4326,13 @@ msgid "Customer Part"
 msgstr "Kundenteile"
 
 msgid "Customer Part ID"
-msgstr "Kundenteile-ID"
+msgstr "Kundenartikelnummer"
 
 msgid "Customer Part Number"
 msgstr "Kundenteilenummer"
 
 msgid "Customer Part Revision"
-msgstr "Kundenteilvision"
+msgstr "Kundenteils-Revision"
 
 msgid "Customer Parts"
 msgstr "Kundenteile"
@@ -4356,7 +4356,7 @@ msgid "Customer Portals"
 msgstr "Kundenportale"
 
 msgid "Customer pricing"
-msgstr "Kundenpreise"
+msgstr "Kundenpreisgestaltung"
 
 msgid "Customer reference"
 msgstr "Kundenreferenz"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Kundentypen"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Kundenabschreibung (Forderungsausfälle)"
+msgstr "Kundenausbuchung (Uneinbringliche Forderung)"
 
 msgid "customers"
 msgstr "Kunden"
@@ -4407,13 +4407,13 @@ msgid "Customers"
 msgstr "Kunden"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Anpassungen, Schulung und Integrationen"
 
 msgid "Customize"
 msgstr "Anpassen"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
-msgstr "Passen Sie das Layout Ihrer PDF-Dokumente an — ordnen Sie Abschnitte neu an, blenden Sie aus, was Sie nicht benötigen, und fügen Sie Ihre eigenen Blöcke hinzu."
+msgstr "Passen Sie das Layout Ihrer PDF-Dokumente an — ordnen Sie Abschnitte neu, verbergen Sie, was Sie nicht benötigen, und fügen Sie eigene Blöcke hinzu."
 
 msgid "Cut over to Carbon and freeze the old system"
 msgstr "Zu Carbon wechseln und das alte System einfrieren"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "Cutover-Unterstützung"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "Bestandszählung durchführen und mit Audit-Trail anpassen"
+msgstr "Permanente Inventur durchführen und anpassen mit Audit-Trail"
 
 msgid "Daily"
 msgstr "Täglich"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Fälligkeitstage"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Tage vom Bestellen eines Teils bis zu seiner Verfügbarkeit; die Planung verschiebt die Nachfrage um diesen Betrag nach hinten."
+msgstr "Tage vom Bestellen eines Teils bis zu seiner Verfügbarkeit; der Planungsversatz verschiebt den Bedarf um diese Zeit zurück."
 
 msgid "Days Off"
 msgstr "Tage frei"
@@ -4562,7 +4562,7 @@ msgid "Deactivate Users"
 msgstr "Benutzer deaktivieren"
 
 msgid "Deactivate Work Center"
-msgstr "Arbeitszentrum deaktivieren"
+msgstr "Arbeitsplatz deaktivieren"
 
 msgid "Deadline type"
 msgstr "Fristtyp"
@@ -4571,29 +4571,29 @@ msgid "Deadline Type"
 msgstr "Deadline-Typ"
 
 msgid "Debit"
-msgstr "Belastung"
+msgstr "Soll"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
-msgstr "Belastung ({0})"
+msgstr "Soll ({0})"
 
 msgid "Debit Account"
-msgstr "Belastungskonto"
+msgstr "Sollkonto"
 
 msgid "Debit Memo"
-msgstr "Lastschrift"
+msgstr "Sollschrift"
 
 msgid "Debits"
-msgstr "Belastungen"
+msgstr "Soll"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "Entscheiden Sie, was ein Bediener sieht, wenn er versucht, einen Batch oder eine Seriennummer auszugeben, die bereits abgelaufen ist."
+msgstr "Entscheiden Sie, was ein Werker sieht, wenn er versucht, ein abgelaufenes Los oder eine abgelaufene Seriennummer zu verbrauchen."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Legen Sie fest, was passiert, wenn ein Bediener auf dem Shopfloor die Funktion \"Fertig\" drückt, während Material noch nicht kommissioniert ist."
+msgstr "Entscheiden Sie, was passiert, wenn ein Werker in der Werkstatt „Fertig\" drückt, während Material noch nicht kommissioniert wurde."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "Entscheiden Sie, wann Material, das zu einem Arbeitszentrum gepickt, aber nicht verbraucht wurde, ins Lager zurückfließt."
+msgstr "Entscheiden Sie, wann Material, das zu einem Arbeitsplatz kommissioniert, aber nicht verbraucht wurde, zum Lager zurückfließt."
 
 msgid "Decimal Places"
 msgstr "Dezimalstellen"
@@ -4605,13 +4605,13 @@ msgid "Default"
 msgstr "Standard"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Standardkonto für die Buchung von Verkaufseinnahmen aus Rechnungen"
+msgstr "Standardkonto für Umsatzerlöse aus Rechnungen"
 
 msgid "Default Accounts"
 msgstr "Standardkonten"
 
 msgid "Default accounts for business expenses"
-msgstr "Standardkonten für Geschäftsausgaben"
+msgstr "Standardkonten für geschäftliche Aufwendungen"
 
 msgid "Default accounts for customer transactions and receivables"
 msgstr "Standardkonten für Kundentransaktionen und Forderungen"
@@ -4620,13 +4620,13 @@ msgid "Default accounts for long-term assets and depreciation"
 msgstr "Standardkonten für langfristige Vermögenswerte und Abschreibungen"
 
 msgid "Default accounts for sales and income"
-msgstr "Standardkonten für Verkauf und Einkommen"
+msgstr "Konten für Vertrieb und Erträge"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "Standardkonten für steuerbezogene Transaktionen"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Standardkonten für die Kosten der verkauften Waren und indirekte Käufe"
+msgstr "Standardkonten für Umsatzkosten und indirekte Einkäufe"
 
 msgid "Default Approver"
 msgstr "Standardgenehmiger"
@@ -4635,10 +4635,10 @@ msgid "Default Attachments"
 msgstr "Standardanhänge"
 
 msgid "Default cash account for transactions in non-base currencies."
-msgstr "Standard-Bargeldkonto für Transaktionen in Nicht-Basiswährungen."
+msgstr "Standardkassenkonto für Transaktionen in Fremdwährungen"
 
 msgid "Default cash account for transactions in your base currency."
-msgstr "Standard-Bargeldkonto für Transaktionen in Ihrer Basiswährung."
+msgstr "Standardkassenkonto für Transaktionen in Ihrer Basiswährung."
 
 msgid "Default cc"
 msgstr "Standard-CC"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "Standard-CC-Empfänger"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "Standardmäßiges Sachkonto, das bei einem Gewinn aus der Veräußerung eines Anlagevermögens gutgeschrieben wird."
+msgstr "Standard-Sachkonto, das bei einem Gewinn aus einem Anlagenabgang gutgeschrieben wird."
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "Standardmäßiges Sachkonto, das bei einem Verlust aus der Veräußerung eines Anlagevermögens belastet wird."
+msgstr "Standard-Sachkonto, das bei einem Verlust aus einem Anlagenabgang belastet wird."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
-msgstr "Standard-GL-Konto für Bargeldtransaktionen, wenn kein spezifisches Bankkonto ausgewählt ist."
+msgstr "Standard-Sachkonto für Kassentransaktionen, wenn kein spezifisches Bankkonto ausgewählt ist."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Standard-GL-Ausgabenkonto für Wartung von Ausrüstung und Einrichtungen."
+msgstr "Standard-Aufwandskonto für Instandhaltung von Anlagen und Einrichtungen."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Standard-GL-Ausgabenkonto für regelmäßige Abschreibungsläufe."
+msgstr "Standard-Aufwandskonto für regelmäßige Abschreibungsläufe."
 
 msgid "Default Method"
 msgstr "Standardmethode"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Standardmethode, die in dieser Klasse auf neuen Vermögenswerten vorausgefüllt wird (immer noch pro Vermögenswert bearbeitbar)."
 
 msgid "Default method type"
-msgstr "Standard-Methodentyp"
+msgstr "Standard-Bereitstellungsart"
 
 msgid "Default Method Type"
-msgstr "Standardmethodentyp"
+msgstr "Standard-Bereitstellungsart"
 
 msgid "Default Permissions"
 msgstr "Standardberechtigungen"
@@ -4680,7 +4680,7 @@ msgid "Default Priority"
 msgstr "Standardpriorität"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "Standard-Einnahmen-GL-Konto, das gutgeschrieben wird, wenn eine Verkaufsrechnung gebucht wird."
+msgstr "Standard-Sachkonto für Umsatzerlöse, das gutgeschrieben wird, wenn eine Ausgangsrechnung gebucht wird."
 
 msgid "Default Sampling"
 msgstr "Standard-Stichprobenprüfung"
@@ -4710,22 +4710,22 @@ msgid "Defaults"
 msgstr "Standardwerte"
 
 msgid "Deferred Tax Expense"
-msgstr "Aufgeschobener Steueraufwand"
+msgstr "Latente Steueraufwendungen"
 
 msgid "Deferred Tax Expense (default)"
-msgstr "Aufgeschobener Steueraufwand (Standard)"
+msgstr "Latente Steueraufwendungen (Standard)"
 
 msgid "Deferred Tax Liability"
-msgstr "Aufgeschobene Steuerschuld"
+msgstr "Latente Steuerverpflichtung"
 
 msgid "Deferred Tax Liability (default)"
-msgstr "Aufgeschobene Steuerschuld (Standard)"
+msgstr "Latente Steuerverpflichtung (Standard)"
 
 msgid "Define a manufacturing operation first."
-msgstr "Definieren Sie zunächst einen Herstellungsbetrieb."
+msgstr "Definieren Sie zuerst einen Fertigungsarbeitsgang."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Definieren Sie mehrstufige Stücklisten und Bill of Process (Herstellungsmethoden)"
+msgstr "Definieren Sie mehrstufige BOMs und Arbeitsganglisten (Fertigungsmethoden)"
 
 msgid "Delete"
 msgstr "Löschen"
@@ -4756,7 +4756,7 @@ msgid "Delete Asset"
 msgstr "Anlage löschen"
 
 msgid "Delete Asset Class"
-msgstr "Anlageklasse löschen"
+msgstr "Anlagenklasse löschen"
 
 msgid "Delete Assignment"
 msgstr "Zuweisung löschen"
@@ -4780,7 +4780,7 @@ msgid "Delete Contact"
 msgstr "Kontakt löschen"
 
 msgid "Delete Contractor"
-msgstr "Auftragnehmer löschen"
+msgstr "Externen Mitarbeiter löschen"
 
 msgid "Delete Count"
 msgstr "Anzahl löschen"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "Dimension löschen"
 
 msgid "Delete Dispatch"
-msgstr "Dispatch löschen"
+msgstr "Instandhaltungsauftrag löschen"
 
 msgid "Delete Document"
 msgstr "Dokument löschen"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Feiertag löschen"
 
 msgid "Delete Inspection Plan"
-msgstr "Inspektionsplan löschen"
+msgstr "Prüfplan löschen"
 
 msgid "Delete Issue"
 msgstr "Problem löschen"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Artikelgruppe löschen"
 
 msgid "Delete Journal Entry"
-msgstr "Journaleintrag löschen"
+msgstr "Buchungszeile löschen"
 
 msgid "Delete line"
 msgstr "Zeile löschen"
@@ -4852,10 +4852,10 @@ msgid "Delete Material Dimension"
 msgstr "Materialdimension löschen"
 
 msgid "Delete Material Finish"
-msgstr "Materialfinish löschen"
+msgstr "Oberflächenbehandlung löschen"
 
 msgid "Delete Material Grade"
-msgstr "Materialgüte löschen"
+msgstr "Werkstoffgüte löschen"
 
 msgid "Delete Material Shape"
 msgstr "Materialform löschen"
@@ -4894,19 +4894,19 @@ msgid "Delete Portal"
 msgstr "Portal löschen"
 
 msgid "Delete Price Break"
-msgstr "Preisabstufung löschen"
+msgstr "Preisstaffel löschen"
 
 msgid "Delete Pricing Rule"
 msgstr "Preisregel löschen"
 
 msgid "Delete Procedure"
-msgstr "Verfahren löschen"
+msgstr "Verfahrensanweisung löschen"
 
 msgid "Delete Process"
 msgstr "Prozess löschen"
 
 msgid "Delete Purchase Invoice"
-msgstr "Kaufrechnung löschen"
+msgstr "Eingangsrechnung löschen"
 
 msgid "Delete Purchase Order"
 msgstr "Bestellung löschen"
@@ -4945,10 +4945,10 @@ msgid "Delete Rule"
 msgstr "Regel löschen"
 
 msgid "Delete Sales Invoice"
-msgstr "Verkaufsrechnung löschen"
+msgstr "Ausgangsrechnung löschen"
 
 msgid "Delete Sales Order"
-msgstr "Verkaufsauftrag löschen"
+msgstr "Kundenauftrag löschen"
 
 msgid "Delete Schedule"
 msgstr "Zeitplan löschen"
@@ -4960,10 +4960,10 @@ msgid "Delete Shift"
 msgstr "Schicht löschen"
 
 msgid "Delete Shipment"
-msgstr "Sendung löschen"
+msgstr "Lieferung löschen"
 
 msgid "Delete shipment line"
-msgstr "Versandzeile löschen"
+msgstr "Lieferposition löschen"
 
 msgid "Delete Shipping Method"
 msgstr "Versandmethode löschen"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "Speichertyp löschen"
 
 msgid "Delete Storage Unit"
-msgstr "Speichereinheit löschen"
+msgstr "Lagereinheit löschen"
 
 msgid "Delete Substance"
 msgstr "Substanz löschen"
@@ -5003,7 +5003,7 @@ msgstr "Lieferantentyp löschen"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Den Preisrabatt für Menge {0} löschen? Dies kann nicht rückgängig gemacht werden."
+msgstr "Die Preisstaffel für Menge {0} löschen? Dies kann nicht rückgängig gemacht werden."
 
 msgid "Delete Timecard"
 msgstr "Zeitkarte löschen"
@@ -5018,13 +5018,13 @@ msgid "Delete Transfer"
 msgstr "Übertragung löschen"
 
 msgid "Delete Transfer Line"
-msgstr "Transferzeile löschen"
+msgstr "Umlagerungsposition löschen"
 
 msgid "Delete Type"
 msgstr "Typ löschen"
 
 msgid "Delete Unit of Measure"
-msgstr "Maßeinheit löschen"
+msgstr "Mengeneinheit löschen"
 
 msgid "Delete view"
 msgstr "Ansicht löschen"
@@ -5042,31 +5042,31 @@ msgid "Delete Workflow"
 msgstr "Workflow löschen"
 
 msgid "Delivery Date"
-msgstr "Lieferdatum"
+msgstr "Liefertermin"
 
 msgid "Delivery Location"
 msgstr "Lieferort"
 
 msgid "Demand"
-msgstr "Nachfrage"
+msgstr "Bedarf"
 
 msgid "Demand forecast"
 msgstr "Bedarfsprognose"
 
 msgid "Demand Forecast"
-msgstr "Nachfrageprognose"
+msgstr "Bedarfsprognose"
 
 msgid "Demand Forecast — Driven by"
-msgstr "Nachfragevorhersage — Angetrieben durch"
+msgstr "Bedarfsprognose — Gesteuert durch"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Bedarfsprognose = BOM-explodierter Bedarf aus offenen Verkaufsaufträgen, aktiven Aufträgen und Produktionsprognosen."
+msgstr "Bedarfsprognose = BOM-gesprengter Bedarf aus offenen Kundenaufträgen, aktiven Fertigungsaufträgen und Produktionsprognosen."
 
 msgid "Demand projection"
 msgstr "Bedarfsprognose"
 
 msgid "Demand Projections"
-msgstr "Nachfrageprojektionen"
+msgstr "Bedarfsprognosen"
 
 msgid "Demand-Based"
 msgstr "Nachfragebasiert"
@@ -5120,13 +5120,13 @@ msgid "Depreciation reversal when a fixed asset is disposed"
 msgstr "Abschreibungsumkehrung bei Entsorgung eines Anlagevermögens"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "Abschreibungsläufe, die in dieser Periode enden und noch im Entwurfsstadium sind, sollten gebucht werden, damit die Periode die korrekte Abschreibungsausgabe und kumulierte Abschreibung widerspiegelt. Überspringen Sie mit Begründung, wenn die Abschreibung in dieser Periode nicht anwendbar ist."
+msgstr "Abschreibungsläufe, die in dieser Periode enden und sich noch im Entwurf befinden, sollten gebucht werden, damit die Periode den korrekten Abschreibungsaufwand und die kumulierte Abschreibung widerspiegelt. Überspringen Sie mit einem Grund, wenn Abschreibung in dieser Periode nicht anwendbar ist."
 
 msgid "Depreciation Start Date"
 msgstr "Abschreibungsstartdatum"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Leiten Sie die Haltbarkeitsdauer dieses Elements aus der kürzesten Haltbarkeitsdauer seiner Komponenten ab, wobei das obige Feld \"Tage\" ignoriert wird."
+msgstr "Leiten Sie die Haltbarkeit dieses Artikels von der kürzesten Haltbarkeit seiner Komponenten ab und ignorieren Sie das obige Feld „Tage\"."
 
 msgid "Description"
 msgstr "Beschreibung"
@@ -5156,10 +5156,10 @@ msgid "Digital Quote"
 msgstr "Digitales Angebot"
 
 msgid "Digital quote accepted by"
-msgstr "Digitales Angebot akzeptiert von"
+msgstr "Digitales Angebot angenommen von"
 
 msgid "Digital quote accepted by email"
-msgstr "Digitales Angebot per E-Mail akzeptiert"
+msgstr "Digitales Angebot per E-Mail angenommen"
 
 msgid "Digital quote rejected by"
 msgstr "Digitales Angebot abgelehnt von"
@@ -5180,13 +5180,13 @@ msgid "Dimension slots"
 msgstr "Dimensions-Slots"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Dimensionswerte in gebuchten Journalen, die noch keine Provider-Zuordnung haben."
+msgstr "Dimensionswerte auf gebuchten Buchungssätzen, die noch keine Anbieter-Zuordnung haben."
 
 msgid "dimensions"
 msgstr "Dimensionen"
 
 msgid "Dimensions"
-msgstr "Abmessungen"
+msgstr "Dimensionen"
 
 msgid "Direct"
 msgstr "Direkt"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Verwerfen"
 
 msgid "Dispatch"
-msgstr "Einsatz"
+msgstr "Instandhaltungsauftrag"
 
 msgid "Dispatch ID"
-msgstr "Versand-ID"
+msgstr "Instandhaltungsauftrag-ID"
 
 msgid "Dispatch priority"
-msgstr "Versandsysteme"
+msgstr "Instandhaltungsauftrag-Priorität"
 
 msgid "Dispatches"
-msgstr "Einsätze"
+msgstr "Instandhaltungsaufträge"
 
 msgid "Display Settings"
 msgstr "Anzeigeeinstellungen"
 
 msgid "Disposal"
-msgstr "Entsorgung"
+msgstr "Abgang"
 
 msgid "Disposal Date"
-msgstr "Entsorgungsdatum"
+msgstr "Abgangsdatum"
 
 msgid "Dispose"
 msgstr "Entsorgen"
@@ -5277,10 +5277,10 @@ msgid "Disposed"
 msgstr "Ausgemustert"
 
 msgid "Disposition"
-msgstr "Disposition"
+msgstr "Verwendungsentscheid"
 
 msgid "Dispositions"
-msgstr "Dispositionen"
+msgstr "Verwendungsentscheide"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
 msgstr "Möchten Sie die aktuellen Berechtigungen des Benutzers mit den Standardberechtigungen für diesen Mitarbeitertyp überschreiben?"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Dokumente"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Dokumente leitet Rechnungen, Eingangsrechnungen und Zahlungen als native Anbieterurkunden weiter; deren Journale werden als durch das Dokument abgedeckt erfasst. Es werden auch von dem Anbieter erfasste Zahlungen zurück in Carbon importiert, um die zugehörige Rechnung oder den Eingangsbeleg zu schließen und ein Carbon GL-Journal zu buchen. Aus erfasst sie als bewusst ausgeschlossen."
+msgstr "Dokumente sendet Rechnungen, Lieferscheine und Zahlungen als native Anbieter-Dokumente; ihre Buchungssätze werden als durch das Dokument abgedeckt erfasst. Es zieht auch im Anbieter erfasste Zahlungen in Carbon zurück, schließt die übereinstimmende Rechnung oder den Lieferschein und bucht einen Carbon-Hauptbuch-Buchungssatz. Off erfasst sie als absichtlich ausgeschlossen."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Dokumente, die Sie öffnen, werden hier zur schnellen Zugreifbarkeit angezeigt."
@@ -5325,10 +5325,10 @@ msgid "done"
 msgstr "erledigt"
 
 msgid "Done"
-msgstr "Fertig"
+msgstr "Erledigt"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Abgeschlossen, wenn der tägliche Betrieb ohne uns im Raum läuft"
+msgstr "Erledigt, wenn der Tagesablauf ohne unsere Anwesenheit läuft"
 
 msgid "Download"
 msgstr "Herunterladen"
@@ -5359,7 +5359,7 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "Entwurf ist bearbeitbar; Aktiv ist in Verwendung und erfordert eine neue Version zum Ändern; Archiviert ist deaktiviert."
 
 msgid "Draft Journal Entries"
-msgstr "Entwurfs-Journaleinträge"
+msgstr "Entwurfs-Buchungszeilen"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "Dateien ziehen und ablegen oder zum Durchsuchen klicken"
@@ -5395,10 +5395,10 @@ msgid "Drawing replaced. Balloon placements were removed; feature rows are uncha
 msgstr "Zeichnung ersetzt. Ballonplatzierungen wurden entfernt; Funktionszeilen bleiben unverändert."
 
 msgid "Drop Shipment"
-msgstr "Direktversand"
+msgstr "Direktlieferung"
 
 msgid "Drop Shipment Statuses"
-msgstr "Drop-Shipment-Status"
+msgstr "Direktlieferungs-Status"
 
 msgid "Drop whole pages or sections a customer doesn't need."
 msgstr "Ganze Seiten oder Abschnitte entfernen, die ein Kunde nicht benötigt."
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "Datei hier ablegen oder zum Durchsuchen klicken."
 
 msgid "Drop-ship"
-msgstr "Direktversand"
+msgstr "Direktlieferung"
 
 msgid "Due"
 msgstr "Fällig"
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Fälligkeitsdatum des letzten Auftrags"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Fälligkeitsdatum des frühesten Auftrags im Stapelauftrag; spätere Aufträge verteilen sich gleichmäßig zwischen diesem Datum und dem Fälligkeitsdatum des letzten Auftrags."
+msgstr "Fälligkeitsdatum des frühesten Fertigungsauftrags in der Gruppe; spätere Fertigungsaufträge verteilen sich gleichmäßig zwischen diesem Datum und dem Fälligkeitsdatum des letzten Fertigungsauftrags."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Fälligkeitsdatum des letzten Auftrags im Stapelauftrag; kombiniert mit dem Fälligkeitsdatum des ersten Auftrags, um die Aufträge gleichmäßig zu verteilen."
+msgstr "Fälligkeitsdatum des abschließenden Fertigungsauftrags in der Gruppe; kombiniert mit dem Fälligkeitsdatum des ersten Fertigungsauftrags, um die Fertigungsaufträge gleichmäßig zu verteilen."
 
 msgid "Due Days"
 msgstr "Fälligkeitstage"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "z.B. 48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "z.B. Acme Manufacturing"
+msgstr "z. B. Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "z.B. Detroit"
@@ -5519,10 +5519,10 @@ msgid "e.g. Zebra 2x1"
 msgstr "z.B. Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Das ungenutzte Material jedes Vorgangs wird sofort nach Abschluss des Vorgangs zurückgegeben."
+msgstr "Die ungenutzten Materialien jedes Arbeitsgangs werden zurückgegeben, sobald der Arbeitsgang erledigt ist."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
-msgstr "Jede physische Einheit erhält ihre eigene nachverfocgte Einheit und eindeutige Nummer — eine Einheit, eine Einheit."
+msgstr "Jede physische Einheit erhält ihre eigene verfolgte Einheit und eine eindeutige Nummer – eine verfolgte Einheit, ein Stück."
 
 msgid "Each, lb, ft…"
 msgstr "Stück, kg, m…"
@@ -5534,7 +5534,7 @@ msgid "Easier to extend"
 msgstr "Einfacher zu erweitern"
 
 msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
-msgstr "Wirtschaftsbeteiligungs-Registrierungs- und Identifizierungsnummer; erforderlich für Waren, die Zollgrenzen in der EU/UK überqueren."
+msgstr "Registrierungs- und Identifizierungsnummer für Wirtschaftsbeteiligte; erforderlich für Waren, die Zollgrenzen in der EU/UK überschreiten."
 
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -5588,7 +5588,7 @@ msgid "Edit Contact"
 msgstr "Kontakt bearbeiten"
 
 msgid "Edit Contractor"
-msgstr "Auftragnehmer bearbeiten"
+msgstr "Externer Mitarbeiter bearbeiten"
 
 msgid "Edit Cost Center"
 msgstr "Kostenstelle bearbeiten"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "Dimension bearbeiten"
 
 msgid "Edit Dispatch"
-msgstr "Versand bearbeiten"
+msgstr "Instandhaltungsauftrag bearbeiten"
 
 msgid "Edit Employee"
 msgstr "Mitarbeiter bearbeiten"
@@ -5627,10 +5627,10 @@ msgid "Edit Employee Type"
 msgstr "Mitarbeitertyp bearbeiten"
 
 msgid "Edit expiration date"
-msgstr "Ablaufdatum bearbeiten"
+msgstr "Verfallsdatum bearbeiten"
 
 msgid "Edit Expiry"
-msgstr "Ablaufdatum bearbeiten"
+msgstr "Verfall bearbeiten"
 
 msgid "Edit Failure Mode"
 msgstr "Fehlermodus bearbeiten"
@@ -5639,10 +5639,10 @@ msgid "Edit Fixed Asset"
 msgstr "Anlagevermögen bearbeiten"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Messuhr-Kalibrierungsdatensatz bearbeiten"
+msgstr "Prüfmittel-Kalibrierprotokoll bearbeiten"
 
 msgid "Edit Gauge Type"
-msgstr "Messuhr-Typ bearbeiten"
+msgstr "Prüfmittelart bearbeiten"
 
 msgid "Edit Group"
 msgstr "Gruppe bearbeiten"
@@ -5651,13 +5651,13 @@ msgid "Edit Holiday"
 msgstr "Feiertag bearbeiten"
 
 msgid "Edit Inspection Plan"
-msgstr "Inspektionsplan bearbeiten"
+msgstr "Prüfplan bearbeiten"
 
 msgid "Edit Item Group"
 msgstr "Artikelgruppe bearbeiten"
 
 msgid "Edit Journal Entry"
-msgstr "Journaleintrag bearbeiten"
+msgstr "Buchungszeile bearbeiten"
 
 msgid "Edit Kanban"
 msgstr "Kanban bearbeiten"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Standort bearbeiten"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Wartungseinsatz bearbeiten"
+msgstr "Instandhaltungsauftrag bearbeiten"
 
 msgid "Edit Material"
 msgstr "Material bearbeiten"
@@ -5678,16 +5678,16 @@ msgid "Edit Material Dimension"
 msgstr "Material Dimension bearbeiten"
 
 msgid "Edit Material Finish"
-msgstr "Material Finish bearbeiten"
+msgstr "Oberflächenbehandlung bearbeiten"
 
 msgid "Edit Material Grade"
-msgstr "Material Grade bearbeiten"
+msgstr "Werkstoffgüte bearbeiten"
 
 msgid "Edit Material Shape"
 msgstr "Materialform bearbeiten"
 
 msgid "Edit Material Substance"
-msgstr "Material Substance bearbeiten"
+msgstr "Grundwerkstoff bearbeiten"
 
 msgid "Edit Material Type"
 msgstr "Material Type bearbeiten"
@@ -5726,10 +5726,10 @@ msgid "Edit Portal"
 msgstr "Portal bearbeiten"
 
 msgid "Edit Price Override"
-msgstr "Preisüberschreibung bearbeiten"
+msgstr "Preis-Übersteuerung bearbeiten"
 
 msgid "Edit Pricing"
-msgstr "Preisgestaltung bearbeiten"
+msgstr "Preisfindung bearbeiten"
 
 msgid "Edit Pricing Rule"
 msgstr "Preisregel bearbeiten"
@@ -5771,10 +5771,10 @@ msgid "Edit Schedule"
 msgstr "Zeitplan bearbeiten"
 
 msgid "Edit Scheduled Maintenance"
-msgstr "Geplante Wartung bearbeiten"
+msgstr "Geplante Instandhaltung bearbeiten"
 
 msgid "Edit Sequence"
-msgstr "Sequenz bearbeiten"
+msgstr "Nummernkreis bearbeiten"
 
 msgid "Edit Serial Number"
 msgstr "Seriennummer bearbeiten"
@@ -5786,7 +5786,7 @@ msgid "Edit Shift"
 msgstr "Schicht bearbeiten"
 
 msgid "Edit Shipment"
-msgstr "Sendung bearbeiten"
+msgstr "Lieferung bearbeiten"
 
 msgid "Edit Shipping"
 msgstr "Versand bearbeiten"
@@ -5807,7 +5807,7 @@ msgid "Edit Storage Type"
 msgstr "Speichertyp bearbeiten"
 
 msgid "Edit Storage Unit"
-msgstr "Lagerverwaltungseinheit bearbeiten"
+msgstr "Lagereinheit bearbeiten"
 
 msgid "Edit Substance"
 msgstr "Substanz bearbeiten"
@@ -5819,7 +5819,7 @@ msgid "Edit Supplier Part"
 msgstr "Lieferantenteil bearbeiten"
 
 msgid "Edit supplier process"
-msgstr "Lieferantenprozess bearbeiten"
+msgstr "Lieferantenverfahren bearbeiten"
 
 msgid "Edit Supplier Type"
 msgstr "Lieferantentyp bearbeiten"
@@ -5840,13 +5840,13 @@ msgid "Edit Transfer"
 msgstr "Transfer bearbeiten"
 
 msgid "Edit Transfer Line"
-msgstr "Transferzeile bearbeiten"
+msgstr "Umlagerungsposition bearbeiten"
 
 msgid "Edit Type"
 msgstr "Typ bearbeiten"
 
 msgid "Edit Unit of Measure"
-msgstr "Maßeinheit bearbeiten"
+msgstr "Mengeneinheit bearbeiten"
 
 msgid "Edit View"
 msgstr "Ansicht bearbeiten"
@@ -5855,7 +5855,7 @@ msgid "Edit Webhook"
 msgstr "Webhook bearbeiten"
 
 msgid "Edit Work Center"
-msgstr "Arbeitszentrum bearbeiten"
+msgstr "Arbeitsplatz bearbeiten"
 
 msgid "Eliminated"
 msgstr "Beseitigt"
@@ -5888,7 +5888,7 @@ msgid "Emoji"
 msgstr "Emoji"
 
 msgid "employee"
-msgstr "Angestellter"
+msgstr "Mitarbeiter"
 
 msgid "Employee"
 msgstr "Mitarbeiter"
@@ -5903,7 +5903,7 @@ msgid "Employee Types"
 msgstr "Mitarbeitertypen"
 
 msgid "employees"
-msgstr "Angestellte"
+msgstr "Mitarbeiter"
 
 msgid "Employees"
 msgstr "Mitarbeiter"
@@ -5918,31 +5918,31 @@ msgid "Empty list"
 msgstr "Leere Liste"
 
 msgid "Empty work centers"
-msgstr "Leere Arbeitszentren"
+msgstr "Leere Arbeitsplätze"
 
 msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "Aktivieren Sie die Audit-Protokollierung in den Einstellungen, um Änderungen an Ihren Daten zu verfolgen."
 
 msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
-msgstr "Aktivieren Sie digitale Angebote für Ihr Unternehmen. Dies ermöglicht es Ihnen, digitale Angebote an Ihre Kunden zu senden und ihnen, diese online zu akzeptieren."
+msgstr "Aktivieren Sie digitale Angebote für Ihr Unternehmen. Dies ermöglicht es Ihnen, digitale Angebote an Ihre Kunden zu senden, und ermöglicht es ihnen, diese online anzunehmen."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Aktivieren Sie die vollständige Periodenrechnung mit Journaleinträgen, Finanzberichten und Hauptbuchbuchungen."
+msgstr "Aktivieren Sie vollständige periodengerechte Buchhaltung mit Buchungssätzen, Finanzberichten und Buchungen im Hauptbuch."
 
 msgid "Enable in Settings"
 msgstr "In Einstellungen aktivieren"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "Aktivieren Sie Benachrichtigungen, wenn eine Anfrage als angebotbereit markiert wird."
+msgstr "Aktivieren Sie Benachrichtigungen, wenn eine Anfrage als Angebotsbereit gekennzeichnet ist."
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
-msgstr "Aktivieren Sie den Modus für gemeinsame Arbeitsstationen für MES-Terminals. Operatoren identifizieren sich über eine PIN, bevor sie arbeiten."
+msgstr "Aktivieren Sie den freigegebenen Workstation-Modus für MES-Terminals. Werker identifizieren sich über eine PIN, bevor sie arbeiten."
 
 msgid "Enable this rule to automatically require approval for matching documents"
 msgstr "Aktivieren Sie diese Regel, um automatisch eine Genehmigung für übereinstimmende Dokumente zu verlangen"
 
 msgid "Enable timecard tracking for work shifts."
-msgstr "Zeiterfassung für Arbeitseinsätze aktivieren."
+msgstr "Aktivieren Sie die Zeiterfassung für Schichten."
 
 msgid "Enable to allow shared workstation mode."
 msgstr "Aktivieren Sie diese Option, um den Modus für gemeinsame Arbeitsstationen zu ermöglichen."
@@ -5951,7 +5951,7 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "Aktivieren Sie diese Option, um Transaktionen automatisch ins Hauptbuch zu buchen."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "Aktivieren Sie diese Option, um steuerspezifische Abschreibungsmethoden für Anlageklassen zu konfigurieren (z. B. MACRS, beschleunigt)."
+msgstr "Ermöglichen Sie die Konfiguration steuerlicher Abschreibungsmethoden für Anlagenklassen (z. B. MACRS, beschleunigt)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
 msgstr "Aktivieren Sie diese Option, um IDs und Beschreibungen für Rohstoffe zu generieren."
@@ -5960,7 +5960,7 @@ msgid "Enable to start tracking changes to your data."
 msgstr "Aktivieren Sie diese Option, um Änderungen an Ihren Daten zu verfolgen."
 
 msgid "Enable to start tracking work shifts."
-msgstr "Aktivieren Sie diese Option, um die Verfolgung von Arbeitszeiträumen zu starten."
+msgstr "Aktivieren Sie die Nachverfolgung von Schichten."
 
 msgid "Enable to use metric units for material dimensions."
 msgstr "Aktivieren Sie diese Option, um metrische Einheiten für Materialdimensionen zu verwenden."
@@ -5994,7 +5994,7 @@ msgid "Enforce — edits are blocked"
 msgstr "Erzwingen — Bearbeitungen sind gesperrt"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
-msgstr "Erzwingen Sie eine Validierung und Richtlinien pro Artikel über Eingänge, Lieferungen, Transfers und Anpassungen hinweg."
+msgstr "Erzwingen Sie artikelspezifische Validierung und Richtlinien über Wareneingänge, Lieferungen, Umlagerungen und Korrekturen."
 
 msgid "Engagement tier"
 msgstr "Engagement-Stufe"
@@ -6003,10 +6003,10 @@ msgid "Engineering"
 msgstr "Ingenieurwesen"
 
 msgid "Engineering changes and CAD"
-msgstr "Konstruktionsänderungen und CAD"
+msgstr "Technische Änderungen und CAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "Konstruktionsänderungen und CAD"
+msgstr "Technische Änderungen und CAD"
 
 msgid "Engineering Contact"
 msgstr "Technischer Kontakt"
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "Registrieren"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "Geben Sie eine Chargennummer ein, bevor Sie das Ablaufdatum festlegen"
+msgstr "Geben Sie eine Losnummer ein, bevor Sie das Verfallsdatum festlegen"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "Geben Sie eine Menge zwischen 1 und {0} ein."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Lieferantenrechnungen gegen eine Bestellung eingeben und genehmigen (dreigliedriger Abgleich)"
+msgstr "Erfassen und genehmigen Sie Lieferantenrechnungen gegen eine Bestellung (Dreiwege-Abgleich)"
 
 msgid "Enter number…"
 msgstr "Zahl eingeben…"
@@ -6061,7 +6061,7 @@ msgid "Entity"
 msgstr "Entität"
 
 msgid "Entity certification: Accepted"
-msgstr "Unternehmenszertifizierung: Akzeptiert"
+msgstr "Entity-Zertifizierung: Angenommen"
 
 msgid "Entity certification: Expired"
 msgstr "Unternehmenszertifizierung: Abgelaufen"
@@ -6091,7 +6091,7 @@ msgid "Equity account for accumulated profits or losses"
 msgstr "Eigenkapitalkonto für angesammelte Gewinne oder Verluste"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Eigenkapitalkonto für Währungsumrechnungsgewinne/-verluste (CTA)"
+msgstr "Eigenkapitalkonto für Währungsumrechnungsanpassungen (CTA)"
 
 msgid "Error"
 msgstr "Fehler"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Fehler beim Abrufen von Lieferantendaten"
 
 msgid "Error loading assigned dispatches"
-msgstr "Fehler beim Laden zugewiesener Einsätze"
+msgstr "Fehler beim Laden zugewiesener Instandhaltungsaufträge"
 
 msgid "Error loading assigned documents"
 msgstr "Fehler beim Laden zugewiesener Dokumente"
@@ -6121,7 +6121,7 @@ msgid "Error loading job tree."
 msgstr "Fehler beim Laden des Jobbaums."
 
 msgid "Error loading make method"
-msgstr "Fehler beim Laden der Herstellungsmethode"
+msgstr "Fehler beim Laden der Fertigungsmethode"
 
 msgid "Error moving file"
 msgstr "Fehler beim Verschieben der Datei"
@@ -6139,16 +6139,16 @@ msgid "Error removing model from job"
 msgstr "Fehler beim Entfernen des Modells aus dem Auftrag"
 
 msgid "Error removing model from quote line"
-msgstr "Fehler beim Entfernen des Modells aus der Angebotszeile"
+msgstr "Fehler beim Entfernen des Modells aus der Angebotsposition"
 
 msgid "Error removing model from RFQ line"
 msgstr "Fehler beim Entfernen des Modells aus der Angebotsanforderungszeile"
 
 msgid "Error removing model from sales invoice line"
-msgstr "Fehler beim Entfernen des Modells aus der Verkaufsrechnungszeile"
+msgstr "Fehler beim Entfernen des Modells aus der Ausgangsrechnungsposition"
 
 msgid "Error removing model from sales order line"
-msgstr "Fehler beim Entfernen des Modells aus der Bestellzeile"
+msgstr "Fehler beim Entfernen des Modells aus der Kundenauftragsposition"
 
 msgid "Escalate to the project leads"
 msgstr "Eskalieren Sie an die Projektleiter"
@@ -6166,10 +6166,10 @@ msgid "Estimated Duration (minutes)"
 msgstr "Geschätzte Dauer (Minuten)"
 
 msgid "Estimated Scrap Quantity"
-msgstr "Geschätzte Verschrottungsmenge"
+msgstr "Geschätzte Ausschussmenge"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Geschätzte Verschrottungsmenge, die auf jeden Auftrag in der Stapelcharge angewendet wird."
+msgstr "Geschätzte Ausschussmenge, die auf jeden Fertigungsauftrag in der Batch-Serie angewendet wird."
 
 msgid "Estimated time"
 msgstr "Geschätzte Zeit"
@@ -6211,7 +6211,7 @@ msgid "Everything else"
 msgstr "Alles andere"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "Alles andere umfasst Personen, Importe, Integrationen und die API – alles, das nicht eine Ihrer Workflows ist."
+msgstr "Alles andere deckt Personal, Importe, Integrationen und die API ab – alles, was nicht einer Ihrer Workflows ist."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Überschreitet {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB insgesamt – entfernen Sie einige Anhänge zum Senden."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Vorhandene Zuordnungen. Wählen Sie eine andere Provider-Option zum Neu-Zuordnen."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Bestehender Stripe-Kunde"
 
 msgid "Expand"
 msgstr "Erweitern"
@@ -6269,7 +6269,7 @@ msgid "Expand features table"
 msgstr "Features-Tabelle erweitern"
 
 msgid "Expand Labor"
-msgstr "Arbeit ausklappen"
+msgstr "Personal erweitern"
 
 msgid "Expand Machine"
 msgstr "Maschine ausklappen"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "Unterstruktur erweitern"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Erwartete zukünftige Nachfrage nach einem herzustellenden Teil, wöchentlich eingegeben, bevor eine Bestellung vorhanden ist; Planung rechnet sie gegen Angebot und zerlegt die Methode, um Komponenten im Voraus zu bestellen."
+msgstr "Erwarteter zukünftiger Bedarf für ein Eigenfertigungsteil, das Woche für Woche eingegeben wird, bevor ein Kundenauftrag vorhanden ist; die Planung setzt ihn gegen die Deckung ab und explodiert die Methode, um Komponenten im Voraus zu bestellen."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "Erwartete zukünftige Nachfrage nach einem Artikel, nach Periode gegliedert, ausgefüllt durch den Planungslauf neben der tatsächlichen Nachfrage."
+msgstr "Erwarteter zukünftiger Bedarf für einen Artikel, in Perioden eingeteilt, aufgefüllt durch den Planungslauf neben dem tatsächlichen Bedarf."
 
 msgid "Expected Receipt"
 msgstr "Erwarteter Eingang"
@@ -6293,40 +6293,40 @@ msgid "Expected Receipt Date"
 msgstr "Erwartetes Eingangsdatum"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Aufwandskonto für Kundenguthaben, die bei der Debitorenausgleichung als uneinbringlich abgeschrieben werden"
+msgstr "Aufwandskonto für Kundensalden, die beim Debitoren-Abgleich als uneinbringlich abgeschrieben werden"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
-msgstr "Aufwandskonto für aufgeschobene Steueranpassungen auf Abschreibungen"
+msgstr "Aufwandskonto für Anpassungen der latenten Steuern auf Abschreibungen"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "Aufwandskonto für Ausrüstungs- und Anlagenwartung"
+msgstr "Aufwandskonto für Anlagen und Instandhaltung"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
-msgstr "Ausgabenkonto für Devisenverluste, wenn eine Zahlung eine Rechnung in Fremdwährung zu einem ungünstigeren Kurs ausgleicht"
+msgstr "Aufwandskonto für Wechselkursverluste, wenn eine Zahlung eine Rechnung in Fremdwährung zu einem ungünstigeren Kurs begleicht"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Aufwandskonto für Einkäufe ohne Lagerbestand (Dienstleistungen, Verbrauchsmaterial)"
+msgstr "Aufwandskonto für Käufe von nicht lagerhaltigen Artikeln (Dienstleistungen, Verbrauchsmaterialien)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Aufwandskonto, das belastet wird, wenn Bestand gegen einen Verkauf versendet/ausgegeben wird."
+msgstr "Aufwandskonto für die Kosten der verkauften Artikel"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Aufwandseite der aufgeschobenen Steuerbewegungen (gekoppelt mit aufgeschobene Steuerschuld)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Aktivaklasse konnte nicht erstellt werden: {0}"
+msgstr "Aufwandseite für Bewegungen latenter Steuern (gekoppelt mit latenter Steuerschuld)."
 
 msgid "Expenses"
-msgstr "Ausgaben"
+msgstr "Aufwendungen"
 
 msgid "Expert guidance"
 msgstr "Fachkundige Anleitung"
 
 msgid "Expiration date"
-msgstr "Ablaufdatum"
+msgstr "Verfallsdatum"
 
 msgid "Expiration Date"
-msgstr "Ablaufdatum"
+msgstr "Verfallsdatum"
 
 msgid "Expiration Date (applies to all serials on this line)"
 msgstr "Verfallsdatum (gilt für alle Seriennummern in dieser Zeile)"
@@ -6362,13 +6362,13 @@ msgid "Expiring first"
 msgstr "Verfällt zuerst"
 
 msgid "Expiry"
-msgstr "Ablaufdatum"
+msgstr "Verfall"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "Ablauf beginnt, wenn der ausgewählte Prozess abgeschlossen ist."
+msgstr "Der Verfall beginnt, wenn das ausgewählte Verfahren abgeschlossen ist."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "Ablauf beginnt, wenn der ausgewählte Prozess startet."
+msgstr "Der Verfall beginnt, wenn das ausgewählte Verfahren beginnt."
 
 msgid "Expiry trace"
 msgstr "Verfallsdatum-Nachverfolgung"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Zusätzliche Informationen, die mit der Anfrage gesendet werden, z. B. ein Autorisierungsschlüssel; Header-Werte sind im Ausführungsverlauf verborgen, die Namen bleiben jedoch lesbar."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Zusätzliche Tags zum Aufteilen Ihrer GL-Berichte"
+msgstr "Zusätzliche Tags zum Aufschlüsseln Ihrer Hauptbuch-Berichterstattung"
 
 msgid "Fail"
-msgstr "Fehlgeschlagen"
+msgstr "Nicht bestanden"
 
 msgid "Failed"
 msgstr "Fehlgeschlagen"
@@ -6432,7 +6432,7 @@ msgstr "Fehlgeschlagene Merkmale"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (First-Expiry-First-Out)"
+msgstr "Anlagenklasse konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Fehler beim Erstellen des Fehlermodus: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Fehler beim Erstellen des Messtyps: {0}"
+msgstr "Prüfmittelart konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6480,7 +6480,7 @@ msgstr "Fehler beim Erstellen des Standorts: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "Fehler beim Erstellen des Wartungsplans: {0}"
+msgstr "Instandhaltungsplan konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
@@ -6488,7 +6488,7 @@ msgstr "Fehler beim Erstellen der Materialdimension: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "Fehler beim Erstellen der Materialoberfläche: {0}"
+msgstr "Oberflächenbehandlung konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
@@ -6496,11 +6496,11 @@ msgstr "Fehler beim Erstellen des Materialformulars: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "Fehler beim Erstellen der Materialgüte: {0}"
+msgstr "Werkstoffgüte konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Fehler beim Erstellen der Materialsubstanz: {0}"
+msgstr "Grundwerkstoff konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6512,7 +6512,7 @@ msgstr "Fehler beim Erstellen des Materials: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Fehler beim Erstellen der Ablehnungsgrund: {0}"
+msgstr "Ablehnungsgrund konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6536,7 +6536,7 @@ msgstr "Fehler beim Erstellen der Versandmethode: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "Fehler beim Erstellen der Bestandstransferposition: {0}"
+msgstr "Umlagerungsposition konnte nicht erstellt werden: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6556,7 +6556,7 @@ msgstr "Fehler beim Erstellen des Webhooks: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
-msgstr "Fehler beim Erstellen des Arbeitszentrums: {0}"
+msgstr "Arbeitsplatz konnte nicht erstellt werden: {0}"
 
 msgid "Failed to delete file from old location"
 msgstr "Fehler beim Löschen der Datei vom alten Speicherort"
@@ -6583,7 +6583,7 @@ msgid "Failed to initialize Carbon client"
 msgstr "Fehler beim Initialisieren des Carbon-Clients"
 
 msgid "Failed to insert quote line"
-msgstr "Fehler beim Einfügen der Angebotszeile"
+msgstr "Angebotsposition konnte nicht eingefügt werden"
 
 msgid "Failed to insert supplier quote line"
 msgstr "Fehler beim Einfügen der Lieferantenangebotszeile"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Fehler beim Laden von Daten"
 
 msgid "Failed to load inbound inspections"
-msgstr "Fehler beim Laden von Eingangsprüfungen"
+msgstr "Wareneingangsprüfungen konnten nicht geladen werden"
 
 msgid "Failed to load item data"
 msgstr "Fehler beim Laden der Elementdaten"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "Fehler beim Laden der Artikeldetails"
 
 msgid "Failed to load job operations"
-msgstr "Fehler beim Laden von Arbeitsvorgängen"
+msgstr "Auftragsvorgänge konnten nicht geladen werden"
 
 msgid "Failed to load jobs"
-msgstr "Fehler beim Laden von Aufträgen"
+msgstr "Fertigungsaufträge konnten nicht geladen werden"
 
 msgid "Failed to load purchase order lines"
 msgstr "Fehler beim Laden von Bestellpositionen"
@@ -6625,13 +6625,13 @@ msgid "Failed to load receipts"
 msgstr "Fehler beim Laden von Quittungen"
 
 msgid "Failed to load sales order lines"
-msgstr "Fehler beim Laden von Verkaufsauftragszeilen"
+msgstr "Kundenauftragsposition konnten nicht geladen werden"
 
 msgid "Failed to load sales orders"
-msgstr "Verkaufsaufträge konnten nicht geladen werden"
+msgstr "Kundenaufträge konnten nicht geladen werden"
 
 msgid "Failed to load shipment lines"
-msgstr "Fehler beim Laden von Versandpositionen"
+msgstr "Lieferpositionen konnten nicht geladen werden"
 
 msgid "Failed to load shipments"
 msgstr "Fehler beim Laden von Lieferungen"
@@ -6647,7 +6647,7 @@ msgid "Failed to move account: {0}"
 msgstr "Konto konnte nicht verschoben werden: {0}"
 
 msgid "Failed to regenerate thumbnail"
-msgstr "Fehler beim Neuerstellen der Miniaturansicht"
+msgstr "Vorschaubild konnte nicht neu generiert werden"
 
 msgid "Failed to register passkey"
 msgstr "Passkey konnte nicht registriert werden"
@@ -6656,7 +6656,7 @@ msgid "Failed to remove image: {errorMessage}"
 msgstr "Fehler beim Entfernen des Bildes: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "Fehler beim Entfernen des Modellminiaturbild"
+msgstr "Modell-Vorschaubild konnte nicht entfernt werden"
 
 msgid "Failed to remove purchase order"
 msgstr "Fehler beim Entfernen der Bestellung"
@@ -6710,16 +6710,16 @@ msgid "Failed to update item cost"
 msgstr "Fehler beim Aktualisieren der Artikelkosten"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "Fehler beim Aktualisieren der Gelegenheit mit Bestellung"
+msgstr "Verkaufschance konnte nicht mit Bestellung aktualisiert werden"
 
 msgid "Failed to update quote line"
-msgstr "Angebot konnte nicht aktualisiert werden"
+msgstr "Angebotsposition konnte nicht aktualisiert werden"
 
 msgid "Failed to update supplier quote line"
 msgstr "Fehler beim Aktualisieren der Lieferantenangebotszeile"
 
 msgid "Failed to update thumbnail path"
-msgstr "Fehler beim Aktualisieren des Miniaturbildpfads"
+msgstr "Vorschaubild-Pfad konnte nicht aktualisiert werden"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
@@ -6732,7 +6732,7 @@ msgid "Failed to upload CSV file."
 msgstr "CSV-Datei konnte nicht hochgeladen werden."
 
 msgid "Failed to upload file"
-msgstr "Datei-Upload fehlgeschlagen"
+msgstr "Datei konnte nicht hochgeladen werden"
 
 msgid "Failed to upload file to new location"
 msgstr "Fehler beim Hochladen der Datei an den neuen Speicherort"
@@ -6746,13 +6746,13 @@ msgid "Failed to upload image"
 msgstr "Fehler beim Hochladen des Bildes"
 
 msgid "Failed to upload logo: {errorMessage}"
-msgstr "Logo-Upload fehlgeschlagen: {errorMessage}"
+msgstr "Logo konnte nicht hochgeladen werden: {errorMessage}"
 
 msgid "Failed to upload model"
 msgstr "Fehler beim Hochladen des Modells"
 
 msgid "Failed to upload PDF"
-msgstr "PDF-Upload fehlgeschlagen"
+msgstr "PDF konnte nicht hochgeladen werden"
 
 msgid "Failed to upload thumbnail"
 msgstr "Fehler beim Hochladen des Vorschaubildes"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Gebühren"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Oberfläche"
+msgstr "FEFO (Zuerst verfallend, zuerst entnommen)"
 
 msgid "Fetch"
 msgstr "Abrufen"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "Abschließen"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Abschluss eines Geschäftsmonats durch den Open → Locked → Closed-Lebenszyklus; eine geschlossene Periode ist eingefroren und ihre Salden sind erfasst, nur durch explizites Wiedereröffnen rückgängig zu machen."
+msgstr "Abschluss eines Geschäftsmonats durch den Zyklus Offen → Gesperrt → Abgeschlossen; eine abgeschlossene Periode ist eingefroren und ihre Salden sind Snapshots, die nur durch explizites Wieder öffnen rückgängig gemacht werden können."
 
 msgid "Financial Statements"
 msgstr "Jahresabschlussberichte"
@@ -6871,13 +6871,13 @@ msgid "Finish with material unpicked?"
 msgstr "Mit nicht gepicktem Material beenden?"
 
 msgid "Finished goods"
-msgstr "Oberflächen"
+msgstr "fertigwaren"
 
 msgid "Finished Goods"
-msgstr "Fertigerzeugnisse"
+msgstr "Fertigwaren"
 
 msgid "Finished Goods (default)"
-msgstr "Fertigerzeugnisse (Standard)"
+msgstr "Fertigwaren (Standard)"
 
 msgid "finishes"
 msgstr "Zusätzlicher Abzug im ersten Jahr, bevor der reguläre MACRS-Plan beginnt."
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Fest"
 
 msgid "Fixed asset"
-msgstr "Abweichung der Fixkostenabschreibung, wenn die Losgröße vom Standard abweicht"
+msgstr "anlagegut"
 
 msgid "Fixed Asset"
 msgstr "Anlagevermögen"
@@ -6937,10 +6937,10 @@ msgid "Fixed Assets"
 msgstr "Anlagevermögen"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Gewinne und Verluste"
+msgstr "Abweichung der Rüstkostenumlage, wenn die Losgröße vom Sollwert abweicht"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
-msgstr "Festgelegt, sobald Abrechnungsperioden gebucht oder geschlossen wurden. Löschen Sie alle offenen Perioden, um dies zu ändern."
+msgstr "Festgelegt, sobald Buchungsperioden gebucht oder abgeschlossen wurden. Löschen Sie alle offenen Perioden, um dies zu ändern."
 
 msgid "Fixed Reorder"
 msgstr "Feste Nachbestellung"
@@ -6962,16 +6962,16 @@ msgstr "für alles. Sie werden die richtige Person hinzuziehen."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Prognosemethode: <0>{0}</0>. Diese Zeile wurde nicht aus aktiven Aufträgen abgeleitet, daher sind keine übergeordneten Quellen verfügbar."
+msgstr "Prognosemethode: <0>{0}</0>. Diese Zeile wurde nicht von laufenden Fertigungsaufträgen abgeleitet, daher sind keine übergeordneten Quellen verfügbar."
 
 msgid "Forgot to Clock Out?"
-msgstr "Vergessen auszustempeln?"
+msgstr "Ausstempeln vergessen?"
 
 msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Techniker vor Ort"
 
 msgid "Foundation"
 msgstr "Grundlagen"
@@ -6983,10 +6983,10 @@ msgid "Freeze the old system, no new transactions"
 msgstr "Altes System einfrieren, keine neuen Transaktionen"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "Fracht, die dem Kunden für diese Zeile in Rechnung gestellt wird, unabhängig vom Stückpreis der Zeile."
+msgstr "Versandkosten, die dem Kunden für diese Position berechnet werden, getrennt vom Einzelpreis der Position."
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
-msgstr "Fracht, die dieser Lieferant für diese Zeile berechnet, wenn er den Versand separat aufzählt, anstatt ihn in den Stückpreis einzubeziehen."
+msgstr "Versandkosten, die dieser Lieferant für diese Position berechnet, wenn er die Versandkosten separat ausweist, anstatt sie in den Einzelpreis einzurechnen."
 
 msgid "Frequencies"
 msgstr "Häufigkeiten"
@@ -7021,13 +7021,13 @@ msgid "From Storage Unit"
 msgstr "Von Lagereinheit"
 
 msgid "Fulfillment Location"
-msgstr "Erfüllungsort"
+msgstr "Versandstandort"
 
 msgid "Full name"
 msgstr "Vollständiger Name"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Vollständiges Setup und Migrationen"
 
 msgid "Fully Depreciated"
 msgstr "Vollständig abgeschrieben"
@@ -7039,52 +7039,52 @@ msgid "FX G/L"
 msgstr "FX G/L"
 
 msgid "Gain on Disposal"
-msgstr "Gewinn aus Veräußerung"
+msgstr "Gewinn aus Abgang"
 
 msgid "Gain on Disposal (default)"
-msgstr "Gewinn aus Veräußerung (Standard)"
+msgstr "Gewinn aus Abgang (Standard)"
 
 msgid "Gain on Disposal Account"
-msgstr "Konto für Gewinn aus Veräußerung"
+msgstr "Konto für Gewinn aus Abgang"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "Bei der Veräußerung von Anlagevermögen erfasste Gewinne"
+msgstr "Gewinne, die bei der Veräußerung von Anlagegütern anfallen"
 
 msgid "gauge"
-msgstr "Spurweiten"
+msgstr "prüfmittel"
 
 msgid "Gauge"
-msgstr "Messinstrument"
+msgstr "Prüfmittel"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Kalibrierung von Messinstrumenten – Benachrichtigungen"
+msgstr "Kalibrierbenachrichtigungen für Prüfmittel"
 
 msgid "Gauge ID"
-msgstr "Messuhr-ID"
+msgstr "Prüfmittel-ID"
 
 msgid "Gauge not found"
-msgstr "Messuhr nicht gefunden"
+msgstr "Prüfmittel nicht gefunden"
 
 msgid "Gauge Type"
-msgstr "Messgerätetyp"
+msgstr "Prüfmittelart"
 
 msgid "Gauge Types"
-msgstr "Messuhr-Typen"
+msgstr "Prüfmittelarten"
 
 msgid "gauges"
-msgstr "Genealogie"
+msgstr "prüfmittel"
 
 msgid "Gauges"
-msgstr "Messinstrumente"
+msgstr "Prüfmittel"
 
 msgid "Genealogy"
-msgstr "Hauptbuch"
+msgstr "Genealogie"
 
 msgid "General"
 msgstr "Allgemein"
 
 msgid "General ledger"
-msgstr "GL-Konto, das Kostenunterschiede bei Fremdbearbeitungsvorgängen erfasst."
+msgstr "hauptbuch"
 
 msgid "General Ledger"
 msgstr "Hauptbuch"
@@ -7096,7 +7096,7 @@ msgid "Generate"
 msgstr "Generieren"
 
 msgid "Generate a new 4-digit PIN. Share it with the operator so they can pin in at MES terminals."
-msgstr "Generieren Sie eine neue 4-stellige PIN. Teilen Sie diese mit dem Bediener, damit er sich an MES-Terminals anmelden kann."
+msgstr "Generieren Sie eine neue 4-stellige PIN. Teilen Sie sie dem Werker mit, damit er sich an MES-Terminals anmelden kann."
 
 msgid "Generate and send customer invoices"
 msgstr "Kundenrechnungen generieren und versenden"
@@ -7126,10 +7126,10 @@ msgid "Generating suggestions…"
 msgstr "Vorschläge werden generiert…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "Gehen Sie live auf Carbon: ein System, das Angebote, Einkauf, Shopfloor, Bestand und Finanzen ausführt und die aktuellen Tools ersetzt."
+msgstr "Starten Sie mit Carbon: ein System für Angebote, Einkauf, Werkstatt, Bestände und Finanzen, das die bisherigen Tools ersetzt."
 
 msgid "Get Method"
-msgstr "Methode abrufen"
+msgstr "Methode übernehmen"
 
 msgid "Get started"
 msgstr "Erste Schritte"
@@ -7144,25 +7144,25 @@ msgid "Getting set up"
 msgstr "Erste Schritte"
 
 msgid "Give it an owner and a date"
-msgstr "Geben Sie es einem Besitzer und einem Datum"
+msgstr "Weisen Sie einen Verantwortlichen und ein Datum zu"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Hauptbuch"
 
 msgid "GL Account"
 msgstr "Sachkonto"
 
 msgid "GL account capturing cost differences on outside-processing operations."
-msgstr "GL-Konto, das Kostenunterschiede bei Fremdbearbeitungsvorgängen erfasst."
+msgstr "Sachkonto zur Erfassung von Kostenabweichungen bei Fremdbearbeitung."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "GL-Konto, das Unterschiede zwischen kalkuliertem und tatsächlichem Fertigungsaufwand erfasst."
+msgstr "Sachkonto zur Erfassung der Abweichungen zwischen umgelegten und tatsächlichen Fertigungsgemeinkosten."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "GL-Konto, das Unterschiede zwischen BOM-erwarteten und tatsächlich verbrauchtem Material erfasst."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "GL-Konto, das Unterschiede zwischen routing-erwarteter und tatsächlicher Arbeits-/Maschinenzeit erfasst."
+msgstr "Sachkonto zur Erfassung der Abweichungen zwischen plan- und ist-Personal-/Maschinenzeiten."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "GL-Konto, das Fixkostenunterschiede erfasst, wenn die tatsächliche Losgröße von der geplanten abweicht."
@@ -7171,34 +7171,34 @@ msgid "GL account credited to remove the asset's original cost when it is dispos
 msgstr "GL-Konto, das gutgeschrieben wird, um die ursprünglichen Kosten des Anlagevermögens bei dessen Entsorgung zu entfernen."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "GL-Konto, das gutgeschrieben wird, wenn eine Lieferantenrechnung gebucht wird (AP-Saldo)."
+msgstr "Sachkonto, das gutgeschrieben wird, wenn eine Lieferantenrechnung gebucht wird (Kreditorensaldo)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "GL-Konto, das gutgeschrieben wird, wenn Arbeits- oder Maschinenkosten in einen Produktionsauftrag aufgenommen werden."
+msgstr "Sachkonto, das gutgeschrieben wird, wenn Personal- oder Maschinenkosten in einen Fertigungsauftrag aufgenommen werden."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
-msgstr "GL-Konto, das gutgeschrieben wird, wenn Herstellungsgemeinkosten in einen Produktionsauftrag aufgenommen werden."
+msgstr "Sachkonto, das gutgeschrieben wird, wenn Fertigungsgemeinkosten in einen Fertigungsauftrag aufgenommen werden."
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "GL-Konto, das belastet wird, um die angesammelte Abschreibung zu löschen, wenn ein Vermögenswert entsorgt wird."
+msgstr "Sachkonto, das belastet wird, um die kumulierte Abschreibung zu löschen, wenn ein Anlagegut abgegangen ist."
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
 msgstr "GL-Konto, das belastet wird, wenn eine Kundenrechnung gebucht wird; gelöscht, wenn der Kunde bezahlt."
 
 msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
-msgstr "GL-Konto, das belastet wird, wenn ein Anlagevermögen erworben wird (Kauf oder aktivierter Betrag)."
+msgstr "Sachkonto, das belastet wird, wenn ein Anlagegut erworben wird (Kauf oder aktivierte Kosten)."
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "GL-Konto für Bankgebühren und ähnliche Kosten."
+msgstr "Sachkonto für Bankgebühren und ähnliche Gebühren."
 
 msgid "GL account for interest income or expense."
-msgstr "GL-Konto für Zinseinnahmen oder -ausgaben."
+msgstr "Sachkonto für Zinseinnahmen oder Zinsaufwendungen."
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "GL-Konto für die an Lieferanten gezahlte Vorsteuer (abzugsfähig bzw. erstattungsfähig)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "GL-Konto für Steuern, die unter Reverse-Charge-Regeln anfallen, wenn der Käufer die Steuer selbst berechnet."
+msgstr "Sachkonto für Steuern, die nach Reverse-Charge-Regelungen anfallen, wenn der Käufer selbst einzieht."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "GL-Konto für Steuerzeitunterschiede (z.B. beschleunigte Steuerabschreibung vs. Buchwertabschreibung)."
@@ -7207,7 +7207,7 @@ msgid "GL account hit when physical counts differ from system inventory."
 msgstr "GL-Konto, das bebucht wird, wenn die körperliche Bestandszählung vom Systembestand abweicht."
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "GL-Konto in dem Quellunternehmen, das für diese konzerninterne Transaktion belastet wird."
+msgstr "Sachkonto im Quellenunternehmen, das für diese Intercompany-Transaktion belastet wird."
 
 msgid "GL account in the target company to credit for this intercompany transaction."
 msgstr "GL-Konto in dem Zielunternehmen, das für diese konzerninterne Transaktion gutgeschrieben wird."
@@ -7222,13 +7222,13 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "GL-Konto, das die ursprünglichen Anschaffungskosten eines Vermögenswerts führt — belastet bei Erwerb und in voller Höhe der Anschaffungskosten gutgeschrieben, wenn er entsorgt oder verkauft wird."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "GL-Konto, das den Wert von Arbeitsaufträgen in der Produktion hält, bis sie auf fertige Waren buchen."
+msgstr "Sachkonto, das den Wert der Fertigungsaufträge in der Produktion hält, bis sie auf Fertigwaren gebucht werden."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
-msgstr "Sachkonto, das den Wert hergestellter Waren (Herstellartikel) enthält; belastet bei Auftragsabschluss, entlastet bei Versand."
+msgstr "Sachkonto, das den Wert der gefertigten Waren (Eigenfertigung-Artikel) hält; wird beim Abschluss des Fertigungsauftrags belastet, beim Versand gutgeschrieben."
 
 msgid "GL account that holds the value of purchased stock and components (Buy items); debited on receipt, credited on issue/shipment."
-msgstr "Sachkonto, das den Wert gekaufter Bestände und Komponenten (Kaufartikel) enthält; belastet bei Eingang, entlastet bei Entnahme/Versand."
+msgstr "Sachkonto, das den Wert des gekauften Bestands und der Komponenten (Fremdbeschaffungs-Artikel) hält; wird bei Wareneingang belastet, bei Materialentnahme/Versand gutgeschrieben."
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
 msgstr "GL-Konto, das verwendet wird, wenn ein Kunde vor Ausstellung einer Rechnung bezahlt; wird gelöscht, wenn die Rechnung gebucht wird."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "GL-Konto, auf dem von Lieferanten in Anspruch genommene Frühzahlungsrabatte erfasst werden."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "GL-Gegenkonto zum Anlagevermögen, das bei jeder periodischen Abschreibungsbuchung gutgeschrieben und bei Verkauf oder Verschrottung des Vermögenswerts in voller Höhe belastet wird."
+msgstr "Gegenpositions-Sachkonto zur Bilanzaktiva, das gutgeschrieben wird, wenn Abschreibung in jeder Periode gebucht wird, und vollständig belastet wird, wenn das Anlagegut verkauft oder abgegangen ist."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "GL-Gegenkonto für Vermögenswerte, das Abschreibungen sammelt, die gegen Anlagevermögen verbucht werden."
+msgstr "Gegenpositions-Sachkonto zur Bilanzaktiva, das die kumulierte Abschreibung gegen Anlagegüter sammelt."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "GL-Eigenkapitalkonto (CTA-Reserve), das nicht realisierte Wechselkursdifferenzen aus der Neubewertung von Fremdwährungssalden am Periodenende hält; getrennt von realisierten Wechselkursgewinnen/-verlusten in der GuV."
+msgstr "Eigenkapital-Sachkonto (CTA-Rückstellung), das nicht realisierte Wechselkursdifferenzen aus der Neuumrechnung von Fremdwährungssalden am Periodenende hält; getrennt vom realisierten Wechselkursgewinn/-verlust in der Gewinn- und Verlustrechnung."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "GL-Eigenkapitalkonto, auf das der Nettoertrag am Geschäftsjahresende abgeschlossen wird."
+msgstr "Eigenkapital-Sachkonto, auf dem der Nettogewinn am Ende des Geschäftsjahres abgeschlossen wird."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "GL-Ausgabenkonto, das jede Periode belastet wird, wenn Abschreibungen gebucht werden."
+msgstr "Aufwands-Sachkonto, das in jeder Periode belastet wird, wenn Abschreibung gebucht wird."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "GL-Aufwandskonto, das belastet wird, wenn der Buchwert eines Vermögenswerts durch eine Wertminderung reduziert wird, d.h. wenn der erzielbare Betrag unter den Nettobuchwert fällt."
+msgstr "Aufwands-Sachkonto, das belastet wird, wenn der Buchwert eines Anlageguts durch eine Wertminderung reduziert wird, d. h. wenn sein erzielbarer Betrag unter den Restbuchwert fällt."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "GL-Ausgabenkonto für Käufe ohne Bestandsaufnahme (Verbrauchsmaterialien, Dienstleistungen)."
+msgstr "Aufwands-Sachkonto für Nicht-Bestands-Käufe (Materialien, Dienstleistungen)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "GL-Haftungskonto für Umsatzsteuer, die von Kunden eingezogen wird."
+msgstr "Verbindlichkeiten-Sachkonto, das für eingezogene Umsatzsteuer von Kunden gutgeschrieben wird."
 
 msgid "GL tie-out"
-msgstr "GL-Abstimmung"
+msgstr "Sachkontoabstimmung"
 
 msgid "GL Tie-Out"
-msgstr "GL-Abstimmung"
+msgstr "Sachkontoabstimmung"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Starten Sie richtig beim ersten Mal — mit unserem Team an Ihrer Seite"
@@ -7277,7 +7277,7 @@ msgid "Go to {0}"
 msgstr "Gehe zu {0}"
 
 msgid "Go to implementation hub"
-msgstr "Gehe zum Implementierungs-Hub"
+msgstr "Zum Umsetzungs-Hub gehen"
 
 msgid "Go-Live"
 msgstr "Go-Live"
@@ -7313,13 +7313,13 @@ msgid "Google Places API key not configured"
 msgstr "Google Places API-Schlüssel nicht konfiguriert"
 
 msgid "GR/IR (goods received, not invoiced)"
-msgstr "GR/IR (Waren eingegangen, nicht in Rechnung gestellt)"
+msgstr "WE/RE (Wareneingang, nicht fakturiert)"
 
 msgid "GR/IR Clearing"
-msgstr "GR/IR-Clearing"
+msgstr "WE/RE-Ausgleich"
 
 msgid "GR/IR Clearing (default)"
-msgstr "GR/IR-Clearing (Standard)"
+msgstr "WE/RE-Ausgleich (Standard)"
 
 msgid "grade"
 msgstr "Klasse"
@@ -7355,10 +7355,10 @@ msgid "Guided"
 msgstr "Geführt"
 
 msgid "Guided implementation"
-msgstr "Geführte Implementierung"
+msgstr "Geführte Umsetzung"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Wiederkehrende und stornierende Journaleinträge verarbeiten"
+msgstr "Wiederkehrende und stornierte Buchungssätze verwalten"
 
 msgid "Hands-on"
 msgstr "Praktisch"
@@ -7409,7 +7409,7 @@ msgid "History"
 msgstr "Verlauf"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Das Journal als Warnung zum Beheben halten."
+msgstr "Den Buchungssatz als Warnung zum Beheben speichern."
 
 msgid "Holiday"
 msgstr "Feiertag"
@@ -7442,13 +7442,13 @@ msgid "Hours/Piece"
 msgstr "Stunden/Stück"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Wie ein Element insgesamt aufgefüllt wird (Kauf, Herstellung oder Kauf und Herstellung), auf Elementebene gesetzt, im Gegensatz zum Methodentyp pro Zeile."
+msgstr "Wie ein Artikel insgesamt aufgefüllt wird (Fremdbeschaffung, Eigenfertigung oder Fremdbeschaffung und Eigenfertigung), pro Artikel festgelegt, anders als die Bereitstellungsart pro Position."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Wie ein Element aufgefüllt wird: Manueller Nachbestellung, Nachbestellung auf Nachfragebasis, Nachbestellung mit fester Menge oder Maximale Menge."
 
 msgid "How an item is sourced when added to a method or BOM line."
-msgstr "Wie ein Element bezogen wird, wenn es einer Methode- oder Stücklisten-Zeile hinzugefügt wird."
+msgstr "Wie ein Artikel beschafft wird, wenn er zu einer Methode oder BOM-Position hinzugefügt wird."
 
 msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
 msgstr "Wie der Stückkosten eines Elements bewertet wird: Standard, Durchschnitt, FIFO oder LIFO. Pro Element gesetzt."
@@ -7460,7 +7460,7 @@ msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank
 msgstr "Wie lange jede Phase läuft, in Wochen. Bestimmt die Plan-Zeitleiste; lassen Sie das Feld leer, um den Standard zu verwenden."
 
 msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
-msgstr "Wie lange eine Ausführung dieses Zeitplans normalerweise dauert; Die Planung sperrt das Arbeitszentrum für diese viele Minuten für jede geplante Instanz."
+msgstr "Wie lange eine Ausführung dieses Terminplans typischerweise dauert; die Planung blockiert den Arbeitsplatz für diese Anzahl von Minuten bei jeder geplanten Instanz."
 
 msgid "How many"
 msgstr "Wie viele"
@@ -7487,7 +7487,7 @@ msgid "How many of the successor replace one old part"
 msgstr "Wie viele der Nachfolger ersetzen ein altes Teil"
 
 msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
-msgstr "Wie viel dieses Materials es braucht, um eine vom Auftrag übergeordnetes Element zu bauen; multipliziert mit Auftragsquantität, um den Verbrauch zu bestimmen."
+msgstr "Wie viele dieses Werkstoffs benötigt werden, um ein übergeordnetes Teil des Fertigungsauftrags herzustellen; multipliziert mit der Fertigungsauftrag-Menge, um den Verbrauch zu berechnen."
 
 msgid "How many units each individual job in the bulk batch builds; the last job's quantity may be smaller if Total Quantity doesn't divide evenly."
 msgstr "Wie viele Einheiten jeder einzelne Auftrag in der Stapelcharge baut; die Menge des letzten Auftrags kann kleiner sein, wenn sich die Gesamtmenge nicht gleichmäßig teilt."
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Wie oft dieser Messschieber neu kalibriert werden muss; kombiniert mit Letztes Kalibrierungsdatum, um das nächste Kalibrierungsdatum automatisch neu zu berechnen."
+msgstr "Wie oft dieses Prüfmittel kalibriert werden muss; kombiniert mit dem letzten Kalibrierungsdatum, um das nächste Kalibrierungsdatum automatisch neu zu berechnen."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Wie oft diese Wartung wiederkehrt — Täglich, Wöchentlich, Monatlich, Bei Zykluszählung; Täglich zeigt den Wochentag-Selektor an, die anderen verwenden einfachere Intervallmathematik."
+msgstr "Wie oft diese Instandhaltung wiederkehrt — Täglich, Wöchentlich, Monatlich, Bei Permanenter Inventur; Täglich zeigt die Wähler für Wochentage an, die anderen verwenden einfachere Intervallberechnung."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Wie streng das Fälligkeitsdatum ist — Hard Deadline blockiert die Planung, Soft Deadline lässt die Planung mit einer Warnung schieben, No Deadline ignoriert es ganz."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "Wie das Material beschafft wird (Herstellen, Einkaufen oder Entnahme aus dem Bestand) und die Lagereinheit, aus der es entnommen wird."
+msgstr "Wie der Werkstoff beschafft wird (Eigenfertigung, Kauf oder Entnahme aus Bestand) und die Lagereinheit, aus der er entnommen wird."
 
 msgid "How the resolved price was calculated."
 msgstr "Wie der aufgelöste Preis berechnet wurde."
@@ -7514,7 +7514,7 @@ msgid "How the sample size is decided — Inspect All, Inspect First N, Percenta
 msgstr "Wie die Stichprobengröße entschieden wird — Alle inspizieren, Erste N inspizieren, Prozentsatz des Loses oder AQL (Z1.4 / ISO 2859-1). Jeder Modus zeigt seine eigenen Parameterfelder unten."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Wie dieses Messinstrument verwendet wird — Standard (regelmäßige Kontrollen) oder Meister (kalibriert andere Messinstrumente)."
+msgstr "Wie dieses Prüfmittel verwendet wird — Normal (regelmäßige Überprüfungen) oder Referenz (kalibriert andere Prüfmittel)."
 
 msgid "How this price was calculated"
 msgstr "Wie dieser Preis berechnet wurde"
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "So liest du dieses Diagramm"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Wie dringend diese Bestellung ist — Niedrig / Mittel / Hoch / Kritisch; kombiniert mit Priorität und OEE-Auswirkung, um den Zeitplanzugangs zu entscheiden."
+msgstr "Wie dringend dieser Instandhaltungsauftrag ist — Niedrig / Mittel / Hoch / Kritisch; kombiniert mit Priorität und OEE-Auswirkung, um den Terminplanplatz zu bestimmen."
 
 msgid "How we know we're done"
 msgstr "Wie wir wissen, dass wir fertig sind"
@@ -7595,19 +7595,19 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "Wenn es nicht bis zum nächsten Anruf warten kann, entscheiden die Leiter auf beiden Seiten."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "Wenn es blockiert oder ein Termin gefährdet ist, erhält es einen Besitzer und wird nachverfolgt."
+msgstr "Falls es blockiert oder ein Datum gefährdet ist, erhält es einen Verantwortlichen und wird nachverfolgt."
 
 msgid "If items already exist"
 msgstr "Wenn Artikel bereits vorhanden sind"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "Falls bestellt, kein Lagerbestand in den nächsten 48 Wochen prognostiziert"
+msgstr "Falls bestellt, ist kein Fehlbestand in den nächsten 48 Wochen geplant"
 
 msgid "If something is off track"
 msgstr "Wenn etwas aus dem Ruder läuft"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "Wenn Sie die Teilenummern ändern möchten, klicken Sie bitte auf Abbrechen und weisen Sie die Teile für jedes Zeilenelement manuell zu, bevor Sie konvertieren."
+msgstr "Wenn Sie die Teilenummern ändern möchten, klicken Sie bitte Abbrechen und weisen Sie manuell die Teile für jede Position zu, bevor Sie konvertieren."
 
 msgid "II (normal default)"
 msgstr "II (normalstandard)"
@@ -7622,13 +7622,13 @@ msgid "Imperial"
 msgstr "Imperial"
 
 msgid "Implementation"
-msgstr "Implementierung"
+msgstr "Umsetzung"
 
 msgid "Implementation Hub"
-msgstr "Implementierungs-Hub"
+msgstr "Umsetzungs-Hub"
 
 msgid "Implementation Lead"
-msgstr "Implementierungsleiter"
+msgstr "Umsetzungsleiter"
 
 msgid "Import {label} CSV"
 msgstr "Importiere {label} CSV"
@@ -7637,14 +7637,14 @@ msgid "Import results"
 msgstr "Importergebnisse"
 
 msgid "Import your BOM"
-msgstr "Importieren Sie Ihre Stückliste"
+msgstr "Importieren Sie Ihre BOM"
 
 #. placeholder {0}: precise?.text
 msgid "in {0}"
 msgstr "in {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "Bearbeiten Sie in Onshape die Berechtigungen dieser OAuth-Anwendung, sodass sie „Application can write to your documents“ enthalten, und verbinden Sie sich dann erneut."
+msgstr "Bearbeiten Sie in Onshape die Berechtigungen dieser OAuth-Anwendung, um \"Application can write to your documents\" einzubeziehen, und verbinden Sie sich dann erneut."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Um diese Anfrage in ein Angebot umzuwandeln, müssen alle Positionen eine interne Teilenummer haben."
@@ -7653,7 +7653,7 @@ msgid "In order to convert this RFQ to a quote, it must be associated with a cus
 msgstr "Um diese Anfrage in ein Angebot umzuwandeln, muss sie mit einem Kunden verknüpft sein."
 
 msgid "In order to convert this RFQ to a quote, it must have a customer."
-msgstr "Um diese Anfrage in ein Angebot umzuwandeln, muss sie einen Kunden haben."
+msgstr "Um diese Anfrage in ein Angebot umzuwandeln, muss ein Kunde vorhanden sein."
 
 msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
 msgstr "Um diese RFQ an Lieferanten zu senden, müssen Sie zunächst Lieferanten zur RFQ hinzufügen."
@@ -7707,7 +7707,7 @@ msgid "Inbox"
 msgstr "Posteingang"
 
 msgid "Include extra parts in shipment"
-msgstr "Zusätzliche Teile in Sendung einbeziehen"
+msgstr "Zusätzliche Teile zur Lieferung hinzufügen"
 
 msgid "Include Inactive"
 msgstr "Inaktive einschließen"
@@ -7719,7 +7719,7 @@ msgid "Includes tax and shipping costs"
 msgstr "Enthält Steuern und Versandkosten"
 
 msgid "Income / Balance (inherited)"
-msgstr "Einkommen / Bilanz (geerbt)"
+msgstr "Erträge / Saldo (geerbt)"
 
 msgid "Income Statement"
 msgstr "Gewinn- und Verlustrechnung"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "Einkommensteuer"
 
 msgid "Income/Balance"
-msgstr "Einnahmen/Bilanz"
+msgstr "Erträge/Saldo"
 
 msgid "incoming"
 msgstr "eingehend"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Geerbt vom übergeordneten Element"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Geerbt aus der Gruppe: Top-Level-Klassifizierung (Vermögenswert, Haftung, Eigenkapital, Einnahme, Ausgabe)."
+msgstr "Geerbt aus der Gruppe: oberste Klassifizierung (Anlage, Verbindlichkeit, Eigenkapital, Umsatzerlöse, Aufwand)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Geerbt aus der Gruppe: wo dieses Konto auf Finanzberichten erscheint."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Geerbt aus der Gruppe: ob dieses Konto zum Einbehalt von Gewinnen (Einkommen) oder Weiterleitung (Bilanz) schließt."
+msgstr "Geerbt aus der Gruppe: ob dieses Konto zum Gewinnvortrag (Erträge) geschlossen wird oder vorgetragen wird (Saldo)."
 
 msgid "Inherited from the parent group."
 msgstr "Geerbt aus der übergeordneten Gruppe."
@@ -7803,37 +7803,37 @@ msgid "Inspect Item"
 msgstr "Artikel überprüfen"
 
 msgid "Inspection"
-msgstr "Inspektion"
+msgstr "Prüfung"
 
 msgid "Inspection document"
-msgstr "Inspektionsdokument"
+msgstr "Prüfdokument"
 
 msgid "Inspection Level"
-msgstr "Inspektionsstufe"
+msgstr "Prüfniveau"
 
 msgid "Inspection Plan"
-msgstr "Inspektionsplan"
+msgstr "Prüfplan"
 
 msgid "Inspection Plan Assignments"
-msgstr "Inspektionsplan-Zuweisungen"
+msgstr "Prüfplan-Zuordnungen"
 
 msgid "Inspection Plans"
-msgstr "Inspektionspläne"
+msgstr "Prüfpläne"
 
 msgid "Inspection Status"
-msgstr "Inspektionsstatus"
+msgstr "Prüfstatus"
 
 msgid "Inspections"
-msgstr "Inspektionen"
+msgstr "Prüfungen"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Inspektionen, Nichtkonformität und CAPA"
+msgstr "Prüfungen, Nichtkonformität und CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Inspektionen, Nichtkonformität, CAPA"
+msgstr "Prüfungen, Nichtkonformität, CAPA"
 
 msgid "Inspections: Require Different Inspector"
-msgstr "Inspektionen: Unterschiedlichen Inspektor erforderlich"
+msgstr "Prüfungen: Unterschiedliche Inspektoren erforderlich"
 
 msgid "Install"
 msgstr "Installieren"
@@ -7845,7 +7845,7 @@ msgid "Instructions"
 msgstr "Anweisungen"
 
 msgid "Instructions are inherited from the procedure."
-msgstr "Anweisungen werden vom Verfahren geerbt."
+msgstr "Anweisungen werden von der Verfahrensanweisung geerbt."
 
 msgid "Integration"
 msgstr "Integration"
@@ -7863,7 +7863,7 @@ msgid "Intercompany"
 msgstr "Intercompany"
 
 msgid "Intercompany Balances"
-msgstr "Konzernausgleiche"
+msgstr "Konzernübergreifende Salden"
 
 msgid "Intercompany company"
 msgstr "Konzernunternehmen"
@@ -7875,10 +7875,10 @@ msgid "Intercompany transactions involving this company that are still Unmatched
 msgstr "Konzerninternen Transaktionen, die dieses Unternehmen betreffen und noch nicht abgestimmt sind, sollten abgestimmt und eliminiert werden, damit konsolidierte Ergebnisse die Aktivität zwischen Entitäten nicht doppelt erfassen."
 
 msgid "Interest"
-msgstr "Interesse"
+msgstr "Zinsen"
 
 msgid "Interest (default)"
-msgstr "Interesse (Standard)"
+msgstr "Zinsen (Standard)"
 
 msgid "Interest income or expense from banking activities"
 msgstr "Zinsertrag oder -aufwand aus Bankaktivitäten"
@@ -7917,10 +7917,10 @@ msgid "Inventory actions"
 msgstr "Bestandsverwaltungsaktionen"
 
 msgid "Inventory Adjustment"
-msgstr "Bestandsanpassung"
+msgstr "Bestandskorrektur"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Bestandsanpassung (Standard)"
+msgstr "Bestandskorrektur (Standard)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Bestand und Einkauf mit automatisierter Planung"
@@ -7953,7 +7953,7 @@ msgid "Inventory Tracking"
 msgstr "Bestandsverfolgung"
 
 msgid "Inventory Unit of Measure"
-msgstr "Bestandseinheit"
+msgstr "Bestands-Mengeneinheit"
 
 msgid "Inventory Valuation"
 msgstr "Bestandsbewertung"
@@ -8028,7 +8028,7 @@ msgid "Invoiced"
 msgstr "Fakturiert"
 
 msgid "Invoiced Amount:"
-msgstr "Rechnungsbetrag:"
+msgstr "Fakturierter Betrag:"
 
 msgid "Invoiced Statuses"
 msgstr "Fakturierte Status"
@@ -8040,7 +8040,7 @@ msgid "Invoices this memo has been applied to. Click a row to open the document.
 msgstr "Rechnungen, auf die dieses Memo angewendet wurde. Klicken Sie auf eine Zeile, um das Dokument zu öffnen."
 
 msgid "Invoicing"
-msgstr "Rechnungsstellung"
+msgstr "Fakturierung"
 
 msgid "is"
 msgstr "ist"
@@ -8049,7 +8049,7 @@ msgid "is any of"
 msgstr "ist einer von"
 
 msgid "Is console operator"
-msgstr "Ist Konsolenoperator"
+msgstr "Ist Konsolenbediener"
 
 msgid "Is customer org group"
 msgstr "Ist Kundenorganisationsgruppe"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "Problemablauf-Workflows"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "Problemarbeitsabläufe definierten die voreingestellten Werte für ein Problem. Beispielsweise können Sie einen 8D-Arbeitsablauf oder einen Eindämmungsarbeitsablauf haben."
+msgstr "Abweichungs-Workflows definieren die voreingestellten Werte für eine Abweichung. Sie können beispielsweise einen 8D-Workflow oder einen Containment-Workflow haben."
 
 msgid "Issued"
 msgstr "Ausgegeben"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Probleme"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Es wird nicht mehr ausgeführt, bis Sie erneut eine Version veröffentlichen. Nichts wird gelöscht."
 
 msgid "ITAR Certifications"
 msgstr "ITAR-Zertifikationen"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Artikelstamm und Fertigungsmethoden"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Artikelstamm, Stücklisten und Fertigungsprozess"
+msgstr "Artikel-Stammdaten, BOMs und Arbeitsgangliste"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "Element muss einem ausgewählten Typ UND einer ausgewählten Gruppe entsprechen"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Artikel in diesem Fenster erhalten ein gelbes Abzeichen."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Artikel: Artikelstamm, Stücklisten, Fertigungsprozess, Konstruktionsänderungen, CAD"
+msgstr "Artikel: Artikel-Stammdaten, BOMs, Arbeitsgangliste, technische Änderungen, CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "Sein Design kann sich ändern, bevor die Änderungsmitteilung freigegeben wird."
@@ -8229,13 +8229,13 @@ msgid "Job Materials"
 msgstr "Auftragsmaterialien"
 
 msgid "Job operation"
-msgstr "Joboperation"
+msgstr "Auftragsvorgang"
 
 msgid "Job Operation"
-msgstr "Arbeitsgang"
+msgstr "Auftragsvorgang"
 
 msgid "Job Operations"
-msgstr "Arbeitsvorgänge"
+msgstr "Auftragsvorgang­änge"
 
 msgid "Job Priority"
 msgstr "Auftragspriorität"
@@ -8244,38 +8244,38 @@ msgid "Job readable"
 msgstr "Auftrag lesbar"
 
 msgid "Job Traveler"
-msgstr "Arbeitsbegleitzettel"
+msgstr "Fertigungsauftrag-Laufkarte"
 
 msgid "Jobs"
-msgstr "Aufträge"
+msgstr "Fertigungsaufträge"
 
 msgid "Jobs Assigned to Me"
-msgstr "Mir zugewiesene Aufträge"
+msgstr "Mir zugewiesene Fertigungsaufträge"
 
 msgid "Jobs Required"
-msgstr "Aufträge erforderlich"
+msgstr "Erforderliche Fertigungsaufträge"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Aufträge, die diesen Artikel auf ihrer Stückliste haben"
+msgstr "Fertigungsaufträge, die diesen Artikel auf ihrer Stückliste haben"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Treten Sie {0} bei"
 
 msgid "Journal"
-msgstr "Tagebuch"
+msgstr "Buchungssatz"
 
 msgid "Journal Entries"
-msgstr "Journaleinträge"
+msgstr "Buchungszeilen"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "Journaleinträge mit Datum in dieser Periode, die noch im Entwurf sind, müssen gebucht oder in eine spätere offene Periode umgebucht werden. Entwurfseinträge sind nicht Teil des Ledgers, daher würden ihre Belastungen und Gutschriften beim Abschluss fehlen."
+msgstr "Buchungszeilen mit Datum in diesem Zeitraum, die sich noch im Entwurf befinden, müssen gebucht oder in einen späteren offenen Zeitraum neu datiert werden. Entwurfzeilen sind nicht Teil des Hauptbuchs, daher würden ihre Sollbeträge und Habenbeträge im Abschluss fehlen."
 
 msgid "Journal Entry"
-msgstr "Journaleintrag"
+msgstr "Buchungszeile"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Journale mit Datum am oder vor diesem Datum werden als gesperrt behandelt. Mit dem vom Provider gemeldeten Sperrungsdatum zusammengeführt, wenn beide existieren."
+msgstr "Buchungssätze mit Datum an oder vor diesem Datum werden als gesperrt behandelt. Sie werden mit dem vom Anbieter gemeldeten Sperrdatum zusammengeführt, falls beide vorhanden sind."
 
 msgid "Just one"
 msgstr "Nur eine"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Aktuell behalten"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Behalten Sie bestehende Preise, fügen Sie nur neue Artikel hinzu"
+msgstr "Behalten Sie die bestehenden Preise, fügen Sie nur neue Artikel hinzu."
 
 msgid "Keep only items where…"
 msgstr "Nur Artikel behalten, bei denen…"
@@ -8323,7 +8323,7 @@ msgid "Kind of record"
 msgstr "Art des Datensatzes"
 
 msgid "Kit"
-msgstr "Bausatz"
+msgstr "Set"
 
 msgid "Label"
 msgstr "Bezeichnung"
@@ -8342,40 +8342,40 @@ msgid "Labels"
 msgstr "Etiketten"
 
 msgid "Labor"
-msgstr "Arbeit"
+msgstr "Personal"
 
 msgid "Labor & Machine Absorption"
-msgstr "Arbeits- und Maschinenabsorption"
+msgstr "Personal- & Maschinenabsorption"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "Arbeits- und Maschinenabsorption (Standard)"
+msgstr "Personal- & Maschinenabsorption (Standard)"
 
 msgid "Labor & Machine Variance"
-msgstr "Arbeits- und Maschinen-Varianz"
+msgstr "Personal- & Maschinenabweichung"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Arbeits- und Maschinen-Varianz (Standard)"
+msgstr "Personal- & Maschinenabweichung (Standard)"
 
 msgid "Labor rate"
-msgstr "Arbeitssatz"
+msgstr "Personalsatz"
 
 msgid "Labor Rate"
-msgstr "Arbeitssatz"
+msgstr "Personalsatz"
 
 msgid "Labor Rate (Hourly)"
-msgstr "Arbeitssatz (Stundensatz)"
+msgstr "Personalsatz (stündlich)"
 
 msgid "Labor time"
-msgstr "Arbeitszeit"
+msgstr "Personalzeit"
 
 msgid "Labor Time"
-msgstr "Arbeitszeit"
+msgstr "Personalzeit"
 
 msgid "Labor unit"
-msgstr "Arbeitseinheit"
+msgstr "Personaleinheit"
 
 msgid "Labor Unit"
-msgstr "Arbeitseinheit"
+msgstr "Personaleinheit"
 
 msgid "Language"
 msgstr "Sprache"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Breitengrad"
 
 msgid "Lead time"
-msgstr "Vorlaufzeit"
+msgstr "Beschaffungszeit"
 
 msgid "Lead Time"
-msgstr "Lieferzeit"
+msgstr "Beschaffungszeit"
 
 msgid "Lead time (days)"
-msgstr "Lieferzeit (Tage)"
+msgstr "Beschaffungszeit (Tage)"
 
 msgid "Lead Time (Days)"
-msgstr "Lieferzeit (Tage)"
+msgstr "Beschaffungszeit (Tage)"
 
 msgid "Lead Time:"
-msgstr "Lieferzeit:"
+msgstr "Beschaffungszeit:"
 
 msgid "Learn"
 msgstr "Lernen"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Weniger manuelle Arbeit, weniger Fehler"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Bauen wir"
 
 msgid "Let's build something"
 msgstr "Lassen Sie uns etwas bauen"
@@ -8501,10 +8501,10 @@ msgid "Letter"
 msgstr "Buchstabe"
 
 msgid "Liability account for deferred taxes from accelerated depreciation"
-msgstr "Haftungskonto für aufgeschobene Steuern aus beschleunigter Abschreibung"
+msgstr "Verbindlichkeitskonto für latente Steuern aus beschleunigter Abschreibung"
 
 msgid "Liability account for sales tax collected from customers"
-msgstr "Haftungskonto für Umsatzsteuer, die von Kunden eingezogen wird"
+msgstr "Verbindlichkeitskonto für eingezogene Umsatzsteuer"
 
 msgid "Liability account for tax paid on purchases"
 msgstr "Haftungskonto für Steuern auf Einkäufe"
@@ -8549,10 +8549,10 @@ msgid "Lines need internal part numbers"
 msgstr "Zeilen benötigen interne Teilenummern"
 
 msgid "Lines need prices or lead times"
-msgstr "Zeilen benötigen Preise oder Lieferzeiten"
+msgstr "Positionen benötigen Preise oder Beschaffungszeiten"
 
 msgid "Lineside"
-msgstr "Einsatzort"
+msgstr "Linienlager"
 
 msgid "Link"
 msgstr "Verknüpfung"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Linear-Problem verknüpfen"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Verknüpfen Sie diesen Carbon-Kunden mit einem davon, oder erstellen Sie einen separaten Stripe-Kunden."
 
 msgid "Link to sales order line"
-msgstr "Mit Verkaufsauftragszeile verknüpfen"
+msgstr "Mit Kundenauftragsposition verknüpfen"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Zuletzt geladen, direkt bei der Umstellung, damit die Salden aktuell sind."
 
 msgid "Loading associated jobs..."
-msgstr "Zugehörige Aufträge werden geladen..."
+msgstr "Zugehörige Fertigungsaufträge werden geladen..."
 
 msgid "Loading current quantity…"
 msgstr "Aktuelle Menge wird geladen…"
@@ -8622,7 +8622,7 @@ msgid "Loading item details..."
 msgstr "Artikeldetails werden geladen..."
 
 msgid "Loading your own data with Carbon's import tools"
-msgstr "Laden Sie Ihre eigenen Daten mit Carbons Importwerkzeugen"
+msgstr "Laden Sie Ihre eigenen Daten mit Carbons Importtools"
 
 msgid "Loading..."
 msgstr "Wird geladen..."
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Gesperrt"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "Das Sperren macht die Periode schreibgeschützt für operative Dokumente (Eingänge, Versände, Rechnungen), erlaubt aber weiterhin Buchhaltungsanpassungen wie Abschreibungen und Ausrangierungen. Eine Periode muss gesperrt werden, bevor sie geschlossen werden kann."
+msgstr "Durch Sperren wird die Periode schreibgeschützt für operative Dokumente (Wareneingänge, Lieferungen, Rechnungen), während Buchhaltungsanpassungen wie Abschreibung und Abgang noch möglich sind. Eine Periode muss gesperrt werden, bevor sie abgeschlossen werden kann."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Nichtkonformitäten protokollieren und CAPA einleiten"
@@ -8695,16 +8695,16 @@ msgid "Looks empty here"
 msgstr "Sieht hier leer aus"
 
 msgid "Loss on Disposal"
-msgstr "Verlust aus Veräußerung"
+msgstr "Verlust bei Abgang"
 
 msgid "Loss on Disposal (default)"
-msgstr "Verlust aus Veräußerung (Standard)"
+msgstr "Verlust bei Abgang (Standard)"
 
 msgid "Loss on Disposal Account"
-msgstr "Konto für Verlust aus Veräußerung"
+msgstr "Konto für Verlust bei Abgang"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "Bei der Veräußerung von Anlagevermögen erfasste Verluste"
+msgstr "Beim Abgang von Anlagegütern erfasste Verluste"
 
 msgid "Lost"
 msgstr "Verloren"
@@ -8719,16 +8719,16 @@ msgid "Lot Size"
 msgstr "Losgröße"
 
 msgid "Lot Size Variance"
-msgstr "Losgröße Varianz"
+msgstr "Losgröße-Abweichung"
 
 msgid "Lot Size Variance (default)"
-msgstr "Losgröße Varianz (Standard)"
+msgstr "Losgröße-Abweichung (Standard)"
 
 msgid "Lot Size:"
 msgstr "Losgröße:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Losbasierte Prüfung empfangener Waren gemäß einem Prüfplan; die Einheiten werden bei Erhalt Wartend gebucht und nur zu Verfügbar freigegeben, sobald das Los als angenommen angesehen wird."
+msgstr "Chargenbasierte Überprüfung empfangener Waren gegen einen Stichprobenplan; die Einheiten erhalten beim Wareneingang den Status Angehalten und werden nur freigegeben zu Verfügbar, nachdem die Charge mit dem Verwendungsentscheid Angenommen versehen wurde."
 
 msgid "Low"
 msgstr "Niedrig"
@@ -8776,25 +8776,25 @@ msgid "Maintain a single part and item master"
 msgstr "Verwalten Sie einen einzigen Teil- und Artikelstamm"
 
 msgid "Maintenance"
-msgstr "Wartung"
+msgstr "Instandhaltung"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Wartungs-Versand-Benachrichtigungen"
+msgstr "Instandhaltungsauftrag-Benachrichtigungen"
 
 msgid "Maintenance Dispatches"
-msgstr "Wartungseinsätze"
+msgstr "Instandhaltungsaufträge"
 
 msgid "Maintenance Expense"
-msgstr "Wartungskosten"
+msgstr "Instandhaltung-Aufwand"
 
 msgid "Maintenance Expense (default)"
-msgstr "Wartungskosten (Standard)"
+msgstr "Instandhaltung-Aufwand (Standard)"
 
 msgid "Maintenance Schedules"
-msgstr "Wartungspläne"
+msgstr "Instandhaltungspläne"
 
 msgid "Maintenance Type"
-msgstr "Wartungstyp"
+msgstr "Instandhaltungstyp"
 
 msgid "Make"
 msgstr "Herstellen"
@@ -8809,10 +8809,10 @@ msgid "Make Inactive"
 msgstr "Inaktiv machen"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "Make-Artikel können nicht direkt in Rechnung gestellt werden. Ändern Sie die Methode zu Pick, um fortzufahren."
+msgstr "Eigenfertigung-Artikel können nicht direkt fakturiert werden. Ändern Sie die Bereitstellungsart zu Kommissionierung, um fortzufahren."
 
 msgid "Make Method Version"
-msgstr "Herstellungsmethode-Version"
+msgstr "Fertigungsmethode-Version"
 
 msgid "Make Payment"
 msgstr "Zahlung leisten"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Treffen Sie die Go-/No-Go-Entscheidung"
 
 msgid "Make to Order"
-msgstr "Auf Bestellung fertigen"
+msgstr "Auftragsfertigung"
 
 msgid "Make tracked entities available again"
 msgstr "Verfolgbare Entitäten wieder verfügbar machen"
@@ -8878,13 +8878,13 @@ msgid "Manufacturer Part Number"
 msgstr "Herstellerteilnummer"
 
 msgid "Manufacturing"
-msgstr "Herstellung"
+msgstr "Fertigung"
 
 msgid "Map accounts"
 msgstr "Konten zuordnen"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Ordnen Sie Carbon-Konten dem Kontenrahmen des Providers zu. Gebuchte Journale werden mithilfe des zugeordneten Provider-Kontocodes gesendet."
+msgstr "Ordnen Sie Carbon-Konten dem Kontenplan des Anbieters zu. Gebuchte Buchungssätze werden mit der zugeordneten Anbieter-Kontonummer übertragen."
 
 msgid "Map Extracted Invoice Lines"
 msgstr "Extrahierte Rechnungspositionen zuordnen"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "Zum Löschen markieren"
 
 msgid "Master gauge"
-msgstr "Meister-Messinstrument"
+msgstr "Normalprüfmittel"
 
 msgid "Master records"
 msgstr "Stammdaten"
@@ -9008,19 +9008,19 @@ msgid "Material dimensions use metric units."
 msgstr "Materialdimensionen verwenden metrische Einheiten."
 
 msgid "Material Finish"
-msgstr "Materialfinish"
+msgstr "Oberflächenbehandlung"
 
 msgid "Material Finishes"
-msgstr "Materialoberflächen"
+msgstr "Oberflächenbehandlungen"
 
 msgid "Material Form"
 msgstr "Materialform"
 
 msgid "Material Grade"
-msgstr "Materialgüte"
+msgstr "Werkstoffgüte"
 
 msgid "Material Grades"
-msgstr "Materialqualitäten"
+msgstr "Werkstoffgüten"
 
 msgid "Material ID"
 msgstr "Material-ID"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Materialformen"
 
 msgid "Material Substance"
-msgstr "Materialstoff"
+msgstr "Grundwerkstoff"
 
 msgid "Material Substances"
-msgstr "Materialsubstanzen"
+msgstr "Grundwerkstoffe"
 
 msgid "material type"
 msgstr "Materialtyp"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "Materialtypen"
 
 msgid "Material Usage Variance"
-msgstr "Materialverbrauchsvarianz"
+msgstr "Materialverbrauchsabweichung"
 
 msgid "Material Usage Variance (default)"
-msgstr "Materialverbrauchsvarianz (Standard)"
+msgstr "Materialverbrauchsabweichung (Standard)"
 
 msgid "materials"
 msgstr "Materialien"
@@ -9152,13 +9152,13 @@ msgid "Method Materials"
 msgstr "Methodenmaterialien"
 
 msgid "Method Operations"
-msgstr "Methodenvorgänge"
+msgstr "Methoden-Arbeitsgänge"
 
 msgid "Method type"
-msgstr "Methodentyp"
+msgstr "Bereitstellungsart"
 
 msgid "Method Type"
-msgstr "Methodentyp"
+msgstr "Bereitstellungsart"
 
 msgid "Methods"
 msgstr "Methoden"
@@ -9218,7 +9218,7 @@ msgid "Missing Information"
 msgstr "Fehlende Informationen"
 
 msgid "Missing Operations"
-msgstr "Fehlende Operationen"
+msgstr "Fehlende Arbeitsgänge"
 
 msgid "Missing Shipping Costs"
 msgstr "Fehlende Versandkosten"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Element verschieben"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Verschieben Sie einen Teil der Menge in eine neue Dispositionszeile, damit MRB jede Portion separat entscheiden kann (z. B. einige verschrotten, einige überarbeiten)."
+msgstr "Lagern Sie einen Teil der Menge in eine neue Verwendungsentscheid-Zeile um, damit MRB jede Portion separat entscheiden kann (z. B. einige verschrotten, einige nacharbeiten)."
 
 msgid "Move to"
 msgstr "Verschieben nach"
@@ -9385,13 +9385,13 @@ msgid "Needs ordering"
 msgstr "Bestellung erforderlich"
 
 msgid "Negative Adjustment"
-msgstr "Negative Anpassung"
+msgstr "Negative Korrektur"
 
 msgid "Net book value"
-msgstr "Nettobuchwert"
+msgstr "Restbuchwert"
 
 msgid "Net Book Value"
-msgstr "Nettobuchwert"
+msgstr "Restbuchwert"
 
 msgid "Net Change"
 msgstr "Nettoänderung"
@@ -9418,7 +9418,7 @@ msgid "New Approval Rule"
 msgstr "Neue Genehmigungsregel"
 
 msgid "New Asset Class"
-msgstr "Neue Anlageklasse"
+msgstr "Neue Anlagenklasse"
 
 msgid "New Assignment"
 msgstr "Neue Zuweisung"
@@ -9439,16 +9439,16 @@ msgid "New Change Notice Type"
 msgstr "Neuer Änderungsmitteilung-Typ"
 
 msgid "New Consumable"
-msgstr "Neuer Verbrauchsstoff"
+msgstr "Neues Verbrauchsmaterial"
 
 msgid "New Contractor"
-msgstr "Neuer Auftragnehmer"
+msgstr "Neuer Externer Mitarbeiter"
 
 msgid "New Cost Center"
-msgstr "Neues Kostenzentrum"
+msgstr "Neue Kostenstelle"
 
 msgid "New Credit / Debit Memo"
-msgstr "Neue Gutschrift / Lastschrift-Notiz"
+msgstr "Neue Haben-/Soll-Buchung"
 
 msgid "New Custom Field"
 msgstr "Neues benutzerdefiniertes Feld"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "Neuer Mitarbeitertyp"
 
 msgid "New expiration date"
-msgstr "Neues Ablaufdatum"
+msgstr "Neues Verfallsdatum"
 
 msgid "New Failure Mode"
 msgstr "Neuer Fehlermodus"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Neues Anlage"
 
 msgid "New Gauge"
-msgstr "Neue Messgerät"
+msgstr "Neues Prüfmittel"
 
 msgid "New Gauge Calibration Record"
-msgstr "Neuer Messmittel-Kalibrierungsdatensatz"
+msgstr "Neues Prüfmittel-Kalibrierprotokoll"
 
 msgid "New Gauge Type"
-msgstr "Neuer Messmitteltyp"
+msgstr "Neue Prüfmittelart"
 
 msgid "New Group"
 msgstr "Neue Gruppe"
@@ -9499,7 +9499,7 @@ msgid "New IC Transaction"
 msgstr "Neue IC-Transaktion"
 
 msgid "New Inspection Plan"
-msgstr "Neuer Inspektionsplan"
+msgstr "Neuer Prüfplan"
 
 msgid "New Inventory Count"
 msgstr "Neue Bestandszählung"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "Neuer Standort"
 
 msgid "New Maintenance Dispatch"
-msgstr "Neue Wartungseinsatz"
+msgstr "Neuer Instandhaltungsauftrag"
 
 msgid "New Material"
 msgstr "Neues Material"
@@ -9535,16 +9535,16 @@ msgid "New Material Dimension"
 msgstr "Neue Materialdimension"
 
 msgid "New Material Finish"
-msgstr "Neue Materialoberfläche"
+msgstr "Neue Oberflächenbehandlung"
 
 msgid "New Material Grade"
-msgstr "Neue Materialgüte"
+msgstr "Neue Werkstoffgüte"
 
 msgid "New Material Shape"
 msgstr "Neue Materialform"
 
 msgid "New Material Substance"
-msgstr "Neue Materialsubstanz"
+msgstr "Neuer Grundwerkstoff"
 
 msgid "New Material Type"
 msgstr "Neuer Materialtyp"
@@ -9553,10 +9553,10 @@ msgid "New Non Conformance Type"
 msgstr "Neuer Nichtkonformitätstyp"
 
 msgid "New Owner"
-msgstr "Neuer Eigentümer"
+msgstr "Neuer Verantwortlicher"
 
 msgid "New Part"
-msgstr "Neuer Teil"
+msgstr "Neues Neuteil"
 
 msgid "New Password"
 msgstr "Neues Passwort"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "Neue Zahlung"
 
 msgid "New Payment Term"
-msgstr "Neuer Zahlungsbegriff"
+msgstr "Neue Zahlungsbedingung"
 
 msgid "New Picking List"
 msgstr "Neue Kommissionierliste"
@@ -9577,13 +9577,13 @@ msgid "New PO"
 msgstr "Neue Bestellung"
 
 msgid "New Price Override"
-msgstr "Neue Preisüberschreibung"
+msgstr "Neue Preisübersteuerung"
 
 msgid "New Pricing Rule"
 msgstr "Neue Preisregel"
 
 msgid "New Procedure"
-msgstr "Neues Verfahren"
+msgstr "Neue Verfahrensanweisung"
 
 msgid "New Process"
 msgstr "Neuer Prozess"
@@ -9598,7 +9598,7 @@ msgid "New Quote"
 msgstr "Neues Angebot"
 
 msgid "New Quote Line"
-msgstr "Neue Angebotszeile"
+msgstr "Neue Angebotsposition"
 
 msgid "New Receipt"
 msgstr "Neue Quittung"
@@ -9619,19 +9619,19 @@ msgid "New Rule"
 msgstr "Neue Regel"
 
 msgid "New Sales Invoice"
-msgstr "Neue Verkaufsrechnung"
+msgstr "Neue Ausgangsrechnung"
 
 msgid "New Sales Invoice Line"
-msgstr "Neue Verkaufsrechnungsposition"
+msgstr "Neue Ausgangsrechnungsposition"
 
 msgid "New Sales Order"
-msgstr "Neue Verkaufsbestellung"
+msgstr "Neuer Kundenauftrag"
 
 msgid "New Sales Order Line"
-msgstr "Neue Verkaufsauftragsposition"
+msgstr "Neue Kundenauftragsposition"
 
 msgid "New Scheduled Maintenance"
-msgstr "Neue geplante Wartung"
+msgstr "Neue geplante Instandhaltung"
 
 msgid "New Serial Number"
 msgstr "Neue Seriennummer"
@@ -9643,7 +9643,7 @@ msgid "New Shift"
 msgstr "Neue Schicht"
 
 msgid "New Shipment"
-msgstr "Neue Sendung"
+msgstr "Neue Lieferung"
 
 msgid "New Shipping Method"
 msgstr "Neue Versandmethode"
@@ -9676,10 +9676,10 @@ msgid "New Transfer"
 msgstr "Neue Übertragung"
 
 msgid "New Transfer Line"
-msgstr "Neue Transferzeile"
+msgstr "Neue Umlagerungsposition"
 
 msgid "New Unit of Measure"
-msgstr "Neue Maßeinheit"
+msgstr "Neue Mengeneinheit"
 
 msgid "New Version"
 msgstr "Neue Version"
@@ -9691,7 +9691,7 @@ msgid "New Webhook"
 msgstr "Neuer Webhook"
 
 msgid "New Work Center"
-msgstr "Neues Arbeitszentrum"
+msgstr "Neuer Arbeitsplatz"
 
 msgid "New Workflow"
 msgstr "Neuer Workflow"
@@ -9721,7 +9721,7 @@ msgid "Next page"
 msgstr "Nächste Seite"
 
 msgid "Next Sequence"
-msgstr "Nächste Sequenz"
+msgstr "Nächster Nummernkreis"
 
 msgid "Next step"
 msgstr "Nächster Schritt"
@@ -9738,14 +9738,14 @@ msgstr "Keine {0} gefunden"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "Keine {0} Synchronisierungsoperationen"
+msgstr "Keine {0}-Synchronisierungsvorgänge"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
 msgstr "Noch keine {0}"
 
 msgid "No abilities added"
-msgstr "Keine Fähigkeiten hinzugefügt"
+msgstr "Keine Qualifikationen hinzugefügt"
 
 msgid "No Access"
 msgstr "Kein Zugriff"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Keine Aktionen ausgewählt"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Keine aktiven Aufträge für diese Bestellung gefunden. Die Bestellung wird direkt storniert."
+msgstr "Keine aktiven Fertigungsaufträge für diesen Kundenauftrag gefunden. Der Auftrag wird direkt storniert."
 
 msgid "No active plan"
 msgstr "Kein aktiver Plan"
@@ -9785,7 +9785,7 @@ msgstr "Keine Anwendungen. Zahlung erfolgt auf Kontostand."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Noch keine archivierten Protokolle. Protokolle älter als {0} Tage werden automatisch archiviert und sind hier zum Download verfügbar."
+msgstr "Noch keine archivierten Protokolle vorhanden. Protokolle, die älter als {0} Tage sind, werden automatisch archiviert und sind hier zum Herunterladen verfügbar."
 
 msgid "No attachments."
 msgstr "Keine Anhänge."
@@ -9803,7 +9803,7 @@ msgid "No CAD model to preview."
 msgstr "Kein CAD-Modell zum Vorschau verfügbar."
 
 msgid "No calibration records found"
-msgstr "Keine Kalibrierungsdatensätze gefunden"
+msgstr "Keine Kalibrierprotokolle gefunden"
 
 msgid "No changes recorded"
 msgstr "Keine Änderungen aufgezeichnet"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Noch keine Kommentare. Seien Sie der Erste, der einen Kommentar hinzufügt."
 
 msgid "No completed jobs within range"
-msgstr "Keine abgeschlossenen Aufträge im Bereich"
+msgstr "Keine fertiggestellten Fertigungsaufträge im Bereich"
 
 msgid "No condition may match"
 msgstr "Keine Bedingung darf zutreffen"
@@ -9827,7 +9827,7 @@ msgid "No conversion is required"
 msgstr "Keine Umrechnung erforderlich"
 
 msgid "No cost history found"
-msgstr "Keine Kostenhistorie gefunden"
+msgstr "Kein Kostenverlauf gefunden"
 
 msgid "No Data"
 msgstr "Keine Daten"
@@ -9848,7 +9848,7 @@ msgid "No dimension values mapped yet"
 msgstr "Noch keine Dimensionswerte zugeordnet"
 
 msgid "No draft make method for this item yet."
-msgstr "Noch keine Entwurfsmethode für dieses Element."
+msgstr "Noch kein Fertigungsmethoden-Entwurf für diesen Artikel."
 
 msgid "No draft versions available"
 msgstr "Keine Entwurfsversionen verfügbar"
@@ -9869,16 +9869,16 @@ msgid "No events found."
 msgstr "Keine Ereignisse gefunden."
 
 msgid "No extra cutover steps yet. Add anything specific to this customer."
-msgstr "Noch keine zusätzlichen Cutover-Schritte. Fügen Sie alles Kundenspezifische hinzu."
+msgstr "Noch keine zusätzlichen Umstellungsschritte vorhanden. Fügen Sie alles Kundenspezifische hinzu."
 
 msgid "No extra data sets yet. Add anything specific to this customer."
-msgstr "Noch keine zusätzlichen Datensätze. Fügen Sie alles Kundenspezifische hinzu."
+msgstr "Noch keine zusätzlichen Datensätze vorhanden. Fügen Sie alles Kundenspezifische hinzu."
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "Noch keine zusätzlichen Anforderungen. Fügen Sie alles Kundenspezifische hinzu."
+msgstr "Keine zusätzlichen Anforderungen vorhanden. Fügen Sie etwas Kundenspezifisches hinzu."
 
 msgid "No extra setup items yet. Add anything specific to this customer."
-msgstr "Noch keine zusätzlichen Setup-Elemente. Fügen Sie alles Kundenspezifische hinzu."
+msgstr "Keine zusätzlichen Einrichtungselemente vorhanden. Fügen Sie etwas Kundenspezifisches hinzu."
 
 msgid "No failure path — the run stops here and is marked failed"
 msgstr "Kein Fehlerpfad — der Durchlauf stoppt hier und ist als fehlgeschlagen markiert"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Keine Dateien hochgeladen"
 
 msgid "No Gauge Selected"
-msgstr "Keine Messuhr ausgewählt"
+msgstr "Kein Prüfmittel ausgewählt"
 
 msgid "No grouped notifications"
 msgstr "Keine gruppierten Benachrichtigungen"
@@ -9908,7 +9908,7 @@ msgid "No image"
 msgstr "Kein Bild"
 
 msgid "No inspection plans"
-msgstr "Keine Inspektionspläne"
+msgstr "Keine Prüfpläne"
 
 msgid "No issue types configured"
 msgstr "Keine Problemtypen konfiguriert"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Hier gibt es noch keine Bestandsbewegungen."
 
 msgid "No jobs were created"
-msgstr "Keine Aufträge wurden erstellt"
+msgstr "Keine Fertigungsaufträge wurden erstellt"
 
 msgid "No journal lines in scope for this period"
-msgstr "Keine Journalzeilen im Bereich für diesen Zeitraum"
+msgstr "Keine Buchungssatzpositionen im Umfang für diesen Zeitraum"
 
 msgid "No lines to map"
 msgstr "Keine Zeilen zum Zuordnen"
@@ -9950,7 +9950,7 @@ msgid "No matches. Type to create one."
 msgstr "Keine Übereinstimmungen. Geben Sie ein, um eine zu erstellen."
 
 msgid "No matching bins"
-msgstr "Keine übereinstimmenden Lagerfächer"
+msgstr "Keine übereinstimmenden Lagerplätze"
 
 msgid "No new notifications"
 msgstr "Keine neuen Benachrichtigungen"
@@ -9965,16 +9965,16 @@ msgid "No open orders for this item are available to link."
 msgstr "Für diesen Artikel sind keine offenen Bestellungen zum Verknüpfen verfügbar."
 
 msgid "No open sales order lines"
-msgstr "Keine offenen Verkaufsbestellpositionen"
+msgstr "Keine offenen Kundenauftragsposition"
 
 msgid "No operations found."
-msgstr "Keine Operationen gefunden."
+msgstr "Keine Arbeitsgänge gefunden."
 
 msgid "No operations require picking at this location"
-msgstr "Keine Operationen erfordern Kommissionierung an diesem Standort"
+msgstr "Keine Arbeitsgänge erfordern Kommissionierung an diesem Standort"
 
 msgid "No operators."
-msgstr "Keine Operatoren."
+msgstr "Keine Werker."
 
 msgid "No option found."
 msgstr "Keine Option gefunden."
@@ -9983,10 +9983,10 @@ msgid "No options found."
 msgstr "Keine Optionen gefunden."
 
 msgid "No other bins hold this item"
-msgstr "Keine anderen Behälter halten diesen Artikel"
+msgstr "Keine anderen Lagerplätze enthalten diesen Artikel"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
-msgstr "Keine anderen Mitarbeiter gefunden. Fügen Sie Mitarbeiter hinzu, um die Eigentumsübertragung zu aktivieren."
+msgstr "Keine weiteren Mitarbeiter gefunden. Fügen Sie Mitarbeiter hinzu, um die Übertragung der Verantwortung zu ermöglichen."
 
 msgid "No outstanding trainings"
 msgstr "Keine ausstehenden Schulungen"
@@ -10016,13 +10016,13 @@ msgid "No planning data"
 msgstr "Keine Planungsdaten"
 
 msgid "No posted journals in this period for this account"
-msgstr "Keine gebuchten Journale in diesem Zeitraum für dieses Konto"
+msgstr "Keine gebuchten Buchungssätze in diesem Zeitraum für dieses Konto"
 
 msgid "No pricing for selected quantity"
-msgstr "Keine Preisgestaltung für die ausgewählte Menge"
+msgstr "Keine Preisfindung für die ausgewählte Menge"
 
 msgid "No pricing options found"
-msgstr "Keine Preisoptionen gefunden"
+msgstr "Keine Preisfindungsoptionen gefunden"
 
 msgid "No printer configured"
 msgstr "Kein Drucker konfiguriert"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "Keine Berichte entsprechen Ihrer Suche."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "Kein Vertreter dieses Unternehmens hat den Carbon GovCloud Rider bisher akzeptiert. Ein Administrator dieses Unternehmens muss ihn akzeptieren, bevor jemand Zugriff auf Carbon erhält — Carbon-Mitarbeiter können ihn nicht in Ihrem Namen akzeptieren."
+msgstr "Kein Vertreter dieses Unternehmens hat den Carbon GovCloud Rider noch akzeptiert. Ein Administrator dieses Unternehmens muss es akzeptieren, bevor jemand auf Carbon zugreifen kann — Carbon-Mitarbeiter können es nicht in Ihrem Namen akzeptieren."
 
 msgid "No results"
 msgstr "Keine Ergebnisse"
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "Kein Bestand an diesem Ort"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "Keine Lagerbestände-Ausfall wird in den nächsten 48 Wochen prognostiziert"
+msgstr "Kein Fehlbestand für die nächsten 48 Wochen erwartet"
 
 msgid "No storage unit"
 msgstr "Keine Lagereinheit"
@@ -10100,7 +10100,7 @@ msgid "No suppliers yet"
 msgstr "Noch keine Lieferanten"
 
 msgid "No sync operations yet"
-msgstr "Noch keine Synchronisierungsoperationen"
+msgstr "Keine Synchronisierungsvorgänge vorhanden"
 
 msgid "No time entries for this week"
 msgstr "Keine Zeiteinträge für diese Woche"
@@ -10136,10 +10136,10 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "Kein Lagerbestand für diesen Artikel ist erfasst. Sie können ihn trotzdem kommissionieren — der verfügbare Bestand wird negativ, bis die Inventur abgestimmt ist."
 
 msgid "No work center utilization data within range"
-msgstr "Keine Daten zur Auslastung des Arbeitszentrums im angegebenen Bereich"
+msgstr "Keine Auslastungsdaten des Arbeitsplatzes im Bereich vorhanden"
 
 msgid "No work centers exist"
-msgstr "Es existieren keine Arbeitszentren"
+msgstr "Keine Arbeitsplätze vorhanden"
 
 msgid "Nom"
 msgstr "Nom"
@@ -10160,16 +10160,16 @@ msgid "Non-conformance (issue)"
 msgstr "Nichtkonformität (Problem)"
 
 msgid "Non-Inventory"
-msgstr "Nicht-Bestand"
+msgstr "Nicht lagergeführt"
 
 msgid "Non-Inventory Tracking"
-msgstr "Verfolgung ohne Bestand"
+msgstr "Nachverfolgung ohne Lagerbestand"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
-msgstr "Betriebsfremdes Aufwendungskonto, das belastet wird, wenn ein Vermögenswert dieser Klasse unterhalb seines Nettobuchwerts verkauft oder verschrottet wird."
+msgstr "Außergewöhnlicher Aufwand, der belastet wird, wenn eine Anlage dieser Klasse unter ihrem Restbuchwert verkauft oder verschrottet wird."
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "Betriebsfremdes Ertragskonto, das gutgeschrieben wird, wenn ein Vermögenswert dieser Klasse oberhalb seines Nettobuchwerts verkauft wird."
+msgstr "Außergewöhnliches Ertragskonto, das belastet wird, wenn eine Anlage dieser Klasse über ihrem Restbuchwert verkauft wird."
 
 msgid "Non-Taxable Add-On Cost"
 msgstr "Nicht steuerpflichtiger Zusatzkosten"
@@ -10190,7 +10190,7 @@ msgid "Not certified"
 msgstr "Nicht zertifiziert"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Nicht genug Aufträge zur Deckung der Menge"
+msgstr "Nicht genug Fertigungsaufträge zur Abdeckung der Menge"
 
 msgid "Not reached"
 msgstr "Nicht erreicht"
@@ -10214,7 +10214,7 @@ msgid "Not started"
 msgstr "Nicht gestartet"
 
 msgid "Not started training for"
-msgstr "Noch nicht mit dem Training begonnen für"
+msgstr "Schulung nicht gestartet für"
 
 msgid "Not yet"
 msgstr "Noch nicht"
@@ -10275,22 +10275,22 @@ msgid "Number of lines"
 msgstr "Anzahl der Zeilen"
 
 msgid "Number of open operations"
-msgstr "Anzahl offener Operationen"
+msgstr "Anzahl offener Arbeitsgänge"
 
 msgid "Number of open tasks"
 msgstr "Anzahl offener Aufgaben"
 
 msgid "Number of operations"
-msgstr "Anzahl der Operationen"
+msgstr "Anzahl der Arbeitsgänge"
 
 msgid "Numbering sequence"
-msgstr "Nummernvergabe"
+msgstr "Nummernkreis"
 
 msgid "OEE Impact"
 msgstr "OEE-Auswirkung"
 
 msgid "OEM (original equipment manufacturer)"
-msgstr "OEM (Original Equipment Manufacturer)"
+msgstr "OEM (Originalgerätehersteller)"
 
 msgid "of"
 msgstr "von"
@@ -10299,7 +10299,7 @@ msgid "Off — handled outside the sync"
 msgstr "Aus — außerhalb der Synchronisierung behandelt"
 
 msgid "Off — released revisions stay editable"
-msgstr "Aus — veröffentlichte Versionen bleiben bearbeitbar"
+msgstr "Aus — ausgegebene Revisionen bleiben bearbeitbar"
 
 msgid "OK"
 msgstr "OK"
@@ -10326,10 +10326,10 @@ msgid "On Hand"
 msgstr "Verfügbar"
 
 msgid "On Hold"
-msgstr "In Bearbeitung"
+msgstr "Angehalten"
 
 msgid "On Jobs"
-msgstr "In Aufträgen"
+msgstr "Auf Fertigungsaufträgen"
 
 msgid "On order"
 msgstr "Bestellt"
@@ -10341,7 +10341,7 @@ msgid "On Purchase Order"
 msgstr "In Bestellung"
 
 msgid "On Sales Order"
-msgstr "In Verkaufsauftrag"
+msgstr "Auf Kundenauftrag"
 
 msgid "On Storage Unit"
 msgstr "Auf Lagereinheit"
@@ -10374,7 +10374,7 @@ msgid "On-time delivery"
 msgstr "Pünktliche Lieferung"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "Eine Ausführung eines Workflows, die Schritt für Schritt mit den Werten, die jeder Schritt verwendet und erstellt hat, aufgezeichnet wird und durchgehend mit den Berechtigungen des Workflow-Besitzers handelt."
+msgstr "Ein Workflow-Durchlauf, aufgezeichnet Schritt für Schritt mit den Werten, die jeder Schritt verwendet und erzeugt, ausgeführt mit den Berechtigungen des Verantwortlichen des Workflows."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
 msgstr "Eine Serieneinheit oder eine Partie, die Carbon einzeln verfolgt und ihre eigenen Status und Attribute wie ein Verfallsdatum trägt."
@@ -10383,13 +10383,13 @@ msgid "One set of numbers"
 msgstr "Ein Satz von Zahlen"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Ein Schritt in der Routing eines Auftrags, der einen Prozess und ein Arbeitszentrum benennt und seine eigenen Setup-, Arbeits- und Maschinenzeiten und -sätze trägt."
+msgstr "Ein Schritt im Arbeitsplan eines Fertigungsauftrags, der ein Verfahren und einen Arbeitsplatz benennt und seine eigenen Rüst-, Personal- und Maschinenzeiten sowie Sätze trägt."
 
 msgid "One system from quote to cash"
-msgstr "Ein System von der Anfrage bis zur Bezahlung"
+msgstr "Ein System vom Angebot bis zur Kasse"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "Nur Entwurfsverfahren sind bearbeitbar. Erstellen Sie eine neue Version, um ein aktives oder archiviertes Verfahren zu ändern."
+msgstr "Nur Verfahrensanweisungen im Entwurf sind bearbeitbar. Erstellen Sie eine neue Version, um eine aktive oder archivierte Verfahrensanweisung zu ändern."
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Nur leere, offene Perioden können gelöscht werden."
@@ -10428,16 +10428,16 @@ msgid "Open Actions"
 msgstr "Offene Maßnahmen"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "Öffnen Sie eine NCR zur MRB-Disposition"
+msgstr "Öffnen Sie ein NCR für MRB-Verwendungsentscheid"
 
 msgid "Open AP"
-msgstr "Offene Verbindlichkeiten"
+msgstr "Offene Kreditoren"
 
 msgid "Open AR"
-msgstr "Offene Forderungen"
+msgstr "Offene Debitoren"
 
 msgid "Open Audit Log"
-msgstr "Audit-Protokoll öffnen"
+msgstr "Änderungsprotokoll öffnen"
 
 msgid "Open date"
 msgstr "Öffnungsdatum"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Öffnungsdatum"
 
 msgid "Open Dispatches"
-msgstr "Offene Einsätze"
+msgstr "Instandhaltungsaufträge öffnen"
 
 msgid "Open in Carbon"
 msgstr "In Carbon öffnen"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "Öffnen Sie in der Änderungsmitteilung {ids}. Geben Sie sie frei, um neue Versionen oder Überarbeitungen zu erstellen."
+msgstr "In der Änderungsmitteilung {ids} öffnen. Geben Sie sie frei, um neue Versionen oder Revisionen zu erstellen."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "Öffnen Sie in den Änderungsmitteilungen {ids}. Geben Sie sie frei, um neue Versionen oder Überarbeitungen zu erstellen."
+msgstr "In den Änderungsmitteilungen {ids} öffnen. Geben Sie sie frei, um neue Versionen oder Revisionen zu erstellen."
 
 msgid "Open in MES"
 msgstr "Im MES öffnen"
@@ -10464,10 +10464,10 @@ msgid "Open Issues"
 msgstr "Offene Probleme"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Offene Auftragsanforderung plus ausstehende Transfers aus diesem Behälter"
+msgstr "Offener Fertigungsauftrag-Bedarf plus ausstehende Umlagerungen aus diesem Lagerplatz"
 
 msgid "Open jobs"
-msgstr "Offene Aufträge"
+msgstr "Offene Fertigungsaufträge"
 
 msgid "Open menu"
 msgstr "Menü öffnen"
@@ -10476,7 +10476,7 @@ msgid "Open payables by supplier and age"
 msgstr "Offene Verbindlichkeiten nach Lieferant und Fälligkeitsdauer"
 
 msgid "Open Purchase Invoices"
-msgstr "Offene Kaufrechnungen"
+msgstr "Offene Eingangsrechnungen"
 
 msgid "Open purchase orders"
 msgstr "Offene Bestellungen"
@@ -10497,10 +10497,10 @@ msgid "Open RFQs"
 msgstr "Offene Anfragen"
 
 msgid "Open sales orders"
-msgstr "Offene Verkaufsaufträge"
+msgstr "Offene Kundenaufträge"
 
 msgid "Open Sales Orders"
-msgstr "Offene Verkaufsaufträge"
+msgstr "Offene Kundenaufträge"
 
 msgid "Open Scheduled"
 msgstr "Offene geplante Wartungen"
@@ -10530,16 +10530,16 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Eröffnungssaldo der bereits vor dem Hinzufügen dieses Vermögenswerts zu Carbon gebuchten Abschreibung (für neue Akquisitionen 0 verwenden)."
 
 msgid "Operating Expenses"
-msgstr "Betriebsausgaben"
+msgstr "Betriebsaufwendungen"
 
 msgid "Operating Income"
-msgstr "Betriebseinkommen"
+msgstr "Betriebserträge"
 
 msgid "Operation"
 msgstr "Betrieb"
 
 msgid "Operation lead time"
-msgstr "Vorlaufzeit der Operation"
+msgstr "Beschaffungszeit des Arbeitsgangs"
 
 msgid "Operation minimum cost"
 msgstr "Mindestkosten der Operation"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "Betriebsmenge"
 
 msgid "Operation supplier process"
-msgstr "Betriebsprozess des Lieferanten"
+msgstr "Lieferantenverfahren des Arbeitsgangs"
 
 msgid "Operation type"
 msgstr "Betriebstyp"
@@ -10566,43 +10566,43 @@ msgid "Operation unit cost"
 msgstr "Einheitskosten der Operation"
 
 msgid "Operations"
-msgstr "Operationen"
+msgstr "Arbeitsgänge"
 
 msgid "Operations / steps"
-msgstr "Operationen / Schritte"
+msgstr "Arbeitsgänge / Schritte"
 
 msgid "Operations Type"
-msgstr "Betriebstyp"
+msgstr "Arbeitsgangstyp"
 
 msgid "Operator"
-msgstr "Operator"
+msgstr "Werker"
 
 msgid "Operator gets a warning. Stock still goes through."
-msgstr "Operator erhält eine Warnung. Bestand wird trotzdem verarbeitet."
+msgstr "Der Werker erhält eine Warnung. Der Bestand wird dennoch verarbeitet."
 
 msgid "Operator must pick a different batch/serial."
-msgstr "Operator muss einen anderen Batch/eine andere Seriennummer auswählen."
+msgstr "Der Werker muss ein anderes Los/eine andere Seriennummer kommissionieren."
 
 msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
-msgstr "Der Bediener sieht die fehlenden Artikel, kann bestätigen und abschließen. Die Liste ist als \"Teilbestand\" gekennzeichnet."
+msgstr "Der Werker sieht die fehlenden Artikel, kann diese bestätigen und die Bearbeitung abschließen. Die Liste wird als Teilweise gekennzeichnet."
 
 msgid "Operators"
-msgstr "Operatoren"
+msgstr "Werker"
 
 msgid "Operators can use shared workstations with PIN authentication."
-msgstr "Operatoren können gemeinsame Arbeitsstationen mit PIN-Authentifizierung nutzen."
+msgstr "Werker können gemeinsame Arbeitsplätze mit PIN-Authentifizierung verwenden."
 
 msgid "Operators start on the Scan tab"
-msgstr "Bediener beginnen auf der Registerkarte Scan"
+msgstr "Werker starten auf der Registerkarte Scannen"
 
 msgid "Operators start the timer themselves when they begin an operation."
-msgstr "Bediener starten den Timer selbst, wenn sie eine Operation beginnen."
+msgstr "Werker starten den Timer selbst, wenn sie einen Arbeitsgang beginnen."
 
 msgid "Opportunity"
-msgstr "Gelegenheit"
+msgstr "Verkaufschance"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr "Optimiert für schnelle Vorschau — Downloads liefern immer die ursprüngliche hochgeladene Datei"
+msgstr "Optimiert für schnelle Vorschaubilder – Downloads stellen immer die ursprüngliche hochgeladene Datei bereit"
 
 msgid "Optional"
 msgstr "Optional"
@@ -10645,7 +10645,7 @@ msgid "Order Date"
 msgstr "Bestelldatum"
 
 msgid "Order Multiple"
-msgstr "Bestellmenge"
+msgstr "Bestellvielfaches"
 
 msgid "Order Parts"
 msgstr "Teile bestellen"
@@ -10684,16 +10684,16 @@ msgid "Original Count"
 msgstr "Ursprüngliche Anzahl"
 
 msgid "Other Expense"
-msgstr "Sonstige Ausgaben"
+msgstr "Sonstige Aufwendungen"
 
 msgid "Other Income"
-msgstr "Sonstiges Einkommen"
+msgstr "Sonstige Erträge"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "Sonstige Einnahmen für Wechselkursgewinne, wenn eine Zahlung eine Rechnung in Fremdwährung zu einem günstigeren Kurs ausgleicht"
+msgstr "Konto Sonstige Erträge für Wechselkursgewinne, wenn eine Zahlung eine Rechnung in Fremdwährung zu einem günstigeren Kurs ausgleicht"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Sonstige Einnahmenkonto für Lieferantensalden, die ohne vollständige Zahlung bei AP-Ausgleich gelöscht wurden"
+msgstr "Konto Sonstige Erträge für Lieferantensalden, die ohne vollständige Zahlung beim Kreditorenausgleich gelöscht werden"
 
 msgid "Other Type"
 msgstr "Sonstiger Typ"
@@ -10726,10 +10726,10 @@ msgid "Overdue"
 msgstr "Überfällig"
 
 msgid "Overhead Absorption"
-msgstr "Gemeinkosten-Absorption"
+msgstr "Gemeinkostenverrechnung"
 
 msgid "Overhead Absorption (default)"
-msgstr "Gemeinkosten-Absorption (Standard)"
+msgstr "Gemeinkostenverrechnung (Standard)"
 
 msgid "Overhead rate"
 msgstr "Gemeinkostensatz"
@@ -10744,22 +10744,22 @@ msgid "Overhead Variance"
 msgstr "Gemeinkostenabweichung (Standard)"
 
 msgid "Overhead Variance (default)"
-msgstr "Eigentümer (Kostenstelle)"
+msgstr "Gemeinkostenabweichung (Standard)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "Außerkraftsetzung erfordert die Berechtigung inventory:update und einen Grund."
+msgstr "Die Übersteuerung benötigt die Berechtigung Inventar:Aktualisieren und einen Grund."
 
 msgid "Override Price"
-msgstr "Überschreibungspreis"
+msgstr "Preis übersteuern"
 
 msgid "Override price for a single customer"
-msgstr "Preis für einen einzelnen Kunden überschreiben"
+msgstr "Preis für einen einzelnen Kunden übersteuern"
 
 msgid "Override price for all customers of a type"
-msgstr "Preis für alle Kunden eines Typs überschreiben"
+msgstr "Preis für alle Kunden eines Typs übersteuern"
 
 msgid "Override the expiration on {label}."
-msgstr "Verfallsdatum für {label} überschreiben."
+msgstr "Verfallsdatum auf {label} übersteuern."
 
 msgid "Overtime"
 msgstr "Überstunden"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "Überschreiben Sie die Zielfertigungsmethode mit der Angebotsmethode"
 
 msgid "Owner"
-msgstr "Besitzer"
+msgstr "Verantwortlicher"
 
 msgid "Owner (cost center)"
-msgstr "Übergeordnete Kostenstelle"
+msgstr "Verantwortlicher (Kostenstelle)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10808,16 +10808,16 @@ msgid "Parameters"
 msgstr "Parameter"
 
 msgid "Parameters are inherited from the procedure."
-msgstr "Parameter werden von der Prozedur geerbt."
+msgstr "Parameter werden von der Verfahrensanweisung geerbt."
 
 msgid "Params"
 msgstr "Parameter"
 
 msgid "Parent cost center"
-msgstr "Teil"
+msgstr "Übergeordnete Kostenstelle"
 
 msgid "Parent Cost Center"
-msgstr "Übergeordnetes Kostenzentrum"
+msgstr "Übergeordnete Kostenstelle"
 
 msgid "Parent Department"
 msgstr "Übergeordnete Abteilung"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Als Fehler zwischenspeichern"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Legen Sie das Journal mit einer Warnung beiseite, bis der Wert zugeordnet ist"
+msgstr "Den Buchungssatz mit einer Warnung speichern, bis der Wert zugeordnet ist"
 
 msgid "part"
 msgstr "Teile"
@@ -10856,16 +10856,16 @@ msgid "Part ID"
 msgstr "Teile-ID"
 
 msgid "Part is configured for manufacturing"
-msgstr "Teil ist für die Herstellung konfiguriert"
+msgstr "Teil ist für Fertigung konfiguriert"
 
 msgid "Part Number"
 msgstr "Teilenummer"
 
 msgid "Part Supersession"
-msgstr "Teilersatz"
+msgstr "Teil-Ablösung"
 
 msgid "Partial"
-msgstr "Teilbestand"
+msgstr "Teilweise"
 
 msgid "Partner"
 msgstr "Partner"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Partner"
 
 msgid "parts"
-msgstr "Kreditorenkonten"
+msgstr "Teile"
 
 msgid "Parts"
 msgstr "Teile"
@@ -10913,13 +10913,13 @@ msgid "Pay Rate"
 msgstr "Zahlungskurs"
 
 msgid "Payables"
-msgstr "Kreditorenkonten (Standard)"
+msgstr "Verbindlichkeiten"
 
 msgid "Payables (AP)"
-msgstr "Verbindlichkeiten (AP)"
+msgstr "Verbindlichkeiten (Kreditoren)"
 
 msgid "Payables (default)"
-msgstr "Zahlungsbedingung"
+msgstr "Verbindlichkeiten (Standard)"
 
 msgid "Payables aging"
 msgstr "Verbindlichkeiten nach Fälligkeit"
@@ -10946,7 +10946,7 @@ msgid "Payment Term"
 msgstr "Zahlungsbedingung"
 
 msgid "payment terms"
-msgstr "Personen"
+msgstr "Zahlungsbedingungen"
 
 msgid "Payment Terms"
 msgstr "Zahlungsbedingungen"
@@ -10958,7 +10958,7 @@ msgid "Payments"
 msgstr "Zahlungen"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "Zahlungen und Gutschriften, die auf diese Rechnung angewendet wurden. Klicken Sie auf eine Zeile, um das Quelldokument zu öffnen."
+msgstr "Zahlungen und Gutschriften, die auf diese Rechnung angerechnet wurden. Klicken Sie auf eine Zeile, um den Ursprungsbeleg zu öffnen."
 
 msgid "PDF"
 msgstr "PDF"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "Ausstehend"
 
 msgid "people"
-msgstr "Regelmäßige Abschreibungsaufwendungen für Anlagevermögen"
+msgstr "Personal"
 
 msgid "People"
 msgstr "Personen"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Pro Einheit"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Pro-Zeilen-Überschreibung des Erfüllungsorts der Bestellkopfzeile; wird für geteilte Lieferungen und Direktlieferungen verwendet."
+msgstr "Zeilenweise Übersteuerung des Versandstandorts im Bestellkopf; wird für Teillieferungen und Direktlieferungen verwendet."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Pro-Zeilen-Überschreibung des Lieferorts der PO-Kopfzeile; wird für geteilte Lieferungen zu mehreren Lagern oder Direktlieferungen verwendet."
+msgstr "Zeilenweise Übersteuerung des Lieferorts im Bestellkopf; wird für Teillieferungen an mehrere Lager oder Direktlieferungen verwendet."
 
 msgid "Percentage"
 msgstr "Prozentsatz"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "Zeitraumsperrrichtlinie"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Kommissionierung bietet verfolgten Einheiten mit frühestem Verfallsdatum zuerst an, sodass das am schnellsten ablaufende Lager standardmäßig zuerst ausgeht."
+msgstr "Periodischer Abschreibungsaufwand für Anlagegüter"
 
 msgid "Permanently Delete"
 msgstr "Dauerhaft löschen"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Phasendauern"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Auslaufen eines Artikels zugunsten eines Nachfolgeteils, sodass die Planung die Nachfrage des alten Artikels – multipliziert mit einem Umrechnungsfaktor – auf den neuen umleitet."
+msgstr "Ausmusterung eines Artikels zugunsten eines Nachfolger-Teils, damit die Planung den Bedarf des alten Artikels — multipliziert mit dem Umrechnungsfaktor — auf den Nachfolger umleitet."
 
 msgid "Phone"
 msgstr "Telefon"
@@ -11054,13 +11054,13 @@ msgid "Pick"
 msgstr "Auswählen"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "Wählen Sie eine Carbon-Dimension und das Provider-Ziel aus, auf das sie publiziert wird. Auto-create fügt beim Versenden fehlende Provider-Optionen nach Namen hinzu."
+msgstr "Wählen Sie eine Carbon-Dimension und das Provider-Ziel aus, zu dem sie übertragen wird. Auto-create fügt zum Zeitpunkt des Übertragens fehlende Provider-Optionen nach Name hinzu."
 
 msgid "Pick a column to sort by"
 msgstr "Wählen Sie eine Spalte zum Sortieren"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "Wählen Sie einen Kunden oder einen Kundentyp aus, um deren Preise anzuzeigen."
+msgstr "Wählen Sie einen Kunden oder Kundentyp aus, um deren Preisfindung anzuzeigen."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "Wählen Sie ein Datum oder lassen Sie es leer, um es zu löschen."
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "Entnahmereihenfol­ge"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "Wählen Sie das Behältnis, das Bestand benötigt, und wählen Sie dann die Behältnisse zum Entnehmen aus."
+msgstr "Wählen Sie den Lagerplatz mit Bestandsbedarf aus, dann die Lagerplätze, von denen Sie ihn entnehmen möchten."
 
 msgid "Pick tracked item"
 msgstr "Verfolgtes Element auswählen"
@@ -11120,7 +11120,7 @@ msgid "Picking Lists"
 msgstr "Kommissionierlisten"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Geplant"
+msgstr "Die Kommissionierung priorisiert verfolgbare Entitäten nach frühestem Verfallsdatum, sodass der bald verfallende Bestand standardmäßig zuerst entnommen wird."
 
 msgid "Pieces/Hour"
 msgstr "Stück/Stunde"
@@ -11164,7 +11164,7 @@ msgid "Planned Order"
 msgstr "Geplante Bestellung"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "Geplante Bestellung = MRP-Vorschlag zur Deckung der prognostizierten Nachfrage basierend auf der Nachbestellungsrichtlinie des Artikels (oder manuell hinzugefügt)."
+msgstr "Geplanter Auftrag = MRP-Vorschlag zur Deckung des erwarteten Bedarfs basierend auf der Bestellpolitik des Artikels (oder manuell hinzugefügt)."
 
 msgid "Planned purchase order"
 msgstr "Geplante Bestellung"
@@ -11215,7 +11215,7 @@ msgid "Please select an item"
 msgstr "Bitte wählen Sie einen Artikel aus"
 
 msgid "Please upload a CSV file of your data"
-msgstr "Bitte laden Sie eine CSV-Datei Ihrer Daten hoch"
+msgstr "Bitte laden Sie eine CSV-Datei mit Ihren Daten hoch."
 
 msgid "PO"
 msgstr "PO"
@@ -11230,7 +11230,7 @@ msgid "Policy"
 msgstr "Richtlinie"
 
 msgid "Policy & Procedure"
-msgstr "Richtlinie & Verfahren"
+msgstr "Richtlinie & Verfahrensanweisung"
 
 msgid "Portal Link"
 msgstr "Portal-Link"
@@ -11239,7 +11239,7 @@ msgid "Portals"
 msgstr "Portale"
 
 msgid "Positive Adjustment"
-msgstr "Positive Anpassung"
+msgstr "Positive Korrektur"
 
 msgid "Post"
 msgstr "Buchen"
@@ -11251,13 +11251,13 @@ msgid "Post Invoice"
 msgstr "Rechnung buchen"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "Journaleinträge mit korrekten Konto- und Beschreibungscodes buchen"
+msgstr "Buchen Sie Buchungssätze mit korrekten Konto- und Beschreibungscodes."
 
 msgid "Post Receipt"
 msgstr "Beleg buchen"
 
 msgid "Post Shipment"
-msgstr "Sendung buchen"
+msgstr "Lieferung buchen"
 
 msgid "Postal code"
 msgstr "Postleitzahl"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Gepostet von"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Gebuchte Journale mit diesen Quellentypen werden immer synchronisiert. Die tägliche Zusammenfassung gruppiert die Journale eines Tages in einen Anbieter pro Konto."
+msgstr "Gebuchte Buchungssätze mit diesen Quellentypen werden immer synchronisiert. Die tägliche Zusammenfassung gruppiert die Buchungssätze eines Tages in einen Provider-Eintrag pro Konto."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Einmal verbucht, {corrections} mal korrigiert."
@@ -11290,7 +11290,7 @@ msgid "Posted once, no corrections."
 msgstr "Einmal verbucht, keine Korrektionen."
 
 msgid "Posting"
-msgstr "Vorauszahlungen"
+msgstr "Buchung"
 
 msgid "Posting date"
 msgstr "Buchungsdatum"
@@ -11311,10 +11311,10 @@ msgid "Prefix"
 msgstr "Präfix"
 
 msgid "Prepayments"
-msgstr "Vorauszahlungen (Standard)"
+msgstr "Anzahlungen"
 
 msgid "Prepayments (default)"
-msgstr "Vorbeugungsmaßnahme"
+msgstr "Anzahlungen (Standard)"
 
 msgid "Present Week"
 msgstr "Aktuelle Woche"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "Zurück"
 
 msgid "Preventive action"
-msgstr "Hauptkonto für Bestandsbewertung"
+msgstr "Vorbeugende Maßnahme"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "Vorbeugende Wartungspläne für Ihre Ausrüstung"
+msgstr "Vorbeugende Instandhaltungspläne für Ihre Anlagen"
 
 msgid "Preview"
 msgstr "Vorschau"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Vorheriger Wert von {0}"
 
 msgid "Price break actions"
-msgstr "Aktionen für Preisabstufung"
+msgstr "Preisstaffel-Aktionen"
 
 msgid "Price Break History"
-msgstr "Preisabstufungs-Verlauf"
+msgstr "Preisstaffel-Verlauf"
 
 msgid "Price Breaks"
-msgstr "Preisabstufungen"
+msgstr "Preisst affeln"
 
 msgid "Price List"
 msgstr "Preisliste"
@@ -11372,13 +11372,13 @@ msgid "Price Lists"
 msgstr "Preislisten"
 
 msgid "Price override"
-msgstr "Preisüberschreibung"
+msgstr "Preisübersteuerung"
 
 msgid "Prices"
 msgstr "Preise"
 
 msgid "Pricing"
-msgstr "Preisgestaltung"
+msgstr "Preisfindung"
 
 msgid "Pricing rule"
 msgstr "Preisregel"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "Preisregeln"
 
 msgid "Pricing Trace"
-msgstr "Preisablauf"
+msgstr "Preisfindungs-Rückverfolgung"
 
 msgid "Primary cash account for bank transactions"
-msgstr "Verfahren"
+msgstr "Primäres Kassenkonto für Banktransaktionen"
 
 msgid "Print"
 msgstr "Drucken"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "Drucke {0} Etiketten"
 
 msgid "Print Jobs"
-msgstr "Druckaufträge"
+msgstr "Fertigungsaufträge drucken"
 
 msgid "Print Label"
 msgstr "Etikett drucken"
@@ -11437,16 +11437,16 @@ msgid "Private"
 msgstr "Privat"
 
 msgid "procedure"
-msgstr "Verfahren"
+msgstr "verfahrensanweisung"
 
 msgid "Procedure"
-msgstr "Verfahren"
+msgstr "Verfahrensanweisung"
 
 msgid "procedures"
-msgstr "Prozess"
+msgstr "verfahrensanweisungen"
 
 msgid "Procedures"
-msgstr "Verfahren"
+msgstr "Verfahrensanweisungen"
 
 msgid "process"
 msgstr "Prozesse"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Produktionsmenge"
 
 msgid "Production variance"
-msgstr "Geplante Nachfrage basierend auf Stücklisten und Prognosen."
+msgstr "Produktionsabweichung"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Produktion: Shop-Floor-App und Planung"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Projektstart"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Geplante Bestände"
+msgstr "Erwarteter Bedarf entfaltet aus BOM und Prognosen."
 
 msgid "Projected inventory"
 msgstr "Geplante Verfügbarkeit"
@@ -11543,14 +11543,14 @@ msgstr "Geplanter Bestand"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Wird die Woche vom {0} unter den Sicherheitsbestand fallen"
+msgstr "Erwarteter Fehlbestand in der Woche von {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "Wird voraussichtlich über dem Sicherheitsbestand bleiben"
 
 msgid "Projected to stay above safety stock"
-msgstr "Bestellung"
+msgstr "Prognostiziert, über dem Sicherheitsbestand zu bleiben"
 
 msgid "Projection"
 msgstr "Projektion"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "Prognosen"
 
 msgid "Promised Date"
-msgstr "Zugesagtes Datum"
+msgstr "Zugesagter Termin"
 
 msgid "Properties"
 msgstr "Eigenschaften"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Veröffentlicht von Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Veröffentlichte Version"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Veröffentlichte Versionen können nicht bearbeitet werden. Schauen Sie sich die Version schreibgeschützt an, oder erstellen Sie einen Branch einer neuen Version, um Änderungen vorzunehmen."
@@ -11638,22 +11638,22 @@ msgid "Purchase History"
 msgstr "Kaufverlauf"
 
 msgid "Purchase invoice"
-msgstr "Kaufrechnung"
+msgstr "eingangsrechnung"
 
 msgid "Purchase Invoice"
-msgstr "Kaufrechnung"
+msgstr "Eingangsrechnung"
 
 msgid "Purchase Invoice Amount"
-msgstr "Betrag der Kaufrechnung"
+msgstr "Betrag der Eingangsrechnung"
 
 msgid "Purchase Invoice Line"
-msgstr "Kaufrechnungsposition"
+msgstr "Eingangsrechnungsposition"
 
 msgid "Purchase Invoices"
-msgstr "Kaufrechnungen"
+msgstr "Eingangsrechnungen"
 
 msgid "Purchase order"
-msgstr "Einkaufspreisabweichung"
+msgstr "bestellung"
 
 msgid "Purchase Order"
 msgstr "Bestellung"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Einkaufspreisabweichung (Standard)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Umsatzsteuer Verbindlichkeiten"
+msgstr "Einkaufspreisabweichung (Standard)"
 
 msgid "Purchase Qty"
 msgstr "Kaufmenge"
@@ -11707,13 +11707,13 @@ msgid "Purchase Tax Payable"
 msgstr "Umsatzsteuer Verbindlichkeiten (Standard)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "Einkauf"
+msgstr "Zahlbare Einkaufssteuer (Standard)"
 
 msgid "Purchase to Order"
-msgstr "Kauf auf Bestellung"
+msgstr "Einzelbeschaffung"
 
 msgid "Purchase Unit of Measure"
-msgstr "Kaufeinheit"
+msgstr "Einkaufs-Mengeneinheit"
 
 msgid "Purchase Unit:"
 msgstr "Kaufeinheit:"
@@ -11728,13 +11728,13 @@ msgid "purchasing"
 msgstr "Einkauf & Kosten der verkauften Waren"
 
 msgid "Purchasing"
-msgstr "Beschaffung"
+msgstr "Einkauf"
 
 msgid "Purchasing & Inventory"
-msgstr "Beschaffung & Bestand"
+msgstr "Einkauf & Bestände"
 
 msgid "Purchasing and auto-planning"
-msgstr "Beschaffung und automatische Planung"
+msgstr "Einkauf und automatische Planung"
 
 msgid "Purchasing contact"
 msgstr "Einkaufskontakt"
@@ -11746,7 +11746,7 @@ msgid "Purchasing Invoices"
 msgstr "Einkaufsrechnungen"
 
 msgid "Purchasing Unit of Measure"
-msgstr "Einkaufsmaßeinheit"
+msgstr "Einkaufs-Mengeneinheit"
 
 msgid "Push"
 msgstr "Senden"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Übertragen Sie Datensatzänderungen in dem Moment an externe Systeme, in dem sie auftreten."
 
 msgid "Push the journal without the dimension"
-msgstr "Publizieren Sie das Journal ohne die Dimension"
+msgstr "Den Buchungssatz ohne die Dimension verbuchen"
 
 msgid "Push to accounting"
 msgstr "Zur Buchhaltung senden"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Menge verschrottet"
 
 msgid "quality"
-msgstr "Angebot bis Zahlungseingang"
+msgstr "qualität"
 
 msgid "Quality"
 msgstr "Qualität"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "Qualitätstyp"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "Qualität: Inspektionen, Nichtkonformität, CAPA"
+msgstr "Qualität: Prüfungen, Nichtkonformität, CAPA"
 
 msgid "Quantities"
 msgstr "Mengen"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Eintreffende Menge – aus offenen Bestellungen plus aus Produktionsaufträgen (Herstellen)."
 
 msgid "Quantity Breaks"
-msgstr "Mengenrabatte"
+msgstr "Mengenstaffeln"
 
 msgid "Quantity complete"
 msgstr "Menge abgeschlossen"
@@ -11840,28 +11840,28 @@ msgid "Quantity must be greater than 0"
 msgstr "Menge muss größer als 0 sein"
 
 msgid "Quantity on hand"
-msgstr "Verfügbare Menge"
+msgstr "istbestand"
 
 msgid "Quantity on Hand"
-msgstr "Menge im Bestand"
+msgstr "Istbestand"
 
 msgid "Quantity on Jobs"
-msgstr "Menge in Aufträgen"
+msgstr "Menge auf Fertigungsaufträgen"
 
 msgid "Quantity on Purchase Order"
 msgstr "Menge in Bestellung"
 
 msgid "Quantity on Sales Order"
-msgstr "Menge in Verkaufsauftrag"
+msgstr "Menge auf Kundenauftrag"
 
 msgid "Quantity Per Job"
 msgstr "Menge pro Auftrag"
 
 msgid "Quantity per Parent"
-msgstr "Menge pro Übergeordnete"
+msgstr "Einbaumenge"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Physisch vorhandene Menge auf der zugewiesenen Lagereinheit (Regal) des Materials. Wird rot, wenn sie unter dem liegt, was diese Einheit liefern muss."
+msgstr "Physische Menge in der zugewiesenen Lagereinheit des Werkstoffs. Wird rot, wenn sie unter dem liegt, was diese Einheit liefern muss."
 
 msgid "Quantity Range"
 msgstr "Mengenbereich"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Mengentyp"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Mengenbasisierte Preisstufen für diese Überschreibung; der angewendete Einheitspreis ist die Zeile mit der größten Mindestmenge, die die Bestellposition erfüllt."
+msgstr "Mengenbasierte Preisstufen für diese Übersteuerung; der angewendete Einzelpreis ist die Zeile mit der größten Mindestmenge, die die Bestellposition erfüllt."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11901,10 +11901,10 @@ msgid "Quote"
 msgstr "Angebot"
 
 msgid "Quote Accepted By"
-msgstr "Angebot akzeptiert von"
+msgstr "Angebot angenommen von"
 
 msgid "Quote Accepted By Email"
-msgstr "Angebot akzeptiert von E-Mail"
+msgstr "Angebot angenommen per E-Mail"
 
 msgid "Quote expired"
 msgstr "Angebot abgelaufen"
@@ -11913,7 +11913,7 @@ msgid "Quote ID"
 msgstr "Angebots-ID"
 
 msgid "Quote line"
-msgstr "Angebotzeile"
+msgstr "Angebotsposition"
 
 msgid "Quote Line"
 msgstr "Angebotsposition"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Angebotsnummer"
 
 msgid "Quote to cash"
-msgstr "Debitorenkonten"
+msgstr "Angebot bis Zahlung"
 
 msgid "Quote Type"
 msgstr "Angebotstyp"
@@ -11949,7 +11949,7 @@ msgid "Quotes"
 msgstr "Angebote"
 
 msgid "Quoting and sales orders"
-msgstr "Angebote und Aufträge"
+msgstr "Angebote und Kundenaufträge"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "Angebote, Bestellungen, Konfigurieren nach Bestellung"
@@ -12006,7 +12006,7 @@ msgid "Ready"
 msgstr "Bereit"
 
 msgid "Ready for Quote"
-msgstr "Bereit für Angebot"
+msgstr "Angebotsbereit"
 
 msgid "ready to keep or revert"
 msgstr "bereit zum Behalten oder Zurücksetzen"
@@ -12042,7 +12042,7 @@ msgid "Reasons"
 msgstr "Gründe"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "Weisen Sie bestimmte nachverfolgbare Entitäten aus dieser Zeile einer anderen Dispositionszeile zu."
+msgstr "Ordnen Sie spezifische verfolgte Einheiten aus dieser Position einer anderen Verwendungsentscheid-Position zu."
 
 msgid "Recalculate"
 msgstr "Neu berechnen"
@@ -12066,25 +12066,25 @@ msgid "Receipt Lines"
 msgstr "Empfangszeilen"
 
 msgid "Receipt Promised Date"
-msgstr "Zugesagtes Lieferdatum"
+msgstr "Zugesagter Termin Wareneingang"
 
 msgid "Receipt Requested Date"
-msgstr "Angeforderte Eingangsdatum"
+msgstr "Wunschtermin Wareneingang"
 
 msgid "Receipts"
 msgstr "Quittungen"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Eingänge, Versände, Verkaufsrechnungen, Kaufrechnungen, Zahlungen und Gutschriften/Lastschriften, die noch im Entwurf oder ausstehend sind, müssen gebucht oder storniert werden – sowohl Dokumente mit Datum in dieser Periode als auch undatierte Dokumente, die bei Buchung ein Datum in dieser Periode erhalten würden. Bis zur Buchung befinden sich ihre Beträge nicht im Hauptbuch, daher wäre die Periode unterschätzt."
+msgstr "Wareneingang, Lieferung, Ausgangsrechnung, Eingangsrechnung, Zahlung und Gut-/Lastschrift, die sich noch in Entwurf oder Ausstehend befinden, müssen gebucht oder storniert werden – sowohl Dokumente, die in diesem Zeitraum datiert sind, als auch undatierte Dokumente, die bei der Buchung in diesem Zeitraum ein Datum erhalten würden. Solange sie nicht gebucht sind, sind ihre Beträge nicht im Hauptbuch enthalten, daher wäre der Zeitraum untererfasst."
 
 msgid "Receivables"
-msgstr "Debitorenkonten (Standard)"
+msgstr "Forderungen"
 
 msgid "Receivables (AR)"
-msgstr "Forderungen (AR)"
+msgstr "Forderungen (Debitoren)"
 
 msgid "Receivables (default)"
-msgstr "Abstimmung einer Bestellung mit dem Empfangenen und Rechnungsgestellten — implizit in Carbon über die Zeilenmengen und GR/IR-Bilanz."
+msgstr "Forderungen (Standard)"
 
 msgid "Receivables aging"
 msgstr "Forderungen nach Alter"
@@ -12145,34 +12145,34 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "Bei der Abstimmung wurden Abweichungen mit dem Anbieter gefunden"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Abschreibungsdauer"
+msgstr "Abstimmung einer Bestellung gegen das, was eingegangen und fakturiert wurde – implizit in Carbon über die Positionsmengen und den WE/RE-Saldo."
 
 msgid "Record"
 msgstr "Aufnahme"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "Erfassen Sie eine Gutschrift oder Belastungsmitteilung für einen Kunden oder Lieferanten. Anwendungen auf bestimmte Rechnungen werden nach der Erstellung der Mitteilung hinzugefügt."
+msgstr "Erfassen Sie eine Gutschrift oder Lastschrift gegen einen Kunden oder Lieferanten. Anwendungen auf spezifische Rechnungen werden nach der Erstellung des Dokuments hinzugefügt."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Erfassen Sie Bargeld, das von einem Kunden (Quittung) eingegangen ist oder an einen Lieferanten (Auszahlung) gezahlt wurde. Anwendungen auf bestimmte Rechnungen werden nach der Erstellung der Zahlung hinzugefügt."
+msgstr "Erfassen Sie erhaltene Kasse von einem Kunden oder an einen Lieferanten gezahlte Kasse (Auszahlung). Anwendungen auf spezifische Rechnungen werden nach der Erstellung der Zahlung hinzugefügt."
 
 msgid "Record deleted"
 msgstr "Datensatz gelöscht"
 
 msgid "Record inspections tied to a part and a job"
-msgstr "Inspektionen aufzeichnen, die an ein Teil und einen Auftrag gebunden sind"
+msgstr "Erfassen Sie Prüfungen, die an einen Teil und einen Fertigungsauftrag gebunden sind"
 
 msgid "Record type"
 msgstr "Datensatztyp"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Bei einer Kalibrierung vermerkt, dass das Messinstrument repariert werden muss, bevor seinen Messwerte vertraut werden kann."
+msgstr "Erfasst bei einer Kalibrierung, dass das Prüfmittel repariert werden muss, bevor seinen Messwerten vertraut werden kann."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Aufgezeichnet, dass eine Nachverfolgung nach dieser Kalibrierung erforderlich ist; stellt diese Messgerät in die Warteschlange für offene Aktionen."
+msgstr "Erfasst, dass eine Nachverfolgung nach dieser Kalibrierung erforderlich ist; zeigt dieses Prüfmittel in der Warteschlange der offenen Maßnahmen an."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Aufgezeichnet, dass die Messgerät während dieser Kalibrierung angepasst wurde; beeinflusst, wie sich das Kalibrierungsintervall neu berechnet."
+msgstr "Erfasst, dass das Prüfmittel während dieser Kalibrierung angepasst wurde; wirkt sich darauf aus, wie das Kalibrierintervall neu berechnet wird."
 
 msgid "Records"
 msgstr "Aufzeichnungen"
@@ -12196,10 +12196,10 @@ msgid "Refresh exchange rate"
 msgstr "Wechselkurs aktualisieren"
 
 msgid "Regenerate thumbnail from the 3D model"
-msgstr "Miniaturansicht aus dem 3D-Modell neu generieren"
+msgstr "Vorschaubild aus dem 3D-Modell regenerieren"
 
 msgid "Regenerating thumbnail…"
-msgstr "Miniaturansicht wird neu generiert…"
+msgstr "Vorschaubild wird regeneriert…"
 
 msgid "Register"
 msgstr "Vorhandenes Vermögen registrieren"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Registriert"
 
 msgid "Registered"
-msgstr "Bestellpunkt"
+msgstr "Registriert"
 
 msgid "Registration failed"
 msgstr "Registrierung fehlgeschlagen"
@@ -12244,7 +12244,7 @@ msgid "Relative timeline · dates to be confirmed"
 msgstr "Relative Zeitleiste · Daten müssen noch bestätigt werden"
 
 msgid "Release"
-msgstr "Freigabe"
+msgstr "Freigeben"
 
 msgid "Release change notice"
 msgstr "Änderungsmitteilung freigeben"
@@ -12265,10 +12265,10 @@ msgid "Released date"
 msgstr "Freigabedatum"
 
 msgid "Released revision"
-msgstr "Freigegebene Version"
+msgstr "Freigegebene Revision"
 
 msgid "Released revision is locked"
-msgstr "Freigegebene Version ist gesperrt"
+msgstr "Freigegebene Revision ist gesperrt"
 
 msgid "Remaining"
 msgstr "Verbleibend"
@@ -12335,7 +12335,7 @@ msgid "Remove sort by column"
 msgstr "Sortierung nach Spalte entfernen"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Entfernen Sie diesen Speichertyp aus allen referenzierenden Speichereinheiten und löschen Sie ihn. Dies kann nicht rückgängig gemacht werden."
+msgstr "Entfernen Sie diesen Speichertyp aus allen referenzierenden Lagereinheiten und löschen Sie ihn. Dies kann nicht rückgängig gemacht werden."
 
 msgid "Remove tool"
 msgstr "Werkzeug entfernen"
@@ -12357,7 +12357,7 @@ msgid "Rendering label preview..."
 msgstr "Label-Vorschau wird gerendert..."
 
 msgid "Reopen"
-msgstr "Erneut öffnen"
+msgstr "Wieder öffnen"
 
 msgid "Reorder"
 msgstr "Neu anordnen"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "Gruppe neu anordnen"
 
 msgid "Reorder point"
-msgstr "Bestellpunkt"
+msgstr "Meldebestand"
 
 msgid "Reorder Point"
-msgstr "Bestellpunkt"
+msgstr "Meldebestand"
 
 msgid "Reorder Point:"
-msgstr "Bestellpunkt:"
+msgstr "Meldebestand:"
 
 msgid "Reorder Policy"
 msgstr "Bestellrichtlinie"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "Nachbestellmenge:"
 
 msgid "Reordering policy"
-msgstr "Nachbestellungsrichtlinie"
+msgstr "Dispositionsverfahren"
 
 msgid "Reordering Policy"
-msgstr "Nachbestellungsrichtlinie"
+msgstr "Dispositionsverfahren"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Ordnet nur Versandsequenz und Arbeitsplatz neu — plant nicht um. Termine auf dem Datumsboard ändern."
+msgstr "Sortiert nur die Reihenfolge der Instandhaltungsaufträge und den Arbeitsplatz neu – führt keine Neuplanung durch. Ändern Sie die Daten auf der Datentafel."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Wiederholt einmal für jedes Element in {inputLabel}"
@@ -12405,7 +12405,7 @@ msgid "Replace drawing?"
 msgstr "Zeichnung ersetzen?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Ersetzen Sie vorhandene Preise durch Quellwerte"
+msgstr "Ersetzen Sie die vorhandene Preisfindung durch Quellwerte"
 
 msgid "Replace PDF"
 msgstr "PDF ersetzen"
@@ -12420,10 +12420,10 @@ msgid "Replenishment"
 msgstr "Nachschub"
 
 msgid "Replenishment system"
-msgstr "Nachschubsystem"
+msgstr "Beschaffungsart"
 
 msgid "Replenishment System"
-msgstr "Auffüllungssystem"
+msgstr "Beschaffungsart"
 
 msgid "Report"
 msgstr "Bericht"
@@ -12450,7 +12450,7 @@ msgid "Request Approval"
 msgstr "Genehmigung anfordern"
 
 msgid "Requested Date"
-msgstr "Angeforderte Datum"
+msgstr "Wunschtermin"
 
 msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "Erfordert einen 6-stelligen Code aus einer Authentifikator-App beim Anmelden."
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "Erforderliche Aktionen (in Reihenfolge)"
 
 msgid "Required Date"
-msgstr "Erforderliches Datum"
+msgstr "Bedarfstermin"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Erforderlich in einer kontrollierten Umgebung – Audit-Logging kann nicht deaktiviert werden."
@@ -12507,7 +12507,7 @@ msgid "Requires Action"
 msgstr "Erfordert Maßnahmen"
 
 msgid "Requires Adjustment"
-msgstr "Erfordert Anpassung"
+msgstr "Erfordert Korrektur"
 
 msgid "Requires Repair"
 msgstr "Reparatur erforderlich"
@@ -12547,7 +12547,7 @@ msgid "Residual Value %"
 msgstr "Restwert %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "Beheben Sie diese vor Abschluss des NCR: Jede Zeile muss eine nicht ausstehende Disposition haben, und ihre verknüpften Entitätsmengen müssen mit der Zeilenmenge übereinstimmen."
+msgstr "Lösen Sie diese auf, bevor Sie die NCR abschließen: Jede Zeile muss einen nicht-ausstehenden Verwendungsentscheid haben, und ihre verknüpften Entitätsmengen müssen der Zeilenmenge entsprechen."
 
 msgid "Resolved Price"
 msgstr "Aufgelöster Preis"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Aus dem Papierkorb wiederherstellen"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Diese Entität zum verfügbaren Bestand in dem Behälter und den Kosten zurückholen, von denen sie verschrottet wurde."
+msgstr "Stellen Sie diese Entität als verfügbaren Bestand zum Lagerplatz und zu den Kosten wieder her, von denen sie verschrottet wurde."
 
 msgid "Restore tracked entities to available"
 msgstr "Nachverfolgter Entitäten als verfügbar wiederherstellen"
@@ -12583,13 +12583,13 @@ msgid "Resume Receiving"
 msgstr "Empfang fortsetzen"
 
 msgid "Retained Earnings"
-msgstr "Thesaurierte Gewinne"
+msgstr "Gewinnvortrag"
 
 msgid "Retained Earnings (default)"
-msgstr "Thesaurierte Gewinne (Standard)"
+msgstr "Gewinnvortrag (Standard)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
-msgstr "Außerdienststellung eines Vermögenswerts durch Verschrottung oder Verkauf, wobei ein Gewinn oder Verlust gegen den Nettobuchwert verbucht und der Status auf „Entsorgt” gesetzt wird."
+msgstr "Stillegung eines Vermögenswertes durch Verschrottung oder Verkauf, Buchung von Gewinn oder Verlust gegen den Restbuchwert und Festlegung des Status auf Abgegangen."
 
 msgid "Retry"
 msgstr "Erneut versuchen"
@@ -12616,34 +12616,34 @@ msgid "Rev {revision}"
 msgstr "Rev {revision}"
 
 msgid "Revenue"
-msgstr "Umsatz"
+msgstr "Umsatzerlöse"
 
 msgid "Revenue and expenses over a period"
-msgstr "Umsatz und Aufwendungen über einen Zeitraum"
+msgstr "Umsatzerlöse und Aufwand über einen Zeitraum"
 
 msgid "Reverse all inventory adjustments"
-msgstr "Alle Bestandsanpassungen rückgängig machen"
+msgstr "Alle Bestandskorrektionen rückgängig machen"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "Alle Journal- und Kostenkontoeinträge rückgängig machen"
+msgstr "Alle Buchungssatzeinträge und Kostenbuchhaltungseinträge stornieren"
 
 msgid "Reverse any item ledger entries from this invoice"
 msgstr "Alle Artikelledgereinträge aus dieser Rechnung stornieren"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Stornierungsgebühr"
 
 msgid "Reverse Charge Sales Tax"
-msgstr "Umkehrbuchung Umsatzsteuer"
+msgstr "Reverse-Charge-Verfahren Umsatzsteuer"
 
 msgid "Reverse Charge Sales Tax (default)"
-msgstr "Umkehrbuchung Umsatzsteuer (Standard)"
+msgstr "Reverse-Charge-Verfahren Umsatzsteuer (Standard)"
 
 msgid "Reverse the related journal entries"
-msgstr "Kehren Sie die zugehörigen Journaleinträge um"
+msgstr "Stornieren Sie die zugehörigen Buchungssatzeinträge"
 
 msgid "Reversed"
-msgstr "Rückgängig gemacht"
+msgstr "Storniert"
 
 msgid "Revert"
 msgstr "Zurücksetzen"
@@ -12664,7 +12664,7 @@ msgid "Review the suggested matches before applying. These are a best guess — 
 msgstr "Überprüfen Sie die vorgeschlagenen Zuordnungen vor dem Anwenden. Dies sind Schätzungen — bestätigen Sie, dass jede richtig ist."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Überprüfen Sie die folgenden Warnungen und posten Sie dann die Anzahl, um die Anpassungen anzuwenden."
+msgstr "Überprüfen Sie die folgenden Warnungen und buchen Sie dann die Anzahl, um die Korrektionen anzuwenden."
 
 msgid "Revision"
 msgstr "Revision"
@@ -12677,7 +12677,7 @@ msgid "Revision status"
 msgstr "Revisionsstatus"
 
 msgid "Revisions"
-msgstr "Versionen"
+msgstr "Revisionen"
 
 msgid "Revoke"
 msgstr "Widerrufen"
@@ -12689,13 +12689,13 @@ msgid "Revoke Invites"
 msgstr "Einladungen widerrufen"
 
 msgid "Rework"
-msgstr "Nachbearbeitung"
+msgstr "Nacharbeit"
 
 msgid "RFQ"
 msgstr "RFQ"
 
 msgid "RFQ (request for quote)"
-msgstr "RFQ (Angebotanforderung)"
+msgstr "RFQ (Anfrage)"
 
 msgid "RFQ Date"
 msgstr "RFQ-Datum"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "Anfragen"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Carbon-Dimensionen in gepushten Journalen mitführen. Jeder Slot ordnet eine Carbon-Dimension einem Analytics-Ziel des Providers zu; die Wertzuordnung unten ordnet einzelne Dimensionswerte Provider-Optionen zu."
+msgstr "Fahren Sie Carbon-Dimensionen auf gepushten Buchungssätzen mit. Jeder Steckplatz ordnet eine Carbon-Dimension einem Anbieter-Analyseziel zu; die Wertzuordnung unten paart einzelne Dimensionswerte mit Anbieteroptionen."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12732,7 +12732,7 @@ msgid "Risk"
 msgstr "Risiko"
 
 msgid "Risk register"
-msgstr "Risikoverzeichnis"
+msgstr "Risikoregister"
 
 msgid "Risks"
 msgstr "Risiken"
@@ -12765,10 +12765,10 @@ msgid "Rounding Account (default)"
 msgstr "Rundungskonto (Standard)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Leiten Sie alle AP-Rechnungen an eine Adresse (z. B. Unternehmenszentrale) statt an einzelne Einkäufer weiter."
+msgstr "Leiten Sie alle Kreditorenrechnungen an eine Adresse (z. B. Unternehmenszentrale) anstelle einzelner Einkäufer weiter."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Leiten Sie alle AR-Rechnungen an eine Adresse (z. B. Unternehmenszentrale) statt an einzelne Standorte weiter."
+msgstr "Leiten Sie alle Debitorenrechnungen an eine Adresse (z. B. Unternehmenszentrale) anstelle einzelner Standorte weiter."
 
 msgid "Routing"
 msgstr "Arbeitsplan"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Führen Sie die Akzeptanzprüfliste bis zum Bestehen durch"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Betrieb auf Tablets: Arbeitszeit erfassen, Fortschritt melden, Anweisungen anzeigen"
+msgstr "Führen Sie die Werkstatt auf Tablets aus: Personaleinsatz erfassen, Fortschritt melden, Anweisungen anzeigen"
 
 msgid "Run this workflow now?"
 msgstr "Diesen Workflow jetzt ausführen?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "Wird ausgeführt"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "Bestände nach jeder Woche laufen nach Angebot und Nachfrage — die Linie."
+msgstr "Bestandsverwaltung nach wöchentlicher Deckung und Bedarf — die Zeile."
 
 msgid "Running Total"
 msgstr "Laufender Gesamtbetrag"
@@ -12883,88 +12883,88 @@ msgid "Sale Price"
 msgstr "Verkaufspreis"
 
 msgid "sales"
-msgstr "Verkaufserlöse"
+msgstr "vertrieb"
 
 msgid "Sales"
-msgstr "Verkauf"
+msgstr "Vertrieb"
 
 msgid "Sales (default)"
-msgstr "Verkaufserlöse (Standard)"
+msgstr "Vertrieb (Standard)"
 
 msgid "Sales & Quoting"
 msgstr "Vertrieb & Angebotserstellung"
 
 msgid "Sales & Revenue"
-msgstr "Umsatz & Ertrag"
+msgstr "Vertrieb & Umsatzerlöse"
 
 msgid "Sales contact"
-msgstr "Verkaufskontakt"
+msgstr "Vertriebskontakt"
 
 msgid "Sales Contact"
-msgstr "Verkaufskontakt"
+msgstr "Vertriebskontakt"
 
 msgid "Sales Discounts"
-msgstr "Verkaufsrabatte"
+msgstr "Vertriebsrabatte"
 
 msgid "Sales Discounts (default)"
-msgstr "Verkaufsrabatte (Standard)"
+msgstr "Vertriebsrabatte (Standard)"
 
 msgid "Sales Funnel"
-msgstr "Verkaufstrichter"
+msgstr "Vertriebstrichter"
 
 msgid "Sales invoice"
-msgstr "Verkaufsrechnung"
+msgstr "Ausgangsrechnung"
 
 msgid "Sales Invoice"
-msgstr "Verkaufsrechnung"
+msgstr "Ausgangsrechnung"
 
 msgid "Sales Invoice Line"
-msgstr "Verkaufsrechnungsposition"
+msgstr "Ausgangsrechnungsposition"
 
 msgid "Sales Invoices"
-msgstr "Verkaufsrechnungen"
+msgstr "Ausgangsrechnungen"
 
 msgid "Sales Job Notifications"
-msgstr "Verkaufsauftragsbenachrichtigungen"
+msgstr "Fertigungsauftrags-Benachrichtigungen"
 
 msgid "Sales order"
-msgstr "Verkaufsauftrag"
+msgstr "Kundenauftrag"
 
 msgid "Sales Order"
-msgstr "Verkaufsauftrag"
+msgstr "Kundenauftrag"
 
 msgid "Sales Order ID"
-msgstr "Verkaufsauftrags-ID"
+msgstr "Kundenauftrag-ID"
 
 msgid "Sales order line"
-msgstr "Verkaufsauftragszeile"
+msgstr "Kundenauftragsposition"
 
 msgid "Sales Order Line"
-msgstr "Verkaufsauftragszeile"
+msgstr "Kundenauftragsposition"
 
 msgid "Sales Order Line (job)"
-msgstr "Verkaufsauftragszeile (Job)"
+msgstr "Kundenauftragsposition (Fertigungsauftrag)"
 
 msgid "Sales Order Location"
-msgstr "Verkaufsauftrag-Standort"
+msgstr "Kundenauftrag Standort"
 
 msgid "Sales Order Number"
-msgstr "Verkaufsauftragsnummer"
+msgstr "Kundenauftragsnummer"
 
 msgid "Sales Orders"
-msgstr "Verkaufsaufträge"
+msgstr "Kundenaufträge"
 
 msgid "Sales Person"
 msgstr "Verkäufer"
 
 msgid "Sales Revenue"
-msgstr "Verkaufsumsatz"
+msgstr "Umsatzerlöse"
 
 msgid "Sales Tax Payable"
-msgstr "Umsatzsteuer"
+msgstr "Umsatzsteuer zu zahlen"
 
 msgid "Sales Tax Payable (default)"
-msgstr "Umsatzsteuer (Standard)"
+msgstr "Umsatzsteuer zu zahlen (Standard)"
 
 msgid "Sales, Estimator"
 msgstr "Vertrieb, Schätzer"
@@ -13051,7 +13051,7 @@ msgid "Scan or choose a serial number"
 msgstr "Scannieren oder wählen Sie eine Seriennummer"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Scannen oder geben Sie die Kennung der verfolgten Entität, Seriennummer oder Chargennummer ein"
+msgstr "Scannen Sie oder geben Sie die ID der verfolgten Einheit, Seriennummer oder Los ein"
 
 msgid "Scan or enter tracking number"
 msgstr "Scannen oder Verfolgungsnummer eingeben"
@@ -13060,7 +13060,7 @@ msgid "Scan or search..."
 msgstr "Scannen oder suchen..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Scannen Sie eine verfolgbare Entität aus dieser Charge oder wählen Sie eine aus, um sie als Beispielspalte hinzuzufügen, und erfassen Sie dann ihr Ergebnis in der Tabelle."
+msgstr "Scannen oder wählen Sie eine verfolgte Einheit aus dieser Charge aus, um sie als Spalte hinzuzufügen, und erfassen Sie das Ergebnis dann in der Tabelle."
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
 msgstr "Scannen Sie diesen QR-Code mit Ihrer Authentifikator-App (z. B. Google Authenticator oder 1Password) und geben Sie dann den 6-stelligen Code ein, den sie anzeigt."
@@ -13078,16 +13078,16 @@ msgid "Schedule"
 msgstr "Zeitplan"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Aufträge gegen Arbeitszentrum-Kapazität planen"
+msgstr "Fertigungsaufträge gegen Arbeitszellenkapazität terminieren"
 
 msgid "Schedule Name"
 msgstr "Zeitplanname"
 
 msgid "Scheduled Maintenance"
-msgstr "Geplante Wartung"
+msgstr "Geplante Instandhaltung"
 
 msgid "Scheduled Maintenances"
-msgstr "Geplante Wartungen"
+msgstr "Geplante Instandhaltungen"
 
 msgid "Schedules"
 msgstr "Zeitpläne"
@@ -13108,10 +13108,10 @@ msgid "Scopes"
 msgstr "Bereiche"
 
 msgid "Scrap"
-msgstr "Verschrottung"
+msgstr "Ausschuss"
 
 msgid "Scrap / Cost of Quality"
-msgstr "Verschrott / Qualitätskosten"
+msgstr "Ausschuss / Qualitätskosten"
 
 msgid "Scrap Percent"
 msgstr "Ausschussquote"
@@ -13126,22 +13126,22 @@ msgid "Scrap quantity"
 msgstr "Ausschussmenge"
 
 msgid "Scrap Quantity"
-msgstr "Verschrottungsmenge"
+msgstr "Ausschussmenge"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Ausschussmenge pro Auftrag"
 
 msgid "scrap reason"
-msgstr "Verschrottungsgrund"
+msgstr "Ausschussgrund"
 
 msgid "Scrap Reason"
-msgstr "Verschrottungsgrund"
+msgstr "Ausschussgrund"
 
 msgid "scrap reasons"
-msgstr "Verschrottungsgründe"
+msgstr "Ausschussgründe"
 
 msgid "Scrap Reasons"
-msgstr "Verschrottungsgründe"
+msgstr "Ausschussgründe"
 
 msgid "Scrapped"
 msgstr "Verschrottet"
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "Suchen Sie nach einem vorhandenen oder erstellen Sie einen neuen"
 
 msgid "Search items or bins"
-msgstr "Artikel oder Behälter durchsuchen"
+msgstr "Artikel oder Lagerplätze suchen"
 
 msgid "Search Job"
 msgstr "Job durchsuchen"
@@ -13192,10 +13192,10 @@ msgid "Search list variables…"
 msgstr "Listvariablen durchsuchen…"
 
 msgid "Search operations…"
-msgstr "Vorgänge durchsuchen…"
+msgstr "Arbeitsgänge suchen…"
 
 msgid "Search operators..."
-msgstr "Operatoren durchsuchen..."
+msgstr "Werker suchen..."
 
 msgid "Search parts..."
 msgstr "Teile durchsuchen..."
@@ -13246,7 +13246,7 @@ msgid "Select"
 msgstr "Auswählen"
 
 msgid "Select a assignee"
-msgstr "Wählen Sie einen Bevollmächtigten"
+msgstr "Einen Bearbeiter auswählen"
 
 msgid "Select a default approver"
 msgstr "Wählen Sie einen Standard-Genehmiger"
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "Dokument auswählen"
 
 msgid "Select a new owner"
-msgstr "Wählen Sie einen neuen Eigentümer"
+msgstr "Einen neuen Verantwortlichen auswählen"
 
 msgid "Select a new parent group for this account."
 msgstr "Wählen Sie eine neue übergeordnete Gruppe für dieses Konto."
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "Wählen Sie ein Angebot aus"
 
 msgid "Select a quote line"
-msgstr "Wählen Sie eine Angebotszeile aus"
+msgstr "Eine Angebotsposition auswählen"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "Wählen Sie einen Grund aus, warum das Angebot nicht erstellt wurde."
@@ -13307,7 +13307,7 @@ msgid "Select an action…"
 msgstr "Aktion auswählen…"
 
 msgid "Select an assignee"
-msgstr "Wählen Sie einen Verantwortlichen aus"
+msgstr "Einen Bearbeiter auswählen"
 
 msgid "Select an event…"
 msgstr "Ereignis auswählen…"
@@ -13331,7 +13331,7 @@ msgid "Select an option"
 msgstr "Wählen Sie eine Option"
 
 msgid "Select at least one line to convert"
-msgstr "Wählen Sie mindestens eine Zeile zum Konvertieren aus"
+msgstr "Wählen Sie mindestens eine Position zum Umwandeln aus"
 
 msgid "Select Contact"
 msgstr "Kontakt auswählen"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Feld auswählen"
 
 msgid "Select Gauge"
-msgstr "Messuhr auswählen"
+msgstr "Prüfmittel wählen"
 
 msgid "Select groups or individuals"
 msgstr "Gruppen oder Einzelpersonen auswählen"
@@ -13376,7 +13376,7 @@ msgid "Select invoices in a single currency"
 msgstr "Wählen Sie Rechnungen in einer einzigen Währung aus"
 
 msgid "Select Item Type"
-msgstr "Elementtyp auswählen"
+msgstr "Artikelart wählen"
 
 msgid "Select items"
 msgstr "Artikel auswählen"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Wählen Sie die Gruppen aus, die diese Schulung absolvieren sollen"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Wählen Sie die Rechnungen aus, die diese Zahlung begleicht. Rabatt und Abschreibung sind in Rechnungswährung."
+msgstr "Wählen Sie die Rechnungen aus, die diese Zahlung begleicht. Rabatt und Ausbuchung sind in Rechnungswährung."
 
 msgid "Select value"
 msgstr "Wert auswählen"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Selbst verwaltet"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Selbstgehostet oder verwaltet"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Selbstgesteuertes Onboarding"
 
 msgid "Self-paced"
 msgstr "Selbstgesteuertes Lernen"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "Versendet an jeden Empfänger, der E-Mail-Benachrichtigungen aktiviert hat."
 
 msgid "Sequences"
-msgstr "Sequenzen"
+msgstr "Nummernkreise"
 
 msgid "Serial"
 msgstr "Seriennummer"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "Seriennummer / Charge"
 
 msgid "Serial items require a sales order"
-msgstr "Serienartikel erfordern einen Verkaufsauftrag"
+msgstr "Serienartikel erfordern einen Kundenauftrag"
 
 msgid "Serial Number"
 msgstr "Seriennummer"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Ziel festlegen"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Richten Sie Carbon entsprechend der Funktionsweise Ihres Unternehmens ein: Standorte, Teile, Stücklisten, Fertigungsprozess und die von Ihnen verwendeten Abläufe."
+msgstr "Richten Sie Carbon um die Betriebsweise Ihres Unternehmens ein: Betriebsstätten, Teile, BOMs, Arbeitsgangliste und die von Ihnen verwendeten Abläufe."
 
 msgid "Set Clock Out"
-msgstr "Abmeldung festlegen"
+msgstr "Ausstempeln festlegen"
 
 msgid "Set clock-out time"
 msgstr "Abmeldungszeit festlegen"
@@ -13572,16 +13572,16 @@ msgid "Set Console PIN"
 msgstr "Console-PIN festlegen"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Legen Sie standardmäßige Aufschlagsprozentsätze für jede Kostenkategorie auf neuen Angebotszeilen fest"
+msgstr "Standard-Aufschlagsprozentz für jede Kostenkategorie auf neuen Angebotspositionen festlegen"
 
 msgid "Set demand projection values for each week"
-msgstr "Legen Sie Nachfrageprognosen für jede Woche fest"
+msgstr "Bedarfsprognose-Werte für jede Woche festlegen"
 
 msgid "Set due date"
 msgstr "Fälligkeitsdatum festlegen"
 
 msgid "Set Pricing"
-msgstr "Preisgestaltung festlegen"
+msgstr "Preisfindung festlegen"
 
 msgid "Set Quantity"
 msgstr "Menge festlegen"
@@ -13596,10 +13596,10 @@ msgid "Set up two-factor authentication"
 msgstr "Zwei-Faktor-Authentifizierung einrichten"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "Richten Sie Ihr Unternehmen mit einem Schritt-für-Schritt-Implementierungsplan ein, der Einrichtung, Daten, Schulung und Go-live abdeckt."
+msgstr "Richten Sie Ihr Unternehmen mit einem Schritt-für-Schritt-Umsetzungsplan ein, der Einrichtung, Daten, Schulung und Go-Live abdeckt."
 
 msgid "Set up your own data with import tools and LLM help"
-msgstr "Richten Sie Ihre eigenen Daten mit Importtools und LLM-Hilfe ein"
+msgstr "Richten Sie Ihre eigenen Daten mit Importwerkzeugen und LLM-Hilfe ein"
 
 msgid "Set up your resources and settings"
 msgstr "Richten Sie Ihre Ressourcen und Einstellungen ein"
@@ -13723,25 +13723,25 @@ msgid "Ship-From Location"
 msgstr "Versendungsort"
 
 msgid "Shipment"
-msgstr "Sendung"
+msgstr "Lieferung"
 
 msgid "Shipment Date"
-msgstr "Versanddatum"
+msgstr "Lieferdatum"
 
 msgid "Shipment ID"
-msgstr "Versand-ID"
+msgstr "Lieferungs-ID"
 
 msgid "Shipment Line"
-msgstr "Versandposition"
+msgstr "Lieferposition"
 
 msgid "Shipment Lines"
-msgstr "Versandzeilen"
+msgstr "Lieferpositionen"
 
 msgid "Shipment Location"
-msgstr "Versandort"
+msgstr "Lieferungsstandort"
 
 msgid "Shipments"
-msgstr "Sendungen"
+msgstr "Lieferungen"
 
 msgid "Shipped Qty"
 msgstr "Versendete Menge"
@@ -13786,13 +13786,13 @@ msgid "Shipping:"
 msgstr "Versand:"
 
 msgid "Shop Floor"
-msgstr "Shopfloor"
+msgstr "Werkstatt"
 
 msgid "Shop Floor and Scheduling"
-msgstr "Shopfloor und Planung"
+msgstr "Werkstatt und Planung"
 
 msgid "Shop Floor leads, Planner"
-msgstr "Schichtleiter, Planer"
+msgstr "Werkstatt-Leiter, Planer"
 
 msgid "Shop-floor app and scheduling"
 msgstr "Shop-Floor-App und Planung"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Die ersten 500 Zeilen werden angezeigt"
 
 msgid "Showing the newest 200 journals"
-msgstr "Die neuesten 200 Journale werden angezeigt"
+msgstr "Die neuesten 200 Buchungssätze werden angezeigt"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Die Top 1.000 Gruppen nach Betrag werden angezeigt"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Wird dem Benutzer angezeigt, wenn diese Regel fehlschlägt."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Bei Carbon anmelden"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Melden Sie sich mit Biometrie statt mit einem Magic Link an. Passkeys sind durch Face ID, Touch ID oder Ihre Geräte-PIN gesichert."
@@ -13898,7 +13898,7 @@ msgid "Sign out instead"
 msgstr "Stattdessen abmelden"
 
 msgid "Sign-off review before moving to the next step"
-msgstr "Abzeichnung vor dem Übergang zum nächsten Schritt"
+msgstr "Freigabeüberprüfung vor dem Wechsel zum nächsten Schritt"
 
 msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
 msgstr "Zeichen-Offs, die aufgezeichnet werden müssen, bevor diese Ausgabe geschlossen werden kann; zusätzlich zu denen, die der Workflow erfordert."
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "Standorte & Lagerorte"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "Standorte, Orte, Arbeitszentren, Benutzer, Lieferanten und Ihre Unternehmenseinstellungen — die Grundlage, auf der alles andere aufbaut. Beginnen Sie mit vorgefertigten Vorlagen."
+msgstr "Betriebsstätten, Standorte, Arbeitsplätze, Benutzer, Lieferanten und Ihre Unternehmenseinstellungen — die Grundlage, auf der alles andere aufbaut. Beginnen Sie mit vorgefertigten Vorlagen."
 
 msgid "Size"
 msgstr "Größe"
@@ -13940,7 +13940,7 @@ msgid "Skip raw-material dates set at receipt. Only inputs with their own shelf-
 msgstr "Überspringen Sie Rohmaterialdaten, die beim Empfang festgelegt wurden. Nur Eingaben mit ihrer eigenen Haltbarkeitspolitik zählen."
 
 msgid "Skip scheduled maintenance on company holidays"
-msgstr "Geplante Wartung an Betriebsfeiertagen überspringen"
+msgstr "Geplante Instandhaltung an Betriebsferien überspringen"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Überspringen Sie den freigegebenen, aber nicht gestarteten Zustand – der Auftrag startet sofort beim Scannen."
@@ -13955,10 +13955,10 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "Teile die Vermögensaktivität nach Standort, Artikel oder einer beliebigen Dimension auf"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "Teile die Ausgaben nach Standort, Kostenstelle oder einer beliebigen Dimension auf"
+msgstr "Teilen Sie Aufwendungen nach Standort, Kostenstelle oder einer beliebigen Dimension auf"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Umsatz nach Kunde, Kundentyp oder beliebiger Dimension aufschlüsseln"
+msgstr "Teilen Sie Umsatzerlöse nach Kunde, Kundentyp oder einer beliebigen Dimension auf"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Smoke-Test der täglichen Kernabläufe von Anfang bis Ende"
@@ -14000,19 +14000,19 @@ msgid "Source Analysis"
 msgstr "Quellenanalyse"
 
 msgid "Source Company"
-msgstr "Quellfirma"
+msgstr "Quellunternehmen"
 
 msgid "Source document"
-msgstr "Quelldokument"
+msgstr "Ursprungsbeleg"
 
 msgid "Source Document"
-msgstr "Quelldokument"
+msgstr "Ursprungsbeleg"
 
 msgid "Source Document ID"
-msgstr "Quelldokument-ID"
+msgstr "Ursprungsbeleg-ID"
 
 msgid "Source document readable"
-msgstr "Quelldokument lesbar"
+msgstr "Ursprungsbeleg lesbar"
 
 msgid "Source Item"
 msgstr "Quellartikel"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "Beleg-Position aufteilen"
 
 msgid "Split shipment line"
-msgstr "Versandzeile teilen"
+msgstr "Lieferposition teilen"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Hosting einrichten"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "Standardfaktor"
 
 msgid "Standard Lead Time"
-msgstr "Standardisierte Lieferzeit"
+msgstr "Standard-Beschaffungszeit"
 
 msgid "Start"
 msgstr "Starten"
@@ -14202,7 +14202,7 @@ msgid "Steps are inherited from the assembly instruction."
 msgstr "Die Schritte werden von der Montageanleitungen geerbt."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "Schritte werden vom Inspektionsplan geerbt."
+msgstr "Schritte werden vom Prüfplan übernommen."
 
 msgid "Stock movement corrected"
 msgstr "Lagerbewegung korrigiert"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "Lagerbestandstransfer-ID"
 
 msgid "Stock Transfer Lines"
-msgstr "Bestandstransfer-Zeilen"
+msgstr "Umlagerungspositionen"
 
 msgid "Stock Transfer Notes"
 msgstr "Bestandsüberführungsnotizen"
@@ -14230,7 +14230,7 @@ msgid "Stocked for spares only."
 msgstr "Nur für Ersatzteile gelagert."
 
 msgid "Stockout"
-msgstr "Ausverkauft"
+msgstr "Fehlbestand"
 
 msgid "Stop raising purchase orders after this date"
 msgstr "Bestellungen nach diesem Datum nicht mehr aufgeben"
@@ -14257,7 +14257,7 @@ msgid "Storage Types"
 msgstr "Speichertypen"
 
 msgid "storage unit"
-msgstr "Lagerbereich"
+msgstr "Lagereinheit"
 
 msgid "Storage unit"
 msgstr "Lagereinheit"
@@ -14269,37 +14269,37 @@ msgid "Storage Unit (optional)"
 msgstr "Lagereinheit (optional)"
 
 msgid "storage units"
-msgstr "Lagerbereiche"
+msgstr "Lagereinheiten"
 
 msgid "Storage Units"
 msgstr "Lagereinheiten"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Ablaufdatum wird für jede Charge oder Seriennummer festgelegt, wenn sie erstellt wird (oder wenn der Triggerprozess ausgeführt wird, falls festgelegt)."
+msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Verfallsdatum wird für jedes Los oder jede Seriennummer beim Erstellen festgelegt (oder wenn der Auslöseprozess läuft, falls aktiviert)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Ablaufdatum wird für jede Charge oder Seriennummer festgelegt, wenn sie empfangen oder erstellt wird (oder wenn der Triggerprozess ausgeführt wird, falls festgelegt)."
+msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Verfallsdatum wird für jedes Los oder jede Seriennummer festgelegt, wenn es eingegangen oder erstellt wird (oder wenn der Auslösungsprozess ausgeführt wird, falls eingestellt)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Ablaufdatum wird für jede Charge oder Seriennummer bei Erhalt festgelegt."
+msgstr "Speichern Sie eine feste Anzahl von Tagen für diesen Artikel. Das Verfallsdatum wird für jedes Los oder jede Seriennummer festgelegt, wenn es eingegangen wird."
 
 msgid "Straight line"
 msgstr "Linear"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe hat bereits einen Kunden mit dieser E-Mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe-Fälligkeitsdatum"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe sendet die Rechnung per E-Mail an den Kunden, daher ist eine Adresse erforderlich. Dies wird auch im Kontakt in Carbon gespeichert."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe hat noch keinen Kunden für diesen Carbon-Kunden. Die Buchung erstellt einen auf Ihrem verbundenen Konto."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Stil der Kanban-Ausgabe, die in der Kanban-Tabelle angezeigt werden soll"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "Zur Genehmigung einreichen"
 
 msgid "Submit Inspection"
-msgstr "Inspektion einreichen"
+msgstr "Prüfung einreichen"
 
 msgid "Submitted By"
 msgstr "Eingereicht von"
@@ -14371,10 +14371,10 @@ msgid "Successfully created a new revision"
 msgstr "Neue Revision erfolgreich erstellt"
 
 msgid "Successor effectivity"
-msgstr "Nachfolger-Effektivität"
+msgstr "Nachfolger-Gültigkeit"
 
 msgid "Successor Effectivity Date"
-msgstr "Nachfolger-Effektivitätsdatum"
+msgstr "Nachfolger-Gültigkeitsdatum"
 
 msgid "Successor Part"
 msgstr "Nachfolgeteil"
@@ -14413,13 +14413,13 @@ msgid "Supersedes"
 msgstr "Ersetzt"
 
 msgid "Supersession"
-msgstr "Nachfolge"
+msgstr "Ablösung"
 
 msgid "Supersession chain detected"
-msgstr "Supersession-Kette erkannt"
+msgstr "Ablösungskette erkannt"
 
 msgid "Supersession Mode"
-msgstr "Nachfolgemodus"
+msgstr "Ablösungsmodus"
 
 msgid "supplier"
 msgstr "Lieferant"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Lieferantenteil"
 
 msgid "Supplier Part ID"
-msgstr "Lieferanten-Artikel-ID"
+msgstr "Lieferantenartikelnummer"
 
 msgid "Supplier Part Number"
 msgstr "Lieferantenteilnummer"
@@ -14485,16 +14485,16 @@ msgid "Supplier Payment Discounts (default)"
 msgstr "Lieferanten-Zahlungsrabatte (Standard)"
 
 msgid "Supplier Prepayments"
-msgstr "Lieferanten-Vorauszahlungen"
+msgstr "Lieferantenanzahlungen"
 
 msgid "supplier process"
-msgstr "Lieferantenprozess"
+msgstr "Lieferantenverfahren"
 
 msgid "supplier processes"
-msgstr "Lieferantenprozesse"
+msgstr "Lieferantenverfahren"
 
 msgid "Supplier Processes"
-msgstr "Lieferantenprozesse"
+msgstr "Lieferantenverfahren"
 
 msgid "Supplier Quality"
 msgstr "Lieferantenqualität"
@@ -14542,7 +14542,7 @@ msgid "Supplier Types"
 msgstr "Lieferantentypen"
 
 msgid "Supplier Unit Price"
-msgstr "Lieferanten-Stückpreis"
+msgstr "Lieferanten-Einzelpreis"
 
 msgid "Supplier updated"
 msgstr "Lieferant aktualisiert"
@@ -14557,10 +14557,10 @@ msgid "Suppliers"
 msgstr "Lieferanten"
 
 msgid "Supply"
-msgstr "Versorgung"
+msgstr "Deckung"
 
 msgid "Supply & Demand"
-msgstr "Angebot & Nachfrage"
+msgstr "Deckung & Bedarf"
 
 msgid "Support"
 msgstr "Support"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "Passen Sie diesen Hub für den Kunden an. Änderungen werden live für alle angewendet, die ihn anzeigen. Wird dem Kunden hier nie angezeigt."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Nehmen Sie die kürzeste verbleibende Haltbarkeitsdauer der Materialien, die zur Herstellung dieses Artikels verbraucht werden. Verwenden Sie dies, wenn die Haltbarkeit des Produkts von seinen Inhaltsstoffen abhängt."
+msgstr "Berücksichtigen Sie die kürzeste verbleibende Haltbarkeit der verbrauchten Werkstoffe zur Herstellung dieses Artikels. Verwenden Sie dies, wenn der Verfall des Produkts von seinen Inhaltsstoffen abhängt."
 
 msgid "taken"
 msgstr "genommen"
@@ -14648,10 +14648,10 @@ msgid "Target Company"
 msgstr "Zielunternehmen"
 
 msgid "Target customers by type."
-msgstr "Zielartikel"
+msgstr "Zielen Sie auf Kunden nach Typ ab."
 
 msgid "Target disposition row"
-msgstr "Zieldispositionszeile"
+msgstr "Verwendungsentscheid-Position"
 
 msgid "Target go-live"
 msgstr "Zieltermin für Live-Schaltung"
@@ -14690,7 +14690,7 @@ msgid "Tasks still open"
 msgstr "Aufgaben noch offen"
 
 msgid "Tasks that must be completed before this issue can be closed; selecting actions here adds them on top of whatever the workflow specifies."
-msgstr "Aufgaben, die abgeschlossen werden müssen, bevor diese Ausgabe geschlossen werden kann; durch die Auswahl von Aktionen hier werden sie zusätzlich zu dem hinzugefügt, was der Workflow angibt."
+msgstr "Aufgaben, die abgeschlossen werden müssen, bevor dieses Problem geschlossen werden kann; die Auswahl von Aktionen hier fügt sie zu den vom Workflow angegebenen Aktionen hinzu."
 
 msgid "Tax"
 msgstr "Steuern"
@@ -14714,7 +14714,7 @@ msgid "Tax Depreciation Method"
 msgstr "Steuerabschreibungsmethode"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Steuerbefreit"
 
 msgid "Tax Exempt"
 msgstr "Steuerbefreit"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Team trainiert"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Technischer Support"
 
 msgid "Temperature"
 msgstr "Temperatur"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "Vorlagen"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "Temporäres Entsorgungs-Verrechnungskonto, das beim Versand mit dem Nettobuchwert eines Vermögenswerts belastet und bei Rechnungsstellung mit dem Nettobuchwert gutgeschrieben wird — gleicht sich über den Verkaufszyklus auf null aus."
+msgstr "Temporäres Veräußerungskonto, das mit dem Restbuchwert eines Vermögenswerts bei der Lieferung belastet und mit seinem Restbuchwert bei der Fakturierung gutgeschrieben wird, was sich über den Verkaufszyklus auf Null ausmacht."
 
 msgid "Terms and Privacy"
 msgstr "Bedingungen und Datenschutz"
@@ -14810,7 +14810,7 @@ msgstr "Die Phase „{0}\" wird automatisch abgeschlossen, sobald alle ihre Aufg
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "Die Phase „{0}\" ist abgeschlossen – ihr Kontrollpunkt „{1}\" wurde erreicht."
+msgstr "Die Phase „{0}\" ist abgeschlossen – ihr Kontrollpunkt „{1}\" wurde bestanden."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
@@ -14823,7 +14823,7 @@ msgid "The accounts Carbon posts to automatically"
 msgstr "Die Konten, auf die Carbon automatisch bucht"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "Die Aktion, die eine gespeicherte Methode (ihre Materialien, Vorgänge und Arbeitsanweisungen) auf eine Auftrags- oder Angebotszeile kopiert."
+msgstr "Die Aktion, die eine gespeicherte Methode (ihre Werkstoffe, Arbeitsgänge und Arbeitsanweisungen) auf einen Fertigungsauftrag oder eine Angebotsposition kopiert."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "Die zulässigen Werte für ein listenartiges Attribut; Benutzer wählen aus diesen anstelle von frei tippseln."
@@ -14832,7 +14832,7 @@ msgid "The allowed values users can pick when tagging postings with this dimensi
 msgstr "Die zulässigen Werte, die Benutzer beim Markieren von Buchungen mit dieser Dimension auswählen können."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "Die Anzahl der Tage nach der Berechnungsmethode, für die der Skonto verfügbar ist"
+msgstr "Die Anzahl der Tage nach der Berechnungsmethode, in denen der Kassenskonto verfügbar ist."
 
 msgid "The amount of days after the calculation method that the payment is due"
 msgstr "Die Anzahl der Tage nach der Berechnungsmethode, bis die Zahlung fällig ist"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "Die Autorisierung wurde in Onshape abgelehnt. Versuchen Sie die Verbindung erneut."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Das Buch aller gebuchten Journalzeilen, summiert nach Konto – wird nur geschrieben, wenn die Buchhaltung für das Unternehmen aktiviert ist."
+msgstr "Das Buch aller gebuchten Buchungssatzpositionen, summiert nach Konto – geschrieben nur, wenn die Buchhaltung für das Unternehmen aktiviert ist."
 
 msgid "The buckets you track costs against"
 msgstr "Die Behälter, gegen die Sie Kosten nachverfolgen"
@@ -14865,7 +14865,7 @@ msgid "The Carbon user who owns this RFQ; supplier responses and reminders route
 msgstr "Der Carbon-Benutzer, der diese RFQ besitzt; Lieferantenantworten und Erinnerungen werden an ihn weitergeleitet."
 
 msgid "The carrier and service a shipment goes out on, supplying the tracking-URL template that turns a tracking number into a link and the account freight charges post to."
-msgstr "Der Transportdienstleister und die Dienstleistung, mit der eine Sendung versandt wird. Stellt die Tracking-URL-Vorlage bereit, die eine Trackingnummer in einen Link umwandelt, und das Konto, auf dem Frachtkosten verbucht werden."
+msgstr "Der Spediteur und die Dienstleistung, mit der eine Lieferung erfolgt, mit Angabe der Tracking-URL-Vorlage, die eine Trackingnummer in einen Link umwandelt, und des Kontos, auf das Frachtkosten gebucht werden."
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
 msgstr "Der Spediteur, der Waren von diesem Lieferanten liefert, wenn dieser sich vom Lieferanten selbst unterscheidet (z. B. Lieferant verkauft, FedEx versendet)."
@@ -14877,7 +14877,7 @@ msgid "The carriers and methods you ship orders with"
 msgstr "Die Spediteure und Methoden, mit denen Sie Bestellungen versenden"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "Der Skonto, den der Kunde in Anspruch nehmen kann, wenn er innerhalb der Rabattzeitspanne zahlt."
+msgstr "Der Kassenskonto, den der Kunde erhalten kann, wenn er innerhalb des Rabattfensters bezahlt."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
 msgstr "Die Kataloggrund, der diesen Ausschuss erklärt; wird in Ausschussberichte eingegeben, die nach Grund statt nach Menge eingegeben werden."
@@ -14910,10 +14910,10 @@ msgid "The category this supplier belongs to (raw-material, services, contract-m
 msgstr "Die Kategorie, zu der dieser Lieferant gehört (Rohstoff, Dienstleistungen, Vertragsfertigungsunternehmen); bestimmt Standard-GL-Konten und Berichtsgruppierungen."
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "Der auf der Kanban-Karte gedruckte Code, den Bediener scannen, um den Auftrag als abgeschlossen zu markieren; automatisch generiert, wenn leer gelassen."
+msgstr "Der auf der Kanban-Karte gedruckte Code, den Werker scannen, um den Fertigungsauftrag als abgeschlossen zu markieren; wird automatisch generiert, wenn leer gelassen."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "Die erwartete wöchentliche Verfügbarkeit des Auftragnehmers; die Planung verwendet dies als Obergrenze, wenn dieser Auftragnehmer über die Woche hinweg Operationen zugewiesen wird."
+msgstr "Die erwartete wöchentliche Verfügbarkeit des externen Mitarbeiters; die Planung verwendet dies als Obergrenze, wenn dieser externe Mitarbeiter über die Woche hinweg Arbeitsgängen zugewiesen wird."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "Das korrigierte Ablaufdatum für dieses Los/diese Seriennummer; vorhandener Bestand wird nach der Änderung gegen die Haltbarkeitsrichtlinie neu bewertet."
@@ -14925,13 +14925,13 @@ msgid "The customer record this portal account links to; only contacts already o
 msgstr "Der Kundendatensatz, mit dem dieses Portal-Konto verknüpft ist; nur Kontakte, die bereits bei diesem Kunden sind, können als Kontoinhaber unten ausgewählt werden."
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "Der Kunde, an den Waren geliefert werden, wenn dieser sich vom Rechnungskunden unterscheidet (z. B. Rechnung an Zentrale, Versand an Filiale)."
+msgstr "Der Kunde, an den die Waren geliefert werden, wenn dieser sich vom fakturierten Kunden unterscheidet (z. B. Rechnung an Zentrale, Lieferung an Zweigstelle)."
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
 msgstr "Der Kunde, für den dieser Portal-Link bereitgestellt wird; nur Kontakte auf diesem Kunden können sich über den Link anmelden."
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "Eigene Referenz des Kunden für dieses Dokument – normalerweise seine RFQ- oder PO-Nummer auf seinem System; wird auf der druckbaren Ausgabe angezeigt und in alle Dokumente übertragen, in die dieses umgewandelt wird."
+msgstr "Die eigene Referenz des Kunden für dieses Dokument – typischerweise ihre Anfrage- oder Bestellnummer in ihrem System; dargestellt auf der druckbaren Ausgabe und in jedes Dokument übernommen, in das dieses umgewandelt wird."
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
 msgstr "Das Revisions-Tag des Kunden für seine Teil-ID, wenn es sich von unserem unterscheidet; auf der Cross-Reference-Ebene fest, nicht auf unserer Revision."
@@ -14952,22 +14952,22 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "Das Datum, an dem die Abschreibung für diesen Gegenstand beginnt; normalerweise das Inbetriebnahmedatum."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "Das Datum, nach dem die Preise dieses Angebots nicht mehr gelten; Die Umwandlung in eine Bestellung nach diesem Datum kann eine Neubewertung erfordern."
+msgstr "Das Datum, nach dem die Preisgestaltung dieses Angebots nicht mehr gültig ist; das Umwandeln einer Bestellung nach diesem Datum kann eine erneute Preisgestaltung erforderlich machen."
 
 msgid "The date the customer expects to receive the goods"
-msgstr "Das Datum, an dem der Kunde die Waren erhalten soll"
+msgstr "Das Datum, an dem der Kunde erwartet, die Ware zu erhalten"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "Das Datum, an dem die Waren tatsächlich das Lagerhaus verlassen; wird beim Versand und zur Bewertung der Lieferzeit verwendet."
+msgstr "Das Datum, an dem die Waren tatsächlich das Lager verlassen; wird bei der Lieferbuchung erfasst und für die Bewertung der pünktlichen Lieferung verwendet."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "Das Datum, an dem der Artikel vor Ort erforderlich ist, um die prognostizierte Nachfrage des Zeitraums zu decken."
+msgstr "Das Datum, an dem der Artikel vor Ort benötigt wird, um den Bedarf des Zeitraums zu decken."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "Das Datum, an dem dieser Gegenstand aus dem Dienst genommen wird; die Abschreibung endet an diesem Datum und der verbleibende Buchwert wird auf das Abgangskonto gebucht."
+msgstr "Das Datum, an dem das Anlagevermögen aus dem Dienst genommen wird; die Abschreibung endet an diesem Datum und der verbleibende Restbuchwert wird auf das Abgangskonto gebucht."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
-msgstr "Das Datum, an dem dieser Eintrag in das Hauptbuch aufgenommen wird; bestimmt die Rechnungsperiode, in die er fällt."
+msgstr "Das Datum, an dem dieser Eintrag in das Hauptbuch gebucht wird; bestimmt die Buchungsperiode, in die er fällt."
 
 msgid "The date this intercompany transaction hits both companies' ledgers."
 msgstr "Das Datum, an dem diese konzernübergreifende Transaktion in den Hauptbüchern beider Unternehmen aufgezeichnet wird."
@@ -14985,28 +14985,28 @@ msgid "The default run quantity when this part is made; planning rounds replenis
 msgstr "Die Standard-Ausführungsmenge, wenn dieser Teil hergestellt wird; die Planungsrunden gleichen die Auffüllung auf Vielfache davon ab."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "Der für diesen Kunden geltende Standard-Steuersatz, der auf Angebots- und Verkaufsauftragszeilen angewendet wird, vor Zeilen-Overrides; die behördungsspezifische Steuerberechnung läuft darauf."
+msgstr "Der Steuersatz, der auf die Angebots- und Kundenauftrags-Positionen dieses Kunden angewendet wird, vor spezifischen Positionsübersteuerungen; die jurisdiktionsspezifische Steuerberechnung erfolgt zusätzlich."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "Die Abteilung, unter die diese für Berichterstattung und Kopfzahlen-Hierarchien untergeordnet ist; leer lassen für eine Abteilung der obersten Ebene."
 
 msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
-msgstr "Die Qualitätsmethode nach acht Disziplinen, modelliert mit den Aufgaben des Abweichungs-Workflows anstelle von hart codierter Logik."
+msgstr "Die Acht-Disziplinen-Qualitätsmethode, modelliert mit den Aufgaben des Nichtkonformitäts-Workflows statt hartcodiert."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "Der Mitarbeiter, der für dieses Kostenzentrum verantwortlich ist – wenn Bestellgenehmigungen aktiviert sind, ist er der Genehmiger für Ausgaben, die gegen ihn gebucht werden."
+msgstr "Der Mitarbeiter, der für diese Kostenstelle verantwortlich ist – wenn Bestellungsgenehmigungen aktiviert sind, ist er der Genehmiger für Ausgaben, die dagegen gebucht werden."
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "Der durchgängige Geschäflauf vom Angebot an einen Kunden bis zur Zahlungseingang: Angebotsanfrage über Angebot zu Kundenauftrag, dann Versand, Rechnung und ausgleichener Zahlung."
+msgstr "Der durchgehende kommerzielle Ablauf von der Angebotserstellung für einen Kunden bis zum Zahlungsempfang: Anfrage zu Angebot zu Kundenauftrag, dann Lieferung, Rechnung und eingegangene Zahlung."
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "Der Endpunkt, der eine POST-Anfrage mit den aktualisierten Daten empfängt, wenn die Tabelle aktualisiert wird"
 
 msgid "The engineering drawing this inspection plan is tied to; inspections recorded against this part reference back to this drawing."
-msgstr "Die technische Zeichnung, mit der dieser Inspektionsplan verknüpft ist; Inspektionen, die gegen dieses Teil aufgezeichnet werden, verweisen auf diese Zeichnung."
+msgstr "Die technische Zeichnung, an die dieser Prüfplan gekoppelt ist; Prüfungen, die gegen diesen Teil aufgezeichnet werden, beziehen sich auf diese Zeichnung."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "Der erwartete Prozentsatz der Produktion dieses Teils, der während der Produktion verloren geht; die Planung multipliziert die Nachfrage mit 1 / (1 − Ausschuss) zur Kompensation."
+msgstr "Der erwartete Prozentsatz der Ausgabe dieses Artikels, der während der Produktion verloren geht; die Planung multipliziert den Bedarf mit 1 / (1 − Ausschuss), um dies auszugleichen."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Das Aufwandskonto, auf das diese indirekte Ausgabenzeile gebucht wird; erforderlich, da indirekte Zeilen keinen Bestandsposten haben, von dem das Konto abgeleitet werden kann."
@@ -15024,31 +15024,31 @@ msgid "The fixed-asset record this sale disposes; the line's shipment posts the 
 msgstr "Die Anlagenaufzeichnung, die dieser Verkauf verfügt; die Lieferung der Zeile posts das Nettobuchenwert-Abgangeintrag des Vermögenswerts statt COGS."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "Die Untergrenze, bis zu der ein Vermögenswert abgeschrieben wird; wenn der Buchwert sie erreicht, wird der Vermögenswert auf \"Vollständig abgeschrieben\" gesetzt."
+msgstr "Das Minimum, bis zu dem ein Anlagevermögen abgeschrieben wird; wenn der Restbuchwert dieses Minimum erreicht, wechselt das Anlagevermögen zu Vollständig abgeschrieben."
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "Die Werkstatt und das Büro lesen die gleichen Bestands- und Kostenzahlen."
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "Die folgenden Baugruppen haben keine Operationen. Bitte weisen Sie jeder Baugruppe eine Operation zu, bevor Sie sie freigeben."
+msgstr "Die folgenden Baugruppen haben keine Arbeitsgänge. Bitte weisen Sie jedem einen Arbeitsgang zu, bevor Sie freigeben."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "Die folgenden Positionen haben keine Preise oder Lieferzeiten:"
+msgstr "Den folgenden Positionen fehlen Preise oder Beschaffungszeiten:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Die folgenden Aufgaben sind noch nicht abgeschlossen:"
+msgstr "Die folgenden Aufgaben sind noch nicht erledigt:"
 
 msgid "The forms and shapes your raw materials come in"
 msgstr "Die Formen und Formen, in denen Ihre Rohstoffe geliefert werden"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "Der Anteil jedes Loses zur Inspektionen; die tatsächliche Anzahl wird zum Zeitpunkt der Inspektionen aus der Losgröße berechnet."
+msgstr "Der Anteil jeder Charge, der inspiziert werden soll; die tatsächliche Anzahl wird zur Zeit der Prüfung aus der Losgröße berechnet."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
 msgstr "Die Differenz zwischen dem Preis einer Bestellung und der Lieferantenrechnung, die auf ein Abweichungskonto gebucht wird, wenn die Rechnung gebucht wird."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
-msgstr "Das GL-Konto, auf das Gebühren für diesen Spediteur buchen (Frachtkosten, Fracht ein/aus)."
+msgstr "Das Sachkonto, auf das Gebühren für diesen Spediteur gebucht werden (Frachtaufwand, Fracht ein/aus)."
 
 msgid "The goal"
 msgstr "Das Ziel"
@@ -15060,28 +15060,28 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "Das Gruppenkonto, auf das dieses Konto abrollt; bestimmt seinen Typ, seine Klasse und seine Platzierung in der Bilanz."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "Die Stundensätze der Betreiberlabor auf diesem Arbeitszentrum; kombiniert mit protokollierten Arbeitsstunden zur Abrechnung von Arbeitskosten in WIP eines Auftrags."
+msgstr "Die Personalstundensätze an diesem Arbeitsplatz; kombiniert mit erfassten Personalstunden zur Berechnung der Personalkosten in das WIP eines Fertigungsauftrags."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "Die Stundensätze des Betriebs der Maschinen auf diesem Arbeitszentrum; kombiniert mit protokollierten Maschinenstunden zur Abrechnung von Maschinenkosten in WIP eines Auftrags."
+msgstr "Die Stundensätze für Maschinenkosten an diesem Arbeitsplatz; kombiniert mit erfassten Maschinenstunden zur Berechnung der Maschinenkosten in das WIP eines Fertigungsauftrags."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "Die stündliche indirekte Kostenlast, die auf dieses Arbeitszentrum angewendet wird; der Unterschied zwischen Arbeit + Maschine und dem vollständigen Angebotssatz ist das Overhead absorbiert."
+msgstr "Die auf diesem Arbeitsplatz angewendeten Stundensätze für indirekte Kosten; der Unterschied zwischen Personal + Maschine und dem vollständigen Angebotssatz wird durch die Gemeinkosten abgedeckt."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "Die HTTPS-Adresse, an die der Webhook-Schritt eines Workflows sendet — einfaches HTTP, Umleitungen und Hosts, die sich zu privaten oder lokal-Link-Adressen auflösen, werden abgelehnt, und der Aufruf gibt nach zehn Sekunden auf."
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "Die für Menschen lesbare Dokumentennummer (wie J000001 oder ECO-000001), die aus einer Sequenz generiert und im Datensatz gespeichert wird und sich von ihrer internen ID unterscheidet."
+msgstr "Die lesbare Dokumentnummer (wie J000001 oder ECO-000001), die aus einem Nummernkreis generiert und im Datensatz gespeichert wird, unterschiedlich von seiner internen ID."
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "Der Identifikation, den der Kunde für diesen Teil auf seinen POs verwendet; Carbon löst ihn bei der Bestellimport zu unserer internen Teile-ID auf."
+msgstr "Der Bezeichner, den der Kunde für diesen Teil in seinen Bestellungen verwendet; Carbon löst ihn beim Bestellimport in unsere interne Teilnummer auf."
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
 msgstr "Der Identifikation, den der Lieferant für diesen Teil auf seinen Angeboten und Rechnungen verwendet; Carbon löst ihn zu unserer internen Teile-ID auf."
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
-msgstr "Die sofortige Abweichungsaufgabe, die betroffene Bestände oder Arbeiten unter Quarantäne stellt, bevor die Grundursache bekannt ist."
+msgstr "Die unmittelbare Nichtkonformitäts-Aufgabe, die betroffene Bestände oder Arbeiten unter Quarantäne stellt, bevor die Grundursache bekannt ist."
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
 msgstr "Die Auswirkungsbewertung, wenn das Risiko realisiert wird (1 = vernachlässigbar bis 5 = katastrophal); gepaart mit Wahrscheinlichkeit zur Berechnung der Risikosbewertung."
@@ -15096,7 +15096,7 @@ msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight
 msgstr "Die Incoterms-Regel (FOB, DAP, EXW, CIF, ...), die regelt, wer Fracht bezahlt, wer Risiko trägt und wo der Eigentumstitel bei Lieferungen an diesen Kunden auftritt."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Die Bestandskosten, die bei der Buchung einer Lieferung erfasst werden, bewertet nach der Kostenmethode des Artikels."
+msgstr "Die Bestandskosten, die bei einer Lieferbuchung anerkannt werden, bewertet nach der Kalkulationsmethode des Artikels."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "Die IRS-Wiederherstellungsperiode-Klasse für diesen Gegenstand nach MACRS (3, 5, 7, 10, 15, 20, 27,5, 39 Jahre)."
@@ -15105,19 +15105,19 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "Der Auftrag, dessen Operation diese Außenbearbeitungslinie abdeckt; der Beleg der Zeile schließt die Operation gegen diesen Auftrag."
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "Die Position des Auftrags in der Warteschlange seines Standorts — eine Dezimalzahl, die Carbon aus dem Fälligkeitsdatum und dem Deadline-Typ berechnet, kein Low/High-Rating."
+msgstr "Die Position des Fertigungsauftrags in der Terminplanwarteschlange des Standorts — eine Dezimalzahl, die Carbon aus dem Fälligkeitsdatum und dem Termintyp berechnet, keine Hoch/Niedrig-Bewertung."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "Die Art der Anpassung, die diese Regel anwendet – Rabatt, Zuschlag oder feste Überschreibung; kombiniert mit Betragtyp zur Berechnung des tatsächlichen Delta auf jeder Zeile."
+msgstr "Die Art der Korrektur, die diese Regel anwendet – Rabatt, Zuschlag oder feste Übersteuerung; kombiniert mit dem Betragtyp zur Berechnung des tatsächlichen Unterschieds auf jeder Position."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "Die Art des Wertes, den dieses Attribut akzeptiert (Text, Zahl, Datum, Boolesch, Liste); gesperrt, nachdem das Attribut aufgezeichnete Werte hat."
+msgstr "Die Art des Werts, den dieses Attribut akzeptiert (Text, Zahl, Datum, Boolean, Liste); wird gesperrt, nachdem das Attribut erfasste Werte hat."
 
 msgid "The label and document printers your company prints to"
 msgstr "Die Etiketten- und Dokumentendrucker, auf die Ihr Unternehmen druckt"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "Das späteste Datum, um diese Bestellung aufzugeben, damit sie bis zum erforderlichen Datum ankommt, unter Berücksichtigung der Lieferzeit des Lieferanten."
+msgstr "Das späteste Datum, um diese Bestellung aufzugeben, damit sie bis zum Bedarfsdatum eintrifft, angesichts der Beschaffungszeit des Lieferanten."
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "Die juristische Person, an die die Rechnung gesendet wird, wenn diese sich vom Kunden unterscheidet, der die Waren erhält – für Mutter-/Tochtergesellschaften oder Rechnungen Dritter."
@@ -15135,19 +15135,19 @@ msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approv
 msgstr "Der Lebenszykluszustand dieses Lieferanten – Aktiv, Inaktiv, Genehmigung Ausstehend, usw.; nur aktive Lieferanten werden in PO / Angebots-Selektoren angezeigt."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "Die lokale Zeitzone, in die dieser Standort Zeit meldet; Zeitpläne, Stundenzetteln und Schichtstunden an diesem Standort werden unabhängig vom Browser-Gebietsschema des Benutzers in dieser Zone interpretiert."
+msgstr "Die Zeitzone dieses Standorts; Terminpläne, Zeiterfassung und Schichtstunden an diesem Standort werden in dieser Zone interpretiert, unabhängig vom Browser-Gebietsschema des Benutzers."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "Der Standort, an den dieser Mitarbeiter sich standardmäßig auf; treibt die Zeitzoneninterpretation auf ihren Zeitkarten und die Standardschicht-Selektoren in ihrem Auftragsbestand."
+msgstr "Der Standardstandort dieses Mitarbeiters; steuert die Zeitzoneinterpretation in seiner Zeiterfassung und die Standard-Schichtwähler in seinem Fertigungsauftrag."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "Der Standort, von dem aus diese Bestellung erfüllt wird; Pro-Zeilen-Standorte überschreiben dies, wenn gesetzt."
+msgstr "Der Standort, von dem dieser Auftrag erfüllt wird; Standorte pro Position überschreiben dies, wenn sie gesetzt sind."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "Der Standort, von dem aus dieses Angebot erfüllt wird, wenn es in eine Bestellung umgewandelt wird; wird von der Planung verwendet, um Angebot am richtigen Lagerhaus zu projizieren."
+msgstr "Der Standort, von dem dieses Angebot erfüllt wird, wenn es in einen Kundenauftrag umgewandelt wird; wird von der Planung zur Prognose der Deckung im richtigen Lager verwendet."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
-msgstr "Der Standort, von dem aus diese Anfrage erfüllt würde, wenn sie in ein Angebot und dann in eine Bestellung umgewandelt wird."
+msgstr "Der Standort, von dem diese Anfrage erfüllt würde, wenn sie sich in ein Angebot und dann einen Kundenauftrag umwandelt."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
 msgstr "Das Protokoll von Risiken und Chancen, die gegen jede Entität aufgehoben werden, jeweils bewertet durch unabhängige 1–5 Schweregrad und Wahrscheinlichkeit und zu einer Lösung geführt."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "Der Stichprobenplan pro Merkmal des Loses wird aus dem ausgewählten Dokument neu aufgelöst."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "Der niedrigste Betrag, den dieser Lieferant für diesen Prozess berechnet, unabhängig von der Menge; Aufträge unter dem Gewinnschwellen-Volumen kosten immer noch mindestens diesen Betrag."
+msgstr "Der niedrigste Betrag, den dieser Lieferant für dieses Verfahren berechnet, unabhängig von der Menge; Fertigungsaufträge unter dem Break-Even-Volumen kosten mindestens diesen Betrag."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Die Maschinen, Zellen und Stationen, durch die Ihre Arbeit läuft"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "Die wahrscheinlichste Fehlerart, die der Anforderer verdächtigt; der Techniker bestätigt oder ersetzt diese bei der Schließung, und die Differenz zwischen verdächtig und tatsächlich speist Zuverlässigkeitsberichte."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "Der ausgehandelte Preis pro Einheit auf dieser Zeile; das Inline-Trace-Symbol zeigt, welche Preisregel oder Überschreibung es produziert hat."
+msgstr "Der ausgehandelte Preis pro Einheit auf dieser Position; das Inline-Verfolgungssymbol zeigt, welche Preisregel oder Übersteuerung ihn hervorgebracht hat."
 
 msgid "The new version number of the document"
 msgstr "Die neue Versionsnummer des Dokuments"
@@ -15204,19 +15204,19 @@ msgid "The new version number of the method"
 msgstr "Die neue Versionsnummer der Methode"
 
 msgid "The new version number of the procedure"
-msgstr "Die neue Versionsnummer des Verfahrens"
+msgstr "Die neue Versionsnummer der Verfahrensanweisung"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Die Anzahl der Tage zwischen der Aufgabe einer Bestellung bei dem bevorzugten Lieferanten und dem Eintreffen der Waren auf dem Dock; die Planung versetzt die Nachfrage um diesen Betrag rückwärts."
+msgstr "Die Anzahl der Tage zwischen der Aufgabe einer Bestellung beim bevorzugten Lieferant und dem Eintreffen der Waren an der Rampe; die Planung verschiebt den Bedarf um diesen Betrag nach hinten."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Die Anzahl der Tage zum Erstellen eines Satzes dieses Artikels, gemessen von der Auftragsfreigabe bis zum Abschluss; die Planung versetzt die Nachfrage um diesen Betrag rückwärts."
+msgstr "Die Anzahl der Tage zur Herstellung eines Los dieses Artikels, gemessen von der Freigabe des Fertigungsauftrags bis zur Fertigstellung; die Planung verschiebt den Bedarf um diesen Betrag nach hinten."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
 msgstr "Die Anzahl der zusätzlichen Einheiten zum Bauen um den erwarteten Ausschuss zu kompensieren; Planung summiert dies mit der Bestellmenge bei der Reservierung von Materialien."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "Die Anzahl der Stunden pro Woche, die der Auftragnehmer zur Verfügung steht."
+msgstr "Die Anzahl der Stunden pro Woche, die der externe Mitarbeiter verfügbar ist."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "Die Anzahl der Monate, über die dieses Vermögen abgeschrieben wird."
@@ -15225,13 +15225,13 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "Das Handbestandsniveau, das eine neue Auffüllungsbestellung gemäß den mengengestützten Richtlinien auslöst."
 
 msgid "The operations and steps your parts move through"
-msgstr "Die Operationen und Schritte, die Ihre Teile durchlaufen"
+msgstr "Die Arbeitsgänge und Schritte, die Ihre Teile durchlaufen"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
 msgstr "Die geordnete Liste der Aufgaben, die Probleme mit diesem Workflow ausführen müssen; die Reihenfolge hier ist die Reihenfolge, in der sie auf dem Problem angezeigt werden."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "Die geordnete Abfolge von Operationen, die ein Auftrag durchläuft, kopiert aus der Prozeßliste des Verfahrens."
+msgstr "Die geordnete Abfolge der Arbeitsgänge, die ein Fertigungsauftrag durchläuft, kopiert aus der Arbeitsgangliste der Methode."
 
 msgid "The original model file is no longer available"
 msgstr "Die ursprüngliche Modelldatei ist nicht mehr verfügbar"
@@ -15240,7 +15240,7 @@ msgid "The outbound posting document that takes goods out of stock to a customer
 msgstr "Das ausgehende Buchungsdokument, das Waren aus dem Lager zu einem Kunden herausnimmt und dabei COGS bucht."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Die externen Lieferanten, die diesen Prozess ausführen; jeder erhält eine Zeile von Preis- und Vorlaufzeiteingaben im Lieferantenprozessformular."
+msgstr "Die Lieferanten, die dieses Verfahren durchführen; jeder erhält eine Position mit Preis- und Lieferzeitinputs im Lieferantenverfahren-Formular."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "Die Eltern-Kind-Kette der verfolgten Einheiten – was eine Einheit aus gebaut wurde und was sie wurde."
@@ -15249,10 +15249,10 @@ msgid "The part is manufactured as its own job when the parent that needs it is 
 msgstr "Der Teil wird als eigener Auftrag hergestellt, wenn das Elternteil, das es benötigt, gebaut wird."
 
 msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
-msgstr "Der Teil wird aus bestehendem Bestand genommen, wenn sein Elternteil gebaut wird – kein neuer Auftrag oder Kaufauftrag."
+msgstr "Der Teil wird dem bestehenden Bestand entnommen, wenn das übergeordnete Teil hergestellt wird – kein neuer Fertigungsauftrag oder Bestellung."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Die Personen auf der Carbon-Seite, die Ihre Implementierung durchführen, und wie Sie sie erreichen."
+msgstr "Die Mitarbeiter auf der Carbon-Seite, die Ihre Umsetzung durchführen, und wie Sie sie erreichen."
 
 msgid "The people on your team and their access to Carbon"
 msgstr "Die Personen in Ihrem Team und deren Zugriff auf Carbon"
@@ -15261,10 +15261,10 @@ msgid "The per-company counter behind a document type's readable number, assembl
 msgstr "Der Zähler pro Unternehmen hinter der lesbaren Nummer eines Dokumenttyps, der das Präfix, den nullen-aufgefüllten nächsten Wert und das Suffix zusammensetzt und mit der Erstellung jedes Dokuments voranschreitet."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "Das artikelweise Ergebnis, das auf dem betroffenen Material einer Nichtkonformität aufgezeichnet wird — Ausstehend, Rückkehr zum Lieferanten, Nachbearbeitung, Ausschuss oder Wie-Ist-Verwendung — für jede betroffene Charge oder Seriennummer separat entschieden."
+msgstr "Das pro-Artikel-Ergebnis auf einem betroffenen Werkstoff einer Nichtkonformität – Ausstehend, An Lieferant Zurück, Nacharbeit, Ausschuss oder Wie Erhalten – entschieden für jede betroffene Charge oder Seriennummer einzeln."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "Der Prozentsatz des Skonto. Verwenden Sie 0 für keinen Rabatt."
+msgstr "Der Prozentsatz des Kassenrabatts. Verwenden Sie 0 für keinen Rabatt."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Der Berechtigungssatz, den neue Mitarbeiter dieses Typs automatisch erhalten; durch die Bearbeitung hier wird nur die Vorlage für zukünftige Mitarbeiter geändert – vorhandene Mitarbeiter behalten das, was sie haben, es sei denn, es wird explizit in großen Mengen aktualisiert."
@@ -15273,7 +15273,7 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Die Fabriken, Lagerhäuser und Standorte, an denen sich Ihre Arbeit und Bestände befinden"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "Das voreingestellte Bundle von Aufgaben und Genehmigungsanforderungen, die auf dieses Problem angewendet werden; setzt den Standard-Workflow des Problemtyps außer Kraft, wenn dieser festgelegt ist."
+msgstr "Das vordefinierte Paket aus Aufgaben und Genehmigungsanforderungen, das auf diesen Fall angewendet wird; überschreibt den Standard-Workflow des Falltyps, wenn festgelegt."
 
 msgid "The principle:"
 msgstr "Das Prinzip:"
@@ -15282,16 +15282,16 @@ msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certa
 msgstr "Die Wahrscheinlichkeitsbewertung, dass das Risiko auftritt (1 = selten bis 5 = fast sicher); gepaart mit Schweregrad zur Berechnung der Risikosbewertung."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "Das Verfahren, das Techniker befolgen, wenn diese Wartung durchgeführt wird; das Ersetzen danach, nachdem Zeitpläne bereits generiert wurden, wirkt sich nur auf zukünftige Instanzen aus."
+msgstr "Die Verfahrensanweisung, die Techniker befolgen, wenn diese Instandhaltung durchgeführt wird; ein Ersetzen nach bereits generierten Terminplänen wirkt sich nur auf zukünftige Instanzen aus."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Die Prozesse, die dieses Arbeitszentrum ausführen kann; wird in Prozessauswahlern beim Planen von Operationen angezeigt und beschränkt, welche Aufträge durch dieses Arbeitszentrum geleitet werden können."
+msgstr "Die Verfahren, die dieser Arbeitsplatz ausführen kann; erscheint in Verfahren-Auswahlfeldern beim Planen von Arbeitsgängen und begrenzt, welche Fertigungsaufträge über diesen Arbeitsplatz laufen können."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "Der Provider bietet keine Dimensionsziele. Aktivieren Sie die Funktion zuerst beim Provider (z. B. Tracking-Kategorien, Klassenverfolgung oder Felder)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "Die Mengenumbruchspunkte, zu denen diese Zeile bepreist wird; jede Spalte führt ihren eigenen Preis pro Einheit für Käufer-Lieferanten-Verhandlungen und für die Umwandlung in nachgelagerte Dokumente."
+msgstr "Die Mengensprungpunkte, zu denen diese Position bepreist ist; jede Spalte trägt ihren eigenen Einzelpreis für Käufer–Lieferant-Verhandlung und zum Konvertieren in nachgelagerte Dokumente."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "Die Menge des Artikels, die bei der scan-basierten Nachbestellung neu bestellt werden soll."
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "Der Datensatz, auf den eine Workflow-Benachrichtigung verweist, benannt als eine ID plus seine Art; lassen Sie sie leer und die Benachrichtigung verweist auf den Workflow-Ausführungsdatensatz selbst."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "Der Datensatz, der eine Zahlung oder ein Memo auf einer Rechnung anwendet und die angewandten Rabatt- und Wertberichtigungsbeträge trägt."
+msgstr "Der Datensatz, der eine Zahlung oder einen Vermerk auf eine Rechnung anwendet und die angewendete, Rabatt- und Ausbuchung-Beträge trägt."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "Die aufgezeichnete Genealogie der verfolgten Einheiten – welche Eingaben wurden verbraucht, um welche Ausgaben zu produzieren, Beleg bis Lieferung."
@@ -15329,18 +15329,18 @@ msgstr "Die Referenzdaten, auf denen alles andere aufbaut. Wird zuerst geladen."
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will be expected again and counted as incoming supply."
-msgstr "Die restliche {0} {1} wird erneut erwartet und als eingehende Versorgung gezählt."
+msgstr "Die verbleibenden {0} {1} werden erwartet und als eingehende Deckung gezählt."
 
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "Die restliche {0} {1} wird nicht mehr erwartet. Die Bestellversorgung und MRP werden sie nicht mehr berücksichtigen. Die bestellte Menge und die Preisgestaltung bleiben unverändert."
+msgstr "Die verbleibenden {0} {1} werden nicht mehr erwartet. Bestellte Deckung und MRP zählen sie nicht mehr. Die bestellte Menge und Preise bleiben unverändert."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "Der Anforderungstext wird wörtlich mit einem JSON-Inhaltstyp gesendet, nachdem Workflow-Variablen darin ersetzt wurden, bei den Methoden, die einen haben."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "Das Residualwip, das ein Auftrag bei Schließung verlassen hat, gefegt auf ein Produktionsvarianzverkehr – die einzige Varianz Carbon Bücher für einen Auftrag."
+msgstr "Die verbleibende WIP, die ein Fertigungsauftrag beim Abschließen zurückgelassen hat, aufgeräumt auf ein Produktionsabweichungs-Konto – die einzige Abweichung, die Carbon für einen Fertigungsauftrag bucht."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "In der Antwort von Onshape fehlten erforderliche Parameter. Versuchen Sie die Verbindung erneut."
@@ -15352,16 +15352,16 @@ msgid "The revision number of the part"
 msgstr "Die Revisionsnummer des Teils"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "Die Verkaufsauftragsposition, für die dieser Auftrag erstellt wurde, um die Kundenanforderung dahinter zu verbinden."
+msgstr "Die Kundenauftragsposition, für die dieser Fertigungsauftrag erstellt wurde und die den Fertigungsauftrag an die dahinter stehende Kundennachfrage koppelt."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "Der Zeitplan, der zur Verbreitung der Kosten dieses Vermögenswerts über seine Nutzungsdauer verwendet wird (Straight-Line, Declining Balance, Produktionseinheiten)."
+msgstr "Der Zeitplan, der verwendet wird, um die Kosten dieses Vermögenswerts über seine Nutzungsdauer zu verteilen (linear, degressiv, Produktionseinheiten)."
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "Die Regale und Behälter, in denen der Bestand physisch gelagert wird"
+msgstr "Die Regale und Lagerplätze, an denen Bestand physisch sitzt"
 
 msgid "The shop supplies and consumables you keep on hand"
-msgstr "Die Betriebsmaterialien und Verbrauchsgüter, die Sie vorrätig halten"
+msgstr "Die Werkstattbedarf und Verbrauchsmaterialien, die Sie bereithalten"
 
 msgid "The sign-offs every issue using this workflow needs before it can be closed."
 msgstr "Die Zeichen-Offs, die jede Ausgabe mit diesem Workflow benötigt, bevor es geschlossen werden kann."
@@ -15370,10 +15370,10 @@ msgid "The size of the part"
 msgstr "Die Größe des Teils"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Die Fähigkeiten und Kompetenzen, die Sie für Ihre Mitarbeiter nachverfolgen"
+msgstr "Die Fähigkeiten und Qualifikationen, die Sie für Ihr Personal verfolgen"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "Die kleinste Menge, die dieser Lieferant auf einer PO-Zeile für diesen Teil akzeptiert; die Planung rundet auf sie auf."
+msgstr "Die kleinste Menge, die dieser Lieferant auf einer Bestellungsposition für diesen Teil akzeptiert; Planung rundet darauf auf."
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
 msgstr "Der spezifische Kontakt auf dem ausgewählten Kunden, der dieses Portal-Konto besitzt; seine E-Mail wird zum Anmelde-Identifikator."
@@ -15382,25 +15382,25 @@ msgid "The specific contact on the selected supplier who will own this portal ac
 msgstr "Der spezifische Kontakt auf dem ausgewählten Lieferanten, der dieses Portal-Konto besitzt; seine E-Mail wird zum Anmelde-Identifikator."
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "Die spezifische Operation im obigen Job, die diese PO-Zeile kauft; nur Operationen, die für externe Verarbeitung markiert sind, sind auswählbar."
+msgstr "Der bestimmte Arbeitsgang des oben genannten Fertigungsauftrags, den diese Bestellungsposition kauft; nur als Fremdarbeit gekennzeichnete Arbeitsgänge können ausgewählt werden."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "Die spezifische PO, Rückgabe oder Übertragung, gegen die dieser Beleg posts; verfügbare IDs hängen vom obigen Quelldokumenttyp ab."
+msgstr "Die bestimmte Bestellung, Rückgabe oder Umlagerung, auf die dieser Wareneingang gebucht wird; verfügbare IDs hängen vom Ursprungsbeltyp oben ab."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "Die spezifische SO, Übertragung oder RMA, gegen die diese Lieferung posts; verfügbare IDs hängen vom obigen Quelldokumenttyp ab."
+msgstr "Der bestimmte Kundenauftrag, die Umlagerung oder die RMA, auf die diese Lieferung gebucht wird; verfügbare IDs hängen vom Ursprungsbeltyp oben ab."
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "Die Standardabmessungen, in denen Ihre Materialien gelagert werden"
+msgstr "Die Standardabmessungen, in denen Ihre Werkstoffe lagern"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "Der Standardfaktor (Stunden, Minuten, Stücke), nach dem Operationen auf diesem Arbeitszentrum standardmäßig gemessen werden; Pro-Operation-Überschreibungen gewinnen, wenn festgelegt."
+msgstr "Der Standardfaktor (Stunden, Minuten, Stückzahl), in dem Arbeitsgänge auf diesem Arbeitsplatz standardmäßig gemessen werden; pro-Arbeitsgang-Übersteuerungen gewinnen, wenn festgelegt."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
-msgstr "Der Standardfaktor zur Messung dieses Prozesses – Stunden, Minuten, Stücke, Quadratfuß – wenn seine Operationen geschätzt und berechnet werden."
+msgstr "Der Standardfaktor zur Messung dieses Verfahrens – Stunden, Minuten, Stückzahl, Quadratfuß – wenn seine Arbeitsgänge geschätzt und kalkuliert werden."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "Der Zustand dieser Angebotszeile – Entwurf, Kein Angebot, Fertig; Kein Angebot offenbart das Feld Grund und schließt die Zeile von der Angebotssumme aus."
+msgstr "Der Status dieser Angebotsposition – Entwurf, Kein Angebot, Abschließen; Kein Angebot zeigt das Feld Grund und schließt die Position aus dem Angebot-Gesamtbetrag aus."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Der Abrechnungskübel, den alle Konten in dieser Gruppe verwenden."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "Die Einstellungen des Schritts — diese Ausführung stammt von vor dem Aufzeichnen der verwendeten Werte."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Die Lagergrößen, in denen dieses Material gekauft und gelagert wird; jede Größe wird zu einer separaten auswählbaren Variante auf Jobs und POs."
+msgstr "Die Bestandsgrößen, in denen dieser Werkstoff gekauft und gelagert wird; jede Größe wird zu einer separaten wählbaren Variante auf Fertigungsaufträgen und Bestellungen."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "Die Lagerkammer, von der dieser Zeile pickt; wenn blank, verwendet das Picking die Standard-Lagereinheit des Artikels."
+msgstr "Der Lagerplatz, von dem diese Position kommissioniert wird; falls leer, verwendet Kommissionierung die Standard-Lagereinheit des Artikels."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "Der Speicherdienst hat nicht rechtzeitig geantwortet. Bitte versuchen Sie es erneut."
@@ -15427,7 +15427,7 @@ msgid "The supplier record this portal account links to; only contacts already o
 msgstr "Der Lieferantendatensatz, mit dem dieses Portal-Konto verknüpft ist; nur Kontakte, die bereits bei diesem Lieferanten sind, können als Kontoinhaber unten ausgewählt werden."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "Die eigene Angebots-/Vorschlagsnummer des Lieferanten; aufgezeichnet für die Verfolgbarkeit im PO, das aus diesem Angebot konvertiert wird."
+msgstr "Die eigene Angebots- oder Vorschlagsnummer des Lieferanten; aufgezeichnet für Rückverfolgbarkeit auf der Bestellung, die aus diesem Angebot konvertiert wird."
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "Die eigene Referenz des Lieferanten für diese Bestellung (ihre SO-Nummer auf ihrem System); aufgezeichnet für Audit und auf dem Beleg angezeigt."
@@ -15439,7 +15439,7 @@ msgid "The suppliers and vendors you buy from"
 msgstr "Die Lieferanten und Anbieter, von denen Sie kaufen"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Die Lieferanten, die diese RFQ erhalten; jeder erhält seine eigene Zeile auf der RFQ, auf die sie mit ihrer eigenen Preisgestaltung reagieren."
+msgstr "Die Lieferanten, die diese Anfrage erhalten; jeder erhält seine eigene Position auf der Anfrage, auf die er mit seinen eigenen Preisen antwortet."
 
 msgid "The surface finishes available on your materials"
 msgstr "Die auf Ihren Materialien verfügbaren Oberflächenfinishes"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "Das System besteht jeden relevanten Akzeptanztest in Ihrem konfigurierten System mit Ihren Daten; die Daten werden validiert; und Sie geben die Freigabe. Dann Go-live."
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "Der Thread, der eine Verkaufs-RFQ, sein Angebot und die resultierende Verkaufsauftrag verknüpft – eine Verknüpfung, kein Dokument mit eigenem Status."
+msgstr "Der Strang, der eine Verkaufs-Anfrage, ihr Angebot und den resultierenden Kundenauftrag verbindet – ein Join, kein Dokument mit eigenem Status."
 
 msgid "The timer starts automatically"
 msgstr "Der Timer startet automatisch"
@@ -15457,31 +15457,31 @@ msgid "The timer starts manually"
 msgstr "Der Timer wird manuell gestartet"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Die Werkzeuge und Vorrichtungen, auf die Ihre Betriebe angewiesen sind"
+msgstr "Das Werkzeug und die Vorrichtungen, auf die Ihre Arbeitsgänge angewiesen sind"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Die Gesamtmenge, die über alle in dieser Massenschicht erstellten Aufträge hergestellt werden soll; kombiniert mit Menge Pro Job, um zu entscheiden, wie viele Jobs zu erstellen sind."
+msgstr "Der Gesamtbetrag zum Herstellen über alle in dieser Massengroserie erstellten Fertigungsaufträge; kombiniert mit Menge Pro Fertigungsauftrag, um zu entscheiden, wie viele Fertigungsaufträge erstellt werden."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "Die nachverfolgbare Referenz (z. B. NIST-Standard, Seriennummer des Hauptmessgeräts), gegen die die Kalibrierungswerte verglichen wurden."
+msgstr "Die nachverfolgbare Referenz (z. B. NIST-Norm, Seriennummer des Normal-Prüfmittels), gegen die die Kalibrierungswerte verglichen wurden."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "Der Arbeitsbegleitzettel listet jedes Element der Stückliste mit seiner Menge auf."
+msgstr "Die Laufkarte listet jeden Artikel auf der Stückliste mit seiner Menge auf."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "Der Typ bestimmt, welche Standardberechtigungen der neue Mitarbeiter erhält; die Auswahl hier füllt die Berechtigungsmatrix aus der Vorlage des Typs vorab aus."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Die typische Anzahl von Tagen zwischen dem Versand von Arbeit an diesen Lieferanten für diesen Prozess und dem Erhalt; Planung versetzt die Nachfrage um diesen Betrag bei der Auswahl eines Lieferanten."
+msgstr "Die typische Anzahl von Tagen zwischen dem Versand von Arbeit an diesen Lieferant für diesen Verfahren und dem Rückerhalten; die Planung verlagert Bedarf um diese Anzahl von Tagen bei der Lieferantenauswahl."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "Der eindeutige Identifikation auf dieser physischen Einheit; eine Zeile pro Seriennummer, die Menge ist immer 1."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "Die Einheit, in der eine Routingzeit ausgedrückt wird, z. B. Stunden/Stück oder Gesamtstunden, die Carbon mitteilt, ob die Zeit mit der Menge skaliert oder pro Durchlauf festgelegt ist."
+msgstr "Die Einheit, in der eine Arbeitplanzeit ausgedrückt wird, wie z. B. Stunden/Stück oder Gesamtstunden, die Carbon mitteilt, ob die Zeit mit der Menge skaliert oder pro Durchführung behoben ist."
 
 msgid "The unit price of the item at the time of the purchase"
-msgstr "Der Stückpreis des Artikels zum Zeitpunkt des Kaufs"
+msgstr "Der Einzelpreis des Artikels zum Zeitpunkt des Kaufs"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
 msgstr "Die Einheit, in der Lieferanten den Preis und den Versand dieses Artikels durchführen, wenn dieser sich von der Bestandseinheit unterscheidet (z. B. Kasten vs. jeweils); gepaart mit Umrechnungsfaktor."
@@ -15493,7 +15493,7 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "Die Maßeinheiten, in denen Sie kaufen, lagern und verkaufen"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "Das US-Steuerverschreibungssystem mit IRS-Eigenschaftsklasse-Tabellen, als separater Steuerzeitplan neben dem Buchzeitplan ausgeführt."
+msgstr "Das US-Steuersystem für Abschreibung mit IRS-Anlageklassen-Tabellen, das als separater Steuerstundungsplan neben dem Handelsabschreibungsplan läuft."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "Die Benutzer in dieser Gruppe; Berechtigungen und Benachrichtigungen mit Gruppengültigkeitsbereich gelten für jedes Mitglied, und Benutzer können mehreren Gruppen angehören (effektive Berechtigungen sind die Vereinigung)."
@@ -15502,13 +15502,13 @@ msgid "The version of the new document"
 msgstr "Die Version des neuen Dokuments"
 
 msgid "The version of the new procedure"
-msgstr "Die Version des neuen Verfahrens"
+msgstr "Die Version der neuen Verfahrensanweisung"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
 msgstr "Der Versionsstempel für dieses Dokument; neue Versionen erstellen eine Kopie, die die vorherige ersetzt, ohne sie zu löschen."
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "Der Versionsstempel für dieses Verfahren; neue Versionen erstellen eine Kopie, die die vorherige ersetzt, ohne sie zu löschen."
+msgstr "Der Versionsstempel für diese Verfahrensanweisung; neue Versionen erstellen eine Kopie, die die vorherige ersetzt, ohne sie zu löschen."
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
 msgstr "Das Lagerhaus, von dem diese Bestellung versendet wird; der Versandort des Kunden ist der Ort, an dem sie ankommen."
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "Das Lagerhaus, von dem dieses Angebot versendet wird; der Versandort des Kunden ist der Ort, an dem sie ankommen."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "Die Ausfallarten von Ausrüstungen für Wartungs- und Qualitätsverfolgung"
+msgstr "Die Ausfallarten der Anlage für die Instandhaltung und Qualitätsverfolgung"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Der eigene Behälter des Arbeitszentrums, in dem das kommissionierte Material zur Entnahme durch die Produktion bereitgestellt wird, im Gegensatz zu seinem Lagerquellregal."
+msgstr "Der eigene Lagerplatz des Arbeitsplatzes, wo kommissionierte Materialien für die Produktion bereitgestellt werden, im Gegensatz zu seinem Lager-Quellenregal."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Die Arbeitszeiten und Kalender, die die Planung steuern"
@@ -15538,7 +15538,7 @@ msgid "There are no active supplier quotes to compare for this RFQ."
 msgstr "Es gibt keine aktiven Lieferantenofferten zum Vergleichen für diese Anfrage."
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "Es gibt externe Operationen, die mit diesem Auftrag verknüpft sind und keine Lieferanten haben. Bitte weisen Sie jedem externen Betrieb einen Lieferanten zu, bevor Sie ihn freigeben."
+msgstr "Es gibt diesem Fertigungsauftrag zugeordnete Außenarbeitsgänge, die keine Lieferanten haben. Bitte weisen Sie vor der Freigabe jedem Außenarbeitsgang einen Lieferanten zu."
 
 msgid "There's nothing outstanding to apply these credits to."
 msgstr "Es gibt nichts Ausstehende, auf das diese Gutschriften angewendet werden können."
@@ -15559,16 +15559,16 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Diese Artikel enthalten noch Material zum Kommissionieren. Das Beenden markiert die Liste als Teilweise."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Diese Aufträge haben Operationen, die diesem Arbeitszentrum zugewiesen sind:"
+msgstr "Diese Fertigungsaufträge haben diesem Arbeitsplatz zugewiesene Arbeitsgänge:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Diese Journaleinträge sind noch im Entwurf, daher befinden sich ihre Belastungen und Gutschriften nicht im Ledger für diese Periode. Buchen Sie jeden Eintrag, oder buchen Sie ihn in eine spätere offene Periode um."
+msgstr "Diese Buchungssätze sind noch Entwurf, sodass ihre Sollposten und Habenposten nicht im Sachkonto für diesen Zeitraum enthalten sind. Buchen Sie jeden einzelnen oder ändern Sie das Datum zu einem späteren offenen Zeitraum."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "Dieser Carbon-Instanz fehlen die Onshape-OAuth-Anmeldedaten. Bitten Sie einen Administrator, sie einzurichten."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "Diese Änderungsmitteilung wird gerade implementiert, daher sind ihre Änderungen gesperrt. Öffnen Sie sie erneut zum Bearbeiten."
+msgstr "Diese Änderungsmitteilung wird gerade umgesetzt, daher sind ihre Änderungen gesperrt. Öffnen Sie sie erneut, um sie zu bearbeiten."
 
 msgid "This change notice is closed, so its changes are read-only."
 msgstr "Diese Änderungsmitteilung ist geschlossen, daher sind ihre Änderungen schreibgeschützt."
@@ -15577,13 +15577,13 @@ msgid "This completes the Discovery step."
 msgstr "Dies schließt den Discovery-Schritt ab."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Dieser Kontakt hat keine E-Mail-Adresse"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Dieser Geschäftspartner hat keine ausstehenden Forderungen — die Zahlung wird auf Kontokorrent verbucht."
 
 msgid "This download link is invalid or has been tampered with."
-msgstr "Dieser Download-Link ist ungültig oder wurde manipuliert."
+msgstr "Dieser Downloadlink ist ungültig oder wurde manipuliert."
 
 msgid "This file is no longer available, or you don't have permission to download it."
 msgstr "Diese Datei ist nicht mehr verfügbar, oder Sie haben keine Berechtigung, sie herunterzuladen."
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Diese Informationen sind für alle Benutzer sichtbar, daher seien Sie vorsichtig, was Sie teilen."
 
 msgid "this inspection plan"
-msgstr "dieser Inspektionsplan"
+msgstr "dieser Prüfplan"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Diese Einladung zum Beitritt zu {0} ist abgelaufen. Sie können eine neue Einladung anfordern, die an Ihre E-Mail gesendet wird."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Diese Rechnung hat kein nutzbares Fälligkeitsdatum – wählen Sie eines für Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Diese Rechnung wird dem Stripe-Kunden in Rechnung gestellt, der bereits mit diesem Carbon-Kunden verknüpft ist. Um die Details zu ändern, bearbeiten Sie diese im Stripe Dashboard."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Dies ist eine kontrollierte Umgebung, daher ist eine Authentifizierungs-App erforderlich."
@@ -15638,10 +15638,10 @@ msgid "this item"
 msgstr "diesen Artikel"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Dieser Artikel wird über einen Konfigurator gebaut und löst seine Komponenten pro Bestellung auf; für ihn erstellte Aufträge erben die aufgelöste Stückliste des Konfigurators."
+msgstr "Dieser Artikel wird über einen Konfigurator erstellt und löst seine Komponenten pro Bestellung auf; für ihn erstellte Fertigungsaufträge erben die aufgelöste Stückliste des Konfigurators."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "Die Stückliste dieses Artikels hat keine Eingaben mit aktivierter Haltbarkeitsdauer, daher wird kein Verfallsdatum aus der Stückliste berechnet."
+msgstr "Die Stückliste dieses Artikels hat keine Eingaben mit aktivierter Haltbarkeitsdauer, daher wird kein Verfall aus der Stückliste berechnet."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
 msgstr "Dieser Auftrag wird im Bestand eingegangen. Er ist nicht mehr auf der Werkstatt verfügbar."
@@ -15665,7 +15665,7 @@ msgid "This Month"
 msgstr "Dieser Monat"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "Diese Seite deines Implementation Hub wird gerade aufgebaut. Starten Sie vom Command Center, während wir sie fertigstellen."
+msgstr "Diese Seite Ihres Umsetzungs-Hub wird gerade erstellt. Beginnen Sie vom Befehlszentrum, während wir sie fertigstellen."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "Dieses Teil hat {quantityOnHand} auf Lager an diesem Standort. „Kein Bestand\" bedeutet, dass es weder geplant noch verbraucht wird."
@@ -15680,13 +15680,13 @@ msgid "This part is obsolete (No Stock)."
 msgstr "Dieses Teil ist veraltet (Kein Bestand)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "Dieses Teil ist überholt und auf „Nur Bestand\" eingestellt — es wird bis zur Reservefläche für Ersatzteile aufgefüllt, unabhängig von der Nachfrage."
+msgstr "Dieses Teil wird durch ein anderes ersetzt und auf „Nur Bestand\" gesetzt – es wird auf seinen Ersatzteile-Reservemindestwert aufgefüllt, unabhängig vom Bedarf."
 
 msgid "This path only decides what runs next"
 msgstr "Dieser Pfad entscheidet nur darüber, was als nächstes ausgeführt wird"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "Diese Periode hat keine Journaleinträge und kann dauerhaft gelöscht werden. Dies kann nicht rückgängig gemacht werden."
+msgstr "Dieser Zeitraum hat keine gebuchten Buchungssätze und kann dauerhaft gelöscht werden. Dies kann nicht rückgängig gemacht werden."
 
 msgid "this purchase order"
 msgstr "diese Bestellung"
@@ -15698,10 +15698,10 @@ msgid "This removes their authenticator app, so their next sign-in only needs a 
 msgstr "Dies entfernt ihre Authentifizierungs-App, daher benötigt ihre nächste Anmeldung nur einen Magic Link. Verwenden Sie dies, wenn sie den Zugriff auf ihre Authentifizierungs-App verloren haben. Dies wirkt sich auf ihre Anmeldung bei jedem Unternehmen aus, zu dem sie gehören."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "Diese Überarbeitung wird freigegeben (Produktion). Änderungen sollten normalerweise durch eine Änderungsmitteilung fließen."
+msgstr "Diese Revision ist freigegeben (Produktion). Änderungen sollten normalerweise durch eine Änderungsmitteilung fließen."
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "Diese Überarbeitung wird freigegeben (Produktion). Öffnen Sie eine Änderungsmitteilung, um sie zu ändern."
+msgstr "Diese Revision ist freigegeben (Produktion). Erstellen Sie eine Änderungsmitteilung, um diese zu ändern."
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "Diese Ausführung hat mehr Schritte, als wir hier anzeigen. Nur die ersten {MAX_RUN_STEPS} werden aufgelistet."
@@ -15710,14 +15710,14 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Dies führt den Workflow wirklich aus. Es werden Datensätze erstellt, Benachrichtigungen gesendet und alle Webhooks genau wie bei einer Live-Ausführung aufgerufen. Dies kann nicht rückgängig gemacht werden."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Diese Bestellung hat zugeordnete Aufträge. Wählen Sie, was damit geschehen soll."
+msgstr "Dieser Kundenauftrag hat zugeordnete Fertigungsaufträge. Wählen Sie, was damit zu tun ist."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Diese Bestellung hat Positionen, für die Aufträge erstellt werden müssen"
+msgstr "Dieser Kundenauftrag hat Positionen, für die Fertigungsaufträge erstellt werden müssen"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "Dieser Speichertyp wird derzeit von {usageCount} Speichereinheit{0} verwendet."
+msgstr "Dieser Speichertyp wird derzeit von {usageCount} Lagereinheit{0} verwendet."
 
 msgid "this supplier"
 msgstr "dieser Lieferant"
@@ -15745,16 +15745,16 @@ msgid "This version cannot be opened"
 msgstr "Diese Version kann nicht geöffnet werden"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Diese Version ist veröffentlicht"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Diese Version ist veröffentlicht. Erstellen Sie eine neue Version, um sie zu bearbeiten."
 
 msgid "This version's definition could not be read."
 msgstr "Die Definition dieser Version konnte nicht gelesen werden."
 
 msgid "This will make this version read-only and replace any material make methods with this version."
-msgstr "Dies macht diese Version schreibgeschützt und ersetzt alle Material-Make-Methoden durch diese Version."
+msgstr "Dies macht diese Version schreibgeschützt und ersetzt alle Werkstoff-Fertigungsmethoden durch diese Version."
 
 msgid "This will overwrite the existing job method"
 msgstr "Dies wird die vorhandene Arbeitsmethode überschreiben"
@@ -15766,12 +15766,12 @@ msgid "This will overwrite the existing quote method"
 msgstr "Dies wird die vorhandene Angebotsmethode überschreiben"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "Dies wird die Stückkosten aus der aktiven Herstellungsmethode, deren Stückliste und Prozesse unter Verwendung der Chargengröße neu berechnen. Die aktuellen Kosten werden überschrieben. Möchten Sie fortfahren?"
+msgstr "Dies berechnet die Stückkosten aus der Stückliste und den Arbeitsgängen der aktiven Fertigungsmethode neu, wobei die Chargengröße verwendet wird. Die aktuellen Kosten werden überschrieben. Möchten Sie fortfahren?"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "Dies wird die Verknüpfung von {0} mit {1} entfernen. Der Auftrag wird nicht mehr unter dem Auftrag angezeigt und Lieferungen können ihn nicht finden."
+msgstr "Dies entfernt die Verknüpfung zwischen {0} und {1}. Der Fertigungsauftrag wird nicht mehr unter dem Kundenauftrag angezeigt und Lieferungen werden ihn nicht finden."
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "Dies ersetzt alle Methodenmaterialien anderer Revisionen durch diese Revision."
@@ -15780,35 +15780,35 @@ msgid "This will replace all method materials of other sizes with this size."
 msgstr "Dies ersetzt alle Methodenmaterialien anderer Größen durch diese Größe."
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "Dadurch wird die aktuelle Version der Herstellungsmethode auf Aktiv gesetzt und schreibgeschützt."
+msgstr "Dies setzt die aktuelle Version der Fertigungsmethode auf Aktiv und macht sie schreibgeschützt."
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "Dies schreibt den verbleibenden Buchwert des Vermögenswerts ab."
 
 msgid "Three-way match"
-msgstr "Dreiweg-Vergleich"
+msgstr "Dreiwege-Abgleich"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
 msgstr "Bis {0}"
 
 msgid "Thumbnail"
-msgstr "Miniaturansicht"
+msgstr "Vorschaubild"
 
 msgid "Thumbnail is still generating"
-msgstr "Miniaturansicht wird noch generiert"
+msgstr "Vorschaubild wird noch generiert"
 
 msgid "Thumbnail path"
-msgstr "Miniaturbild-Pfad"
+msgstr "Vorschaubildpfad"
 
 msgid "Thumbnail removed"
 msgstr "Vorschaubild entfernt"
 
 msgid "Thumbnail updated"
-msgstr "Miniaturansicht aktualisiert"
+msgstr "Vorschaubild aktualisiert"
 
 msgid "Thumbnail uploaded"
-msgstr "Miniaturansicht hochgeladen"
+msgstr "Vorschaubild hochgeladen"
 
 msgid "Thursday"
 msgstr "Donnerstag"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Tie-Out nicht verfügbar"
 
 msgid "Tightened"
-msgstr "Gestrafft"
+msgstr "Verschärft"
 
 msgid "Time of day"
 msgstr "Tageszeit"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "Zeitkarte"
 
 msgid "Timecards"
-msgstr "Zeitkarten"
+msgstr "Zeiterfassung"
 
 msgid "Timecards are disabled"
 msgstr "Zeiterfassungen sind deaktiviert"
 
 msgid "Timecards are enabled"
-msgstr "Zeitkarten sind aktiviert"
+msgstr "Zeiterfassung ist aktiviert"
 
 msgid "Timezone"
 msgstr "Zeitzone"
@@ -15859,16 +15859,16 @@ msgid "To Location"
 msgstr "Zielort"
 
 msgid "To reactivate, use the row menu and choose Send Invite. The employee becomes active once they accept."
-msgstr "Um zu reaktivieren, verwenden Sie das Zeilenmenü und wählen Sie Einladung senden. Der Mitarbeiter wird aktiv, sobald er die Einladung annimmt."
+msgstr "Um zu reaktivieren, verwenden Sie das Zeilenmenü und wählen Sie Einladung senden. Der Mitarbeiter wird aktiv, sobald er akzeptiert."
 
 msgid "To Receive"
 msgstr "Zum Empfangen"
 
 msgid "To Ship"
-msgstr "Zum Versand"
+msgstr "Zu versenden"
 
 msgid "To Ship and Receive"
-msgstr "Zum Versand und Empfang"
+msgstr "Zu versenden und zu empfangen"
 
 msgid "To Storage Unit"
 msgstr "Zu Lagereinheit"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "Umschalten"
 
 msgid "Toggle Assignee"
-msgstr "Zuweiser umschalten"
+msgstr "Bearbeiter umschalten"
 
 msgid "Toggle break active"
 msgstr "Pause umschalten"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Werkzeuge"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Klassifizierung auf oberster Ebene (Anlage / Verbindlichkeit / Eigenkapital / Umsatz / Ausgaben); nur auf Wurzelgruppen eingestellt, von Kindern geerbt."
+msgstr "Oberste Klassifizierung (Vermögenswert / Verbindlichkeit / Eigenkapital / Umsatzerlöse / Aufwand); nur auf Root-Gruppen festgelegt, wird von Untergruppen geerbt."
 
 msgid "Topic"
 msgstr "Thema"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "Gesamtmenge"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Gesamtbestand des Artikels über alle Lagereinheiten an diesem Standort. Wird rot, wenn Bestand plus Zugänge die Gesamtnachfrage nicht decken können."
+msgstr "Gesamtmenge des Artikels im Bestand über alle Lagereinheiten an diesem Standort. Wird rot, wenn der verfügbare Bestand plus eingehende Waren den Gesamtbedarf nicht abdecken können."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Gesamtmenge, die über alle aktiven Aufträge und Kundenaufträge an diesem Standort benötigt wird – nicht nur für diesen Auftrag."
+msgstr "Gesamtmenge erforderlich über alle aktiven Fertigungsaufträge und Kundenaufträge an diesem Standort – nicht nur dieser Fertigungsauftrag."
 
 msgid "Total scrap quantity"
-msgstr "Gesamtverschrottungsmenge"
+msgstr "Gesamtausschussmenge"
 
 msgid "Total tax"
 msgstr "Gesamtsteuern"
@@ -16015,10 +16015,10 @@ msgid "Track every change to your orders, invoices, customers, suppliers, and mo
 msgstr "Verfolgen Sie jede Änderung an Ihren Bestellungen, Rechnungen, Kunden, Lieferanten und mehr."
 
 msgid "Track real-time inventory by location and bin"
-msgstr "Echtzeit-Bestand nach Lagerort und Behälter verfolgen"
+msgstr "Verfolgen Sie den Echtzeit-Bestand nach Standort und Lagerplatz"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "Verfolgen Sie Serien-/Chargennummern und erfüllen Sie Verkaufsaufträge."
+msgstr "Verfolgen Sie Serien-/Chargennummern und erfüllen Sie Kundenaufträge."
 
 msgid "Track tax depreciation separately"
 msgstr "Steuerliche Abschreibung separat nachverfolgen"
@@ -16036,16 +16036,16 @@ msgid "Tracked Entities"
 msgstr "Nachverfolgter Entitäten"
 
 msgid "Tracked entity"
-msgstr "Verfolgtes Unternehmen"
+msgstr "Verfolgte Einheit"
 
 msgid "Tracked Entity"
-msgstr "Verfolgtes Objekt"
+msgstr "Verfolgte Einheit"
 
 msgid "Tracked entity ID is required but none was found"
-msgstr "Tracked Entity ID ist erforderlich, aber keine wurde gefunden"
+msgstr "Verfolgte-Einheit-ID ist erforderlich, aber keine wurde gefunden"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "Verfolgtes Material wird nach Entnahmeverfahren (FEFO) vorausgewählt, auch ohne Pickliste."
+msgstr "Verfolgte Materialien werden nach Kommissionierauftrag vorabausgewählt (FEFO), auch ohne Kommissionierliste."
 
 msgid "Tracking"
 msgstr "Verfolgung"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "Schulungen"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "Transaktionen erstellen Journaleinträge und aktualisieren das Hauptbuch."
+msgstr "Transaktionen erstellen Buchungssätze und aktualisieren das Hauptbuch."
 
 msgid "Transfer"
 msgstr "Übertragung"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "Transfer-ID"
 
 msgid "Transfer Lines"
-msgstr "Transferzeilen"
+msgstr "Umlagerungspositionen"
 
 msgid "Transfer Ownership"
 msgstr "Eigentümerschaft übertragen"
@@ -16177,10 +16177,10 @@ msgid "Type a message..."
 msgstr "Geben Sie eine Nachricht ein..."
 
 msgid "Type an email and press Enter to add an external recipient"
-msgstr "Geben Sie eine E-Mail ein und drücken Sie die Eingabetaste, um einen externen Empfänger hinzuzufügen"
+msgstr "Geben Sie eine E-Mail ein und drücken Sie Eingabe, um einen externen Empfänger hinzuzufügen"
 
 msgid "Type of Permission Update"
-msgstr "Berechtigungsupdate-Typ"
+msgstr "Art der Berechtigungsaktualisierung"
 
 msgid "Type to search across your workspace"
 msgstr "Geben Sie ein, um in Ihrem Arbeitsbereich zu suchen"
@@ -16222,10 +16222,10 @@ msgid "Under Demand-Based Reorder, planning sums demand inside this rolling wind
 msgstr "Unter Demand-Based Reorder summiert die Planung den Bedarf in diesem rollierenden Fenster beim Berechnen einer Auffüllungsmenge."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "Unter Fixed Reorder Quantity plant das System bei jedem Auslösen des Meldebestands die genaue Menge."
+msgstr "Bei Festgelegt Bestellmenge ordert die Planung jedes Mal die exakte Menge an, wenn der Meldebestand erreicht wird."
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "Unter Maximum Quantity-Richtlinie plant das System bis zu diesem Lagerbestands-Level, wenn der Meldebestand ausgelöst wird."
+msgstr "Nach der Richtlinie Maximale Menge ordert die Planung bis zu diesem Istbestandsniveau an, wenn der Meldebestand auslöst wird."
 
 msgid "Undo"
 msgstr "Rückgängig machen"
@@ -16243,25 +16243,25 @@ msgid "Unit Cost"
 msgstr "Stückkosten"
 
 msgid "unit of measure"
-msgstr "Maßeinheit"
+msgstr "mengeneinheit"
 
 msgid "Unit of measure"
-msgstr "Maßeinheit"
+msgstr "Mengeneinheit"
 
 msgid "Unit of Measure"
-msgstr "Maßeinheit"
+msgstr "Mengeneinheit"
 
 msgid "Unit of measure code"
-msgstr "Maßeinheitencode"
+msgstr "Mengeneinheitscode"
 
 msgid "Unit of Measures"
-msgstr "Maßeinheiten"
+msgstr "Mengeneinheiten"
 
 msgid "Unit price"
-msgstr "Stückpreis"
+msgstr "einzelpreis"
 
 msgid "Unit Price"
-msgstr "Stückpreis"
+msgstr "Einzelpreis"
 
 msgid "Unit Sale Price"
 msgstr "Einheitlicher Verkaufspreis"
@@ -16270,7 +16270,7 @@ msgid "Units"
 msgstr "Einheiten"
 
 msgid "Units of base currency per one unit of this currency; used to translate amounts on posting."
-msgstr "Einheiten der Basiswährung pro eine Einheit dieser Währung; wird zur Umrechnung von Beträgen beim Buchen verwendet."
+msgstr "Einheiten der Basiswährung pro einer Einheit dieser Währung; wird verwendet, um Beträge bei der Buchung umzuwandeln."
 
 msgid "units of measure"
 msgstr "Maßeinheiten"
@@ -16291,16 +16291,16 @@ msgid "unknown location"
 msgstr "unbekannter Ort"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Unbegrenzter funktionaler Support"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Unbegrenzte Datensätze"
 
 msgid "Unlink"
 msgstr "Verknüpfung aufheben"
 
 msgid "Unlink job from sales order?"
-msgstr "Auftrag von Verkaufsauftrag trennen?"
+msgstr "Fertigungsauftrag von Kundenauftrag trennen?"
 
 msgid "Unlock"
 msgstr "Entsperren"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Unveröffentlichte Dokumente"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Veröffentlichung aufheben"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Veröffentlichung von {name} aufheben?"
 
 msgid "Unreceived POs"
 msgstr "Nicht eingegangene Bestellungen"
@@ -16360,7 +16360,7 @@ msgid "Unshipped orders"
 msgstr "Nicht versendete Bestellungen"
 
 msgid "Unsupported source document type: {sourceDocument}"
-msgstr "Nicht unterstützter Quelldokumenttyp: {sourceDocument}"
+msgstr "Ursprungsbeleg-Typ nicht unterstützt: {sourceDocument}"
 
 msgid "Untitled Diagram"
 msgstr "Unbenanntes Diagramm"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "Unbenannte Zeile"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "Ungenutztes Pickmaterial aus dem Arbeitszentrum zurück ins Lager gespült."
+msgstr "Ungenutzte kommissionierte Materialien werden vom Arbeitsplatz zurück ins Lager geleitet."
 
 msgid "UoM"
 msgstr "UoM"
@@ -16393,10 +16393,10 @@ msgid "Update a receipt"
 msgstr "Einen Eingang aktualisieren"
 
 msgid "Update a sales order"
-msgstr "Einen Verkaufsauftrag aktualisieren"
+msgstr "Aktualisieren Sie einen Kundenauftrag"
 
 msgid "Update a shipment"
-msgstr "Eine Sendung aktualisieren"
+msgstr "Aktualisieren Sie eine Lieferung"
 
 msgid "Update a supplier"
 msgstr "Einen Lieferanten aktualisieren"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Linear-Problem aktualisieren"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Aktualisieren Sie die Teillaufzeiten aus gebuchten Kaufbelegen."
+msgstr "Aktualisieren Sie die Beschaffungszeiten von Teilen aus gebuchten Wareneingängen."
 
 msgid "Update Password"
 msgstr "Passwort aktualisieren"
@@ -16441,7 +16441,7 @@ msgid "Update Rule"
 msgstr "Regel aktualisieren"
 
 msgid "Update source document quantities"
-msgstr "Quellendokumentmengen aktualisieren"
+msgstr "Aktualisieren Sie Ursprungsbeleg-Mengen"
 
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Aktualisieren Sie die Kanban-Informationen für die scanbasierte Auffüllung."
@@ -16472,7 +16472,7 @@ msgstr "Upgrade to Business"
 
 #. placeholder {0}: targetCopy.noun
 msgid "Upgrade to unlock {0} rules"
-msgstr "Upgrade to unlock {0} rules"
+msgstr "Upgraden Sie, um {0} Regeln freizuschalten"
 
 msgid "Upgrade to unlock audit history"
 msgstr "Upgrade freischalten, um Audit-Verlauf zu entsperren"
@@ -16481,7 +16481,7 @@ msgid "Upload"
 msgstr "Hochladen"
 
 msgid "Upload a PDF first"
-msgstr "Laden Sie zuerst eine PDF-Datei hoch"
+msgstr "Laden Sie zuerst eine PDF hoch"
 
 msgid "Upload completed but no file path returned"
 msgstr "Upload abgeschlossen, aber kein Dateipfad zurückgegeben"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "Wird hochgeladen…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "Beim Klicken auf „Konvertieren\" werden Teile mit den folgenden internen Teilenummern erstellt:"
+msgstr "Beim Klicken auf Umwandeln werden Teile mit den folgenden internen Teilenummern erstellt:"
 
 msgid "URL"
 msgstr "URL"
@@ -16555,7 +16555,7 @@ msgid "Used In"
 msgstr "Verwendet in"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "Wird in der Navigation und in Dokumenten wie Verkaufsaufträgen verwendet"
+msgstr "Wird in der Navigation und auf Dokumenten wie Kundenaufträgen verwendet"
 
 msgid "Used in the navigation in dark mode"
 msgstr "Wird in der Navigation im dunklen Modus verwendet"
@@ -16657,7 +16657,7 @@ msgid "Variance between actual and standard BOM component consumption"
 msgstr "Abweichung zwischen tatsächlichem und Standard-BOM-Komponentenverbrauch"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Abweichung zwischen tatsächlicher und Standard-Bearbeitungszeit und -sätzen"
+msgstr "Abweichung zwischen tatsächlichen und Standard-Arbeitsplänen (Stunden und Sätze)"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "Abweichung zwischen tatsächlichem Kaufpreis und Standardkosten"
@@ -16666,19 +16666,19 @@ msgid "Variance between applied and actual manufacturing overhead"
 msgstr "Abweichung zwischen angewendetem und tatsächlichem Fertigungsgemeinkosten"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "Abweichung durch Anpassungen der physischen Bestandsaufnahme"
+msgstr "Abweichung von physischen Bestandskorrekturen"
 
 msgid "Variance in outside processing costs"
 msgstr "Abweichung bei Fremdbearbeitungskosten"
 
 msgid "Variance only"
-msgstr "Nur Varianz"
+msgstr "Nur Abweichung"
 
 msgid "VAT Number"
-msgstr "Umsatzsteuer-Identifikationsnummer"
+msgstr "USt-IdNr."
 
 msgid "Vendor Write-Off Income"
-msgstr "Lieferantenschreib-Off-Ertrag"
+msgstr "Ausbuchungserträge von Lieferanten"
 
 msgid "Verification Error"
 msgstr "Verifizierungsfehler"
@@ -16703,7 +16703,7 @@ msgstr "Version"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Version {0} ist jetzt veröffentlicht und wird ersetzt."
 
 msgid "Version:"
 msgstr "Version:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Anzeigen"
 
 msgid "View Active Jobs"
-msgstr "Aktive Aufträge anzeigen"
+msgstr "Aktive Fertigungsaufträge anzeigen"
 
 msgid "View Active Quotes"
 msgstr "Aktive Angebote anzeigen"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Anlage anzeigen"
 
 msgid "View Assigned Jobs"
-msgstr "Zugewiesene Aufträge anzeigen"
+msgstr "Zugewiesene Fertigungsaufträge anzeigen"
 
 msgid "View Attachment"
 msgstr "Anhang anzeigen"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Artikelstamm anzeigen"
 
 msgid "View Journal Entry"
-msgstr "Journaleintrag anzeigen"
+msgstr "Buchungszeile anzeigen"
 
 msgid "View Lists"
 msgstr "Listen anzeigen"
 
 msgid "View maintenance dispatch"
-msgstr "Wartungseinsatz anzeigen"
+msgstr "Instandhaltungsauftrag anzeigen"
 
 msgid "View Memo"
 msgstr "Memo anzeigen"
@@ -16847,7 +16847,7 @@ msgid "View Production Events"
 msgstr "Produktionsereignisse anzeigen"
 
 msgid "View Purchase Invoice"
-msgstr "Kaufrechnung anzeigen"
+msgstr "Eingangsrechnung anzeigen"
 
 msgid "View Reactive"
 msgstr "Reaktive anzeigen"
@@ -16865,7 +16865,7 @@ msgid "View Scheduled"
 msgstr "Geplante anzeigen"
 
 msgid "View Shipment"
-msgstr "Sendung anzeigen"
+msgstr "Lieferung anzeigen"
 
 msgid "View Status"
 msgstr "Status anzeigen"
@@ -16907,31 +16907,31 @@ msgid "Void Invoice"
 msgstr "Rechnung stornieren"
 
 msgid "Void Purchase Invoice"
-msgstr "Kaufrechnung stornieren"
+msgstr "Eingangsrechnung stornieren"
 
 msgid "Void Receipt"
 msgstr "Beleg stornieren"
 
 msgid "Void Sales Invoice"
-msgstr "Verkaufsrechnung stornieren"
+msgstr "Ausgangsrechnung stornieren"
 
 msgid "Void Shipment"
-msgstr "Sendung stornieren"
+msgstr "Lieferung stornieren"
 
 msgid "Voided"
 msgstr "Storniert"
 
 msgid "Voiding this purchase invoice will:"
-msgstr "Das Stornieren dieser Einkaufsrechnung wird:"
+msgstr "Das Stornieren dieser Eingangsrechnung wird:"
 
 msgid "Voiding this receipt will:"
 msgstr "Das Stornieren dieses Belegs führt zu:"
 
 msgid "Voiding this shipment will:"
-msgstr "Das Stornieren dieser Sendung wird:"
+msgstr "Das Stornieren dieser Lieferung wird:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Gehen Sie jeden Bereich mit Ihrem Champion durch und deaktivieren Sie alles, das außerhalb des Umfangs liegt. Codes lesen Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Gehen Sie mit Ihrem Champion jeden Bereich durch und deaktivieren Sie alles, das außerhalb des Umfangs liegt. Codes werden gelesen als Modul.Bereich.Nummer (ACC.GL.01 = Buchhaltung, Hauptbuch, Position 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Gehen Sie Ihren aktuellen Prozess, Ihre Systeme und Ihre Daten durch"
@@ -16952,13 +16952,13 @@ msgid "Warn"
 msgstr "Warnung"
 
 msgid "Warn — edits succeed with a warning"
-msgstr "Warnung — Änderungen werden mit einer Warnung erfolgreich durchgeführt"
+msgstr "Warnen – Bearbeitungen sind erfolgreich mit einer Warnung"
 
 msgid "Warn but allow"
 msgstr "Warnen, aber zulassen"
 
 msgid "Warn this many days before expiry"
-msgstr "Warnen Sie diese vielen Tage vor Ablauf"
+msgstr "Diese Anzahl von Tagen vor Verfall warnen"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Warnen Sie, wenn die Person, die einen eingegangenen Artikel prüft, dieselbe Person ist, die ihn erhalten hat."
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "Wöchentlich"
 
 msgid "Weekly demand"
-msgstr "Wöchentliche Nachfrage"
+msgstr "Wöchentlicher Bedarf"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17077,7 +17077,7 @@ msgid "Welcome, {companyName}"
 msgstr "Willkommen, {companyName}"
 
 msgid "What category of failure this is — Mechanical, Electrical, Software, Operator, Material, etc.; rolls up into the failure-mode pareto report so the category breakdown is meaningful."
-msgstr "Welche Fehlerkategorie dies ist — Mechanisch, Elektrisch, Software, Bedienung, Material usw.; wird im Pareto-Bericht für Ausfallarten zusammengefasst, damit die Kategorieaufschlüsselung aussagekräftig ist."
+msgstr "Welche Fehlerkategorie dies ist – Mechanisch, Elektrisch, Software, Bediener, Material usw.; wird in den Fehlermodus-Pareto-Bericht hochgerechnet, sodass die Kategorieaufschlüsselung aussagekräftig ist."
 
 msgid "What changes day to day"
 msgstr "Was sich täglich ändert"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Was den Bestand nach oben oder unten getrieben hat, nach beliebiger Dimension"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Was passiert, wenn ein Journal in einem gesperrten Zeitraum datiert ist."
+msgstr "Was passiert, wenn ein Buchungssatz in einem gesperrten Zeitraum datiert ist."
 
 msgid "What is {translatedTerm}?"
 msgstr "{translatedTerm} ist was?"
@@ -17101,7 +17101,7 @@ msgid "What it is"
 msgstr "Was es ist"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "Welche Art von Änderung dies ist: Version aktualisiert, wie das Teil hergestellt wird, Revision überarbeitet seine Details und Dokumente, Ersatzteil tauscht eine neue Teilenummer ein, die die alte ersetzt, und Neuer Teil führt ein völlig neues Teil ohne Vorgänger ein."
+msgstr "Welche Art von Änderung dies ist: Version aktualisiert, wie das Teil hergestellt wird, Revision überarbeitet seine Details und Dokumente, Ersatzteil tauscht eine neue Teilenummer ein, die die alte ersetzt, und Neuteil führt ein völlig neues Teil ohne Vorgänger ein."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
 msgstr "Welche Art von Ausgabe dieser Eintrag aufzeichnet — Produktion (gute Einheiten), Ausschuss (nicht behebbar) oder Nacharbeiten (zur Korrektur zurückgesendet); zeigt Ausschussgrund an, wenn Ausschuss."
@@ -17125,13 +17125,13 @@ msgid "What this receipt is fulfilling — a purchase order, a return, an inboun
 msgstr "Was dieser Beleg erfüllt — eine Bestellung, eine Rücksendung, eine eingehende Übertragung oder ein manueller Beleg ohne übergeordneter Beleg."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "Was diese Sendung erfüllt — eine Verkaufsbestellung, eine ausgehende Übertragung, eine RMA-Rücksendung oder eine manuelle Sendung."
+msgstr "Was diese Lieferung erfüllt – einen Kundenauftrag, eine ausgehende Umlagerung, eine RMA-Rücksendung oder eine manuelle Lieferung."
 
 msgid "What this task means"
 msgstr "Was diese Aufgabe bedeutet"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Was dieser Zeiteintrag zählt als — Arbeit (Bedienerzeit), Maschine (Laufzeit) oder Einrichtung (Umstellungszeit); jede wird unter einer anderen Rate aggregiert."
+msgstr "Wofür dieser Zeiteintrag zählt – Personal (Werkerzeit), Maschine (Bearbeitungszeit) oder Rüsten (Umrüstzeit); jede wird unter einer anderen Rate zusammengefasst."
 
 msgid "What to set up"
 msgstr "Was einzurichten ist"
@@ -17167,7 +17167,7 @@ msgid "When expired stock is used"
 msgstr "Wenn abgelaufene Bestände verwendet werden"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "Wenn MRP den Nachfolger für neue Nachfrage verwendet"
+msgstr "Wenn MRP den Nachfolger für neuen Bedarf verwendet"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "Wenn aktiviert, erscheinen Attribute in dieser Kategorie im öffentlichen Profil einer Person; andernfalls sind sie nur für Administratoren sichtbar."
@@ -17176,16 +17176,16 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Wenn aktiviert, können Mitarbeiter den Wert dieses Attributs in ihrem eigenen Profil bearbeiten; andernfalls können nur Administratoren dies tun."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Wenn aktiviert, gelten Preisregeln (Volumenrabatte, Promotionen) weiterhin auf dieser Außerkraftsetzung; wenn deaktiviert, ist diese Außerkraftsetzung der endgültige Preis."
+msgstr "Wenn aktiviert, gelten Preisregeln (Mengenrabatte, Aktionen) zusätzlich zu dieser Übersteuerung; wenn deaktiviert, ist diese Übersteuerung der endgültige Preis."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
-msgstr "Wenn aktiviert, meldet das Scannen des Operationsbarcodes dieses Prozesses alle verbleibende offene Menge auf einmal als abgeschlossen; deaktivieren, wenn Operatoren routinemäßig Teilmengen melden."
+msgstr "Wenn aktiviert, meldet das Scannen des Operationsstrichcodes dieses Verfahrens alle verbleibende offene Menge in einer Aktion als abgeschlossen; deaktivieren Sie, wenn Werker routinemäßig Teilweise melden."
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
 msgstr "Wenn aktiviert, überspringen die Rechnungen dieser Partei die Steuerberechnung; die Partei ist verantwortlich für die Aktualisierung des Befreiungszertifikats."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Wenn aktiviert, gilt diese Preisüberschreibung auf übereinstimmende Bestellungen; wenn deaktiviert, wird die Überschreibung ohne Löschen beibehalten, um den Verlauf für die Prüfung zu bewahren."
+msgstr "Wenn aktiviert, gilt diese Preisübersteuerung für entsprechende Aufträge; das Ausschalten ohne Löschen bewahrt den Verlauf für die Prüfung."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Wenn aktiviert, wird diese Regel für jedes Ziel ihres Typs ausgelöst. Zuordnungszeilen werden ignoriert, aber beibehalten."
@@ -17194,25 +17194,25 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "Wann Lieferantenreaktionen erwartet werden; Lieferanten sehen dieses Datum auf dem RFQ-Portal und Carbon akzeptiert keine späten Antworten danach (konfigurierbar)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "Wann der Käufer die Waren angefordert hat; der Lieferant kann etwas anderes auf dem zugesagten Datum versprechen und etwas anderes wieder am Lieferdatum buchen."
+msgstr "Wenn der Einkäufer die Ware anforderte; der Lieferant kann am Zugesagten Termin etwas anderes zusagen und am Liefertermin wieder etwas anderes liefern."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "Wann der Käufer diese Zeilenwaren benötigt am Dock; Planung nutzt dieses Datum für die Lagerverfügbarkeit und Fremdbearbeitungsplanung."
+msgstr "Wenn der Einkäufer diese Positionsware auf der Rampe benötigt; die Planung verwendet dieses Datum für Bestandsverfügbarkeit und Fremdbearbeitung-Planung."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "Wann der Kunde die Lieferung angefordert hat; die Bestellung bindend an das zugesagte Datum, das sich unterscheiden kann."
+msgstr "Wenn der Kunde um Lieferung bat; der Auftrag verpflichtet sich zum Zugesagten Termin, der abweichen kann."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Wann der Kunde die Warenvereinbarung erhalten möchte; das Angebot verpflichtet sich zu diesem Datum, wenn der Kunde akzeptiert."
+msgstr "Wenn der Kunde um den Empfang der Ware bat; das Angebot verpflichtet sich zu diesem Datum, wenn der Kunde akzeptiert."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Wann der Kunde die Warenvereinbarung erhalten möchte."
+msgstr "Wenn der Kunde um den Empfang der Ware bat."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "Wann der Kunde diese RFQ eingereicht hat; die Antwort-Uhr startet von diesem Datum."
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "Wenn die Kundenanfrage nicht mehr aktuell ist; nach diesem Datum wird die RFQ automatisch geschlossen und akzeptiert keine Angebote mehr, sofern nicht erneut geöffnet."
+msgstr "Wenn die Anfrage des Kunden nicht mehr aktuell ist; nach diesem Datum wird die Anfrage automatisch geschlossen und akzeptiert keine Angebotsantworten, es sei denn, sie wird erneut geöffnet."
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
 msgstr "Wenn die Waren tatsächlich ankamen; auf dem Beleg aufgezeichnet und zur Bewertung der Liefertreue des Lieferanten verwendet."
@@ -17227,19 +17227,19 @@ msgid "When the supplier committed to deliver; planning uses this date for the i
 msgstr "Wann sich der Lieferant zur Lieferung verpflichtet hat; Planung nutzt dieses Datum für die Eingangslagerprognose."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "Wann die Preisgestaltung des Lieferanten nicht mehr gültig ist; Das Umwandeln dieses Angebots in eine PO nach diesem Datum kann eine Neubewertung erfordern."
+msgstr "Wenn die Preisfindung des Lieferanten nicht mehr gültig ist; das Umwandeln dieses Angebots in eine Bestellung nach diesem Datum kann ein Neuangebot erfordern."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Wann dieses Messinstrument zur Kalibrierung fällig wird; sobald es überfällig ist, liest es Außerkalibrierung."
+msgstr "Wenn dieses Prüfmittel zur Kalibrierung fällig wird; sobald es überfällig ist, wird es als „Außer Kalibrierung\" angezeigt."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Wann dieses Gerät zuletzt erfolgreich kalibriert wurde; das nächste Kalibrierungsdatum wird von diesem Wert plus dem Intervall neu berechnet."
+msgstr "Wann dieses Prüfmittel zuletzt erfolgreich kalibriert wurde; das nächste Kalibrierungsdatum wird aus diesem Wert plus dem Intervall neu berechnet."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "Wenn dies richtig aussieht, markieren Sie es als vereinbart. Dies schließt den Discovery-Schritt in Ihrem Command Center ab."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Wann diese bestimmte Linie zum Versand versprochen wird; Pro-Linie-Außerkraftsetzung des Orderkopfs ist Promised Date für geteilte Sendungen."
+msgstr "Wann diese spezifische Position versendet werden soll; Übersteuerung des Zugesagten Termins pro Position im Bestellkopf für geteilte Lieferungen."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
 msgstr "Wann diese bestimmte Charge/Seriennummer abläuft; treibt FEFO-Kommissionierung und die Lagerfähigkeit-Richtlinie beim Verbrauch."
@@ -17254,19 +17254,19 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "Wohin eine Workflow-Benachrichtigung versendet wird – in-app wird immer versendet, während E-Mail einen Business- oder Partner-Plan benötigt und Slack Ihren Slack-Arbeitsbereich erfordert."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Wo ein Betrieb läuft; trägt Arbeits- und Angebotstarife, mit Overhead dem Unterschied zwischen ihnen."
+msgstr "Wo ein Arbeitsgang läuft; trägt Personal- und Angebotstarife, mit Gemeinkosten als die Differenz zwischen ihnen."
 
 msgid "Where and how you make things."
 msgstr "Wo und wie Sie Dinge herstellen."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Wohin Waren auf dieser PO standardmäßig vom Lieferanten versandt werden; Pro-Linie-Lieferstellen auf der PO überschreiben dies für Drop-Ship- und Split-Delivery-Szenarien."
+msgstr "Wohin die Waren auf dieser Bestellung standardmäßig versendet werden; pro Position Lieferstandorte der Bestellung setzen das für Direktlieferung und geteilte Lieferungen außer Kraft."
 
 msgid "Where it lives today"
 msgstr "Wo es heute lebt"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Wo neuer Bestand dieses Artikels standardmäßig beim Empfang landet; Pro-Linie-Speicherauswahl auf einem Beleg überschreiben es."
+msgstr "Wohin neue Bestände dieses Artikels standardmäßig bei Wareneingang landen; pro Position Lagerauswahlen beim Wareneingang setzen das außer Kraft."
 
 msgid "Where stock lives and how it ships."
 msgstr "Wo Bestände lagern und wie sie versendet werden."
@@ -17275,16 +17275,16 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "Wo die betroffenen Elemente im System verwendet werden. Informativ – nichts hier blockiert die Freigabe."
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "Woher dieser Eintrag stammt (manueller Eintrag, Buchung aus Verkauf/Einkauf, wiederkehrende Vorlage usw.)."
+msgstr "Woher dieser Eintrag stammt (manuelle Eingabe, Buchung aus Vertrieb/Einkauf, wiederkehrende Vorlage, usw.)."
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
 msgstr "Woher dieses Problem kam — interne QS, Kundenbeschwerde, Lieferantenprüfung usw.; dient der Berichterstattung, blockiert nicht den Workflow."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "Wo diese Zeilenwaren bei Empfang im Lager landen; Falls leer, verwenden die Quittungen die Standard-Lagerstelle des Artikels."
+msgstr "Wohin die Waren dieser Position beim Wareneingang ins Lager landen; wenn leer, verwenden Wareneingänge die standardmäßige Lagereinheit des Artikels."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "Woher diese Wartungsanfrage kam — vom Bediener gemeldet, geplant, Zustandsüberwachungs-Trigger, Nachkontrolle; treibt die Quelle-Aufschlüsselung in Wartungsberichten."
+msgstr "Woher diese Wartungsanforderung stammt — von Werker gemeldet, geplant, Zustandsüberwachungs-Auslöser, Inspektion nach Fertigungsauftrag; treibt die Quellenaufschlüsselung in Wartungsberichten."
 
 msgid "Where you are today"
 msgstr "Wo du heute stehst"
@@ -17296,7 +17296,7 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Ob der Betrag als Prozentsatz des Zeilenpreises oder als fester Währungsbetrag interpretiert wird."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Ob Carbon jede Einheit (Serial), jedes Los (Batch), die Menge (Inventory) oder keine Nachverfolgung (Non-Inventory) verfolgt."
+msgstr "Ob Carbon jede Einheit (Seriell) verfolgt, jede Charge (Los), die Menge (Bestände) oder keine Verfolgung (Nicht lagergeführt)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Ob die Uhr startet, wenn der gewählte Prozess beginnt oder wenn er abgeschlossen ist."
@@ -17305,19 +17305,19 @@ msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail 
 msgstr "Ob dieses Los/diese Seriennummer die Prüfung besteht (Pass) oder nicht besteht (Fail); ein Fail verhindert, dass der Bestand in den verfügbaren Bestand aufgenommen wird."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Ob dieser Prozess in internen Arbeitszentren (Prozess, Montage oder Inspektion) oder bei externen Lieferanten (Fremdbearbeitung) abläuft; zeigt verschiedene nachgelagerte Felder an, ändert die Funktionsweise von Planungsrouten für diesen Prozess und legt den Standardoperationstyp für neue Operationen fest."
+msgstr "Ob dieses Verfahren auf internen Arbeitsplätzen läuft (Verfahren, Montage oder Prüfung) oder bei externen Lieferanten (Fremdbearbeitung); zeigt verschiedene nachgelagerte Felder, ändert, wie Planungsrouten für dieses Verfahren funktionieren, und setzt den Standard des Arbeitsgangtyps bei neuen Arbeitsgängen."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "Ob diese Arbeit die Produktion blockiert (Ausfall), sie beeinträchtigt (Auswirkung), in einem geplanten Ausfallzeitfenster stattfindet (Geplant) oder keine Produktionsauswirkung hat (Keine Auswirkung); informiert die Planung und die kundenorientierte Ausfallzeitkommunikation."
+msgstr "Ob diese Arbeit die Produktion blockiert (Ausfall), sie beeinträchtigt (Auswirkung), in einem geplanten Stillstandszeitfenster liegt (Geplant) oder keine Produktionsauswirkung hat (Keine Auswirkung); informiert die Planung und die kundenorientierte Stillstandszeitkommunikation."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
-msgstr "Ob die ausgewählten Berechtigungen auf das hinzugefügt werden, was jeder Benutzer bereits hat, oder Aktualisierung durch Ersetzen des Berechtigungssatzes jedes Benutzers mit der folgenden Auswahl."
+msgstr "Ob die ausgewählten Berechtigungen zu dem hinzugefügt werden, das jeder Benutzer bereits hat, oder die Berechtigungssätze jedes Benutzers durch die folgende Auswahl ersetzen."
 
 msgid "Which document drives each inspection flow for this item."
-msgstr "Welches Dokument bestimmt jeden Inspektionsfluss für diesen Artikel."
+msgstr "Welches Dokument treibt jeden Inspektionsablauf für diesen Artikel an."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Welche Art von Anfrage zu senden: GET liest etwas, POST erstellt, PUT und PATCH aktualisieren, DELETE entfernt. Ein neuer Schritt beginnt mit GET, und nur POST, PUT und PATCH enthalten einen Text."
+msgstr "Welche Art von Anfrage zu senden ist: GET liest etwas, POST erstellt, PUT und PATCH aktualisieren, DELETE löscht. Ein neuer Schritt beginnt bei GET, und nur POST, PUT und PATCH enthalten einen Text."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "Welches Fertigungsereignis die Lagerfrist-Uhr startet — z. B. Füllen, Versiegeln oder endgültiges QS."
@@ -17338,7 +17338,7 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Wer muss Angebote, Bestellungen und Käufe genehmigen – und wann"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Wer sollte Benachrichtigungen für wartungsbezogene Einsätze erhalten?"
+msgstr "Wer sollte Benachrichtigungen für wartungsbezogene Instandhaltungsaufträge erhalten?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
 msgstr "Wer sollte Benachrichtigungen für betriebsbezogene Einsätze erhalten?"
@@ -17350,19 +17350,19 @@ msgid "Who should receive notifications for quality-related dispatches?"
 msgstr "Wer sollte Benachrichtigungen für qualitätsbezogene Einsätze erhalten?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein digitales Angebot akzeptiert oder abgelaufen ist?"
+msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein digitales Angebot angenommen oder abgelaufen ist?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein Messinstrument außer Kalibrierung gerät?"
+msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein Prüfmittel außer Kalibrierung geht?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein neuer Vorschlag eingereicht wird?"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "Wer sollte Benachrichtigungen erhalten, wenn eine Anfrage als angebotbereit markiert wird?"
+msgstr "Wer sollte Benachrichtigungen erhalten, wenn eine Anfrage als angebotsbereit gekennzeichnet wird?"
 
 msgid "Who should receive notifications when a sales job is completed?"
-msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein Verkaufsauftrag abgeschlossen ist?"
+msgstr "Wer sollte Benachrichtigungen erhalten, wenn ein Vertriebsfertigungsauftrag fertiggestellt wird?"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
 msgstr "Wer sollte benachrichtigt werden, wenn ein Lieferantengebot eingereicht wird?"
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "WIP"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Ohne eine Pickliste wählen Bediener Material von der Registerkarte Scan aus."
+msgstr "Ohne eine Kommissionierliste kommissionieren Werker Werkstoff vom Scannen-Tab."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17424,37 +17424,37 @@ msgid "Wordmark Light Mode"
 msgstr "Wortmarke Hellmodus"
 
 msgid "work center"
-msgstr "Arbeitszentrum"
+msgstr "Arbeitsplatz"
 
 msgid "Work center"
-msgstr "Arbeitszentrum"
+msgstr "Arbeitsplatz"
 
 msgid "Work Center"
-msgstr "Arbeitszentrum"
+msgstr "Arbeitsplatz"
 
 msgid "Work Center Utilization"
-msgstr "Auslastung des Arbeitszentrums"
+msgstr "Arbeitsplatz-Auslastung"
 
 msgid "work centers"
-msgstr "Arbeitszentren"
+msgstr "Arbeitsplätze"
 
 msgid "Work centers"
-msgstr "Arbeitszentren"
+msgstr "Arbeitsplätze"
 
 msgid "Work Centers"
-msgstr "Arbeitszentren"
+msgstr "Arbeitsplätze"
 
 msgid "Work in process (WIP)"
 msgstr "Halbfabrikate (WIP)"
 
 msgid "Work in progress"
-msgstr "Laufende Arbeiten"
+msgstr "Arbeit in Bearbeitung"
 
 msgid "Work in Progress (default)"
-msgstr "Halbfabrikate (Standard)"
+msgstr "Arbeit in Bearbeitung (Standard)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Halbfabrikate (WIP)"
+msgstr "Arbeit in Bearbeitung (WIP)"
 
 msgid "Work instruction"
 msgstr "Arbeitsanweisung"
@@ -17466,7 +17466,7 @@ msgid "Work Phone"
 msgstr "Geschäftstelefon"
 
 msgid "Work shift tracking is active."
-msgstr "Arbeitszeitverfolgung ist aktiv."
+msgstr "Die Schicht-Verfolgung ist aktiv."
 
 msgid "Workflow"
 msgstr "Workflow"
@@ -17487,23 +17487,23 @@ msgid "Worst Performing Machines"
 msgstr "Schlechteste Maschinen"
 
 msgid "Write-Down Account"
-msgstr "Wertberichtigungskonto"
+msgstr "Abwertungskonto"
 
 msgid "Write-off"
-msgstr "Abschreibung"
+msgstr "Ausbuchung"
 
 msgid "Write-Off"
-msgstr "Abschreibung"
+msgstr "Ausbuchung"
 
 msgid "Write-Off Account"
-msgstr "Abschreibungskonto"
+msgstr "Ausbuchungskonto"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Abschreibung für {0}"
+msgstr "Ausbuchung für {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Abschreibung von Lagern, die durch Inspektionsablehnungen und NCR-Verfügungen verschrottet oder zurückgegeben wurden"
+msgstr "Ausbuchung von Bestand, der verschrottet oder über Inspektionsablehnungen und NCR-Verwendungsentscheide zurückgegeben wurde"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
 msgstr "Den Wert eines Vermögenswerts über seine Lebensdauer abschreiben — ein monatlicher Batch, den Sie erstellen, als Entwurf überprüfen und dann buchen."
@@ -17518,10 +17518,10 @@ msgid "Yes"
 msgstr "Ja"
 
 msgid "Yes, Accept"
-msgstr "Ja, akzeptieren"
+msgstr "Ja, Annehmen"
 
 msgid "Yes, also delete every nested storage unit."
-msgstr "Ja, auch alle verschachtelten Speichereinheiten löschen."
+msgstr "Ja, auch jede verschachtelte Lagereinheit löschen."
 
 msgid "Yes, Reject"
 msgstr "Ja, ablehnen"
@@ -17542,7 +17542,7 @@ msgid "You can only see this key once. Store it safely."
 msgstr "Du kannst diesen Schlüssel nur einmal sehen. Speichere ihn sicher."
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Abmeldungszeit unten ändern oder bestätigen, dass Sie noch arbeiten."
+msgstr "Sie sind um <0/> eingestempelt. Sie können Ihre Ausstempelzeit unten bearbeiten oder bestätigen, dass Sie noch arbeiten."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity
@@ -17560,10 +17560,10 @@ msgid "You don't have permission to edit this bill of material."
 msgstr "Sie haben keine Berechtigung, diese Stückliste zu bearbeiten."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Sie haben keine Berechtigung, diesen Betriebsplan zu bearbeiten."
+msgstr "Sie haben nicht die Berechtigung, diese Arbeitsgangliste zu bearbeiten."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "Du bestimmst das Tempo; wir sorgen dafür, dass es richtig gemacht wird. Fachkundige Augen auf dein Setup, deine Daten und deinen Go-Live."
+msgstr "Sie treiben es voran; wir stellen sicher, dass es richtig gemacht wird. Fachleute überwachen Ihre Einrichtung, Daten und Go-Live."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Du bist live auf Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Sie sind einen Schritt entfernt von Ihrem Arbeitsbereich."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Du richtest Carbon selbst ein, in deinem eigenen Tempo"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Du bist seit {hoursElapsed} Stunden angemeldet. Hast du vergessen, dich abzumelden?"
+msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie das Ausstempeln vergessen?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Ihr Konto bleibt sicher, auch wenn Ihr Anmeldedaten gestohlen werden"
@@ -17627,10 +17627,10 @@ msgid "Your GL accounts"
 msgstr "Ihre Sachkonten"
 
 msgid "your Implementation Lead"
-msgstr "Ihr Implementierungsleiter"
+msgstr "Ihr Umsetzungsleiter"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "Ihre Einladung ist ungültig oder wurde bereits akzeptiert. Bitte kontaktieren Sie den Support, wenn Sie glauben, dass dies ein Fehler ist."
+msgstr "Ihre Einladung ist ungültig oder wurde bereits angenommen. Bitte kontaktieren Sie den Support, wenn Sie glauben, dass dies ein Fehler ist."
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "Ihre Aufgabe hier: Überprüfen Sie ein echtes Beispiel jeder Zeile und markieren Sie es dann als validiert. Grundlagendaten werden zuerst geladen, dann Masterdatensätze, dann offene Transaktionen beim Cutover."
@@ -17639,7 +17639,7 @@ msgid "Your legal name, addresses, branding, and document defaults"
 msgstr "Ihr rechtlicher Name, Adressen, Branding und Dokumentstandards"
 
 msgid "Your main point of contact"
-msgstr "Ihr Hauptansprechpartner"
+msgstr "Ihr Hauptkontakt"
 
 msgid "Your Name"
 msgstr "Ihr Name"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "dir selbst"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Z1.4 Inspektionsstufe (I / II / III); höhere Stufen bedeuten größere Probengrößen für das gleiche Los."
+msgstr "Z1.4 Prüfniveau (I / II / III); höhere Niveaus bedeuten größere Stichprobenumfänge für die gleiche Charge."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4 Schweregrad (Normal / Verschärft / Reduziert); Schaltet sich nach Regel basierend auf der jüngsten Losannahmehistorie um."
+msgstr "Z1.4 Schweregrad (Normal / Verschärft / Reduziert); Wechsel nach Regel basierend auf dem letzten Charge-Akzeptierungs-Verlauf."
 
 msgid "Zoom Box"
 msgstr "Zoom-Feld"

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -94,7 +94,7 @@ msgid "Add & Issue"
 msgstr "Hinzufügen & Ausgeben"
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Fügen Sie einen Drucker in den Druckeinstellungen hinzu, um Etiketten direkt zu drucken."
+msgstr "Einen Drucker in den Druckeinstellungen hinzufügen, um Etiketten direkt zu drucken."
 
 msgid "Add Inventory"
 msgstr "Bestand hinzufügen"
@@ -112,7 +112,7 @@ msgid "All clear"
 msgstr "Alles klar"
 
 msgid "All rework"
-msgstr "Alle Überarbeitungen"
+msgstr "Alle Nacharbeit"
 
 msgid "All scrap"
 msgstr "Alles Ausschuss"
@@ -145,7 +145,7 @@ msgid "Assigned to Me"
 msgstr "Mir zugewiesen"
 
 msgid "Assignee"
-msgstr "Zugewiesener"
+msgstr "Bearbeiter"
 
 msgid "Authentication Error"
 msgstr "Authentifizierungsfehler"
@@ -192,7 +192,7 @@ msgid "Cancel"
 msgstr "Abbrechen"
 
 msgid "Cancelled"
-msgstr "Abgebrochen"
+msgstr "Storniert"
 
 msgid "Carbon Logo"
 msgstr "Carbon Logo"
@@ -282,7 +282,7 @@ msgstr "Verbrauchte abgelaufen"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr "Kosten für ungeplante Wartung, letzte {0} Tage"
+msgstr "Kosten der ungeplanten Instandhaltung der letzten {0} Tage"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -296,7 +296,7 @@ msgid "Create Quality Issue"
 msgstr "Qualitätsproblem erstellen"
 
 msgid "Create Rework"
-msgstr "Rework erstellen"
+msgstr "Nacharbeit erstellen"
 
 msgid "Current work"
 msgstr "Aktuelle Arbeit"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Details"
 
 msgid "Dispatch not found"
-msgstr "Einsatz nicht gefunden"
+msgstr "Instandhaltungsauftrag nicht gefunden"
 
 msgid "Display"
 msgstr "Anzeige"
@@ -353,14 +353,14 @@ msgid "Down"
 msgstr "Stillstand"
 
 msgid "Down for maintenance"
-msgstr "Wartung läuft"
+msgstr "Zur Instandhaltung außer Betrieb"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr "Wartung läuft · {0}"
+msgstr "Zur Instandhaltung außer Betrieb · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "Wegen geplanter Wartung außer Betrieb"
+msgstr "Zur geplanten Instandhaltung außer Betrieb"
 
 msgid "Download"
 msgstr "Herunterladen"
@@ -379,7 +379,7 @@ msgstr "Zeichnung und Funktionen durch Ziehen vergrößern/verkleinern"
 
 #. placeholder {0}: active.data.current?.type
 msgid "Dragging {0} cancelled."
-msgstr "Ziehen von {0} abgebrochen."
+msgstr "Ziehen von {0} storniert."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
@@ -398,7 +398,7 @@ msgid "Due today?"
 msgstr "Fällig heute?"
 
 msgid "Duplicate batch number"
-msgstr "Doppelte Chargennummer"
+msgstr "Doppelte Losnummer"
 
 msgid "Duplicate serial number"
 msgstr "Doppelte Seriennummer"
@@ -416,7 +416,7 @@ msgid "Email Address"
 msgstr "E-Mail-Adresse"
 
 msgid "Empty work centers"
-msgstr "Leere Arbeitszentren"
+msgstr "Leere Arbeitsplätze"
 
 msgid "End Operations"
 msgstr "Arbeitsgänge beenden"
@@ -482,10 +482,10 @@ msgstr "Ergebnis konnte nicht gespeichert werden"
 
 #. placeholder {0}: fileUpload.name
 msgid "Failed to upload file: {0}"
-msgstr "Datei konnte nicht hochgeladen werden: {0}"
+msgstr "Datei-Upload fehlgeschlagen: {0}"
 
 msgid "Failed to upload image"
-msgstr "Bild konnte nicht hochgeladen werden"
+msgstr "Bild-Upload fehlgeschlagen"
 
 msgid "Feature"
 msgstr "Funktion"
@@ -500,7 +500,7 @@ msgid "Files"
 msgstr "Dateien"
 
 msgid "Files related to the job and the opportunity line."
-msgstr "Dateien zum Auftrag und zur Anfragenposition."
+msgstr "Dateien bezogen auf den Fertigungsauftrag und die Verkaufschance-Position."
 
 msgid "Filter"
 msgstr "Filter"
@@ -519,7 +519,7 @@ msgid "Finish Anyways"
 msgstr "Trotzdem beenden"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Beenden Sie die Einrichtung Ihres Kontos"
 
 msgid "Finish with material unpicked?"
 msgstr "Mit nicht gepicktem Material abschließen?"
@@ -531,7 +531,7 @@ msgid "Go back to operation"
 msgstr "Zurück zur Operation"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Gehen Sie zum Onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
@@ -616,19 +616,19 @@ msgid "Job Details"
 msgstr "Auftragsdetails"
 
 msgid "Job Traveler"
-msgstr "Auftragsbegleitkarte"
+msgstr "Fertigungsauftrag-Laufkarte"
 
 msgid "Jobs"
-msgstr "Aufträge"
+msgstr "Fertigungsaufträge"
 
 msgid "Keep picking"
-msgstr "Weiterpicken"
+msgstr "Kommissionierung fortsetzen"
 
 msgid "Kit"
-msgstr "Bausatz"
+msgstr "Set"
 
 msgid "Labor"
-msgstr "Arbeit"
+msgstr "Personal"
 
 msgid "Last completed"
 msgstr "Zuletzt abgeschlossen"
@@ -691,7 +691,7 @@ msgid "Machine"
 msgstr "Maschine"
 
 msgid "Machine down for maintenance now?"
-msgstr "Maschine jetzt zur Wartung heruntergefahren?"
+msgstr "Maschine jetzt zur Instandhaltung außer Betrieb?"
 
 msgid "Maintenance"
 msgstr "Instandhaltung"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Instandhaltung abgeschlossen"
 
 msgid "Maintenance overdue"
-msgstr "Wartung überfällig"
+msgstr "Instandhaltung überfällig"
 
 msgid "Make a replacement"
 msgstr "Ersatzteil erstellen"
@@ -773,7 +773,7 @@ msgid "No"
 msgstr "Nein"
 
 msgid "No active job at this work center"
-msgstr "Kein aktiver Auftrag in diesem Arbeitszentrum"
+msgstr "Kein aktiver Fertigungsauftrag an diesem Arbeitsplatz"
 
 msgid "No active maintenance dispatches"
 msgstr "Keine aktiven Instandhaltungseinsätze"
@@ -782,7 +782,7 @@ msgid "No active operations"
 msgstr "Keine aktiven Arbeitsgänge"
 
 msgid "No active work centers at this location."
-msgstr "Keine aktiven Arbeitszentren an diesem Ort."
+msgstr "Keine aktiven Arbeitsplätze an diesem Standort."
 
 msgid "No assigned operations"
 msgstr "Keine zugewiesenen Arbeitsgänge"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Keine verfügbaren verfolgten Entitäten gefunden"
 
 msgid "No dispatches assigned to you"
-msgstr "Keine Einsätze an Sie zugewiesen"
+msgstr "Keine Instandhaltungsaufträge an Sie zugewiesen"
 
 msgid "No files"
 msgstr "Keine Dateien"
@@ -818,13 +818,13 @@ msgid "No materials"
 msgstr "Keine Materialien"
 
 msgid "No open jobs"
-msgstr "Keine offenen Aufträge"
+msgstr "Keine offenen Fertigungsaufträge"
 
 msgid "No open units to allocate"
 msgstr "Keine offenen Einheiten zum Zuordnen"
 
 msgid "No operators"
-msgstr "Keine Bediener"
+msgstr "Keine Werker"
 
 msgid "No option found."
 msgstr "Keine Option gefunden."
@@ -896,10 +896,10 @@ msgid "Nothing running"
 msgstr "Nichts läuft"
 
 msgid "Nothing scheduled at this work center"
-msgstr "Nichts geplant in diesem Arbeitszentrum"
+msgstr "Nichts an diesem Arbeitsplatz geplant"
 
 msgid "Nothing to scrap"
-msgstr "Nichts zum Verschrotten"
+msgstr "Nichts zum Ausschuss"
 
 msgid "OEE Impact"
 msgstr "OEE-Auswirkung"
@@ -921,13 +921,13 @@ msgid "Open"
 msgstr "Offen"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "Öffnen Sie eine Anzeigetafel auf dem Bildschirm am Arbeitszentrum und lassen Sie ihn laufen. Jede Tafel aktualisiert sich selbstständig."
+msgstr "Öffnen Sie eine Anzeige auf dem am Arbeitsplatz montierten Bildschirm und lassen Sie sie laufen. Jede Tafel aktualisiert sich von selbst."
 
 msgid "Open an NCR for MRB disposition"
-msgstr "NCR für MRB-Disposition öffnen"
+msgstr "Öffnen Sie einen NCR für MRB-Verwendungsentscheid"
 
 msgid "Open Jobs"
-msgstr "Offene Aufträge"
+msgstr "Offene Fertigungsaufträge"
 
 msgid "Operations"
 msgstr "Arbeitsgänge"
@@ -936,10 +936,10 @@ msgid "Operations ended"
 msgstr "Arbeitsgänge beendet"
 
 msgid "Operator"
-msgstr "Bediener"
+msgstr "Werker"
 
 msgid "Operator Performed"
-msgstr "Vom Bediener durchgeführt"
+msgstr "Von Werker durchgeführt"
 
 msgid "Optional"
 msgstr "Optional"
@@ -963,7 +963,7 @@ msgid "Partial"
 msgstr "Teilweise"
 
 msgid "Partial Disposition"
-msgstr "Teilweise Disposition"
+msgstr "Teilweise Verwendungsentscheid"
 
 msgid "Passed Inspection"
 msgstr "Prüfung bestanden"
@@ -972,7 +972,7 @@ msgid "Passkey unlock failed"
 msgstr "Passkey-Entsperrung fehlgeschlagen"
 
 msgid "Pause"
-msgstr "Pause"
+msgstr "Unterbrechen"
 
 msgid "Pick"
 msgstr "Kommissionieren"
@@ -1026,7 +1026,7 @@ msgid "Priority"
 msgstr "Priorität"
 
 msgid "Procedure"
-msgstr "Verfahren"
+msgstr "Verfahrensanweisung"
 
 msgid "Process"
 msgstr "Prozess"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "Warteschlange leer"
 
 msgid "Reason for rework"
-msgstr "Grund für Überarbeitung"
+msgstr "Grund für Nacharbeit"
 
 msgid "Recent"
 msgstr "Zuletzt"
@@ -1093,19 +1093,19 @@ msgid "Remove part"
 msgstr "Teil entfernen"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "Unterbaugruppe erneut öffnen und Ersatzeinheit erstellen"
+msgstr "Baugruppe wieder öffnen und Ersatzeinheit erstellen"
 
 msgid "Result"
 msgstr "Ergebnis"
 
 msgid "Rework"
-msgstr "Überarbeitung"
+msgstr "Nacharbeit"
 
 msgid "Rework created successfully"
-msgstr "Überarbeitung erfolgreich erstellt"
+msgstr "Nacharbeit erfolgreich erstellt"
 
 msgid "Rework quantity"
-msgstr "Rework-Menge"
+msgstr "Nacharbeitsmenge"
 
 msgid "Running"
 msgstr "Läuft"
@@ -1120,13 +1120,13 @@ msgid "Scan"
 msgstr "Scannen"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "Verfolgtes Objekt scannen, um die erste Beispielspalte hinzuzufügen."
+msgstr "Verfolgte Einheit scannen, um die erste Probe-Spalte hinzuzufügen."
 
 msgid "Scan or enter serial number"
 msgstr "Seriennummer scannen oder eingeben"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Verfolgtes Objekt mit ID, Seriennummer oder Batch scannen oder eingeben"
+msgstr "Verfolgte Einheit, Seriennummer oder Los scannen oder eingeben"
 
 msgid "Scan or enter tracking number"
 msgstr "Scannen oder Verfolgungsnummer eingeben"
@@ -1135,7 +1135,7 @@ msgid "Scan or search serial number..."
 msgstr "Seriennummer scannen oder suchen..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Scannen oder wählen Sie aus dieser Charge ein verfolgtes Objekt aus, um es als Beispielspalte hinzuzufügen, und notieren Sie dann das Ergebnis im Raster."
+msgstr "Verfolgte Einheit aus dieser Charge scannen oder auswählen, um sie als Probe-Spalte hinzuzufügen, dann ihr Ergebnis im Raster eintragen."
 
 msgid "Schedule"
 msgstr "Zeitplan"
@@ -1144,13 +1144,13 @@ msgid "Scrap"
 msgstr "Ausschuss"
 
 msgid "Scrap {readableId}"
-msgstr "{readableId} verschrotten"
+msgstr "Ausschuss {readableId}"
 
 msgid "Scrap material"
-msgstr "Material verschrotten"
+msgstr "Ausschusspaterial"
 
 msgid "Scrap quantity"
-msgstr "Verschrottungsmenge"
+msgstr "Ausschussmenge"
 
 msgid "Scrap Reason"
 msgstr "Ausschussgrund"
@@ -1171,7 +1171,7 @@ msgid "Search by job or item ID"
 msgstr "Nach Job oder Artikel-ID suchen"
 
 msgid "Search operators..."
-msgstr "Bediener suchen..."
+msgstr "Werker suchen..."
 
 msgid "Search..."
 msgstr "Suchen..."
@@ -1215,7 +1215,7 @@ msgid "Select Serial Number"
 msgstr "Seriennummer auswählen"
 
 msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
-msgstr "Wählen Sie den Vorgang aus, zu dem Sie zurückkehren möchten. Alle Vorgänge von diesem Punkt bis zum aktuellen Vorgang werden wiederholt."
+msgstr "Wählen Sie den Arbeitsgang, zu dem Sie zurückkehren möchten. Alle Arbeitsgänge von diesem Punkt bis zum aktuellen Arbeitsgang werden wiederholt."
 
 msgid "Selected"
 msgstr "Ausgewählt"
@@ -1316,7 +1316,7 @@ msgstr "Station: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "Statistische Annahme fehlgeschlagen, daher wird die gesamte Charge von {0} als nicht konform betrachtet (ISO 9001:2015 §8.7) — {passes} Stichproben bestanden und {fails} Fehler. Leiten Sie die Einheiten unten zum Verschrott oder zur Nachbearbeitung weiter, oder erfassen Sie nur das Ergebnis."
+msgstr "Statistische Annahme fehlgeschlagen, daher wird die gesamte Charge von {0} als nicht konform betrachtet (ISO 9001:2015 §8.7) — {passes} bestandene und {fails} Fehler. Leiten Sie die Einheiten unten an Ausschuss oder Nacharbeit weiter oder zeichnen Sie nur das Urteil auf."
 
 msgid "Status"
 msgstr "Status"
@@ -1346,7 +1346,7 @@ msgid "Support Required"
 msgstr "Unterstützung erforderlich"
 
 msgid "Switch Operator"
-msgstr "Bediener wechseln"
+msgstr "Werker wechseln"
 
 msgid "Tag"
 msgstr "Tag"
@@ -1373,10 +1373,10 @@ msgid "This lot is expired and can't be picked."
 msgstr "Dieses Los ist abgelaufen und kann nicht entnommen werden."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Dieses Teil wurde auf Bestellung gefertigt. Durch das Verschrotten kann seine Arbeitsfolge erneut geöffnet werden, um ein Ersatzteil zu erstellen."
+msgstr "Dieses Teil wurde auf Bestellung gefertigt. Es als Ausschuss zu kennzeichnen kann seinen Arbeitsplan wieder öffnen, um einen Ersatz herzustellen."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "Dieses Teil wird aus dem Lager verschrottet. Sein Bedarf bleibt offen, damit Sie ein Ersatzteil ausgeben können."
+msgstr "Dieses Teil wird als Ausschuss aus dem Bestand verbucht. Seine Anforderung bleibt offen, damit Sie einen Ersatz entnehmen können."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "Diese Einheit wird endgültig verschrottet und es wird eine neue Seriennummer erstellt."
@@ -1409,7 +1409,7 @@ msgid "Total: {0}"
 msgstr "Gesamt: {0}"
 
 msgid "Tracked Entity"
-msgstr "Verfolgtes Objekt"
+msgstr "Verfolgte Einheit"
 
 msgid "Tracking"
 msgstr "Verfolgung"
@@ -1446,11 +1446,11 @@ msgid "Unpick {0}"
 msgstr "Entfernen {0}"
 
 msgid "Unplanned downtime"
-msgstr "Ungeplante Ausfallzeit"
+msgstr "Ungeplante Stillstandszeit"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr "Ungeplante Wartungsposten, letzte {0} Tage"
+msgstr "Ungeplante Instandhaltungsartikel, letzte {0} Tage"
 
 msgid "Unsaved changes"
 msgstr "Nicht gespeicherte Änderungen"
@@ -1501,19 +1501,19 @@ msgid "Work Center"
 msgstr "Arbeitsplatz"
 
 msgid "Work Center Displays"
-msgstr "Arbeitszentrum-Anzeigetafeln"
+msgstr "Arbeitsplatzanzeigen"
 
 msgid "Yes"
 msgstr "Ja"
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Abmeldungszeit unten ändern oder bestätigen, dass Sie noch arbeiten."
+msgstr "Sie haben sich um <0/> angemeldet. Sie können Ihre Ausstempelzeit unten bearbeiten oder bestätigen, dass Sie noch arbeiten."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen auszustempeln?"
+msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen, sich auszustempeln?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Ihr Konto ist noch nicht Teil eines Unternehmens. Schließen Sie das Onboarding in Carbon ERP ab, um fortzufahren."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ihre Organisation erfordert eine Authentifizierungs-App. Richten Sie sie in Carbon ein und kommen Sie dann hierher zurück."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -520,7 +520,6 @@ msgstr "Trotzdem beenden"
 
 msgid "Finish setting up your account"
 msgstr "Beenden Sie die Einrichtung Ihres Kontos"
-msgstr "Richten Sie Ihr Konto ein"
 
 msgid "Finish with material unpicked?"
 msgstr "Mit nicht gepicktem Material abschließen?"
@@ -533,7 +532,6 @@ msgstr "Zurück zur Operation"
 
 msgid "Go to onboarding"
 msgstr "Gehen Sie zum Onboarding"
-msgstr "Zum Onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Wie viele wurden tatsächlich gepickt?"
@@ -1516,7 +1514,6 @@ msgstr "Sie sind seit {hoursElapsed} Stunden eingestempelt. Haben Sie vergessen,
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Ihr Konto ist noch nicht Teil eines Unternehmens. Schließen Sie das Onboarding in Carbon ERP ab, um fortzufahren."
-msgstr "Ihr Konto gehört noch zu keinem Unternehmen. Schließen Sie das Onboarding in der Carbon ERP ab, um fortzufahren."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ihre Organisation erfordert eine Authentifizierungs-App. Richten Sie sie in Carbon ein und kommen Sie dann hierher zurück."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -361,7 +361,6 @@ msgstr "Un contratista es un contacto de proveedor con habilidades particulares 
 
 msgid "A custom solution to meet your needs"
 msgstr "Una solución personalizada para satisfacer sus necesidades"
-msgstr "Una solución personalizada para satisfacer tus necesidades"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente es una empresa o persona que compra tus piezas o servicios."
@@ -478,7 +477,6 @@ msgstr "Una versión de Carbon alojada en la nube y administrada"
 
 msgid "A managed version with all the advanced features"
 msgstr "Una versión administrada con todas las características avanzadas"
-msgstr "Una versión administrada y alojada en la nube de Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Una versión administrada con todas las funciones avanzadas"
@@ -2626,7 +2624,6 @@ msgstr "Examinar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Explore la versión publicada de solo lectura. Aún puede reorganizar pasos para ordenar el diseño."
-msgstr "Explora la versión publicada en solo lectura. Aún puedes reorganizar pasos para organizar el diseño."
 
 msgid "Bucket"
 msgstr "Depósito"
@@ -3042,7 +3039,6 @@ msgstr "Revisa tu correo electrónico"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
-msgstr "Comprobando Stripe para este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Punto de control ·"
@@ -3184,7 +3180,6 @@ msgstr "Nube, o tu entorno autohospedado."
 
 msgid "CMMC compliant"
 msgstr "Cumple con CMMC"
-msgstr "Compatible con CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -6992,7 +6987,6 @@ msgstr "Formato"
 
 msgid "Forward deployed engineer"
 msgstr "Ingeniero desplegado en sitio"
-msgstr "Ingeniero desplegado en campo"
 
 msgid "Foundation"
 msgstr "Fundación"
@@ -8146,7 +8140,6 @@ msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Se detendrá hasta que publique una Versión nuevamente. Nada se elimina."
-msgstr "Dejará de ejecutarse hasta que publiques una versión nuevamente. Nada se elimina."
 
 msgid "ITAR Certifications"
 msgstr "Certificaciones ITAR"
@@ -8599,7 +8592,6 @@ msgstr "Vincular problema de Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Vincule este cliente de Carbon a uno de ellos o cree un cliente de Stripe separado."
-msgstr "Vincula este cliente de Carbon a uno de ellos, o crea un cliente de Stripe separado."
 
 msgid "Link to sales order line"
 msgstr "Vínculo a línea de pedido de venta"
@@ -11650,7 +11642,6 @@ msgstr "Publicado por Carbon"
 
 msgid "Published Version"
 msgstr "Versión publicada"
-msgstr "Versión Publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Las versiones publicadas no se pueden editar. Explora en solo lectura, o crea una nueva versión para hacer cambios."
@@ -12674,7 +12665,6 @@ msgstr "Revertir cualquier entrada del libro mayor de artículos de esta factura
 
 msgid "Reverse charge"
 msgstr "Inversión del sujeto pasivo"
-msgstr "Cobro invertido"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Impuesto a las ventas de cargo inverso"
@@ -13496,7 +13486,6 @@ msgstr "Autohospedado o gestionado"
 
 msgid "Self-onboarding"
 msgstr "Autoincorporación"
-msgstr "Alojado localmente o administrado"
 
 msgid "Self-onboarding"
 msgstr "Incorporación automática"
@@ -13922,7 +13911,6 @@ msgstr "Mostrado al usuario cuando falla esta regla."
 
 msgid "Sign in to Carbon"
 msgstr "Inicie sesión en Carbon"
-msgstr "Iniciar sesión en Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Inicie sesión con biometría en lugar de un enlace mágico. Las llaves de acceso se aseguran con Face ID, Touch ID o su PIN de dispositivo."
@@ -14351,7 +14339,6 @@ msgstr "Stripe envía la factura al cliente por correo electrónico, por lo que 
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La contabilización creará uno en su cuenta conectada."
-msgstr "Fecha de Vencimiento de Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe envía la factura por correo electrónico al cliente, por lo que se requiere una dirección. Esto también se guardará en el contacto en Carbon."
@@ -15667,7 +15654,6 @@ msgstr "Esta factura no tiene una fecha de vencimiento utilizable — elige una 
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Esta factura se facturará al cliente de Stripe ya vinculado a este cliente de Carbon. Para cambiar sus detalles, edítalo en el panel de Stripe."
-msgstr "Esta factura se cobrará al cliente de Stripe ya vinculado a este cliente de Carbon. Para cambiar sus detalles, edítalo en el panel de control de Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Este es un entorno controlado, por lo que se requiere una aplicación autenticadora."
@@ -15808,7 +15794,6 @@ msgstr "Esta versión está publicada"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Esta versión está publicada. Cree una nueva versión para editar."
-msgstr "Esta versión se ha publicado"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Esta versión se ha publicado. Crea una nueva versión para editar."
@@ -16767,7 +16752,6 @@ msgstr "Versión"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "Versión {0} está publicada ahora y será reemplazada."
-msgstr "La versión {0} se ha publicado ahora y será reemplazada."
 
 msgid "Version:"
 msgstr "Versión:"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -83,7 +83,7 @@ msgstr "{0} asientos de diario en borrador"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} trabajos creados"
+msgstr "{0} órdenes de trabajo creadas"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} valores faltantes"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} piezas omitidas — ya tienen trabajos abiertos"
+msgstr "{alreadyPlannedItemCount} piezas omitidas — ya tienen órdenes de trabajo abiertas"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% de cuentas por pagar"
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} de {count} operaciones"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} más: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} meses con totales no coincidentes"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} diarios faltantes en el proveedor"
+msgstr "{missingCount} asientos faltantes en el proveedor"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} diarios faltantes y {mismatchCount} meses no coincidentes"
+msgstr "{missingCount} asientos faltantes y {mismatchCount} meses desajustados"
 
 msgid "{name} deleted"
 msgstr "{name} eliminado"
@@ -220,7 +220,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} trabajos actualizados"
+msgstr "{updatedJobCount} órdenes de trabajo actualizadas"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "Se ha subido {uploadedFileName} — se han completado los campos a partir del documento."
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 día"
 
 msgid "1 draft journal entry"
-msgstr "1 asiento de diario en borrador"
+msgstr "1 apunte de borrador"
 
 msgid "1 job created"
 msgstr "1 trabajo creado"
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Mínimo de 5 usuarios"
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -330,7 +330,7 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Una migración de datos ejecutada por Carbon — usted carga sus propios datos"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Un aviso de cambio rastrea un cambio de ingeniería o fabricación controlado a través de revisión e implementación."
+msgstr "Un aviso de cambio rastrea un cambio de ingeniería o manufactura controlado a través de revisión e implementación."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "Una cuenta de compensación que mantiene el valor de bienes recibidos pero aún no facturados; la factura del proveedor la cancela."
@@ -345,22 +345,22 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "Un campo adicional definido por la empresa adjunto a una tabla principal (cliente, parte, orden); aparece en el formulario del registro, se guarda junto con los campos integrados y se puede consultar a través de la API."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Un eje de etiqueta definido por la empresa adjunto a líneas de diario para que se puedan dividir las mismas cuentas por ubicación, departamento o cualquier eje personalizado sin multiplicar el plan de cuentas."
+msgstr "Un eje de etiqueta definido por la empresa adjunto a líneas de asiento para que las mismas cuentas se puedan dividir por ubicación, departamento o cualquier eje personalizado sin multiplicar el plan de cuentas."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "Un Descuento o Margen de ganancia con alcance de empresa, por porcentaje o cantidad fija, que ajusta el precio de una línea hacia arriba o hacia abajo cuando la línea coincide con las condiciones de cantidad, fecha, artículo y cliente de la regla."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "La salida de un trabajo completado, recibida en inventario al costo WIP real acumulado del trabajo."
+msgstr "La salida de una orden de trabajo completada, recibida en inventario al costo de producto en proceso acumulado real de la orden."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un consumible es un artículo físico utilizado para fabricar una pieza que se puede usar en múltiples trabajos"
+msgstr "Un consumible es un artículo físico utilizado para hacer una pieza que se puede utilizar en múltiples órdenes de trabajo"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
 msgstr "Un contratista es un contacto de proveedor con habilidades particulares y horas disponibles"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Una solución personalizada para satisfacer sus necesidades"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente es una empresa o persona que compra tus piezas o servicios."
@@ -396,10 +396,10 @@ msgid "A dated record proving a gauge was checked against a traceable standard; 
 msgstr "Un registro fechado que prueba que un instrumento de medición fue verificado contra un estándar rastreable; pasa a menos que se marque una bandera de requiere-acción, -ajuste o -reparación, y reinicia la fecha de próximo vencimiento del instrumento."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Una ventana fechada en la que caen los asientos; su estado de cierre cambia de Abierto → Bloqueado → Cerrado, y un período cerrado se congela contra nuevos asientos."
+msgstr "Una ventana fechada en la que caen los asientos; su estado de cierre se mueve Abierto → Bloqueado → Cerrado, y un período cerrado está congelado contra nuevos asientos."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
-msgstr "Un método de depreciación que carga un porcentaje fijo del valor contable restante cada período, más pesado al principio, más ligero después."
+msgstr "Un método de depreciación que carga un porcentaje fijo del valor en libros restante cada período — más pesado al principio, más ligero después."
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
 msgstr "Un método de depreciación que carga una cantidad igual cada período durante la vida útil del activo."
@@ -426,13 +426,13 @@ msgid "A job is deleted"
 msgstr "Se elimina un trabajo"
 
 msgid "A job is put on hold"
-msgstr "Un trabajo se pone en espera"
+msgstr "Una orden de trabajo se pone en suspenso"
 
 msgid "A job is released"
 msgstr "Se libera un trabajo"
 
 msgid "A job operation is completed"
-msgstr "Se completa una operación de trabajo"
+msgstr "Una operación de la orden se completa"
 
 msgid "A job's assignee changes"
 msgstr "El asignado de un trabajo cambia"
@@ -467,19 +467,19 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Una lista está conectada a {0}, por lo que este paso se ejecuta una vez para cada elemento — hasta {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Un componente Hacer bajo pedido que obtiene su propio trabajo y enrutamiento dentro de la compilación del padre."
+msgstr "Un componente de Fabricación bajo pedido que obtiene su propia orden de trabajo y ruta de fabricación dentro de la construcción de su padre."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Un componente Hacer bajo pedido cuyos componentes se emiten juntos en el trabajo padre, sin compilación separada."
+msgstr "Un componente de Fabricación bajo pedido cuyas piezas se emiten juntas en la orden de trabajo principal — sin construcción separada."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Una versión de Carbon alojada en la nube y administrada"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Una versión administrada con todas las características avanzadas"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un material es un artículo físico utilizado para fabricar una pieza que se puede usar en múltiples trabajos"
+msgstr "Un material es un artículo físico utilizado para hacer una pieza que se puede utilizar en múltiples órdenes de trabajo"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
 msgstr "Un instrumento de medición (calibrador, micrómetro, calibrador de pasadores, MMC) rastreado como un registro y sujeto a un cronograma de calibración recurrente."
@@ -488,7 +488,7 @@ msgid "A name is required to save a view"
 msgstr "Se requiere un nombre para guardar una vista"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Un precio negociado fijado para un artículo específico — por cliente, tipo de cliente, o todos los clientes — que reemplaza el precio base por completo, opcionalmente con descuentos por cantidad."
+msgstr "Un precio negociado fijado para un artículo específico — por cliente, tipo de cliente o todos los clientes — que reemplaza completamente el precio base, opcionalmente con escalas de cantidades."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
 msgstr "Se creará una nueva orden de compra para cada proveedor. Alternativamente, puede elegir una orden de compra en borrador existente para el proveedor y agregar las operaciones externas a ella."
@@ -500,16 +500,16 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Se creará un nuevo tamaño utilizando una copia del tamaño actual"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Se creará un nuevo cliente de Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "Un documento sin efectivo que liquida una factura contra una cuenta de razón: un crédito reduce lo adeudado, un débito lo aumenta."
+msgstr "Un documento sin efectivo que liquida una factura contra una cuenta de razón: un haber reduce lo que se debe, un debe lo aumenta."
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
 msgstr "Una no conformidad compartida con un proveedor a través de un enlace /share/scar sin inicio de sesión, para que puedan responder al problema y actualizar sus tareas desde fuera de Carbon."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Un recargo no tributable (p. ej. gastos recuperables como tasas de permisos) que se suma a la línea y se excluye de la base imponible."
+msgstr "Un recargo no imponible (p. ej. gastos recuperables como tasas de permisos) agregado a la línea; excluido de la base imponible."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
 msgstr "Una tarea de inconformidad que corrige una causa raíz confirmada, a diferencia de una acción preventiva o de contención inmediata."
@@ -527,7 +527,7 @@ msgid "A point in one of Carbon's own flows that a workflow can watch — a job 
 msgstr "Un punto en uno de los propios flujos de Carbon que un flujo de trabajo puede observar — un trabajo liberado, una cotización aceptada, un envío publicado — a diferencia de un cambio de campo bruto; proporciona al flujo de trabajo los registros involucrados por id."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Un asiento contable registrado: un encabezado más líneas de débito y crédito equilibradas contra cuentas GL."
+msgstr "Un asiento contable contabilizado: un encabezado más líneas de debe y haber equilibradas contra cuentas contables."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
 msgstr "Una transacción de efectivo registrada — un Recibo de un cliente o un Desembolso a un proveedor — aplicada a facturas a través de liquidaciones, moviéndose de Borrador → Registrado → Anulado."
@@ -575,13 +575,13 @@ msgid "A purchase order's type changes"
 msgstr "El tipo de una orden de compra cambia"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Un problema de calidad — una desviación registrada o un defecto con un flujo de trabajo configurable de tareas de investigación y acción."
+msgstr "Un problema de calidad — una desviación registrada o defecto con un flujo de trabajo configurable de tareas de investigación y acción."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Una cantidad de unidades idénticas comparte una entidad rastreada y número de lote — una entidad, muchas unidades."
 
 msgid "A quote is a set of prices for specific parts and quantities."
-msgstr "Una cotización es un conjunto de precios para partes y cantidades específicas."
+msgstr "Una cotización es un conjunto de precios para piezas específicas y cantidades."
 
 msgid "A quote is accepted"
 msgstr "Se acepta una cotización"
@@ -596,7 +596,7 @@ msgid "A quote is sent"
 msgstr "Se envía una cotización"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Una línea de cotización contiene precios y tiempos de entrega para una parte específica"
+msgstr "Una línea de cotización contiene precios y plazos de entrega para una pieza particular"
 
 msgid "A quote's assignee changes"
 msgstr "El asignado de una cotización cambia"
@@ -641,7 +641,7 @@ msgid "A receipt's location changes"
 msgstr "La ubicación de un recibo cambia"
 
 msgid "A receipt's posting date changes"
-msgstr "La fecha de publicación de un recibo cambia"
+msgstr "La fecha de contabilización de una recepción cambia"
 
 msgid "A receipt's source document changes"
 msgstr "El documento de origen de un recibo cambia"
@@ -656,10 +656,10 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Un conjunto reutilizable y versionado de instrucciones de trabajo adjunto a un proceso, que proporciona a una operación sus pasos ordenados para registrar y verificar, además de los parámetros en los que se ejecuta."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Un paso de enrutamiento en un trabajo liberado, la copia propia del trabajo de una operación, que lleva un estado que el piso impulsa de Pendiente a Completado."
+msgstr "Un paso de ruta de fabricación en una orden de trabajo liberada, la copia propia de la orden de una operación, llevando un estado que el piso impulsa de Por hacer a Hecho."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Una factura de venta (usted factura a un cliente) o factura de compra (un proveedor lo factura a usted), liquidada mediante la aplicación de pagos y notas de crédito o débito."
+msgstr "Una factura de venta (usted factura a un cliente) o factura de compra (un proveedor le factura), liquidada por la aplicación de pagos y notas de crédito o débito."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
 msgstr "Una factura de venta es un documento que especifica los productos o servicios vendidos a un cliente y el costo correspondiente."
@@ -671,7 +671,7 @@ msgid "A sales invoice line contains invoice details for a particular item"
 msgstr "Una línea de factura de venta contiene detalles de factura para un artículo en particular"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Una orden de venta contiene información sobre el acuerdo entre la empresa y un cliente específico para piezas y servicios."
+msgstr "Un pedido de venta contiene información sobre el acuerdo entre la empresa y un cliente específico para piezas y servicios."
 
 msgid "A sales order is created"
 msgstr "Se crea un pedido de venta"
@@ -707,7 +707,7 @@ msgid "A sales order's status changes"
 msgstr "El estado de un pedido de venta cambia"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Una solicitud de presupuesto de ventas (RFQ) es una consulta de cliente para obtener precios en un conjunto de piezas y cantidades. Puede resultar en un presupuesto."
+msgstr "Una solicitud de cotización (RFQ) de ventas es una consulta del cliente sobre precios para un conjunto de piezas y cantidades. Puede resultar en una cotización."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "Un RFQ de venta (un cliente te pide que cotices) o un RFQ de compra (tu solicitas a proveedores); ambos alimentan el hilo de oportunidad."
@@ -722,10 +722,10 @@ msgid "A service is a billable activity that is bought or performed — it is ne
 msgstr "Un servicio es una actividad facturable que se compra o realiza; nunca se envía, recibe o almacena"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Un conjunto de empresas bajo un mismo propietario que comparten una configuración con alcance de grupo —el plan de cuentas, las monedas y las dimensiones— de modo que la misma configuración contable abarca todas las empresas del grupo."
+msgstr "Un conjunto de empresas bajo un propietario que comparten configuración de alcance de grupo — el plan de cuentas, divisas y dimensiones — para que la misma configuración contable abarque cada empresa en el grupo."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Un conjunto de instrucciones para extraer los materiales pendientes de un trabajo del almacén y prepararlos en el costado de la línea; una selección mueve el stock al punto de uso en lugar de consumirlo."
+msgstr "Un conjunto de instrucciones para extraer los materiales pendientes de una orden de trabajo del almacén y organizarlos en pie de línea; un picking mueve existencias al punto de uso en lugar de consumirlas."
 
 msgid "A shipment is created"
 msgstr "Se crea un envío"
@@ -749,7 +749,7 @@ msgid "A shipment's location changes"
 msgstr "La ubicación de un envío cambia"
 
 msgid "A shipment's posting date changes"
-msgstr "La fecha de publicación de un envío cambia"
+msgstr "La fecha de contabilización de un envío cambia"
 
 msgid "A shipment's shipping method changes"
 msgstr "El método de envío de un envío cambia"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "El nombre de un proveedor cambia"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "La respuesta con precio de un proveedor a un RFQ de compra — uno por proveedor; Borrador → Activo cuando presentan, o Rechazado."
+msgstr "La respuesta con precio de un proveedor a una RFQ de compra — una por proveedor; Borrador → Activo cuando envían, o Rechazado."
 
 msgid "A supplier's status changes"
 msgstr "El estado de un proveedor cambia"
@@ -794,25 +794,25 @@ msgid "A supplier's type changes"
 msgstr "El tipo de un proveedor cambia"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "Un recargo tributable (manipulación, configuración, combustible) que se suma a la línea e incluye en la base imponible."
+msgstr "Un cargo sujeto a impuestos (manipulación, preparación, combustible) agregado a la línea; se incluye en la base imponible."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Un registro cronometrado de trabajo de Configuración, Mano de Obra o Máquina registrado contra una operación de trabajo, cuya duración se acumula en el costo real de la operación."
+msgstr "Un registro temporizado de trabajo de Preparación, Mano de obra o Máquina registrado en una operación de la orden, cuya duración se suma al costo real de la operación."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Una herramienta es un artículo físico utilizado para fabricar una pieza que se puede usar en múltiples trabajos"
+msgstr "Una herramienta es un artículo físico utilizado para fabricar una pieza que puede utilizarse en múltiples órdenes de trabajo."
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "Un usuario registra la fecha de vencimiento en cada lote o número de serie cuando se reciben los bienes. Úsalo cuando los proveedores envían lotes con diferentes fechas de vencimiento."
+msgstr "Un usuario registra la fecha de caducidad en cada lote de producción o serie cuando se reciben los bienes. Usar cuando los proveedores envían lotes con diferentes fechas de caducidad."
 
 msgid "abilities"
-msgstr "capacidades"
+msgstr "habilidades"
 
 msgid "Abilities"
 msgstr "Habilidades"
 
 msgid "ability"
-msgstr "capacidad"
+msgstr "habilidad"
 
 msgid "About"
 msgstr "Acerca de"
@@ -842,7 +842,7 @@ msgid "Acceptance"
 msgstr "Aceptación"
 
 msgid "Acceptance passed"
-msgstr "Aceptación aprobada"
+msgstr "Aceptación superada"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
@@ -855,7 +855,7 @@ msgid "Account & Details"
 msgstr "Cuenta y detalles"
 
 msgid "Account balances with debits and credits"
-msgstr "Saldos de cuenta con débitos y créditos"
+msgstr "Saldos de cuenta con debe y haber"
 
 msgid "Account for advance payments made before goods or services are received"
 msgstr "Contabilice los pagos por adelantado realizados antes de recibir bienes o servicios."
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "Períodos Contables"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Contabilidad: GL, AR, AP y cierre de fin de mes"
+msgstr "Contabilidad: Libro mayor, Cuentas por cobrar, Cuentas por pagar, y cierre de mes"
 
 msgid "Accounts"
 msgstr "Cuentas"
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "Cuentas por cobrar para montos adeudados por clientes."
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Cuentas referenciadas por defectos de registro o historial de diarios que aún no tienen asignación de proveedor."
+msgstr "Cuentas referenciadas por predeterminados de contabilización o historial de asientos que aún no tienen asignación de proveedor."
 
 msgid "Accumulated Depreciation"
 msgstr "Depreciación acumulada"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Cuenta de depreciación acumulada"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Depreciación acumulada en la disposición"
+msgstr "Depreciación acumulada en Baja"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Depreciación acumulada en la disposición (predeterminada)"
+msgstr "Depreciación acumulada en Baja (predeterminada)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Período de Acumulación (Semanas)"
@@ -1011,13 +1011,13 @@ msgid "Active"
 msgstr "Activo"
 
 msgid "Active Jobs"
-msgstr "Trabajos Activos"
+msgstr "Órdenes de trabajo activas"
 
 msgid "Active Statuses"
 msgstr "Estados Activos"
 
 msgid "Active Supplier Quotes"
-msgstr "Cotizaciones de Proveedores Activas"
+msgstr "Cotizaciones del proveedor activas"
 
 msgid "Activity"
 msgstr "Actividad"
@@ -1047,19 +1047,19 @@ msgid "Add & Issue"
 msgstr "Agregar y Emitir"
 
 msgid "Add a column below to sort the view"
-msgstr "Añade una columna a continuación para ordenar la vista"
+msgstr "Agregue una columna debajo para ordenar la vista"
 
 msgid "Add a comment..."
-msgstr "Añade un comentario..."
+msgstr "Agregue un comentario..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Agregue una fila de precios personalizada para anular cantidad, precio, envío, tiempo de entrega e impuestos"
+msgstr "Agregue una fila de fijación de precios personalizada para sobrescribir cantidad, precio, envío, plazo de entrega e impuesto"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
-msgstr "Añade una sección de materiales que liste cada artículo en la lista de materiales con su cantidad."
+msgstr "Agregue una sección de materiales que enumere cada artículo en la lista de materiales con su cantidad."
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Añade una impresora en la configuración de impresión para imprimir etiquetas directamente."
+msgstr "Agregue una impresora en la configuración de impresión para imprimir etiquetas directamente."
 
 msgid "Add a requirement"
 msgstr "Agregar un requisito"
@@ -1080,10 +1080,10 @@ msgid "Add Adjustment"
 msgstr "Agregar ajuste"
 
 msgid "Add Affected Item"
-msgstr "Añadir elemento afectado"
+msgstr "Agregar artículo afectado"
 
 msgid "Add any notes about your decision..."
-msgstr "Añade cualquier nota sobre tu decisión..."
+msgstr "Agregue notas sobre su decisión..."
 
 msgid "Add Approval Requirement"
 msgstr "Agregar Requisito de Aprobación"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Agregar Nota"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Añade notas y documentación para este despacho de mantenimiento"
+msgstr "Agregue notas y documentación para esta orden de mantenimiento"
 
 msgid "Add Operation"
 msgstr "Agregar Operación"
@@ -1170,7 +1170,7 @@ msgid "Add parts"
 msgstr "Agregar piezas"
 
 msgid "Add Passkey"
-msgstr "Agregar contraseña de acceso"
+msgstr "Agregar llave de acceso"
 
 msgid "Add path"
 msgstr "Agregar ruta"
@@ -1200,7 +1200,7 @@ msgid "Add rule"
 msgstr "Agregar regla"
 
 msgid "Add Sample"
-msgstr "Añadir Muestra"
+msgstr "Agregar muestra"
 
 msgid "Add Selector"
 msgstr "Agregar selector"
@@ -1212,7 +1212,7 @@ msgid "Add Shipping"
 msgstr "Agregar Envío"
 
 msgid "Add slot"
-msgstr "Añadir espacio"
+msgstr "Agregar espacio"
 
 msgid "Add Spare Part"
 msgstr "Agregar Pieza de Repuesto"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Todas las {0} celdas cierran"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Todas las {total} fases están completadas. Buen trabajo — tu equipo está en funcionamiento."
+msgstr "Todas las {total} fases terminaron. Buen trabajo — tu equipo está en funcionamiento."
 
 msgid "All accounts"
 msgstr "Todas las cuentas"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Todas las acciones seleccionadas"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Todas las funciones avanzadas disponibles"
 
 msgid "All Audit Logs"
 msgstr "Todos los Registros de Auditoría"
@@ -1364,7 +1364,7 @@ msgid "All members of selected groups and selected individuals will be able to a
 msgstr "Todos los miembros de los grupos seleccionados e individuos seleccionados podrán aprobar solicitudes"
 
 msgid "All posting accounts are mapped"
-msgstr "Todas las cuentas de registro están asignadas"
+msgstr "Todas las cuentas de contabilización están asignadas"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas las filas importadas — {inserted} insertadas, {updated} actualizadas."
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Cantidad"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Monto que aumenta activos/gastos o disminuye pasivos/patrimonio/ingresos en esta línea."
+msgstr "Cantidad que aumenta activos/gastos o disminuye pasivos/patrimonio/ingresos por ventas en esta línea."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Monto que aumenta pasivos/patrimonio/ingresos o disminuye activos/gastos en esta línea."
+msgstr "Cantidad que aumenta pasivos/patrimonio/ingresos por ventas o disminuye activos/gastos en esta línea."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "Tipo de Cantidad"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Un área contable que agrupa gastos por departamento o función para que la GL pueda reportar gastos por grupo, no solo por cuenta."
+msgstr "Un depósito contable que agrupa gastos por departamento o función para que el libro mayor pueda reportar gastos por grupo, no solo por cuenta."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Un registro contable de un elemento capitalizado que deprecia en lugar de gastos; Borrador → Activo → Totalmente depreciado → Dispuesto."
+msgstr "Un registro contable para un artículo capitalizado que se deprecia en lugar de ser gastado; Borrador → Activo → Totalmente depreciado → Dado de baja."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Una alerta de que algo necesita la atención de una persona, distribuida desde un evento carbon/notify a la bandeja de entrada en la aplicación más correo electrónico y Slack opcionales, silenciable por tema por usuario."
@@ -1500,7 +1500,7 @@ msgid "An item's assignee changes"
 msgstr "El asignado de un elemento cambia"
 
 msgid "An item's default method type changes"
-msgstr "El tipo de método predeterminado de un elemento cambia"
+msgstr "El tipo de suministro predeterminado de un artículo cambia"
 
 msgid "An item's name changes"
 msgstr "El nombre de un elemento cambia"
@@ -1576,19 +1576,19 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "Cualquier cosa no explícitamente listada en el alcance anterior"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Cuentas por pagar"
 
 msgid "AP Aging"
-msgstr "Análisis de Antigüedad de CxP"
+msgstr "Antigüedad de Cuentas por pagar"
 
 msgid "AP Clerk"
 msgstr "Empleado de Cuentas por Pagar"
 
 msgid "AP Outstanding"
-msgstr "AP Pendiente"
+msgstr "Cuentas por pagar pendientes"
 
 msgid "AP Overdue"
-msgstr "AP Vencido"
+msgstr "Cuentas por pagar vencidas"
 
 msgid "API Docs"
 msgstr "Documentación de API"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Claves API para acceso programático a tus datos de Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks e integraciones"
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -1709,13 +1709,13 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Cuentas por cobrar"
 
 msgid "AR / AP representation"
-msgstr "Representación de AR / AP"
+msgstr "Representación de Cuentas por cobrar / Cuentas por pagar"
 
 msgid "AR Aging"
-msgstr "Análisis de Antigüedad de CxC"
+msgstr "Antigüedad de Cuentas por cobrar"
 
 msgid "AR Clerk"
 msgstr "Empleado de Cuentas por Cobrar"
@@ -1724,10 +1724,10 @@ msgid "AR Outstanding"
 msgstr "Cuentas por Cobrar Pendientes"
 
 msgid "AR Overdue"
-msgstr "AR Vencido"
+msgstr "Cuentas por cobrar Atrasadas"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Cuentas por cobrar/Cuentas por pagar"
 
 msgid "Archive"
 msgstr "Archivo"
@@ -1750,21 +1750,21 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "¿Estás seguro de que deseas activar el proceso: {name}? Volverá a aparecer en los menús desplegables."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "¿Está seguro de que desea activar este calibrador?."
+msgstr "¿Está seguro de que desea activar este instrumento de medición?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "¿Estás seguro de que deseas cancelar {0}? Se cerrará y será de solo lectura hasta que lo vuelvas a abrir."
+msgstr "¿Está seguro de que desea cancelar {0}? Será cerrado y de solo lectura hasta que lo reabra."
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
-msgstr "¿Estás seguro de que deseas cancelar {0}? Esto también cancelará todas las cotizaciones de proveedores relacionadas."
+msgstr "¿Está seguro de que desea cancelar {0}? Esto también cancelará todas las cotizaciones del proveedor relacionadas."
 
 msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "¿Estás seguro de que deseas cancelar {orderLabel}? Esto cerrará la orden."
 
 msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
-msgstr "¿Estás seguro de que deseas cancelar este trabajo? Ya no estará disponible en el piso de producción."
+msgstr "¿Está seguro de que desea cancelar esta orden de trabajo? Ya no estará disponible en la planta."
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
 msgstr "¿Estás seguro de que deseas cambiar la propiedad {propertyName}? Como utilizas IDs de material generados, esto cambiará el ID de la pieza de esta pieza y todas las revisiones relacionadas."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "¿Estás seguro de que deseas completar esta transferencia de inventario?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "¿Está seguro de que desea confirmar este pedido de venta? Confirmar el pedido afectará las cantidades de pedido utilizadas para calcular la oferta y la demanda."
+msgstr "¿Está seguro de que desea confirmar este pedido de venta? Confirmar el pedido afectará las cantidades en pedido utilizadas para calcular el suministro y la demanda."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "¿Estás seguro de que deseas convertir la RFQ a una cotización?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "¿Estás seguro de que deseas crear trabajos para esta orden de venta? Esto creará trabajos para todas las líneas que aún no tengan trabajos."
+msgstr "¿Está seguro de que desea crear órdenes de trabajo para este pedido de venta? Esto creará órdenes de trabajo para todas las líneas que no tengan ya órdenes de trabajo."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "¿Estás seguro de que deseas desactivar estos usuarios?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "¿Está seguro de que desea desactivar este calibrador?."
+msgstr "¿Está seguro de que desea desactivar este instrumento de medición?."
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "¿Estás seguro de que deseas desactivar este usuario?"
@@ -1899,7 +1899,7 @@ msgstr "¿Estás seguro de que deseas eliminar el modo de fallo: {name}? Esto no
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar el tipo de calibre: {0}? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea eliminar el tipo de instrumento: {0}? Esto no se puede deshacer."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1949,7 +1949,7 @@ msgstr "¿Estás seguro de que deseas eliminar el grado de material: {0}? Esto n
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "¿Está seguro de que desea eliminar la sustancia material: {0}? Esta acción no se puede deshacer."
+msgstr "¿Está seguro de que desea eliminar el material base: {0}? Esto no se puede deshacer."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1964,7 +1964,7 @@ msgstr "¿Estás seguro de que deseas eliminar el socio: {name}? Esto no se pued
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar el término de pago: {0}? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea eliminar las condiciones de pago: {0}? Esto no se puede deshacer."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1991,7 +1991,7 @@ msgstr "¿Estás seguro de que deseas eliminar la línea de pedido de venta para
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar la razón de rechazo: {0}? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea eliminar el motivo de desperdicio: {0}? Esto no se puede deshacer."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
 msgstr "¿Está seguro de que desea eliminar la secuencia de número de serie de {itemLabel}? Esto no se puede deshacer."
@@ -2034,7 +2034,7 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "¿Está seguro de que desea eliminar este aviso de cambio?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "¿Estás seguro de que deseas eliminar este calibrador?"
+msgstr "¿Está seguro de que desea eliminar este instrumento de medición?"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "¿Está seguro de que desea eliminar este plan de inspección?"
@@ -2052,10 +2052,10 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "¿Estás seguro de que deseas eliminar esta tarjeta kanban? Esto no se puede deshacer."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar este despacho de mantenimiento? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea eliminar esta orden de mantenimiento? Esto no se puede deshacer."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
-msgstr "¿Está seguro de que desea eliminar esta contraseña de acceso? Ya no podrá usarla para iniciar sesión."
+msgstr "¿Está seguro de que desea eliminar esta llave de acceso? Ya no podrá usarla para iniciar sesión."
 
 msgid "Are you sure you want to delete this quality document?"
 msgstr "¿Estás seguro de que deseas eliminar este documento de calidad?"
@@ -2112,17 +2112,17 @@ msgid "Are you sure you want to reject this quote?"
 msgstr "¿Estás seguro de que deseas rechazar esta cotización?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "¿Está seguro de que desea liberar este trabajo? Estará disponible para el piso de producción e impulsará las compras y la producción."
+msgstr "¿Está seguro de que desea liberar esta orden de trabajo? Estará disponible para la planta e impulsará las compras y la producción."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar {0} como proveedor para este artículo? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea quitar {0} como proveedor para este artículo? Esto no se puede deshacer."
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar {supplierName} como proveedor de este artículo? Esto no se puede deshacer."
+msgstr "¿Está seguro de que desea quitar {supplierName} como proveedor para este artículo? Esto no se puede deshacer."
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "¿Estás seguro de que deseas eliminar este artículo de la lista de precios? Esta acción no se puede deshacer."
+msgstr "¿Está seguro de que desea quitar este artículo de la lista de precios? Esto no se puede deshacer."
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "¿Estás seguro de que deseas revocar la invitación para este usuario?"
@@ -2221,10 +2221,10 @@ msgid "Asset Classes"
 msgstr "Clases de Activos"
 
 msgid "Asset Cost on Disposal"
-msgstr "Costo de activos en la disposición"
+msgstr "Costo del activo en baja"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Costo de activos en la disposición (predeterminado)"
+msgstr "Costo del activo en baja (predeterminado)"
 
 msgid "Asset ID"
 msgstr "ID de Activo"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Asignaciones"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Asigna esta unidad de almacenamiento a un centro de trabajo (lineside)"
+msgstr "Asigna esta unidad de almacenamiento a un centro de trabajo (pie de línea)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Asigna esta unidad a un centro de trabajo para material en el costado de la línea, para que los operadores la vean en la vista de producción; heredado de la unidad principal cuando se establece allí."
+msgstr "Asigna esta unidad a un centro de trabajo para material de pie de línea, de modo que los operarios la vean en la vista de producción; se hereda de la unidad padre cuando se establece allí."
 
 msgid "At each gate"
 msgstr "En cada puerta"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Atributo"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Estándar de muestreo de atributos utilizado para calcular tamaños de lote de muestra y números de aceptación/rechazo en inspecciones de entrada."
+msgstr "Estándar de muestreo por atributos utilizado para calcular tamaños de muestra de lotes y números de aceptación/rechazo en inspecciones de recepción."
 
 msgid "Attributes"
 msgstr "Atributos"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Registro de Auditoría"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registro de auditoría"
 
 msgid "Audit Logging"
 msgstr "Registro de Auditoría"
@@ -2353,7 +2353,7 @@ msgid "Auto-generated QR Code"
 msgstr "Código QR generado automáticamente"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Formatos de numeración automática para pedidos, trabajos, piezas y más"
+msgstr "Formatos de numeración automática para pedidos, órdenes de trabajo, piezas y más"
 
 msgid "Auto-suggest purchases from demand and reorder points"
 msgstr "Sugerir automáticamente compras según la demanda y puntos de reorden"
@@ -2371,13 +2371,13 @@ msgid "Automatic Cost Updates"
 msgstr "Actualizaciones automáticas de costos"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Actualizaciones Automáticas de Tiempo de Entrega"
+msgstr "Actualizaciones automáticas del plazo de entrega"
 
 msgid "Automatic Updates"
 msgstr "Actualizaciones Automáticas"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Actualizaciones y copias de seguridad automáticas"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático prorrateado de materiales no rastreados de un trabajo cuando se reporta la salida — los materiales rastreados se emiten manualmente."
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "Volver a trazabilidad"
 
 msgid "Backflush"
-msgstr "Retroceso"
+msgstr "Consumo retroactivo"
 
 msgid "Backups"
 msgstr "Copias de seguridad"
@@ -2456,7 +2456,7 @@ msgid "Bank — Local Currency (default)"
 msgstr "Banco — Moneda local (predeterminada)"
 
 msgid "Bank / Cash Account"
-msgstr "Cuenta Bancaria / Caja"
+msgstr "Banco / Cuenta de efectivo"
 
 msgid "Bank account denominated in a foreign currency"
 msgstr "Cuenta bancaria denominada en una moneda extranjera."
@@ -2465,10 +2465,10 @@ msgid "Bank account denominated in the local currency"
 msgstr "Cuenta bancaria denominada en la moneda local."
 
 msgid "Bank and financial service charge expenses"
-msgstr "Gastos de cargos de servicios financieros."
+msgstr "Gastos de bancos y cargos de servicio financiero"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Las barras muestran el flujo semanal de cada semana: &lt;0&gt;oferta&lt;/0&gt; empuja el inventario hacia arriba, &lt;1&gt;demanda&lt;/1&gt; lo baja. La &lt;2&gt;línea&lt;/2&gt; es tu inventario disponible proyectado — cuando cae por debajo &lt;3&gt;del stock de seguridad&lt;/3&gt; corres riesgo, y por debajo de cero es un &lt;4&gt;falta de existencias&lt;/4&gt;."
+msgstr "Las barras muestran el flujo de cada semana: <0>suministro</0> empuja el inventario hacia arriba, <1>demanda</1> lo tira hacia abajo. La <2>línea</2> es tu inventario disponible proyectado — cuando desciende por debajo de <3>stock de seguridad</3> estás en riesgo, y por debajo de cero es una <4>rotura de stock</4>."
 
 msgid "Base Currency"
 msgstr "Moneda Base"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Precio Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funcionalidad básica de ERP, MES y QMS"
 
 msgid "Basic Information"
 msgstr "Información Básica"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "Lote / Serie"
 
 msgid "Batch items require a sales order"
-msgstr "Los artículos por lote requieren una orden de venta"
+msgstr "Los artículos de lote de producción requieren un pedido de venta"
 
 msgid "Batch number"
 msgstr "Número de lote"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "Beta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Mayores causas de desechos por razón, artículo o centro de trabajo"
+msgstr "Las principales causas de desperdicio por motivo, artículo o centro de trabajo"
 
 msgid "Bill of Material"
 msgstr "Lista de Materiales"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "Lista de Materiales"
 
 msgid "Bill of Process"
-msgstr "Orden de Fabricación"
+msgstr "Lista de operaciones"
 
 msgid "Bill To"
 msgstr "Facturar a"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Bloquear con un error"
 
 msgid "Block, allow override"
-msgstr "Bloquear, permitir anulación"
+msgstr "Bloquear, permitir sobrescritura"
 
 msgid "Blocked"
 msgstr "Bloqueado"
@@ -2581,7 +2581,7 @@ msgid "BOM synced successfully"
 msgstr "BOM sincronizado exitosamente"
 
 msgid "BOMs"
-msgstr "Listas de materiales"
+msgstr "BOMs"
 
 msgid "Bonus Depreciation %"
 msgstr "Depreciación de bonificación %"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Migas de pan"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Importa tus piezas, BOMs, Bill of Process y costos — con las herramientas de importación de Carbon, CSV o ayuda de LLM."
+msgstr "Traiga sus piezas, BOMs, lista de operaciones y costeo — con herramientas de importación de Carbon, CSV o ayuda de LLM."
 
 msgid "Browse library"
 msgstr "Examinar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Explore la versión publicada de solo lectura. Aún puede reorganizar pasos para ordenar el diseño."
 
 msgid "Bucket"
 msgstr "Depósito"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Crear integraciones y personalizaciones"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Crear presupuestos extrayendo datos en vivo de piezas, costos y Lista de Procesos"
+msgstr "Cree cotizaciones extrayendo datos de piezas, costos y lista de operaciones en tiempo real"
 
 msgid "Build role-based training materials"
 msgstr "Crear materiales de capacitación basados en roles"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Importación masiva"
 
 msgid "Bulk Jobs"
-msgstr "Trabajos en Lote"
+msgstr "Órdenes de trabajo en lote"
 
 msgid "Business moment"
 msgstr "Momento empresarial"
@@ -2746,7 +2746,7 @@ msgid "Can't delete this period"
 msgstr "No se puede eliminar este período"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "No se puede desactivar el único intervalo activo. Agregue otro intervalo o active/desactive el estado Activo de la anulación en su lugar."
+msgstr "No puede desactivar el único descanso activo. Agregue otro descanso o cambie el estado Activo de la sobrescritura."
 
 msgid "Can't download this file"
 msgstr "No se puede descargar este archivo"
@@ -2770,7 +2770,7 @@ msgid "Cancel Purchase Order"
 msgstr "Cancelar orden de compra"
 
 msgid "Cancel Sales Order"
-msgstr "Cancelar Orden de Venta"
+msgstr "Cancelar pedido de venta"
 
 msgid "Cancel SO"
 msgstr "Cancelar SO"
@@ -2821,13 +2821,13 @@ msgid "Cannot send RFQ"
 msgstr "No se puede enviar RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "No se puede enviar a través de Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
-msgstr "No se puede cargar — la interacción con el proveedor aún no se ha creado"
+msgstr "No se puede subir — interacción con proveedor aún no creada"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "No se puede cargar en el depósito de piezas sin ID de artículo"
+msgstr "No se puede subir a depósito de piezas sin ID de artículo"
 
 msgid "Caption"
 msgstr "Leyenda"
@@ -2891,16 +2891,16 @@ msgid "Carbon's name for a bill of material and bill of process (routing): the c
 msgstr "El nombre de Carbon para una lista de materiales y lista de procesos (enrutamiento): los componentes más las operaciones que fabrican una pieza."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "La ejecución de planificación de Carbon netea la oferta contra la demanda y explota métodos, revelando escasez — pero no crea órdenes en sí."
+msgstr "La ejecución de planificación de Carbon compensa el suministro contra la demanda y desglosa métodos, surgiendo déficit — pero no crea órdenes por sí sola."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Orden de producción de Carbon — un trabajo construye una cantidad de un artículo a partir de su método y enrutamiento copiados."
+msgstr "Orden de producción de Carbon — una orden de trabajo construye una cantidad de un artículo a partir de su propio método y ruta de fabricación copiados."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "La aplicación de taller de Carbon donde los operadores ejecutan operaciones, informan cantidades, emiten materiales y registran tiempo contra trabajos liberados en tiempo real."
+msgstr "Aplicación de planta de Carbon donde los operarios ejecutan operaciones, reportan cantidades, emiten material y registran tiempo contra órdenes de trabajo liberadas en tiempo real."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "El único registro de Carbon para cualquier cosa con un número de parte — Pieza, Material, Herramienta, Servicio, Consumible o Accesorio — al que apuntan los trabajos, métodos, pedidos e inventario."
+msgstr "Registro único de Carbon para cualquier cosa con un número de pieza — Pieza, Material, Herramienta, Servicio, Consumible o Dispositivo de sujeción — al que apuntan órdenes de trabajo, métodos, pedidos e inventario."
 
 msgid "Cards"
 msgstr "Tarjetas"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Revise el libro mayor de artículos para buscar artículos con cantidad negativa en existencia al final del período — generalmente se debe a un recibo faltante o un envío fuera de orden que distorsiona el valor del inventario y el costo de bienes vendidos. Marque como hecho una vez revisado o omita con una razón."
+msgstr "Verifique el libro mayor de artículos para cualquier artículo con cantidad negativa en existencias a fin de período — generalmente una recepción faltante o una contabilización fuera de orden que distorsiona el valor del inventario y el costo de ventas. Márquelo como completado una vez revisado, o omítalo con un motivo."
 
 msgid "Check your email"
 msgstr "Revisa tu correo electrónico"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Verificando Stripe para este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Punto de control ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Elegir otro archivo"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Elige qué aparece en la hoja de ruta impresa."
+msgstr "Elija qué aparece en la hoja viajera de la orden de trabajo impresa."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Elige tu idioma preferido para la interfaz."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Clase (heredada)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Clasifica una operación de enrutamiento: Las operaciones de Proceso, Montaje e Inspección se ejecutan en su propio piso de taller en el MES — El Montaje obtiene la vista de montaje guiado e Inspección una verificación de calidad — mientras que una operación de Procesamiento Externo se subcontrata a un proveedor y crea una orden de compra; el proceso lleva el mismo tipo y lo establece como predeterminado en nuevas operaciones."
+msgstr "Clasifica una operación de ruta de fabricación: las operaciones de Proceso, Ensamblaje e Inspección se ejecutan en su propia planta en el MES — Ensamblaje obtiene la vista de ensamblaje guiado e Inspección una verificación de calidad — mientras que una operación de Subcontratación se subcontrata a un proveedor y crea una orden de compra; el proceso lleva el mismo tipo y lo establece como predeterminado en nuevas operaciones."
 
 msgid "Clean and approve the migrated data"
 msgstr "Limpiar y aprobar los datos migrados"
@@ -3089,19 +3089,19 @@ msgid "Clear search"
 msgstr "Limpiar búsqueda"
 
 msgid "Clear search query"
-msgstr "Borrar consulta de búsqueda"
+msgstr "Limpiar consulta de búsqueda"
 
 msgid "Clear selection"
 msgstr "Limpiar selección"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Liquida esta factura con los créditos registrados de la parte así como con efectivo. Los créditos se aplican directamente — no se requiere registro."
+msgstr "Liquide esta factura con los créditos contabilizados de la parte así como efectivo. Los créditos se aplican directamente — no se requiere contabilización."
 
 msgid "Clear value"
 msgstr "Limpiar valor"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Cuenta de compensación entre recepción de bienes e factura del proveedor; se compensa cuando ambos se han registrado."
+msgstr "Cuenta de compensación entre recepción de bienes y factura del proveedor; se equilibra cuando ambas han sido contabilizadas."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Cuenta de compensación para recepción de bienes / coincidencia de recepción de factura"
@@ -3116,13 +3116,13 @@ msgid "Click to rename"
 msgstr "Haz clic para renombrar"
 
 msgid "Click to upload a PDF drawing"
-msgstr "Haz clic para cargar un dibujo en PDF"
+msgstr "Haga clic para subir un dibujo PDF"
 
 msgid "Clock In"
-msgstr "Entrada"
+msgstr "Fichar entrada"
 
 msgid "Clock Out"
-msgstr "Salida"
+msgstr "Fichar salida"
 
 msgid "Clocked in since <0/>"
 msgstr "Fichado desde <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Nube, o tu entorno autohospedado."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Cumple con CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "Confirmar un recibo, envío o factura: las cantidades se mueven, los asientos del diario alcanzan el mayor, y el estado se vuelve Publicado."
 
 msgid "Community support"
-msgstr ""
+msgstr "Soporte comunitario"
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3266,7 +3266,7 @@ msgid "Compare Quotes"
 msgstr "Comparar Cotizaciones"
 
 msgid "Compare Supplier Quotes"
-msgstr "Comparar Cotizaciones de Proveedores"
+msgstr "Comparar cotizaciones del proveedor"
 
 msgid "Complete"
 msgstr "Completar"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Configurar cuentas predeterminadas para transacciones de proveedor y suministrador"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Configurar cuentas predeterminadas de patrimonio y ganancias retenidas"
+msgstr "Configure cuentas predeterminadas de patrimonio y resultados acumulados"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configura los valores predeterminados para el panel de calidad."
@@ -3357,25 +3357,25 @@ msgid "Configure Item"
 msgstr "Configurar Artículo"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Configura notificaciones para cuando los calibres se descalibren."
+msgstr "Configure notificaciones para cuando los instrumentos de medición se salgan de calibración."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Configura notificaciones para cuando se completen los trabajos."
+msgstr "Configure notificaciones para cuando las órdenes de trabajo se hayan completado."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Configura notificaciones para cuando se crean despachos de mantenimiento desde el piso de producción. Las notificaciones se enrutan según el tipo de modo de falla."
+msgstr "Configure notificaciones para cuando se creen órdenes de mantenimiento desde la planta. Las notificaciones se enrutan según el tipo de modo de falla."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Configura notificaciones para cuando se envíen nuevas sugerencias."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Configurar sitios, centros de trabajo, Estructura de Procesos, BOMs, costos, roles"
+msgstr "Configure sitios, centros de trabajo, lista de operaciones, BOMs, costeo, roles"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Configura las cuentas predeterminadas utilizadas para varios tipos de transacciones en todo tu sistema"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "Configura los meses de inicio para tus años fiscales y tributarios"
+msgstr "Configure los meses de inicio de sus años fiscales e impositivos"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "Configura cuándo se deben actualizar los costos de artículos comprados a partir de transacciones de proveedores."
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Existencias entrantes confirmadas — órdenes de compra y producción (barras por encima de cero)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Existencias salientes confirmadas — órdenes de venta y materiales de trabajo (barras por debajo de cero)."
+msgstr "Existencias de salida confirmadas — pedidos de venta y materiales de la orden (barras por debajo de cero)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Confirma que cada asiento de diario contabilizado en el período tiene débitos y créditos iguales. Si algún asiento está desbalanceado, el balance de prueba no cuadrará, por lo que debe corregirse antes de que el período pueda cerrarse."
+msgstr "Confirma que cada apunte contabilizado en el período tiene igual debe y haber. Si algún apunte está desequilibrado, el balance de comprobación no cuadrará, por lo que debe ser corregido antes de que el período pueda cerrarse."
 
 msgid "Conflict reason"
 msgstr "Razón del conflicto"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Contáctenos"
 
 msgid "contacts"
 msgstr "contactos"
@@ -3568,7 +3568,7 @@ msgid "Control design changes with revisions / ECOs"
 msgstr "Controlar cambios de diseño con revisiones / ECOs"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "Controla cómo los operarios recogen material y registran el tiempo en el taller."
+msgstr "Controle cómo los operarios recogen material y rastrean tiempo en la planta."
 
 msgid "Controller, Accountant"
 msgstr "Controlador, Contador"
@@ -3577,7 +3577,7 @@ msgid "Controls how planning handles a discontinued item: Consume First exhausts
 msgstr "Controla cómo la planificación maneja un artículo descontinuado: Consumir Primero agota el inventario disponible antes de cambiar al sucesor, Preferir Nuevo redirige la nueva demanda al sucesor inmediatamente, Solo Stock mantiene solo una reserva de servicio mínima, y Sin Stock elimina el artículo de la planificación por completo."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Controla si la lista de materiales y lista de procesos de una revisión liberada (Producción) pueden ser editadas fuera de una orden de cambio."
+msgstr "Controla si la lista de materiales y lista de operaciones de una revisión (Producción) liberada pueden ser editadas fuera de una orden de cambio."
 
 msgid "Convention"
 msgstr "Convención"
@@ -3598,16 +3598,16 @@ msgid "Convert"
 msgstr "Convertir"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "Convertir una cotización a una orden de venta sin re-ingreso de datos"
+msgstr "Convertir una cotización a un pedido de venta sin re-entrada de datos"
 
 msgid "Convert Line to Job"
 msgstr "Convertir Línea a Trabajo"
 
 msgid "Convert Lines to Jobs"
-msgstr "Convertir Líneas a Trabajos"
+msgstr "Convertir líneas a órdenes de trabajo"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Convierte sugerencias de MRP en órdenes de compra y trabajos."
+msgstr "Convertir sugerencias de MRP en órdenes de compra y órdenes de trabajo."
 
 msgid "Convert to Quote"
 msgstr "Convertir a Cotización"
@@ -3616,7 +3616,7 @@ msgid "Converting…"
 msgstr "Convirtiendo…"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "Convierte la unidad de compra de un proveedor a su unidad de inventario en una línea de pedido, recepción o factura — compre en cajas de 12, reserve en individuos."
+msgstr "Convierte la unidad de compra del proveedor a tu unidad de inventario en una OC, recepción o línea de factura — comprar en cajas de 12, existencias en unidades."
 
 msgid "Copied link to clipboard"
 msgstr "Enlace copiado al portapapeles"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "Copiar"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Copiar todos los artículos y precios a otro cliente o tipo."
+msgstr "Copiar todos los artículos y fijación de precios a otro cliente o tipo."
 
 msgid "Copy API Key"
 msgstr "Copiar clave API"
@@ -3637,10 +3637,10 @@ msgid "Copy consumable number"
 msgstr "Copiar número de consumible"
 
 msgid "Copy dispatch ID"
-msgstr "Copiar ID de despacho"
+msgstr "Copiar ID de orden de mantenimiento"
 
 msgid "Copy dispatch number"
-msgstr "Copiar número de despacho"
+msgstr "Copiar número de orden de mantenimiento"
 
 msgid "Copy document name"
 msgstr "Copiar nombre del documento"
@@ -3670,7 +3670,7 @@ msgid "Copy link to consumable"
 msgstr "Copiar enlace al consumible"
 
 msgid "Copy link to dispatch"
-msgstr "Copiar enlace a la orden de trabajo"
+msgstr "Copiar enlace a orden de mantenimiento"
 
 msgid "Copy link to document"
 msgstr "Copiar enlace al documento"
@@ -3718,10 +3718,10 @@ msgid "Copy PIN"
 msgstr "Copiar PIN"
 
 msgid "Copy pricing to a single customer"
-msgstr "Copiar precios a un cliente individual"
+msgstr "Copiar fijación de precios a un solo cliente"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Copiar precios a todos los clientes de un tipo"
+msgstr "Copiar fijación de precios a todos los clientes de un tipo"
 
 msgid "Copy Procedure"
 msgstr "Copiar Procedimiento"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "Copiar identificador único del servicio"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Copiar el precio de este artículo a otro ámbito."
+msgstr "Copiar la fijación de precios de este artículo a otro alcance."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "Copia este enlace para compartir la cotización con un cliente"
@@ -3763,7 +3763,7 @@ msgid "Copy tool unique identifier"
 msgstr "Copiar identificador único de la herramienta"
 
 msgid "Copy training name"
-msgstr "Copiar nombre del entrenamiento"
+msgstr "Copiar nombre de capacitación"
 
 msgid "Copy training unique identifier"
 msgstr "Copiar identificador único de capacitación"
@@ -3820,13 +3820,13 @@ msgid "Cost History"
 msgstr "Historial de Costos"
 
 msgid "Cost of Goods Sold"
-msgstr "Costo de Bienes Vendidos"
+msgstr "Costo de ventas"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Costo de bienes vendidos (COGS)"
+msgstr "Costo de ventas (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Costo de Bienes Vendidos (predeterminado)"
+msgstr "Costo de ventas (predeterminado)"
 
 msgid "Cost of Sales"
 msgstr "Costo de Ventas"
@@ -3835,7 +3835,7 @@ msgid "Costing"
 msgstr "Cálculo de costos"
 
 msgid "Costing & Posting"
-msgstr "Costeo y Registro"
+msgstr "Costeo y contabilización"
 
 msgid "Costing method"
 msgstr "Método de cálculo de costos"
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Crea una nueva tarjeta kanban para reabastecimiento basado en escaneo."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Crear un nuevo despacho de mantenimiento para rastrear reparaciones de equipos y actividades de mantenimiento"
+msgstr "Crear una nueva orden de mantenimiento para hacer seguimiento de reparaciones de equipos y actividades de mantenimiento"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Crear un nuevo trabajo de producción para cumplir con el pedido de venta"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Crear un nuevo cliente de Stripe en su lugar"
 
 msgid "Create a new version"
 msgstr "Crear una nueva versión"
@@ -3948,7 +3948,7 @@ msgid "Create a quote with a new quote ID"
 msgstr "Crear una cotización con un nuevo ID de cotización"
 
 msgid "Create a sales order"
-msgstr "Crear una orden de venta"
+msgstr "Crear un pedido de venta"
 
 msgid "Create Account"
 msgstr "Crear Cuenta"
@@ -3975,7 +3975,7 @@ msgid "Create Issue"
 msgstr "Crear Problema"
 
 msgid "Create Jobs"
-msgstr "Crear Trabajos"
+msgstr "Crear órdenes de trabajo"
 
 msgid "Create Kanban"
 msgstr "Crear Kanban"
@@ -4050,7 +4050,7 @@ msgid "Created cost center"
 msgstr "Centro de costos creado"
 
 msgid "Created customer portal"
-msgstr "Portal de cliente creado"
+msgstr "Se creó el portal del cliente"
 
 msgid "Created customer status"
 msgstr "Estado de cliente creado"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Modo de fallo creado"
 
 msgid "Created gauge type"
-msgstr "Tipo de calibrador creado"
+msgstr "Se creó el tipo de instrumento"
 
 msgid "Created item group"
 msgstr "Grupo de artículos creado"
@@ -4087,7 +4087,7 @@ msgid "Created material dimension"
 msgstr "Dimensión de material creada"
 
 msgid "Created material finish"
-msgstr "Material finish creado"
+msgstr "Se creó el acabado"
 
 msgid "Created material form"
 msgstr "Formulario de material creado"
@@ -4096,7 +4096,7 @@ msgid "Created material grade"
 msgstr "Grado de material creado"
 
 msgid "Created material substance"
-msgstr "Sustancia material creada"
+msgstr "Se creó el material base"
 
 msgid "Created material type"
 msgstr "Tipo de material creado"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Parte creada"
 
 msgid "Created payment term"
-msgstr "Término de pago creado"
+msgstr "Se crearon las condiciones de pago"
 
 msgid "Created process"
 msgstr "Proceso creado"
@@ -4120,7 +4120,7 @@ msgid "Created required action"
 msgstr "Acción requerida creada"
 
 msgid "Created scrap reason"
-msgstr "Razón de rechazo creada"
+msgstr "Se creó el motivo de desperdicio"
 
 msgid "Created service"
 msgstr "Servicio creado"
@@ -4151,7 +4151,7 @@ msgid "Created work center"
 msgstr "Centro de trabajo creado"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "Crea los 12 períodos mensuales para un año fiscal. Se conservan los períodos que ya existen."
+msgstr "Crea los 12 períodos mensuales de un ejercicio fiscal. Se conservan los períodos que ya existen."
 
 msgid "Creating part..."
 msgstr "Creando parte..."
@@ -4164,22 +4164,22 @@ msgid "Credit ({0})"
 msgstr "Crédito ({0})"
 
 msgid "Credit / debit memo"
-msgstr "Nota de crédito / débito"
+msgstr "Nota de crédito / Nota de débito"
 
 msgid "Credit / Debit Memos"
-msgstr "Memorandos de Crédito / Débito"
+msgstr "Notas de crédito / Notas de débito"
 
 msgid "Credit Account"
 msgstr "Cuenta de Crédito"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Cuenta de Crédito cuando se absorbe el tiempo de trabajo/máquina en WIP"
+msgstr "Cuenta de haber cuando la mano de obra/tiempo de máquina se absorbe en producto en proceso"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Cuenta de crédito cuando el gasto indirecto se absorbe en WIP"
+msgstr "Cuenta de haber cuando los costos indirectos se absorben en producto en proceso"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Cuentas de crédito utilizadas cuando los costos de fabricación se absorben en WIP"
+msgstr "Cuentas de haber utilizadas cuando los costos de manufactura se absorben en producto en proceso"
 
 msgid "Credit Memo"
 msgstr "Nota de Crédito"
@@ -4188,7 +4188,7 @@ msgid "Credits"
 msgstr "Créditos"
 
 msgid "Credits & Debits"
-msgstr "Créditos y Débitos"
+msgstr "Haberes y débitos"
 
 msgid "Credits applied"
 msgstr "Créditos aplicados"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "Parte del Cliente"
 
 msgid "Customer Part ID"
-msgstr "ID de Parte del Cliente"
+msgstr "Referencia del cliente"
 
 msgid "Customer Part Number"
 msgstr "Número de Parte del Cliente"
@@ -4335,7 +4335,7 @@ msgid "Customer Part Revision"
 msgstr "Revisión de Parte del Cliente"
 
 msgid "Customer Parts"
-msgstr "Partes del Cliente"
+msgstr "Piezas del cliente"
 
 msgid "Customer Payment Discounts"
 msgstr "Descuentos de Pago de Clientes"
@@ -4353,10 +4353,10 @@ msgid "Customer Portal"
 msgstr "Portal del Cliente"
 
 msgid "Customer Portals"
-msgstr "Portales de Cliente"
+msgstr "Portales del cliente"
 
 msgid "Customer pricing"
-msgstr "Precios de cliente"
+msgstr "Fijación de precios del cliente"
 
 msgid "Customer reference"
 msgstr "Referencia del cliente"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Tipos de Cliente"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Cancelación de Cliente (Deuda Incobrable)"
+msgstr "Cancelación contable de cliente (deuda incobrable)"
 
 msgid "customers"
 msgstr "clientes"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clientes"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizaciones, capacitación e integraciones"
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "Soporte de transición"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "Recuento cíclico y ajuste con registro de auditoría"
+msgstr "Conteo cíclico y ajuste con pista de auditoría"
 
 msgid "Daily"
 msgstr "Diariamente"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Días Vencidos"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Días desde ordenar una pieza hasta tenerla disponible; la planificación compensa la demanda hacia atrás por esta cantidad."
+msgstr "Días desde ordenar una pieza hasta tenerla disponible; el desfase de planificación retrasa la demanda por esta cantidad."
 
 msgid "Days Off"
 msgstr "Días libres"
@@ -4571,26 +4571,26 @@ msgid "Deadline Type"
 msgstr "Tipo de Plazo"
 
 msgid "Debit"
-msgstr "Débito"
+msgstr "Debe"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
-msgstr "Débito ({0})"
+msgstr "Debe ({0})"
 
 msgid "Debit Account"
-msgstr "Cuenta Deudora"
+msgstr "Cuenta de debe"
 
 msgid "Debit Memo"
-msgstr "Nota de Débito"
+msgstr "Nota de débito"
 
 msgid "Debits"
 msgstr "Débitos"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "Decide qué ve un operador si intenta emitir un lote o número de serie que ya ha expirado."
+msgstr "Decide qué ve el operario si intenta hacer una salida de material de un lote o número de serie que ya está vencido."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Decidir qué sucede cuando un operador presiona Finalizar en el piso de producción con material aún sin recoger."
+msgstr "Decide qué ocurre cuando un operario presiona Finalizar en la planta con material aún no recolectado."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
 msgstr "Decide cuándo el material enviado a un centro de trabajo pero no consumido fluye de vuelta al almacén."
@@ -4599,13 +4599,13 @@ msgid "Decimal Places"
 msgstr "Lugares Decimales"
 
 msgid "Declining balance"
-msgstr "Balance decreciente"
+msgstr "Saldo decreciente"
 
 msgid "Default"
 msgstr "Predeterminado"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Cuenta predeterminada para registrar ingresos por ventas de facturas"
+msgstr "Cuenta predeterminada para contabilizar ingresos por ventas de facturas"
 
 msgid "Default Accounts"
 msgstr "Cuentas Predeterminadas"
@@ -4626,7 +4626,7 @@ msgid "Default accounts for tax-related transactions"
 msgstr "Cuentas predeterminadas para transacciones relacionadas con impuestos"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Cuentas predeterminadas para el costo de bienes vendidos y compras indirectas"
+msgstr "Cuentas predeterminadas para el costo de ventas y compras indirectas"
 
 msgid "Default Approver"
 msgstr "Aprobador Predeterminado"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "Destinatarios CC predeterminados"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "Cuenta contable predeterminada acreditada cuando la disposición de un activo fijo genera una ganancia."
+msgstr "Cuenta contable predeterminada acreditada cuando una baja de activo fijo resulta en ganancia."
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "Cuenta contable predeterminada debitada cuando la disposición de un activo fijo genera una pérdida."
+msgstr "Cuenta contable predeterminada debitada cuando una baja de activo fijo resulta en pérdida."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
 msgstr "Cuenta GL predeterminada utilizada para transacciones en efectivo cuando no se selecciona una cuenta bancaria específica."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Cuenta GL de gastos predeterminada para mantenimiento de equipos e instalaciones."
+msgstr "Cuenta de gasto contable predeterminada para mantenimiento de equipo e instalaciones."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Cuenta GL de gastos predeterminada para corridas de depreciación periódica."
+msgstr "Cuenta de gasto contable predeterminada para ejecuciones de depreciación periódicas."
 
 msgid "Default Method"
 msgstr "Método Predeterminado"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Método predeterminado que se completa previamente en nuevos activos en esta clase (aún editable por activo)."
 
 msgid "Default method type"
-msgstr "Tipo de método por defecto"
+msgstr "Tipo de suministro predeterminado"
 
 msgid "Default Method Type"
-msgstr "Tipo de Método Predeterminado"
+msgstr "Tipo de suministro predeterminado"
 
 msgid "Default Permissions"
 msgstr "Permisos Predeterminados"
@@ -4680,7 +4680,7 @@ msgid "Default Priority"
 msgstr "Prioridad Predeterminada"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "Cuenta GL de ingresos predeterminada acreditada cuando se contabiliza una factura de venta."
+msgstr "Cuenta contable de ingresos predeterminada acreditada cuando una factura de venta se contabiliza."
 
 msgid "Default Sampling"
 msgstr "Muestreo Predeterminado"
@@ -4695,7 +4695,7 @@ msgid "Default Storage Unit"
 msgstr "Unidad de Almacenamiento Predeterminada"
 
 msgid "Default tax depreciation method for new assets in this class."
-msgstr "Método de depreciación fiscal predeterminado para nuevos activos en esta clase."
+msgstr "Método de depreciación fiscal predeterminado para activos nuevos en esta clase."
 
 msgid "Default tax-book life for new assets in this class."
 msgstr "Vida fiscal predeterminada para nuevos activos en esta clase."
@@ -4710,22 +4710,22 @@ msgid "Defaults"
 msgstr "Valores predeterminados"
 
 msgid "Deferred Tax Expense"
-msgstr "Gasto Fiscal Diferido"
+msgstr "Gasto por impuesto diferido"
 
 msgid "Deferred Tax Expense (default)"
-msgstr "Gasto Fiscal Diferido (predeterminado)"
+msgstr "Gasto por impuesto diferido (predeterminado)"
 
 msgid "Deferred Tax Liability"
-msgstr "Pasivo Fiscal Diferido"
+msgstr "Pasivo por impuesto diferido"
 
 msgid "Deferred Tax Liability (default)"
-msgstr "Pasivo Fiscal Diferido (predeterminado)"
+msgstr "Pasivo por impuesto diferido (predeterminado)"
 
 msgid "Define a manufacturing operation first."
-msgstr "Defina primero una operación de fabricación."
+msgstr "Primero define una operación de manufactura."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Definir BOMs multinivel y Bill of Process (métodos de fabricación)"
+msgstr "Define BOM multinivel y lista de operaciones (métodos de fabricación)"
 
 msgid "Delete"
 msgstr "Eliminar"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "Eliminar Dimensión"
 
 msgid "Delete Dispatch"
-msgstr "Eliminar Despacho"
+msgstr "Eliminar orden de mantenimiento"
 
 msgid "Delete Document"
 msgstr "Eliminar Documento"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Eliminar grupo de artículos"
 
 msgid "Delete Journal Entry"
-msgstr "Eliminar Asiento de Diario"
+msgstr "Eliminar apunte"
 
 msgid "Delete line"
 msgstr "Eliminar línea"
@@ -4873,16 +4873,16 @@ msgid "Delete Partner"
 msgstr "Eliminar Socio"
 
 msgid "Delete passkey"
-msgstr "Eliminar contraseña de acceso"
+msgstr "Eliminar llave de acceso"
 
 msgid "Delete Passkey"
-msgstr "Eliminar Contraseña de Acceso"
+msgstr "Eliminar llave de acceso"
 
 msgid "Delete Payment"
 msgstr "Eliminar Pago"
 
 msgid "Delete Payment Term"
-msgstr "Eliminar Término de Pago"
+msgstr "Eliminar condiciones de pago"
 
 msgid "Delete Period"
 msgstr "Eliminar Período"
@@ -4894,7 +4894,7 @@ msgid "Delete Portal"
 msgstr "Eliminar Portal"
 
 msgid "Delete Price Break"
-msgstr "Eliminar Desglose de Precio"
+msgstr "Eliminar escala de precios"
 
 msgid "Delete Pricing Rule"
 msgstr "Eliminar Regla de Precios"
@@ -4948,7 +4948,7 @@ msgid "Delete Sales Invoice"
 msgstr "Eliminar Factura de Venta"
 
 msgid "Delete Sales Order"
-msgstr "Eliminar Orden de Venta"
+msgstr "Eliminar pedido de venta"
 
 msgid "Delete Schedule"
 msgstr "Eliminar Programa"
@@ -4996,14 +4996,14 @@ msgid "Delete Supplier"
 msgstr "Eliminar Proveedor"
 
 msgid "Delete Supplier Quote"
-msgstr "Eliminar Cotización de Proveedor"
+msgstr "Eliminar cotización del proveedor"
 
 msgid "Delete Supplier Type"
 msgstr "Eliminar Tipo de Proveedor"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "¿Eliminar el descuento por cantidad {0}? Esto no se puede deshacer."
+msgstr "¿Eliminar la escala de precios para cantidad {0}? No se puede deshacer."
 
 msgid "Delete Timecard"
 msgstr "Eliminar Tarjeta de Tiempo"
@@ -5060,7 +5060,7 @@ msgid "Demand Forecast — Driven by"
 msgstr "Pronóstico de Demanda — Impulsado por"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Pronóstico de demanda = demanda desglosada por BOM de pedidos de venta abiertos, trabajos activos y proyecciones de producción."
+msgstr "Pronóstico de demanda = Demanda desglosada por BOM de pedidos de venta abiertos, órdenes de trabajo activas, y proyecciones de producción."
 
 msgid "Demand projection"
 msgstr "Proyección de demanda"
@@ -5126,7 +5126,7 @@ msgid "Depreciation Start Date"
 msgstr "Fecha de Inicio de Depreciación"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Derive la vida útil de este artículo de la vida útil más corta de sus componentes, ignorando el campo Días anterior."
+msgstr "Deriva la vida de anaquel del artículo de la vida de anaquel más corta de sus componentes, ignorando el campo Días arriba."
 
 msgid "Description"
 msgstr "Descripción"
@@ -5180,7 +5180,7 @@ msgid "Dimension slots"
 msgstr "Espacios de dimensión"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Valores de dimensión en diarios publicados que aún no tienen mapeo de proveedor."
+msgstr "Valores de dimensión en asientos contabilizados que aún no tienen mapeo de proveedor."
 
 msgid "dimensions"
 msgstr "dimensiones"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Descartar"
 
 msgid "Dispatch"
-msgstr "Despacho"
+msgstr "Orden de mantenimiento"
 
 msgid "Dispatch ID"
-msgstr "ID de Despacho"
+msgstr "ID de orden de mantenimiento"
 
 msgid "Dispatch priority"
-msgstr "Prioridad de despacho"
+msgstr "Prioridad de Orden de mantenimiento"
 
 msgid "Dispatches"
-msgstr "Despachos"
+msgstr "Órdenes de mantenimiento"
 
 msgid "Display Settings"
 msgstr "Configuración de pantalla"
 
 msgid "Disposal"
-msgstr "Disposición"
+msgstr "Baja"
 
 msgid "Disposal Date"
-msgstr "Fecha de Disposición"
+msgstr "Fecha de baja"
 
 msgid "Dispose"
 msgstr "Desechar"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Documentos"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documentos envía facturas, facturas de gasto y pagos como documentos nativos del proveedor; sus diarios se registran como cubiertos por el documento. También extrae pagos registrados en el proveedor a Carbon, cerrando la factura o factura de gasto correspondiente y registrando un diario GL de Carbon. Desactivado los registra como deliberadamente excluidos."
+msgstr "Documentos envía facturas, facturas de compra y pagos como documentos nativos del proveedor; sus asientos se registran como cubiertos por el documento. También extrae pagos registrados en el proveedor de vuelta a Carbon, cerrando la factura o factura de compra coincidente y registrando un asiento de Libro mayor de Carbon. Desactivado los registra como deliberadamente excluidos."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Los documentos que abras aparecerán aquí para un acceso rápido."
@@ -5325,10 +5325,10 @@ msgid "done"
 msgstr "hecho"
 
 msgid "Done"
-msgstr "Listo"
+msgstr "Hecho"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Completado cuando el día a día funciona sin nosotros en la sala"
+msgstr "Hecho cuando las operaciones diarias se ejecutan sin nosotros en la sala"
 
 msgid "Download"
 msgstr "Descargar"
@@ -5389,7 +5389,7 @@ msgid "Drawing"
 msgstr "Extrayendo"
 
 msgid "Drawing Number"
-msgstr "Número de Dibujo"
+msgstr "Número de plano"
 
 msgid "Drawing replaced. Balloon placements were removed; feature rows are unchanged."
 msgstr "Dibujo reemplazado. Las ubicaciones de globos se eliminaron; las filas de características no cambiaron."
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Fecha de vencimiento del último trabajo"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Fecha de vencimiento del trabajo más antiguo en el lote; los trabajos posteriores se espacian uniformemente entre esta fecha y la fecha de vencimiento del último trabajo."
+msgstr "Fecha de vencimiento de la orden de trabajo más temprana en el lote de producción; órdenes de trabajo posteriores se espacian uniformemente entre esta fecha y Fecha de vencimiento de la Última Orden de Trabajo."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Fecha de vencimiento del trabajo final en el lote; combinada con la fecha de vencimiento del primer trabajo para espaciar los trabajos de manera uniforme."
+msgstr "Fecha de vencimiento de la orden de trabajo final en el lote de producción; combinada con Fecha de vencimiento de la Primera Orden de Trabajo para espaciar las órdenes de trabajo uniformemente."
 
 msgid "Due Days"
 msgstr "Días de Vencimiento"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "p. ej. Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "El material no utilizado de cada operación se devuelve tan pronto como la operación finaliza."
+msgstr "El material no utilizado de cada operación se devuelve tan pronto como la operación está lista."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "Cada unidad física obtiene su propia entidad rastreada y número único — una entidad, una unidad."
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "Editar Dimensión"
 
 msgid "Edit Dispatch"
-msgstr "Editar Despacho"
+msgstr "Editar Orden de mantenimiento"
 
 msgid "Edit Employee"
 msgstr "Editar Empleado"
@@ -5627,10 +5627,10 @@ msgid "Edit Employee Type"
 msgstr "Editar Tipo de Empleado"
 
 msgid "Edit expiration date"
-msgstr "Editar fecha de vencimiento"
+msgstr "Editar fecha de caducidad"
 
 msgid "Edit Expiry"
-msgstr "Editar Vencimiento"
+msgstr "Editar Caducidad"
 
 msgid "Edit Failure Mode"
 msgstr "Editar Modo de Falla"
@@ -5639,10 +5639,10 @@ msgid "Edit Fixed Asset"
 msgstr "Editar Activo Fijo"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Editar Registro de Calibración de Calibrador"
+msgstr "Editar Registro de calibración de instrumento de medición"
 
 msgid "Edit Gauge Type"
-msgstr "Editar Tipo de Calibrador"
+msgstr "Editar Tipo de instrumento"
 
 msgid "Edit Group"
 msgstr "Editar Grupo"
@@ -5657,7 +5657,7 @@ msgid "Edit Item Group"
 msgstr "Editar Grupo de Artículos"
 
 msgid "Edit Journal Entry"
-msgstr "Editar Asiento de Diario"
+msgstr "Editar Apunte"
 
 msgid "Edit Kanban"
 msgstr "Editar Kanban"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Editar Ubicación"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Editar Despacho de Mantenimiento"
+msgstr "Editar Orden de mantenimiento"
 
 msgid "Edit Material"
 msgstr "Editar Material"
@@ -5687,7 +5687,7 @@ msgid "Edit Material Shape"
 msgstr "Editar Forma de Material"
 
 msgid "Edit Material Substance"
-msgstr "Editar Sustancia Material"
+msgstr "Editar Material base"
 
 msgid "Edit Material Type"
 msgstr "Editar Tipo de Material"
@@ -5705,19 +5705,19 @@ msgid "Edit Partner"
 msgstr "Editar Socio"
 
 msgid "Edit Passkey"
-msgstr "Editar Contraseña de Acceso"
+msgstr "Editar Llave de acceso"
 
 msgid "Edit Payment"
 msgstr "Editar Pago"
 
 msgid "Edit Payment Term"
-msgstr "Editar Término de Pago"
+msgstr "Editar Condiciones de pago"
 
 msgid "Edit permissions"
-msgstr "Permisos de edición"
+msgstr "Editar permisos"
 
 msgid "Edit Permissions"
-msgstr "Permisos de edición"
+msgstr "Editar Permisos"
 
 msgid "Edit Picking List"
 msgstr "Editar Lista de Picking"
@@ -5726,10 +5726,10 @@ msgid "Edit Portal"
 msgstr "Editar Portal"
 
 msgid "Edit Price Override"
-msgstr "Editar Anulación de Precio"
+msgstr "Editar Sobrescritura de Precio"
 
 msgid "Edit Pricing"
-msgstr "Editar Precios"
+msgstr "Editar Fijación de precios"
 
 msgid "Edit Pricing Rule"
 msgstr "Editar Regla de Precios"
@@ -5825,7 +5825,7 @@ msgid "Edit Supplier Type"
 msgstr "Editar Tipo de Proveedor"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "Editar la regla para eliminar la marca \"Aplica a todos\""
+msgstr "Editar la regla para quitar la indicación \"Se aplica a todos\""
 
 msgid "Edit Timecard"
 msgstr "Editar Tarjeta de Tiempo"
@@ -5972,7 +5972,7 @@ msgid "End Date"
 msgstr "Fecha de Fin"
 
 msgid "End of Last Fiscal Year"
-msgstr "Fin del Último Año Fiscal"
+msgstr "Fin del Último Ejercicio fiscal"
 
 msgid "End of Last Month"
 msgstr "Fin del mes anterior"
@@ -5991,7 +5991,7 @@ msgid "Ending ({0})"
 msgstr "Final ({0})"
 
 msgid "Enforce — edits are blocked"
-msgstr "Aplicar — las ediciones están bloqueadas"
+msgstr "Aplicar — ediciones bloqueadas"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
 msgstr "Aplicar validación y directrices por artículo en recibos, envíos, transferencias y ajustes."
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "Inscribir"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "Ingrese un número de lote antes de establecer la fecha de vencimiento"
+msgstr "Ingrese un número de lote antes de establecer la fecha de caducidad"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "Ingrese una cantidad entre 1 y {0}."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Ingresar y aprobar facturas de proveedores contra una OC (coincidencia de tres vías)"
+msgstr "Ingrese y apruebe facturas de proveedores contra una Orden de compra (conciliación de tres vías)"
 
 msgid "Enter number…"
 msgstr "Ingrese número…"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Error al obtener datos del proveedor"
 
 msgid "Error loading assigned dispatches"
-msgstr "Error al cargar los despachos asignados"
+msgstr "Error al cargar órdenes de mantenimiento asignadas"
 
 msgid "Error loading assigned documents"
 msgstr "Error al cargar documentos asignados"
@@ -6148,7 +6148,7 @@ msgid "Error removing model from sales invoice line"
 msgstr "Error al eliminar el modelo de la línea de factura de venta"
 
 msgid "Error removing model from sales order line"
-msgstr "Error al eliminar el modelo de la línea de orden de venta"
+msgstr "Error al eliminar modelo de línea de pedido de venta"
 
 msgid "Escalate to the project leads"
 msgstr "Escalar a los líderes del proyecto"
@@ -6169,7 +6169,7 @@ msgid "Estimated Scrap Quantity"
 msgstr "Cantidad de Desperdicio Estimada"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Cantidad estimada de desecho aplicada a cada trabajo en el lote."
+msgstr "Cantidad de desperdicio estimada aplicada a cada orden de trabajo en el lote de producción."
 
 msgid "Estimated time"
 msgstr "Tiempo estimado"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Cada coincidencia"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Todas las tareas requeridas deben estar Completadas u Omitidas antes de que se pueda cerrar el período."
+msgstr "Cada tarea requerida debe estar Hecha u Omitida antes de que el período pueda cerrarse."
 
 msgid "Every row was imported successfully."
 msgstr "Cada fila se importó correctamente."
@@ -6214,7 +6214,7 @@ msgid "Everything else covers people, imports, integrations and the API — anyt
 msgstr "Todo lo demás cubre personas, importaciones, integraciones y la API — cualquier cosa que no sea uno de tus flujos de trabajo."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "Excede {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB en total — elimina algunos archivos adjuntos para enviar."
+msgstr "Excede {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB en total — elimine algunos archivos adjuntos para enviar."
 
 msgid "Exchange rate"
 msgstr "Tipo de cambio"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeos existentes. Elige una opción de proveedor diferente para remapear."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente de Stripe existente"
 
 msgid "Expand"
 msgstr "Expandir"
@@ -6281,7 +6281,7 @@ msgid "Expand subtree"
 msgstr "Expandir subárbol"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Demanda futura esperada para una parte de fabricación ingresada semana a semana antes de que exista cualquier orden de venta; la planificación la compensa contra el suministro y explota el método para ordenar componentes con anticipación."
+msgstr "Demanda futura esperada para una pieza de fabricación ingresada semana tras semana antes de que exista cualquier pedido de venta; la planificación la neta contra el suministro y explota el método para ordenar componentes anticipadamente."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
 msgstr "Demanda futura esperada para un artículo, agrupada por período, rellenada por la ejecución de la planificación junto con la demanda real."
@@ -6308,13 +6308,13 @@ msgid "Expense account for non-inventory purchases (services, supplies)"
 msgstr "Cuenta de gastos para compras que no son de inventario (servicios, suministros)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Cuenta de gasto GL debitada cuando el inventario se envía/emite contra una venta."
+msgstr "Cuenta de gasto para el costo de artículos vendidos"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Lado de gastos de los movimientos de impuestos diferidos (emparejado con pasivo de impuesto diferido)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Error al crear la clase de activo: {0}"
+msgstr "Lado de gasto de movimientos de impuesto diferido (emparejado con pasivo de impuesto diferido)."
 
 msgid "Expenses"
 msgstr "Gastos"
@@ -6323,24 +6323,24 @@ msgid "Expert guidance"
 msgstr "Orientación experta"
 
 msgid "Expiration date"
-msgstr "Fecha de vencimiento"
+msgstr "Fecha de caducidad"
 
 msgid "Expiration Date"
-msgstr "Fecha de Vencimiento"
+msgstr "Fecha de caducidad"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Fecha de vencimiento (se aplica a todos los números de serie en esta línea)"
+msgstr "Fecha de caducidad (se aplica a todos los números de serie en esta línea)"
 
 msgid "Expired"
-msgstr "Expirado"
+msgstr "Vencido"
 
 #. placeholder {0}: formatDate(date)
 #. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
-msgstr "Expirado {0}"
+msgstr "Vencido {0}"
 
 msgid "Expired batch"
-msgstr "Lote expirado"
+msgstr "Lote de producción vencido"
 
 msgid "Expired Batches"
 msgstr "Lotes Vencidos"
@@ -6362,7 +6362,7 @@ msgid "Expiring first"
 msgstr "Expirando primero"
 
 msgid "Expiry"
-msgstr "Vencimiento"
+msgstr "Caducidad"
 
 msgid "Expiry begins when the selected process completes."
 msgstr "La caducidad comienza cuando el proceso seleccionado se completa."
@@ -6371,7 +6371,7 @@ msgid "Expiry begins when the selected process starts."
 msgstr "La caducidad comienza cuando se inicia el proceso seleccionado."
 
 msgid "Expiry trace"
-msgstr "Rastreo de vencimiento"
+msgstr "Trazabilidad de caducidad"
 
 msgid "Export"
 msgstr "Exportar"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Información adicional enviada con la solicitud, como una clave de autorización; los valores de encabezado se ocultan en el historial de ejecución, aunque los nombres permanecen legibles."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Etiquetas adicionales para segmentar tu informe de GL"
+msgstr "Etiquetas adicionales para segmentar tu informe del Libro mayor"
 
 msgid "Fail"
-msgstr "Fallar"
+msgstr "No conforme"
 
 msgid "Failed"
 msgstr "Fallido"
@@ -6432,7 +6432,7 @@ msgstr "Características fallidas"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (primero que vence, primero que sale)"
+msgstr "No se pudo crear Clase de activo: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Error al crear el modo de fallo: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Error al crear tipo de calibre: {0}"
+msgstr "No se pudo crear Tipo de instrumento: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6500,7 +6500,7 @@ msgstr "Error al crear grado de material: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Error al crear sustancia material: {0}"
+msgstr "No se pudo crear Material base: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6520,7 +6520,7 @@ msgstr "Error al crear la pieza: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Error al crear el término de pago: {0}"
+msgstr "No se pudo crear Condiciones de pago: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6586,7 +6586,7 @@ msgid "Failed to insert quote line"
 msgstr "Error al insertar línea de cotización"
 
 msgid "Failed to insert supplier quote line"
-msgstr "Error al insertar línea de cotización de proveedor"
+msgstr "No se pudo insertar la línea de cotización del proveedor"
 
 msgid "Failed to load configuration parameters"
 msgstr "Error al cargar los parámetros de configuración"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Error al cargar datos"
 
 msgid "Failed to load inbound inspections"
-msgstr "Error al cargar inspecciones de entrada"
+msgstr "No se pudo cargar inspecciones de recepción"
 
 msgid "Failed to load item data"
 msgstr "Error al cargar los datos del artículo"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "Error al cargar los detalles del artículo"
 
 msgid "Failed to load job operations"
-msgstr "Error al cargar las operaciones de trabajo"
+msgstr "No se pudo cargar operaciones de la orden"
 
 msgid "Failed to load jobs"
-msgstr "Error al cargar los trabajos"
+msgstr "No se pudo cargar órdenes de trabajo"
 
 msgid "Failed to load purchase order lines"
 msgstr "Error al cargar las líneas de orden de compra"
@@ -6628,7 +6628,7 @@ msgid "Failed to load sales order lines"
 msgstr "Error al cargar las líneas de pedido de venta"
 
 msgid "Failed to load sales orders"
-msgstr "Error al cargar órdenes de venta"
+msgstr "No se pudo cargar pedidos de venta"
 
 msgid "Failed to load shipment lines"
 msgstr "Error al cargar las líneas de envío"
@@ -6650,19 +6650,19 @@ msgid "Failed to regenerate thumbnail"
 msgstr "Error al regenerar miniatura"
 
 msgid "Failed to register passkey"
-msgstr "Error al registrar la contraseña de acceso"
+msgstr "No se pudo registrar llave de acceso"
 
 msgid "Failed to remove image: {errorMessage}"
-msgstr "Error al eliminar la imagen: {errorMessage}"
+msgstr "No se pudo quitar la imagen: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "Error al eliminar la miniatura del modelo"
+msgstr "No se pudo quitar miniatura del modelo"
 
 msgid "Failed to remove purchase order"
-msgstr "Error al eliminar la orden de compra"
+msgstr "No se pudo quitar orden de compra"
 
 msgid "Failed to remove thumbnail"
-msgstr "Error al eliminar la miniatura"
+msgstr "No se pudo quitar miniatura"
 
 msgid "Failed to resize image"
 msgstr "Error al redimensionar la imagen"
@@ -6723,39 +6723,39 @@ msgstr "Error al actualizar la ruta de la miniatura"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
-msgstr "Error al cargar {0}"
+msgstr "No se pudo subir {0}"
 
 msgid "Failed to upload certificate"
-msgstr "Error al cargar el certificado"
+msgstr "No se pudo subir certificado"
 
 msgid "Failed to upload CSV file."
-msgstr "Error al cargar el archivo CSV."
+msgstr "No se pudo subir archivo CSV."
 
 msgid "Failed to upload file"
-msgstr "Error al cargar el archivo"
+msgstr "No se pudo subir archivo"
 
 msgid "Failed to upload file to new location"
-msgstr "Error al cargar el archivo en la nueva ubicación"
+msgstr "No se pudo subir archivo a nueva ubicación"
 
 #. placeholder {0}: file.name
 #. placeholder {0}: fileUpload.name
 msgid "Failed to upload file: {0}"
-msgstr "Error al cargar el archivo: {0}"
+msgstr "No se pudo subir archivo: {0}"
 
 msgid "Failed to upload image"
-msgstr "Error al cargar la imagen"
+msgstr "No se pudo subir imagen"
 
 msgid "Failed to upload logo: {errorMessage}"
-msgstr "Error al cargar el logo: {errorMessage}"
+msgstr "No se pudo subir logotipo: {errorMessage}"
 
 msgid "Failed to upload model"
-msgstr "Error al cargar el modelo"
+msgstr "No se pudo subir modelo"
 
 msgid "Failed to upload PDF"
-msgstr "No se pudo cargar el PDF"
+msgstr "No se pudo subir PDF"
 
 msgid "Failed to upload thumbnail"
-msgstr "Error al cargar la miniatura"
+msgstr "No se pudo subir miniatura"
 
 msgid "Failure"
 msgstr "Fallo"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Tarifas"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Acabado"
+msgstr "FEFO (primero en expirar, primero en salir)"
 
 msgid "Fetch"
 msgstr "Obtener"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Finalizar un mes fiscal a través del ciclo de vida Abierto → Bloqueado → Cerrado; un período cerrado se congela y sus saldos se capturan, reversibles solo mediante reapertura explícita."
+msgstr "Finalizando un mes fiscal a través del ciclo de vida Abierto → Bloqueado → Cerrado; un período cerrado está congelado y sus saldos se capturan en una fotografía, reversibles solo mediante reapertura explícita."
 
 msgid "Financial Statements"
 msgstr "Estados Financieros"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "¿Finalizar sin recoger el material?"
 
 msgid "Finished goods"
-msgstr "Acabados"
+msgstr "Producto terminado"
 
 msgid "Finished Goods"
 msgstr "Productos Terminados"
@@ -6904,19 +6904,19 @@ msgid "First-year additional deduction taken before the regular MACRS schedule b
 msgstr "Activo Fijo"
 
 msgid "Fiscal year"
-msgstr "Año fiscal"
+msgstr "Ejercicio fiscal"
 
 msgid "Fiscal Year"
-msgstr "Año Fiscal"
+msgstr "Ejercicio fiscal"
 
 msgid "Fiscal Year Settings"
-msgstr "Configuración del Año Fiscal"
+msgstr "Configuración del Ejercicio fiscal"
 
 msgid "Fiscal Year to Date"
-msgstr "Año Fiscal hasta la Fecha"
+msgstr "Año fiscal hasta la fecha"
 
 msgid "Fiscal Years"
-msgstr "Años Fiscales"
+msgstr "Ejercicios fiscales"
 
 msgid "Fit view"
 msgstr "Ajustar vista"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Fijo"
 
 msgid "Fixed asset"
-msgstr "Varianza de amortización de costo fijo cuando el tamaño del lote difiere del estándar"
+msgstr "Activo fijo"
 
 msgid "Fixed Asset"
 msgstr "Activo Fijo"
@@ -6937,7 +6937,7 @@ msgid "Fixed Assets"
 msgstr "Activos Fijos"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Ganancias y Pérdidas"
+msgstr "Desviación de amortización de costos fijos cuando el tamaño del lote difiere del estándar"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "Se fija una vez que los períodos contables se han registrado o cerrado. Elimine todos los períodos abiertos para cambiarlo."
@@ -6946,13 +6946,13 @@ msgid "Fixed Reorder"
 msgstr "Reorden Fijo"
 
 msgid "Fixed Shelf Life"
-msgstr "Vida Útil Fija"
+msgstr "Vida de anaquel fija"
 
 msgid "Fixture"
-msgstr "Accesorio"
+msgstr "Dispositivo de sujeción"
 
 msgid "Fixture ID"
-msgstr "ID de Accesorio"
+msgstr "ID de dispositivo de sujeción"
 
 msgid "Flags"
 msgstr "Banderas"
@@ -6962,16 +6962,16 @@ msgstr "para cualquier cosa. Ellos traerán a la persona indicada."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Método de pronóstico: <0>{0}</0>. Esta fila no se derivó de trabajos activos, por lo que no hay fuentes principales disponibles."
+msgstr "Método de pronóstico: <0>{0}</0>. Esta fila no se derivó de órdenes de trabajo activas, por lo que no hay fuentes principales disponibles."
 
 msgid "Forgot to Clock Out?"
-msgstr "¿Olvidaste marcar la salida?"
+msgstr "¿Olvidó fichar salida?"
 
 msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingeniero desplegado en sitio"
 
 msgid "Foundation"
 msgstr "Fundación"
@@ -7021,13 +7021,13 @@ msgid "From Storage Unit"
 msgstr "Desde Unidad de Almacenamiento"
 
 msgid "Fulfillment Location"
-msgstr "Ubicación de Cumplimiento"
+msgstr "Ubicación de despacho"
 
 msgid "Full name"
 msgstr "Nombre completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configuración completa y migraciones"
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -7039,52 +7039,52 @@ msgid "FX G/L"
 msgstr "FX G/L"
 
 msgid "Gain on Disposal"
-msgstr "Ganancia en la Disposición"
+msgstr "Ganancia por baja"
 
 msgid "Gain on Disposal (default)"
-msgstr "Ganancia en la Disposición (predeterminada)"
+msgstr "Ganancia por baja (predeterminado)"
 
 msgid "Gain on Disposal Account"
-msgstr "Cuenta de Ganancia en la Disposición"
+msgstr "Cuenta contable de ganancia por baja"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "Ganancias reconocidas en la disposición de activos fijos"
+msgstr "Ganancias reconocidas en la baja de activos fijos"
 
 msgid "gauge"
-msgstr "Calibres"
+msgstr "instrumento de medición"
 
 msgid "Gauge"
-msgstr "Calibrador"
+msgstr "Instrumento de medición"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Notificaciones de Calibración de Calibres"
+msgstr "Notificaciones de calibración de instrumentos de medición"
 
 msgid "Gauge ID"
-msgstr "ID de Calibrador"
+msgstr "ID de instrumento de medición"
 
 msgid "Gauge not found"
-msgstr "Calibrador no encontrado"
+msgstr "Instrumento de medición no encontrado"
 
 msgid "Gauge Type"
-msgstr "Tipo de Calibrador"
+msgstr "Tipo de instrumento"
 
 msgid "Gauge Types"
-msgstr "Tipos de Calibre"
+msgstr "Tipos de instrumento"
 
 msgid "gauges"
-msgstr "Genealogía"
+msgstr "instrumentos de medición"
 
 msgid "Gauges"
-msgstr "Medidores"
+msgstr "Instrumentos de medición"
 
 msgid "Genealogy"
-msgstr "Libro Mayor"
+msgstr "Genealogía"
 
 msgid "General"
 msgstr "General"
 
 msgid "General ledger"
-msgstr "Cuenta GL que captura diferencias de costos en operaciones de procesamiento externo."
+msgstr "Libro mayor"
 
 msgid "General Ledger"
 msgstr "Libro Mayor"
@@ -7102,10 +7102,10 @@ msgid "Generate and send customer invoices"
 msgstr "Generar y enviar facturas de cliente"
 
 msgid "Generate fiscal year"
-msgstr "Generar año fiscal"
+msgstr "Generar ejercicio fiscal"
 
 msgid "Generate Fiscal Year"
-msgstr "Generar Año Fiscal"
+msgstr "Generar ejercicio fiscal"
 
 msgid "Generate material IDs and descriptions based on the properties of the material."
 msgstr "Generar IDs de materiales y descripciones basadas en las propiedades del material."
@@ -7147,7 +7147,7 @@ msgid "Give it an owner and a date"
 msgstr "Asígnale un propietario y una fecha"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Libro mayor"
 
 msgid "GL Account"
 msgstr "Cuenta Contable"
@@ -7156,28 +7156,28 @@ msgid "GL account capturing cost differences on outside-processing operations."
 msgstr "Cuenta GL que captura las diferencias de costo en las operaciones de procesamiento externo (subcontratación)."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Cuenta GL que captura las diferencias entre los gastos generales de fabricación aplicados y reales."
+msgstr "Cuenta contable que captura diferencias entre los costos indirectos de manufactura aplicados y los reales."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Cuenta GL que captura las diferencias entre el material esperado por BOM y el consumido realmente."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Cuenta GL que captura las diferencias entre el tiempo de enrutamiento esperado y el tiempo de trabajo/máquina real."
+msgstr "Cuenta contable que captura diferencias entre el tiempo de mano de obra/máquina esperado en la ruta y el real."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Cuenta GL que captura diferencias de costos fijos cuando el tamaño real del lote difiere del planeado."
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "Cuenta GL acreditada para remover el costo original del activo cuando se dispone de él."
+msgstr "Cuenta contable acreditada para eliminar el costo original del activo cuando se da de baja."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "Cuenta GL acreditada cuando se registra una factura del proveedor (saldo AP)."
+msgstr "Cuenta contable acreditada cuando se contabiliza una factura del proveedor (saldo de cuentas por pagar)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Cuenta GL acreditada cuando el costo de trabajo o máquina se absorbe en un trabajo de producción."
+msgstr "Cuenta contable acreditada cuando el costo de mano de obra o máquina se absorbe en una orden de trabajo de producción."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
-msgstr "Cuenta GL acreditada cuando el gasto indirecto de fabricación se absorbe en un trabajo de producción."
+msgstr "Cuenta contable acreditada cuando los costos indirectos de manufactura se absorben en una orden de trabajo de producción."
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
 msgstr "Cuenta GL debitada para limpiar la depreciación acumulada cuando se dispone de un activo."
@@ -7201,19 +7201,19 @@ msgid "GL account for tax accrued under reverse-charge rules where the buyer sel
 msgstr "Cuenta GL para impuestos acumulados bajo reglas de cargo invertido donde el comprador se autoevalúa."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "Cuenta GL para diferencias de tiempo fiscal (p. ej., depreciación fiscal acelerada vs. depreciación contable)."
+msgstr "Cuenta contable para diferencias de tiempo fiscal (p. ej., depreciación fiscal acelerada vs. depreciación contable)."
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Cuenta GL afectada cuando los conteos físicos difieren del inventario del sistema."
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "Cuenta GL en la empresa fuente a debitar para esta transacción intercompañía."
+msgstr "Cuenta contable en la empresa de origen a debitar para esta transacción interempresarial."
 
 msgid "GL account in the target company to credit for this intercompany transaction."
 msgstr "Cuenta GL en la empresa destino a acreditar para esta transacción intercompañía."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
-msgstr "Cuenta GL que absorbe diferencias de redondeo de sub-céntimos al registrar."
+msgstr "Cuenta contable que absorbe diferencias de redondeo de fracción de centavo en la contabilización."
 
 msgid "GL account that captures the difference between standard cost and actual purchase cost."
 msgstr "Cuenta GL que captura la diferencia entre costo estándar y costo de compra real."
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "Cuenta contable (GL) que registra el costo de adquisición original de un activo — se debita al adquirirlo y se acredita por el costo bruto total cuando se da de baja o se vende."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Cuenta GL que contiene el valor de los trabajos en producción hasta que se registran como productos terminados."
+msgstr "Cuenta contable que mantiene el valor de las órdenes de trabajo en producción hasta que se contabilizan en producto terminado."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "Cuenta de contabilidad general que retiene el valor de los bienes manufacturados (artículos Fabricar); se debita al completar el trabajo, se acredita en el envío."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "Cuenta GL donde se registran los descuentos por pago anticipado obtenidos de los proveedores."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Cuenta contable (GL) contraactivo que se acredita a medida que se registra la depreciación acumulada cada período y se debita en su totalidad cuando el activo se vende o se desecha."
+msgstr "Cuenta de activo de contrapartida del Libro mayor acreditada cuando se contabilizan depreciaciones cada período y debitada en su totalidad cuando el activo se vende o se desecha."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Cuenta GL contra activos que acumula la depreciación registrada contra activos fijos."
+msgstr "Cuenta de activo de contrapartida del Libro mayor que acumula depreciación contabilizada contra Activos fijos."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Cuenta GL de patrimonio (reserva CTA) que mantiene diferencias FX no realizadas de la retraducción de saldos en moneda extranjera al cierre del período; separada de la ganancia/pérdida FX realizada en el P&L."
+msgstr "Cuenta de Patrimonio del Libro mayor (reserva CTA) que mantiene diferencias de cambio no realizadas por la retradución de saldos en moneda extranjera al final del período; separada de las ganancias/pérdidas de cambio realizadas en P&L."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Cuenta GL de patrimonio donde se cierra el ingreso neto al final del año fiscal."
+msgstr "Cuenta de Patrimonio del Libro mayor donde se cierran los ingresos netos al fin del año fiscal."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Cuenta GL de gastos debitada cada período cuando se registra la depreciación."
+msgstr "Cuenta de Gasto del Libro mayor debitada cada período cuando se contabiliza la depreciación."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Cuenta de gastos (GL) que se debita cuando el valor contable de un activo se reduce por deterioro, es decir, cuando su importe recuperable cae por debajo del valor contable neto (NBV)."
+msgstr "Cuenta de Gasto del Libro mayor debitada cuando el valor en libros de un activo se reduce por deterioro, es decir, cuando su importe recuperable es menor que el Valor neto en libros."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Cuenta GL de gastos para compras que no son de inventario (suministros, servicios)."
+msgstr "Cuenta de Gasto del Libro mayor para compras no inventariables (suministros, servicios)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Cuenta GL de pasivos acreditada por impuesto a las ventas cobrado de los clientes."
+msgstr "Cuenta de Pasivo del Libro mayor acreditada por el Impuesto a las ventas cobrado de los clientes."
 
 msgid "GL tie-out"
-msgstr "Conciliación GL"
+msgstr "Cuadre del Libro mayor"
 
 msgid "GL Tie-Out"
-msgstr "Conciliación GL"
+msgstr "Cuadre del Libro Mayor"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Activa en el primer intento — con nuestro equipo a tu lado"
@@ -7400,16 +7400,16 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "Datos históricos anteriores a los que están en el Mapa de Migración de Datos"
 
 msgid "Historical Rate (equity)"
-msgstr "Tasa Histórica (Patrimonio)"
+msgstr "Tipo de cambio histórico (Patrimonio)"
 
 msgid "Historical Rate (Equity)"
-msgstr "Tasa Histórica (Patrimonio)"
+msgstr "Tipo de cambio histórico (Patrimonio)"
 
 msgid "History"
 msgstr "Historial"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Mantener el diario como advertencia para corregir."
+msgstr "Mantener el Asiento como advertencia para corregir."
 
 msgid "Holiday"
 msgstr "Día festivo"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Horas/Pieza"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Cómo se repone un artículo en general (Comprar, Fabricar o Comprar y Fabricar), establecido por artículo, a diferencia del tipo de método por línea."
+msgstr "Cómo se repone un Artículo en general (Compra, Fabricación, o Compra y fabricación), establecido por Artículo, a diferencia del Tipo de suministro por Línea."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Cómo se repone un artículo: Reorden Manual, Reorden Basado en Demanda, Cantidad de Reorden Fija o Cantidad Máxima."
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Con qué frecuencia este calibre debe ser recalibrado; combinado con la última fecha de calibración para recalcular automáticamente la próxima fecha de calibración."
+msgstr "Con qué frecuencia debe recalibrarse este Instrumento de medición; combinado con la Fecha de última calibración para recalcular automáticamente la Fecha de próxima calibración."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Con qué frecuencia se repite este mantenimiento — Diariamente, Semanalmente, Mensualmente, En Conteo de Ciclo; Diariamente revela el selector de día de la semana, los demás usan matemáticas de intervalo más simple."
+msgstr "Con qué frecuencia se repite este Mantenimiento — Diario, Semanal, Mensual, En Conteo cíclico; Diario revela el selector de día de la semana, los otros usan matemática de intervalo más simple."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Qué tan estricta es la fecha de vencimiento — Hard Deadline bloquea la programación, Soft Deadline permite que la planificación se extienda con una advertencia, No Deadline la ignora completamente."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "Cómo se obtiene el material (fabricar, comprar o extraer del inventario) y la unidad de almacenamiento de la que se extrae."
+msgstr "Cómo se obtiene el Material (por fabricación, compra, o tomándolo del inventario) y de qué Unidad de almacenamiento se toma."
 
 msgid "How the resolved price was calculated."
 msgstr "Cómo se calculó el precio resuelto."
@@ -7526,10 +7526,10 @@ msgid "How to read this chart"
 msgstr "Cómo leer este gráfico"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Qué tan urgente es este despacho — Bajo / Medio / Alto / Crítico; combinado con Prioridad e Impacto OEE para decidir el espacio del cronograma."
+msgstr "Cuán urgente es esta Orden de mantenimiento — Bajo / Medio / Alto / Crítico; combinado con Prioridad e Impacto de OEE para decidir la ranura de Programa."
 
 msgid "How we know we're done"
-msgstr "Cómo sabemos que hemos terminado"
+msgstr "Cómo sabemos que está hecho"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
 msgstr "Cómo nos mantenemos alineados y cómo se resuelven los problemas. Tu parte: asiste a la llamada semanal y señala los obstáculos temprano, antes de que se conviertan en retrasos."
@@ -7601,19 +7601,19 @@ msgid "If items already exist"
 msgstr "Si los artículos ya existen"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "Si se ordena, no se proyecta falta de existencias en las próximas 48 semanas"
+msgstr "Si hay un Pedido, ninguna Rotura de stock proyectada en las próximas 48 semanas"
 
 msgid "If something is off track"
 msgstr "Si algo se desvía del plan"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "Si deseas cambiar los números de parte, haz clic en Cancelar y asigna manualmente las partes para cada elemento de línea antes de convertir."
+msgstr "Si desea cambiar los números de pieza, haga clic en Cancelar y Asigne manualmente las Piezas para cada Línea de Artículo antes de convertir."
 
 msgid "II (normal default)"
 msgstr "II (normal predeterminado)"
 
 msgid "III (tightened)"
-msgstr "III (apretado)"
+msgstr "III (Rigurosa)"
 
 msgid "Impact"
 msgstr "Impacto"
@@ -7662,10 +7662,10 @@ msgid "In Process Only"
 msgstr "Solo en proceso"
 
 msgid "In progress"
-msgstr "En progreso"
+msgstr "En curso"
 
 msgid "In Progress"
-msgstr "En Progreso"
+msgstr "En Curso"
 
 msgid "in scope"
 msgstr "en alcance"
@@ -7701,7 +7701,7 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Las acciones inactivas no aparecerán en las listas de selección"
 
 msgid "Inbound inspection"
-msgstr "Inspección de entrada"
+msgstr "Inspección de recepción"
 
 msgid "Inbox"
 msgstr "Bandeja de entrada"
@@ -7719,13 +7719,13 @@ msgid "Includes tax and shipping costs"
 msgstr "Incluye impuestos y costos de envío"
 
 msgid "Income / Balance (inherited)"
-msgstr "Ingreso / Balance (heredado)"
+msgstr "Ingresos / Saldo (heredado)"
 
 msgid "Income Statement"
 msgstr "Estado de Resultados"
 
 msgid "Income Tax"
-msgstr "Impuesto a la Renta"
+msgstr "Impuesto a los Ingresos"
 
 msgid "Income/Balance"
 msgstr "Ingresos/Saldo"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Heredado del padre"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Heredado del grupo: clasificación de nivel superior (activo, pasivo, patrimonio, ingresos, gastos)."
+msgstr "Heredado del grupo: clasificación de nivel superior (activo, pasivo, patrimonio, ingresos, gasto)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Heredado del grupo: donde aparece esta cuenta en los estados financieros."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Heredado del grupo: si esta cuenta se cierra a ganancias retenidas (ingreso) o se transfiere (balance)."
+msgstr "Heredado del grupo: si esta cuenta se cierra a Resultados acumulados (ingresos) o se traslada (saldo)."
 
 msgid "Inherited from the parent group."
 msgstr "Heredado del grupo padre."
@@ -7827,10 +7827,10 @@ msgid "Inspections"
 msgstr "Inspecciones"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Inspecciones, incumplimiento y CAPA"
+msgstr "Inspecciones, No conformidad y CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Inspecciones, Incumplimiento, CAPA"
+msgstr "Inspecciones, No conformidad, CAPA"
 
 msgid "Inspections: Require Different Inspector"
 msgstr "Inspecciones: Requerir Inspector Diferente"
@@ -7962,7 +7962,7 @@ msgid "Invite"
 msgstr "Invitar"
 
 msgid "Invite Expired"
-msgstr "Invitación Expirada"
+msgstr "Invitación Vencida"
 
 msgid "Invited"
 msgstr "Invitado"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Se detendrá hasta que publique una Versión nuevamente. Nada se elimina."
 
 msgid "ITAR Certifications"
 msgstr "Certificaciones ITAR"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Maestro de Artículos y Métodos de Fabricación"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Maestro de artículos, BOM y Lista de Procesos"
+msgstr "Maestro de Artículos, BOMs y Lista de operaciones"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "El artículo debe coincidir con un tipo seleccionado Y un grupo seleccionado"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Los artículos dentro de esta ventana obtienen una insignia amarilla."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Artículos: maestro de artículos, BOMs, Bill of Process, cambios de ingeniería, CAD"
+msgstr "Artículos: Maestro de Artículos, BOMs, Lista de operaciones, Cambios de ingeniería, CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "Su diseño puede cambiar antes de que se libere el aviso de cambio."
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "Ubicación del Trabajo"
 
 msgid "Job make method"
-msgstr "Método de producción"
+msgstr "Método de fabricación de la Orden de trabajo"
 
 msgid "Job Materials"
-msgstr "Materiales de Trabajo"
+msgstr "Materiales de la Orden"
 
 msgid "Job operation"
-msgstr "Operación de trabajo"
+msgstr "Operación de la orden"
 
 msgid "Job Operation"
-msgstr "Operación de Trabajo"
+msgstr "Operación de la Orden"
 
 msgid "Job Operations"
-msgstr "Operaciones de Trabajo"
+msgstr "Operaciones de la Orden"
 
 msgid "Job Priority"
 msgstr "Prioridad del trabajo"
@@ -8244,26 +8244,26 @@ msgid "Job readable"
 msgstr "Trabajo legible"
 
 msgid "Job Traveler"
-msgstr "Hoja de Ruta de Trabajo"
+msgstr "Hoja viajera"
 
 msgid "Jobs"
-msgstr "Trabajos"
+msgstr "Órdenes de trabajo"
 
 msgid "Jobs Assigned to Me"
-msgstr "Trabajos Asignados a Mí"
+msgstr "Órdenes de trabajo asignadas a mí"
 
 msgid "Jobs Required"
-msgstr "Trabajos Requeridos"
+msgstr "Órdenes de trabajo requeridas"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Trabajos que tienen este artículo en su lista de materiales"
+msgstr "Órdenes de trabajo que tienen este artículo en su lista de materiales"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Unirse a {0}"
 
 msgid "Journal"
-msgstr "Diario"
+msgstr "Asiento"
 
 msgid "Journal Entries"
 msgstr "Asientos de Diario"
@@ -8272,10 +8272,10 @@ msgid "Journal entries dated in this period that are still Draft must be posted,
 msgstr "Los asientos de diario fechados en este período que aún están en Borrador deben contabilizarse o reescalonarse a un período abierto posterior. Los asientos en borrador no son parte del libro mayor, por lo que sus débitos y créditos estarían faltando del cierre."
 
 msgid "Journal Entry"
-msgstr "Asiento de Diario"
+msgstr "Apunte"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Los diarios con fecha en o antes de esta fecha se tratan como bloqueados. Se fusionan con la fecha de bloqueo reportada por el proveedor cuando ambas existen."
+msgstr "Los asientos fechados en o antes de esta fecha se tratan como bloqueados. Se combinan con la fecha de bloqueo reportada por el proveedor cuando ambas existen."
 
 msgid "Just one"
 msgstr "Solo uno"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Mantener Actual"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Mantener precios existentes, solo agregar elementos nuevos"
+msgstr "Mantener fijación de precios existente, solo agregar artículos nuevos"
 
 msgid "Keep only items where…"
 msgstr "Mantener solo elementos donde..."
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "Mantener Abierto"
 
 msgid "Keep picking"
-msgstr "Continuar recogiendo"
+msgstr "Continuar picking"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantiene órdenes, cotizaciones y configuración tras una segunda verificación"
@@ -8351,10 +8351,10 @@ msgid "Labor & Machine Absorption (default)"
 msgstr "Absorción de Mano de Obra y Máquina (predeterminada)"
 
 msgid "Labor & Machine Variance"
-msgstr "Varianza de Mano de Obra y Máquina"
+msgstr "Desviación de mano de obra y máquina"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Varianza de Mano de Obra y Máquina (predeterminada)"
+msgstr "Desviación de mano de obra y máquina (predeterminada)"
 
 msgid "Labor rate"
 msgstr "Tarifa de mano de obra"
@@ -8375,7 +8375,7 @@ msgid "Labor unit"
 msgstr "Unidad de mano de obra"
 
 msgid "Labor Unit"
-msgstr "Unidad de Trabajo"
+msgstr "Unidad de mano de obra"
 
 msgid "Language"
 msgstr "Idioma"
@@ -8399,7 +8399,7 @@ msgid "Last day"
 msgstr "Último día"
 
 msgid "Last Fiscal Year"
-msgstr "Último Año Fiscal"
+msgstr "Último ejercicio fiscal"
 
 msgid "Last Login"
 msgstr "Último Inicio de Sesión"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Latitud"
 
 msgid "Lead time"
-msgstr "Tiempo de Entrega"
+msgstr "Plazo de entrega"
 
 msgid "Lead Time"
-msgstr "Tiempo de Entrega"
+msgstr "Plazo de entrega"
 
 msgid "Lead time (days)"
-msgstr "Tiempo de entrega (días)"
+msgstr "Plazo de entrega (días)"
 
 msgid "Lead Time (Days)"
-msgstr "Tiempo de Entrega (Días)"
+msgstr "Plazo de entrega (días)"
 
 msgid "Lead Time:"
-msgstr "Tiempo de entrega:"
+msgstr "Plazo de entrega:"
 
 msgid "Learn"
 msgstr "Aprender"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Menos trabajo manual, menos errores"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Construyamos"
 
 msgid "Let's build something"
 msgstr "Construyamos algo"
@@ -8549,10 +8549,10 @@ msgid "Lines need internal part numbers"
 msgstr "Las líneas necesitan números de parte internos"
 
 msgid "Lines need prices or lead times"
-msgstr "Las líneas necesitan precios o tiempos de entrega"
+msgstr "Las líneas necesitan precios o plazos de entrega"
 
 msgid "Lineside"
-msgstr "Costado de la línea"
+msgstr "Pie de línea"
 
 msgid "Link"
 msgstr "Enlace"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Vincular problema de Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Vincule este cliente de Carbon a uno de ellos o cree un cliente de Stripe separado."
 
 msgid "Link to sales order line"
-msgstr "Vincular a una línea de orden de venta"
+msgstr "Vínculo a línea de pedido de venta"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Cargado al final, justo en el corte, para que los saldos estén actualizados."
 
 msgid "Loading associated jobs..."
-msgstr "Cargando trabajos asociados..."
+msgstr "Cargando órdenes de trabajo asociadas..."
 
 msgid "Loading current quantity…"
 msgstr "Cargando cantidad actual…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Bloqueado"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "El bloqueo hace que el período sea de solo lectura para documentos operativos (recibos, envíos, facturas) mientras permite ajustes contables como depreciación y disposiciones. Un período debe bloquearse antes de poder cerrarse."
+msgstr "El bloqueo hace que el período sea de solo lectura para documentos operativos (recepciones, envíos, facturas) mientras aún permite ajustes contables como depreciación y bajas. Un período debe bloquearse antes de que pueda cerrarse."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Registrar no conformidades e impulsar un CAPA"
@@ -8695,16 +8695,16 @@ msgid "Looks empty here"
 msgstr "Se ve vacío aquí"
 
 msgid "Loss on Disposal"
-msgstr "Pérdida en la Disposición"
+msgstr "Pérdida en baja"
 
 msgid "Loss on Disposal (default)"
-msgstr "Pérdida en la Disposición (predeterminada)"
+msgstr "Pérdida en baja (predeterminada)"
 
 msgid "Loss on Disposal Account"
-msgstr "Cuenta de Pérdida en la Disposición"
+msgstr "Cuenta de pérdida en baja"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "Pérdidas reconocidas en la disposición de activos fijos"
+msgstr "Pérdidas reconocidas en la baja de activos fijos"
 
 msgid "Lost"
 msgstr "Perdido"
@@ -8719,16 +8719,16 @@ msgid "Lot Size"
 msgstr "Tamaño de Lote"
 
 msgid "Lot Size Variance"
-msgstr "Varianza de Tamaño de Lote"
+msgstr "Desviación de tamaño de lote"
 
 msgid "Lot Size Variance (default)"
-msgstr "Varianza de Tamaño de Lote (predeterminada)"
+msgstr "Desviación de tamaño de lote (predeterminada)"
 
 msgid "Lot Size:"
 msgstr "Tamaño de lote:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Inspección basada en lotes de bienes recibidos según un plan de muestreo; las unidades se registran En espera en la recepción y solo se liberan a Disponible una vez que el lote se dispone como aceptado."
+msgstr "Inspección de mercancías recibidas basada en lotes según un plan de muestreo; las unidades se contabilizan como Suspendidas en la recepción y solo se liberan a Disponible una vez que el lote se dispone como Aceptado."
 
 msgid "Low"
 msgstr "Bajo"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "Mantenimiento"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Notificaciones de Despacho de Mantenimiento"
+msgstr "Notificaciones de orden de mantenimiento"
 
 msgid "Maintenance Dispatches"
-msgstr "Despachos de Mantenimiento"
+msgstr "Órdenes de mantenimiento"
 
 msgid "Maintenance Expense"
 msgstr "Gasto de Mantenimiento"
@@ -8806,7 +8806,7 @@ msgid "Make Default"
 msgstr "Establecer como predeterminado"
 
 msgid "Make Inactive"
-msgstr "Desactivar"
+msgstr "Inactivar"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
 msgstr "Los artículos de fabricación no se pueden facturar directamente. Cambie el método a Recoger para continuar."
@@ -8851,7 +8851,7 @@ msgid "Manage"
 msgstr "Gestionar"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "Administra cómo se rastrea, calcula y aplica la vida útil en todo el inventario."
+msgstr "Administre cómo se rastrea, se calcula y se aplica la vida de anaquel en todo el inventario."
 
 msgid "Manage Ownership"
 msgstr "Gestionar Propiedad"
@@ -8878,13 +8878,13 @@ msgid "Manufacturer Part Number"
 msgstr "Número de Parte del Fabricante"
 
 msgid "Manufacturing"
-msgstr "Fabricación"
+msgstr "Manufactura"
 
 msgid "Map accounts"
 msgstr "Asignar cuentas"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Asigna cuentas de Carbon al catálogo de cuentas del proveedor. Los diarios registrados se envían utilizando el código de cuenta de proveedor asignado."
+msgstr "Mapee las cuentas de Carbon al plan de cuentas del proveedor. Los asientos contabilizados se envían utilizando el código de cuenta del proveedor mapeado."
 
 msgid "Map Extracted Invoice Lines"
 msgstr "Mapear Líneas de Factura Extraídas"
@@ -8906,7 +8906,7 @@ msgstr "Valores mapeados"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "¿Marcar \"{0}\" como aprobado?"
+msgstr "¿Marcar \"{0}\" como superado?"
 
 msgid "Mark all as configured"
 msgstr "Marcar todo como configurado"
@@ -8924,7 +8924,7 @@ msgid "Mark as Unpaid"
 msgstr "Marcar como No Pagado"
 
 msgid "Mark checkpoint passed"
-msgstr "Marcar punto de control como completado"
+msgstr "Marcar punto de control como superado"
 
 msgid "Mark Complete"
 msgstr "Marcar como completado"
@@ -8936,13 +8936,13 @@ msgid "Mark done"
 msgstr "Marcar como hecho"
 
 msgid "Mark Done"
-msgstr "Marcar como Completado"
+msgstr "Marcar como hecho"
 
 msgid "Mark Light Mode"
 msgstr "Marca Modo Claro"
 
 msgid "Mark not done"
-msgstr "Marcar como no realizado"
+msgstr "Marcar como no hecho"
 
 msgid "Mark scope as agreed"
 msgstr "Marcar alcance como acordado"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "Marcar para eliminar"
 
 msgid "Master gauge"
-msgstr "Instrumento maestro"
+msgstr "Instrumento patrón"
 
 msgid "Master records"
 msgstr "Registros maestros"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Formas de Material"
 
 msgid "Material Substance"
-msgstr "Sustancia Material"
+msgstr "Material base"
 
 msgid "Material Substances"
-msgstr "Sustancias Materiales"
+msgstr "Materiales base"
 
 msgid "material type"
 msgstr "Tipo de Material"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "Tipos de Material"
 
 msgid "Material Usage Variance"
-msgstr "Varianza de Uso de Material"
+msgstr "Desviación de uso de material"
 
 msgid "Material Usage Variance (default)"
-msgstr "Varianza de Uso de Material (predeterminada)"
+msgstr "Desviación de uso de material (predeterminado)"
 
 msgid "materials"
 msgstr "Materiales"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "Tiempo Medio de Reparación"
 
 msgid "Measurement Standard"
-msgstr "Estándar de Medición"
+msgstr "Patrón de medición"
 
 msgid "Media Size"
 msgstr "Tamaño de Medio"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Operaciones de Método"
 
 msgid "Method type"
-msgstr "Tipo de Método"
+msgstr "Tipo de suministro"
 
 msgid "Method Type"
-msgstr "Tipo de Método"
+msgstr "Tipo de suministro"
 
 msgid "Methods"
 msgstr "Métodos"
@@ -9275,7 +9275,7 @@ msgid "Monthly"
 msgstr "Mensual"
 
 msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
-msgstr "Meses durante los cuales este activo se deprecia para propósitos fiscales (cuando no se utiliza MACRS)."
+msgstr "Meses durante los cuales este activo se deprecia para fines fiscales (cuando no se utiliza MACRS)."
 
 msgid "More"
 msgstr "Más"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Mover elemento"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Mueve parte de la cantidad a una nueva fila de disposición para que MRB pueda decidir cada porción por separado (p. ej. descartar algunas, reprocesar algunas)."
+msgstr "Mover parte de la cantidad a una nueva línea de disposición para que MRB pueda decidir cada porción por separado (por ejemplo, desperdiciar parte, retrabajar parte)."
 
 msgid "Move to"
 msgstr "Mover a"
@@ -9448,7 +9448,7 @@ msgid "New Cost Center"
 msgstr "Nuevo Centro de Costos"
 
 msgid "New Credit / Debit Memo"
-msgstr "Nuevo Memorándum de Crédito / Débito"
+msgstr "Nuevo memorando de crédito/débito"
 
 msgid "New Custom Field"
 msgstr "Nuevo Campo Personalizado"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "Nuevo Tipo de Empleado"
 
 msgid "New expiration date"
-msgstr "Nueva fecha de vencimiento"
+msgstr "Nueva fecha de caducidad"
 
 msgid "New Failure Mode"
 msgstr "Nuevo Modo de Falla"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Nuevo Activo Fijo"
 
 msgid "New Gauge"
-msgstr "Nuevo Indicador"
+msgstr "Nuevo instrumento de medición"
 
 msgid "New Gauge Calibration Record"
-msgstr "Nuevo Registro de Calibración de Calibrador"
+msgstr "Nuevo registro de calibración del instrumento de medición"
 
 msgid "New Gauge Type"
-msgstr "Nuevo Tipo de Calibrador"
+msgstr "Nuevo tipo de instrumento"
 
 msgid "New Group"
 msgstr "Nuevo Grupo"
@@ -9538,13 +9538,13 @@ msgid "New Material Finish"
 msgstr "Nuevo Acabado de Material"
 
 msgid "New Material Grade"
-msgstr "Nueva Clasificación de Material"
+msgstr "Nuevo grado"
 
 msgid "New Material Shape"
 msgstr "Nueva Forma de Material"
 
 msgid "New Material Substance"
-msgstr "Nueva Sustancia Material"
+msgstr "Nuevo material base"
 
 msgid "New Material Type"
 msgstr "Nuevo Tipo de Material"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "Nuevo Pago"
 
 msgid "New Payment Term"
-msgstr "Nuevo Término de Pago"
+msgstr "Nuevas condiciones de pago"
 
 msgid "New Picking List"
 msgstr "Nueva Lista de Picking"
@@ -9577,7 +9577,7 @@ msgid "New PO"
 msgstr "Nuevo PO"
 
 msgid "New Price Override"
-msgstr "Nuevo Descuento de Precio"
+msgstr "Nueva sobrescritura de precio"
 
 msgid "New Pricing Rule"
 msgstr "Nueva Regla de Precios"
@@ -9628,7 +9628,7 @@ msgid "New Sales Order"
 msgstr "Nuevo Pedido de Venta"
 
 msgid "New Sales Order Line"
-msgstr "Nueva Línea de Orden de Venta"
+msgstr "Nueva línea de pedido de venta"
 
 msgid "New Scheduled Maintenance"
 msgstr "Nuevo Mantenimiento Programado"
@@ -9670,7 +9670,7 @@ msgid "New Tool"
 msgstr "Nueva Herramienta"
 
 msgid "New Training"
-msgstr "Nuevo Entrenamiento"
+msgstr "Nueva capacitación"
 
 msgid "New Transfer"
 msgstr "Nueva Transferencia"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "No hay acciones seleccionadas"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "No se encontraron trabajos activos para esta orden de venta. La orden será cancelada directamente."
+msgstr "No se encontraron órdenes de trabajo en curso para este pedido de venta. El pedido será cancelado directamente."
 
 msgid "No active plan"
 msgstr "Sin plan activo"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "No hay comentarios aún. Sé el primero en agregar un comentario."
 
 msgid "No completed jobs within range"
-msgstr "No hay trabajos completados dentro del rango"
+msgstr "No hay órdenes de trabajo completadas dentro del rango"
 
 msgid "No condition may match"
 msgstr "Ninguna condición puede coincidir"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "No hay archivos cargados"
 
 msgid "No Gauge Selected"
-msgstr "Sin calibrador seleccionado"
+msgstr "Ningún instrumento de medición seleccionado"
 
 msgid "No grouped notifications"
 msgstr "Sin notificaciones agrupadas"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Aún no hay actividad de inventario de artículos aquí."
 
 msgid "No jobs were created"
-msgstr "No se crearon trabajos"
+msgstr "No se crearon órdenes de trabajo"
 
 msgid "No journal lines in scope for this period"
-msgstr "Sin líneas de diario en alcance para este período"
+msgstr "No hay líneas de asiento en el alcance para este período"
 
 msgid "No lines to map"
 msgstr "Sin líneas para mapear"
@@ -10004,7 +10004,7 @@ msgid "No parts"
 msgstr "Sin piezas"
 
 msgid "No passkeys registered yet."
-msgstr "Aún no hay contraseñas de acceso registradas."
+msgstr "Sin llaves de acceso registradas aún."
 
 msgid "No payables"
 msgstr "Sin cuentas por pagar"
@@ -10016,13 +10016,13 @@ msgid "No planning data"
 msgstr "Sin datos de planificación"
 
 msgid "No posted journals in this period for this account"
-msgstr "Sin diarios registrados en este período para esta cuenta"
+msgstr "No hay asientos contabilizados en este período para esta cuenta"
 
 msgid "No pricing for selected quantity"
-msgstr "Sin precios para la cantidad seleccionada"
+msgstr "Sin fijación de precios para la cantidad seleccionada"
 
 msgid "No pricing options found"
-msgstr "No se encontraron opciones de precios"
+msgstr "No se encontraron opciones de fijación de precios"
 
 msgid "No printer configured"
 msgstr "Sin impresora configurada"
@@ -10061,7 +10061,7 @@ msgid "No remaining entities to inspect."
 msgstr "No hay entidades restantes para inspeccionar."
 
 msgid "No reports match your search."
-msgstr "Ningún reporte coincide con su búsqueda."
+msgstr "Ningún informe coincide con tu búsqueda."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
 msgstr "Ningún representante de esta empresa ha aceptado todavía el Carbon GovCloud Rider. Un administrador de esta empresa debe aceptarlo antes de que cualquier persona pueda acceder a Carbon — el personal de Carbon no puede aceptarlo en su nombre."
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "Sin stock en esta ubicación"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "No se proyecta falta de inventario en las próximas 48 semanas"
+msgstr "Sin proyección de rotura de stock en las próximas 48 semanas"
 
 msgid "No storage unit"
 msgstr "Sin unidad de almacenamiento"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "No es una tabla sino un saldo del libro mayor: el costo se acumula cuando se emiten materiales de trabajo y se borra cuando el trabajo se recibe en inventario."
+msgstr "No es una tabla, sino un saldo del mayor general: el costo se acumula cuando se emiten los materiales de la orden de trabajo y se liquida cuando la orden se recibe en existencias."
 
 msgid "Not certified"
 msgstr "No certificado"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "No hay suficientes trabajos para cubrir la cantidad"
+msgstr "No hay suficientes órdenes de trabajo para cubrir la cantidad"
 
 msgid "Not reached"
 msgstr "No alcanzado"
@@ -10214,7 +10214,7 @@ msgid "Not started"
 msgstr "No iniciado"
 
 msgid "Not started training for"
-msgstr "Sin comenzar el entrenamiento para"
+msgstr "Sin capacitación iniciada para"
 
 msgid "Not yet"
 msgstr "Aún no"
@@ -10326,10 +10326,10 @@ msgid "On Hand"
 msgstr "En Stock"
 
 msgid "On Hold"
-msgstr "En Espera"
+msgstr "Suspendido"
 
 msgid "On Jobs"
-msgstr "En Trabajos"
+msgstr "En órdenes de trabajo"
 
 msgid "On order"
 msgstr "Pedido realizado"
@@ -10341,7 +10341,7 @@ msgid "On Purchase Order"
 msgstr "En Orden de Compra"
 
 msgid "On Sales Order"
-msgstr "En Orden de Venta"
+msgstr "En pedido de venta"
 
 msgid "On Storage Unit"
 msgstr "En Unidad de Almacenamiento"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "El inventario disponible permanece"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "Valor disponible por ubicación o artículo, con conciliación GL"
+msgstr "Valor disponible por ubicación o artículo, con conciliación del Libro mayor"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "Valor disponible de bienes manufacturados (artículos Fabricar)"
@@ -10377,19 +10377,19 @@ msgid "One firing of a workflow, recorded step by step with the values each step
 msgstr "Una ejecución de un flujo de trabajo, registrada paso a paso con los valores que cada paso usó y produjo, actuando en todo momento con los permisos del propietario del flujo de trabajo."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Una unidad de serie o un lote que Carbon rastrea individualmente, llevando su propio estado y atributos como una fecha de vencimiento."
+msgstr "Una unidad serial o un lote de producción que Carbon sigue individualmente, llevando su propio estado y atributos como una fecha de caducidad."
 
 msgid "One set of numbers"
 msgstr "Un único conjunto de números"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Un paso en la ruta de un trabajo, que nombra un proceso y un centro de trabajo y lleva sus propios tiempos y tarifas de configuración, trabajo y máquina."
+msgstr "Un paso en la ruta de fabricación de una orden de trabajo, que especifica un proceso y un centro de trabajo y lleva su propia preparación, mano de obra, y tiempos y tasas de máquina."
 
 msgid "One system from quote to cash"
 msgstr "Un sistema de presupuesto a efectivo"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "Solo los procedimientos en borrador son editables. Cree una nueva versión para cambiar un procedimiento activo o archivado."
+msgstr "Solo se pueden editar los procedimientos en Borrador. Crear una nueva versión para cambiar un procedimiento Activo o Archivado."
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Solo se pueden eliminar los períodos vacíos y abiertos."
@@ -10413,7 +10413,7 @@ msgid "Onshape Status"
 msgstr "Estado de Onshape"
 
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
-msgstr "¡Oops! El enlace que intentas acceder ha expirado o ya no es válido."
+msgstr "¡Oops! El enlace al que está intentando acceder ha caducado o ya no es válido."
 
 msgid "Oops! The link you're trying to access is not valid."
 msgstr "¡Oops! El enlace que intentas acceder no es válido."
@@ -10431,10 +10431,10 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Abrir un NCR para disposición de MRB"
 
 msgid "Open AP"
-msgstr "AP abierto"
+msgstr "Cuentas por pagar abiertas"
 
 msgid "Open AR"
-msgstr "AR abierto"
+msgstr "Cuentas por cobrar abiertas"
 
 msgid "Open Audit Log"
 msgstr "Abrir Registro de Auditoría"
@@ -10446,7 +10446,7 @@ msgid "Open Date"
 msgstr "Fecha de Apertura"
 
 msgid "Open Dispatches"
-msgstr "Despachos Abiertos"
+msgstr "Órdenes de mantenimiento abiertas"
 
 msgid "Open in Carbon"
 msgstr "Abrir en Carbon"
@@ -10467,7 +10467,7 @@ msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "Demanda de trabajo abierto más transferencias pendientes de este contenedor"
 
 msgid "Open jobs"
-msgstr "Trabajos abiertos"
+msgstr "Órdenes de trabajo abiertas"
 
 msgid "Open menu"
 msgstr "Abrir menú"
@@ -10500,7 +10500,7 @@ msgid "Open sales orders"
 msgstr "Pedidos de venta abiertos"
 
 msgid "Open Sales Orders"
-msgstr "Órdenes de Venta Abiertas"
+msgstr "Pedidos de venta abiertos"
 
 msgid "Open Scheduled"
 msgstr "Programado Abierto"
@@ -10539,7 +10539,7 @@ msgid "Operation"
 msgstr "Operación"
 
 msgid "Operation lead time"
-msgstr "Tiempo de entrega de la operación"
+msgstr "Plazo de entrega de la operación"
 
 msgid "Operation minimum cost"
 msgstr "Costo mínimo de la operación"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "Cantidad de operación"
 
 msgid "Operation supplier process"
-msgstr "Proceso de proveedor de operación"
+msgstr "Proceso del proveedor de la operación"
 
 msgid "Operation type"
 msgstr "Tipo de operación"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "Contexto opcional para esta regla"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "Tasa fija opcional utilizada al traducir saldos de capital según IAS 21 (en lugar de la tasa del período)."
+msgstr "Tasa fija opcional utilizada al traducir saldos de patrimonio según IAS 21 (en lugar de la tasa del período)."
 
 msgid "Optional pages & sections"
 msgstr "Páginas y secciones opcionales"
@@ -10693,7 +10693,7 @@ msgid "Other Income account for FX gains when a payment settles a foreign-curren
 msgstr "Cuenta de Otros Ingresos para ganancias de divisas cuando un pago liquida una factura en moneda extranjera a una tasa más favorable"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Cuenta de Otros Ingresos para saldos de proveedores liquidados sin pago completo en la liquidación de AP"
+msgstr "Cuenta de Otros ingresos para saldos de proveedores compensados sin pago completo en la liquidación de Cuentas por pagar"
 
 msgid "Other Type"
 msgstr "Otro Tipo"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Salida"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "El producto nunca durará más que sus materias primas. Vuelve a la duración fija cuando ninguna entrada tiene una fecha de vencimiento."
+msgstr "La producción nunca dura más que sus materias primas. Recurre a la duración fija cuando ninguna entrada tiene una fecha de caducidad."
 
 msgid "Outside operation"
 msgstr "Varianza de Gastos Indirectos"
@@ -10723,43 +10723,43 @@ msgid "Overall result"
 msgstr "Resultado general"
 
 msgid "Overdue"
-msgstr "Vencido"
+msgstr "Atrasado"
 
 msgid "Overhead Absorption"
-msgstr "Absorción de Gasto Indirecto"
+msgstr "Absorción de costos indirectos"
 
 msgid "Overhead Absorption (default)"
-msgstr "Absorción de Gasto Indirecto (predeterminado)"
+msgstr "Absorción de costos indirectos (predeterminada)"
 
 msgid "Overhead rate"
-msgstr "Tasa de gastos generales"
+msgstr "Tasa de costos indirectos"
 
 msgid "Overhead Rate"
-msgstr "Tasa de Gastos Generales"
+msgstr "Tasa de costos indirectos"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "Tasa de Gastos Generales (Por Hora)"
+msgstr "Tasa de costos indirectos (Horaria)"
 
 msgid "Overhead Variance"
-msgstr "Varianza de Gastos Indirectos (predeterminada)"
+msgstr "Desviación de costos indirectos"
 
 msgid "Overhead Variance (default)"
-msgstr "Propietario (centro de costos)"
+msgstr "Desviación de costos indirectos (predeterminada)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "La anulación requiere el permiso inventory:update y una razón."
+msgstr "La sobrescritura necesita el permiso inventory:update y una razón."
 
 msgid "Override Price"
-msgstr "Precio de Anulación"
+msgstr "Sobrescribir precio"
 
 msgid "Override price for a single customer"
-msgstr "Anular precio para un cliente individual"
+msgstr "Sobrescribir precio para un único cliente"
 
 msgid "Override price for all customers of a type"
-msgstr "Anular precio para todos los clientes de un tipo"
+msgstr "Sobrescribir precio para todos los clientes de un tipo"
 
 msgid "Override the expiration on {label}."
-msgstr "Anular la expiración en {label}."
+msgstr "Sobrescribir la caducidad en {label}."
 
 msgid "Overtime"
 msgstr "Horas extras"
@@ -10774,13 +10774,13 @@ msgid "Overwrite the quote method with the source method"
 msgstr "Sobrescribir el método de cotización con el método de origen"
 
 msgid "Overwrite the target manufacturing method with the quote method"
-msgstr "Sobrescribir el método de fabricación objetivo con el método de cotización"
+msgstr "Sobrescribir el método de manufactura objetivo con el método de cotización"
 
 msgid "Owner"
 msgstr "Propietario"
 
 msgid "Owner (cost center)"
-msgstr "Centro de costos principal"
+msgstr "Propietario (centro de costos)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,7 +10814,7 @@ msgid "Params"
 msgstr "Parámetros"
 
 msgid "Parent cost center"
-msgstr "pieza"
+msgstr "Centro de costos padre"
 
 msgid "Parent Cost Center"
 msgstr "Centro de Costos Principal"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Estacionar como error"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Aparcar el diario con una advertencia hasta que el valor esté mapeado"
+msgstr "Aparcar el asiento con una advertencia hasta que se asigne el valor"
 
 msgid "part"
 msgstr "piezas"
@@ -10856,13 +10856,13 @@ msgid "Part ID"
 msgstr "ID de Pieza"
 
 msgid "Part is configured for manufacturing"
-msgstr "La pieza está configurada para fabricación"
+msgstr "La pieza está configurada para manufactura"
 
 msgid "Part Number"
 msgstr "Número de pieza"
 
 msgid "Part Supersession"
-msgstr "Sustitución de Pieza"
+msgstr "Reemplazo de pieza"
 
 msgid "Partial"
 msgstr "Parcial"
@@ -10874,13 +10874,13 @@ msgid "Partners"
 msgstr "Socios"
 
 msgid "parts"
-msgstr "Cuentas por Pagar"
+msgstr "piezas"
 
 msgid "Parts"
 msgstr "Piezas"
 
 msgid "Parts & items"
-msgstr "Partes y artículos"
+msgstr "Piezas & artículos"
 
 msgid "Parts, materials, and how you classify them."
 msgstr "Piezas, materiales y cómo los clasificas."
@@ -10892,19 +10892,19 @@ msgid "Pass"
 msgstr "Aprobar"
 
 msgid "Passed"
-msgstr "Aprobado"
+msgstr "Superado"
 
 msgid "Passkey name"
-msgstr "Nombre de la contraseña de acceso"
+msgstr "Nombre de llave de acceso"
 
 msgid "Passkey unlock failed"
-msgstr "Error al desbloquear la contraseña de acceso"
+msgstr "Fallo al desbloquear llave de acceso"
 
 msgid "Passkeys"
-msgstr "Contraseñas de Acceso"
+msgstr "Llaves de acceso"
 
 msgid "Passkeys are disabled"
-msgstr "Las contraseñas de acceso están deshabilitadas"
+msgstr "Las llaves de acceso están deshabilitadas"
 
 msgid "Path"
 msgstr "Ruta"
@@ -10919,7 +10919,7 @@ msgid "Payables (AP)"
 msgstr "Cuentas por pagar (AP)"
 
 msgid "Payables (default)"
-msgstr "término de pago"
+msgstr "Cuentas por pagar (predeterminado)"
 
 msgid "Payables aging"
 msgstr "Envejecimiento de cuentas por pagar"
@@ -10937,22 +10937,22 @@ msgid "Payment ID"
 msgstr "ID de Pago"
 
 msgid "payment term"
-msgstr "términos de pago"
+msgstr "condiciones de pago"
 
 msgid "Payment term"
-msgstr "Plazo de pago"
+msgstr "Condiciones de pago"
 
 msgid "Payment Term"
-msgstr "Término de Pago"
+msgstr "Condiciones de pago"
 
 msgid "payment terms"
-msgstr "personas"
+msgstr "condiciones de pago"
 
 msgid "Payment Terms"
-msgstr "Términos de Pago"
+msgstr "Condiciones de pago"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "Términos de pago como Neto 30 o pagadero a la recepción"
+msgstr "Condiciones de pago como Neto 30 o pagadero a la recepción"
 
 msgid "Payments"
 msgstr "Pagos"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "Pendiente"
 
 msgid "people"
-msgstr "Gasto de depreciación periódica para activos fijos"
+msgstr "personal"
 
 msgid "People"
 msgstr "Personas"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Por unidad"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Anulación por línea de la ubicación de cumplimiento del encabezado del pedido; se utiliza para envíos divididos y entregas directas."
+msgstr "Sobrescritura de línea de la Ubicación de despacho del encabezado del pedido; se utiliza para envíos divididos y envíos directos."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Anulación por línea de la ubicación de entrega del encabezado de PO; se utiliza para entregas divididas a múltiples almacenes o envíos directos."
+msgstr "Sobrescritura de línea de la Ubicación de entrega del encabezado de la OC; se utiliza para entregas divididas a múltiples almacenes o envíos directos."
 
 msgid "Percentage"
 msgstr "Porcentaje"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "Política de Bloqueo de Período"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "La selección ofrece entidades rastreadas en orden de vencimiento más antiguo primero, por lo que el inventario que expira más pronto se agota primero de forma predeterminada."
+msgstr "Gasto periódico de depreciación para activos fijos"
 
 msgid "Permanently Delete"
 msgstr "Eliminar permanentemente"
@@ -11054,13 +11054,13 @@ msgid "Pick"
 msgstr "Seleccionar"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "Elige una dimensión Carbon y el destino del proveedor al que se publica. Crear automáticamente añade opciones de proveedor faltantes por nombre en el momento del envío."
+msgstr "Selecciona una dimensión de Carbon y el objetivo del proveedor al que se contabiliza. La creación automática añade las opciones del proveedor faltantes por nombre al momento de enviar."
 
 msgid "Pick a column to sort by"
 msgstr "Elige una columna para ordenar"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "Selecciona un cliente o tipo de cliente para ver sus precios."
+msgstr "Selecciona un cliente o tipo de cliente para ver su fijación de precios."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "Elige una fecha o déjala en blanco para borrarla."
@@ -11120,7 +11120,7 @@ msgid "Picking Lists"
 msgstr "Listas de Picking"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Planeado"
+msgstr "Picking ofrece entidades rastreadas ordenadas por vencimiento más próximo, de modo que el stock que vence más pronto se retira primero de forma predeterminada."
 
 msgid "Pieces/Hour"
 msgstr "Piezas/Hora"
@@ -11215,7 +11215,7 @@ msgid "Please select an item"
 msgstr "Por favor selecciona un artículo"
 
 msgid "Please upload a CSV file of your data"
-msgstr "Por favor, carga un archivo CSV de tus datos"
+msgstr "Por favor, suba un archivo CSV de sus datos"
 
 msgid "PO"
 msgstr "OC"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Publicado por"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Los diarios publicados con estos tipos de origen siempre se sincronizan. El resumen diario agrupa los diarios de un día en una entrada de proveedor por cuenta."
+msgstr "Los asientos contabilizados con estos tipos de origen siempre se sincronizan. El resumen diario agrupa los asientos de un día en una entrada de proveedor por cuenta."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Publicado una vez, corregido {corrections} veces."
@@ -11290,13 +11290,13 @@ msgid "Posted once, no corrections."
 msgstr "Publicado una vez, sin correcciones."
 
 msgid "Posting"
-msgstr "Anticipos"
+msgstr "Contabilización"
 
 msgid "Posting date"
-msgstr "Fecha de publicación"
+msgstr "fecha de contabilización"
 
 msgid "Posting Date"
-msgstr "Fecha de Registro"
+msgstr "Fecha de contabilización"
 
 msgid "Potential Data Loss"
 msgstr "Pérdida potencial de datos"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "Anticipos (predeterminado)"
 
 msgid "Prepayments (default)"
-msgstr "Acción preventiva"
+msgstr "Anticipos (predeterminado)"
 
 msgid "Present Week"
 msgstr "Semana actual"
@@ -11323,7 +11323,7 @@ msgid "Prev"
 msgstr "Anterior"
 
 msgid "Preventive action"
-msgstr "Cuenta principal para valoración de inventario disponible"
+msgstr "Acción preventiva"
 
 msgid "Preventive maintenance schedules for your equipment"
 msgstr "Calendarios de mantenimiento preventivo para su equipo"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Valor anterior de {0}"
 
 msgid "Price break actions"
-msgstr "Acciones de desglose de precios"
+msgstr "Acciones de escala de precios"
 
 msgid "Price Break History"
-msgstr "Historial de Tramos de Precio"
+msgstr "Historial de escala de precios"
 
 msgid "Price Breaks"
-msgstr "Desgloses de Precio"
+msgstr "Escalas de precios"
 
 msgid "Price List"
 msgstr "Lista de Precios"
@@ -11372,13 +11372,13 @@ msgid "Price Lists"
 msgstr "Listas de Precios"
 
 msgid "Price override"
-msgstr "Anulación de precio"
+msgstr "Sobrescritura de precio"
 
 msgid "Prices"
 msgstr "Precios"
 
 msgid "Pricing"
-msgstr "Precios"
+msgstr "Fijación de precios"
 
 msgid "Pricing rule"
 msgstr "Regla de precios"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "Reglas de Precios"
 
 msgid "Pricing Trace"
-msgstr "Seguimiento de Precios"
+msgstr "Traza de fijación de precios"
 
 msgid "Primary cash account for bank transactions"
-msgstr "procedimiento"
+msgstr "Cuenta de efectivo principal para transacciones bancarias"
 
 msgid "Print"
 msgstr "Imprimir"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "Imprimir {0} etiquetas"
 
 msgid "Print Jobs"
-msgstr "Trabajos de Impresión"
+msgstr "Imprimir órdenes de trabajo"
 
 msgid "Print Label"
 msgstr "Imprimir Etiqueta"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Procedimiento"
 
 msgid "procedures"
-msgstr "proceso"
+msgstr "procedimientos"
 
 msgid "Procedures"
 msgstr "Procedimientos"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Cantidad de Producción"
 
 msgid "Production variance"
-msgstr "Demanda proyectada explosionada de listas de materiales y pronósticos."
+msgstr "Desviación de producción"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Producción: aplicación de planta y programación"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Inicio del proyecto"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Inventario Proyectado"
+msgstr "Demanda proyectada desglosada de BOM y pronósticos."
 
 msgid "Projected inventory"
 msgstr "Disponible Proyectado"
@@ -11543,14 +11543,14 @@ msgstr "Stock proyectado"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Proyectado a caer por debajo del stock de seguridad la semana del {0}"
+msgstr "Rotura de stock proyectada la semana del {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "Proyectado a mantenerse por encima del stock de seguridad"
 
 msgid "Projected to stay above safety stock"
-msgstr "Orden de Compra"
+msgstr "Proyectado para mantenerse por encima del stock de seguridad"
 
 msgid "Projection"
 msgstr "Proyección"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Publicado por Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versión publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Las versiones publicadas no se pueden editar. Explora en solo lectura, o crea una nueva versión para hacer cambios."
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "Extraer de contabilidad"
 
 msgid "Pull from Inventory"
-msgstr "Extraer del Inventario"
+msgstr "Tomar del inventario"
 
 msgid "Pull, map, and load your data"
 msgstr "Extraer, asignar y cargar sus datos"
@@ -11653,7 +11653,7 @@ msgid "Purchase Invoices"
 msgstr "Facturas de Compra"
 
 msgid "Purchase order"
-msgstr "Varianza de Precio de Compra"
+msgstr "Orden de compra"
 
 msgid "Purchase Order"
 msgstr "Orden de Compra"
@@ -11692,13 +11692,13 @@ msgid "Purchase planning"
 msgstr "Planificación de compras"
 
 msgid "Purchase price variance"
-msgstr "Varianza de Precio de Compra"
+msgstr "Desviación de precio de compra"
 
 msgid "Purchase Price Variance"
-msgstr "Varianza de Precio de Compra (predeterminada)"
+msgstr "Desviación de precio de compra"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Impuesto de Compra por Pagar"
+msgstr "Desviación de precio de compra (default)"
 
 msgid "Purchase Qty"
 msgstr "Cantidad de Compra"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "Impuesto de Compra por Pagar (predeterminado)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "compras"
+msgstr "Impuesto de compra pagadero (default)"
 
 msgid "Purchase to Order"
-msgstr "Compra por Encargo"
+msgstr "Compra bajo pedido"
 
 msgid "Purchase Unit of Measure"
 msgstr "Unidad de Medida de Compra"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Envía cambios de registros a sistemas externos en el momento en que ocurren."
 
 msgid "Push the journal without the dimension"
-msgstr "Enviar el diario sin la dimensión"
+msgstr "Enviar el asiento sin la dimensión"
 
 msgid "Push to accounting"
 msgstr "Enviar a contabilidad"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Cant. Desechada"
 
 msgid "quality"
-msgstr "Cotización a Efectivo"
+msgstr "Calidad"
 
 msgid "Quality"
 msgstr "Calidad"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Cantidad por llegar: en órdenes de compra abiertas más en órdenes de producción (fabricación)."
 
 msgid "Quantity Breaks"
-msgstr "Saltos de Cantidad"
+msgstr "Escala de cantidades"
 
 msgid "Quantity complete"
 msgstr "Cantidad completa"
@@ -11840,19 +11840,19 @@ msgid "Quantity must be greater than 0"
 msgstr "La cantidad debe ser mayor que 0"
 
 msgid "Quantity on hand"
-msgstr "Cantidad disponible"
+msgstr "Cantidad en existencia"
 
 msgid "Quantity on Hand"
-msgstr "Cantidad disponible"
+msgstr "Cantidad en existencia"
 
 msgid "Quantity on Jobs"
-msgstr "Cantidad en Trabajos"
+msgstr "Cantidad en órdenes de trabajo"
 
 msgid "Quantity on Purchase Order"
 msgstr "Cantidad en Orden de Compra"
 
 msgid "Quantity on Sales Order"
-msgstr "Cantidad en Orden de Venta"
+msgstr "Cantidad en pedido de venta"
 
 msgid "Quantity Per Job"
 msgstr "Cantidad Por Trabajo"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Tipo de Cantidad"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Niveles de precios basados en cantidad para esta anulación; el precio unitario aplicado es la fila con la cantidad mínima más grande que satisface la línea de pedido."
+msgstr "Escalas de precios basadas en cantidad para esta sobrescritura; el precio unitario aplicado es la fila con la cantidad mínima más grande que satisface la línea de pedido."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11907,7 +11907,7 @@ msgid "Quote Accepted By Email"
 msgstr "Correo electrónico de aceptación de cotización"
 
 msgid "Quote expired"
-msgstr "Presupuesto expirado"
+msgstr "Cotización vencida"
 
 msgid "Quote ID"
 msgstr "ID de Cotización"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Número de Cotización"
 
 msgid "Quote to cash"
-msgstr "Cuentas por Cobrar"
+msgstr "De cotización a efectivo"
 
 msgid "Quote Type"
 msgstr "Tipo de Cotización"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "Cuentas por cobrar (AR)"
 
 msgid "Receivables (default)"
-msgstr "Conciliación de una orden de compra con lo que se recibió y se facturó — implícito en Carbon, a través de las cantidades de línea y el balance GR/IR."
+msgstr "Cuentas por cobrar (default)"
 
 msgid "Receivables aging"
 msgstr "Envejecimiento de cuentas por cobrar"
@@ -12145,13 +12145,13 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "La reconciliación encontró discrepancias con el proveedor"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Período de Recuperación"
+msgstr "Conciliación de una orden de compra contra lo que se recibió y se facturó — implícita en Carbon, a través de las cantidades de línea y el saldo de GR/IR."
 
 msgid "Record"
 msgstr "Registro"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "Registre un memorándum de crédito o débito contra un cliente o proveedor. Las aplicaciones a facturas específicas se agregan después de que se crea el memorándum."
+msgstr "Registrar una nota de crédito o débito contra un cliente o proveedor. Las aplicaciones a facturas específicas se agregan después de que se crea la nota."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
 msgstr "Registre el efectivo recibido de un cliente (Recepción) o pagado a un proveedor (Desembolso). Las aplicaciones a facturas específicas se agregan después de que se crea el pago."
@@ -12166,13 +12166,13 @@ msgid "Record type"
 msgstr "Tipo de registro"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Registrado en una calibración que la galga necesita reparación antes de que sus lecturas puedan ser confiables."
+msgstr "Registrado en una calibración que el instrumento de medición necesita reparación antes de que se pueda confiar en sus lecturas."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Registrado que se requiere seguimiento después de esta calibración; coloca este indicador en la cola de acciones abiertas."
+msgstr "Registrado que se necesita seguimiento después de esta calibración; coloca este instrumento de medición en la cola de acciones abiertas."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Registrado que el indicador fue ajustado durante esta calibración; afecta cómo se recalcula el intervalo de calibración."
+msgstr "Registrado que el instrumento de medición fue ajustado durante esta calibración; afecta cómo se recalcula el intervalo de calibración."
 
 msgid "Records"
 msgstr "Registros"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Registrado"
 
 msgid "Registered"
-msgstr "Punto de Reorden"
+msgstr "Registrado"
 
 msgid "Registration failed"
 msgstr "Error en el registro"
@@ -12250,10 +12250,10 @@ msgid "Release change notice"
 msgstr "Liberar aviso de cambio"
 
 msgid "Release control"
-msgstr "Control de lanzamiento"
+msgstr "Control de liberación"
 
 msgid "Release Control"
-msgstr "Control de lanzamiento"
+msgstr "Control de liberación"
 
 msgid "Release Job"
 msgstr "Liberar Trabajo"
@@ -12280,65 +12280,65 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "Recuerda este PIN. Lo necesitarás para salir del modo consola en terminales MES."
 
 msgid "Remove"
-msgstr "Eliminar"
+msgstr "Quitar"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "Eliminar {0}"
+msgstr "Quitar {0}"
 
 msgid "Remove {label}"
-msgstr "Eliminar {label}"
+msgstr "Quitar {label}"
 
 msgid "Remove authenticator app"
 msgstr "Quitar aplicación de autenticación"
 
 msgid "Remove clause"
-msgstr "Eliminar cláusula"
+msgstr "Quitar cláusula"
 
 msgid "Remove condition"
-msgstr "Eliminar condición"
+msgstr "Quitar condición"
 
 msgid "Remove filter"
-msgstr "Eliminar filtro"
+msgstr "Quitar filtro"
 
 msgid "Remove Filters"
-msgstr "Eliminar filtros"
+msgstr "Quitar filtros"
 
 msgid "Remove from Price List"
-msgstr "Eliminar de la Lista de Precios"
+msgstr "Quitar de la lista de precios"
 
 msgid "Remove line"
-msgstr "Eliminar línea"
+msgstr "Quitar línea"
 
 msgid "Remove order"
-msgstr "Eliminar orden"
+msgstr "Quitar pedido"
 
 msgid "Remove pair"
-msgstr "Eliminar par"
+msgstr "Quitar par"
 
 msgid "Remove part"
-msgstr "Eliminar pieza"
+msgstr "Quitar pieza"
 
 msgid "Remove path"
-msgstr "Eliminar ruta"
+msgstr "Quitar ruta"
 
 msgid "Remove row"
-msgstr "Eliminar fila"
+msgstr "Quitar fila"
 
 msgid "Remove slide"
-msgstr "Eliminar diapositiva"
+msgstr "Quitar diapositiva"
 
 msgid "Remove slot"
-msgstr "Eliminar espacio"
+msgstr "Quitar espacio"
 
 msgid "Remove sort by column"
-msgstr "Eliminar ordenamiento por columna"
+msgstr "Quitar ordenamiento por columna"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Elimina este tipo de almacenamiento de todas las unidades de almacenamiento que lo referencian y elimínalo. Esto no se puede deshacer."
+msgstr "Quitar este tipo de almacenamiento de todas las unidades de almacenamiento que lo referencian y eliminarlo. No se puede deshacer."
 
 msgid "Remove tool"
-msgstr "Eliminar herramienta"
+msgstr "Quitar herramienta"
 
 msgid "Remove two-factor authentication"
 msgstr "Quitar autenticación de dos factores"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "Cantidad de Reorden:"
 
 msgid "Reordering policy"
-msgstr "Política de reorden"
+msgstr "Política de reaprovisionamiento"
 
 msgid "Reordering Policy"
-msgstr "Política de Reorden"
+msgstr "Política de reaprovisionamiento"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Reordena solo la secuencia de despacho y el centro de trabajo — no reprograma. Cambie las fechas en el tablero de fechas."
+msgstr "Reordena solo la secuencia de órdenes de mantenimiento y el centro de trabajo — no reprograma. Cambiar fechas en el tablero de Fechas."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Se repite una vez para cada elemento en {inputLabel}"
@@ -12405,7 +12405,7 @@ msgid "Replace drawing?"
 msgstr "¿Reemplazar dibujo?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Reemplazar precios existentes con valores de origen"
+msgstr "Reemplazar la fijación de precios existente con valores de origen"
 
 msgid "Replace PDF"
 msgstr "Reemplazar PDF"
@@ -12414,16 +12414,16 @@ msgid "Replace this company's data with a demo dataset — snapshotted first, so
 msgstr "Reemplaza los datos de esta empresa con un conjunto de datos de demostración, capturado primero para que puedas revertir."
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "Reemplazar el PDF elimina todas las ubicaciones de globos en este documento. Las filas de características y sus valores se mantienen; puede colocar globos nuevamente en el nuevo dibujo."
+msgstr "Reemplazar el PDF elimina todas las colocaciones de globos en este documento. Las filas de características y sus valores permanecen; puede colocar globos nuevamente en el nuevo dibujo."
 
 msgid "Replenishment"
 msgstr "Reabastecimiento"
 
 msgid "Replenishment system"
-msgstr "Sistema de reabastecimiento"
+msgstr "Sistema de reposición"
 
 msgid "Replenishment System"
-msgstr "Sistema de Reabastecimiento"
+msgstr "Sistema de reposición"
 
 msgid "Report"
 msgstr "Informe"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Restaurar desde la papelera"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Restaurar esta entidad al inventario disponible en la ubicación y el costo desde el que fue descartada."
+msgstr "Restaurar esta entidad al stock disponible en el contenedor al costo desde el cual fue descartado."
 
 msgid "Restore tracked entities to available"
 msgstr "Restaurar entidades rastreadas a disponibles"
@@ -12583,13 +12583,13 @@ msgid "Resume Receiving"
 msgstr "Reanudar recepción"
 
 msgid "Retained Earnings"
-msgstr "Ganancias retenidas"
+msgstr "Resultados acumulados"
 
 msgid "Retained Earnings (default)"
-msgstr "Ganancias retenidas (predeterminado)"
+msgstr "Resultados acumulados (predeterminado)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
-msgstr "Retirar un activo de servicio mediante desecho o venta, registrando cualquier ganancia o pérdida contra el valor contable neto y estableciendo su estado como Dado de baja."
+msgstr "Retirar un activo del servicio mediante la baja o venta, registrando cualquier ganancia o pérdida contra el valor neto en libros y estableciendo su estado como Dado de baja."
 
 msgid "Retry"
 msgstr "Reintentar"
@@ -12616,10 +12616,10 @@ msgid "Rev {revision}"
 msgstr "Rev {revision}"
 
 msgid "Revenue"
-msgstr "Ingresos"
+msgstr "Ingresos por ventas"
 
 msgid "Revenue and expenses over a period"
-msgstr "Ingresos y gastos durante un período"
+msgstr "Ingresos por ventas y gastos durante un período"
 
 msgid "Reverse all inventory adjustments"
 msgstr "Revertir todos los ajustes de inventario"
@@ -12631,7 +12631,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Revertir cualquier entrada del libro mayor de artículos de esta factura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Inversión del sujeto pasivo"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Impuesto a las ventas de cargo inverso"
@@ -12689,7 +12689,7 @@ msgid "Revoke Invites"
 msgstr "Revocar Invitaciones"
 
 msgid "Rework"
-msgstr "Reparación"
+msgstr "Retrabajo"
 
 msgid "RFQ"
 msgstr "RFQ"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "RFQs"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Llevar dimensiones Carbon junto en diarios enviados. Cada espacio mapea una dimensión Carbon a un destino de análisis del proveedor; el mapeo de valores a continuación empareja valores de dimensión individuales con opciones de proveedor."
+msgstr "Llevar las dimensiones de Carbon en los asientos enviados. Cada espacio asigna una dimensión de Carbon a un objetivo de análisis del proveedor; el mapeo de valores a continuación empareja valores de dimensiones individuales con opciones del proveedor."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "Cuenta de redondeo (predeterminado)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Enruta todas las facturas de AP a una dirección (p. ej., sede corporativa) en lugar de compradores individuales."
+msgstr "Enrutar todas las facturas de Cuentas por pagar a una dirección (p. ej. sede corporativa) en lugar de a compradores individuales."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Enruta todas las facturas de AR a una dirección (p. ej. sede corporativa) en lugar de ubicaciones individuales."
+msgstr "Enrutar todas las facturas de Cuentas por cobrar a una dirección (p. ej. sede corporativa) en lugar de a ubicaciones individuales."
 
 msgid "Routing"
-msgstr "Ruta de operaciones"
+msgstr "Ruta de fabricación"
 
 msgid "rows"
 msgstr "filas"
@@ -12895,7 +12895,7 @@ msgid "Sales & Quoting"
 msgstr "Ventas y Cotización"
 
 msgid "Sales & Revenue"
-msgstr "Ventas e ingresos"
+msgstr "Ventas e Ingresos por ventas"
 
 msgid "Sales contact"
 msgstr "Contacto de ventas"
@@ -12931,34 +12931,34 @@ msgid "Sales order"
 msgstr "Pedido de venta"
 
 msgid "Sales Order"
-msgstr "Orden de Venta"
+msgstr "Pedido de venta"
 
 msgid "Sales Order ID"
-msgstr "ID de Orden de Venta"
+msgstr "ID de pedido de venta"
 
 msgid "Sales order line"
 msgstr "Línea de pedido de ventas"
 
 msgid "Sales Order Line"
-msgstr "Línea de Orden de Venta"
+msgstr "Línea de pedido de venta"
 
 msgid "Sales Order Line (job)"
 msgstr "Línea de pedido de ventas (trabajo)"
 
 msgid "Sales Order Location"
-msgstr "Ubicación de Orden de Venta"
+msgstr "Ubicación de pedido de venta"
 
 msgid "Sales Order Number"
-msgstr "Número de Orden de Venta"
+msgstr "Número de pedido de venta"
 
 msgid "Sales Orders"
-msgstr "Órdenes de Venta"
+msgstr "Pedidos de venta"
 
 msgid "Sales Person"
 msgstr "Persona de Ventas"
 
 msgid "Sales Revenue"
-msgstr "Ingresos de Ventas"
+msgstr "Ingresos por ventas"
 
 msgid "Sales Tax Payable"
 msgstr "Impuesto de venta por pagar"
@@ -13078,7 +13078,7 @@ msgid "Schedule"
 msgstr "Programación"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Programar trabajos contra la capacidad del centro de trabajo"
+msgstr "Programar órdenes de trabajo contra la capacidad del centro de trabajo"
 
 msgid "Schedule Name"
 msgstr "Nombre de Programación"
@@ -13108,40 +13108,40 @@ msgid "Scopes"
 msgstr "Alcances"
 
 msgid "Scrap"
-msgstr "Desecho"
+msgstr "Desperdicio"
 
 msgid "Scrap / Cost of Quality"
-msgstr "Rechazo / Costo de Calidad"
+msgstr "Desperdicio / Costo de Calidad"
 
 msgid "Scrap Percent"
-msgstr "Porcentaje de Rechazo"
+msgstr "Porcentaje de desperdicio"
 
 msgid "Scrap percentage"
-msgstr "Porcentaje de desecho"
+msgstr "Porcentaje de desperdicio"
 
 msgid "Scrap Qty"
-msgstr "Cantidad de Rechazo"
+msgstr "Cantidad de desperdicio"
 
 msgid "Scrap quantity"
-msgstr "Cantidad de desecho"
+msgstr "Cantidad de desperdicio"
 
 msgid "Scrap Quantity"
-msgstr "Cantidad de Rechazo"
+msgstr "Cantidad de desperdicio"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Cantidad de Desperdicio Por Trabajo"
 
 msgid "scrap reason"
-msgstr "Motivo de desecho"
+msgstr "motivo de desperdicio"
 
 msgid "Scrap Reason"
-msgstr "Motivo de Rechazo"
+msgstr "Motivo de desperdicio"
 
 msgid "scrap reasons"
-msgstr "Motivos de desecho"
+msgstr "motivos de desperdicio"
 
 msgid "Scrap Reasons"
-msgstr "Razones de Rechazo"
+msgstr "Motivos de desperdicio"
 
 msgid "Scrapped"
 msgstr "Descartada"
@@ -13240,7 +13240,7 @@ msgid "Security"
 msgstr "Seguridad"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "Segmentos que impulsan los precios y términos del cliente"
+msgstr "Segmentos que determinan los precios y términos del cliente"
 
 msgid "Select"
 msgstr "Seleccionar"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Seleccionar campo"
 
 msgid "Select Gauge"
-msgstr "Seleccionar Calibrador"
+msgstr "Seleccionar instrumento de medición"
 
 msgid "Select groups or individuals"
 msgstr "Seleccionar grupos o individuos"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Selecciona los grupos que deben completar esta capacitación"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Selecciona las facturas que este pago liquida. El descuento y la cancelación están en la moneda de la factura."
+msgstr "Seleccione las facturas que este pago liquida. El descuento y la cancelación contable están en la moneda de la factura."
 
 msgid "Select value"
 msgstr "Seleccionar valor"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Autogestionado"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Autohospedado o gestionado"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Autoincorporación"
 
 msgid "Self-paced"
 msgstr "Ritmo propio"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "Serie / Lote"
 
 msgid "Serial items require a sales order"
-msgstr "Los artículos seriales requieren una orden de venta"
+msgstr "Los artículos seriales requieren un pedido de venta"
 
 msgid "Serial Number"
 msgstr "Número de Serie"
@@ -13536,10 +13536,10 @@ msgid "Service"
 msgstr "Servicio"
 
 msgid "Service Charges"
-msgstr "Cargos de servicio"
+msgstr "Cargos por servicio"
 
 msgid "Service Charges (default)"
-msgstr "Cargos de servicio (predeterminado)"
+msgstr "Cargos por servicio (predeterminado)"
 
 msgid "Service Details"
 msgstr "Detalles del servicio"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Establecer un objetivo"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Configura Carbon según cómo funciona tu empresa: sitios, piezas, BOMs, Bill of Process y los flujos que utilizas."
+msgstr "Configure Carbon de acuerdo con cómo funciona su empresa: ubicaciones, piezas, BOMs, lista de operaciones y los flujos que utiliza."
 
 msgid "Set Clock Out"
-msgstr "Establecer Salida"
+msgstr "Establecer ficha de salida"
 
 msgid "Set clock-out time"
 msgstr "Establecer hora de salida"
@@ -13572,7 +13572,7 @@ msgid "Set Console PIN"
 msgstr "Establecer PIN de Consola"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Establecer porcentajes de margen predeterminados para cada categoría de costo en nuevas líneas de presupuesto"
+msgstr "Establecer porcentajes de margen predeterminados para cada categoría de costo en nuevas líneas de cotización"
 
 msgid "Set demand projection values for each week"
 msgstr "Establecer valores de proyección de demanda para cada semana"
@@ -13581,7 +13581,7 @@ msgid "Set due date"
 msgstr "Establecer fecha de vencimiento"
 
 msgid "Set Pricing"
-msgstr "Establecer Precio"
+msgstr "Establecer precios"
 
 msgid "Set Quantity"
 msgstr "Establecer Cantidad"
@@ -13596,7 +13596,7 @@ msgid "Set up two-factor authentication"
 msgstr "Configurar autenticación de dos factores"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "Configure su empresa con un plan de implementación paso a paso que cubre la configuración, los datos, la formación y la puesta en marcha."
+msgstr "Configure su empresa con un plan de implementación paso a paso que cubra preparación, datos, capacitación y puesta en marcha."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configura tus propios datos con herramientas de importación y ayuda de LLM"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Mapa de Configuración"
 
 msgid "Setup time"
-msgstr "Tiempo de configuración"
+msgstr "tiempo de preparación"
 
 msgid "Setup Time"
-msgstr "Tiempo de Configuración"
+msgstr "Tiempo de preparación"
 
 msgid "Setup unit"
 msgstr "Unidad de configuración"
@@ -13645,7 +13645,7 @@ msgid "Severities"
 msgstr "Severidades"
 
 msgid "Severity"
-msgstr "Gravedad"
+msgstr "Severidad"
 
 msgid "shape"
 msgstr "forma"
@@ -13681,13 +13681,13 @@ msgid "Shared Sections"
 msgstr "Secciones Compartidas"
 
 msgid "Shelf life"
-msgstr "Vida útil"
+msgstr "vida de anaquel"
 
 msgid "Shelf Life (Days)"
-msgstr "Vida Útil (Días)"
+msgstr "Vida de anaquel (días)"
 
 msgid "Shelf Life Start Process"
-msgstr "Proceso de Inicio de Vida Útil"
+msgstr "Proceso de inicio de vida de anaquel"
 
 msgid "Shelf-Life"
 msgstr "Vida útil"
@@ -13789,7 +13789,7 @@ msgid "Shop Floor"
 msgstr "Planta de Producción"
 
 msgid "Shop Floor and Scheduling"
-msgstr "Piso de Producción y Programación"
+msgstr "Planta y programación"
 
 msgid "Shop Floor leads, Planner"
 msgstr "Líderes de planta, Planificador"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Mostrando las primeras 500 líneas"
 
 msgid "Showing the newest 200 journals"
-msgstr "Mostrando los 200 diarios más recientes"
+msgstr "Mostrando los 200 últimos asientos"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Mostrando los 1,000 grupos principales por cantidad"
@@ -13868,13 +13868,13 @@ msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Se muestra como un fondo tenue detrás de cada página de los PDF generados"
 
 msgid "Shown to the user when this rule fails."
-msgstr "Se muestra al usuario cuando esta regla falla."
+msgstr "Mostrado al usuario cuando falla esta regla."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Inicie sesión en Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
-msgstr "Inicie sesión con biometría en lugar de un enlace mágico. Las contraseñas de acceso están protegidas por Face ID, Touch ID o el PIN de su dispositivo."
+msgstr "Inicie sesión con biometría en lugar de un enlace mágico. Las llaves de acceso se aseguran con Face ID, Touch ID o su PIN de dispositivo."
 
 msgid "Sign in with Email"
 msgstr "Iniciar sesión con correo electrónico"
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "Iniciar sesión con Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Iniciar sesión con Passkey"
+msgstr "Inicie sesión con llave de acceso"
 
 msgid "Sign out"
 msgstr "Cerrar sesión"
@@ -13958,7 +13958,7 @@ msgid "Slice expenses by location, cost center, or any dimension"
 msgstr "Dividir gastos por ubicación, centro de costos o cualquier dimensión"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Dividir ingresos por cliente, tipo de cliente o cualquier dimensión"
+msgstr "Divida los ingresos por ventas por cliente, tipo de cliente o cualquier dimensión"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Prueba de humo de los flujos diarios principales de principio a fin"
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "Pronto"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "La fecha de vencimiento más próxima entre todos los materiales establece el producto terminado."
+msgstr "La caducidad más próxima en todos los materiales determina el producto terminado."
 
 msgid "Sort"
 msgstr "Ordenar"
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "Dividir línea de envío"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configurar alojamiento"
@@ -14090,13 +14090,13 @@ msgid "Standard cloud Carbon fits how your company runs"
 msgstr "Carbon en la nube estándar se adapta a cómo funciona tu empresa"
 
 msgid "Standard Cost Variances"
-msgstr "Varianzas de Costo Estándar"
+msgstr "Desviaciones de costo estándar"
 
 msgid "Standard factor"
 msgstr "Factor estándar"
 
 msgid "Standard Lead Time"
-msgstr "Tiempo de Entrega Estándar"
+msgstr "Plazo de entrega estándar"
 
 msgid "Start"
 msgstr "Iniciar"
@@ -14130,10 +14130,10 @@ msgid "Start Now"
 msgstr "Comenzar Ahora"
 
 msgid "Start of Fiscal Year"
-msgstr "Inicio del Año Fiscal"
+msgstr "Inicio del ejercicio fiscal"
 
 msgid "Start of Tax Year"
-msgstr "Inicio del Año Fiscal"
+msgstr "Inicio del año fiscal"
 
 msgid "Start Time"
 msgstr "Hora de Inicio"
@@ -14230,7 +14230,7 @@ msgid "Stocked for spares only."
 msgstr "Almacenado solo para repuestos."
 
 msgid "Stockout"
-msgstr "Agotado"
+msgstr "Rotura de stock"
 
 msgid "Stop raising purchase orders after this date"
 msgstr "Dejar de crear órdenes de compra después de esta fecha"
@@ -14275,31 +14275,31 @@ msgid "Storage Units"
 msgstr "Unidades de Almacenamiento"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "Almacena un número fijo de días en este artículo. La fecha de inicio de vencimiento se establece en cada lote o serie cuando se crea (o cuando se ejecuta el proceso de activación, si está configurado)."
+msgstr "Almacenar cantidad fija de días en este artículo. La fecha de inicio de caducidad se establece en cada lote de producción o serial cuando se crea (o cuando se ejecuta el proceso de desencadenador, si se configura)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "Almacena un número fijo de días en este artículo. La fecha de inicio de vencimiento se establece en cada lote o serie cuando se recibe o se crea (o cuando se ejecuta el proceso de activación, si está configurado)."
+msgstr "Almacenar un número fijo de días en este artículo. La fecha de inicio de caducidad se establece en cada lote o serie cuando se recibe o se crea (o cuando se ejecuta el proceso desencadenante, si está configurado)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Almacena un número fijo de días en este artículo. La fecha de inicio de vencimiento se establece en cada lote o serie cuando se recibe."
+msgstr "Almacenar un número fijo de días en este artículo. La fecha de inicio de caducidad se establece en cada lote o serie cuando se recibe."
 
 msgid "Straight line"
 msgstr "Línea recta"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe ya tiene un cliente con este correo electrónico"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Fecha de vencimiento de Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe envía la factura al cliente por correo electrónico, por lo que se requiere una dirección. Esta también se guardará en el contacto en Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La contabilización creará uno en tu cuenta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de salida de kanban para mostrar en la tabla Kanban"
@@ -14311,13 +14311,13 @@ msgid "Sub-Departments"
 msgstr "Sub-Departamentos"
 
 msgid "Subassembly"
-msgstr "Subconjunto"
+msgstr "Subensamble"
 
 msgid "Subcontracting Variance"
-msgstr "Variación de Subcontratación"
+msgstr "Desviación de Subcontratación"
 
 msgid "Subcontracting Variance (default)"
-msgstr "Variación de Subcontratación (predeterminada)"
+msgstr "Desviación de Subcontratación (predeterminada)"
 
 msgid "Subject"
 msgstr "Asunto"
@@ -14413,13 +14413,13 @@ msgid "Supersedes"
 msgstr "Reemplaza"
 
 msgid "Supersession"
-msgstr "Sustitución"
+msgstr "Reemplazo"
 
 msgid "Supersession chain detected"
-msgstr "Cadena de supersesión detectada"
+msgstr "Se detectó una cadena de reemplazo"
 
 msgid "Supersession Mode"
-msgstr "Modo de Supersesión"
+msgstr "Modo de reemplazo"
 
 msgid "supplier"
 msgstr "Proveedor"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Parte del Proveedor"
 
 msgid "Supplier Part ID"
-msgstr "ID de Pieza del Proveedor"
+msgstr "Referencia del proveedor"
 
 msgid "Supplier Part Number"
 msgstr "Número de Parte del Proveedor"
@@ -14488,31 +14488,31 @@ msgid "Supplier Prepayments"
 msgstr "Pagos Anticipados de Proveedores"
 
 msgid "supplier process"
-msgstr "Proceso de Proveedor"
+msgstr "proceso del proveedor"
 
 msgid "supplier processes"
-msgstr "Procesos de Proveedor"
+msgstr "procesos del proveedor"
 
 msgid "Supplier Processes"
-msgstr "Procesos de Proveedor"
+msgstr "Procesos del proveedor"
 
 msgid "Supplier Quality"
 msgstr "Calidad del Proveedor"
 
 msgid "Supplier quote"
-msgstr "Cotización de Proveedor"
+msgstr "Cotización del proveedor"
 
 msgid "Supplier Quote"
 msgstr "Cotización del Proveedor"
 
 msgid "Supplier Quote ID"
-msgstr "ID de Cotización de Proveedor"
+msgstr "ID de cotización del proveedor"
 
 msgid "Supplier Quote Notifications"
-msgstr "Notificaciones de Cotización de Proveedores"
+msgstr "Notificaciones de cotización del proveedor"
 
 msgid "Supplier Quotes"
-msgstr "Cotizaciones de Proveedores"
+msgstr "Cotizaciones del proveedor"
 
 msgid "Supplier Ref."
 msgstr "Ref. Proveedor"
@@ -14560,7 +14560,7 @@ msgid "Supply"
 msgstr "Suministro"
 
 msgid "Supply & Demand"
-msgstr "Oferta y Demanda"
+msgstr "Suministro y Demanda"
 
 msgid "Support"
 msgstr "Soporte"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "Personaliza este hub para el cliente. Los cambios se aplican en vivo para todos los que lo visualizan. Nunca se muestra al cliente aquí."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Toma la vida útil restante más corta entre los materiales consumidos para hacer este artículo. Úsalo cuando la caducidad del producto dependa de sus ingredientes."
+msgstr "Toma la vida de anaquel más corta restante entre los artículos consumidos para fabricar este artículo. Usa esto cuando la caducidad del producto depende de sus ingredientes."
 
 msgid "taken"
 msgstr "tomado"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "Empresa Objetivo"
 
 msgid "Target customers by type."
-msgstr "Artículo Destino"
+msgstr "Orientar clientes por tipo."
 
 msgid "Target disposition row"
 msgstr "Fila de disposición de destino"
@@ -14705,34 +14705,34 @@ msgid "Tax Amount"
 msgstr "Monto de Impuesto"
 
 msgid "Tax codes, rates"
-msgstr "Códigos fiscales, tasas"
+msgstr "Códigos de impuesto, tasas"
 
 msgid "Tax Depreciation"
-msgstr "Depreciación Fiscal"
+msgstr "Depreciación fiscal"
 
 msgid "Tax Depreciation Method"
-msgstr "Método de Depreciación Fiscal"
+msgstr "Método de depreciación fiscal"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Exento de impuestos"
 
 msgid "Tax Exempt"
 msgstr "Exento de Impuestos"
 
 msgid "Tax ID"
-msgstr "ID Fiscal"
+msgstr "ID fiscal"
 
 msgid "Tax Information"
-msgstr "Información Fiscal"
+msgstr "Información fiscal"
 
 msgid "Tax liability for reverse-charge transactions"
-msgstr "Obligación Fiscal para Transacciones de Inversión del Sujeto Pasivo"
+msgstr "Responsabilidad fiscal por transacciones de cargo inverso"
 
 msgid "Tax Method"
-msgstr "Método Fiscal"
+msgstr "Método fiscal"
 
 msgid "Tax Method (default)"
-msgstr "Método Fiscal (predeterminado)"
+msgstr "Método fiscal (predeterminado)"
 
 msgid "Tax percent"
 msgstr "Porcentaje de impuesto"
@@ -14741,16 +14741,16 @@ msgid "Tax Percent"
 msgstr "Porcentaje de Impuesto"
 
 msgid "Tax Residual Value %"
-msgstr "Valor Residual Fiscal %"
+msgstr "Valor residual fiscal %"
 
 msgid "Tax Useful Life (default)"
-msgstr "Vida Útil Fiscal (predeterminada)"
+msgstr "Vida útil fiscal (predeterminada)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Vida Útil Fiscal (meses)"
+msgstr "Vida útil fiscal (meses)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Vida Útil Fiscal (Meses)"
+msgstr "Vida útil fiscal (meses)"
 
 msgid "Tax:"
 msgstr "Impuesto:"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Equipo capacitado"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Soporte técnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "Plantillas"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "Cuenta transitoria de compensación por baja o disposición que se debita por el valor contable neto de un activo al momento del envío y se acredita por el valor contable neto al facturar, quedando en cero a lo largo del ciclo de venta."
+msgstr "Cuenta temporal de disposición-compensación debitada por el valor neto en libros del activo en el envío y acreditada por su valor neto en libros en la facturación, compensándose a cero durante el ciclo de venta."
 
 msgid "Terms and Privacy"
 msgstr "Términos y Privacidad"
@@ -14810,14 +14810,14 @@ msgstr "La fase \"{0}\" se marca como completada una vez que todas sus tareas en
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "La fase \"{0}\" está completa — su punto de control \"{1}\" ha sido superado."
+msgstr "La fase \"{0}\" está hecha — su punto de control \"{1}\" ha sido superado."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
 msgstr "Los {0} fases para lanzamiento, cada una terminando en un punto de control. Marca cada tarea conforme la completes."
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "La dimensión contable que categoriza artículos para informes y análisis."
+msgstr "La dimensión contable que categoriza los artículos para informes y análisis."
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "Las cuentas a las que Carbon publica automáticamente"
@@ -14829,7 +14829,7 @@ msgid "The allowed values for a list-type attribute; users pick from these rathe
 msgstr "Los valores permitidos para un atributo de tipo lista; los usuarios eligen entre estos en lugar de escribir libremente."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Los valores permitidos que los usuarios pueden seleccionar al etiquetar registros con esta dimensión."
+msgstr "Los valores permitidos que los usuarios pueden seleccionar al etiquetar asientos con esta dimensión."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
 msgstr "La cantidad de días después del método de cálculo en que el descuento en efectivo está disponible"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "La autorización se rechazó en Onshape. Vuelve a intentar la conexión."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "El libro de todas las líneas de diario registradas, sumadas por cuenta – se escribe solo cuando la empresa tiene la contabilidad habilitada."
+msgstr "El libro de todos los asientos contabilizados, sumados por cuenta — escrito solo cuando la empresa tiene la contabilidad habilitada."
 
 msgid "The buckets you track costs against"
 msgstr "Los depósitos contra los que rastrear costos"
@@ -14853,7 +14853,7 @@ msgid "The capital assets you own and depreciate"
 msgstr "Los activos fijos que posee y deprecia"
 
 msgid "The Carbon user currently responsible for working this record, set per record and independent of ownership fields like Account Manager or Sales Person."
-msgstr "El usuario de Carbon actualmente responsable de trabajar en este registro, establecido por registro e independiente de campos de propiedad como Gerente de Cuenta o Vendedor."
+msgstr "El usuario de Carbon actualmente responsable de trabajar en este registro, establecido por registro e independiente de campos de propiedad como Account Manager o Sales Person."
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
 msgstr "El usuario de Carbon responsable de esta relación con el cliente; los correos electrónicos y recordatorios sobre este cliente se enrutan a ellos."
@@ -14880,13 +14880,13 @@ msgid "The cash discount the customer can take if they pay within the discount w
 msgstr "El descuento en efectivo que el cliente puede aprovechar si paga dentro de la ventana de descuento."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "La razón del catálogo que explica este rechazo; se acumula en informes de rechazo indexados por razón en lugar de por cantidad."
+msgstr "La razón del catálogo que explica este desperdicio; se agrega en reportes de desperdicio ordenados por razón en lugar de cantidad."
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "El catálogo en el que trabajas. Se carga una vez que la base está lista."
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "Las categorías de inventario permitidas en esta unidad; se usa para aplicar reglas de recepción (por ejemplo, cadena de frío, peligroso)."
+msgstr "Las categorías de existencias permitidas en esta unidad; utilizadas para aplicar reglas de almacenamiento (p. ej., cadena de frío, peligroso)."
 
 msgid "The categories you group your suppliers into"
 msgstr "Las categorías en las que agrupas tus proveedores"
@@ -14931,7 +14931,7 @@ msgid "The customer this portal link is provisioned for; only contacts on this c
 msgstr "El cliente para el cual se proporciona este enlace del portal; solo los contactos en este cliente pueden iniciar sesión a través del enlace."
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "Referencia propia del cliente para este documento - típicamente su número de RFQ o PO en su sistema; mostrada en la salida imprimible y llevada adelante a cualquier documento en el que se convierta."
+msgstr "La referencia propia del cliente para este documento — típicamente su número de RFQ u orden de compra en su sistema; visible en la salida imprimible y llevada adelante a cualquier documento en el que se convierta este."
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
 msgstr "La etiqueta de revisión del cliente para su ID de Parte, cuando difiere de la nuestra; fijado a nivel de referencia cruzada, no en nuestra revisión."
@@ -14952,19 +14952,19 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "La fecha en que comienza la depreciación de este activo; normalmente la fecha en que entra en servicio."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "La fecha después de la cual los precios de esta cotización ya no son válidos; la conversión a un pedido después de esta fecha puede requerir re-cotización."
+msgstr "La fecha después de la cual el precio de esta cotización ya no es válido; convertir a una orden después de esta fecha puede requerir una nueva cotización."
 
 msgid "The date the customer expects to receive the goods"
 msgstr "La fecha en que el cliente espera recibir los bienes"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "La fecha en que los bienes realmente salen del almacén; se registra en el lanzamiento de envíos y se utiliza para la puntuación de envío a tiempo."
+msgstr "La fecha en que los bienes salen del almacén; registrada en la contabilización del envío y utilizada para calificación de envío a tiempo."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
 msgstr "La fecha en que se requiere el artículo en el sitio para cubrir la demanda proyectada del período."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "La fecha en que este activo se retira de servicio; la depreciación se detiene en esta fecha y el valor neto en libros restante se registra en la cuenta de disposición."
+msgstr "La fecha en que este activo se retira del servicio; la depreciación se detiene en esta fecha y el valor neto en libros restante se registra en la cuenta de baja."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "La fecha en que esta entrada se registra en el libro mayor; determina el período contable en el que se incluye."
@@ -14979,13 +14979,13 @@ msgid "The deadline to send your quote to the customer."
 msgstr "La fecha límite para enviar su presupuesto al cliente."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "El orden de selección predeterminado utiliza para ofrecer entidades rastreadas: FEFO (vencimiento más antiguo primero), FIFO (más antiguo primero) o LIFO (más nuevo primero)."
+msgstr "El orden predeterminado que usa picking para ofrecer entidades rastreadas: FEFO (primero vencimiento más próximo), FIFO (primero el más antiguo), o LIFO (primero el más nuevo)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "La cantidad de ejecución predeterminada cuando se fabrica esta parte; las rondas de planificación reponen hasta múltiplos de esto."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "La tasa fiscal predeterminada aplicada a las líneas de cotización y orden de venta de este cliente, antes de anulaciones por línea; la matemática fiscal específica de la jurisdicción se ejecuta en la parte superior."
+msgstr "La tasa fiscal predeterminada aplicada a las líneas de cotización y orden de venta de este cliente, antes de los ajustes por línea; las matemáticas fiscales específicas de la jurisdicción se aplican después."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "El departamento bajo el cual se agrupa para informes y jerarquías de conteo de encabezados; dejar en blanco para un departamento de nivel superior."
@@ -15021,10 +15021,10 @@ msgid "The fixed-asset record this purchase capitalizes against; the line's rece
 msgstr "El registro de activos fijos contra el cual esta compra se capitaliza; el recibo de la línea crea una entrada de activos en lugar de una entrada de inventario."
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "El registro de activos fijos que esta venta enajena; el envío de la línea contabiliza la entrada de disposición del valor neto en libros del activo en lugar de COGS."
+msgstr "El registro de activo fijo que esta venta da de baja; el envío de la línea contabiliza la entrada de baja del valor neto en libros del activo en lugar de COGS."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "El piso al que se deprecia un activo; cuando el valor neto en libros lo alcanza, el activo se convierte en Completamente Depreciado."
+msgstr "El piso al que un activo se deprecia; cuando el valor neto en libros lo alcanza, el activo cambia a Totalmente depreciado."
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "El taller y la oficina leen las mismas cifras de inventario y costo."
@@ -15033,10 +15033,10 @@ msgid "The following assemblies have no operations. Please assign an operation t
 msgstr "Los siguientes conjuntos no tienen operaciones. Por favor, asigne una operación a cada uno antes de liberar."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "Los siguientes artículos de línea no tienen precios ni tiempos de entrega:"
+msgstr "Los siguientes artículos de línea no tienen precios ni plazos de entrega:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Las siguientes tareas aún no están completadas:"
+msgstr "Las siguientes tareas aún no están hechas:"
 
 msgid "The forms and shapes your raw materials come in"
 msgstr "Las formas y figuras en que vienen tus materias primas"
@@ -15045,7 +15045,7 @@ msgid "The fraction of each lot to inspect; the actual count is computed from lo
 msgstr "La fracción de cada lote a inspeccionar; el recuento real se calcula a partir del tamaño del lote en el momento de la inspección."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "La brecha entre el precio de una orden de compra y la factura del proveedor, registrada en una cuenta de variación cuando se registra la factura."
+msgstr "La brecha entre el precio de la orden de compra y la factura del proveedor, contabilizada en una cuenta de desviación cuando se contabiliza la factura."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "La cuenta GL en la que se contabilizan los cargos de este transportista (gasto de flete, flete dentro/fuera)."
@@ -15060,10 +15060,10 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "La cuenta de grupo a la que se agrupa esta cuenta; determina su tipo, clase y colocación en el estado."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "El costo horario de la mano de obra del operador en este centro de trabajo; combinado con horas de trabajo registradas para cargar el costo de mano de obra en WIP de un trabajo."
+msgstr "El costo por hora de la mano de obra del operario en este centro de trabajo; combinado con horas de mano de obra registradas para cargar el costo de mano de obra al producto en proceso de la orden de trabajo."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "El costo horario de ejecutar la maquinaria en este centro de trabajo; combinado con horas de máquina registradas para cargar el costo de máquina en WIP de un trabajo."
+msgstr "El costo por hora de funcionamiento de la maquinaria en este centro de trabajo; combinado con horas de máquina registradas para cargar el costo de máquina al producto en proceso de la orden de trabajo."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
 msgstr "La carga de costo indirecto por hora aplicada a este centro de trabajo; la diferencia entre mano de obra + máquina y la tasa de cotización completa es lo que absorbe el overhead."
@@ -15087,7 +15087,7 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "La calificación de impacto si el riesgo se realiza (1 = insignificante a 5 = catastrófico); emparejado con Probabilidad para calcular la puntuación de riesgo."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "El documento de envío entrante que ingresa mercancías al inventario (desde una PO, transferencia o salida de trabajo) y crea cualquier entidad rastreada."
+msgstr "El documento de contabilización entrante que recibe bienes en existencias (de una orden de compra, transferencia, o salida de orden de trabajo) y crea cualquier entidad rastreada."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
 msgstr "La regla de Incoterms (FOB, DAP, EXW, CIF, ...) que rige quién paga el flete, quién asume el riesgo y dónde se produce la transferencia de título en envíos de este proveedor."
@@ -15108,7 +15108,7 @@ msgid "The job's position in its location's schedule queue — a fractional numb
 msgstr "La posición del trabajo en la cola de programación de su ubicación — un número fraccionario que Carbon calcula a partir de la fecha de vencimiento y tipo de plazo, no una calificación Bajo/Alto."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "El tipo de ajuste que aplica esta regla - descuento, recargo o anulación fija; combinado con Tipo de Cantidad para calcular el delta real en cada línea."
+msgstr "El tipo de ajuste que aplica esta regla — descuento, recargo, o sobrescritura fija; combinado con Tipo de Monto para calcular el delta real en cada línea."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
 msgstr "El tipo de valor que acepta este atributo (texto, número, fecha, booleano, lista); bloqueado después de que el atributo tiene valores registrados."
@@ -15117,7 +15117,7 @@ msgid "The label and document printers your company prints to"
 msgstr "Las impresoras de etiquetas y documentos a las que imprime su empresa"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "La fecha más reciente para realizar este PO de modo que llegue en la fecha requerida, considerando el tiempo de entrega del proveedor."
+msgstr "La fecha más reciente para colocar esta orden de compra para que llegue en la fecha requerida, dado el plazo de entrega del proveedor."
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "La entidad legal a facturar, cuando es diferente del cliente que recibe los bienes - para arreglos de facturas de terceros o padres/subsidiarias."
@@ -15135,19 +15135,19 @@ msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approv
 msgstr "El estado del ciclo de vida de este proveedor - Activo, Inactivo, Aprobación Pendiente, etc.; solo los proveedores Activos aparecen en PO / selectores de cotización."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "La zona horaria local en la que esta ubicación reporta la hora; los horarios, tarjetas de tiempo y horas de turno en esta ubicación se interpretan en esta zona independientemente de la configuración regional del navegador del usuario."
+msgstr "La zona horaria local en que esta ubicación informa la hora; programas, registro de tiempos, y horas de turno en esta ubicación se interpretan en esta zona independientemente de la configuración regional del navegador del usuario."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
 msgstr "La ubicación a la que este empleado se establece por defecto; impulsa la interpretación de zona horaria en sus tarjetas de tiempo y los selectores de turno predeterminados en su registro de trabajo."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "La ubicación desde la que se cumplirá esta orden; las ubicaciones por línea la anulan cuando se configuran."
+msgstr "La ubicación desde la cual se cumplirá esta orden; las ubicaciones por línea anulan esto cuando se establece."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "La ubicación desde la que se cumplirá esta cotización si se convierte en un pedido; utilizada por la planificación para proyectar suministro en el almacén correcto."
+msgstr "La ubicación desde la cual se cumplirá esta cotización si se convierte en una orden; utilizada por planificación para proyectar suministro en el almacén correcto."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
-msgstr "La ubicación desde la que se cumpliría esta solicitud si se convierte en una cotización y luego en un pedido."
+msgstr "La ubicación desde la cual se cumpliría este RFQ si se convierte en una cotización y luego en una orden."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
 msgstr "El registro de riesgos y oportunidades planteadas contra cualquier entidad, cada una calificada por severidad independiente de 1–5 y probabilidad e impulsada hacia una resolución."
@@ -15159,7 +15159,7 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "El identificador de lote para este inventario; una fila por lote, la cantidad es la en mano para ese lote."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "El lote será marcado como Aprobado. {fails} fallo(s) muestreado(s) se registran para sus registros."
+msgstr "El lote será marcado Superado. Se registran {fails} falla(s) muestreada(s) para su referencia."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "El lote seguirá siendo rechazado, pero no se puede crear un NCR hasta que se configure al menos un tipo de problema."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "El plan de muestreo por característica del lote se volverá a resolver desde el documento seleccionado."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "La cantidad mínima que este proveedor cobrará por este proceso, independientemente de la cantidad; los trabajos por debajo del volumen de equilibrio aún cuestan al menos esta cantidad."
+msgstr "El monto mínimo que este proveedor cobrará por este proceso, independientemente de la cantidad; órdenes de trabajo por debajo del volumen de equilibrio todavía cuestan al menos esto."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Las máquinas, celdas y estaciones por las que pasa tu trabajo"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "El mes en que comienza su año fiscal; los períodos se numeran a partir de este mes."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "El mes en que comienza su año fiscal; puede diferir del año fiscal en algunas jurisdicciones."
+msgstr "El mes en que comienza su año fiscal; puede diferir del ejercicio fiscal en algunas jurisdicciones."
 
 msgid "The monthly periods you post into and close"
 msgstr "Los períodos mensuales en los que registra y cierra"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "El modo de falla más probable que el solicitante sospecha; el técnico confirma o reemplaza esto al cerrar, y la diferencia entre sospechado y real alimenta informes de confiabilidad."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "El precio negociado por unidad en esta línea; el icono de seguimiento en línea muestra qué regla de precios o anulación lo produjo."
+msgstr "El precio negociado por unidad en esta línea; el icono de rastreo en línea muestra qué regla de precios o sobrescritura lo produjo."
 
 msgid "The new version number of the document"
 msgstr "El nuevo número de versión del documento"
@@ -15207,13 +15207,13 @@ msgid "The new version number of the procedure"
 msgstr "El nuevo número de versión del procedimiento"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "El número de días entre la colocación de una PO con el proveedor preferido y la llegada de los bienes al muelle; la planificación compensa la demanda hacia atrás por esta cantidad."
+msgstr "El número de días entre colocar una orden de compra con el proveedor preferido y la llegada de los bienes al muelle; planificación compensa la demanda hacia atrás por esto."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "El número de días para construir un lote de este artículo, medido desde la liberación del trabajo hasta la finalización; la planificación compensa la demanda hacia atrás por esta cantidad."
+msgstr "El número de días para construir un lote de producción de este artículo, medido desde la liberación de la orden de trabajo hasta su finalización; planificación compensa la demanda hacia atrás por esto."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "El número de unidades adicionales a construir para compensar el rechazo esperado; la planificación suma esto con la cantidad de pedido al reservar materiales."
+msgstr "El número de unidades adicionales a construir para compensar el desperdicio esperado; planificación suma esto con la cantidad de la orden al reservar materiales."
 
 msgid "The number of hours per week the contractor is available to work."
 msgstr "El número de horas por semana que el contratista está disponible para trabajar."
@@ -15240,7 +15240,7 @@ msgid "The outbound posting document that takes goods out of stock to a customer
 msgstr "El documento de contabilización de salida que saca bienes del inventario a un cliente, contabilizando COGS en el camino."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Los proveedores externos que realizan este proceso; cada uno obtiene una fila de entradas de precio y tiempo de entrega en el formulario de proceso de proveedor."
+msgstr "Los proveedores externos que realizan este proceso; cada uno obtiene una fila de entradas de precios y plazo de entrega en el formulario del proceso del proveedor."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "La cadena padre-hijo de entidades rastreadas - de qué se construyó una unidad y en qué se convirtió."
@@ -15261,7 +15261,7 @@ msgid "The per-company counter behind a document type's readable number, assembl
 msgstr "El contador por empresa detrás del número legible de un tipo de documento, ensamblando el prefijo, el siguiente valor relleno de ceros, y el sufijo, y avanzando a medida que se crea cada documento."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "El resultado por artículo registrado en el material afectado por una no conformidad — Pendiente, Devolver al Proveedor, Reproceso, Rechazo o Usar Como Está — decidido para cada lote o número de serie afectado de forma independiente."
+msgstr "El resultado por artículo registrado en el material afectado de una no conformidad — Pendiente, Devolución al Proveedor, Retrabajo, Desperdicio, o Usar como está — decidido para cada lote o número de serie afectado en forma independiente."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
 msgstr "El porcentaje del descuento en efectivo. Utiliza 0 para sin descuento."
@@ -15273,7 +15273,7 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Las plantas, almacenes y sitios donde viven tu trabajo e inventario"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "El conjunto predeterminado de tareas y requisitos de aprobación aplicados a este problema; anula el flujo de trabajo predeterminado del tipo de problema cuando se establece."
+msgstr "El conjunto predeterminado de tareas y requisitos de aprobación aplicados a este asunto; anula el flujo de trabajo predeterminado del tipo de asunto cuando se establece."
 
 msgid "The principle:"
 msgstr "El principio:"
@@ -15285,7 +15285,7 @@ msgid "The procedure technicians follow when this maintenance is performed; repl
 msgstr "El procedimiento que siguen los técnicos cuando se realiza este mantenimiento; reemplazarlo después de que ya se hayan generado cronogramas solo afecta futuras instancias."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Los procesos que este centro de trabajo puede ejecutar; aparece en selectores de proceso al programar operaciones, y limita qué trabajos pueden fluir a través de este centro de trabajo."
+msgstr "Los procesos que puede ejecutar este centro de trabajo; aparece en selectores de procesos cuando se programan operaciones, y limita qué órdenes de trabajo pueden enrutar a través de este centro de trabajo."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "El proveedor no ofrece destinos de dimensión. Habilita la función en el proveedor primero (p. ej. categorías de seguimiento, seguimiento de clases o campos)."
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "El registro al que apunta una notificación de flujo de trabajo, nombrado como un id más su tipo; déjalo vacío y la notificación se vincula a la ejecución del flujo de trabajo en sí."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "El registro que aplica un pago o memorándum a una factura, llevando los montos aplicados, descuento y castigo."
+msgstr "El registro que aplica un pago o nota a una factura, llevando los montos aplicados, descuento, y cancelación contable."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "La genealogía registrada de entidades rastreadas - qué entradas se consumieron para producir qué salidas, recepción a través de envío."
@@ -15334,13 +15334,13 @@ msgstr "Los {0} {1} restantes se esperarán nuevamente y se contarán como sumin
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "Los {0} {1} restantes ya no se esperarán. El suministro pendiente y el MRP dejarán de contarlos. La cantidad pedida y los precios permanecen sin cambios."
+msgstr "Los {0} {1} restantes ya no se esperarán. El suministro pedido y MRP dejarán de contarlos. La cantidad pedida y los precios no cambian."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "El cuerpo de la solicitud enviado textualmente con un tipo de contenido JSON después de que se sustituyen las variables del flujo de trabajo dentro de él, en los métodos que llevan uno."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "El WIP residual que un trabajo ha dejado al cerrar, barrido a una cuenta de varianza de producción - la única varianza que Carbon registra para un trabajo."
+msgstr "El producto en proceso residual que una orden de trabajo deja al cierre, trasladado a una cuenta de Desviación de Producción — la única desviación que Carbon contabiliza para una orden de trabajo."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "La respuesta de Onshape no incluía los parámetros requeridos. Vuelve a intentar la conexión."
@@ -15352,7 +15352,7 @@ msgid "The revision number of the part"
 msgstr "El número de revisión de la pieza"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "La línea del pedido de venta para la que se creó este trabajo, vinculando el trabajo a la demanda del cliente detrás de él."
+msgstr "La línea de pedido de venta que esta orden de trabajo fue creada para surtir, vinculando la orden de trabajo a la demanda del cliente detrás de ella."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
 msgstr "El cronograma utilizado para distribuir el costo de este activo durante su vida útil (línea recta, saldo decreciente, unidades de producción)."
@@ -15370,7 +15370,7 @@ msgid "The size of the part"
 msgstr "El tamaño de la pieza"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Las habilidades y capacidades que registras para tu equipo"
+msgstr "Las habilidades que realiza un seguimiento para su personal"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "La cantidad más pequeña que este proveedor aceptará en una línea de PO para esta parte; la planificación la redondea."
@@ -15394,7 +15394,7 @@ msgid "The standard dimensions your materials are stocked in"
 msgstr "Las dimensiones estándar en las que se almacenan tus materiales"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "El factor estándar (horas, minutos, piezas) operaciones en este centro de trabajo se miden por defecto; los override de por operación ganan cuando se configuran."
+msgstr "La unidad estándar (horas, minutos, piezas) en la que se miden las operaciones en este centro de trabajo por defecto; las sobrescrituras por operación prevalecen cuando se establecen."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
 msgstr "El factor estándar utilizado para medir este proceso - horas, minutos, piezas, pies cuadrados - cuando se estiman y cotizan sus operaciones."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "La configuración del paso — esta ejecución predice el registro de los valores que usó."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Los tamaños de stock en los que se compran y se mantienen este material; cada tamaño se convierte en una variante seleccionable separada en trabajos y POs."
+msgstr "Los tamaños de existencias en que este material se compra y se mantiene; cada tamaño se convierte en una variante seleccionable separada en órdenes de trabajo y pedidos de compra."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "El contenedor de almacenamiento de este que la línea recoge; si está en blanco, la selección utiliza la unidad de almacenamiento predeterminada del artículo."
+msgstr "El contenedor de almacenamiento del que esta línea hace picking; si está en blanco, el picking utiliza la unidad de almacenamiento predeterminada del artículo."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "El servicio de almacenamiento no respondió a tiempo. Por favor, inténtelo de nuevo."
@@ -15427,7 +15427,7 @@ msgid "The supplier record this portal account links to; only contacts already o
 msgstr "El registro del proveedor que este contrato del portal se vincula a; solo los contactos ya en ese proveedor pueden ser seleccionados como el titular de la cuenta a continuación."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "El número de cotización/propuesta propio del proveedor; registrado para la trazabilidad en el PO que se convierte a partir de esta cotización."
+msgstr "El número de cotización / propuesta propio del proveedor; registrado para trazabilidad en el pedido de compra que se convierte de esta cotización."
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "La referencia propia del proveedor para esta orden (su número de SO en su sistema); registrada para auditoría y mostrada en el recibo."
@@ -15439,7 +15439,7 @@ msgid "The suppliers and vendors you buy from"
 msgstr "Los proveedores y vendedores de los que compra"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Los proveedores que reciben esta RFQ; cada uno obtiene su propia línea en la RFQ con la que responden con su propio precio."
+msgstr "Los proveedores que reciben esta RFQ; cada uno obtiene su propia línea en la RFQ a la que responden con sus propios precios."
 
 msgid "The surface finishes available on your materials"
 msgstr "Los acabados de superficie disponibles en tus materiales"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "El sistema pasa todas las pruebas de aceptación dentro del alcance en tu sistema configurado, con tus datos; los datos se validan; y das tu aprobación. Luego, lanzamiento."
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "El hilo que vincula una RFQ de ventas, su cotización y la orden de venta resultante - una unión, no un documento con su propio estado."
+msgstr "La conexión que vincula una RFQ de ventas, su cotización, y el pedido de venta resultante — una unión, no un documento con su propio estado."
 
 msgid "The timer starts automatically"
 msgstr "El cronómetro se inicia automáticamente"
@@ -15457,28 +15457,28 @@ msgid "The timer starts manually"
 msgstr "El cronómetro se inicia manualmente"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Las herramientas y accesorios en los que dependen tus operaciones"
+msgstr "Las herramientas y dispositivos de sujeción en los que confían sus operaciones"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "El total a fabricar en todos los trabajos creados en este lote masivo; combinado con Cantidad por Trabajo para decidir cuántos trabajos crear."
+msgstr "El total a fabricar en todas las órdenes de trabajo creadas en esta operación en lote; combinado con Cantidad por Orden de trabajo para decidir cuántas órdenes de trabajo crear."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "La referencia rastreable (por ejemplo, estándar NIST, número de serie de indicador maestro) contra la cual se compararon los valores de calibración."
+msgstr "La referencia trazable (por ejemplo, estándar NIST, número de serie del instrumento maestro) contra la que se compararon los valores de calibración."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "La hoja de ruta lista cada artículo en la lista de materiales con su cantidad."
+msgstr "La hoja viajera lista cada artículo en la lista de materiales con su cantidad."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "El tipo controla qué permisos predeterminados recibe el nuevo empleado; seleccionarlo aquí completa previamente la matriz de permisos de la plantilla del tipo."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "El número típico de días entre enviar trabajo a este proveedor para este proceso y devolverlo; la planificación compensa la demanda por esta cantidad al seleccionar un proveedor."
+msgstr "El número típico de días entre enviar el trabajo a este proveedor para este proceso y recibirlo de regreso; la planificación aplica un desfase a la demanda por este tiempo cuando se selecciona un proveedor."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "El identificador único en esta unidad física; una fila por número de serie, la cantidad siempre es 1."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "La unidad en la que se expresa un tiempo de enrutamiento, como Horas/Pieza u Horas Totales, que indica a Carbon si el tiempo se escala con la cantidad o es fijo por ejecución."
+msgstr "La unidad en la que se expresa el tiempo de ruta, como Horas/Pieza u Horas totales, indicando a Carbon si el tiempo se escala con la cantidad o es fijo por ejecución."
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "El precio unitario del artículo en el momento de la compra"
@@ -15493,7 +15493,7 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "Las unidades de medida en las que compras, almacenas y vendes"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "El sistema de depreciación fiscal estadounidense con tablas de clase de propiedad del IRS, ejecutado como un cronograma fiscal separado junto al cronograma de libros."
+msgstr "El sistema de depreciación fiscal de EE.UU. con tablas de clase de propiedad del IRS, ejecutado como un programa fiscal separado junto al programa contable."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "Los usuarios en este grupo; los permisos y notificaciones con alcance de grupo se aplican a cada miembro, y los usuarios pueden pertenecer a varios grupos (los permisos efectivos son la unión)."
@@ -15517,7 +15517,7 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "El almacén desde el cual se enviarán los bienes de esta cotización; la ubicación de envío del cliente es donde llegarán."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "Las formas en que los equipos fallan, para el seguimiento del mantenimiento y la calidad"
+msgstr "Las formas en que el equipo falla, para el seguimiento de mantenimiento y calidad"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
 msgstr "El contenedor propio del centro de trabajo donde el material recogido se prepara para que la producción lo consuma, a diferencia de su estante fuente del almacén."
@@ -15535,7 +15535,7 @@ msgid "Then by"
 msgstr "Luego por"
 
 msgid "There are no active supplier quotes to compare for this RFQ."
-msgstr "No hay presupuestos de proveedores activos para comparar en esta solicitud de cotización."
+msgstr "No hay cotizaciones de proveedor activas para comparar para esta RFQ."
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
 msgstr "Hay operaciones externas asociadas con este trabajo que no tienen proveedores. Por favor, asigne un proveedor a cada operación externa antes de liberarlo."
@@ -15559,25 +15559,25 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Estos elementos aún tienen material para recoger. Finalizar ahora marca la lista como Parcial."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Estos trabajos tienen operaciones asignadas a este centro de trabajo:"
+msgstr "Estas órdenes de trabajo tienen operaciones asignadas a este centro de trabajo:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Estos asientos de diario aún están en Borrador, por lo que sus débitos y créditos no están en el libro mayor para este período. Contabilice cada uno, o reescalone a un período abierto posterior."
+msgstr "Estos asientos aún están en Borrador, por lo que sus debe y haber no están en el libro mayor para este período. Contabiliza cada uno, o cambia su fecha a un período abierto posterior."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "Esta instancia de Carbon no tiene credenciales OAuth de Onshape. Pide a un administrador que las configure."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "Esta notificación de cambio está siendo implementada, por lo que sus cambios están bloqueados. Reabrala para editar."
+msgstr "Este aviso de cambio se está implementando, por lo que sus cambios están bloqueados. Reabre para editar."
 
 msgid "This change notice is closed, so its changes are read-only."
-msgstr "Esta notificación de cambio está cerrada, por lo que sus cambios son de solo lectura."
+msgstr "Este aviso de cambio está cerrado, por lo que sus cambios son de solo lectura."
 
 msgid "This completes the Discovery step."
 msgstr "Esto completa el paso de Descubrimiento."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Este contacto no tiene dirección de correo electrónico"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Este tercero no tiene nada pendiente — el pago se registrará en cuenta."
@@ -15589,7 +15589,7 @@ msgid "This file is no longer available, or you don't have permission to downloa
 msgstr "Este archivo ya no está disponible, o no tienes permiso para descargarlo."
 
 msgid "This Fiscal Year"
-msgstr "Este Año Fiscal"
+msgstr "Este Ejercicio fiscal"
 
 msgid "This information will be used on document headers"
 msgstr "Esta información se utilizará en los encabezados de documentos"
@@ -15602,13 +15602,13 @@ msgstr "este plan de inspección"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr "Esta invitación para unirse a {0} ha expirado. Puedes solicitar que se envíe una nueva invitación a tu correo electrónico."
+msgstr "Esta invitación para unirse a {0} ha vencido. Puedes solicitar que se envíe una nueva invitación a tu correo electrónico."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Esta factura no tiene una fecha de vencimiento utilizable — elige una para Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Esta factura se facturará al cliente de Stripe ya vinculado a este cliente de Carbon. Para cambiar sus detalles, edítalo en el panel de Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Este es un entorno controlado, por lo que se requiere una aplicación autenticadora."
@@ -15629,37 +15629,37 @@ msgid "This is taking longer than expected. It may still finish — if it doesn'
 msgstr "Esto está tomando más tiempo del esperado. Aún puede terminar; si no lo hace, reintenta el reverso para restaurar tus datos."
 
 msgid "This is the month your fiscal year starts."
-msgstr "Este es el mes en que comienza tu año fiscal."
+msgstr "Este es el mes en que comienza tu ejercicio fiscal."
 
 msgid "This is the month your tax year starts."
-msgstr "Este es el mes en que comienza tu año fiscal."
+msgstr "Este es el mes en que comienza tu año tributario."
 
 msgid "this item"
 msgstr "este artículo"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Este artículo se construye a través de un configurador y resuelve sus componentes por pedido; los trabajos creados para él heredan la BOM resuelta del configurador."
+msgstr "Este artículo se construye mediante un configurador y resuelve sus componentes por pedido; las órdenes de trabajo creadas para él heredan la BOM resuelta del configurador."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "La lista de materiales de este artículo no tiene entradas con vida útil habilitada, por lo que no se calculará ninguna fecha de vencimiento a partir de la lista de materiales."
+msgstr "La lista de materiales de este artículo no tiene entradas con vida útil habilitada, por lo que no se calculará ninguna caducidad de la BOM."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "Este trabajo será recibido en el inventario. Ya no estará disponible en el piso de producción."
+msgstr "Esta orden de trabajo será recibida al inventario. Ya no estará disponible en la planta."
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "Este trabajo ya no estará disponible en el piso de producción."
+msgstr "Esta orden de trabajo ya no estará disponible en la planta."
 
 msgid "This job's own required quantity for the material."
 msgstr "La cantidad propia requerida por este trabajo para el material."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Este lote ha expirado y no se puede seleccionar."
+msgstr "Este lote ha vencido y no puede ser preparado."
 
 msgid "This may take a moment. Hang tight."
 msgstr "Esto puede tomar un momento. Aguanta firme."
 
 msgid "This method version is read-only. Create a new version from the method menu to make changes."
-msgstr "Esta versión del método es de solo lectura. Cree una nueva versión desde el menú del método para realizar cambios."
+msgstr "Esta versión del método es de solo lectura. Crea una nueva versión desde el menú del método para hacer cambios."
 
 msgid "This Month"
 msgstr "Este Mes"
@@ -15695,7 +15695,7 @@ msgid "This Quarter"
 msgstr "Este Trimestre"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "Esto elimina su aplicación autenticadora, por lo que su próximo inicio de sesión solo necesita un enlace mágico. Úsalo cuando hayan perdido acceso a su autenticador. Afecta su inicio de sesión para cada empresa a la que pertenecen."
+msgstr "Esto elimina su aplicación autenticadora, por lo que su próximo inicio de sesión solo necesita un enlace mágico. Usa esto cuando hayan perdido acceso a su autenticador. Afecta su inicio de sesión en cada empresa a la que pertenecen."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Esta revisión se ha liberado (Producción). Los cambios normalmente deben fluir a través de un aviso de cambio."
@@ -15710,10 +15710,10 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Esto ejecuta el flujo de trabajo de verdad. Creará registros, enviará notificaciones y llamará a cualquier webhook exactamente como lo haría una ejecución en vivo. Esto no se puede deshacer."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Este pedido de venta tiene trabajos asociados. Elige qué hacer con ellos."
+msgstr "Este pedido de venta tiene órdenes de trabajo asociadas. Elige qué hacer con ellas."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Esta orden de venta tiene líneas que requieren que se creen trabajos"
+msgstr "Este pedido de venta tiene líneas que requieren que se creen órdenes de trabajo"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "Esta versión no se puede abrir"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Esta versión está publicada"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Esta versión está publicada. Cree una nueva versión para editar."
 
 msgid "This version's definition could not be read."
 msgstr "La definición de esta versión no se pudo leer."
@@ -15760,7 +15760,7 @@ msgid "This will overwrite the existing job method"
 msgstr "Esto sobrescribirá el método de trabajo existente"
 
 msgid "This will overwrite the existing manufacturing method and the latest versions of all subassemblies."
-msgstr "Esto sobrescribirá el método de fabricación existente y las versiones más recientes de todos los subensamblajes."
+msgstr "Esto sobrescribirá el método de fabricación existente y las últimas versiones de todos los subensamblajes."
 
 msgid "This will overwrite the existing quote method"
 msgstr "Esto sobrescribirá el método de cotización existente"
@@ -15771,7 +15771,7 @@ msgstr "Esto recalculará el costo unitario del método de fabricación activo b
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "Esto eliminará el vínculo de {0} con {1}. El trabajo ya no aparecerá bajo la orden de venta y los envíos no lo encontrarán."
+msgstr "Esto eliminará el vínculo de {0} con {1}. La orden de trabajo ya no aparecerá bajo el pedido de venta y los envíos no la encontrarán."
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "Esto reemplazará todos los materiales de método de otras revisiones con esta revisión."
@@ -15786,7 +15786,7 @@ msgid "This will write off the remaining book value of the asset."
 msgstr "Esto liquidará el valor en libros restante del activo."
 
 msgid "Three-way match"
-msgstr "Coinciencia de tres vías"
+msgstr "Conciliación de tres vías"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Conciliación no disponible"
 
 msgid "Tightened"
-msgstr "Apretado"
+msgstr "Rigurosa"
 
 msgid "Time of day"
 msgstr "Hora del día"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "Tarjeta de tiempo"
 
 msgid "Timecards"
-msgstr "Tarjetas de tiempo"
+msgstr "Registro de tiempos"
 
 msgid "Timecards are disabled"
-msgstr "Las tarjetas de tiempo están deshabilitadas"
+msgstr "Registro de tiempos deshabilitado"
 
 msgid "Timecards are enabled"
-msgstr "Las tarjetas de tiempo están habilitadas"
+msgstr "Registro de tiempos habilitado"
 
 msgid "Timezone"
 msgstr "Zona horaria"
@@ -15865,10 +15865,10 @@ msgid "To Receive"
 msgstr "Por Recibir"
 
 msgid "To Ship"
-msgstr "Para Enviar"
+msgstr "Por enviar"
 
 msgid "To Ship and Receive"
-msgstr "Para Enviar y Recibir"
+msgstr "Por enviar y recibir"
 
 msgid "To Storage Unit"
 msgstr "Unidad de almacenamiento destino"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Herramientas"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Clasificación de nivel superior (activo/pasivo/patrimonio/ingresos/gastos); establecido solo en grupos raíz, heredado por hijos."
+msgstr "Clasificación de nivel superior (activo / pasivo / patrimonio / ingresos por ventas / gasto); se establece solo en grupos raíz, heredado por secundarios."
 
 msgid "Topic"
 msgstr "Tema"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "Cantidad Total"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Cantidad total disponible del artículo en todas las unidades de almacenamiento de esta ubicación. Se vuelve roja cuando lo disponible más lo entrante no puede cubrir la demanda total."
+msgstr "Cantidad total en existencia del artículo en todas las unidades de almacenamiento en esta ubicación. Se vuelve rojo cuando la cantidad en existencia más lo que viene no puede cubrir la demanda total."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Cantidad total requerida en todos los trabajos activos y órdenes de venta en esta ubicación, no solo en este trabajo."
+msgstr "Cantidad total requerida en todas las órdenes de trabajo activas y pedidos de venta en esta ubicación, no solo esta orden de trabajo."
 
 msgid "Total scrap quantity"
-msgstr "Cantidad total de desechos"
+msgstr "Cantidad total de desperdicio"
 
 msgid "Total tax"
 msgstr "Impuesto total"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "Valor Total"
 
 msgid "Total Variance"
-msgstr "Varianza Total"
+msgstr "Desviación total"
 
 msgid "Total:"
 msgstr "Total:"
@@ -16021,10 +16021,10 @@ msgid "Track serial/lot numbers and fulfil sales orders."
 msgstr "Rastrear números de serie/lote y cumplir pedidos de ventas."
 
 msgid "Track tax depreciation separately"
-msgstr "Rastrear la depreciación fiscal por separado"
+msgstr "Registrar depreciación tributaria por separado"
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "Realiza un seguimiento de la depreciación fiscal por separado de la depreciación contable y registra automáticamente los asientos de pasivo fiscal diferido."
+msgstr "Registrar depreciación tributaria por separado de la depreciación contable y contabilizar automáticamente las entradas de pasivo por impuesto diferido."
 
 msgid "Track transactions by segment (cost center, project, service line)"
 msgstr "Rastrear transacciones por segmento (centro de costos, proyecto, línea de servicio)"
@@ -16045,7 +16045,7 @@ msgid "Tracked entity ID is required but none was found"
 msgstr "El ID de entidad rastreada es obligatorio pero no se encontró ninguno"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "El material rastreado está preseleccionado por orden de selección (FEFO), incluso sin una lista de selección."
+msgstr "El material rastreado se preselecciona por orden de picking (FEFO), incluso sin lista de picking."
 
 msgid "Tracking"
 msgstr "Seguimiento"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "Papelera"
 
 msgid "Trial Balance"
-msgstr "Balance de Comprobación"
+msgstr "Balance de prueba"
 
 msgid "Trigger"
 msgstr "Disparador"
@@ -16291,22 +16291,22 @@ msgid "unknown location"
 msgstr "ubicación desconocida"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Soporte funcional ilimitado"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Registros ilimitados"
 
 msgid "Unlink"
 msgstr "Desenlazar"
 
 msgid "Unlink job from sales order?"
-msgstr "¿Desenlazar trabajo de la orden de venta?"
+msgstr "¿Desconectar la orden de trabajo del pedido de venta?"
 
 msgid "Unlock"
 msgstr "Desbloquear"
 
 msgid "Unlock with passkey"
-msgstr "Desbloquear con contraseña de acceso"
+msgstr "Desbloquear con llave de acceso"
 
 msgid "Unmapped accounts"
 msgstr "Cuentas no asignadas"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Documentos No Contabilizados"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Despublicar"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "¿Despublicar {name}?"
 
 msgid "Unreceived POs"
 msgstr "POs no recibidas"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Actualizar problema de Linear"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Actualizar los tiempos de entrega de piezas a partir de recibos de compra registrados."
+msgstr "Actualizar plazos de entrega de piezas desde recepciones de compra contabilizadas."
 
 msgid "Update Password"
 msgstr "Actualizar Contraseña"
@@ -16478,16 +16478,16 @@ msgid "Upgrade to unlock audit history"
 msgstr "Actualizar para desbloquear el historial de auditoría"
 
 msgid "Upload"
-msgstr "Cargar"
+msgstr "Subir"
 
 msgid "Upload a PDF first"
-msgstr "Primero carga un PDF"
+msgstr "Subir un PDF primero"
 
 msgid "Upload completed but no file path returned"
-msgstr "Carga completada pero no se devolvió la ruta del archivo"
+msgstr "Carga completada pero no se devolvió ruta de archivo"
 
 msgid "Upload CSV"
-msgstr "Cargar CSV"
+msgstr "Subir CSV"
 
 msgid "Upload failed. Please try again."
 msgstr "Error al subir el archivo. Inténtalo de nuevo."
@@ -16597,7 +16597,7 @@ msgid "Users and groups allowed to open or download this document; the uploader 
 msgstr "Usuarios y grupos autorizados a abrir o descargar este documento; quien lo subió siempre está incluido."
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "Usuarios y grupos autorizados a renombrar, reemplazar o reetiquetar este documento; quien lo subió siempre está incluido y el acceso de edición implica el de visualización."
+msgstr "Usuarios y grupos autorizados a renombrar, reemplazar o reetiquetar este documento; el que carga siempre se incluye, y el acceso de edición implica acceso de visualización."
 
 msgid "Users can update this value for themselves"
 msgstr "Los usuarios pueden actualizar este valor por sí mismos"
@@ -16651,34 +16651,34 @@ msgid "Variables"
 msgstr "Variables"
 
 msgid "Variance"
-msgstr "Variación"
+msgstr "Desviación"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Varianza entre el consumo real y el estándar de componentes de BOM"
+msgstr "Desviación entre el consumo real y estándar de componentes de BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Varianza entre las horas y tarifas reales y estándar de enrutamiento"
+msgstr "Desviación entre horas y tarifas reales y estándar de la ruta de fabricación"
 
 msgid "Variance between actual purchase price and standard cost"
-msgstr "Varianza entre el precio de compra real y el costo estándar"
+msgstr "Desviación entre precio de compra real y costo estándar"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Varianza entre los gastos generales de fabricación reales y aplicados"
+msgstr "Desviación entre costos indirectos aplicados y reales de manufactura"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "Varianza por ajustes de conteo de inventario físico"
+msgstr "Desviación de ajustes de conteo físico de inventario"
 
 msgid "Variance in outside processing costs"
-msgstr "Varianza en los costos de procesamiento externo"
+msgstr "Desviación en costos de subcontratación"
 
 msgid "Variance only"
-msgstr "Solo varianza"
+msgstr "Solo desviación"
 
 msgid "VAT Number"
 msgstr "Número de IVA"
 
 msgid "Vendor Write-Off Income"
-msgstr "Ingresos por Cancelación de Proveedores"
+msgstr "Ingresos por cancelación contable de proveedor"
 
 msgid "Verification Error"
 msgstr "Error de verificación"
@@ -16703,7 +16703,7 @@ msgstr "Versión"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Versión {0} está publicada ahora y será reemplazada."
 
 msgid "Version:"
 msgstr "Versión:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Ver"
 
 msgid "View Active Jobs"
-msgstr "Ver trabajos activos"
+msgstr "Ver órdenes de trabajo activas"
 
 msgid "View Active Quotes"
 msgstr "Ver Cotizaciones Activas"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Ver Activo"
 
 msgid "View Assigned Jobs"
-msgstr "Ver trabajos asignados"
+msgstr "Ver órdenes de trabajo asignadas"
 
 msgid "View Attachment"
 msgstr "Ver Adjunto"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Ver Maestro de Artículos"
 
 msgid "View Journal Entry"
-msgstr "Ver Asiento de Diario"
+msgstr "Ver apunte"
 
 msgid "View Lists"
 msgstr "Ver Listas"
 
 msgid "View maintenance dispatch"
-msgstr "Ver despacho de mantenimiento"
+msgstr "Ver orden de mantenimiento"
 
 msgid "View Memo"
 msgstr "Ver Memorándum"
@@ -16931,7 +16931,7 @@ msgid "Voiding this shipment will:"
 msgstr "Anular este envío hará lo siguiente:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Recorre cada área con tu campeón y desactiva cualquier cosa fuera del alcance. Los códigos se leen Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Recorre cada área con tu campeón y marca cualquier cosa como fuera del alcance. Los códigos se leen como Módulo.Área.Número (ACC.GL.01 = Contabilidad, Libro mayor, elemento 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Recorre tu proceso actual, sistemas y datos"
@@ -16952,13 +16952,13 @@ msgid "Warn"
 msgstr "Advertencia"
 
 msgid "Warn — edits succeed with a warning"
-msgstr "Advertencia — las ediciones se realizan con una advertencia"
+msgstr "Advertir — las ediciones se realizan con una advertencia"
 
 msgid "Warn but allow"
 msgstr "Advertir pero permitir"
 
 msgid "Warn this many days before expiry"
-msgstr "Advertir esta cantidad de días antes del vencimiento"
+msgstr "Avisar esta cantidad de días antes de la caducidad"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Advertir cuando la persona que inspecciona un artículo entrante es la misma persona que lo recibió."
@@ -17083,7 +17083,7 @@ msgid "What changes day to day"
 msgstr "Qué cambia día a día"
 
 msgid "What changes when you move to Carbon, and roughly what it's worth. Estimates, not a forecast."
-msgstr "Qué cambia cuando te pasas a Carbon y aproximadamente cuánto vale. Estimaciones, no una previsión."
+msgstr "Qué cambia cuando migras a Carbon, y aproximadamente cuál es su valor. Estimaciones, no un pronóstico."
 
 msgid "What data"
 msgstr "Qué datos"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Qué impulsó el inventario hacia arriba o hacia abajo, por cualquier dimensión"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "¿Qué sucede cuando un diario está fechado en un período cerrado?"
+msgstr "Qué sucede cuando un asiento se registra en un período bloqueado."
 
 msgid "What is {translatedTerm}?"
 msgstr "¿Qué es {translatedTerm}?"
@@ -17104,13 +17104,13 @@ msgid "What kind of change this is: Version updates how the part is made, Revisi
 msgstr "Qué tipo de cambio es este: Versión actualiza cómo se fabrica la pieza, Revisión revisa sus detalles y documentos, Pieza de Reemplazo cambia por un nuevo número de pieza que reemplaza al anterior, y Nueva Pieza introduce una pieza completamente nueva sin predecesor."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Qué tipo de salida registra esta entrada — Producción (unidades buenas), Scrap (irrecuperable) o Rework (enviado de vuelta para corrección); revela Scrap Reason cuando Scrap."
+msgstr "Qué tipo de salida registra esta entrada — Producción (unidades buenas), Desperdicio (irrecuperable) o Retrabajo (enviado de vuelta para corrección); revela Motivo de desperdicio cuando es Desperdicio."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Qué tipo de PO es esta — bienes estándar, servicios, procesamiento externo o acuerdo global; impulsa el diseño de línea y las reglas de contabilización GL."
+msgstr "Qué tipo de PO es — bienes estándar, servicios, subcontratación o acuerdo general; determina el diseño de línea y las reglas de contabilización del libro mayor."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
-msgstr "Qué tipo de cotización es esta — cotización de proveedor estándar, cotización con precio de acuerdo global, o cotización de fabricación por contrato; impulsa el diseño de línea de PO cuando se convierte."
+msgstr "Qué tipo de cotización es — cotización de proveedor estándar, cotización con acuerdo general o cotización de fabricación personalizada; determina el diseño de línea de PO cuando se convierte."
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
 msgstr "De qué fuente esta dimensión obtiene sus valores permitidos (lista personalizada o una entidad existente como cliente, ubicación, empleado)."
@@ -17125,13 +17125,13 @@ msgid "What this receipt is fulfilling — a purchase order, a return, an inboun
 msgstr "Lo que este recibo está cumpliendo — una orden de compra, una devolución, una transferencia entrante o un recibo manual sin padre."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "Lo que este envío está cumpliendo — una orden de venta, una transferencia saliente, una devolución RMA o un envío manual."
+msgstr "Qué es lo que este envío está cumpliendo — un pedido de venta, una transferencia de salida, una devolución RMA o un envío manual."
 
 msgid "What this task means"
 msgstr "Qué significa esta tarea"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Como qué cuenta esta entrada de tiempo — Trabajo (tiempo del operador), Máquina (tiempo de ejecución) o Configuración (tiempo de cambio); cada uno se resume bajo una tasa diferente."
+msgstr "Qué cuenta esta entrada de tiempo como — Mano de obra (tiempo del operario), Máquina (tiempo de ejecución) o Preparación (tiempo de cambio); cada una se acumula bajo una tasa diferente."
 
 msgid "What to set up"
 msgstr "Qué configurar"
@@ -17155,10 +17155,10 @@ msgid "When {name} changes"
 msgstr "Cuando {name} cambia"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "Cuando la vida útil de un producto terminado se establece en Calculada, elige qué insumos consumidos alimentan el cálculo."
+msgstr "Cuando la vida de anaquel del producto terminado se establece en Calculada, selecciona qué materiales consumidos alimentan el cálculo."
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
-msgstr "Cuándo vence un serial o lote, y qué sucede si se usa después — una política de la compañía puede Advertir, Bloquear o BloquearConOversimplificación."
+msgstr "Cuando un serial o lote caduca, y qué sucede si se usa después — una política de la empresa puede Advertir, Bloquear o Bloquear con anulación."
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
 msgstr "Cuándo Carbon se comprometió a que llegaran los bienes; combinado con los días de tránsito del método de envío, esto impulsa el cálculo hacia atrás de la fecha de envío."
@@ -17176,7 +17176,7 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Cuando está activado, los empleados pueden editar el valor de este atributo en su propio perfil; de lo contrario, solo los administradores pueden hacerlo."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Cuando está activado, las reglas de precios (descuentos por volumen, promociones) aún se aplican además de esta invalidación; cuando está desactivado, esta invalidación es el precio final."
+msgstr "Cuando está activado, las reglas de precios (descuentos por volumen, promociones) aún se aplican sobre esta sobrescritura; cuando está desactivado, esta sobrescritura es el precio final."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Cuando está activado, escanear el código de barras de operación de este proceso reporta toda la cantidad abierta restante como completada en una acción; desactivar cuando los operadores informan habitualmente de cantidades parciales."
@@ -17185,7 +17185,7 @@ msgid "When on, this party's invoices skip tax calculation; the party is respons
 msgstr "Cuando está activado, las facturas de esta parte omiten el cálculo de impuestos; la parte es responsable de mantener el certificado de exención actualizado."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Cuando está activado, esta invalidación de precio se aplica a pedidos coincidentes; cuando está desactivado, la invalidación se conserva sin eliminar para preservar el historial de auditoría."
+msgstr "Cuando está activado, esta sobrescritura de precio se aplica a los pedidos coincidentes; al desactivar sin eliminar se preserva el historial para auditoría."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Cuando está activado, esta regla se dispara para cada objetivo de su tipo. Las filas de asignación se ignoran pero se conservan."
@@ -17203,10 +17203,10 @@ msgid "When the customer asked for delivery; the order commits to Promised Date,
 msgstr "Cuándo el cliente solicitó la entrega; la orden se compromete con la Fecha Prometida, que puede ser diferente."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Cuándo el cliente desea recibir los bienes; la cotización se compromete con esta fecha si el cliente acepta."
+msgstr "Cuándo el cliente solicitó recibir los bienes; la cotización se compromete a esta fecha si el cliente acepta."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Cuándo el cliente desea recibir los bienes."
+msgstr "Cuándo el cliente solicitó recibir los bienes."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "Cuándo el cliente envió esta RFQ; el reloj de respuesta comienza desde esta fecha."
@@ -17221,52 +17221,52 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Cuando se escanea la tarjeta kanban, el trabajo se mueve automáticamente fuera del borrador y se libera al piso."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Cuándo la ubicación receptora espera que llegue el stock; impulsa la disponibilidad MRP en el destino."
+msgstr "Cuándo la ubicación de recepción espera que lleguen las existencias; impulsa la disponibilidad de MRP en el destino."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Cuándo el proveedor se comprometió a entregar; la planificación utiliza esta fecha para la proyección del stock de entrada."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "Cuándo los precios del proveedor dejan de ser honrados; convertir esta cotización a un PO después de esta fecha puede requerir una nueva cotización."
+msgstr "Cuándo el precio del proveedor deja de ser honrado; convertir esta cotización a PO después de esta fecha puede requerir una nueva cotización."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Cuándo esta galga vence para calibración; una vez vencida muestra Fuera de Calibración."
+msgstr "Cuándo este instrumento de medición se vence para calibración; una vez vencido se lee como Fuera de calibración."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Cuándo este calibre fue calibrado por última vez exitosamente; la fecha de próxima calibración se recomputa de este valor más el intervalo."
+msgstr "Cuándo este instrumento de medición fue calibrado exitosamente por última vez; la fecha de próxima calibración se recalcula a partir de este valor más el intervalo."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "Cuando esto se vea correcto, márcalo como acordado. Eso completa el paso de Descubrimiento en tu centro de control."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Cuándo se promete enviar esta línea específica; anulación por línea del Promised Date del encabezado de orden para envíos divididos."
+msgstr "Cuándo se promete que esta línea específica se enviará; sobrescritura por línea de la Fecha prometida del encabezado del pedido para envíos divididos."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Cuándo expira este lote/serie específico; impulsa la recogida FEFO y la política de vida útil en el consumo."
+msgstr "Cuándo este lote/serial específico caduca; impulsa la selección FEFO y la política de vida de anaquel en el consumo."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Cuándo se comprometió a entregar; la planificación trata esto como la fecha de vencimiento de la demanda para la realización."
 
 msgid "When your fiscal and tax years start"
-msgstr "Cuándo comienzan sus años fiscales y tributarios"
+msgstr "Cuándo comienzan tus años fiscales e impositivos"
 
 msgid "Where a workflow notification is delivered — in-app is always sent, while email needs a Business or Partner plan and Slack needs your Slack workspace connected."
 msgstr "Dónde se entrega una notificación de flujo de trabajo — en la aplicación siempre se envía, mientras que el correo electrónico requiere un plan Business o Partner y Slack requiere que tu espacio de trabajo de Slack esté conectado."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Dónde se ejecuta una operación; lleva tasas de trabajo y cotización, con gastos generales la diferencia entre ellas."
+msgstr "Dónde se ejecuta una operación; lleva tasas de mano de obra y cotización, siendo los costos indirectos la diferencia entre ellas."
 
 msgid "Where and how you make things."
 msgstr "Dónde y cómo fabricas las cosas."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Dónde se envían los bienes en esta PO por defecto por el proveedor; las ubicaciones de entrega por línea en la PO anulan esto para escenarios de envío directo y entrega dividida."
+msgstr "Dónde se envían los bienes en este PO por defecto; ubicaciones de entrega por línea en el PO anulan esto para escenarios de envío directo y entrega dividida."
 
 msgid "Where it lives today"
 msgstr "Dónde vive hoy"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Dónde aterriza el nuevo stock de este artículo por defecto al recibirlo; las selecciones de almacenamiento por línea en un recibo lo anulan."
+msgstr "Dónde llegan por defecto las nuevas existencias de este artículo en la recepción; las selecciones de almacenamiento por línea en una recepción la anulan."
 
 msgid "Where stock lives and how it ships."
 msgstr "Dónde vive el stock y cómo se envía."
@@ -17281,7 +17281,7 @@ msgid "Where this issue was raised from — internal QA, customer complaint, sup
 msgstr "De dónde se planteó este problema — QA interno, queja del cliente, auditoría del proveedor, etc.; utilizado para la presentación de informes, no bloquea el flujo de trabajo."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "Dónde aterrizan los bienes de esta línea en el inventario al recibirlo; si está en blanco, los recibos utilizan la ubicación de almacenamiento predeterminada del artículo."
+msgstr "Dónde llegan en existencias los bienes de esta línea en la recepción; si está en blanco, las recepciones usan la unidad de almacenamiento predeterminada del artículo."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
 msgstr "De dónde se originó esta solicitud de mantenimiento — reportado por operador, programado, disparador de monitoreo de condición, inspección posterior; impulsa el desglose de fuente en informes de mantenimiento."
@@ -17296,19 +17296,19 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Si el importe se interpreta como un porcentaje del precio de línea o como un importe fijo de moneda."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Si Carbon sigue cada unidad (Serial), cada lote (Batch), la cantidad (Inventory) o sin seguimiento (Non-Inventory)."
+msgstr "Si Carbon realiza seguimiento de cada unidad (Serial), cada lote (Lote de producción), la cantidad (Inventario) o sin seguimiento (No inventariable)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Si el reloj comienza cuando el proceso elegido empieza o cuando se completa."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Si este lote/número de serie pasa la inspección (Pass) o falla (Fail); un Fail impide que el stock se reciba en el inventario disponible."
+msgstr "Si este lote/serial pasa inspección (Conforme) o falla (No conforme); un No conforme bloquea las existencias de ser recibidas en inventario disponible."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Si este proceso se ejecuta en centros de trabajo internos (Proceso, Montaje o Inspección) o en proveedores externos (Procesamiento Externo); revela diferentes campos posteriores, cambia cómo funcionan las rutas de planificación para este proceso y establece el tipo de operación predeterminado en nuevas operaciones."
+msgstr "Si este proceso se ejecuta en centros de trabajo internos (Proceso, Ensamble o Inspección) o en proveedores externos (Subcontratación); revela diferentes campos posteriores, cambia cómo funcionan las rutas de planificación para este proceso y establece el tipo de operación predeterminado en nuevas operaciones."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "Si este trabajo bloquea la producción (Inactivo), la degrada (Impacto), se encuentra en una ventana de tiempo de inactividad planificada (Planificada) o no tiene impacto de producción (Sin Impacto); informa la programación y la comunicación de tiempo de inactividad orientada al cliente."
+msgstr "Si este trabajo bloquea la producción (Paro), la degrada (Impacto), está en una ventana de tiempo de paro planificado (Planificado) o no tiene impacto en la producción (Sin impacto); informa la programación y la comunicación de tiempo de paro al cliente."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "Si se Agregan los permisos seleccionados además de lo que cada usuario ya tiene, o se Actualizan reemplazando el conjunto de permisos de cada usuario con la selección a continuación."
@@ -17317,10 +17317,10 @@ msgid "Which document drives each inspection flow for this item."
 msgstr "Qué documento conduce cada flujo de inspección para este artículo."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Qué tipo de solicitud enviar: GET lee algo, POST crea, PUT y PATCH actualizan, DELETE elimina. Un nuevo paso comienza con GET, y solo POST, PUT y PATCH llevan un cuerpo."
+msgstr "Qué tipo de solicitud enviar: GET lee algo, POST crea, PUT y PATCH actualizan, DELETE elimina. Un nuevo paso comienza con GET y solo POST, PUT y PATCH llevan un cuerpo."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
-msgstr "Qué evento de fabricación inicia el reloj de vida útil — por ejemplo, rellenado, sellado o QC final."
+msgstr "Qué evento de manufactura inicia el reloj de vida de anaquel — por ejemplo, llenado, sellado o QC final."
 
 msgid "Who Can Approve"
 msgstr "Quién Puede Aprobar"
@@ -17338,22 +17338,22 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Quién debe aprobar cotizaciones, pedidos y compras — y cuándo"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "¿Quién debe recibir notificaciones para despachos relacionados con mantenimiento?"
+msgstr "¿Quién debe recibir notificaciones para órdenes de mantenimiento relacionadas?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "¿Quién debe recibir notificaciones para despachos relacionados con operaciones?"
+msgstr "¿Quién debe recibir notificaciones para órdenes de mantenimiento relacionadas con operaciones?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "¿Quién debe recibir notificaciones para otros despachos?"
+msgstr "¿Quién debe recibir notificaciones para otras órdenes de mantenimiento?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "¿Quién debe recibir notificaciones para despachos relacionados con calidad?"
+msgstr "¿Quién debe recibir notificaciones para órdenes de mantenimiento relacionadas con calidad?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "¿Quién debe recibir notificaciones cuando se acepta o vence una cotización digital?"
+msgstr "¿Quién debe recibir notificaciones cuando una cotización digital es aceptada o ha vencido?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "¿Quién debe recibir notificaciones cuando un calibrador se descalibra?"
+msgstr "¿Quién debe recibir notificaciones cuando un instrumento de medición sale de calibración?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "¿Quién debería recibir notificaciones cuando se envía una nueva sugerencia?"
@@ -17365,7 +17365,7 @@ msgid "Who should receive notifications when a sales job is completed?"
 msgstr "¿Quién debe recibir notificaciones cuando se completa un trabajo de ventas?"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
-msgstr "¿Quién debe recibir notificaciones cuando se envía una cotización de proveedor?"
+msgstr "¿Quién debe recibir notificaciones cuando se envía una cotización del proveedor?"
 
 msgid "Who should receive notifications when an inventory job is completed?"
 msgstr "¿Quién debe recibir notificaciones cuando se completa un trabajo de inventario?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "¿Por qué está bloqueado?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Por qué el stock está cambiando — Positivo (encontrado), Negativo (perdido/scrap) o Establecer (reemplazar cantidad con un valor medido)."
+msgstr "Por qué las existencias están cambiando — Positivo (encontrado), Negativo (perdido/desperdicio) o Establecer (reemplazar el conteo con un valor medido)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Por qué se rechaza esta línea; mostrado en el presupuesto imprimible y registrado para reportes de ganancia-pérdida."
@@ -17401,10 +17401,10 @@ msgid "Window:"
 msgstr "Ventana:"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Producto en proceso"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Sin una lista de selección, los operarios recogen material de la pestaña Escanear."
+msgstr "Sin una lista de picking, los operarios hacen picking del material desde la pestaña Escanear."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17445,16 +17445,16 @@ msgid "Work Centers"
 msgstr "Centros de Trabajo"
 
 msgid "Work in process (WIP)"
-msgstr "Trabajo en proceso (WIP)"
+msgstr "Producto en proceso (WIP)"
 
 msgid "Work in progress"
-msgstr "Trabajo en progreso"
+msgstr "Trabajo en curso"
 
 msgid "Work in Progress (default)"
-msgstr "Trabajo en Progreso (predeterminado)"
+msgstr "Trabajo en curso (predeterminado)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Trabajo en Progreso (WIP)"
+msgstr "Producto en proceso (WIP)"
 
 msgid "Work instruction"
 msgstr "Instrucción de trabajo"
@@ -17487,23 +17487,23 @@ msgid "Worst Performing Machines"
 msgstr "Máquinas con Peor Desempeño"
 
 msgid "Write-Down Account"
-msgstr "Cuenta de Reducción de Valor"
+msgstr "Cuenta de Deterioro"
 
 msgid "Write-off"
-msgstr "Cancelación"
+msgstr "Cancelación contable"
 
 msgid "Write-Off"
-msgstr "Cancelación"
+msgstr "Cancelación contable"
 
 msgid "Write-Off Account"
-msgstr "Cuenta de Cancelación"
+msgstr "Cuenta de Cancelación contable"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Cancelación para {0}"
+msgstr "Cancelación contable para {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Baja de inventario descartado o devuelto a través de rechazos de inspección y disposiciones de NCR"
+msgstr "Cancelación contable de existencias desperdiciadas o devueltas a través de rechazos de inspección y disposiciones de NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
 msgstr "Reducir el valor de un activo a lo largo de su vida útil — un lote mensual que crea, revisa como borrador y luego contabiliza."
@@ -17563,7 +17563,7 @@ msgid "You don't have permission to edit this bill of process."
 msgstr "No tiene permiso para editar esta lista de operaciones."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "Tú lo diriges; nos aseguramos de que se haga bien. Ojos expertos en tu configuración, datos y lanzamiento."
+msgstr "Tú lo diriges; nosotros nos aseguramos de que se haga correctamente. Ojos expertos en tu configuración, datos e implementación."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Estás en vivo en Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Estás a un paso de tu espacio de trabajo."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Estás configurando Carbon por tu cuenta, a tu propio ritmo"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Has estado marcado durante {hoursElapsed} horas. ¿Olvidaste marcar la salida?"
+msgstr "Has estado fichado durante {hoursElapsed} horas. ¿Olvidaste fichar salida?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Tu cuenta permanece segura incluso si tu inicio de sesión es robado"
@@ -17687,7 +17687,7 @@ msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample si
 msgstr "Nivel de inspección Z1.4 (I / II / III); los niveles más altos significan tamaños de muestra más grandes para el mismo lote."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Severidad de Z1.4 (Normal / Tightened / Reduced); cambia por regla basado en el historial de aceptación de lotes recientes."
+msgstr "Severidad Z1.4 (Normal / Rigurosa / Reducida); cambia por regla según el historial reciente de aceptación de lotes."
 
 msgid "Zoom Box"
 msgstr "Cuadro de zoom"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -1088,7 +1088,7 @@ msgid "Add Affected Item"
 msgstr "Agregar artículo afectado"
 
 msgid "Add an extra layer of security by requiring a code from an authenticator app when signing in."
-msgstr "Añada una capa adicional de seguridad requiriendo un código de una aplicación de autenticación al iniciar sesión."
+msgstr "Agregar una capa adicional de seguridad requiriendo un código de una aplicación autenticadora al iniciar sesión."
 
 msgid "Add any notes about your decision..."
 msgstr "Agregue notas sobre su decisión..."
@@ -8931,7 +8931,7 @@ msgid "Map Lines Now"
 msgstr "Mapear líneas ahora"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Asigna tu plan de cuentas al del proveedor. Las cuentas de contabilización predeterminada y de gastos están marcadas como Obligatorias; los diarios contabilizados se envían utilizando el código de cuenta asignado del proveedor."
+msgstr "Asigne su Plan de cuentas al del proveedor. Las cuentas predeterminadas de contabilización y de gasto están marcadas como Requeridas; los asientos contabilizados se impulsan utilizando el código de cuenta del proveedor asignado."
 
 msgid "Map your current process, systems, and data"
 msgstr "Mapea tu proceso actual, sistemas y datos"
@@ -9786,7 +9786,7 @@ msgid "No Access"
 msgstr "Sin acceso"
 
 msgid "No accounts match your search"
-msgstr "Ninguna cuenta coincide con tu búsqueda"
+msgstr "Ninguna cuenta coincide con su búsqueda"
 
 msgid "No action needed"
 msgstr "Sin acción necesaria"
@@ -14350,14 +14350,14 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe envía la factura al cliente por correo electrónico, por lo que se requiere una dirección. Esta también se guardará en el contacto en Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La contabilización creará uno en tu cuenta conectada."
+msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La contabilización creará uno en su cuenta conectada."
 msgstr "Fecha de Vencimiento de Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe envía la factura por correo electrónico al cliente, por lo que se requiere una dirección. Esto también se guardará en el contacto en Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. Al publicar, se creará uno en tu cuenta conectada."
+msgstr "Stripe aún no tiene un cliente para este cliente de Carbon. La contabilización creará uno en su cuenta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de salida de kanban para mostrar en la tabla Kanban"

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -520,7 +520,6 @@ msgstr "Finalizar de todas formas"
 
 msgid "Finish setting up your account"
 msgstr "Finalizar la configuración de su cuenta"
-msgstr "Finaliza la configuración de tu cuenta"
 
 msgid "Finish with material unpicked?"
 msgstr "¿Finalizar con material sin recoger?"
@@ -533,7 +532,6 @@ msgstr "Volver a la operación"
 
 msgid "Go to onboarding"
 msgstr "Ir a la incorporación"
-msgstr "Ir a la configuración"
 
 msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
@@ -1516,7 +1514,6 @@ msgstr "Ha estado fichado durante {hoursElapsed} horas. ¿Olvidó fichar salida?
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Tu cuenta aún no forma parte de una empresa. Completa la incorporación en Carbon ERP para continuar."
-msgstr "Tu cuenta aún no forma parte de una empresa. Completa la configuración inicial en Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Tu organización requiere una aplicación de autenticación. Configúrala en Carbon y luego vuelve aquí."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Descartados"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} unidad(es) aprobada(s) se completará(n)."
+msgstr "{completions} unidades superadas se completarán."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} fallo(s) muestreado(s) registrado(s) y NO serán completado(s) — resuélvalo(s) desde el menú de acciones."
@@ -94,7 +94,7 @@ msgid "Add & Issue"
 msgstr "Agregar y emitir"
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Añade una impresora en la configuración de impresión para imprimir etiquetas directamente."
+msgstr "Agregue una impresora en la configuración de impresión para imprimir etiquetas directamente."
 
 msgid "Add Inventory"
 msgstr "Agregar inventario"
@@ -112,10 +112,10 @@ msgid "All clear"
 msgstr "Todo despejado"
 
 msgid "All rework"
-msgstr "Todo reproceso"
+msgstr "Todo retrabajo"
 
 msgid "All scrap"
-msgstr "Todo chatarra"
+msgstr "Todo desperdicio"
 
 msgid "Allocate failed units"
 msgstr "Asignar unidades fallidas"
@@ -145,7 +145,7 @@ msgid "Assigned to Me"
 msgstr "Asignado a mí"
 
 msgid "Assignee"
-msgstr "Responsable"
+msgstr "Asignado"
 
 msgid "Authentication Error"
 msgstr "Error de autenticación"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Limpiar búsqueda"
 
 msgid "Clock In"
-msgstr "Registrar entrada"
+msgstr "Fichar entrada"
 
 msgid "Clock Out"
-msgstr "Registrar salida"
+msgstr "Fichar salida"
 
 msgid "Clocked in since <0/>"
 msgstr "Marcado entrada desde <0/>"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "Completar todo"
 
 msgid "Complete passed"
-msgstr "Completar aprobados"
+msgstr "Completar superados"
 
 msgid "Completed"
 msgstr "Completado"
@@ -296,7 +296,7 @@ msgid "Create Quality Issue"
 msgstr "Crear Problema de Calidad"
 
 msgid "Create Rework"
-msgstr "Crear Reelaboración"
+msgstr "Crear retrabajo"
 
 msgid "Current work"
 msgstr "Trabajo actual"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Detalles"
 
 msgid "Dispatch not found"
-msgstr "Despacho no encontrado"
+msgstr "Orden de mantenimiento no encontrada"
 
 msgid "Display"
 msgstr "Visualización"
@@ -413,7 +413,7 @@ msgid "Elapsed"
 msgstr "Tiempo transcurrido"
 
 msgid "Email Address"
-msgstr "Correo electrónico"
+msgstr "Dirección de correo electrónico"
 
 msgid "Empty work centers"
 msgstr "Centros de trabajo vacíos"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "Estimado"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "Cada unidad tiene un veredicto: {passes} aprobadas y {fails} rechazadas. El lote se cierra con cada unidad dirigida a su propio resultado."
+msgstr "Cada unidad tiene un veredicto: {passes} superadas y {fails} rechazadas. El lote se cierra con cada unidad dirigida a su propio resultado."
 
 msgid "Expand features table"
 msgstr "Expandir tabla de características"
@@ -448,7 +448,7 @@ msgstr "Vencido"
 
 #. placeholder {0}: formatDate(date)
 msgid "Expired {0}"
-msgstr "Expirado {0}"
+msgstr "Vencido {0}"
 
 msgid "Expires <0/>"
 msgstr "Expira <0/>"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Finalizar de todas formas"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Finalizar la configuración de su cuenta"
 
 msgid "Finish with material unpicked?"
 msgstr "¿Finalizar con material sin recoger?"
 
 msgid "Forgot to Clock Out?"
-msgstr "¿Olvidó registrar la salida?"
+msgstr "¿Olvidó fichar salida?"
 
 msgid "Go back to operation"
 msgstr "Volver a la operación"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Ir a la incorporación"
 
 msgid "How many were actually picked?"
 msgstr "¿Cuántos se recogieron realmente?"
@@ -562,7 +562,7 @@ msgid "in {0}"
 msgstr "en {0}"
 
 msgid "In Progress"
-msgstr "En progreso"
+msgstr "En curso"
 
 msgid "Inspect Item"
 msgstr "Inspeccionar artículo"
@@ -616,13 +616,13 @@ msgid "Job Details"
 msgstr "Detalles del trabajo"
 
 msgid "Job Traveler"
-msgstr "Viajero de trabajo"
+msgstr "Hoja viajera"
 
 msgid "Jobs"
-msgstr "Trabajos"
+msgstr "Órdenes de trabajo"
 
 msgid "Keep picking"
-msgstr "Continuar recogiendo"
+msgstr "Continuar picking"
 
 msgid "Kit"
 msgstr "Kit"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Mantenimiento completado"
 
 msgid "Maintenance overdue"
-msgstr "Mantenimiento vencido"
+msgstr "Mantenimiento atrasado"
 
 msgid "Make a replacement"
 msgstr "Hacer un reemplazo"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "Agregar artículos al inventario manualmente"
 
 msgid "Manually remove items from inventory"
-msgstr "Eliminar artículos del inventario manualmente"
+msgstr "Quitar manualmente artículos del inventario"
 
 msgid "Mark Short"
 msgstr "Marcar como faltante"
@@ -776,7 +776,7 @@ msgid "No active job at this work center"
 msgstr "Sin trabajo activo en este centro de trabajo"
 
 msgid "No active maintenance dispatches"
-msgstr "No hay despachos de mantenimiento activos"
+msgstr "Sin órdenes de mantenimiento en curso"
 
 msgid "No active operations"
 msgstr "No hay operaciones activas"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "No se encontraron entidades rastreadas disponibles"
 
 msgid "No dispatches assigned to you"
-msgstr "No hay despachos asignados a usted"
+msgstr "Sin órdenes de mantenimiento asignadas a usted"
 
 msgid "No files"
 msgstr "Sin archivos"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Sin materiales"
 
 msgid "No open jobs"
-msgstr "Sin trabajos abiertos"
+msgstr "Sin órdenes de trabajo abiertas"
 
 msgid "No open units to allocate"
 msgstr "No hay unidades abiertas para asignar"
@@ -899,7 +899,7 @@ msgid "Nothing scheduled at this work center"
 msgstr "Nada programado en este centro de trabajo"
 
 msgid "Nothing to scrap"
-msgstr "Nada que descartar"
+msgstr "Nada que enviar a desperdicio"
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -927,7 +927,7 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Abrir un NCR para la disposición de MRB"
 
 msgid "Open Jobs"
-msgstr "Trabajos Abiertos"
+msgstr "Órdenes de trabajo abiertas"
 
 msgid "Operations"
 msgstr "Operaciones"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "Resultado general"
 
 msgid "Overdue PMs?"
-msgstr "¿PM vencidos?"
+msgstr "¿Mantenimiento preventivo atrasado?"
 
 msgid "Parameters"
 msgstr "Parámetros"
@@ -966,10 +966,10 @@ msgid "Partial Disposition"
 msgstr "Disposición Parcial"
 
 msgid "Passed Inspection"
-msgstr "Inspección aprobada"
+msgstr "Inspección superada"
 
 msgid "Passkey unlock failed"
-msgstr "Error al desbloquear con clave de acceso"
+msgstr "Desbloqueo con llave de acceso fallido"
 
 msgid "Pause"
 msgstr "Pausar"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "Cola vacía"
 
 msgid "Reason for rework"
-msgstr "Motivo del reproceso"
+msgstr "Motivo del retrabajo"
 
 msgid "Recent"
 msgstr "Recientes"
@@ -1081,37 +1081,37 @@ msgid "Reject Lot"
 msgstr "Rechazar lote"
 
 msgid "Remove"
-msgstr "Eliminar"
+msgstr "Quitar"
 
 msgid "Remove filter"
-msgstr "Eliminar filtro"
+msgstr "Quitar filtro"
 
 msgid "Remove Inventory"
-msgstr "Eliminar inventario"
+msgstr "Quitar inventario"
 
 msgid "Remove part"
-msgstr "Eliminar pieza"
+msgstr "Quitar pieza"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "Reabrir el subconjunto y crear una unidad de reemplazo"
+msgstr "Reabrir el subensamble y crear una unidad de reemplazo"
 
 msgid "Result"
 msgstr "Resultado"
 
 msgid "Rework"
-msgstr "Reelaboración"
+msgstr "Retrabajo"
 
 msgid "Rework created successfully"
-msgstr "Rework creado exitosamente"
+msgstr "Retrabajo creado exitosamente"
 
 msgid "Rework quantity"
-msgstr "Cantidad de reproceso"
+msgstr "Cantidad de retrabajo"
 
 msgid "Running"
 msgstr "En ejecución"
 
 msgid "Sales Order"
-msgstr "Orden de venta"
+msgstr "Pedido de venta"
 
 msgid "Save"
 msgstr "Guardar"
@@ -1141,16 +1141,16 @@ msgid "Schedule"
 msgstr "Programación"
 
 msgid "Scrap"
-msgstr "Descartar"
+msgstr "Desperdicio"
 
 msgid "Scrap {readableId}"
-msgstr "Descartar {readableId}"
+msgstr "Desperdicio {readableId}"
 
 msgid "Scrap material"
-msgstr "Descartar material"
+msgstr "Material de desperdicio"
 
 msgid "Scrap quantity"
-msgstr "Cantidad de desecho"
+msgstr "Cantidad de desperdicio"
 
 msgid "Scrap Reason"
 msgstr "Motivo de desperdicio"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Sesión bloqueada"
 
 msgid "Set Clock Out"
-msgstr "Establecer salida"
+msgstr "Establecer hora de salida"
 
 msgid "Set clock-out time"
 msgstr "Establecer hora de salida"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "Iniciar sesión con Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Iniciar sesión con Passkey"
+msgstr "Iniciar sesión con Llave de acceso"
 
 msgid "Sign out"
 msgstr "Cerrar sesión"
@@ -1316,7 +1316,7 @@ msgstr "Estación: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "La aceptación estadística falló, por lo que el lote completo de {0} se considera no conforme (ISO 9001:2015 §8.7) — {passes} aprobación(es) muestreada(s) y {fails} fallo(s). Dirija las unidades a continuación a desecho o reproceso, o registre solo el veredicto."
+msgstr "La aceptación estadística falló, por lo que todo el lote de {0} se considera no conforme (ISO 9001:2015 §8.7) — {passes} conformes muestreados y {fails} fallo(s). Dirija las unidades a continuación a desperdicio o retrabajo, o registre solo el veredicto."
 
 msgid "Status"
 msgstr "Estado"
@@ -1355,7 +1355,7 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "La cantidad completada para esta operación es menor que la cantidad requerida de {targetQuantity}."
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "El lote se marcará como Aprobado y {remaining} unidad(es) restante(s) se completarán en esta operación."
+msgstr "El lote será marcado como Superado y {remaining} unidades restantes se completarán en esta operación."
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "El lote seguirá siendo disposicionado, pero no se puede crear un NCR hasta que se configure al menos un tipo de problema."
@@ -1370,10 +1370,10 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Estos elementos aún tienen material para recoger. Finalizar ahora marca la lista como Parcial."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Este lote ha expirado y no se puede seleccionar."
+msgstr "Este lote está vencido y no puede ser preparado."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Esta pieza fue hecha por encargo. Descartarla puede reabrir su ruta para hacer un reemplazo."
+msgstr "Esta pieza se fabricó bajo pedido. Descartarla puede reabrir su ruta de fabricación para fabricar un reemplazo."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
 msgstr "Esta pieza será descartada del inventario. Su requisito permanece abierto para que puedas emitir un reemplazo."
@@ -1436,7 +1436,7 @@ msgid "Unlock"
 msgstr "Desbloquear"
 
 msgid "Unlock with passkey"
-msgstr "Desbloquear con clave de acceso"
+msgstr "Desbloquear con Llave de acceso"
 
 msgid "Unpick"
 msgstr "Descoger"
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "Descartar {0}"
 
 msgid "Unplanned downtime"
-msgstr "Tiempo de inactividad no planificado"
+msgstr "Tiempo de paro no planificado"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1459,7 +1459,7 @@ msgid "Up next"
 msgstr "Próximo"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
-msgstr "Hasta {maxAllocatable} unidad(es) pueden asignarse; el resto se registra sin una publicación."
+msgstr "Se pueden asignar hasta {maxAllocatable} unidades; el resto se registra sin contabilización."
 
 msgid "Update"
 msgstr "Actualizar"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "Verificar"
 
 msgid "View maintenance dispatch"
-msgstr "Ver despacho de mantenimiento"
+msgstr "Ver orden de mantenimiento"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "Le hemos enviado un enlace mágico para iniciar sesión en su cuenta."
@@ -1495,7 +1495,7 @@ msgid "What is {translatedTerm}?"
 msgstr "¿Qué es {translatedTerm}?"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Producto en proceso"
 
 msgid "Work Center"
 msgstr "Centro de trabajo"
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Marcaste entrada a las <0/>. Puedes editar tu hora de salida a continuación o confirmar que aún estás trabajando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Ha estado registrado durante {hoursElapsed} horas. ¿Olvidó registrar la salida?"
+msgstr "Ha estado fichado durante {hoursElapsed} horas. ¿Olvidó fichar salida?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Tu cuenta aún no forma parte de una empresa. Completa la incorporación en Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Tu organización requiere una aplicación de autenticación. Configúrala en Carbon y luego vuelve aquí."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -8935,7 +8935,7 @@ msgid "Map Lines Now"
 msgstr "Mapper les lignes maintenant"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Mappez votre plan comptable avec celui du fournisseur. Les comptes par défaut de comptabilisation et les comptes de dépenses sont marqués Obligatoire ; les journaux comptabilisés sont poussés en utilisant le code de compte du fournisseur mappé."
+msgstr "Mappez votre plan comptable au plan comptable du fournisseur. Les comptes de comptabilisation par défaut et les comptes de charge sont marqués Requis ; les écritures comptabilisées utilisent le code de compte du fournisseur mappé."
 
 msgid "Map your current process, systems, and data"
 msgstr "Cartographiez votre processus actuel, vos systèmes et vos données"
@@ -11619,7 +11619,7 @@ msgid "Protect training time and attend"
 msgstr "Protégez le temps de formation et participez"
 
 msgid "Protect your company with advanced security controls like two-factor authentication enforcement."
-msgstr "Protégez votre entreprise avec des contrôles de sécurité avancés, comme l'authentification à deux facteurs obligatoire."
+msgstr "Protégez votre société avec des contrôles de sécurité avancés tels que l'application d'une authentification à deux facteurs."
 
 msgid "Protects your company's data"
 msgstr "Protège les données de votre société"
@@ -12498,7 +12498,7 @@ msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "Exiger un code à 6 chiffres d'une application d'authentification lors de la connexion."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected."
-msgstr "Exiger une application d'authentification avant que quiconque puisse ouvrir cette entreprise. Leurs autres entreprises ne sont pas affectées."
+msgstr "Exigez une application d'authentification avant que quiconque puisse ouvrir cette société. Leurs autres sociétés ne sont pas affectées."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
 msgstr "Exiger une application d'authentification avant que quiconque puisse ouvrir cette société. Leurs autres sociétés ne sont pas affectées. Visitez la <0>page des comptes employé</0> pour voir le statut de chaque personne."
@@ -14357,7 +14357,7 @@ msgstr "Stripe n'a pas encore de client pour ce client Carbon. La comptabilisati
 msgstr "Stripe envoie la facture par email au client, donc une adresse est requise. Celle-ci sera également enregistrée dans le contact dans Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe n'a pas encore de client pour ce client Carbon. La publication en créera un sur votre compte connecté."
+msgstr "Stripe n'a pas encore de client pour ce client Carbon. La comptabilisation en créera un sur votre compte connecté."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Style de sortie kanban à afficher dans le tableau Kanban"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -170,7 +170,6 @@ msgstr "{from}–{to} sur {count} opérations"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "{hiddenCount} autres : {hiddenNames}"
-msgstr "{hiddenCount} de plus : {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -362,7 +361,6 @@ msgstr "Un prestataire est un contact fournisseur ayant des compétences particu
 
 msgid "A custom solution to meet your needs"
 msgstr "Une solution personnalisée pour répondre à vos besoins."
-msgstr "Une solution personnalisée pour répondre à vos besoins"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un client est une entreprise ou une personne qui achète vos pièces ou services."
@@ -479,7 +477,6 @@ msgstr "Une version gérée de Carbon hébergée en nuage."
 
 msgid "A managed version with all the advanced features"
 msgstr "Une version gérée avec toutes les fonctionnalités avancées."
-msgstr "Une version managée du Cloud de Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Une version managée avec toutes les fonctionnalités avancées"
@@ -507,7 +504,6 @@ msgstr "Une nouvelle taille sera créée en utilisant une copie de la taille act
 
 msgid "A new Stripe customer will be created"
 msgstr "Un nouveau client Stripe sera créé."
-msgstr "Un nouveau client Stripe sera créé"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Un document sans trésorerie qui règle une facture sur un compte de raison : un crédit réduit ce qui est dû, un débit l'augmente."
@@ -1617,7 +1613,6 @@ msgstr "Clés API pour un accès programmatique à vos données Carbon."
 
 msgid "API, webhooks, and integrations"
 msgstr "API, Webhooks et Intégrations"
-msgstr "API, webhooks et intégrations"
 
 msgid "Applied"
 msgstr "Appliqué"
@@ -2386,7 +2381,6 @@ msgstr "Mises à jour automatiques"
 
 msgid "Automatic updates and backups"
 msgstr "Mises à jour automatiques et sauvegardes"
-msgstr "Mises à jour et sauvegardes automatiques"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consommation automatique au prorata des matériaux non tracés d'un travail lors du signalement de la production — les matériaux tracés sont émis manuellement."
@@ -2487,7 +2481,6 @@ msgstr "Prix de base"
 
 msgid "Basic ERP, MES, and QMS functionality"
 msgstr "Fonctionnalités de base ERP, MES et QMS"
-msgstr "Fonctionnalité de base ERP, MES et QMS"
 
 msgid "Basic Information"
 msgstr "Informations de base"
@@ -2628,7 +2621,6 @@ msgstr "Parcourir la bibliothèque"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Parcourez la version publiée en lecture seule. Vous pouvez toujours réarranger les étapes pour nettoyer la mise en page."
-msgstr "Consultez la version publiée en lecture seule. Vous pouvez toujours réorganiser les étapes pour organiser la mise en page."
 
 msgid "Bucket"
 msgstr "Compartiment"
@@ -3185,7 +3177,6 @@ msgstr "Cloud, ou votre environnement auto-hébergé."
 
 msgid "CMMC compliant"
 msgstr "CMMC conforme"
-msgstr "Conforme CMMC"
 
 msgid "Code"
 msgstr "Code"
@@ -4426,7 +4417,6 @@ msgstr "Clients"
 
 msgid "Customizations, training, and integrations"
 msgstr "Personnalisations, formations et intégrations"
-msgstr "Personnalisations, formation et intégrations"
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -6994,7 +6984,6 @@ msgstr "Format"
 
 msgid "Forward deployed engineer"
 msgstr "Ingénieur dédié au terrain"
-msgstr "Ingénieur déployé en avant"
 
 msgid "Foundation"
 msgstr "Fondation"
@@ -7051,7 +7040,6 @@ msgstr "Nom complet"
 
 msgid "Full setup and migrations"
 msgstr "Réglage complet et migrations"
-msgstr "Configuration complète et migrations"
 
 msgid "Fully Depreciated"
 msgstr "Totalement amorti"
@@ -8149,7 +8137,6 @@ msgstr "Problèmes"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Elle s'arrêtera d'être exécutée jusqu'à ce que vous publiiez une nouvelle version. Rien n'est supprimé."
-msgstr "Il s'arrêtera jusqu'à ce que vous publiiez à nouveau une version. Rien n'est supprimé."
 
 msgid "ITAR Certifications"
 msgstr "Certifications ITAR"
@@ -8521,7 +8508,6 @@ msgstr "Moins de travail manuel, moins d'erreurs"
 
 msgid "Let's Build"
 msgstr "Allons construire"
-msgstr "Commençons"
 
 msgid "Let's build something"
 msgstr "Construisons quelque chose"
@@ -8603,7 +8589,6 @@ msgstr "Lier un problème Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Liez ce client Carbon à l'un d'entre eux, ou créez un client Stripe distinct."
-msgstr "Liez ce client Carbon à l'un d'eux, ou créez un client Stripe séparé."
 
 msgid "Link to sales order line"
 msgstr "Lier à la ligne de commande client"
@@ -12677,7 +12662,6 @@ msgstr "Inverser les écritures de registre d'articles de cette facture"
 
 msgid "Reverse charge"
 msgstr "Autofacture"
-msgstr "Facture inversée"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Taxe de vente d'autoliquidation"
@@ -13499,7 +13483,6 @@ msgstr "Auto-hébergé ou géré"
 
 msgid "Self-onboarding"
 msgstr "Intégration autonome"
-msgstr "Auto-hébergé ou managé"
 
 msgid "Self-onboarding"
 msgstr "Auto-intégration"
@@ -14344,7 +14327,6 @@ msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
 msgstr "Stripe possède déjà un client avec cet e-mail"
-msgstr "Stripe a déjà un client avec cet email"
 
 msgid "Stripe Due Date"
 msgstr "Date d'échéance Stripe"
@@ -14354,7 +14336,6 @@ msgstr "Stripe envoie par e-mail la facture au client, c'est pourquoi une adress
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe n'a pas encore de client pour ce client Carbon. La comptabilisation en créera un sur votre compte connecté."
-msgstr "Stripe envoie la facture par email au client, donc une adresse est requise. Celle-ci sera également enregistrée dans le contact dans Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe n'a pas encore de client pour ce client Carbon. La comptabilisation en créera un sur votre compte connecté."
@@ -14773,7 +14754,6 @@ msgstr "Méthode d'amortissement fiscal"
 
 msgid "Tax exempt"
 msgstr "Exonéré de taxe"
-msgstr "Exonéré de taxes"
 
 msgid "Tax Exempt"
 msgstr "Exonéré de Taxe"
@@ -15637,7 +15617,6 @@ msgstr "Cela complète l'étape de découverte."
 
 msgid "This contact has no email address"
 msgstr "Ce contact n'a pas d'adresse e-mail"
-msgstr "Ce contact n'a pas d'adresse email"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Ce tiers n'a rien en suspens — le paiement sera enregistré en compte courant."
@@ -15669,7 +15648,6 @@ msgstr "Cette facture n'a pas de date d'échéance utilisable — choisissez-en 
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Cette facture sera facturée au client Stripe déjà lié à ce client Carbon. Pour modifier ses détails, modifiez-le dans le tableau de bord Stripe."
-msgstr "Cette facture sera facturée au client Stripe déjà lié à ce client Carbon. Pour modifier ses détails, modifiez-la dans le tableau de bord Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "C'est un environnement contrôlé, donc une application d'authentification est requise."
@@ -15810,7 +15788,6 @@ msgstr "Cette version est publiée."
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Cette version est publiée. Créez une nouvelle version pour la modifier."
-msgstr "Cette version est publiée"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Cette version est publiée. Créez une nouvelle version à modifier."
@@ -16360,7 +16337,6 @@ msgstr "localisation inconnue"
 
 msgid "Unlimited functional support"
 msgstr "Soutien fonctionnel illimité"
-msgstr "Support fonctionnel illimité"
 
 msgid "Unlimited records"
 msgstr "Enregistrements illimités"
@@ -16770,7 +16746,6 @@ msgstr "Version"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "La version {0} est publiée maintenant et sera remplacée."
-msgstr "La version {0} est maintenant publiée et sera remplacée."
 
 msgid "Version:"
 msgstr "Version :"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -30,10 +30,10 @@ msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
 msgstr "« {0} » n'est pas disponible sur la ou les surfaces sélectionnées. Choisissez un autre champ."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "« ${storageUnitName} » possède ${childCount} unités de stockage imbriquées directes. La supprimer supprimera également ces unités et tout ce qui se trouve en dessous. Cette action ne peut pas être annulée."
+msgstr "« {storageUnitName} » possède {childCount} unités de stockage imbriquées directes. La supprimer supprimera également ces unités et tout ce qui se trouve en dessous. Cette action ne peut pas être annulée."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "« ${storageUnitName} » possède 1 unité de stockage imbriquée directe. La supprimer supprimera également cette unité et tout ce qui se trouve en dessous. Cette action ne peut pas être annulée."
+msgstr "« {storageUnitName} » possède 1 unité de stockage imbriquée directe. La supprimer supprimera également cette unité et tout ce qui se trouve en dessous. Cette action ne peut pas être annulée."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -43,7 +43,7 @@ msgstr "« {taskName} » se coche automatiquement une fois que ses {0} élément
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "« {taskName} » est terminé — tous les {0} éléments de sa Carte de configuration sont configurés."
+msgstr "« {taskName} » est fait – tous les {0} éléments de sa carte de mise en place sont configurés."
 
 msgid "(excluded for this customer)"
 msgstr "(exclu pour ce client)"
@@ -83,7 +83,7 @@ msgstr "{0} écritures de journal brouillon"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} tâches créées"
+msgstr "{0} ordres de fabrication créés"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -145,13 +145,13 @@ msgid "{0} values missing"
 msgstr "{0} valeurs manquantes"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} pièces ignorées — elles ont déjà des tâches ouvertes"
+msgstr "{alreadyPlannedItemCount} pièces ignorées – elles ont déjà des ordres de fabrication ouverts"
 
 msgid "{apOverduePct}% of payables"
-msgstr "{apOverduePct}% des comptes créditeurs"
+msgstr "{apOverduePct}% des dettes fournisseurs"
 
 msgid "{arOverduePct}% of receivables"
-msgstr "{arOverduePct}% des créances"
+msgstr "{arOverduePct}% des créances clients"
 
 msgid "{chainLabel}. Consider pointing this part directly at the final successor."
 msgstr "{chainLabel}. Envisagez de pointer cette pièce directement vers le successeur final."
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} sur {count} opérations"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} autres : {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} mois avec des totaux non concordants"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} journaux manquants chez le fournisseur"
+msgstr "{missingCount} écritures manquantes du fournisseur"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} journaux manquants et {mismatchCount} mois non concordants"
+msgstr "{missingCount} écritures manquantes et {mismatchCount} mois non concordants"
 
 msgid "{name} deleted"
 msgstr "{name} supprimé"
@@ -205,10 +205,10 @@ msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# phase restante} other {# phases restantes}}"
 
 msgid "{scopeCount} permissions"
-msgstr "{scopeCount} permissions"
+msgstr "{scopeCount} autorisations"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "{total} phases pour mettre votre entreprise en ligne sur Carbon. Chacune se termine à un point de contrôle."
+msgstr "{total} phases pour mettre votre société en direct sur Carbon. Chacune se termine à un point de contrôle."
 
 msgid "{total} phases to go live"
 msgstr "{total} phases pour être en direct"
@@ -220,7 +220,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} tâches mises à jour"
+msgstr "{updatedJobCount} ordres de fabrication mis à jour"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} téléchargé — champs remplis à partir du document."
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 jour"
 
 msgid "1 draft journal entry"
-msgstr "1 écriture de journal brouillon"
+msgstr "1 écriture brouillon"
 
 msgid "1 job created"
 msgstr "1 tâche créée"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "5 utilisateurs minimum"
 
 msgid "5-8 weeks"
 msgstr "5-8 semaines"
 
 msgid "52-week demand"
-msgstr "Demande sur 52 semaines"
+msgstr "Besoins sur 52 semaines"
 
 msgid "5MB file limit"
 msgstr "Limite de fichier 5MB"
@@ -330,13 +330,13 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Une migration de données gérée par Carbon — vous chargez vos propres données"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Un avis de modification suit un changement d'ingénierie ou de fabrication contrôlé à travers l'examen et la mise en œuvre."
+msgstr "Un avis de modification suit un changement technique ou de fabrication contrôlé lors de sa revue et de sa mise en œuvre."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "Un compte de compensation tenant la valeur des marchandises reçues mais non encore facturées ; la facture du fournisseur l'apure."
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
-msgstr "Une entreprise qui conçoit et fabrique ses propres produits finis de bout en bout (ici, l'atelier construisant des robots humanoïdes) plutôt que de fabriquer des pièces selon la spécification d'une autre entreprise."
+msgstr "Une société qui conçoit et fabrique ses propres produits finis de bout en bout (ici, l'atelier construisant des robots humanoïdes) plutôt que de fabriquer des pièces selon les spécifications d'une autre société."
 
 msgid "A company that sits at or above selected companies in the group hierarchy and receives their intercompany cancelling entries for consolidated reporting; it is never a party to the trade itself."
 msgstr "Une société qui se situe au même niveau ou au-dessus des sociétés sélectionnées dans la hiérarchie du groupe et reçoit leurs écritures d'élimination interentreprises pour la consolidation ; elle ne participe jamais au commerce lui-même."
@@ -345,22 +345,22 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "Un champ supplémentaire défini par la société, attaché à un tableau principal (client, pièce, commande) ; il s'affiche sur le formulaire de l'enregistrement, s'enregistre aux côtés des champs intégrés et peut être interrogé via l'API."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Un axe de marqueur défini par la société, attaché aux lignes du journal, de sorte que les mêmes comptes peuvent être segmentés par emplacement, département ou tout axe personnalisé sans multiplier le plan comptable."
+msgstr "Un axe d'étiquetage défini par la société attaché aux lignes d'écriture pour que les mêmes comptes puissent être segmentés par site, département ou tout axe personnalisé sans multiplier le plan comptable."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "Une remise ou majoration à l'échelle de la société, en pourcentage ou montant fixe, qui ajuste le prix d'une ligne à la hausse ou à la baisse lorsque la ligne satisfait les conditions de quantité, de date, d'article et de client de la règle."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "La production d'une tâche complétée, reçue en stock au coût WIP cumulé réel de la tâche."
+msgstr "La production d'un ordre de fabrication terminé, reçue en stocks au coût d'en-cours réel accumulé de l'ordre de fabrication."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un consommable est un article physique utilisé pour fabriquer une pièce qui peut être utilisée dans plusieurs travaux"
+msgstr "Un consommable est un article physique utilisé pour fabriquer une pièce qui peut être utilisé dans plusieurs ordres de fabrication."
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Un entrepreneur est un contact fournisseur ayant des compétences particulières et des heures disponibles"
+msgstr "Un prestataire est un contact fournisseur ayant des compétences particulières et des heures disponibles."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Une solution personnalisée pour répondre à vos besoins."
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un client est une entreprise ou une personne qui achète vos pièces ou services."
@@ -384,7 +384,7 @@ msgid "A customer's name changes"
 msgstr "Le nom d'un client change"
 
 msgid "A customer's sales contact changes"
-msgstr "Le contact commercial d'un client change"
+msgstr "Le contact commercial d'un client change."
 
 msgid "A customer's status changes"
 msgstr "Le statut d'un client change"
@@ -396,13 +396,13 @@ msgid "A dated record proving a gauge was checked against a traceable standard; 
 msgstr "Un enregistrement daté prouvant qu'un instrument de mesure a été vérifié par rapport à une norme traçable ; il réussit sauf si un drapeau nécessitant une action, un ajustement ou une réparation est coché, et réinitialise la date d'échéance suivante de l'instrument."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Une fenêtre datée dans laquelle les écritures s'inscrivent ; son statut de clôture passe de Ouvert → Verrouillé → Fermé, et une période fermée est gelée contre les nouvelles écritures."
+msgstr "Une période datée dans laquelle les comptabilisations se placent ; son statut de clôture passe de Ouvert à Verrouillé à Clôturé, et une période clôturée est gelée contre les nouvelles comptabilisations."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "Une méthode d'amortissement qui charge un pourcentage fixe de la valeur comptable restante chaque période — plus lourd au début, plus léger plus tard."
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
-msgstr "Une méthode d'amortissement qui charge un montant égal chaque période sur la durée utile de l'actif."
+msgstr "Une méthode d'amortissement qui impute un montant égal chaque période sur la durée d'utilité de l'immobilisation."
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
 msgstr "Un engagement ferme du client à livrer ; le statut d'exécution se divise entre livraison et facture avant d'atteindre Terminé."
@@ -426,13 +426,13 @@ msgid "A job is deleted"
 msgstr "Un travail est supprimé"
 
 msgid "A job is put on hold"
-msgstr "Un travail est mis en attente"
+msgstr "Un ordre de fabrication est suspendu."
 
 msgid "A job is released"
 msgstr "Un travail est libéré"
 
 msgid "A job operation is completed"
-msgstr "Une opération de travail est terminée"
+msgstr "Une opération d'OF est terminée."
 
 msgid "A job's assignee changes"
 msgstr "L'assigné d'un travail change"
@@ -450,7 +450,7 @@ msgid "A job's quantity changes"
 msgstr "La quantité d'un travail change"
 
 msgid "A job's scrap quantity changes"
-msgstr "La quantité de déchet d'un travail change"
+msgstr "La quantité de rebut d'un ordre de fabrication change."
 
 msgid "A job's start date changes"
 msgstr "La date de début d'un travail change"
@@ -467,19 +467,19 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Une liste est connectée à {0}, donc cette étape s'exécute une fois pour chaque élément — jusqu'à {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Un composant Fabriquer sur commande qui obtient son propre travail et son acheminement à l'intérieur de la construction du parent."
+msgstr "Un composant de fabrication à la commande qui reçoit son propre ordre de fabrication et sa gamme lors de la fabrication du parent."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Un composant Fabriquer sur commande dont les pièces sont émises ensemble dans la tâche parent — pas de construction séparée."
+msgstr "Un composant de fabrication à la commande dont les pièces sont émises ensemble dans l'ordre de fabrication parent – sans fabrication séparée."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Une version gérée de Carbon hébergée en nuage."
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Une version gérée avec toutes les fonctionnalités avancées."
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un matériau est un article physique utilisé pour fabriquer une pièce qui peut être utilisée dans plusieurs travaux"
+msgstr "Une matière est un article physique utilisé pour fabriquer une pièce qui peut être utilisé dans plusieurs ordres de fabrication."
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
 msgstr "Un instrument de mesure (pied à coulisse, micromètre, pige, MMT) suivi en tant qu'enregistrement et soumis à un calendrier d'étalonnage récurrent."
@@ -491,7 +491,7 @@ msgid "A negotiated price pinned for a specific item — by customer, customer t
 msgstr "Un prix négocié fixé pour un article spécifique — par client, type de client ou tous les clients — qui remplace le prix de base purement et simplement, optionnellement avec des paliers de quantité."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "Une nouvelle commande d'achat sera créée pour chaque fournisseur. Vous pouvez également choisir une commande d'achat brouillon existante pour le fournisseur afin d'y ajouter les opérations externes."
+msgstr "Un nouveau bon de commande sera créé pour chaque fournisseur. Vous pouvez également choisir un bon de commande brouillon existant du fournisseur auquel ajouter les opérations externes."
 
 msgid "A new revision will be created using a copy of the current revision"
 msgstr "Une nouvelle révision sera créée en utilisant une copie de la révision actuelle"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Une nouvelle taille sera créée en utilisant une copie de la taille actuelle"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Un nouveau client Stripe sera créé."
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Un document sans trésorerie qui règle une facture sur un compte de raison : un crédit réduit ce qui est dû, un débit l'augmente."
@@ -509,10 +509,10 @@ msgid "A non-conformance shared with a supplier over a login-free /share/scar li
 msgstr "Une non-conformité partagée avec un fournisseur via un lien /share/scar sans connexion, afin qu'il puisse répondre au problème et mettre à jour ses tâches en dehors de Carbon."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Un supplément non imposable (p. ex. dépenses récupérables comme les frais de permis) ajouté à la ligne et exclu de la base imposable."
+msgstr "Une majoration non taxable (par exemple, les dépenses récupérables comme les frais de permis) ajoutée à la ligne ; exclue de la base taxable."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Une tâche de non-conformité qui corrige une cause première confirmée — contrairement à une action préventive ou de confinement immédiat."
+msgstr "Une tâche de non-conformité qui répare une cause racine confirmée – par opposition à une action préventive ou une action immédiate de confinement."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
 msgstr "Une tâche de non-conformité qui empêche le problème de se reproduire ailleurs — distincte de la correction corrective et du confinement."
@@ -521,16 +521,16 @@ msgid "A part contains the information about a specific item that can be purchas
 msgstr "Une pièce contient les informations sur un article spécifique qui peut être acheté ou fabriqué."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "Un signal de retrait physique — une carte imprimée ou un code QR situé avec le stock — qui crée un bon de commande ou une tâche au moment où il est scanné pour remplir un bac."
+msgstr "Un signal de tirage physique – une carte imprimée ou un code QR placé avec les stocks – qui génère un bon de commande ou un ordre de fabrication au moment où il est scanné pour remplir un casier."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
 msgstr "Un point dans l'un des propres flux de Carbon qu'un flux de travail peut surveiller — un travail libéré, un devis accepté, une expédition publiée — par rapport à un simple changement de champ ; il fournit au flux de travail les enregistrements impliqués par id."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Une écriture comptable postée : un en-tête plus des lignes de débit et de crédit équilibrées par rapport aux comptes GL."
+msgstr "Une écriture comptable comptabilisée : un en-tête plus des lignes de débit et de crédit équilibrées contre des comptes généraux."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Une transaction de trésorerie enregistrée — un reçu d'un client ou un décaissement à un fournisseur — appliquée aux factures via des règlements, passant de Brouillon → Enregistré → Annulé."
+msgstr "Une transaction de trésorerie comptabilisée – un encaissement d'un client ou un décaissement vers un fournisseur – appliquée aux factures par le biais de règlements, passant de Brouillon à Comptabilisé à Invalidé."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Une description pré-écrite insérée dans chaque problème utilisant ce flux de travail ; les espaces réservés comme {itemId} et {location} sont remplacés à la création."
@@ -545,37 +545,37 @@ msgid "A purchase invoice is posted"
 msgstr "Une facture d'achat est publiée"
 
 msgid "A purchase order is created"
-msgstr "Une commande d'achat est créée"
+msgstr "Un bon de commande est créé"
 
 msgid "A purchase order is deleted"
-msgstr "Une commande d'achat est supprimée"
+msgstr "Un bon de commande est supprimé"
 
 msgid "A purchase order's assignee changes"
-msgstr "L'assigné d'une commande d'achat change"
+msgstr "L'assigné d'un bon de commande change"
 
 msgid "A purchase order's order date changes"
-msgstr "La date de commande d'une commande d'achat change"
+msgstr "La date de commande d'un bon de commande change"
 
 msgid "A purchase order's status changes"
-msgstr "Le statut d'une commande d'achat change"
+msgstr "Le statut d'un bon de commande change"
 
 msgid "A purchase order's supplier changes"
-msgstr "Le fournisseur d'une commande d'achat change"
+msgstr "Le fournisseur d'un bon de commande change"
 
 msgid "A purchase order's supplier location changes"
-msgstr "L'emplacement du fournisseur d'une commande d'achat change"
+msgstr "Le site du fournisseur d'un bon de commande change"
 
 msgid "A purchase order's supplier reference changes"
-msgstr "La référence du fournisseur d'une commande d'achat change"
+msgstr "La référence fournisseur d'un bon de commande change"
 
 msgid "A purchase order's tags changes"
-msgstr "Les tags d'une commande d'achat changent"
+msgstr "Les étiquettes d'un bon de commande changent"
 
 msgid "A purchase order's type changes"
-msgstr "Le type d'une commande d'achat change"
+msgstr "Le type d'un bon de commande change"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Un problème de qualité — un écart enregistré ou un défaut avec un flux de travail configurable de tâches d'enquête et d'action."
+msgstr "Un problème de qualité — une dérogation ou un défaut signalé avec un workflow configurable d'investigation et de tâches d'action."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Une quantité d'unités identiques partage une entité suivie et un numéro de lot — une entité, plusieurs unités."
@@ -596,7 +596,7 @@ msgid "A quote is sent"
 msgstr "Un devis est envoyé"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Une ligne de devis contient les tarifs et les délais de livraison pour une pièce particulière"
+msgstr "Une ligne de devis contient les tarifs et les délais d'approvisionnement pour une pièce particulière"
 
 msgid "A quote's assignee changes"
 msgstr "L'assignataire d'un devis change"
@@ -641,10 +641,10 @@ msgid "A receipt's location changes"
 msgstr "L'emplacement d'un reçu change"
 
 msgid "A receipt's posting date changes"
-msgstr "La date de publication d'un reçu change"
+msgstr "La date de comptabilisation d'une réception change"
 
 msgid "A receipt's source document changes"
-msgstr "Le document source d'un reçu change"
+msgstr "Le document d'origine d'une réception change"
 
 msgid "A receipt's status changes"
 msgstr "Le statut d'un reçu change"
@@ -653,7 +653,7 @@ msgid "A receipt's supplier changes"
 msgstr "Le fournisseur d'un reçu change"
 
 msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
-msgstr "Un ensemble réutilisable et versionné d'instructions de travail attaché à un processus, donnant à une opération ses étapes ordonnées à enregistrer et vérifier ainsi que les paramètres auxquels elle s'exécute."
+msgstr "Un ensemble réutilisable et versionné de modes opératoires attaché à un procédé, donnant à une opération ses étapes ordonnées à enregistrer et vérifier, ainsi que les paramètres selon lesquels elle s'exécute."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
 msgstr "Une étape de gamme sur un travail lancé, la propre copie d'une opération du travail, portant un statut que l'atelier fait évoluer de À faire à Terminé."
@@ -671,22 +671,22 @@ msgid "A sales invoice line contains invoice details for a particular item"
 msgstr "Une ligne de facture de vente contient les détails de la facture pour un article particulier"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Un bon de commande contient des informations sur l'accord entre l'entreprise et un client spécifique pour les pièces et les services."
+msgstr "Une commande client contient les informations sur l'accord entre la société et un client spécifique pour les pièces et les prestations."
 
 msgid "A sales order is created"
-msgstr "Une commande de vente est créée"
+msgstr "Une commande client est créée"
 
 msgid "A sales order is deleted"
-msgstr "Une commande de vente est supprimée"
+msgstr "Une commande client est supprimée"
 
 msgid "A sales order line contains order details for a particular item"
 msgstr "Une ligne de commande client contient les détails de la commande pour un article particulier"
 
 msgid "A sales order's assignee changes"
-msgstr "L'assignataire d'une commande de vente change"
+msgstr "L'assigné d'une commande client change"
 
 msgid "A sales order's completed date changes"
-msgstr "La date de fin d'une commande de vente change"
+msgstr "La date de fin d'une commande client change"
 
 msgid "A sales order's customer changes"
 msgstr "Le client d'une commande de vente change"
@@ -695,67 +695,67 @@ msgid "A sales order's customer reference changes"
 msgstr "La référence client d'une commande de vente change"
 
 msgid "A sales order's location changes"
-msgstr "L'emplacement d'une commande de vente change"
+msgstr "Le site d'une commande client change"
 
 msgid "A sales order's order date changes"
-msgstr "La date de commande d'une commande de vente change"
+msgstr "La date de commande d'une commande client change"
 
 msgid "A sales order's salesperson changes"
-msgstr "Le vendeur d'une commande de vente change"
+msgstr "Le commercial d'une commande client change"
 
 msgid "A sales order's status changes"
-msgstr "Le statut d'une commande de vente change"
+msgstr "Le statut d'une commande client change"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Une demande de devis (RFQ) est une demande de client pour obtenir des prix sur un ensemble de pièces et de quantités. Elle peut aboutir à un devis."
+msgstr "Une demande de devis (RFQ) est une demande de tarification d'un client pour un ensemble de pièces et de quantités. Elle peut aboutir à un devis."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "Un RFQ de vente (un client vous demande de citer) ou un RFQ d'achat (vous demandez aux fournisseurs) ; les deux alimentent le fil d'opportunité."
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
-msgstr "Un secret limité envoyé en-tête de requête carbon-key qui authentifie les appels programmatiques à Carbon, portant ses propres permissions et limite de débit plutôt que ceux d'une session utilisateur."
+msgstr "Un secret limité en portée envoyé sur l'en-tête de requête carbon-key qui authentifie les appels programmatiques à Carbon, possédant ses propres autorisations et limite de débit plutôt que ceux d'une session utilisateur."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "Un calendrier séparé pour la déclaration fiscale lorsque les règles fiscales exigent une méthode différente de l'amortissement comptable."
+msgstr "Un calendrier d'amortissement distinct pour la déclaration fiscale quand les règles fiscales exigent une méthode différente de l'amortissement comptable."
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "Un service est une activité facturable qui est achetée ou exécutée — il n'est jamais expédié, reçu ou stocké"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Un ensemble d'entreprises sous un même propriétaire qui partagent une configuration à l'échelle du groupe — le plan comptable, les devises et les dimensions — de sorte que la même configuration comptable s'applique à toutes les entreprises du groupe."
+msgstr "Un ensemble de sociétés sous un propriétaire unique qui partagent une configuration au niveau du groupe — le plan comptable, les devises et les axes analytiques — de sorte que la même configuration comptable s'étend à chaque société du groupe."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Un ensemble d'instructions pour retirer les matériaux en attente d'une tâche de l'entrepôt et les préparer au pied de la chaîne ; un prélèvement déplace le stock jusqu'au point d'utilisation plutôt que de le consommer."
+msgstr "Un ensemble d'instructions pour prélever les matières en attente d'un ordre de fabrication du stock et les préparer au bord de ligne; un prélèvement déplace le stock au point d'utilisation plutôt que de le consommer."
 
 msgid "A shipment is created"
-msgstr "Un envoi est créé"
+msgstr "Une expédition est créée"
 
 msgid "A shipment is deleted"
-msgstr "Un envoi est supprimé"
+msgstr "Une expédition est supprimée"
 
 msgid "A shipment is posted"
-msgstr "Un envoi est publié"
+msgstr "Une expédition est comptabilisée"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
 msgstr "Une ligne d'expédition envoyée directement du fournisseur au client, contournant votre entrepôt — définie par ligne, pas dans l'en-tête."
 
 msgid "A shipment's assignee changes"
-msgstr "L'assignataire d'un envoi change"
+msgstr "L'assigné d'une expédition change"
 
 msgid "A shipment's customer changes"
-msgstr "Le client d'un envoi change"
+msgstr "Le client d'une expédition change"
 
 msgid "A shipment's location changes"
-msgstr "L'emplacement d'un envoi change"
+msgstr "Le site d'une expédition change"
 
 msgid "A shipment's posting date changes"
-msgstr "La date de publication d'un envoi change"
+msgstr "La date de comptabilisation d'une expédition change"
 
 msgid "A shipment's shipping method changes"
-msgstr "La méthode d'expédition d'un envoi change"
+msgstr "Le mode d'expédition d'une expédition change"
 
 msgid "A shipment's status changes"
-msgstr "Le statut d'un envoi change"
+msgstr "Le statut d'une expédition change"
 
 msgid "A shipment's tracking number changes"
 msgstr "Le numéro de suivi d'une expédition change"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "Le nom d'un fournisseur change"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "La réponse tarifée d'un fournisseur à un RFQ d'achat — une par fournisseur ; Brouillon → Actif lorsqu'ils envoient, ou Refusé."
+msgstr "La réponse tarifée d'un fournisseur à une RFQ d'achats — une par fournisseur; Brouillon → Actif lors de la soumission, ou Rejetée."
 
 msgid "A supplier's status changes"
 msgstr "Le statut d'un fournisseur change"
@@ -794,25 +794,25 @@ msgid "A supplier's type changes"
 msgstr "Le type d'un fournisseur change"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "Un supplément imposable (manutention, configuration, carburant) ajouté à la ligne et inclus dans la base imposable."
+msgstr "Une majoration taxable (manutention, réglage, carburant) ajoutée à la ligne; s'ajoute à la base imposable."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Un enregistrement horodaté du travail de Configuration, de Main-d'œuvre ou de Machine enregistré par rapport à une opération de travail, dont la durée s'accumule dans le coût réel de l'opération."
+msgstr "Un enregistrement de temps pour travail de Réglage, Main-d'œuvre ou Machine enregistré sur une Opération d'OF, dont la durée s'accumule dans le coût réel de l'opération."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un outil est un article physique utilisé pour fabriquer une pièce qui peut être utilisée dans plusieurs travaux"
+msgstr "Un Outil est un Article physique utilisé pour fabriquer une Pièce qui peut être utilisé sur plusieurs Ordres de fabrication"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "Un utilisateur enregistre la date d'expiration sur chaque lot ou numéro de série à la réception des marchandises. À utiliser lorsque les fournisseurs expédient des lots avec des dates d'expiration différentes."
+msgstr "Un Utilisateur enregistre la date de Péremption pour chaque Lot de production ou numéro de série quand les marchandises sont reçues. À utiliser quand les Fournisseurs expédient des Lots avec différentes dates de péremption."
 
 msgid "abilities"
-msgstr "capacités"
+msgstr "Compétences"
 
 msgid "Abilities"
 msgstr "Compétences"
 
 msgid "ability"
-msgstr "capacité"
+msgstr "Compétence"
 
 msgid "About"
 msgstr "À propos"
@@ -906,7 +906,7 @@ msgid "Accounting is disabled"
 msgstr "La comptabilité est désactivée"
 
 msgid "Accounting is disabled for this company."
-msgstr "La comptabilité est désactivée pour cette entreprise."
+msgstr "La Comptabilité est désactivée pour cette Société."
 
 msgid "Accounting is enabled"
 msgstr "La comptabilité est activée"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "Périodes comptables"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Comptabilité : GL, AR, AP et clôture de fin de mois"
+msgstr "Comptabilité : Grand livre, Comptes clients, Comptes fournisseurs et clôture du mois"
 
 msgid "Accounts"
 msgstr "Comptes"
@@ -927,19 +927,19 @@ msgid "Accounts for recording differences between actual and standard costs"
 msgstr "Comptes d'enregistrement des différences entre les coûts réels et standards"
 
 msgid "Accounts Payable"
-msgstr "Comptes créditeurs"
+msgstr "Comptes fournisseurs"
 
 msgid "Accounts payable for amounts owed to suppliers"
 msgstr "Comptes créditeurs pour les montants dus aux fournisseurs."
 
 msgid "Accounts Receivable"
-msgstr "Comptes débiteurs"
+msgstr "Comptes clients"
 
 msgid "Accounts receivable for amounts owed by customers"
 msgstr "Comptes débiteurs pour les montants dus par les clients."
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Comptes référencés par les valeurs par défaut de comptabilisation ou l'historique des journaux qui n'ont pas encore de mappage fournisseur."
+msgstr "Comptes référencés par les défauts de Comptabilisation ou l'Historique des Écritures qui n'ont pas encore de mapping de fournisseur."
 
 msgid "Accumulated Depreciation"
 msgstr "Amortissement cumulé"
@@ -1002,7 +1002,7 @@ msgid "Activate Process"
 msgstr "Activer le processus"
 
 msgid "Activate Work Center"
-msgstr "Activer le centre de travail"
+msgstr "Activer Poste de travail"
 
 msgid "Activation fee · we advise"
 msgstr "Frais d'activation · nous conseillons"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "Actif"
 
 msgid "Active Jobs"
-msgstr "Tâches actives"
+msgstr "Ordres de fabrication actifs"
 
 msgid "Active Statuses"
 msgstr "Statuts actifs"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "Ajouter un commentaire..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Ajoutez une ligne de tarification personnalisée pour remplacer la quantité, le prix, l'expédition, le délai et la taxe"
+msgstr "Ajouter une ligne de Tarification personnalisée pour substituer Quantité, Prix, expédition, Délai d'approvisionnement et Taxe"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "Ajouter une section de matériaux qui liste chaque article de la nomenclature avec sa quantité."
@@ -1101,13 +1101,13 @@ msgid "Add clause"
 msgstr "Ajouter une clause"
 
 msgid "Add Company"
-msgstr "Ajouter une entreprise"
+msgstr "Ajouter Société"
 
 msgid "Add condition"
 msgstr "Ajouter une condition"
 
 msgid "Add Contractor"
-msgstr "Ajouter un entrepreneur"
+msgstr "Ajouter Prestataire"
 
 msgid "Add cost center"
 msgstr "Ajouter un centre de coûts"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Ajouter une note"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Ajouter des notes et de la documentation pour cette demande de maintenance"
+msgstr "Ajouter des Notes et documentation pour cette Intervention de maintenance"
 
 msgid "Add Operation"
 msgstr "Ajouter une opération"
@@ -1206,7 +1206,7 @@ msgid "Add Selector"
 msgstr "Ajouter un sélecteur"
 
 msgid "Add Shipment"
-msgstr "Ajouter un envoi"
+msgstr "Ajouter Expédition"
 
 msgid "Add Shipping"
 msgstr "Ajouter l'expédition"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Toutes les {0} cellules correspondent"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Toutes les {total} phases sont terminées. Bravo — votre équipe est opérationnelle."
+msgstr "Les {total} phases sont toutes terminées. Bien joué — votre Groupe est opérationnel."
 
 msgid "All accounts"
 msgstr "Tous les comptes"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Toutes les actions sélectionnées"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Toutes les fonctionnalités avancées disponibles"
 
 msgid "All Audit Logs"
 msgstr "Tous les journaux d'audit"
@@ -1370,7 +1370,7 @@ msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Toutes les lignes importées — {inserted} insérées, {updated} mises à jour."
 
 msgid "All slotted dimension values are mapped"
-msgstr "Toutes les valeurs de dimension assignées sont mappées"
+msgstr "Toutes les valeurs d'Axe analytique assignées sont mappées"
 
 msgid "All Suppliers"
 msgstr "Tous les fournisseurs"
@@ -1388,7 +1388,7 @@ msgid "All users"
 msgstr "Tous les utilisateurs"
 
 msgid "All Work Centers"
-msgstr "Tous les centres de travail"
+msgstr "Tous les Postes de travail"
 
 msgid "Allows acknowledge & continue"
 msgstr "Permet d'accuser réception et de continuer"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Montant"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Montant qui augmente les actifs/frais ou diminue les passifs/capitaux propres/revenus sur cette ligne."
+msgstr "Montant qui augmente les actifs/charges ou diminue les passifs/Capitaux propres/Revenus sur cette ligne."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Montant qui augmente les passifs/capitaux propres/revenus ou diminue les actifs/frais sur cette ligne."
+msgstr "Montant qui augmente les passifs/Capitaux propres/Revenus ou diminue les actifs/charges sur cette ligne."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "Type de montant"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Un compte comptable qui regroupe les dépenses par département ou fonction afin que la GL puisse rapporter les dépenses par groupe, et non seulement par compte."
+msgstr "Un groupe comptable qui agrège les Charges par Département ou fonction pour que le Grand livre puisse rapporter les dépenses par groupe, pas seulement par compte."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Un enregistrement comptable pour un élément capitalisé que vous amortissez plutôt que de dépenser; Brouillon → Actif → Entièrement amorti → Cédé."
+msgstr "Un enregistrement comptable pour un Article capitalisé que vous amortissez plutôt que de dépenser ; Brouillon → Actif → Totalement amorti → Cédé."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Une alerte indiquant que quelque chose nécessite l'attention d'une personne, diffusée à partir d'un événement carbon/notify vers la boîte de réception intégrée plus e-mail et Slack optionnels, désactivable par sujet et par utilisateur."
@@ -1440,7 +1440,7 @@ msgid "An automation you build on a canvas: one trigger, then steps that check c
 msgstr "Une automation que vous construisez sur un canevas : un déclencheur, puis des étapes qui vérifient les conditions, recherchent les enregistrements et agissent — en notifiant quelqu'un, en créant ou en mettant à jour un enregistrement, ou en appelant une URL externe."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "Un ordre de modification d'ingénierie : les articles affectés dont les méthodes sont révisées sur un brouillon et publiées ensemble, remplaçant les versions qu'elles remplacent."
+msgstr "Une Modification technique : les Articles affectés dont les Méthodes sont révisées en Brouillon et Lancées ensemble, remplaçant les Versions qu'elles supercèdent."
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "Une requête https que Carbon envoie à l'un de vos systèmes lorsqu'un flux de travail atteint cette étape, portant tous les en-têtes et le corps que vous avez configurés."
@@ -1500,13 +1500,13 @@ msgid "An item's assignee changes"
 msgstr "L'assigné d'un article change"
 
 msgid "An item's default method type changes"
-msgstr "Le type de méthode par défaut d'un article change"
+msgstr "Le Type d'approvisionnement par défaut d'un Article change"
 
 msgid "An item's name changes"
 msgstr "Le nom d'un article change"
 
 msgid "An item's replenishment system changes"
-msgstr "Le système de réapprovisionnement d'un article change"
+msgstr "Le Mode d'approvisionnement d'un Article change"
 
 msgid "An item's revision status changes"
 msgstr "Le statut de révision d'un article change"
@@ -1518,10 +1518,10 @@ msgid "An item's unit of measure changes"
 msgstr "L'unité de mesure d'un article change"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Une opération effectuée par un fournisseur externe plutôt que par un centre de travail interne, couverte par une commande d'achat de sous-traitance."
+msgstr "Une Opération effectuée par un Fournisseur externe plutôt qu'un Poste de travail interne, couverte par un Bon de commande de sous-traitance."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "La position d'une opération dans la file d'attente de son centre de travail — l'ordre dans lequel l'atelier choisit le travail — défini en réorganisant les cartes sur le tableau des Centres de travail sans modifier les dates."
+msgstr "La position d'une Opération dans la file d'attente de son Poste de travail — l'ordre dans lequel l'atelier prend le travail — défini en réorganisant les cartes sur le tableau des Postes de travail sans changer les dates."
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Une erreur inattendue s'est produite lors de la connexion à Onshape. Réessayez de vous connecter."
@@ -1576,19 +1576,19 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "Tout ce qui n'est pas explicitement listé dans le périmètre ci-dessus"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Comptes fournisseurs"
 
 msgid "AP Aging"
-msgstr "Analyse AP"
+msgstr "Ancienneté des Comptes fournisseurs"
 
 msgid "AP Clerk"
-msgstr "Commis aux comptes créditeurs"
+msgstr "Commis aux Comptes fournisseurs"
 
 msgid "AP Outstanding"
-msgstr "AP à payer"
+msgstr "Comptes fournisseurs en attente"
 
 msgid "AP Overdue"
-msgstr "AP En retard"
+msgstr "Comptes fournisseurs En retard"
 
 msgid "API Docs"
 msgstr "Documentation API"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Clés API pour un accès programmatique à vos données Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, Webhooks et Intégrations"
 
 msgid "Applied"
 msgstr "Appliqué"
@@ -1631,10 +1631,10 @@ msgid "Applies to all"
 msgstr "S'applique à tous"
 
 msgid "Applies to all work centers"
-msgstr "S'applique à tous les centres de travail"
+msgstr "S'applique à tous les Postes de travail"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
-msgstr "S'applique aux fonctionnalités sans leur propre règle, et au lot lorsque ce plan détermine une inspection."
+msgstr "S'applique aux fonctionnalités sans leur propre Règle, et au Lot quand ce plan dirige un Contrôle."
 
 msgid "Apply"
 msgstr "Appliquer"
@@ -1706,28 +1706,28 @@ msgid "AQL"
 msgstr "AQL"
 
 msgid "AQL (Z1.4 / ISO 2859-1)"
-msgstr "NQA (Z1.4 / ISO 2859-1)"
+msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Comptes clients"
 
 msgid "AR / AP representation"
-msgstr "Représentation AR / AP"
+msgstr "Représentation Comptes clients / Comptes fournisseurs"
 
 msgid "AR Aging"
-msgstr "Analyse AR"
+msgstr "Ancienneté des comptes clients"
 
 msgid "AR Clerk"
 msgstr "Commis aux comptes clients"
 
 msgid "AR Outstanding"
-msgstr "Créances clients en attente"
+msgstr "Comptes clients en attente"
 
 msgid "AR Overdue"
-msgstr "AR En retard"
+msgstr "Comptes clients en retard"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Comptes clients/Comptes fournisseurs"
 
 msgid "Archive"
 msgstr "Archiver"
@@ -1750,7 +1750,7 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "Êtes-vous sûr de vouloir activer le processus : {name} ? Il réapparaîtra dans les listes déroulantes."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Êtes-vous sûr de vouloir activer cette jauge ?."
+msgstr "Êtes-vous sûr de vouloir activer cet instrument de mesure ?"
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Êtes-vous sûr de vouloir terminer ce transfert de stock ?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Êtes-vous sûr de vouloir confirmer cette commande client ? La confirmation de la commande affectera les quantités commandées utilisées pour calculer l'offre et la demande."
+msgstr "Êtes-vous sûr de vouloir confirmer cette commande client ? La confirmation de la commande affectera les quantités en commande utilisées pour calculer l'approvisionnement et les besoins."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "Êtes-vous sûr de vouloir convertir la demande de devis en devis ?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Êtes-vous sûr de vouloir créer des tâches pour cette commande client ? Cela créera des tâches pour toutes les lignes qui n'en ont pas déjà."
+msgstr "Êtes-vous sûr de vouloir créer des ordres de fabrication pour cette commande client ? Cela créera des ordres de fabrication pour toutes les lignes qui n'en ont pas déjà."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Êtes-vous sûr de vouloir désactiver ces utilisateurs ?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Êtes-vous sûr de vouloir désactiver cette jauge ?."
+msgstr "Êtes-vous sûr de vouloir désactiver cet instrument de mesure ?"
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Êtes-vous sûr de vouloir désactiver cet utilisateur ?"
@@ -1859,7 +1859,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer la clé API : {0}? Cette action ne 
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la classe d'actifs : {0} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer la catégorie d'immobilisation : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
@@ -1870,7 +1870,7 @@ msgid "Are you sure you want to delete the change notice category: {0}? This can
 msgstr "Êtes-vous sûr de vouloir supprimer la catégorie d'avis de modification : {0} ? Cela ne peut pas être annulé."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer l'entrepreneur : {name} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer le prestataire : {name} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer le mode de défaillance : {name} ? 
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer le type de jauge : {0} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer le type d'instrument : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1933,7 +1933,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer le calendrier de maintenance : {nam
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la dimension de matériau : {0}? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer la dimension de matière : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
@@ -1945,7 +1945,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer le formulaire de matériau : {0} ? 
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la classe de matériau : {0}? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer la nuance : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "Êtes-vous sûr de vouloir supprimer le type de matériau : {0} ? Cette 
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la raison sans devis : {0}? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer le motif de refus de devis : {0} ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "Êtes-vous sûr de vouloir supprimer le partenaire : {name} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer le délai de paiement : {0} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer la condition de paiement : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1991,17 +1991,17 @@ msgstr "Êtes-vous sûr de vouloir supprimer la ligne de commande client pour {0
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la raison de rebut : {0}? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer le motif de rebut : {0} ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
 msgstr "Êtes-vous sûr de vouloir supprimer la séquence de numéro de série pour {itemLabel} ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer le quart : {name} de {locationName} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer l'équipe : {name} du site {locationName} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer la méthode d'expédition : {0} ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer le mode d'expédition : {0} ? Cette action ne peut pas être annulée."
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
@@ -2034,13 +2034,13 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "Êtes-vous sûr de vouloir supprimer cet avis de modification ?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Êtes-vous sûr de vouloir supprimer ce jauge ?"
+msgstr "Êtes-vous sûr de vouloir supprimer cet instrument de mesure ?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "Êtes-vous sûr de vouloir supprimer ce plan d'inspection ?"
+msgstr "Êtes-vous sûr de vouloir supprimer ce plan de contrôle ?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer ce plan d'inspection ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer ce plan de contrôle ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Êtes-vous sûr de vouloir supprimer ce flux de travail de problème ?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Êtes-vous sûr de vouloir supprimer cette carte kanban ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer cette demande de maintenance ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir supprimer cette intervention de maintenance ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "Êtes-vous sûr de vouloir supprimer cette clé d'accès ? Vous ne pourrez plus l'utiliser pour vous connecter."
@@ -2106,23 +2106,23 @@ msgid "Are you sure you want to post this receipt?"
 msgstr "Êtes-vous sûr de vouloir valider ce reçu ?"
 
 msgid "Are you sure you want to post this shipment?"
-msgstr "Êtes-vous sûr de vouloir valider cet envoi ?"
+msgstr "Êtes-vous sûr de vouloir comptabiliser cette expédition ?"
 
 msgid "Are you sure you want to reject this quote?"
 msgstr "Êtes-vous sûr de vouloir rejeter ce devis ?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "Êtes-vous sûr de vouloir libérer ce travail ? Il deviendra disponible pour l'atelier et entraînera les achats et la production."
+msgstr "Êtes-vous sûr de vouloir lancer cet ordre de fabrication ? Il deviendra disponible à l'atelier et pilotera les achats et la production."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer {0} en tant que fournisseur pour cet article ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir retirer {0} en tant que fournisseur pour cet article ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer {supplierName} en tant que fournisseur pour cet article ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir retirer {supplierName} en tant que fournisseur pour cet article ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "Êtes-vous sûr de vouloir supprimer cet article de la liste de prix ? Cette action ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir retirer cet article de la liste de prix ? Cette action ne peut pas être annulée."
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "Êtes-vous sûr de vouloir révoquer l'invitation pour cet utilisateur ?"
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Êtes-vous sûr de vouloir envoyer une invitation à cet utilisateur ?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Êtes-vous sûr de vouloir annuler cette facture d'achat ? Cette action inversera toutes les transactions financières et ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir invalider cette facture d'achat ? Cette action annulera toutes les transactions financières et ne peut pas être annulée."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Êtes-vous sûr de vouloir annuler ce reçu ? Cette action inversera toutes les transactions d'inventaire et ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir invalider cette réception ? Cette action annulera toutes les transactions de stocks et ne peut pas être annulée."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Êtes-vous sûr de vouloir annuler cette facture de vente ? Cette action inversera toutes les transactions financières et ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir invalider cette facture de vente ? Cette action annulera toutes les transactions financières et ne peut pas être annulée."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Êtes-vous sûr de vouloir annuler cet envoi ? Cette action inversera toutes les transactions d'inventaire et ne peut pas être annulée."
+msgstr "Êtes-vous sûr de vouloir invalider cette expédition ? Cette action annulera toutes les transactions de stocks et ne peut pas être annulée."
 
 msgid "Are you sure?"
 msgstr "Êtes-vous sûr ?"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "Au :"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "En tant que propriétaire de l'entreprise, vous pouvez transférer la propriété à un autre employé. Cela lui donnera un accès complet à la facturation et aux paramètres administratifs."
+msgstr "En tant que propriétaire de la société, vous pouvez transférer la propriété à un autre employé. Cela lui donnera un accès complet à la facturation et aux paramètres d'administration."
 
 msgid "Ascending"
 msgstr "Croissant"
@@ -2173,7 +2173,7 @@ msgstr "Croissant"
 #. placeholder {0}: copy.moduleLabel
 #. placeholder {1}: copy.noun
 msgid "Ask an admin with {0} permission to add the first {1}."
-msgstr "Demandez à un administrador disposant de la permission {0} d'ajouter le premier {1}."
+msgstr "Demandez à un administrateur disposant de l'autorisation {0} d'ajouter le premier {1}."
 
 msgid "Assemblies"
 msgstr "Assemblages"
@@ -2206,19 +2206,19 @@ msgid "Asset Acquisition Cost (default)"
 msgstr "Coût d'acquisition de l'actif (par défaut)"
 
 msgid "asset class"
-msgstr "classe d'actif"
+msgstr "catégorie d'immobilisation"
 
 msgid "Asset class"
-msgstr "Classe d'actif"
+msgstr "Catégorie d'immobilisation"
 
 msgid "Asset Class"
-msgstr "Classe d'actif"
+msgstr "Catégorie d'immobilisation"
 
 msgid "asset classes"
-msgstr "classes d'actifs"
+msgstr "catégories d'immobilisation"
 
 msgid "Asset Classes"
-msgstr "Classes d'actifs"
+msgstr "Catégories d'immobilisation"
 
 msgid "Asset Cost on Disposal"
 msgstr "Coût de l'actif à la cession"
@@ -2236,13 +2236,13 @@ msgid "Assets, liabilities and equity as of a date"
 msgstr "Actifs, passifs et capitaux propres à une date"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
-msgstr "Attribuez des imprimantes aux emplacements. L'expédition, la réception et les centres de travail héritent de la valeur par défaut de l'emplacement sauf s'ils sont remplacés."
+msgstr "Attribuer des imprimantes aux sites. L'expédition, la réception et les postes de travail héritent du paramètre par défaut du site sauf s'ils sont remplacés."
 
 msgid "Assign To"
-msgstr "Assigner à"
+msgstr "Attribuer à"
 
 msgid "Assign to Groups"
-msgstr "Assigner aux groupes"
+msgstr "Attribuer à des groupes"
 
 msgid "Assigned"
 msgstr "Assigné"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Affectations"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Assigne cette unité de stockage à un centre de travail (linéaire)"
+msgstr "Attribue cette unité de stockage à un poste de travail (bord de ligne)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Attribue cette unité à un centre de travail pour les matériaux en bordure de ligne, afin que les opérateurs la voient dans la vue de production; héritée de l'unité parent lorsqu'elle est définie là."
+msgstr "Attribue cette unité à un poste de travail pour les matériaux du bord de ligne, afin que les opérateurs les voient dans la vue de production ; hérité de l'unité parente lorsqu'il est défini là."
 
 msgid "At each gate"
 msgstr "À chaque étape"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Attribut"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Norme d'échantillonnage par attributs utilisée pour calculer les tailles d'échantillon de lot et les nombres d'acceptation/rejet lors des inspections entrantes."
+msgstr "La norme d'échantillonnage par attribut utilisée pour calculer les tailles d'échantillon de lot et les nombres d'acceptation/rejet lors des contrôles à réception."
 
 msgid "Attributes"
 msgstr "Attributs"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Journal d'audit"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Journalisation d'audit"
 
 msgid "Audit Logging"
 msgstr "Journalisation d'audit"
@@ -2338,10 +2338,10 @@ msgid "Auto arrange"
 msgstr "Arrangement automatique"
 
 msgid "Auto Release"
-msgstr "Libération automatique"
+msgstr "Lancement automatique"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "La libération automatique doit être activée pour démarrer un travail automatiquement"
+msgstr "Le lancement automatique doit être activé pour lancer un ordre de fabrication automatiquement"
 
 msgid "Auto Start Job"
 msgstr "Démarrage automatique du travail"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Code QR généré automatiquement"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Formats de numérotation automatique pour les commandes, les travaux, les pièces, et plus"
+msgstr "Formats de numérotation automatique pour les commandes, les ordres de fabrication, les pièces et plus"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Suggérer automatiquement les achats en fonction de la demande et des points de réapprovisionnement"
+msgstr "Suggérer automatiquement les achats à partir des besoins et des points de commande"
 
 msgid "Automate"
 msgstr "Automatiser"
@@ -2377,13 +2377,13 @@ msgid "Automatic Updates"
 msgstr "Mises à jour automatiques"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Mises à jour automatiques et sauvegardes"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consommation automatique au prorata des matériaux non tracés d'un travail lors du signalement de la production — les matériaux tracés sont émis manuellement."
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "Libérer automatiquement la tâche lorsque le kanban est scanné"
+msgstr "Lancer automatiquement l'ordre de fabrication lorsque le kanban est scanné"
 
 msgid "Automatically start the job when the kanban is scanned"
 msgstr "Démarrer automatiquement le travail lorsque le kanban est scanné"
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "Retour à la traçabilité"
 
 msgid "Backflush"
-msgstr "Retrait automatique"
+msgstr "Post-consommation"
 
 msgid "Backups"
 msgstr "Sauvegardes"
@@ -2435,10 +2435,10 @@ msgid "Balloon"
 msgstr "Ballon"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "Dessins avec annotations et caractéristiques d'inspection."
+msgstr "Dessins éclatés avec fonctionnalités de contrôle."
 
 msgid "Bank - Cash"
-msgstr "Banque - Espèces"
+msgstr "Banque - Trésorerie"
 
 msgid "Bank - Foreign Currency"
 msgstr "Banque - Devise étrangère"
@@ -2447,7 +2447,7 @@ msgid "Bank - Local Currency"
 msgstr "Banque - Devise locale"
 
 msgid "Bank — Cash (default)"
-msgstr "Banque — Espèces (par défaut)"
+msgstr "Banque — Trésorerie (par défaut)"
 
 msgid "Bank — Foreign Currency (default)"
 msgstr "Banque — Devise étrangère (par défaut)"
@@ -2456,19 +2456,19 @@ msgid "Bank — Local Currency (default)"
 msgstr "Banque — Devise locale (par défaut)"
 
 msgid "Bank / Cash Account"
-msgstr "Compte Bancaire / Caisse"
+msgstr "Compte banque / Trésorerie"
 
 msgid "Bank account denominated in a foreign currency"
-msgstr "Compte bancaire libellé en devise étrangère."
+msgstr "Compte bancaire libellé en devise étrangère"
 
 msgid "Bank account denominated in the local currency"
-msgstr "Compte bancaire libellé en devise locale."
+msgstr "Compte bancaire libellé en devise locale"
 
 msgid "Bank and financial service charge expenses"
-msgstr "Dépenses pour charges de services bancaires et financiers."
+msgstr "Dépenses de frais bancaires et de services financiers"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Les barres montrent le flux hebdomadaire de chaque semaine: &lt;0&gt;l'offre&lt;/0&gt; pousse l'inventaire vers le haut, &lt;1&gt;la demande&lt;/1&gt; le fait baisser. La &lt;2&gt;ligne&lt;/2&gt; est votre inventaire disponible projeté — quand il tombe au-dessous &lt;3&gt;du stock de sécurité&lt;/3&gt; vous êtes à risque, et au-dessous de zéro est une &lt;4&gt;rupture de stock&lt;/4&gt;."
+msgstr "Les barres montrent le flux de chaque semaine : <0>l'approvisionnement</0> augmente les stocks, <1>les besoins</1> les diminuent. La <2>ligne</2> est votre inventaire prévu en main — quand elle descend en dessous du <3>stock de sécurité</3>, vous êtes à risque, et en dessous de zéro c'est une <4>rupture de stock</4>."
 
 msgid "Base Currency"
 msgstr "Devise de base"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Prix de base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Fonctionnalités de base ERP, MES et QMS"
 
 msgid "Basic Information"
 msgstr "Informations de base"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "Bêta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Principales causes de rebuts par raison, article ou centre de travail"
+msgstr "Principales causes de rebut par raison, article ou poste de travail"
 
 msgid "Bill of Material"
 msgstr "Nomenclature"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "Nomenclature"
 
 msgid "Bill of Process"
-msgstr "Nomenclature de fabrication"
+msgstr "Liste des opérations"
 
 msgid "Bill To"
 msgstr "Facturer à"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Bloquer avec une erreur"
 
 msgid "Block, allow override"
-msgstr "Bloquer, autoriser le remplacement"
+msgstr "Bloquer, autoriser la substitution"
 
 msgid "Blocked"
 msgstr "Bloqué"
@@ -2566,7 +2566,7 @@ msgid "Blocked by {0}"
 msgstr "Bloqué par {0}"
 
 msgid "Blocks save until resolved"
-msgstr "Bloque la sauvegarde jusqu'à résolution"
+msgstr "Bloque l'enregistrement jusqu'à résolution"
 
 msgid "Body"
 msgstr "Corps"
@@ -2581,10 +2581,10 @@ msgid "BOM synced successfully"
 msgstr "BOM synchronisé avec succès"
 
 msgid "BOMs"
-msgstr "Nomenclatures"
+msgstr "BOMs"
 
 msgid "Bonus Depreciation %"
-msgstr "Bonus Dépréciation %"
+msgstr "Amortissement de prime %"
 
 msgid "Book a call to discuss guided implementation"
 msgstr "Réserver un appel pour discuter de la mise en œuvre guidée"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Fil d'Ariane"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Importez vos pièces, nomenclatures, processus de fabrication et coûts — avec les outils d'importation de Carbon, CSV ou l'aide de l'IA."
+msgstr "Apportez vos pièces, BOMs, Listes des opérations et calcul des coûts — avec les outils d'importation de Carbon, CSV ou aide LLM."
 
 msgid "Browse library"
 msgstr "Parcourir la bibliothèque"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Parcourez la version publiée en lecture seule. Vous pouvez toujours réarranger les étapes pour nettoyer la mise en page."
 
 msgid "Bucket"
 msgstr "Compartiment"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Créer des intégrations et des personnalisations"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Créer des devis en extrayant les données en direct sur les pièces, les coûts et la nomenclature de processus"
+msgstr "Construire les devis en tirant les données de pièces, coûts et Liste des opérations en direct"
 
 msgid "Build role-based training materials"
 msgstr "Créer des matériels de formation basés sur les rôles"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Importation en masse"
 
 msgid "Bulk Jobs"
-msgstr "Travaux en masse"
+msgstr "Ordres de fabrication en masse"
 
 msgid "Business moment"
 msgstr "Moment métier"
@@ -2662,7 +2662,7 @@ msgid "Buy"
 msgstr "Acheter"
 
 msgid "Buy and Make"
-msgstr "Acheter et Fabriquer"
+msgstr "Achat et fabrication"
 
 msgid "Buyer"
 msgstr "Acheteur"
@@ -2701,10 +2701,10 @@ msgid "CAD Model"
 msgstr "Modèle CAO"
 
 msgid "Calculate from BOM"
-msgstr "Calculer à partir de la nomenclature"
+msgstr "Calculer à partir du BOM"
 
 msgid "Calculated finished-good expiry"
-msgstr "Expiration du produit fini calculée"
+msgstr "Péremption du produit fini calculée"
 
 msgid "Calculation Method"
 msgstr "Méthode de calcul"
@@ -2719,16 +2719,16 @@ msgid "Calibration Expiration Notifications"
 msgstr "Notifications d'expiration d'étalonnage"
 
 msgid "Calibration Interval (Months)"
-msgstr "Intervalle d'étalonnage (Mois)"
+msgstr "Périodicité d'étalonnage (mois)"
 
 msgid "Calibration Record"
-msgstr "Registre d'étalonnage"
+msgstr "Enregistrement d'étalonnage"
 
 msgid "Calibration Records"
-msgstr "Dossiers d'étalonnage"
+msgstr "Enregistrements d'étalonnage"
 
 msgid "Calibration Status"
-msgstr "État d'étalonnage"
+msgstr "Statut d'étalonnage"
 
 msgid "Calibration Supplier"
 msgstr "Fournisseur d'étalonnage"
@@ -2821,13 +2821,13 @@ msgid "Cannot send RFQ"
 msgstr "Impossible d'envoyer la demande de devis"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Impossible d'envoyer via Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
-msgstr "Impossible de télécharger — l'interaction fournisseur n'a pas encore été créée"
+msgstr "Impossible de téléverser — interaction fournisseur non créée"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "Impossible de télécharger vers le compartiment des pièces sans ID d'article"
+msgstr "Impossible de téléverser vers le seau des pièces sans ID d'article"
 
 msgid "Caption"
 msgstr "Légende"
@@ -2854,7 +2854,7 @@ msgid "Carbon column"
 msgstr "Colonne Carbon"
 
 msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
-msgstr "Carbon est configuré selon le fonctionnement de votre entreprise, vos données sont chargées, et votre équipe sait l'utiliser en confiance. Quand c'est le cas, vous êtes prêt à passer en production."
+msgstr "Carbon est configuré de la façon dont votre société fonctionne, vos données sont chargées, et votre groupe est confiant en l'utilisant. Quand c'est le cas, vous êtes prêt à vous lancer en production."
 
 msgid "Carbon leads"
 msgstr "Carbon leads"
@@ -2876,7 +2876,7 @@ msgstr "Valeur Carbon"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon utilisera l'IA pour deviner un compte de fournisseur pour chacun de vos {0} comptes non mappés. Les suggestions sont un point de départ — vous pouvez les examiner avant que rien ne soit enregistré."
+msgstr "Carbon utilisera l'IA pour deviner un compte fournisseur pour chacun de vos {0} comptes non mappés. Les suggestions sont un point de départ — vous pouvez les vérifier avant que quoi que ce soit ne soit enregistré."
 
 msgid "Carbon-only"
 msgstr "Carbone uniquement"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Carbon-only · le client voit ce texte, verrouillé."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Le nom de Carbon pour une nomenclature et nomenclature de processus (gamme): les composants plus les opérations qui fabriquent une pièce."
+msgstr "Le nom Carbon pour une nomenclature et une liste des opérations (gamme) : les composants plus les opérations qui fabriquent une pièce."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "L'exécution de la planification de Carbon oppose l'offre à la demande et déploie des méthodes, révélant les pénuries — mais elle ne crée pas elle-même de commandes."
+msgstr "La planification Carbon calcule l'approvisionnement net par rapport aux besoins et décompose les méthodes, révélant les lacunes — mais elle ne crée aucune commande elle-même."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Commande de production de Carbon — une tâche fabrique une quantité d'un article à partir de sa méthode et son routage copiés."
+msgstr "L'ordre de production Carbon — un ordre de fabrication construit une quantité d'un article à partir de sa propre méthode et gamme copiées."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "L'application d'atelier de Carbon où les opérateurs exécutent les opérations, signalent les quantités, éditent les matériaux et enregistrent le temps par rapport aux tâches libérées en temps réel."
+msgstr "L'application atelier de Carbon où les opérateurs exécutent les opérations, rapportent les quantités, prélèvent la matière et enregistrent le temps par rapport aux ordres de fabrication lancés en temps réel."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "L'enregistrement unique de Carbon pour tout ce qui a un numéro de pièce — Article, Matériau, Outil, Service, Consommable ou Fixture — auquel les travaux, les méthodes, les commandes et l'inventaire pointent tous."
+msgstr "L'enregistrement unique Carbon pour tout ce qui a un numéro de pièce — Pièce, Matière, Outil, Prestation, Consommable ou Montage d'usinage — que les ordres de fabrication, les méthodes, les commandes et les stocks référencent tous."
 
 msgid "Cards"
 msgstr "Cartes"
@@ -2963,7 +2963,7 @@ msgid "Change Document"
 msgstr "Modifier le document"
 
 msgid "Change Inspection Plan"
-msgstr "Modifier le plan d'inspection"
+msgstr "Modifier le plan de contrôle"
 
 msgid "Change notice"
 msgstr "Avis de modification"
@@ -2984,7 +2984,7 @@ msgid "Change notices could not be loaded, so new versions and revisions are blo
 msgstr "Les avis de modification n'ont pas pu être chargés, donc les nouvelles versions et révisions sont bloquées. Recharger pour réessayer."
 
 msgid "Change order"
-msgstr "Ordre de changement"
+msgstr "Ordre de modification"
 
 msgid "Change status"
 msgstr "Modifier le statut"
@@ -3008,7 +3008,7 @@ msgid "Changing this will overwrite the existing method"
 msgstr "Modifier ceci remplacera la méthode existante"
 
 msgid "Changing this will update the part ID"
-msgstr "Cela modifiera l'ID de la pièce"
+msgstr "Modifier ceci mettra à jour l'ID de pièce"
 
 msgid "Changing type resets this item's draft edits."
 msgstr "Modifier le type réinitialise les brouillons de cet article."
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "Vérifiez votre email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Vérification de Stripe pour ce client…"
 
 msgid "Checkpoint ·"
 msgstr "Point de contrôle ·"
@@ -3041,7 +3041,7 @@ msgid "Choose a batch number"
 msgstr "Choisir un numéro de lot"
 
 msgid "Choose a company"
-msgstr "Choisir une entreprise"
+msgstr "Choisir une société"
 
 msgid "Choose a row on the left to see where its stock can come from."
 msgstr "Choisissez une ligne à gauche pour voir d'où son stock peut provenir."
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Choisir un autre fichier"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Choisir ce qui apparaît sur le bon de travail imprimé."
+msgstr "Choisir ce qui apparaît sur la fiche suiveuse d'ordre de fabrication imprimée."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Choisissez votre langue préférée pour l'interface."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Classe (héritée)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Classe une opération de routage : les opérations de Processus, Assemblage et Inspection s'exécutent sur votre propre atelier en MES — Assemblage obtient la vue d'assemblage guidée et Inspection un contrôle de qualité — tandis qu'une opération Traitement extérieur est sous-traitée à un fournisseur et crée une commande d'achat ; le processus porte le même type et l'applique par défaut sur les nouvelles opérations."
+msgstr "Classe une opération de gamme : les opérations Procédé, Assemblage et Contrôle s'exécutent dans votre propre atelier dans le MES — Assemblage obtient la vue d'assemblage guidée et Contrôle une vérification de qualité — tandis qu'une opération de sous-traitance est exécutée par un fournisseur et crée un bon de commande ; le procédé porte le même type et le définit par défaut sur les nouvelles opérations."
 
 msgid "Clean and approve the migrated data"
 msgstr "Nettoyer et approuver les données migrées"
@@ -3095,13 +3095,13 @@ msgid "Clear selection"
 msgstr "Effacer la sélection"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Réglez cette facture avec les crédits comptabilisés de la partie ainsi qu'en espèces. Les crédits s'appliquent directement — aucune comptabilisation nécessaire."
+msgstr "Réglez cette facture avec les crédits comptabilisés de la partie ainsi que du numéraire. Les crédits s'appliquent directement — aucune comptabilisation nécessaire."
 
 msgid "Clear value"
 msgstr "Effacer la valeur"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Compte de compensation entre la réception de marchandises et la facture du fournisseur; se compense lorsque les deux ont été comptabilisés."
+msgstr "Compte de régularisation entre la réception de marchandises et la facture fournisseur ; équilibre quand les deux sont comptabilisées."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Compte de compensation pour réception de marchandises / correspondance de réception de facture"
@@ -3116,13 +3116,13 @@ msgid "Click to rename"
 msgstr "Cliquez pour renommer"
 
 msgid "Click to upload a PDF drawing"
-msgstr "Cliquez pour télécharger un dessin PDF"
+msgstr "Cliquer pour téléverser un dessin PDF"
 
 msgid "Clock In"
-msgstr "Pointage d'entrée"
+msgstr "Pointage début"
 
 msgid "Clock Out"
-msgstr "Pointage de sortie"
+msgstr "Pointage fin"
 
 msgid "Clocked in since <0/>"
 msgstr "Connecté depuis <0/>"
@@ -3146,7 +3146,7 @@ msgid "Close Reports"
 msgstr "Fermer les rapports"
 
 msgid "Close Status"
-msgstr "État de fermeture"
+msgstr "Statut de clôture"
 
 msgid "Closed"
 msgstr "Fermé"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, ou votre environnement auto-hébergé."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC conforme"
 
 msgid "Code"
 msgstr "Code"
@@ -3200,7 +3200,7 @@ msgid "Collapse subtree"
 msgstr "Réduire le sous-arbre"
 
 msgid "Column dimension"
-msgstr "Dimension de colonne"
+msgstr "Axe analytique de colonne"
 
 msgid "Column field"
 msgstr "Champ de colonne"
@@ -3230,28 +3230,28 @@ msgid "Commit a champion user for each area"
 msgstr "Engager un utilisateur champion pour chaque domaine"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Valider un reçu, un envoi ou une facture: les quantités se déplacent, les écritures du journal atteignent le grand livre, et le statut devient Validé."
+msgstr "Comptabilisation d'une réception, d'une expédition ou d'une facture : les quantités se déplacent, les écritures frappent le grand livre, et le statut devient comptabilisé."
 
 msgid "Community support"
-msgstr ""
+msgstr "Support communautaire"
 
 msgid "Companies"
 msgstr "Entreprises"
 
 msgid "Company"
-msgstr "Entreprise"
+msgstr "Société"
 
 msgid "Company group"
-msgstr "Groupe d'entreprises"
+msgstr "Groupe de sociétés"
 
 msgid "Company identity, documents, and system defaults."
-msgstr "Identité de l'entreprise, documents et paramètres système par défaut."
+msgstr "Identité de la société, documents et paramètres par défaut du système."
 
 msgid "Company Name"
-msgstr "Nom de l'entreprise"
+msgstr "Nom de la société"
 
 msgid "Company policy asks for a different person to inspect inbound items than the one who received them."
-msgstr "La politique de l'entreprise exige qu'une personne différente inspecte les articles entrants de celle qui les a reçus."
+msgstr "La politique de la société demande qu'une personne différente de celle qui les a reçus contrôle les articles entrants."
 
 msgid "Company-wide — includes all locations"
 msgstr "À l'échelle de l'entreprise — inclut tous les emplacements"
@@ -3275,7 +3275,7 @@ msgid "Complete All"
 msgstr "Tout Compléter"
 
 msgid "Complete all quantities on barcode scan"
-msgstr "Compléter toutes les quantités lors du scan du code-barres"
+msgstr "Terminer toutes les quantités lors du scan de code-barres"
 
 msgid "Complete Job"
 msgstr "Terminer le travail"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Configurer les comptes par défaut pour les transactions de fournisseur et de prestataire"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Configurer les comptes de capitaux propres et de bénéfices non distribués par défaut"
+msgstr "Configurer les comptes de capitaux propres et de report à nouveau par défaut"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configurez les paramètres par défaut du tableau de bord qualité."
@@ -3357,25 +3357,25 @@ msgid "Configure Item"
 msgstr "Configurer l'article"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Configurez les notifications pour quand les jauges sortent de l'étalonnage."
+msgstr "Configurer les notifications pour lorsque les instruments de mesure sortent de l'étalonnage."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Configurez les notifications pour quand les tâches sont terminées."
+msgstr "Configurer les notifications pour lorsque les ordres de fabrication sont terminés."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Configurez les notifications pour lorsque les ordres de maintenance sont créés à partir de l'atelier. Les notifications sont acheminées en fonction du type de mode de défaillance."
+msgstr "Configurer les notifications pour lorsque les interventions de maintenance sont créées à partir de l'atelier. Les notifications sont acheminées en fonction du type de mode de défaillance."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Configurez les notifications pour lorsque de nouvelles suggestions sont soumises."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Configurer les sites, les centres de travail, la nomenclature de processus, les nomenclatures, les coûts, les rôles"
+msgstr "Configurer les sites, postes de travail, listes des opérations, BOMs, calcul des coûts, rôles"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Configurez les comptes par défaut utilisés pour différents types de transactions dans votre système"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "Configurez les mois de début de vos exercices fiscaux et fiscaux"
+msgstr "Configurer les mois de début de vos exercices comptables et fiscaux"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "Configurez quand les coûts des articles achetés doivent être mis à jour à partir des transactions des fournisseurs."
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "Confirmer {0}"
 
 msgid "Confirm & release"
-msgstr "Confirmer et publier"
+msgstr "Confirmer et lancer"
 
 msgid "Confirm all"
 msgstr "Confirmer tout"
@@ -3424,7 +3424,7 @@ msgid "Confirm disconnect"
 msgstr "Confirmer la déconnexion"
 
 msgid "Confirm how your company runs and lock the scope."
-msgstr "Confirmez le fonctionnement de votre entreprise et verrouillez la portée."
+msgstr "Confirmez comment votre société fonctionne et verrouillez la portée."
 
 msgid "Confirm ID Change"
 msgstr "Confirmer le changement d'ID"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Stock entrant confirmé — commandes d'achat et de production (barres au-dessus de zéro)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Stock sortant confirmé — commandes de vente et matériaux de travail (barres en dessous de zéro)."
+msgstr "Stock de sortie confirmé — commandes clients et composants d'OF (barres sous zéro)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Confirme que chaque écriture de journal comptabilisée au cours de la période a des débits et des crédits égaux. Si une écriture est déséquilibrée, la balance de vérification ne concordera pas, elle doit donc être corrigée avant que la période puisse être clôturée."
+msgstr "Vérifie que chaque ligne d'écriture comptabilisée au cours de la période comporte des débits et crédits égaux. Si une écriture est déséquilibrée, la balance de vérification ne convergera pas et doit être corrigée avant la clôture de la période."
 
 msgid "Conflict reason"
 msgstr "Motif du conflit"
@@ -3472,7 +3472,7 @@ msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "Connectez la poignée Sinon à un nœud à exécuter quand aucune condition ne correspond."
 
 msgid "Connect the outside tools your company already runs on"
-msgstr "Connectez les outils externes que votre entreprise utilise déjà"
+msgstr "Connectez les outils externes que votre société utilise déjà"
 
 msgid "Connected to"
 msgstr "Connecté à"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contact (facultatif)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Nous contacter"
 
 msgid "contacts"
 msgstr "contacts"
@@ -3550,19 +3550,19 @@ msgid "Context"
 msgstr "Contexte"
 
 msgid "Contra-asset account for total depreciation of fixed assets"
-msgstr "Compte d'actif contré pour la dépréciation totale des immobilisations"
+msgstr "Compte correcteur d'actif pour l'amortissement total des immobilisations"
 
 msgid "Contra-revenue account for discounts given on sales"
-msgstr "Compte de contre-revenu pour les rabais accordés sur les ventes"
+msgstr "Compte correcteur de revenu pour les remises accordées sur les ventes"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
-msgstr "Compte GL de contre-revenu pour les rabais accordés sur les factures clients."
+msgstr "Compte général correcteur de revenu pour les remises accordées sur les factures clients."
 
 msgid "Contractor"
-msgstr "Entrepreneur"
+msgstr "Prestataire"
 
 msgid "Contractors"
-msgstr "Entrepreneurs"
+msgstr "Prestataires"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "Contrôler les modifications de conception avec des révisions / ECOs"
@@ -3574,10 +3574,10 @@ msgid "Controller, Accountant"
 msgstr "Contrôleur, Comptable"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "Contrôle la façon dont la planification gère un article discontinué : Consommer d'abord épuise le stock existant avant de basculer vers le successeur, Préférer le nouveau redirige immédiatement la nouvelle demande vers le successeur, Stock uniquement conserve uniquement une réserve de service minimale, et Pas de stock supprime l'article de la planification entièrement."
+msgstr "Contrôle comment la planification traite un article discontinué : Consommer d'abord épuise le stock disponible avant de passer au successeur, Privilégier le nouveau redirige immédiatement la nouvelle demande vers le successeur, Stock uniquement conserve uniquement une réserve minimale, et Sans stock supprime l'article de la planification entièrement."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Contrôle si la nomenclature et le processus de fabrication d'une révision publiée (Production) peuvent être modifiés en dehors d'un ordre de modification."
+msgstr "Contrôle si la nomenclature et la liste des opérations d'une révision lancée (Production) peuvent être modifiées en dehors d'un ordre de modification."
 
 msgid "Convention"
 msgstr "Convention"
@@ -3604,10 +3604,10 @@ msgid "Convert Line to Job"
 msgstr "Convertir la ligne en travail"
 
 msgid "Convert Lines to Jobs"
-msgstr "Convertir les lignes en tâches"
+msgstr "Convertir les lignes en ordres de fabrication"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Convertir les suggestions MRP en commandes d'achat et en travaux."
+msgstr "Convertir les suggestions MRP en bons de commande et ordres de fabrication."
 
 msgid "Convert to Quote"
 msgstr "Convertir en devis"
@@ -3625,22 +3625,22 @@ msgid "Copy"
 msgstr "Copier"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Copier tous les articles et les tarifs vers un autre client ou type."
+msgstr "Copier tous les articles et la tarification vers un autre client ou type."
 
 msgid "Copy API Key"
 msgstr "Copier la clé API"
 
 msgid "Copy company unique identifier"
-msgstr "Copier l'identifiant unique de l'entreprise"
+msgstr "Copier l'identifiant unique de la Société"
 
 msgid "Copy consumable number"
 msgstr "Copier le numéro de consommable"
 
 msgid "Copy dispatch ID"
-msgstr "Copier l'ID de la demande"
+msgstr "Copier l'ID de l'intervention de maintenance"
 
 msgid "Copy dispatch number"
-msgstr "Copier le numéro de dispatch"
+msgstr "Copier le numéro de l'intervention de maintenance"
 
 msgid "Copy document name"
 msgstr "Copier le nom du document"
@@ -3670,7 +3670,7 @@ msgid "Copy link to consumable"
 msgstr "Copier le lien vers le consommable"
 
 msgid "Copy link to dispatch"
-msgstr "Copier le lien vers la demande"
+msgstr "Copier le lien vers l'intervention de maintenance"
 
 msgid "Copy link to document"
 msgstr "Copier le lien du document"
@@ -3835,10 +3835,10 @@ msgid "Costing"
 msgstr "Calcul des coûts"
 
 msgid "Costing & Posting"
-msgstr "Coûts et comptabilisation"
+msgstr "Calcul des coûts et comptabilisation"
 
 msgid "Costing method"
-msgstr "Méthode de coûtage"
+msgstr "Méthode de calcul des coûts"
 
 msgid "Costing Method"
 msgstr "Méthode de calcul des coûts"
@@ -3870,10 +3870,10 @@ msgid "Couldn't load documents"
 msgstr "Impossible de charger les documents"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "Impossible de charger les documents associés. Actualisez avant d'en créer un nouveau pour éviter les doublons."
+msgstr "Impossible de charger les documents associés. Actualisez avant de créer un nouveau pour éviter les doublons."
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
-msgstr "Impossible de charger les cibles de dimension du fournisseur — vérifiez la connexion et rechargez."
+msgstr "Impossible de charger les cibles de dimensions du fournisseur — vérifiez la connexion et rechargez."
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Impossible de reprogrammer le travail. Veuillez réessayer."
@@ -3930,25 +3930,25 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Créer une nouvelle carte kanban pour le réapprovisionnement basé sur la numérisation."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Créer une nouvelle demande de maintenance pour suivre les réparations d'équipements et les activités de maintenance"
+msgstr "Créer une nouvelle intervention de maintenance pour suivre les réparations d'équipement et les activités de maintenance"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Créer une nouvelle tâche de production pour honorer la commande client"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Créer un nouveau client Stripe à la place"
 
 msgid "Create a new version"
 msgstr "Créer une nouvelle version"
 
 msgid "Create a purchase order"
-msgstr "Créer une commande d'achat"
+msgstr "Créer un bon de commande"
 
 msgid "Create a quote with a new quote ID"
 msgstr "Créer un devis avec un nouvel identifiant de devis"
 
 msgid "Create a sales order"
-msgstr "Créer une commande de vente"
+msgstr "Créer une commande client"
 
 msgid "Create Account"
 msgstr "Créer un compte"
@@ -3963,7 +3963,7 @@ msgid "Create an issue"
 msgstr "Créer un problème"
 
 msgid "Create and approve purchase orders"
-msgstr "Créer et approuver les commandes d'achat"
+msgstr "Créer et approuver les bons de commande"
 
 msgid "Create audit trail entries"
 msgstr "Créer des entrées de piste d'audit"
@@ -3975,7 +3975,7 @@ msgid "Create Issue"
 msgstr "Créer un problème"
 
 msgid "Create Jobs"
-msgstr "Créer des tâches"
+msgstr "Créer des ordres de fabrication"
 
 msgid "Create Kanban"
 msgstr "Créer Kanban"
@@ -4014,7 +4014,7 @@ msgid "Create Version"
 msgstr "Créer une version"
 
 msgid "Create Work Center"
-msgstr "Créer un centre de travail"
+msgstr "Créer un poste de travail"
 
 msgid "Created"
 msgstr "Créé"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "Compte créé"
 
 msgid "Created asset class"
-msgstr "Classe d'Actif Créée"
+msgstr "Catégorie d'immobilisation créée"
 
 msgid "Created at"
 msgstr "Créé le"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Mode de défaillance créé"
 
 msgid "Created gauge type"
-msgstr "Type de jauge créé"
+msgstr "Type d'instrument créé"
 
 msgid "Created item group"
 msgstr "Groupe d'articles créé"
@@ -4084,7 +4084,7 @@ msgid "Created material"
 msgstr "Matériau créé"
 
 msgid "Created material dimension"
-msgstr "Dimension de matériau créée"
+msgstr "Dimension matière créée"
 
 msgid "Created material finish"
 msgstr "Finition de matériau créée"
@@ -4093,7 +4093,7 @@ msgid "Created material form"
 msgstr "Formulaire de matériau créé"
 
 msgid "Created material grade"
-msgstr "Classe de matériau créée"
+msgstr "Nuance créée"
 
 msgid "Created material substance"
 msgstr "Substance matérielle créée"
@@ -4102,7 +4102,7 @@ msgid "Created material type"
 msgstr "Type de matériau créé"
 
 msgid "Created no quote reason"
-msgstr "Raison sans devis créée"
+msgstr "Raison de refus de devis créée"
 
 msgid "Created non conformance type"
 msgstr "Type de non-conformité créé"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Pièce créée"
 
 msgid "Created payment term"
-msgstr "Terme de paiement créé"
+msgstr "Conditions de paiement créées"
 
 msgid "Created process"
 msgstr "Processus créé"
@@ -4120,13 +4120,13 @@ msgid "Created required action"
 msgstr "Action requise créée"
 
 msgid "Created scrap reason"
-msgstr "Raison de rebut créée"
+msgstr "Motif de rebut créé"
 
 msgid "Created service"
 msgstr "Service créé"
 
 msgid "Created shipping method"
-msgstr "Méthode d'expédition créée"
+msgstr "Mode d'expédition créé"
 
 msgid "Created stock transfer line"
 msgstr "Ligne de transfert de stock créée"
@@ -4148,10 +4148,10 @@ msgid "Created webhook"
 msgstr "Webhook créé"
 
 msgid "Created work center"
-msgstr "Centre de travail créé"
+msgstr "Poste de travail créé"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "Crée les 12 périodes mensuelles pour un exercice fiscal. Les périodes qui existent déjà sont conservées."
+msgstr "Crée les 12 périodes mensuelles pour un exercice comptable. Les périodes qui existent déjà sont conservées."
 
 msgid "Creating part..."
 msgstr "Création de la pièce..."
@@ -4173,16 +4173,16 @@ msgid "Credit Account"
 msgstr "Compte Créditeur"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Compte créditeur lorsque le temps de main-d'œuvre/machine est absorbé en travaux en cours"
+msgstr "Compte crédit en cas d'absorption de la main-d'œuvre/du temps machine dans l'en-cours"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Compte de crédit quand les frais généraux sont absorbés dans les travaux en cours"
+msgstr "Compte crédit en cas d'absorption des frais généraux dans l'en-cours"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Comptes de crédit utilisés quand les coûts de fabrication sont absorbés dans les travaux en cours"
+msgstr "Comptes crédit utilisés lors de l'absorption des coûts de production dans l'en-cours"
 
 msgid "Credit Memo"
-msgstr "Note de crédit"
+msgstr "Avoir"
 
 msgid "Credits"
 msgstr "Crédits"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "Pièce Client"
 
 msgid "Customer Part ID"
-msgstr "ID de pièce client"
+msgstr "Référence client"
 
 msgid "Customer Part Number"
 msgstr "Numéro de pièce client"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Types de clients"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Radiation client (Créance douteuse)"
+msgstr "Passage en perte client (Créance douteuse)"
 
 msgid "customers"
 msgstr "clients"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clients"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personnalisations, formations et intégrations"
 
 msgid "Customize"
 msgstr "Personnaliser"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Jours d'échéance"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Jours entre la commande d'une pièce et sa disponibilité; la planification décale la demande en arrière de cette quantité."
+msgstr "Jours entre la commande d'une pièce et sa disponibilité ; le décalage de planification repousse la demande d'autant."
 
 msgid "Days Off"
 msgstr "Jours de congé"
@@ -4562,7 +4562,7 @@ msgid "Deactivate Users"
 msgstr "Désactiver les utilisateurs"
 
 msgid "Deactivate Work Center"
-msgstr "Désactiver le centre de travail"
+msgstr "Désactiver le poste de travail"
 
 msgid "Deadline type"
 msgstr "Type d'échéance"
@@ -4593,7 +4593,7 @@ msgid "Decide what happens when an operator presses Finish on the shop floor wit
 msgstr "Décidez ce qui se passe lorsqu'un opérateur appuie sur Terminer à l'atelier avec du matériel non prélevé."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "Décidez quand le matériel prélevé vers un centre de travail mais non consommé revient à l'entrepôt."
+msgstr "Décider quand le matériel prélevé vers un poste de travail mais non consommé retourne à l'entrepôt."
 
 msgid "Decimal Places"
 msgstr "Décimales"
@@ -4611,7 +4611,7 @@ msgid "Default Accounts"
 msgstr "Comptes par défaut"
 
 msgid "Default accounts for business expenses"
-msgstr "Comptes par défaut pour les frais d'exploitation"
+msgstr "Comptes par défaut pour les charges commerciales"
 
 msgid "Default accounts for customer transactions and receivables"
 msgstr "Comptes par défaut pour les transactions clients et les créances"
@@ -4620,7 +4620,7 @@ msgid "Default accounts for long-term assets and depreciation"
 msgstr "Comptes par défaut pour les actifs à long terme et l'amortissement"
 
 msgid "Default accounts for sales and income"
-msgstr "Comptes par défaut pour les ventes et les revenus"
+msgstr "Comptes par défaut pour les ventes et les produits"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "Comptes par défaut pour les transactions liées aux impôts"
@@ -4653,13 +4653,13 @@ msgid "Default GL account debited when a fixed-asset disposal results in a loss.
 msgstr "Compte GL par défaut débité lorsqu'une cession d'immobilisation se solde par une perte."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
-msgstr "Compte GL par défaut utilisé pour les transactions de trésorerie lorsqu'aucun compte bancaire spécifique n'est sélectionné."
+msgstr "Compte général par défaut utilisé pour les transactions de trésorerie quand aucun compte bancaire spécifique n'est sélectionné."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Compte GL de dépenses par défaut pour l'entretien des équipements et installations."
+msgstr "Compte général de charge par défaut pour la maintenance des équipements et installations."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Compte GL de dépenses par défaut pour les exécutions d'amortissement périodiques."
+msgstr "Compte général de charge par défaut pour les cycles d'amortissement périodiques."
 
 msgid "Default Method"
 msgstr "Méthode par défaut"
@@ -4668,13 +4668,13 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Méthode par défaut qui se remplit préalablement sur les nouveaux actifs de cette classe (toujours modifiable par actif)."
 
 msgid "Default method type"
-msgstr "Type de méthode par défaut"
+msgstr "Type d'approvisionnement par défaut"
 
 msgid "Default Method Type"
-msgstr "Type de méthode par défaut"
+msgstr "Type d'approvisionnement par défaut"
 
 msgid "Default Permissions"
-msgstr "Permissions par défaut"
+msgstr "Autorisations par défaut"
 
 msgid "Default Priority"
 msgstr "Priorité par défaut"
@@ -4695,7 +4695,7 @@ msgid "Default Storage Unit"
 msgstr "Unité de stockage par défaut"
 
 msgid "Default tax depreciation method for new assets in this class."
-msgstr "Méthode d'amortissement fiscal par défaut pour les nouveaux actifs de cette classe."
+msgstr "Méthode d'amortissement fiscal par défaut pour les nouvelles immobilisations de cette catégorie."
 
 msgid "Default tax-book life for new assets in this class."
 msgstr "Durée fiscale par défaut pour les nouveaux actifs de cette classe."
@@ -4722,10 +4722,10 @@ msgid "Deferred Tax Liability (default)"
 msgstr "Passif d'Impôt Différé (par défaut)"
 
 msgid "Define a manufacturing operation first."
-msgstr "Définissez d'abord une opération de fabrication."
+msgstr "Définir d'abord une opération de production."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Définir les nomenclatures multi-niveaux et la gamme de fabrication (méthodes de fabrication)"
+msgstr "Définir des BOM multi-niveaux et des Listes des opérations (méthodes de fabrication)"
 
 msgid "Delete"
 msgstr "Supprimer"
@@ -4756,7 +4756,7 @@ msgid "Delete Asset"
 msgstr "Supprimer l'actif"
 
 msgid "Delete Asset Class"
-msgstr "Supprimer la classe d'actifs"
+msgstr "Supprimer la catégorie d'immobilisation"
 
 msgid "Delete Assignment"
 msgstr "Supprimer l'affectation"
@@ -4780,7 +4780,7 @@ msgid "Delete Contact"
 msgstr "Supprimer le contact"
 
 msgid "Delete Contractor"
-msgstr "Supprimer l'entrepreneur"
+msgstr "Supprimer le prestataire"
 
 msgid "Delete Count"
 msgstr "Supprimer le décompte"
@@ -4801,10 +4801,10 @@ msgid "Delete Department"
 msgstr "Supprimer le département"
 
 msgid "Delete Dimension"
-msgstr "Supprimer la dimension"
+msgstr "Supprimer l'axe analytique"
 
 msgid "Delete Dispatch"
-msgstr "Supprimer la demande"
+msgstr "Supprimer l'intervention de maintenance"
 
 msgid "Delete Document"
 msgstr "Supprimer le document"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Supprimer le jour férié"
 
 msgid "Delete Inspection Plan"
-msgstr "Supprimer le plan d'inspection"
+msgstr "Supprimer le plan de contrôle"
 
 msgid "Delete Issue"
 msgstr "Supprimer le problème"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Supprimer le groupe d'articles"
 
 msgid "Delete Journal Entry"
-msgstr "Supprimer l'entrée de journal"
+msgstr "Supprimer la ligne d'écriture"
 
 msgid "Delete line"
 msgstr "Supprimer la ligne"
@@ -4849,13 +4849,13 @@ msgid "Delete Material"
 msgstr "Supprimer le matériau"
 
 msgid "Delete Material Dimension"
-msgstr "Supprimer la dimension matérielle"
+msgstr "Supprimer la dimension de matière"
 
 msgid "Delete Material Finish"
 msgstr "Supprimer la finition matérielle"
 
 msgid "Delete Material Grade"
-msgstr "Supprimer la qualité de matériau"
+msgstr "Supprimer la nuance"
 
 msgid "Delete Material Shape"
 msgstr "Supprimer la forme de matériau"
@@ -4882,7 +4882,7 @@ msgid "Delete Payment"
 msgstr "Supprimer le paiement"
 
 msgid "Delete Payment Term"
-msgstr "Supprimer le délai de paiement"
+msgstr "Supprimer la condition de paiement"
 
 msgid "Delete Period"
 msgstr "Supprimer la période"
@@ -4894,7 +4894,7 @@ msgid "Delete Portal"
 msgstr "Supprimer le portail"
 
 msgid "Delete Price Break"
-msgstr "Supprimer la rupture de prix"
+msgstr "Supprimer le palier de prix"
 
 msgid "Delete Pricing Rule"
 msgstr "Supprimer la règle de tarification"
@@ -4909,10 +4909,10 @@ msgid "Delete Purchase Invoice"
 msgstr "Supprimer la facture d'achat"
 
 msgid "Delete Purchase Order"
-msgstr "Supprimer la commande d'achat"
+msgstr "Supprimer le bon de commande"
 
 msgid "Delete Purchase Orders"
-msgstr "Supprimer les commandes d'achat"
+msgstr "Supprimer les bons de commande"
 
 msgid "Delete Question"
 msgstr "Supprimer la question"
@@ -4957,7 +4957,7 @@ msgid "Delete Service"
 msgstr "Supprimer le service"
 
 msgid "Delete Shift"
-msgstr "Supprimer le quart"
+msgstr "Supprimer l'équipe"
 
 msgid "Delete Shipment"
 msgstr "Supprimer l'expédition"
@@ -4966,7 +4966,7 @@ msgid "Delete shipment line"
 msgstr "Supprimer la ligne d'expédition"
 
 msgid "Delete Shipping Method"
-msgstr "Supprimer la méthode d'expédition"
+msgstr "Supprimer le mode d'expédition"
 
 msgid "Delete step"
 msgstr "Supprimer l'étape"
@@ -5003,7 +5003,7 @@ msgstr "Supprimer le type de fournisseur"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Supprimer la remise par quantité {0} ? Cette action est irréversible."
+msgstr "Supprimer le palier de prix pour la quantité {0} ? Cette action ne peut pas être annulée."
 
 msgid "Delete Timecard"
 msgstr "Supprimer la feuille de temps"
@@ -5048,25 +5048,25 @@ msgid "Delivery Location"
 msgstr "Lieu de livraison"
 
 msgid "Demand"
-msgstr "Demande"
+msgstr "Besoins"
 
 msgid "Demand forecast"
-msgstr "Prévision de la Demande"
+msgstr "Prévision de besoins"
 
 msgid "Demand Forecast"
-msgstr "Prévision de la demande"
+msgstr "Prévision de besoins"
 
 msgid "Demand Forecast — Driven by"
-msgstr "Prévision de la demande — Pilotée par"
+msgstr "Prévision de besoins — Déterminé par"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Prévision de la demande = demande éclatée par nomenclature provenant des commandes client ouvertes, des travaux actifs et des projections de production."
+msgstr "Prévision de besoins = besoins éclatés par la nomenclature en provenance des commandes clients ouvertes, ordres de fabrication actifs et projections de production."
 
 msgid "Demand projection"
-msgstr "Projection de la demande"
+msgstr "Projection de besoins"
 
 msgid "Demand Projections"
-msgstr "Projections de la demande"
+msgstr "Projections de besoins"
 
 msgid "Demand-Based"
 msgstr "Basée sur la demande"
@@ -5081,7 +5081,7 @@ msgid "Demo data applied"
 msgstr "Données de démonstration appliquées"
 
 msgid "Demo data was applied to this company. Keep it, or revert to put back exactly what was here before."
-msgstr "Les données de démonstration ont été appliquées à cette entreprise. Conservez-les ou revenez en arrière pour retrouver exactement ce qui était ici avant."
+msgstr "Des données de démonstration ont été appliquées à cette société. Conservez-les ou annulez pour revenir à l'état antérieur."
 
 msgid "department"
 msgstr "département"
@@ -5126,7 +5126,7 @@ msgid "Depreciation Start Date"
 msgstr "Date de Début de l'Amortissement"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Dérivez la durée de vie de cet article de la durée de vie la plus courte de ses composants, en ignorant le champ Jours ci-dessus."
+msgstr "Dériver la durée de conservation de cet article à partir de la durée de conservation la plus courte de ses composants, en ignorant le champ Jours ci-dessus."
 
 msgid "Description"
 msgstr "Description"
@@ -5171,22 +5171,22 @@ msgid "Digital Quotes"
 msgstr "Devis numériques"
 
 msgid "dimension"
-msgstr "dimension"
+msgstr "axe analytique"
 
 msgid "Dimension"
-msgstr "Dimension"
+msgstr "Axe analytique"
 
 msgid "Dimension slots"
-msgstr "Emplacements de dimension"
+msgstr "Emplacements d'axes analytiques"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Valeurs de dimension sur les journaux postés qui n'ont pas encore de mappage de fournisseur."
+msgstr "Valeurs d'axes analytiques sur les écritures comptabilisées qui n'ont pas encore de mappage de fournisseur."
 
 msgid "dimensions"
-msgstr "dimensions"
+msgstr "axes analytiques"
 
 msgid "Dimensions"
-msgstr "Dimensions"
+msgstr "Axes analytiques"
 
 msgid "Direct"
 msgstr "Direct"
@@ -5247,16 +5247,16 @@ msgid "Dismiss"
 msgstr "Fermer"
 
 msgid "Dispatch"
-msgstr "Dépêche"
+msgstr "Intervention de maintenance"
 
 msgid "Dispatch ID"
-msgstr "ID de Dispatch"
+msgstr "Numéro d'intervention de maintenance"
 
 msgid "Dispatch priority"
-msgstr "Priorité de distribution"
+msgstr "Priorité d'intervention de maintenance"
 
 msgid "Dispatches"
-msgstr "Expéditions"
+msgstr "Interventions de maintenance"
 
 msgid "Display Settings"
 msgstr "Paramètres d'affichage"
@@ -5277,13 +5277,13 @@ msgid "Disposed"
 msgstr "Cédé"
 
 msgid "Disposition"
-msgstr "Disposition"
+msgstr "Traitement"
 
 msgid "Dispositions"
-msgstr "Dispositions"
+msgstr "Traitements"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
-msgstr "Voulez-vous remplacer les permissions actuelles de l'utilisateur par les permissions par défaut pour ce type d'employé ?"
+msgstr "Voulez-vous remplacer les autorisations actuelles de l'utilisateur par les autorisations par défaut pour ce type d'employé ?"
 
 msgid "Doc-Backed"
 msgstr "Adossé à un document"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Documents"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documents envoie les factures, les factures fournisseur et les paiements en tant que documents fournisseur natifs ; leurs journaux sont enregistrés comme couverts par le document. Il tire également les paiements enregistrés chez le fournisseur dans Carbon, ferme la facture ou la facture fournisseur correspondante et enregistre un journal GL Carbon. Off les enregistre comme volontairement exclus."
+msgstr "Documents exporte les factures, factures d'achat et paiements en tant que documents natifs du fournisseur ; leurs écritures sont enregistrées comme couvertes par le document. Il récupère également les paiements enregistrés dans le fournisseur dans Carbon, fermant la facture ou facture d'achat correspondante et comptabilisant une écriture du grand livre Carbon. Désactivé les enregistre comme volontairement exclus."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Les documents que vous ouvrez s'afficheront ici pour un accès rapide."
@@ -5322,13 +5322,13 @@ msgid "Don't Cancel"
 msgstr "Ne pas annuler"
 
 msgid "done"
-msgstr "terminé"
+msgstr "fait"
 
 msgid "Done"
-msgstr "Terminé"
+msgstr "Fait"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Terminé quand les opérations quotidiennes fonctionnent sans nous dans la salle"
+msgstr "Terminé quand les opérations quotidiennes fonctionnent sans nous."
 
 msgid "Download"
 msgstr "Télécharger"
@@ -5389,7 +5389,7 @@ msgid "Drawing"
 msgstr "Prélèvement"
 
 msgid "Drawing Number"
-msgstr "Numéro de dessin"
+msgstr "Numéro de plan"
 
 msgid "Drawing replaced. Balloon placements were removed; feature rows are unchanged."
 msgstr "Le dessin a été remplacé. Les placements de bulles ont été supprimés ; les lignes de fonctionnalités restent inchangées."
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "Déposez votre fichier ici, ou cliquez pour parcourir."
 
 msgid "Drop-ship"
-msgstr "Expédition Directe"
+msgstr "Livraison directe"
 
 msgid "Due"
 msgstr "Échéance"
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Date d'échéance du dernier travail"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Date d'échéance du travail le plus ancien du lot; les travaux ultérieurs sont espacés uniformément entre cette date et la date d'échéance du dernier travail."
+msgstr "Date d'échéance de l'ordre de fabrication le plus précoce du lot groupé ; les ordres de fabrication ultérieurs s'espacent uniformément entre cette date et la Date d'échéance du dernier ordre de fabrication."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Date d'échéance du travail final dans le lot; combinée avec la date d'échéance du premier travail pour espacer les travaux uniformément."
+msgstr "Date d'échéance du dernier ordre de fabrication du lot groupé ; combinée avec la Date d'échéance du premier ordre de fabrication pour espacer uniformément les ordres de fabrication."
 
 msgid "Due Days"
 msgstr "Jours d'Échéance"
@@ -5447,7 +5447,7 @@ msgid "Duplicate"
 msgstr "Dupliquer"
 
 msgid "Duplicate Item"
-msgstr "Élément en double"
+msgstr "Dupliquer l'article"
 
 msgid "Duplicate Price List"
 msgstr "Dupliquer la liste de prix"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "p. ex. 48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "p. ex. Acme Manufacturing"
+msgstr "par ex. Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "p. ex. Detroit"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "p. ex. Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Le matériel inutilisé de chaque opération revient dès que l'opération est terminée."
+msgstr "La matière inutilisée de chaque opération est restituée dès que l'opération est terminée."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "Chaque unité physique obtient sa propre entité suivie et un numéro unique — une entité, une unité."
@@ -5558,7 +5558,7 @@ msgid "Edit Asset"
 msgstr "Modifier l'actif"
 
 msgid "Edit Asset Class"
-msgstr "Modifier la Classe d'Actif"
+msgstr "Modifier la catégorie d'immobilisation"
 
 msgid "Edit Assignment"
 msgstr "Modifier l'affectation"
@@ -5588,7 +5588,7 @@ msgid "Edit Contact"
 msgstr "Modifier le contact"
 
 msgid "Edit Contractor"
-msgstr "Modifier le Contractant"
+msgstr "Modifier le prestataire"
 
 msgid "Edit Cost Center"
 msgstr "Modifier le centre de coûts"
@@ -5615,10 +5615,10 @@ msgid "Edit Department"
 msgstr "Modifier le département"
 
 msgid "Edit Dimension"
-msgstr "Modifier la Dimension"
+msgstr "Modifier l'axe analytique"
 
 msgid "Edit Dispatch"
-msgstr "Modifier la demande"
+msgstr "Modifier l'intervention de maintenance"
 
 msgid "Edit Employee"
 msgstr "Modifier l'employé"
@@ -5630,7 +5630,7 @@ msgid "Edit expiration date"
 msgstr "Modifier la date d'expiration"
 
 msgid "Edit Expiry"
-msgstr "Modifier l'expiration"
+msgstr "Modifier la péremption"
 
 msgid "Edit Failure Mode"
 msgstr "Modifier le mode de défaillance"
@@ -5639,10 +5639,10 @@ msgid "Edit Fixed Asset"
 msgstr "Modifier l'Immobilisation"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Modifier l'enregistrement d'étalonnage de jauge"
+msgstr "Modifier l'enregistrement d'étalonnage de l'instrument de mesure"
 
 msgid "Edit Gauge Type"
-msgstr "Modifier le type de jauge"
+msgstr "Modifier le type d'instrument"
 
 msgid "Edit Group"
 msgstr "Modifier le groupe"
@@ -5651,13 +5651,13 @@ msgid "Edit Holiday"
 msgstr "Modifier le congé"
 
 msgid "Edit Inspection Plan"
-msgstr "Éditer le plan d'inspection"
+msgstr "Modifier le plan de contrôle"
 
 msgid "Edit Item Group"
 msgstr "Modifier le groupe d'articles"
 
 msgid "Edit Journal Entry"
-msgstr "Modifier l'entrée de journal"
+msgstr "Modifier la ligne d'écriture"
 
 msgid "Edit Kanban"
 msgstr "Modifier Kanban"
@@ -5669,19 +5669,19 @@ msgid "Edit Location"
 msgstr "Modifier l'emplacement"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Modifier la demande de maintenance"
+msgstr "Modifier l'intervention de maintenance"
 
 msgid "Edit Material"
 msgstr "Modifier le matériau"
 
 msgid "Edit Material Dimension"
-msgstr "Modifier la dimension du matériau"
+msgstr "Modifier la dimension matière"
 
 msgid "Edit Material Finish"
 msgstr "Modifier la finition du matériau"
 
 msgid "Edit Material Grade"
-msgstr "Modifier la classe de matériau"
+msgstr "Modifier la nuance"
 
 msgid "Edit Material Shape"
 msgstr "Modifier la forme du matériau"
@@ -5711,7 +5711,7 @@ msgid "Edit Payment"
 msgstr "Modifier le paiement"
 
 msgid "Edit Payment Term"
-msgstr "Modifier le délai de paiement"
+msgstr "Modifier les conditions de paiement"
 
 msgid "Edit permissions"
 msgstr "Autorisations de modification"
@@ -5726,7 +5726,7 @@ msgid "Edit Portal"
 msgstr "Modifier le portail"
 
 msgid "Edit Price Override"
-msgstr "Modifier le prix de remplacement"
+msgstr "Modifier la substitution de prix"
 
 msgid "Edit Pricing"
 msgstr "Modifier la tarification"
@@ -5747,7 +5747,7 @@ msgid "Edit Production Quantity"
 msgstr "Modifier la Quantité de Production"
 
 msgid "Edit purchase order line type"
-msgstr "Modifier le type de ligne de commande d'achat"
+msgstr "Modifier le type de ligne de bon de commande"
 
 msgid "Edit Question"
 msgstr "Modifier la question"
@@ -5783,7 +5783,7 @@ msgid "Edit Service"
 msgstr "Modifier le service"
 
 msgid "Edit Shift"
-msgstr "Modifier le quart"
+msgstr "Modifier l'équipe"
 
 msgid "Edit Shipment"
 msgstr "Modifier l'expédition"
@@ -5792,7 +5792,7 @@ msgid "Edit Shipping"
 msgstr "Modifier l'expédition"
 
 msgid "Edit Shipping Method"
-msgstr "Modifier la méthode d'expédition"
+msgstr "Modifier le mode d'expédition"
 
 msgid "Edit Size"
 msgstr "Modifier la taille"
@@ -5825,7 +5825,7 @@ msgid "Edit Supplier Type"
 msgstr "Modifier le type de fournisseur"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "Modifiez la règle pour supprimer l'indicateur « S'applique à tous »"
+msgstr "Modifier la règle pour supprimer l'indicateur « S'applique à tous »"
 
 msgid "Edit Timecard"
 msgstr "Modifier la feuille de temps"
@@ -5855,7 +5855,7 @@ msgid "Edit Webhook"
 msgstr "Modifier le Webhook"
 
 msgid "Edit Work Center"
-msgstr "Modifier le centre de travail"
+msgstr "Modifier le poste de travail"
 
 msgid "Eliminated"
 msgstr "Éliminé"
@@ -5876,7 +5876,7 @@ msgid "Email Address"
 msgstr "Adresse e-mail"
 
 msgid "Email notifications are not included in your company's current plan; email preferences will apply if they are enabled."
-msgstr "Les notifications par e-mail ne sont pas incluses dans le forfait actuel de votre entreprise ; les préférences d'e-mail s'appliqueront s'ils sont activés."
+msgstr "Les notifications par e-mail ne sont pas incluses dans le plan actuel de votre société ; les préférences d'e-mail s'appliqueront si elles sont activées."
 
 msgid "Email notifications not configured"
 msgstr "Les notifications par e-mail ne sont pas configurées"
@@ -5918,13 +5918,13 @@ msgid "Empty list"
 msgstr "Liste vide"
 
 msgid "Empty work centers"
-msgstr "Centres de travail vides"
+msgstr "Postes de travail vides"
 
 msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "Activez la journalisation d'audit dans les paramètres pour commencer à suivre les modifications apportées à vos données."
 
 msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
-msgstr "Activez les devis numériques pour votre entreprise. Cela vous permettra d'envoyer des devis numériques à vos clients et de leur permettre de les accepter en ligne."
+msgstr "Activez les devis numériques pour votre société. Cela vous permettra d'envoyer des devis numériques à vos clients et leur permettra de les accepter en ligne."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
 msgstr "Activez la comptabilité d'exercice complète avec les écritures de journal, les rapports financiers et la validation du grand livre."
@@ -5942,7 +5942,7 @@ msgid "Enable this rule to automatically require approval for matching documents
 msgstr "Activez cette règle pour exiger automatiquement une approbation pour les documents correspondants"
 
 msgid "Enable timecard tracking for work shifts."
-msgstr "Activer le suivi des feuilles de temps pour les quarts de travail."
+msgstr "Activez le suivi des feuilles de temps pour les équipes de travail."
 
 msgid "Enable to allow shared workstation mode."
 msgstr "Activez pour autoriser le mode poste de travail partagé."
@@ -5951,7 +5951,7 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "Activez pour publier automatiquement les transactions dans le grand livre."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "Activez cette option pour configurer les méthodes d'amortissement spécifiques aux impôts sur les classes d'actifs (par exemple, MACRS, accéléré)."
+msgstr "Activez pour configurer les méthodes d'amortissement spécifiques aux impôts sur les catégories d'immobilisation (par exemple, MACRS, accéléré)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
 msgstr "Activez pour générer des identifiants et des descriptions pour les matières premières."
@@ -5960,10 +5960,10 @@ msgid "Enable to start tracking changes to your data."
 msgstr "Activez pour commencer à suivre les modifications de vos données."
 
 msgid "Enable to start tracking work shifts."
-msgstr "Activez pour commencer à suivre les quarts de travail."
+msgstr "Activez pour commencer à suivre les équipes de travail."
 
 msgid "Enable to use metric units for material dimensions."
-msgstr "Activez pour utiliser les unités métriques pour les dimensions des matériaux."
+msgstr "Activez pour utiliser les unités métriques pour les dimensions des matières."
 
 msgid "Enabled"
 msgstr "Activé"
@@ -5972,7 +5972,7 @@ msgid "End Date"
 msgstr "Date de fin"
 
 msgid "End of Last Fiscal Year"
-msgstr "Fin du dernier exercice fiscal"
+msgstr "Fin du dernier exercice comptable"
 
 msgid "End of Last Month"
 msgstr "Fin du mois dernier"
@@ -6003,10 +6003,10 @@ msgid "Engineering"
 msgstr "Ingénierie"
 
 msgid "Engineering changes and CAD"
-msgstr "Modifications d'ingénierie et CAO"
+msgstr "Modifications techniques et CAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "Modifications d'ingénierie et CAO"
+msgstr "Modifications techniques et CAD"
 
 msgid "Engineering Contact"
 msgstr "Contact Technique"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Erreur lors de la récupération des données du fournisseur"
 
 msgid "Error loading assigned dispatches"
-msgstr "Erreur lors du chargement des dépannages assignés"
+msgstr "Erreur lors du chargement des interventions de maintenance attribuées"
 
 msgid "Error loading assigned documents"
 msgstr "Erreur lors du chargement des documents assignés"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Chaque correspondance"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Chaque tâche requise doit être terminée ou ignorée avant que la période puisse être fermée."
+msgstr "Chaque tâche requise doit être faite ou ignorée avant que la période ne puisse être clôturée."
 
 msgid "Every row was imported successfully."
 msgstr "Chaque ligne a été importée avec succès."
@@ -6214,7 +6214,7 @@ msgid "Everything else covers people, imports, integrations and the API — anyt
 msgstr "Tout le reste couvre les personnes, les importations, les intégrations et l'API — tout ce qui n'est pas l'un de vos flux de travail."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "Dépasse {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB au total — supprimez certaines pièces jointes pour envoyer."
+msgstr "Dépasse {PO_EMAIL_ATTACHMENT_LIMIT_MB} Mo au total — supprimez certaines pièces jointes pour envoyer."
 
 msgid "Exchange rate"
 msgstr "Taux de change"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mappages existants. Choisissez une option de fournisseur différente pour remapper."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Client Stripe existant"
 
 msgid "Expand"
 msgstr "Développer"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "Développer le sous-arbre"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Demande future attendue pour une pièce à fabriquer saisie semaine après semaine avant l'existence de toute commande de vente ; la planification la compense par rapport à l'offre et détaille la méthode pour commander les composants à l'avance."
+msgstr "Besoins futurs attendus pour une pièce de fabrication saisis semaine par semaine avant qu'une commande client n'existe ; la planification les compense par rapport à l'approvisionnement et détaille la méthode pour commander les composants à l'avance."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "Demande future attendue pour un article, regroupée par période, remplie par la planification aux côtés de la demande réelle."
+msgstr "Besoins futurs attendus pour un article, répartis par période, générés par l'exécution de la planification aux côtés des besoins réels."
 
 msgid "Expected Receipt"
 msgstr "Réception prévue"
@@ -6293,31 +6293,31 @@ msgid "Expected Receipt Date"
 msgstr "Date de réception prévue"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Compte de dépenses pour les soldes clients radiés comme irrécouvrables lors du règlement des créances clients"
+msgstr "Compte de charge pour les soldes clients radiés comme irrécouvrables lors du règlement des comptes clients"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "Compte de charges pour ajustements d'impôt différé sur amortissement"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "Compte de charges pour l'entretien des équipements et des installations"
+msgstr "Compte de charge pour la maintenance de l'équipement et des installations"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
-msgstr "Compte de dépenses pour les pertes de change lorsqu'un paiement règle une facture en devise étrangère à un taux moins favorable"
+msgstr "Compte de charge pour les pertes de change lorsqu'un paiement règle une facture en devise étrangère à un taux moins favorable"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Compte de charges pour achats hors inventaire (services, fournitures)"
+msgstr "Compte de charge pour les achats hors stock (services, fournitures)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Compte de charge GL débité lorsque l'inventaire est expédié/émis contre une vente."
+msgstr "Compte de charge pour le coût des articles vendus"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Côté charges des mouvements d'impôt différé (appairé avec passif d'impôt différé)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Échec de la création de la classe d'actif : {0}"
+msgstr "Côté charge des mouvements d'impôt différé (associé au passif d'impôt différé)."
 
 msgid "Expenses"
-msgstr "Dépenses"
+msgstr "Charges"
 
 msgid "Expert guidance"
 msgstr "Conseils d'experts"
@@ -6362,16 +6362,16 @@ msgid "Expiring first"
 msgstr "Expiration en premier"
 
 msgid "Expiry"
-msgstr "Expiration"
+msgstr "Péremption"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "L'expiration commence lorsque le processus sélectionné est terminé."
+msgstr "La péremption débute quand le procédé sélectionné se termine."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "L'expiration commence quand le processus sélectionné démarre."
+msgstr "La péremption débute quand le procédé sélectionné démarre."
 
 msgid "Expiry trace"
-msgstr "Traçabilité d'expiration"
+msgstr "Trace de péremption"
 
 msgid "Export"
 msgstr "Exporter"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Informations supplémentaires envoyées avec la demande, comme une clé d'autorisation ; les valeurs d'en-tête sont masquées dans l'historique d'exécution, bien que les noms restent lisibles."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Balises supplémentaires pour segmenter vos rapports GL"
+msgstr "Balises supplémentaires pour segmenter vos rapports du Grand livre"
 
 msgid "Fail"
-msgstr "Échouer"
+msgstr "Non conforme"
 
 msgid "Failed"
 msgstr "Échoué"
@@ -6432,7 +6432,7 @@ msgstr "Caractéristiques échouées"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (premier à expirer, premier à sortir)"
+msgstr "Échec de la création de la catégorie d'immobilisation : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Échec de la création du mode de défaillance : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Impossible de créer le type de jauge : {0}"
+msgstr "Échec de la création du type d'instrument : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6476,43 +6476,43 @@ msgstr "Échec de la création du groupe d'articles : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create location: {0}"
-msgstr "Échec de la création de l'emplacement : {0}"
+msgstr "Échec de la création du site : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "Échec de la création du calendrier de maintenance : {0}"
+msgstr "Échec de la création du planning de maintenance : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
-msgstr "Échec de la création de la dimension matérielle : {0}"
+msgstr "Échec de la création de la dimension de matière : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "Échec de la création de la finition matérielle : {0}"
+msgstr "Échec de la création de la finition : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
-msgstr "Échec de la création du formulaire de matériau : {0}"
+msgstr "Échec de la création de la forme de matière : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "Échec de la création de la classe de matériau : {0}"
+msgstr "Échec de la création de la nuance : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Échec de la création de la substance matérielle : {0}"
-
-#. placeholder {0}: fetcher.data.error.message
-msgid "Failed to create material type: {0}"
-msgstr "Échec de la création du type de matériau : {0}"
-
-#. placeholder {0}: fetcher.data.error.message
-msgid "Failed to create material: {0}"
 msgstr "Échec de la création du matériau : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material type: {0}"
+msgstr "Échec de la création du type de matière : {0}"
+
+#. placeholder {0}: fetcher.data.error.message
+msgid "Failed to create material: {0}"
+msgstr "Échec de la création de la matière : {0}"
+
+#. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Échec de la création de la raison sans devis : {0}"
+msgstr "Échec de la création de la raison du refus de devis : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,23 +6520,23 @@ msgstr "Impossible de créer la pièce : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Échec de la création du délai de paiement : {0}"
+msgstr "Échec de la création des conditions de paiement : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
-msgstr "Échec de la création du processus : {0}"
+msgstr "Échec de la création du procédé : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create service: {0}"
-msgstr "Échec de la création du service : {0}"
+msgstr "Échec de la création de la prestation : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create shipping method: {0}"
-msgstr "Échec de la création de la méthode d'expédition : {0}"
+msgstr "Échec de la création du mode d'expédition : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "Échec de la création de la ligne de transfert de stock : {0}"
+msgstr "Échec de la création de la ligne de transfert : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6556,7 +6556,7 @@ msgstr "Échec de la création du webhook : {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
-msgstr "Échec de la création du centre de travail : {0}"
+msgstr "Échec de la création du poste de travail : {0}"
 
 msgid "Failed to delete file from old location"
 msgstr "Impossible de supprimer le fichier de l'ancien emplacement"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Échec du chargement des données"
 
 msgid "Failed to load inbound inspections"
-msgstr "Impossible de charger les inspections entrantes"
+msgstr "Échec du chargement des contrôles à réception"
 
 msgid "Failed to load item data"
 msgstr "Impossible de charger les données de l'article"
@@ -6607,16 +6607,16 @@ msgid "Failed to load item details"
 msgstr "Impossible de charger les détails de l'article"
 
 msgid "Failed to load job operations"
-msgstr "Impossible de charger les opérations de travail"
+msgstr "Échec du chargement des opérations d'OF"
 
 msgid "Failed to load jobs"
-msgstr "Échec du chargement des tâches"
+msgstr "Échec du chargement des ordres de fabrication"
 
 msgid "Failed to load purchase order lines"
-msgstr "Impossible de charger les lignes de commande d'achat"
+msgstr "Échec du chargement des lignes de bon de commande"
 
 msgid "Failed to load purchase orders"
-msgstr "Impossible de charger les commandes d'achat"
+msgstr "Échec du chargement des bons de commande"
 
 msgid "Failed to load receipt lines"
 msgstr "Échec du chargement des lignes de réception"
@@ -6695,67 +6695,67 @@ msgid "Failed to save tools"
 msgstr "Échec de l'enregistrement des outils"
 
 msgid "Failed to update batch property"
-msgstr "Échec de la mise à jour de la propriété de lot"
+msgstr "Échec de la mise à jour de la propriété du lot de production"
 
 msgid "Failed to update category markups"
-msgstr "Échec de la mise à jour des majorations par catégorie"
+msgstr "Échec de la mise à jour des majorations de catégorie"
 
 msgid "Failed to update configuration parameter"
 msgstr "Échec de la mise à jour du paramètre de configuration"
 
 msgid "Failed to update count"
-msgstr "Échec de la mise à jour du décompte"
+msgstr "Impossible de mettre à jour le nombre"
 
 msgid "Failed to update item cost"
-msgstr "Échec de la mise à jour du coût de l'article"
+msgstr "Impossible de mettre à jour le coût de l'article"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "Échec de la mise à jour de l'opportunité avec le bon de commande"
+msgstr "Impossible de mettre à jour l'opportunité avec le bon de commande"
 
 msgid "Failed to update quote line"
-msgstr "Échec de la mise à jour de la ligne de devis"
+msgstr "Impossible de mettre à jour la ligne de devis"
 
 msgid "Failed to update supplier quote line"
-msgstr "Échec de la mise à jour de la ligne de devis fournisseur"
+msgstr "Impossible de mettre à jour la ligne de devis fournisseur"
 
 msgid "Failed to update thumbnail path"
-msgstr "Échec de la mise à jour du chemin de la miniature"
+msgstr "Impossible de mettre à jour le chemin de la miniature"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
-msgstr "Échec du téléchargement {0}"
+msgstr "Impossible de téléverser {0}"
 
 msgid "Failed to upload certificate"
-msgstr "Échec du téléchargement du certificat"
+msgstr "Impossible de téléverser le certificat"
 
 msgid "Failed to upload CSV file."
-msgstr "Échec du téléchargement du fichier CSV."
+msgstr "Impossible de téléverser le fichier CSV."
 
 msgid "Failed to upload file"
-msgstr "Échec du téléchargement du fichier"
+msgstr "Impossible de téléverser le fichier"
 
 msgid "Failed to upload file to new location"
-msgstr "Échec du téléchargement du fichier vers le nouvel emplacement"
+msgstr "Impossible de téléverser le fichier vers le nouveau site"
 
 #. placeholder {0}: file.name
 #. placeholder {0}: fileUpload.name
 msgid "Failed to upload file: {0}"
-msgstr "Échec du téléchargement du fichier : {0}"
+msgstr "Impossible de téléverser le fichier : {0}"
 
 msgid "Failed to upload image"
-msgstr "Échec du téléchargement de l'image"
+msgstr "Impossible de téléverser l'image"
 
 msgid "Failed to upload logo: {errorMessage}"
-msgstr "Échec du téléchargement du logo : {errorMessage}"
+msgstr "Impossible de téléverser le logo : {errorMessage}"
 
 msgid "Failed to upload model"
-msgstr "Échec du téléchargement du modèle"
+msgstr "Impossible de téléverser le modèle"
 
 msgid "Failed to upload PDF"
-msgstr "Échec du téléchargement du PDF"
+msgstr "Impossible de téléverser le PDF"
 
 msgid "Failed to upload thumbnail"
-msgstr "Échec du téléchargement de la miniature"
+msgstr "Impossible de téléverser la miniature"
 
 msgid "Failure"
 msgstr "Échec"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Frais"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Finition"
+msgstr "FEFO (premier périmé, premier sorti)"
 
 msgid "Fetch"
 msgstr "Récupérer"
@@ -6841,7 +6841,7 @@ msgid "Files attached here ride along on every purchase order email sent to this
 msgstr "Les fichiers joints ici sont inclus dans chaque email de bon de commande envoyé à ce fournisseur (en plus des paramètres par défaut à l'échelle de l'entreprise)."
 
 msgid "Fill this company with a realistic industry story so every screen has something in it. You can put back what was here before."
-msgstr "Remplissez cette entreprise avec une histoire d'industrie réaliste afin que chaque écran ait quelque chose. Vous pouvez restaurer ce qui était ici avant."
+msgstr "Remplissez cette société avec une histoire industrielle réaliste pour que chaque écran ait quelque chose dedans. Vous pouvez replacer ce qui était là avant."
 
 msgid "Filter"
 msgstr "Filtre"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "Finaliser"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Finalisation d'un mois fiscal via le cycle de vie Ouvert → Verrouillé → Fermé ; une période fermée est gelée et ses soldes sont capturés, réversible uniquement par une réouverture explicite."
+msgstr "Finalisation d'un mois d'exercice comptable à travers le cycle Ouvert → Verrouillé → Clôturé ; une période clôturée est figée et ses soldes sont capturés, réversible uniquement par réouverture explicite."
 
 msgid "Financial Statements"
 msgstr "États financiers"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "Terminer avec du matériel non prélevé ?"
 
 msgid "Finished goods"
-msgstr "Finitions"
+msgstr "Produits finis"
 
 msgid "Finished Goods"
 msgstr "Produits Finis"
@@ -6904,19 +6904,19 @@ msgid "First-year additional deduction taken before the regular MACRS schedule b
 msgstr "Immobilisation"
 
 msgid "Fiscal year"
-msgstr "Exercice fiscal"
+msgstr "Exercice comptable"
 
 msgid "Fiscal Year"
-msgstr "Exercice fiscal"
+msgstr "Exercice comptable"
 
 msgid "Fiscal Year Settings"
-msgstr "Paramètres de l'exercice fiscal"
+msgstr "Paramètres d'exercice comptable"
 
 msgid "Fiscal Year to Date"
-msgstr "Exercice fiscal à ce jour"
+msgstr "Exercice comptable à date"
 
 msgid "Fiscal Years"
-msgstr "Exercices fiscaux"
+msgstr "Exercices comptables"
 
 msgid "Fit view"
 msgstr "Ajuster la vue"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Fixe"
 
 msgid "Fixed asset"
-msgstr "Variance d'amortissement des coûts fixes lorsque la taille du lot diffère de la norme"
+msgstr "Immobilisation"
 
 msgid "Fixed Asset"
 msgstr "Immobilisation"
@@ -6937,7 +6937,7 @@ msgid "Fixed Assets"
 msgstr "Immobilisations"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Gains et Pertes"
+msgstr "Écart d'amortissement du coût fixe quand la taille du lot de production diffère du normal"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "Fixé une fois que les périodes comptables ont été comptabilisées ou fermées. Supprimez toutes les périodes ouvertes pour le modifier."
@@ -6949,10 +6949,10 @@ msgid "Fixed Shelf Life"
 msgstr "Durée de conservation fixe"
 
 msgid "Fixture"
-msgstr "Accessoire"
+msgstr "Montage d'usinage"
 
 msgid "Fixture ID"
-msgstr "ID d'Accessoire"
+msgstr "ID montage d'usinage"
 
 msgid "Flags"
 msgstr "Indicateurs"
@@ -6962,16 +6962,16 @@ msgstr "pour n'importe quoi. Ils vont faire intervenir la bonne personne."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Méthode de prévision : <0>{0}</0>. Cette ligne n'a pas été dérivée de tâches actives, donc aucune source parent n'est disponible."
+msgstr "Méthode de prévision : <0>{0}</0>. Cette ligne n'a pas été dérivée des ordres de fabrication actifs, donc aucune source parent n'est disponible."
 
 msgid "Forgot to Clock Out?"
-msgstr "Oublié de pointer la sortie ?"
+msgstr "Avez-vous oublié le pointage fin ?"
 
 msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingénieur dédié au terrain"
 
 msgid "Foundation"
 msgstr "Fondation"
@@ -7021,16 +7021,16 @@ msgid "From Storage Unit"
 msgstr "Unité de stockage source"
 
 msgid "Fulfillment Location"
-msgstr "Lieu d'Exécution"
+msgstr "Site d'expédition"
 
 msgid "Full name"
 msgstr "Nom complet"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Réglage complet et migrations"
 
 msgid "Fully Depreciated"
-msgstr "Entièrement amorti"
+msgstr "Totalement amorti"
 
 msgid "Fully trained for"
 msgstr "Entièrement formé pour"
@@ -7051,40 +7051,40 @@ msgid "Gains recognized on disposal of fixed assets"
 msgstr "Gains constatés à la cession d'immobilisations"
 
 msgid "gauge"
-msgstr "Calibres"
+msgstr "instrument de mesure"
 
 msgid "Gauge"
-msgstr "Jauge"
+msgstr "Instrument de mesure"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Notifications d'étalonnage des jauges"
+msgstr "Notifications d'étalonnage de l'instrument de mesure"
 
 msgid "Gauge ID"
-msgstr "ID de jauge"
+msgstr "ID instrument de mesure"
 
 msgid "Gauge not found"
-msgstr "Jauge non trouvée"
+msgstr "Instrument de mesure non trouvé"
 
 msgid "Gauge Type"
-msgstr "Type de jauge"
+msgstr "Type d'instrument"
 
 msgid "Gauge Types"
-msgstr "Types de jauge"
+msgstr "Types d'instrument"
 
 msgid "gauges"
-msgstr "Généalogie"
+msgstr "instruments de mesure"
 
 msgid "Gauges"
-msgstr "Jauges"
+msgstr "Instruments de mesure"
 
 msgid "Genealogy"
-msgstr "Grand Livre"
+msgstr "Généalogie"
 
 msgid "General"
 msgstr "Général"
 
 msgid "General ledger"
-msgstr "Compte GL capturant les différences de coûts sur les opérations de sous-traitance."
+msgstr "Grand livre"
 
 msgid "General Ledger"
 msgstr "Grand Livre"
@@ -7102,10 +7102,10 @@ msgid "Generate and send customer invoices"
 msgstr "Générer et envoyer les factures clients"
 
 msgid "Generate fiscal year"
-msgstr "Générer l'exercice fiscal"
+msgstr "Générer un exercice comptable"
 
 msgid "Generate Fiscal Year"
-msgstr "Générer l'exercice fiscal"
+msgstr "Générer un exercice comptable"
 
 msgid "Generate material IDs and descriptions based on the properties of the material."
 msgstr "Générer les IDs de matériaux et les descriptions en fonction des propriétés du matériau."
@@ -7129,7 +7129,7 @@ msgid "Get live on Carbon: one system running quoting, purchasing, the shop floo
 msgstr "Passer en direct sur Carbon : un seul système pour les devis, les achats, l'atelier, l'inventaire et la finance, remplaçant les outils actuels."
 
 msgid "Get Method"
-msgstr "Obtenir la méthode"
+msgstr "Récupérer la méthode"
 
 msgid "Get started"
 msgstr "Commencer"
@@ -7147,7 +7147,7 @@ msgid "Give it an owner and a date"
 msgstr "Désignez un propriétaire et une date"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Grand livre"
 
 msgid "GL Account"
 msgstr "Compte GL"
@@ -7156,25 +7156,25 @@ msgid "GL account capturing cost differences on outside-processing operations."
 msgstr "Compte GL capturant les différences de coût sur les opérations de sous-traitance."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Compte GL capturant les différences entre les frais généraux de fabrication appliqués et réels."
+msgstr "Compte général enregistrant les écarts entre les frais généraux appliqués et réels de production."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Compte GL capturant les différences entre les matériaux prévus par la BOM et consommés réellement."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Compte GL capturant les différences entre le temps de travail/machine prévu et réel."
+msgstr "Compte général enregistrant les écarts entre les temps de main-d'œuvre et de machine attendus par la gamme et les temps réels."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Compte GL capturant les différences de coûts fixes lorsque la taille réelle du lot diffère de la taille prévue."
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "Compte GL crédité pour supprimer le coût initial de l'actif lors de sa cession."
+msgstr "Compte général crédité pour annuler le coût d'origine de l'immobilisation quand elle est cédée."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
 msgstr "Compte GL crédité lorsqu'une facture fournisseur est enregistrée (solde PA)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Compte GL crédité lorsque le coût du travail ou de la machine est absorbé dans un travail de production."
+msgstr "Compte général crédité quand le coût de main-d'œuvre ou de machine est absorbé dans un ordre de fabrication."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "Compte GL crédité quand les frais généraux de fabrication sont absorbés dans une commande de production."
@@ -7189,19 +7189,19 @@ msgid "GL account debited when a fixed asset is acquired (purchase or capitalize
 msgstr "Compte GL débité lorsqu'une immobilisation est acquise (achat ou coût capitalisé)."
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "Compte GL pour les frais bancaires et frais similaires."
+msgstr "Compte général pour les frais bancaires de service et autres frais similaires."
 
 msgid "GL account for interest income or expense."
-msgstr "Compte GL pour les revenus ou charges d'intérêt."
+msgstr "Compte général pour les produits ou charges d'intérêts."
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "Compte GL pour la taxe d'achat payée aux fournisseurs (ou récupérable)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "Compte GL pour les impôts dus en vertu des règles d'autoliquidation où l'acheteur s'auto-évalue."
+msgstr "Compte général pour la taxe en autoliquidation, où l'acheteur auto-évalue sa charge fiscale."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "Compte GL pour les différences de timing fiscal (p. ex. amortissement fiscal accéléré vs. amortissement comptable)."
+msgstr "Compte général pour les écarts de timing fiscal (p. ex. amortissement fiscal accéléré vs. amortissement comptable)."
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Compte GL affecté lorsque les comptages physiques diffèrent de l'inventaire du système."
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "Compte GL qui porte le coût d'acquisition d'origine d'un actif — débité lors de l'acquisition et crédité pour le coût brut total lorsque l'actif est cédé ou vendu."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Compte GL qui détient la valeur des travaux en production jusqu'à ce qu'ils soient comptabilisés en tant que produits finis."
+msgstr "Compte général qui détient la valeur des ordres de fabrication en cours jusqu'à leur comptabilisation en produits finis."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "Compte GL qui détient la valeur des marchandises manufacturées (Articles Fabriquer); débité à la fin du travail, crédité à l'expédition."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "Compte GL où sont enregistrées les remises de paiement anticipé obtenues des fournisseurs."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Compte GL contre-actif crédité à chaque comptabilisation périodique de l'amortissement et débité intégralement lorsque l'actif est vendu ou mis au rebut."
+msgstr "Compte de contre-immobilisation du grand livre crédité lors de la comptabilisation de l'amortissement chaque période et débité en totalité quand l'immobilisation est vendue ou mise au rebut."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Compte GL contre-actif qui accumule l'amortissement comptabilisé par rapport aux immobilisations."
+msgstr "Compte de contre-immobilisation du grand livre qui accumule l'amortissement comptabilisé contre les immobilisations."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Compte GL de capitaux propres (réserve de conversion) qui détient les différences de change non réalisées résultant de la retraduction des soldes en devises au clôture de la période; séparé des gains/pertes de change réalisés au compte de résultat."
+msgstr "Compte de capitaux propres du grand livre (réserve CTA) qui détient les écarts de change non réalisés provenant de la réévaluation des soldes en devises étrangères en fin de période, distinct des plus ou moins-values de change réalisées au compte de résultat."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Compte GL de capitaux propres où le revenu net est fermé à la fin de l'exercice fiscal."
+msgstr "Compte de capitaux propres du grand livre où le résultat net se clôture en fin d'exercice comptable."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Compte GL de dépenses débité chaque période lorsque l'amortissement est comptabilisé."
+msgstr "Compte de charge du grand livre débité chaque période quand l'amortissement est comptabilisé."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Compte GL de dépenses débité lorsque la valeur comptable d'un actif est réduite par dépréciation, c'est-à-dire lorsque sa valeur recouvrable devient inférieure à la valeur nette comptable."
+msgstr "Compte de charge du grand livre débité quand la valeur comptable d'une immobilisation est réduite par une dépréciation, c'est-à-dire quand sa valeur recouvrable tombe au-dessous de sa valeur nette comptable."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Compte GL de dépenses pour les achats non inventoriables (fournitures, services)."
+msgstr "Compte de charge du grand livre pour les achats hors stock (fournitures, prestations)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Compte GL de passif crédité pour la taxe de vente collectée auprès des clients."
+msgstr "Compte de passif du grand livre crédité pour la taxe de vente collectée auprès des clients."
 
 msgid "GL tie-out"
-msgstr "Rapprochement GL"
+msgstr "Rapprochement du grand livre"
 
 msgid "GL Tie-Out"
-msgstr "Rapprochement GL"
+msgstr "Rapprochement du grand livre"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Lancez-vous correctement du premier coup — avec notre équipe à vos côtés"
@@ -7277,7 +7277,7 @@ msgid "Go to {0}"
 msgstr "Aller à {0}"
 
 msgid "Go to implementation hub"
-msgstr "Aller au hub d'implémentation"
+msgstr "Aller au centre de mise en œuvre"
 
 msgid "Go-Live"
 msgstr "Mise en production"
@@ -7355,7 +7355,7 @@ msgid "Guided"
 msgstr "Guidé"
 
 msgid "Guided implementation"
-msgstr "Implémentation guidée"
+msgstr "Mise en œuvre guidée"
 
 msgid "Handle recurring and reversing journal entries"
 msgstr "Gérer les écritures comptables récurrentes et contrepassées"
@@ -7385,7 +7385,7 @@ msgid "Hide raw"
 msgstr "Masquer le brut"
 
 msgid "Hide system quantities until the review step"
-msgstr "Masquer les quantités du système jusqu'à l'étape d'examen"
+msgstr "Masquer les quantités système jusqu'à l'étape de revue"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Masquer, épingler et réorganiser les colonnes"
@@ -7409,7 +7409,7 @@ msgid "History"
 msgstr "Historique"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Mettre le journal en attente comme avertissement pour correction."
+msgstr "Mettre l'écriture en attente comme avertissement à corriger."
 
 msgid "Holiday"
 msgstr "Jour férié"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Heures/Pièce"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Comment un article est approvisionné globalement (Acheter, Fabriquer ou Acheter et Fabriquer), défini par article, contrairement au type de méthode par ligne."
+msgstr "Comment un article est approvisionné globalement (Achat, Fabrication ou Achat et fabrication), défini par article, contrairement au type d'approvisionnement par ligne."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Comment un article est approvisionné : Approvisionnement Manuel, Approvisionnement Basé sur la Demande, Quantité Fixe de Réapprovisionnement ou Quantité Maximale."
@@ -7460,7 +7460,7 @@ msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank
 msgstr "Durée de chaque phase, en semaines. Détermine la chronologie du Plan ; laissez vide pour utiliser la valeur par défaut."
 
 msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
-msgstr "Combien de temps dure généralement une exécution de ce programme; la planification bloque le centre de travail pendant ce nombre de minutes pour chaque instance planifiée."
+msgstr "Durée typique d'une exécution de ce planning ; le planning réserve le poste de travail pour ce nombre de minutes à chaque instance programmée."
 
 msgid "How many"
 msgstr "Combien"
@@ -7478,7 +7478,7 @@ msgid "How many days from invoice date this customer is given to pay; drives the
 msgstr "Combien de jours à partir de la date de facture ce client a pour payer; détermine la date d'échéance par défaut sur les factures clients."
 
 msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
-msgstr "Combien de jours à partir de la date de facture ce fournisseur s'attend à être payé; détermine la date d'échéance par défaut sur les factures."
+msgstr "Nombre de jours à partir de la date de facture que ce fournisseur s'attend à recevoir le paiement ; détermine la date d'échéance par défaut sur les factures d'achat."
 
 msgid "How many fractional digits to keep when rounding amounts in this currency."
 msgstr "Combien de chiffres fractionnaires à conserver lors de l'arrondi de montants dans cette devise."
@@ -7496,10 +7496,10 @@ msgid "How many were actually picked?"
 msgstr "Combien ont été réellement prélevés ?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "À quelle fréquence cet appareil de mesure doit être réétalonnage; combiné avec la date de dernier réétalonnage pour recalculer automatiquement la date du prochain réétalonnage."
+msgstr "Fréquence d'étalonnage de cet instrument de mesure ; combinée avec la date du dernier étalonnage pour recalculer automatiquement la date du prochain étalonnage."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "À quelle fréquence cet entretien se répète — Quotidiennement, Hebdomadairement, Mensuellement, Au Comptage de Cycle; Quotidiennement révèle le sélecteur du jour de la semaine, les autres utilisent une mathématique d'intervalle plus simple."
+msgstr "Fréquence de récurrence de cette maintenance — Quotidien, Hebdomadaire, Mensuel, À chaque inventaire tournant ; Quotidien affiche le sélecteur de jour de la semaine, les autres utilisent une arithmétique d'intervalle plus simple."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Quelle est la stricture de la date d'échéance — Délai Ferme bloque la planification, Délai Souple permet à la planification de se décaler avec un avertissement, Pas de Délai l'ignore complètement."
@@ -7511,7 +7511,7 @@ msgid "How the resolved price was calculated."
 msgstr "Comment le prix résolu a été calculé."
 
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
-msgstr "Comment la taille de l'échantillon est décidée — Inspecter Tout, Inspecter les Premiers N, Pourcentage du Lot ou AQL (Z1.4 / ISO 2859-1). Chaque mode révèle ses propres champs de paramètres ci-dessous."
+msgstr "Comment la taille d'échantillon est décidée — Inspecter tout, Inspecter les N premiers, Pourcentage du lot ou AQL (Z1.4 / ISO 2859-1). Chaque mode affiche ses propres champs de paramètre ci-dessous."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
 msgstr "Comment cet instrument de mesure est utilisé — Standard (contrôles réguliers) ou Maître (étalonner d'autres instruments)."
@@ -7526,10 +7526,10 @@ msgid "How to read this chart"
 msgstr "Comment lire ce graphique"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "À quelle urgence ce dispatch est — Bas / Moyen / Haut / Critique; combiné avec Priorité et Impact OEE pour décider du créneau de planification."
+msgstr "L'urgence de cette intervention de maintenance — Faible / Moyen / Élevé / Critique ; combinée à la Priorité et à l'Impact OEE pour décider de l'emplacement du planning."
 
 msgid "How we know we're done"
-msgstr "Comment nous savons que c'est terminé"
+msgstr "Comment nous savons que c'est fait"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
 msgstr "Comment nous restons alignés et comment les problèmes sont résolus. Votre rôle : participer à l'appel hebdomadaire et signaler les blocages rapidement, avant qu'ils ne deviennent des retards."
@@ -7541,7 +7541,7 @@ msgid "How We Work Together"
 msgstr "Comment nous travaillons ensemble"
 
 msgid "How your company's process maps to Carbon"
-msgstr "Comment les processus de votre entreprise correspondent à Carbon"
+msgstr "Comment le procédé de votre société s'intègre à Carbon"
 
 msgid "How your quotes, orders, and invoices look when they go out"
 msgstr "Comment vos devis, commandes et factures s'affichent lorsqu'ils sont envoyés"
@@ -7607,7 +7607,7 @@ msgid "If something is off track"
 msgstr "Si quelque chose déraille"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "Si vous souhaitez modifier les numéros de pièce, veuillez cliquer sur Annuler et assigner manuellement les pièces pour chaque article de ligne avant de convertir."
+msgstr "Si vous souhaitez modifier les numéros de pièce, veuillez cliquer sur Annuler et attribuer manuellement les pièces pour chaque ligne avant la conversion."
 
 msgid "II (normal default)"
 msgstr "II (normal par défaut)"
@@ -7622,7 +7622,7 @@ msgid "Imperial"
 msgstr "Impérial"
 
 msgid "Implementation"
-msgstr "Implémentation"
+msgstr "Mise en œuvre"
 
 msgid "Implementation Hub"
 msgstr "Centre de mise en œuvre"
@@ -7637,7 +7637,7 @@ msgid "Import results"
 msgstr "Résultats d'Importation"
 
 msgid "Import your BOM"
-msgstr "Importez votre nomenclature"
+msgstr "Importer votre BOM"
 
 #. placeholder {0}: precise?.text
 msgid "in {0}"
@@ -7701,7 +7701,7 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Les actions inactives n'apparaîtront pas dans les listes de sélection"
 
 msgid "Inbound inspection"
-msgstr "Inspection entrante"
+msgstr "Contrôle à réception"
 
 msgid "Inbox"
 msgstr "Boîte de réception"
@@ -7716,10 +7716,10 @@ msgid "Included"
 msgstr "Inclus"
 
 msgid "Includes tax and shipping costs"
-msgstr "Inclut les taxes et les frais d'expédition"
+msgstr "Comprend les taxes et les frais de port"
 
 msgid "Income / Balance (inherited)"
-msgstr "Revenu / Bilan (hérité)"
+msgstr "Produits / Solde (hérité)"
 
 msgid "Income Statement"
 msgstr "Compte de résultat"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "Impôt sur le revenu"
 
 msgid "Income/Balance"
-msgstr "Revenu/Solde"
+msgstr "Produits/Solde"
 
 msgid "incoming"
 msgstr "entrante"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Hérité du parent"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Hérité du groupe : classification de haut niveau (actif, passif, capitaux propres, revenu, dépense)."
+msgstr "Hérité du groupe : classification de haut niveau (actif, passif, capitaux propres, chiffre d'affaires, charge)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Hérité du groupe : où ce compte apparaît dans les états financiers."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Hérité du groupe : si ce compte se ferme aux bénéfices non distribués (revenus) ou se reporte (bilan)."
+msgstr "Hérité du groupe : si ce compte se ferme sur le report à nouveau (produits) ou se reporte (solde)."
 
 msgid "Inherited from the parent group."
 msgstr "Hérité du groupe parent."
@@ -7803,37 +7803,37 @@ msgid "Inspect Item"
 msgstr "Inspecter l'article"
 
 msgid "Inspection"
-msgstr "Inspection"
+msgstr "Contrôle"
 
 msgid "Inspection document"
-msgstr "Document d'inspection"
+msgstr "Document de contrôle"
 
 msgid "Inspection Level"
-msgstr "Niveau d'inspection"
+msgstr "Niveau de contrôle"
 
 msgid "Inspection Plan"
-msgstr "Plan d'inspection"
+msgstr "Plan de contrôle"
 
 msgid "Inspection Plan Assignments"
-msgstr "Attributions du plan d'inspection"
+msgstr "Attributions du plan de contrôle"
 
 msgid "Inspection Plans"
-msgstr "Plans d'inspection"
+msgstr "Plans de contrôle"
 
 msgid "Inspection Status"
-msgstr "Statut d'inspection"
+msgstr "Statut du contrôle"
 
 msgid "Inspections"
-msgstr "Inspections"
+msgstr "Contrôles"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Inspections, non-conformité et CAPA"
+msgstr "Contrôles, non-conformité et CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Inspections, Non-conformité, CAPA"
+msgstr "Contrôles, Non-conformité, CAPA"
 
 msgid "Inspections: Require Different Inspector"
-msgstr "Inspections : Exiger un inspecteur différent"
+msgstr "Contrôles : Exiger un inspecteur différent"
 
 msgid "Install"
 msgstr "Installer"
@@ -7866,7 +7866,7 @@ msgid "Intercompany Balances"
 msgstr "Soldes interentreprises"
 
 msgid "Intercompany company"
-msgstr "Entreprise intercompagnie"
+msgstr "Société intercompagnies"
 
 msgid "Intercompany Transactions"
 msgstr "Transactions interentreprises"
@@ -7881,7 +7881,7 @@ msgid "Interest (default)"
 msgstr "Intérêt (par défaut)"
 
 msgid "Interest income or expense from banking activities"
-msgstr "Revenu ou charge d'intérêt provenant d'activités bancaires"
+msgstr "Produits ou charges d'intérêts provenant d'activités bancaires"
 
 msgid "Internal"
 msgstr "Interne"
@@ -7917,10 +7917,10 @@ msgid "Inventory actions"
 msgstr "Actions d'inventaire"
 
 msgid "Inventory Adjustment"
-msgstr "Ajustement d'inventaire"
+msgstr "Ajustement de stock"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Ajustement d'Inventaire (par défaut)"
+msgstr "Ajustement de stock (par défaut)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Inventaire et achats, avec planification automatisée"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Problèmes"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Elle s'arrêtera d'être exécutée jusqu'à ce que vous publiiez une nouvelle version. Rien n'est supprimé."
 
 msgid "ITAR Certifications"
 msgstr "Certifications ITAR"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Maître d'article et méthodes de fabrication"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Maître d'article, nomenclatures et gamme de fabrication"
+msgstr "Maître d'articles, BOM et liste des opérations"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "L'article doit correspondre à un type sélectionné ET à un groupe sélectionné"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Les articles dans cette fenêtre reçoivent un badge jaune."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Articles : nomenclature, nomenclatures, gamme de fabrication, modifications d'ingénierie, CAO"
+msgstr "Articles : maître d'articles, BOM, liste des opérations, modifications techniques, CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "Sa conception peut changer avant la publication de l'avis de modification."
@@ -8226,16 +8226,16 @@ msgid "Job make method"
 msgstr "Méthode de fabrication du travail"
 
 msgid "Job Materials"
-msgstr "Matériaux de travail"
+msgstr "Composants d'OF"
 
 msgid "Job operation"
-msgstr "Opération de travail"
+msgstr "Opération d'OF"
 
 msgid "Job Operation"
-msgstr "Opération de travail"
+msgstr "Opération d'OF"
 
 msgid "Job Operations"
-msgstr "Opérations de travail"
+msgstr "Opérations d'OF"
 
 msgid "Job Priority"
 msgstr "Priorité du travail"
@@ -8244,26 +8244,26 @@ msgid "Job readable"
 msgstr "Travail lisible"
 
 msgid "Job Traveler"
-msgstr "Bon de travail"
+msgstr "Fiche suiveuse"
 
 msgid "Jobs"
-msgstr "Travaux"
+msgstr "Ordres de fabrication"
 
 msgid "Jobs Assigned to Me"
-msgstr "Tâches qui m'ont été assignées"
+msgstr "Ordres de fabrication qui m'ont été attribués"
 
 msgid "Jobs Required"
-msgstr "Emplois requis"
+msgstr "Ordres de fabrication requis"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Travaux qui ont cet article dans leur nomenclature"
+msgstr "Ordres de fabrication qui ont cet article sur leur nomenclature"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Rejoindre {0}"
 
 msgid "Journal"
-msgstr "Journal"
+msgstr "Écriture"
 
 msgid "Journal Entries"
 msgstr "Écritures comptables"
@@ -8272,10 +8272,10 @@ msgid "Journal entries dated in this period that are still Draft must be posted,
 msgstr "Les écritures de journal datées de cette période qui sont encore Brouillon doivent être comptabilisées ou redatées à une période ouverte ultérieure. Les écritures brouillon ne font pas partie du grand livre, de sorte que leurs débits et crédits manqueraient à la clôture."
 
 msgid "Journal Entry"
-msgstr "Écriture de journal"
+msgstr "Ligne d'écriture"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Les journaux datés à cette date ou avant sont traités comme verrouillés. Fusionnés avec la date de verrouillage rapportée par le fournisseur quand les deux existent."
+msgstr "Les écritures datées de cette date ou antérieures sont traitées comme verrouillées. Fusionnées avec la date de verrouillage signalée par le fournisseur lorsque les deux existent."
 
 msgid "Just one"
 msgstr "Un seul"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "Garder ouvert"
 
 msgid "Keep picking"
-msgstr "Continuer"
+msgstr "Continuer le prélèvement"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Garde les commandes, les devis et les paramètres derrière une deuxième vérification"
@@ -8342,19 +8342,19 @@ msgid "Labels"
 msgstr "Étiquettes"
 
 msgid "Labor"
-msgstr "Travail"
+msgstr "Main-d'œuvre"
 
 msgid "Labor & Machine Absorption"
-msgstr "Absorption du Travail et de la Machine"
+msgstr "Absorption de main-d'œuvre et machine"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "Absorption du Travail et de la Machine (par défaut)"
+msgstr "Absorption de main-d'œuvre et machine (par défaut)"
 
 msgid "Labor & Machine Variance"
-msgstr "Variance du Travail et de la Machine"
+msgstr "Écart de main-d'œuvre et machine"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Variance du Travail et de la Machine (par défaut)"
+msgstr "Écart de main-d'œuvre et machine (par défaut)"
 
 msgid "Labor rate"
 msgstr "Taux de main-d'œuvre"
@@ -8369,13 +8369,13 @@ msgid "Labor time"
 msgstr "Temps de main-d'œuvre"
 
 msgid "Labor Time"
-msgstr "Temps de travail"
+msgstr "Temps de main-d'œuvre"
 
 msgid "Labor unit"
 msgstr "Unité de main-d'œuvre"
 
 msgid "Labor Unit"
-msgstr "Unité de travail"
+msgstr "Unité de main-d'œuvre"
 
 msgid "Language"
 msgstr "Langue"
@@ -8399,7 +8399,7 @@ msgid "Last day"
 msgstr "Dernier jour"
 
 msgid "Last Fiscal Year"
-msgstr "Dernier exercice fiscal"
+msgstr "Dernier exercice comptable"
 
 msgid "Last Login"
 msgstr "Dernière connexion"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Latitude"
 
 msgid "Lead time"
-msgstr "Délai"
+msgstr "Délai d'approvisionnement"
 
 msgid "Lead Time"
-msgstr "Délai de livraison"
+msgstr "Délai d'approvisionnement"
 
 msgid "Lead time (days)"
-msgstr "Délai de livraison (jours)"
+msgstr "Délai d'approvisionnement (jours)"
 
 msgid "Lead Time (Days)"
-msgstr "Délai de livraison (jours)"
+msgstr "Délai d'approvisionnement (jours)"
 
 msgid "Lead Time:"
-msgstr "Délai de livraison :"
+msgstr "Délai d'approvisionnement :"
 
 msgid "Learn"
 msgstr "Apprendre"
@@ -8486,13 +8486,13 @@ msgid "Less manual work, fewer errors"
 msgstr "Moins de travail manuel, moins d'erreurs"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Allons construire"
 
 msgid "Let's build something"
 msgstr "Construisons quelque chose"
 
 msgid "Let's set up your new company"
-msgstr "Configurons votre nouvelle entreprise"
+msgstr "Configurons votre nouvelle société"
 
 msgid "Let's setup your account"
 msgstr "Configurons votre compte"
@@ -8549,16 +8549,16 @@ msgid "Lines need internal part numbers"
 msgstr "Les lignes ont besoin de numéros de pièces internes"
 
 msgid "Lines need prices or lead times"
-msgstr "Les lignes ont besoin de prix ou de délais"
+msgstr "Les lignes ont besoin de prix ou de délais d'approvisionnement"
 
 msgid "Lineside"
-msgstr "Au pied de la chaîne"
+msgstr "Bord de ligne"
 
 msgid "Link"
 msgstr "Lien"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "Lien (optionnel) — p. ex. /x/settings/…"
+msgstr "Lien (optionnel) — ex. /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Lier un problème Jira"
@@ -8567,7 +8567,7 @@ msgid "Link Linear Issue"
 msgstr "Lier un problème Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Liez ce client Carbon à l'un d'entre eux, ou créez un client Stripe distinct."
 
 msgid "Link to sales order line"
 msgstr "Lier à la ligne de commande client"
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Chargé en dernier, juste au moment du basculement, pour que les soldes soient à jour."
 
 msgid "Loading associated jobs..."
-msgstr "Chargement des tâches associées..."
+msgstr "Chargement des ordres de fabrication associés..."
 
 msgid "Loading current quantity…"
 msgstr "Chargement de la quantité actuelle…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Verrouillé"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "Le verrouillage rend la période en lecture seule pour les documents opérationnels (reçus, expéditions, factures) tout en permettant les ajustements comptables comme l'amortissement et les cessions. Une période doit être verrouillée avant de pouvoir être fermée."
+msgstr "Le verrouillage rend la période en lecture seule pour les documents opérationnels (réceptions, expéditions, factures) tout en permettant les ajustements comptables comme l'amortissement et les cessions. Une période doit être verrouillée avant de pouvoir être clôturée."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Enregistrer les non-conformités et piloter une CAPA"
@@ -8719,19 +8719,19 @@ msgid "Lot Size"
 msgstr "Taille du lot"
 
 msgid "Lot Size Variance"
-msgstr "Variance de Taille de Lot"
+msgstr "Écart de taille de lot"
 
 msgid "Lot Size Variance (default)"
-msgstr "Variance de Taille de Lot (par défaut)"
+msgstr "Écart de taille de lot (par défaut)"
 
 msgid "Lot Size:"
 msgstr "Taille du lot :"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Inspection basée sur les lots des marchandises reçues par rapport à un plan d'échantillonnage ; les unités sont affichées En attente à la réception et ne sont libérées En disponible qu'une fois que le lot est disposé comme accepté."
+msgstr "Contrôle basé sur les lots des biens reçus selon un plan d'échantillonnage ; les unités sont enregistrées Suspendu à la réception et ne sont lancées vers Disponible qu'une fois que le lot est disposé comme Accepté."
 
 msgid "Low"
-msgstr "Bas"
+msgstr "Faible"
 
 msgid "Machine"
 msgstr "Machine"
@@ -8779,16 +8779,16 @@ msgid "Maintenance"
 msgstr "Maintenance"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Notifications de Dispatch de Maintenance"
+msgstr "Notifications d'intervention de maintenance"
 
 msgid "Maintenance Dispatches"
-msgstr "Ordres de maintenance"
+msgstr "Interventions de maintenance"
 
 msgid "Maintenance Expense"
-msgstr "Frais de Maintenance"
+msgstr "Charge de maintenance"
 
 msgid "Maintenance Expense (default)"
-msgstr "Frais de Maintenance (par défaut)"
+msgstr "Charge de maintenance (par défaut)"
 
 msgid "Maintenance Schedules"
 msgstr "Calendriers de maintenance"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Prendre la décision de lancer ou non"
 
 msgid "Make to Order"
-msgstr "Fabriquer sur commande"
+msgstr "Fabrication à la commande"
 
 msgid "Make tracked entities available again"
 msgstr "Rendre les entités suivies disponibles à nouveau"
@@ -8878,13 +8878,13 @@ msgid "Manufacturer Part Number"
 msgstr "Numéro de pièce du fabricant"
 
 msgid "Manufacturing"
-msgstr "Fabrication"
+msgstr "Production"
 
 msgid "Map accounts"
 msgstr "Mapper les comptes"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Mappez les comptes Carbon au plan comptable du fournisseur. Les journaux comptabilisés sont poussés en utilisant le code de compte fournisseur mappé."
+msgstr "Mappez les comptes Carbon au plan comptable du fournisseur. Les écritures comptabilisées sont transmises en utilisant le code de compte fournisseur mappé."
 
 msgid "Map Extracted Invoice Lines"
 msgstr "Mapper les lignes de facture extraites"
@@ -8933,10 +8933,10 @@ msgid "Mark Dark Mode"
 msgstr "Marque Mode Sombre"
 
 msgid "Mark done"
-msgstr "Marquer comme terminé"
+msgstr "Marquer comme fait"
 
 msgid "Mark Done"
-msgstr "Marquer comme terminé"
+msgstr "Marquer comme fait"
 
 msgid "Mark Light Mode"
 msgstr "Marque Mode Clair"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "Marquer pour supprimer"
 
 msgid "Master gauge"
-msgstr "Instrument maître"
+msgstr "Étalon de mesure"
 
 msgid "Master records"
 msgstr "Enregistrements principaux"
@@ -8999,13 +8999,13 @@ msgid "Material"
 msgstr "Matériau"
 
 msgid "Material Dimension"
-msgstr "Dimension de matériau"
+msgstr "Axe analytique de matière"
 
 msgid "Material Dimensions"
-msgstr "Dimensions de matériaux"
+msgstr "Dimensions de matière"
 
 msgid "Material dimensions use metric units."
-msgstr "Les dimensions des matériaux utilisent des unités métriques."
+msgstr "Les dimensions des matières utilisent des unités métriques."
 
 msgid "Material Finish"
 msgstr "Finition de matériau"
@@ -9017,10 +9017,10 @@ msgid "Material Form"
 msgstr "Formulaire de matériau"
 
 msgid "Material Grade"
-msgstr "Qualité de matériau"
+msgstr "Nuance"
 
 msgid "Material Grades"
-msgstr "Grades de matériaux"
+msgstr "Nuances"
 
 msgid "Material ID"
 msgstr "ID Matériau"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "Propriétés des matériaux"
 
 msgid "Material Review Board (MRB)"
-msgstr "Comité d'examen des matériaux (MRB)"
+msgstr "Comité de revue des matériaux (MRB)"
 
 msgid "Material Shape"
 msgstr "Forme de matériau"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "Types de matériaux"
 
 msgid "Material Usage Variance"
-msgstr "Variance d'Utilisation des Matériaux"
+msgstr "Écart d'utilisation de matériel"
 
 msgid "Material Usage Variance (default)"
-msgstr "Variance d'Utilisation des Matériaux (par défaut)"
+msgstr "Écart d'utilisation de matériel (par défaut)"
 
 msgid "materials"
 msgstr "Matériaux"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "Temps Moyen de Réparation"
 
 msgid "Measurement Standard"
-msgstr "Norme de Mesure"
+msgstr "Étalon de mesure"
 
 msgid "Media Size"
 msgstr "Taille du média"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Opérations de méthode"
 
 msgid "Method type"
-msgstr "Type de Méthode"
+msgstr "Type d'approvisionnement"
 
 msgid "Method Type"
-msgstr "Type de méthode"
+msgstr "Type d'approvisionnement"
 
 msgid "Methods"
 msgstr "Méthodes"
@@ -9221,7 +9221,7 @@ msgid "Missing Operations"
 msgstr "Opérations manquantes"
 
 msgid "Missing Shipping Costs"
-msgstr "Frais d'expédition manquants"
+msgstr "Frais de port manquants"
 
 msgid "Missing Suppliers"
 msgstr "Fournisseurs manquants"
@@ -9248,7 +9248,7 @@ msgid "Model removed from line"
 msgstr "Modèle supprimé de la ligne"
 
 msgid "Model upload"
-msgstr "Téléchargement du modèle"
+msgstr "Téléversement de modèle"
 
 msgid "Modified"
 msgstr "Modifié"
@@ -9275,7 +9275,7 @@ msgid "Monthly"
 msgstr "Mensuel"
 
 msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
-msgstr "Mois sur lesquels cet actif est amorti à des fins fiscales (si MACRS n'est pas utilisé)."
+msgstr "Nombre de mois sur lesquels cette immobilisation se déprécie à des fins fiscales (si MACRS n'est pas utilisé)."
 
 msgid "More"
 msgstr "Plus"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Déplacer l'élément"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Déplacez une partie de la quantité vers une nouvelle ligne de disposition afin que le MRB puisse décider de chaque portion séparément (par exemple, rebuter certaines, retravailler certaines)."
+msgstr "Déplacer une partie de la quantité vers une nouvelle ligne de traitement afin que le comité de revue des matériaux puisse décider de chaque portion séparément (par exemple, mettre au rebut une partie, faire une retouche sur une autre)."
 
 msgid "Move to"
 msgstr "Déplacer vers"
@@ -9397,7 +9397,7 @@ msgid "Net Change"
 msgstr "Variation nette"
 
 msgid "Net Income"
-msgstr "Revenu net"
+msgstr "Produits nets"
 
 msgid "Never"
 msgstr "Jamais"
@@ -9418,7 +9418,7 @@ msgid "New Approval Rule"
 msgstr "Nouvelle Règle d'Approbation"
 
 msgid "New Asset Class"
-msgstr "Nouvelle Classe d'Actif"
+msgstr "Nouvelle catégorie d'immobilisation"
 
 msgid "New Assignment"
 msgstr "Nouvelle affectation"
@@ -9442,7 +9442,7 @@ msgid "New Consumable"
 msgstr "Nouveau consommable"
 
 msgid "New Contractor"
-msgstr "Nouveau Contractant"
+msgstr "Nouveau prestataire"
 
 msgid "New Cost Center"
 msgstr "Nouveau centre de coûts"
@@ -9463,7 +9463,7 @@ msgid "New Department"
 msgstr "Nouveau Département"
 
 msgid "New Dimension"
-msgstr "Nouvelle Dimension"
+msgstr "Nouvel axe analytique"
 
 msgid "New Employee Type"
 msgstr "Nouveau Type d'Employé"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Nouvel Actif Immobilisé"
 
 msgid "New Gauge"
-msgstr "Nouveau Jauge"
+msgstr "Nouvel instrument de mesure"
 
 msgid "New Gauge Calibration Record"
-msgstr "Nouveau Dossier d'Étalonnage de Jauge"
+msgstr "Nouvel enregistrement d'étalonnage d'instrument de mesure"
 
 msgid "New Gauge Type"
-msgstr "Nouveau Type de Jauge"
+msgstr "Nouveau type d'instrument"
 
 msgid "New Group"
 msgstr "Nouveau Groupe"
@@ -9499,7 +9499,7 @@ msgid "New IC Transaction"
 msgstr "Nouvelle Transaction IC"
 
 msgid "New Inspection Plan"
-msgstr "Nouveau plan d'inspection"
+msgstr "Nouveau plan de contrôle"
 
 msgid "New Inventory Count"
 msgstr "Nouveau Décompte d'Inventaire"
@@ -9526,19 +9526,19 @@ msgid "New Location"
 msgstr "Nouvelle localisation"
 
 msgid "New Maintenance Dispatch"
-msgstr "Nouvelle Demande de Maintenance"
+msgstr "Nouvelle intervention de maintenance"
 
 msgid "New Material"
 msgstr "Nouveau Matériau"
 
 msgid "New Material Dimension"
-msgstr "Nouvelle Dimension de Matériau"
+msgstr "Nouvelle dimension de matière"
 
 msgid "New Material Finish"
 msgstr "Nouvelle finition de matériau"
 
 msgid "New Material Grade"
-msgstr "Nouvelle Classe de Matériau"
+msgstr "Nouvelle nuance"
 
 msgid "New Material Shape"
 msgstr "Nouvelle Forme de Matériau"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "Nouveau Paiement"
 
 msgid "New Payment Term"
-msgstr "Nouveau Terme de Paiement"
+msgstr "Nouvelles conditions de paiement"
 
 msgid "New Picking List"
 msgstr "Nouvelle Liste de Prélèvement"
@@ -9577,7 +9577,7 @@ msgid "New PO"
 msgstr "Nouveau BC"
 
 msgid "New Price Override"
-msgstr "Nouveau dépassement de prix"
+msgstr "Nouvelle substitution de prix"
 
 msgid "New Pricing Rule"
 msgstr "Nouvelle Règle de Tarification"
@@ -9625,7 +9625,7 @@ msgid "New Sales Invoice Line"
 msgstr "Nouvelle ligne de facture de vente"
 
 msgid "New Sales Order"
-msgstr "Nouvelle Commande Vente"
+msgstr "Nouvelle commande client"
 
 msgid "New Sales Order Line"
 msgstr "Nouvelle ligne de commande client"
@@ -9640,13 +9640,13 @@ msgid "New Service"
 msgstr "Nouveau service"
 
 msgid "New Shift"
-msgstr "Nouveau Quart"
+msgstr "Nouvelle équipe"
 
 msgid "New Shipment"
-msgstr "Nouveau Shipment"
+msgstr "Nouvelle expédition"
 
 msgid "New Shipping Method"
-msgstr "Nouvelle méthode d'expédition"
+msgstr "Nouveau mode d'expédition"
 
 msgid "New Size"
 msgstr "Nouvelle Taille"
@@ -9691,7 +9691,7 @@ msgid "New Webhook"
 msgstr "Nouveau Webhook"
 
 msgid "New Work Center"
-msgstr "Nouveau Centre de Travail"
+msgstr "Nouveau poste de travail"
 
 msgid "New Workflow"
 msgstr "Nouveau flux de travail"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Aucune action sélectionnée"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Aucune tâche active trouvée pour cette commande client. La commande sera annulée directement."
+msgstr "Aucun ordre de fabrication en cours trouvé pour cette commande client. La commande sera annulée directement."
 
 msgid "No active plan"
 msgstr "Aucun plan actif"
@@ -9797,7 +9797,7 @@ msgid "No available tracked entities found"
 msgstr "Aucune entité suivie disponible trouvée"
 
 msgid "No BOM input has a shelf-life policy"
-msgstr "Aucune entrée de nomenclature n'a de politique de durée de vie"
+msgstr "Aucune entrée du BOM n'a de politique de durée de vie"
 
 msgid "No CAD model to preview."
 msgstr "Aucun modèle CAD à prévisualiser."
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Aucun commentaire pour le moment. Soyez le premier à ajouter un commentaire."
 
 msgid "No completed jobs within range"
-msgstr "Aucun travail terminé dans la plage"
+msgstr "Aucun ordre de fabrication terminé dans cette plage"
 
 msgid "No condition may match"
 msgstr "Aucune condition ne doit correspondre"
@@ -9842,10 +9842,10 @@ msgid "No default attachments yet."
 msgstr "Aucune pièce jointe par défaut pour le moment."
 
 msgid "No dimension slots configured"
-msgstr "Aucun emplacement de dimension configuré"
+msgstr "Aucun emplacement d'axe analytique configuré"
 
 msgid "No dimension values mapped yet"
-msgstr "Aucune valeur de dimension mappée pour le moment"
+msgstr "Aucune valeur d'axe analytique mappée jusqu'à présent"
 
 msgid "No draft make method for this item yet."
 msgstr "Aucune méthode de fabrication de brouillon pour cet article pour le moment."
@@ -9875,7 +9875,7 @@ msgid "No extra data sets yet. Add anything specific to this customer."
 msgstr "Pas encore d'ensembles de données supplémentaires. Ajoutez tout ce qui est spécifique à ce client."
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "Pas de conditions supplémentaires pour le moment. Ajoutez tout ce qui est spécifique à ce client."
+msgstr "Aucune exigence supplémentaire pour l'instant. Ajoutez tout ce qui est spécifique à ce client."
 
 msgid "No extra setup items yet. Add anything specific to this customer."
 msgstr "Aucun élément de configuration supplémentaire pour le moment. Ajoutez tout ce qui est spécifique à ce client."
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Aucun fichier téléchargé"
 
 msgid "No Gauge Selected"
-msgstr "Aucune jauge sélectionnée"
+msgstr "Aucun instrument de mesure sélectionné"
 
 msgid "No grouped notifications"
 msgstr "Aucune notification groupée"
@@ -9908,7 +9908,7 @@ msgid "No image"
 msgstr "Aucune image"
 
 msgid "No inspection plans"
-msgstr "Aucun plan d'inspection"
+msgstr "Aucun plan de contrôle"
 
 msgid "No issue types configured"
 msgstr "Aucun type de problème configuré"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Aucun article n'a encore d'activité d'inventaire ici."
 
 msgid "No jobs were created"
-msgstr "Aucune tâche n'a été créée"
+msgstr "Aucun ordre de fabrication n'a été créé"
 
 msgid "No journal lines in scope for this period"
-msgstr "Aucune ligne de journal dans le cadre pour cette période"
+msgstr "Aucune ligne d'écriture dans le périmètre pour cette période"
 
 msgid "No lines to map"
 msgstr "Aucune ligne à mapper"
@@ -9950,7 +9950,7 @@ msgid "No matches. Type to create one."
 msgstr "Aucune correspondance. Tapez pour en créer une."
 
 msgid "No matching bins"
-msgstr "Aucun bac correspondant"
+msgstr "Aucun casier correspondant"
 
 msgid "No new notifications"
 msgstr "Aucune nouvelle notification"
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "Aucune option trouvée."
 
 msgid "No other bins hold this item"
-msgstr "Aucun autre bac ne contient cet article"
+msgstr "Aucun autre casier ne contient cet article"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Aucun autre employé trouvé. Ajoutez des employés pour activer le transfert de propriété."
@@ -10007,7 +10007,7 @@ msgid "No passkeys registered yet."
 msgstr "Aucune clé d'accès enregistrée pour le moment."
 
 msgid "No payables"
-msgstr "Aucun compte créditeur"
+msgstr "Aucune dette fournisseur"
 
 msgid "No payments yet."
 msgstr "Aucun paiement pour le moment."
@@ -10016,10 +10016,10 @@ msgid "No planning data"
 msgstr "Aucune donnée de planification"
 
 msgid "No posted journals in this period for this account"
-msgstr "Aucun journal enregistré pour ce compte au cours de cette période"
+msgstr "Aucune écriture comptabilisée pour cette période sur ce compte"
 
 msgid "No pricing for selected quantity"
-msgstr "Aucun tarif pour la quantité sélectionnée"
+msgstr "Aucune tarification pour la quantité sélectionnée"
 
 msgid "No pricing options found"
 msgstr "Aucune option de tarification trouvée"
@@ -10040,16 +10040,16 @@ msgid "No purchases in this period"
 msgstr "Aucun achat dans cette période"
 
 msgid "No Quote"
-msgstr "Pas de devis"
+msgstr "Refus de devis"
 
 msgid "No Quote Reason"
-msgstr "Aucune raison de devis"
+msgstr "Raison du refus de devis"
 
 msgid "No Quote Reasons"
-msgstr "Aucune raison de devis"
+msgstr "Raisons du refus de devis"
 
 msgid "No receivables"
-msgstr "Aucune créance"
+msgstr "Aucune créance client"
 
 msgid "No records found"
 msgstr "Aucun enregistrement trouvé"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "Aucun rapport ne correspond à votre recherche."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "Aucun représentant de cette entreprise n'a encore accepté le Carbon GovCloud Rider. Un administrateur de cette entreprise doit l'accepter avant que quiconque puisse accéder à Carbon — le personnel de Carbon ne peut pas l'accepter en votre nom."
+msgstr "Aucun représentant de cette société n'a encore accepté l'addendum Carbon GovCloud. Un administrateur de cette société doit l'accepter avant que quelqu'un puisse accéder à Carbon — le personnel Carbon ne peut pas l'accepter en votre nom."
 
 msgid "No results"
 msgstr "Aucun résultat"
@@ -10136,10 +10136,10 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "Aucun stock d'entrepôt n'est enregistré pour cet article. Vous pouvez toujours le prélever — le stock disponible deviendra négatif jusqu'à ce que le décompte soit rapproché."
 
 msgid "No work center utilization data within range"
-msgstr "Aucune donnée d'utilisation du centre de travail dans la plage"
+msgstr "Aucune donnée d'utilisation des postes de travail dans la plage"
 
 msgid "No work centers exist"
-msgstr "Aucun centre de travail n'existe"
+msgstr "Aucun poste de travail n'existe"
 
 msgid "Nom"
 msgstr "Nom"
@@ -10160,16 +10160,16 @@ msgid "Non-conformance (issue)"
 msgstr "Non-conformité (problème)"
 
 msgid "Non-Inventory"
-msgstr "Non-inventaire"
+msgstr "Hors stock"
 
 msgid "Non-Inventory Tracking"
-msgstr "Suivi hors inventaire"
+msgstr "Suivi hors stock"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Compte de charges hors exploitation débité lorsqu'un actif de cette classe est vendu ou mis au rebut en dessous de sa valeur comptable nette."
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "Compte de revenus hors exploitation crédité lorsqu'un actif de cette classe est vendu pour plus que sa valeur comptable nette."
+msgstr "Compte de produits exceptionnels crédité lorsqu'un actif de cette classe est vendu pour plus que sa valeur nette comptable."
 
 msgid "Non-Taxable Add-On Cost"
 msgstr "Coût supplémentaire non imposable"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Pas un tableau mais un solde du grand livre : le coût s'accumule au fur et à mesure que les matériaux de travail sont émis et s'efface lorsque le travail est reçu en stock."
+msgstr "Pas une table mais un solde du grand livre : le coût s'accumule à mesure que les composants d'OF sont émis et s'annule lorsque l'OF est reçu en stock."
 
 msgid "Not certified"
 msgstr "Non certifié"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Pas assez de tâches pour couvrir la quantité"
+msgstr "Pas assez d'ordres de fabrication pour couvrir la quantité"
 
 msgid "Not reached"
 msgstr "Non atteint"
@@ -10223,7 +10223,7 @@ msgid "Not you?"
 msgstr "Ce n'est pas vous ?"
 
 msgid "Note"
-msgstr "Remarque"
+msgstr "Note"
 
 msgid "Notes"
 msgstr "Notes"
@@ -10326,19 +10326,19 @@ msgid "On Hand"
 msgstr "En stock"
 
 msgid "On Hold"
-msgstr "En attente"
+msgstr "Suspendu"
 
 msgid "On Jobs"
-msgstr "Sur les commandes"
+msgstr "Sur ordres de fabrication"
 
 msgid "On order"
 msgstr "Commandé"
 
 msgid "On Production Demand"
-msgstr "En demande de production"
+msgstr "Sur la demande de production"
 
 msgid "On Purchase Order"
-msgstr "En commande d'achat"
+msgstr "Sur bon de commande"
 
 msgid "On Sales Order"
 msgstr "Sur commande client"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "Stock en main disponible"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "Valeur disponible par localisation ou article, avec rapprochement GL"
+msgstr "Valeur en stock par site ou article, avec rapprochement au grand livre"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "Valeur en stock des marchandises manufacturées (Articles Fabriquer)"
@@ -10374,19 +10374,19 @@ msgid "On-time delivery"
 msgstr "Livraison à temps"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "Une exécution d'un flux de travail, enregistrée étape par étape avec les valeurs que chaque étape a utilisées et produites, agissant tout au long avec les permissions du propriétaire du flux de travail."
+msgstr "Une exécution d'un workflow, enregistrée étape par étape avec les valeurs que chaque étape a utilisées et produites, agissant tout au long avec les autorisations du propriétaire du workflow."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Une unité de série ou un lot que Carbon suit individuellement, portant son propre statut et ses attributs tels qu'une date d'expiration."
+msgstr "Une unité de série ou un lot de production que Carbon suit individuellement, portant son propre statut et attributs tels qu'une date de péremption."
 
 msgid "One set of numbers"
 msgstr "Un seul ensemble de chiffres"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Une étape de l'itinéraire d'une tâche, nommant un processus et un centre de travail et portant ses propres temps et taux de configuration, de travail et de machine."
+msgstr "Une étape dans la gamme d'un OF, identifiant un procédé et un poste de travail, et portant ses propres temps et tarifs de réglage, main-d'œuvre et temps machine."
 
 msgid "One system from quote to cash"
-msgstr "Un système du devis à la facturation"
+msgstr "Un système unique du devis à la trésorerie"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
 msgstr "Seules les procédures en brouillon sont modifiables. Créez une nouvelle version pour modifier une procédure active ou archivée."
@@ -10428,13 +10428,13 @@ msgid "Open Actions"
 msgstr "Actions ouvertes"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "Ouvrir un NCR pour la disposition MRB"
+msgstr "Ouvrir une NCR pour traitement MRB"
 
 msgid "Open AP"
-msgstr "AP ouvert"
+msgstr "Comptes fournisseurs ouverts"
 
 msgid "Open AR"
-msgstr "AR ouvert"
+msgstr "Comptes clients ouverts"
 
 msgid "Open Audit Log"
 msgstr "Ouvrir le journal d'audit"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Date d'ouverture"
 
 msgid "Open Dispatches"
-msgstr "Dépannages Ouverts"
+msgstr "Interventions de maintenance ouvertes"
 
 msgid "Open in Carbon"
 msgstr "Ouvrir dans Carbon"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "Ouvert dans l'avis de modification {ids}. Relâchez-le pour créer de nouvelles versions ou révisions."
+msgstr "Ouvert dans l'avis de modification {ids}. Lancez-le pour créer de nouvelles versions ou révisions."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "Ouverts dans les avis de modification {ids}. Relâchez-les pour créer de nouvelles versions ou révisions."
+msgstr "Ouverts dans les avis de modification {ids}. Lancez-les pour créer de nouvelles versions ou révisions."
 
 msgid "Open in MES"
 msgstr "Ouvrir dans MES"
@@ -10464,25 +10464,25 @@ msgid "Open Issues"
 msgstr "Problèmes ouverts"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Demande de travail ouverte plus les transferts en attente sortant de ce bac"
+msgstr "Demande d'OF ouverte plus transferts en attente hors de ce casier"
 
 msgid "Open jobs"
-msgstr "Travaux en cours"
+msgstr "Ordres de fabrication ouverts"
 
 msgid "Open menu"
 msgstr "Ouvrir le menu"
 
 msgid "Open payables by supplier and age"
-msgstr "Comptes créditeurs ouverts par fournisseur et ancienneté"
+msgstr "Dettes fournisseurs ouvertes par fournisseur et ancienneté"
 
 msgid "Open Purchase Invoices"
 msgstr "Factures d'achat ouvertes"
 
 msgid "Open purchase orders"
-msgstr "Commandes d'achat ouvertes"
+msgstr "Bons de commande ouverts"
 
 msgid "Open Purchase Orders"
-msgstr "Commandes d'achat ouvertes"
+msgstr "Bons de commande ouverts"
 
 msgid "Open Quotes"
 msgstr "Devis Ouverts"
@@ -10491,16 +10491,16 @@ msgid "Open Reactive"
 msgstr "Réactif Ouvert"
 
 msgid "Open receivables by customer and age"
-msgstr "Comptes clients ouverts par client et ancienneté"
+msgstr "Créances clients ouvertes par client et par ancienneté"
 
 msgid "Open RFQs"
 msgstr "RFQ ouvertes"
 
 msgid "Open sales orders"
-msgstr "Commandes de vente ouvertes"
+msgstr "Commandes clients ouvertes"
 
 msgid "Open Sales Orders"
-msgstr "Commandes de vente ouvertes"
+msgstr "Commandes clients ouvertes"
 
 msgid "Open Scheduled"
 msgstr "Planifiés ouverts"
@@ -10530,16 +10530,16 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Solde d'ouverture de l'amortissement déjà comptabilisé avant l'ajout de cet actif à Carbon (utilisez 0 pour les nouvelles acquisitions)."
 
 msgid "Operating Expenses"
-msgstr "Frais de Fonctionnement"
+msgstr "Charges d'exploitation"
 
 msgid "Operating Income"
-msgstr "Revenu d'exploitation"
+msgstr "Produits d'exploitation"
 
 msgid "Operation"
 msgstr "Opération"
 
 msgid "Operation lead time"
-msgstr "Délai d'exécution de l'opération"
+msgstr "Délai d'approvisionnement de l'opération"
 
 msgid "Operation minimum cost"
 msgstr "Coût minimum de l'opération"
@@ -10593,7 +10593,7 @@ msgid "Operators can use shared workstations with PIN authentication."
 msgstr "Les opérateurs peuvent utiliser des postes de travail partagés avec authentification par PIN."
 
 msgid "Operators start on the Scan tab"
-msgstr "Les opérateurs commencent par l'onglet Scan"
+msgstr "Les opérateurs commencent par l'onglet Scanner"
 
 msgid "Operators start the timer themselves when they begin an operation."
 msgstr "Les opérateurs démarrent eux-mêmes le chronomètre quand ils commencent une opération."
@@ -10687,13 +10687,13 @@ msgid "Other Expense"
 msgstr "Autre charge"
 
 msgid "Other Income"
-msgstr "Autre revenu"
+msgstr "Autres produits"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "Compte de revenus divers pour les gains de change lorsqu'un paiement règle une facture en devise étrangère à un taux plus favorable"
+msgstr "Compte Autres produits pour les gains de change quand un paiement règle une facture en devises étrangères à un taux plus favorable"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Compte de revenu supplémentaire pour les soldes fournisseurs apurés sans paiement intégral lors du règlement des comptes créditeurs"
+msgstr "Compte Autres produits pour les soldes fournisseurs apurés sans paiement complet au moment du règlement des comptes fournisseurs"
 
 msgid "Other Type"
 msgstr "Autre Type"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Sortie"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "La production ne dépasse jamais la durée de vie de ses matières premières. Revient à la durée fixe lorsqu'aucune entrée n'a de date d'expiration."
+msgstr "La production n'a jamais une durée plus longue que ses matières premières. Se rabat sur la durée fixe quand aucun apport n'a de date de péremption."
 
 msgid "Outside operation"
 msgstr "Écart de Frais Généraux"
@@ -10726,10 +10726,10 @@ msgid "Overdue"
 msgstr "En retard"
 
 msgid "Overhead Absorption"
-msgstr "Absorption des frais généraux"
+msgstr "Imputation des frais généraux"
 
 msgid "Overhead Absorption (default)"
-msgstr "Absorption des frais généraux (par défaut)"
+msgstr "Imputation des frais généraux (par défaut)"
 
 msgid "Overhead rate"
 msgstr "Taux de frais généraux"
@@ -10744,22 +10744,22 @@ msgid "Overhead Variance"
 msgstr "Écart de Frais Généraux (par défaut)"
 
 msgid "Overhead Variance (default)"
-msgstr "Propriétaire (centre de coûts)"
+msgstr "Écart des frais généraux (par défaut)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "Le remplacement nécessite la permission inventory:update et une raison."
+msgstr "La substitution requiert l'autorisation stocks:modification et une raison."
 
 msgid "Override Price"
-msgstr "Prix de remplacement"
+msgstr "Modifier le prix"
 
 msgid "Override price for a single customer"
-msgstr "Remplacer le prix pour un seul client"
+msgstr "Modifier le prix pour un seul client"
 
 msgid "Override price for all customers of a type"
-msgstr "Remplacer le prix pour tous les clients d'un type"
+msgstr "Modifier le prix pour tous les clients d'un type"
 
 msgid "Override the expiration on {label}."
-msgstr "Remplacer la date d'expiration sur {label}."
+msgstr "Modifier la date d'expiration sur {label}."
 
 msgid "Overtime"
 msgstr "Heures supplémentaires"
@@ -10774,13 +10774,13 @@ msgid "Overwrite the quote method with the source method"
 msgstr "Remplacer la méthode de devis par la méthode source"
 
 msgid "Overwrite the target manufacturing method with the quote method"
-msgstr "Remplacer la méthode de fabrication cible par la méthode de devis"
+msgstr "Remplacer la méthode de production cible par la méthode du devis"
 
 msgid "Owner"
 msgstr "Propriétaire"
 
 msgid "Owner (cost center)"
-msgstr "Centre de coûts parent"
+msgstr "Propriétaire (centre de coûts)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,7 +10814,7 @@ msgid "Params"
 msgstr "Paramètres"
 
 msgid "Parent cost center"
-msgstr "pièce"
+msgstr "Centre de coûts parent"
 
 msgid "Parent Cost Center"
 msgstr "Centre de coûts parent"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Parquer comme erreur"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Archiver le journal avec un avertissement jusqu'à ce que la valeur soit mappée"
+msgstr "Mettre l'écriture en attente avec un avertissement jusqu'à ce que la valeur soit mappée"
 
 msgid "part"
 msgstr "pièces"
@@ -10856,7 +10856,7 @@ msgid "Part ID"
 msgstr "ID de pièce"
 
 msgid "Part is configured for manufacturing"
-msgstr "La pièce est configurée pour la fabrication"
+msgstr "La pièce est configurée pour la production"
 
 msgid "Part Number"
 msgstr "Numéro de pièce"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Partenaires"
 
 msgid "parts"
-msgstr "Comptes Créditeurs"
+msgstr "pièces"
 
 msgid "Parts"
 msgstr "Pièces"
@@ -10913,16 +10913,16 @@ msgid "Pay Rate"
 msgstr "Taux de paiement"
 
 msgid "Payables"
-msgstr "Comptes Créditeurs (par défaut)"
+msgstr "Dettes fournisseurs"
 
 msgid "Payables (AP)"
-msgstr "Comptes fournisseurs (AP)"
+msgstr "Dettes fournisseurs (Comptes fournisseurs)"
 
 msgid "Payables (default)"
-msgstr "condition de paiement"
+msgstr "Dettes fournisseurs (par défaut)"
 
 msgid "Payables aging"
-msgstr "Vieillissement des comptes créditeurs"
+msgstr "Ancienneté des dettes fournisseurs"
 
 msgid "Payment"
 msgstr "Paiement"
@@ -10940,13 +10940,13 @@ msgid "payment term"
 msgstr "conditions de paiement"
 
 msgid "Payment term"
-msgstr "Terme de paiement"
+msgstr "Condition de paiement"
 
 msgid "Payment Term"
 msgstr "Condition de paiement"
 
 msgid "payment terms"
-msgstr "personnes"
+msgstr "conditions de paiement"
 
 msgid "Payment Terms"
 msgstr "Conditions de paiement"
@@ -10958,7 +10958,7 @@ msgid "Payments"
 msgstr "Paiements"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "Paiements et crédits appliqués à cette facture. Cliquez sur une ligne pour ouvrir le document source."
+msgstr "Paiements et crédits appliqués à cette facture. Cliquez sur une ligne pour ouvrir le document d'origine."
 
 msgid "PDF"
 msgstr "PDF"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "En attente"
 
 msgid "people"
-msgstr "Charge d'amortissement périodique des immobilisations"
+msgstr "personnel"
 
 msgid "People"
 msgstr "Personnes"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Par unité"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Remplacement par ligne de l'emplacement d'exécution de l'en-tête de la commande; utilisé pour les expéditions fractionnées et les livraisons directes."
+msgstr "Substitution par ligne du site d'expédition de l'en-tête de commande ; utilisé pour les expéditions fractionnées et les livraisons directes."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Remplacement par ligne de l'emplacement de livraison de l'en-tête du PO; utilisé pour les livraisons fractionnées à plusieurs entrepôts ou les livraisons directes."
+msgstr "Substitution par ligne du site de livraison de l'en-tête de BC ; utilisé pour les livraisons fractionnées à plusieurs entrepôts ou les livraisons directes."
 
 msgid "Percentage"
 msgstr "Pourcentage"
@@ -11015,13 +11015,13 @@ msgid "Period lock policy"
 msgstr "Politique de verrouillage des périodes"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Le prélèvement offre des entités suivies dans l'ordre d'expiration le plus proche d'abord, de sorte que le stock qui expire le plus tôt est épuisé en premier par défaut."
+msgstr "Charge d'amortissement périodique des immobilisations"
 
 msgid "Permanently Delete"
 msgstr "Supprimer définitivement"
 
 msgid "Permission groups for granting access in bulk"
-msgstr "Groupes de permissions pour accorder l'accès en masse"
+msgstr "Groupes d'autorisations pour accorder l'accès en masse"
 
 msgid "Permissions"
 msgstr "Autorisations"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Durées des phases"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Retirer progressivement un article au profit d'une pièce de remplacement, de sorte que la planification redirige la demande de l'ancien article — multipliée par un facteur de conversion — vers le nouveau."
+msgstr "Retirer progressivement un article en faveur d'une pièce successeur, pour que la planification redirige la demande de l'ancien article — multipliée par un facteur de conversion — vers le nouveau."
 
 msgid "Phone"
 msgstr "Téléphone"
@@ -11054,13 +11054,13 @@ msgid "Pick"
 msgstr "Prélever"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "Choisissez une dimension Carbon et la cible du fournisseur à laquelle elle est postée. La création automatique ajoute les options de fournisseur manquantes par nom au moment de la poussée."
+msgstr "Choisissez une axe analytique Carbon et la cible du fournisseur vers lequel elle est comptabilisée. Auto-créer ajoute les options de fournisseur manquantes par nom au moment de la transmission."
 
 msgid "Pick a column to sort by"
 msgstr "Choisir une colonne pour trier"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "Sélectionnez un client ou un type de client pour afficher leurs tarifs."
+msgstr "Choisissez un client ou un type de client pour afficher sa tarification."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "Choisissez une date ou laissez vide pour l'effacer."
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "Ordre de prélèvement"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "Choisissez le bac qui a besoin de stock, puis choisissez les bacs à partir desquels le prélever."
+msgstr "Prélever le casier qui a besoin de stock, puis les casiers à prélever."
 
 msgid "Pick tracked item"
 msgstr "Sélectionner un article suivi"
@@ -11120,7 +11120,7 @@ msgid "Picking Lists"
 msgstr "Listes de prélèvement"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Planifié"
+msgstr "Le prélèvement propose d'abord les articles suivis ayant la péremption la plus proche, donc le stock arrivant à expiration le plus tôt quitte en premier par défaut."
 
 msgid "Pieces/Hour"
 msgstr "Pièces/Heure"
@@ -11164,7 +11164,7 @@ msgid "Planned Order"
 msgstr "Commande planifiée"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "Commande planifiée = suggestion MRP pour couvrir la demande projetée en fonction de la politique de réapprovisionnement de l'article (ou ajoutée manuellement)."
+msgstr "Ordre planifié = suggestion MRP pour couvrir la demande projetée basée sur la politique de réapprovisionnement de l'article (ou ajouté manuellement)."
 
 msgid "Planned purchase order"
 msgstr "Bon de commande planifié"
@@ -11215,7 +11215,7 @@ msgid "Please select an item"
 msgstr "Veuillez sélectionner un article"
 
 msgid "Please upload a CSV file of your data"
-msgstr "Veuillez télécharger un fichier CSV de vos données"
+msgstr "Veuillez téléverser un fichier CSV de vos données"
 
 msgid "PO"
 msgstr "BC"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Publié par"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Les journaux publiés avec ces types de sources se synchronisent toujours. Le résumé quotidien regroupe les journaux d'une journée en une seule entrée de fournisseur par compte."
+msgstr "Les écritures comptabilisées avec ces types de source se synchronisent toujours. La synthèse quotidienne regroupe les écritures d'une journée en une entrée de fournisseur par compte."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Posté une fois, corrigé {corrections} fois."
@@ -11290,19 +11290,19 @@ msgid "Posted once, no corrections."
 msgstr "Posté une fois, aucune correction."
 
 msgid "Posting"
-msgstr "Acomptes"
+msgstr "Comptabilisation"
 
 msgid "Posting date"
-msgstr "Date de publication"
+msgstr "Date de comptabilisation"
 
 msgid "Posting Date"
-msgstr "Date de publication"
+msgstr "Date de comptabilisation"
 
 msgid "Potential Data Loss"
 msgstr "Perte de données potentielle"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "Pré-rempli pour un nouvel article lorsque l'expiration est Durée fixe."
+msgstr "Pré-rempli pour un nouvel article quand la péremption est Durée fixe."
 
 msgid "Preferred Supplier"
 msgstr "Fournisseur préféré"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "Acomptes (par défaut)"
 
 msgid "Prepayments (default)"
-msgstr "Action préventive"
+msgstr "Acomptes (par défaut)"
 
 msgid "Present Week"
 msgstr "Semaine en cours"
@@ -11323,7 +11323,7 @@ msgid "Prev"
 msgstr "Précédent"
 
 msgid "Preventive action"
-msgstr "Compte principal pour l'évaluation du stock disponible"
+msgstr "Action préventive"
 
 msgid "Preventive maintenance schedules for your equipment"
 msgstr "Calendriers de maintenance préventive pour votre équipement"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Valeur précédente de {0}"
 
 msgid "Price break actions"
-msgstr "Actions de rupture de prix"
+msgstr "Actions sur les paliers de prix"
 
 msgid "Price Break History"
-msgstr "Historique des tranches de prix"
+msgstr "Historique des paliers de prix"
 
 msgid "Price Breaks"
-msgstr "Tranches de prix"
+msgstr "Paliers de prix"
 
 msgid "Price List"
 msgstr "Liste de prix"
@@ -11372,7 +11372,7 @@ msgid "Price Lists"
 msgstr "Listes de prix"
 
 msgid "Price override"
-msgstr "Remplacement du prix"
+msgstr "Substitution de prix"
 
 msgid "Prices"
 msgstr "Prix"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "Règles de tarification"
 
 msgid "Pricing Trace"
-msgstr "Traçabilité des prix"
+msgstr "Traçage de tarification"
 
 msgid "Primary cash account for bank transactions"
-msgstr "procédure"
+msgstr "Compte de trésorerie principal pour les transactions bancaires"
 
 msgid "Print"
 msgstr "Imprimer"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "Imprimer {0} étiquettes"
 
 msgid "Print Jobs"
-msgstr "Travaux d'impression"
+msgstr "Tâches d'impression"
 
 msgid "Print Label"
 msgstr "Imprimer l'étiquette"
@@ -11413,7 +11413,7 @@ msgid "Print Output ({0})"
 msgstr "Sortie d'impression ({0})"
 
 msgid "Printer Settings"
-msgstr "Paramètres d'impression"
+msgstr "Paramètres d'imprimante"
 
 msgid "Printer URL"
 msgstr "URL de l'imprimante"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Procédure"
 
 msgid "procedures"
-msgstr "processus"
+msgstr "procédures"
 
 msgid "Procedures"
 msgstr "Procédures"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Quantité de Production"
 
 msgid "Production variance"
-msgstr "Demande projetée décomposée à partir des nomenclatures et prévisions."
+msgstr "Écart de production"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Production : application d'atelier et planification"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Démarrage du projet"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Stock Projeté"
+msgstr "Besoins projetés éclatés à partir des BOMs et prévisions."
 
 msgid "Projected inventory"
 msgstr "Disponible Projeté"
@@ -11543,14 +11543,14 @@ msgstr "Stock projeté"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Projeté de chuter en dessous du stock de sécurité la semaine du {0}"
+msgstr "Rupture de stock prévue la semaine du {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "Projeté de rester au-dessus du stock de sécurité"
 
 msgid "Projected to stay above safety stock"
-msgstr "Bon de Commande"
+msgstr "Projeté pour rester au-dessus du stock de sécurité"
 
 msgid "Projection"
 msgstr "Projection"
@@ -11571,7 +11571,7 @@ msgid "Proposed matches where the Carbon account number equals the provider acco
 msgstr "Correspondances proposées où le numéro de compte Carbon est exactement égal au code de compte fournisseur."
 
 msgid "Proposed matches where the Carbon dimension value's name equals a provider option name exactly."
-msgstr "Correspondances proposées où le nom de la valeur de dimension Carbon est exactement égal au nom d'une option de fournisseur."
+msgstr "Correspondances proposées où le nom de la valeur de l'axe analytique Carbon correspond exactement au nom d'une option du fournisseur."
 
 msgid "Protect the go-live date"
 msgstr "Protéger la date de mise en production"
@@ -11580,7 +11580,7 @@ msgid "Protect training time and attend"
 msgstr "Protégez le temps de formation et participez"
 
 msgid "Protects your company's data"
-msgstr "Protège les données de votre entreprise"
+msgstr "Protège les données de votre société"
 
 msgid "Provide process knowledge and inputs"
 msgstr "Fournir les connaissances et les données du processus"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Publié par Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Version publiée"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Les versions publiées ne peuvent pas être modifiées. Consultez en lecture seule, ou créez une branche d'une nouvelle version pour apporter des modifications."
@@ -11632,7 +11632,7 @@ msgid "Pull, map, and load your data"
 msgstr "Extraire, mapper et charger vos données"
 
 msgid "Purchase & manufacture from MRP"
-msgstr "Acheter et fabriquer à partir du PDP"
+msgstr "Acheter et fabriquer à partir de MRP"
 
 msgid "Purchase History"
 msgstr "Historique des achats"
@@ -11653,13 +11653,13 @@ msgid "Purchase Invoices"
 msgstr "Factures d'achat"
 
 msgid "Purchase order"
-msgstr "Écart de Prix d'Achat"
+msgstr "Bon de commande"
 
 msgid "Purchase Order"
 msgstr "Bon de commande"
 
 msgid "Purchase Order Amount"
-msgstr "Montant de la commande d'achat"
+msgstr "Montant du bon de commande"
 
 msgid "Purchase Order approval rule"
 msgstr "Règle d'approbation de bon de commande"
@@ -11671,19 +11671,19 @@ msgid "Purchase Order Line"
 msgstr "Ligne de bon de commande"
 
 msgid "Purchase Order Location"
-msgstr "Localisation de la commande d'achat"
+msgstr "Site du bon de commande"
 
 msgid "Purchase order removed successfully"
 msgstr "Bon de commande supprimé avec succès"
 
 msgid "Purchase Order Type"
-msgstr "Type de Commande d'Achat"
+msgstr "Type de bon de commande"
 
 msgid "Purchase Orders"
 msgstr "Bons de commande"
 
 msgid "Purchase Orders and Planning"
-msgstr "Commandes d'achat et planification"
+msgstr "Bons de commande et planification"
 
 msgid "Purchase orders required"
 msgstr "Bons de commande requis"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Écart de Prix d'Achat (par défaut)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Taxe d'Achat à Payer"
+msgstr "Écart de prix d'achat (par défaut)"
 
 msgid "Purchase Qty"
 msgstr "Quantité d'achat"
@@ -11707,7 +11707,7 @@ msgid "Purchase Tax Payable"
 msgstr "Taxe d'Achat à Payer (par défaut)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "approvisionnement"
+msgstr "Taxe d'achat à payer (par défaut)"
 
 msgid "Purchase to Order"
 msgstr "Achat à la commande"
@@ -11725,10 +11725,10 @@ msgid "Purchases"
 msgstr "Achats"
 
 msgid "purchasing"
-msgstr "Approvisionnement et Coût des Biens Vendus"
+msgstr "achats"
 
 msgid "Purchasing"
-msgstr "Approvisionnement"
+msgstr "Achats"
 
 msgid "Purchasing & Inventory"
 msgstr "Achat & Inventaire"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Poussez les modifications d'enregistrements vers des systèmes externes au moment où elles se produisent."
 
 msgid "Push the journal without the dimension"
-msgstr "Pousser le journal sans la dimension"
+msgstr "Envoyer l'écriture sans l'axe analytique"
 
 msgid "Push to accounting"
 msgstr "Envoyer vers la comptabilité"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Qté. Rebut"
 
 msgid "quality"
-msgstr "Devis à Trésorerie"
+msgstr "qualité"
 
 msgid "Quality"
 msgstr "Qualité"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "Type Qualité"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "Qualité : inspections, non-conformités, CAPA"
+msgstr "Qualité : contrôles, non-conformité, CAPA"
 
 msgid "Quantities"
 msgstr "Quantités"
@@ -11846,13 +11846,13 @@ msgid "Quantity on Hand"
 msgstr "Quantité en stock"
 
 msgid "Quantity on Jobs"
-msgstr "Quantité sur les commandes"
+msgstr "Quantité sur les ordres de fabrication"
 
 msgid "Quantity on Purchase Order"
-msgstr "Quantité en commande d'achat"
+msgstr "Quantité sur le bon de commande"
 
 msgid "Quantity on Sales Order"
-msgstr "Quantité sur Commande Vente"
+msgstr "Quantité sur la commande client"
 
 msgid "Quantity Per Job"
 msgstr "Quantité Par Travail"
@@ -11861,7 +11861,7 @@ msgid "Quantity per Parent"
 msgstr "Quantité par Parent"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Quantité physiquement présente sur l'unité de stockage (étagère) attribuée au matériau. Devient rouge lorsqu'elle est inférieure à ce que cette unité doit fournir."
+msgstr "Quantité physiquement présente sur l'unité de stockage attribuée à la matière (étagère). S'affiche en rouge quand elle est en dessous de ce que cette unité doit fournir."
 
 msgid "Quantity Range"
 msgstr "Plage de Quantité"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Type de quantité"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Niveaux de tarification basés sur la quantité pour ce remplacement; le prix unitaire appliqué est la ligne avec la quantité minimale la plus grande que satisfait la ligne de commande."
+msgstr "Niveaux de tarification basés sur la quantité pour cette substitution ; le prix unitaire appliqué est la ligne avec la quantité minimale la plus élevée que la ligne de commande respecte."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Numéro de devis"
 
 msgid "Quote to cash"
-msgstr "Comptes Clients"
+msgstr "Du devis à la trésorerie"
 
 msgid "Quote Type"
 msgstr "Type de Devis"
@@ -11949,7 +11949,7 @@ msgid "Quotes"
 msgstr "Devis"
 
 msgid "Quoting and sales orders"
-msgstr "Devis et commandes de vente"
+msgstr "Devis et commandes clients"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "Devis, Commandes, Configuration à la commande"
@@ -11994,10 +11994,10 @@ msgid "Readable"
 msgstr "Lisible"
 
 msgid "Readable ID"
-msgstr "ID lisible"
+msgstr "Identifiant lisible"
 
 msgid "Readable id with revision"
-msgstr "ID lisible avec révision"
+msgstr "Identifiant lisible avec révision"
 
 msgid "Reading the document..."
 msgstr "Lecture du document..."
@@ -12042,7 +12042,7 @@ msgid "Reasons"
 msgstr "Raisons"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "Réassignez des entités suivies spécifiques de cette ligne à une autre ligne de disposition."
+msgstr "Réaffecter les entités suivies spécifiques de cette ligne à une autre ligne de traitement."
 
 msgid "Recalculate"
 msgstr "Recalculer"
@@ -12075,19 +12075,19 @@ msgid "Receipts"
 msgstr "Reçus"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Les reçus, expéditions, factures de vente, factures d'achat, paiements et notes de crédit/débit qui sont encore Brouillon ou En attente doivent être comptabilisés ou annulés — à la fois les documents datés au cours de cette période et les documents non datés qui recevraient une date lors de la comptabilisation. Tant qu'ils ne sont pas comptabilisés, leurs montants ne se trouvent pas dans le grand livre, de sorte que la période serait sous-estimée."
+msgstr "Les réceptions, expéditions, factures de vente, factures d'achat, paiements et mémos de crédit/débit restant en brouillon ou en attente doivent être comptabilisés ou invalidés — à la fois les documents datés de cette période et les documents sans date qui recevraient une date à la comptabilisation. Jusqu'à leur comptabilisation, leurs montants ne sont pas dans le grand livre, la période serait donc incomplète."
 
 msgid "Receivables"
-msgstr "Comptes Clients (par défaut)"
+msgstr "Créances clients"
 
 msgid "Receivables (AR)"
-msgstr "Comptes clients (AR)"
+msgstr "Créances clients (Comptes clients)"
 
 msgid "Receivables (default)"
-msgstr "Rapprochement d'une commande d'achat avec ce qui a été reçu et facturé — implicite dans Carbon, via les quantités de ligne et le solde GR/IR."
+msgstr "Créances clients (par défaut)"
 
 msgid "Receivables aging"
-msgstr "Vieillissement des créances"
+msgstr "Ancienneté des créances clients"
 
 msgid "Receive"
 msgstr "Recevoir"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "Quantité reçue"
 
 msgid "Receiving Location"
-msgstr "Lieu de réception"
+msgstr "Site de réception"
 
 msgid "Recent"
 msgstr "Récent"
@@ -12145,7 +12145,7 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "La rapprochement a détecté des écarts avec le fournisseur"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Durée d'Amortissement"
+msgstr "Rapprochement d'un bon de commande par rapport à ce qui a été reçu et facturé — implicite dans Carbon, via les quantités de ligne et le solde GR/IR."
 
 msgid "Record"
 msgstr "Enregistrer"
@@ -12154,25 +12154,25 @@ msgid "Record a credit or debit memo against a customer or supplier. Application
 msgstr "Enregistrez un avoir ou un débit contre un client ou un fournisseur. Les applications à des factures spécifiques sont ajoutées après la création de l'avoir."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Enregistrez les espèces reçues d'un client (Reçu) ou versées à un fournisseur (Décaissement). Les applications à des factures spécifiques sont ajoutées après la création du paiement."
+msgstr "Enregistrer la trésorerie reçue d'un client (Réception) ou versée à un fournisseur (Décaissement). Les allocations aux factures spécifiques sont ajoutées après la création du paiement."
 
 msgid "Record deleted"
 msgstr "Enregistrement supprimé"
 
 msgid "Record inspections tied to a part and a job"
-msgstr "Enregistrer les inspections liées à une pièce et à un travail"
+msgstr "Enregistrer les contrôles liés à une pièce et à un ordre de fabrication"
 
 msgid "Record type"
 msgstr "Type d'enregistrement"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Enregistré lors d'un étalonnage indiquant que la jauge nécessite une réparation avant que ses lectures ne puissent être fiables."
+msgstr "Enregistré lors d'un étalonnage que l'instrument de mesure a besoin d'une réparation avant que ses mesures puissent être fiables."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Enregistré que le suivi est nécessaire après cet étalonnage; affiche ce jauge dans la file d'attente des actions ouvertes."
+msgstr "Enregistré que le suivi est nécessaire après cet étalonnage ; met cet instrument de mesure en évidence dans la file d'attente des actions ouvertes."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Enregistré que le jauge a été ajusté lors de cet étalonnage; affecte le recalcul de l'intervalle d'étalonnage."
+msgstr "Enregistré que l'instrument de mesure a été ajusté lors de cet étalonnage ; affecte la façon dont la périodicité d'étalonnage se recalcule."
 
 msgid "Records"
 msgstr "Enregistrements"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Enregistré"
 
 msgid "Registered"
-msgstr "Point de Réapprovisionnement"
+msgstr "Enregistré"
 
 msgid "Registration failed"
 msgstr "L'enregistrement a échoué"
@@ -12244,16 +12244,16 @@ msgid "Relative timeline · dates to be confirmed"
 msgstr "Chronologie relative · dates à confirmer"
 
 msgid "Release"
-msgstr "Libération"
+msgstr "Lancer"
 
 msgid "Release change notice"
-msgstr "Publier l'avis de modification"
+msgstr "Lancer l'avis de modification"
 
 msgid "Release control"
-msgstr "Contrôle de la version"
+msgstr "Contrôle de lancement"
 
 msgid "Release Control"
-msgstr "Contrôle de la version"
+msgstr "Contrôle de lancement"
 
 msgid "Release Job"
 msgstr "Lancer le travail"
@@ -12280,68 +12280,68 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "Mémorisez ce code PIN. Vous en aurez besoin pour quitter le mode console sur les terminaux MES."
 
 msgid "Remove"
-msgstr "Supprimer"
+msgstr "Retirer"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "Supprimer {0}"
+msgstr "Retirer {0}"
 
 msgid "Remove {label}"
-msgstr "Supprimer {label}"
+msgstr "Retirer {label}"
 
 msgid "Remove authenticator app"
-msgstr "Supprimer l'application d'authentification"
+msgstr "Retirer l'application authenticateur"
 
 msgid "Remove clause"
-msgstr "Supprimer la clause"
+msgstr "Retirer la clause"
 
 msgid "Remove condition"
-msgstr "Supprimer la condition"
+msgstr "Retirer la condition"
 
 msgid "Remove filter"
-msgstr "Supprimer le filtre"
+msgstr "Retirer le filtre"
 
 msgid "Remove Filters"
-msgstr "Supprimer les filtres"
+msgstr "Retirer les filtres"
 
 msgid "Remove from Price List"
-msgstr "Supprimer de la liste de prix"
+msgstr "Retirer de la liste de prix"
 
 msgid "Remove line"
-msgstr "Supprimer la ligne"
+msgstr "Retirer la ligne"
 
 msgid "Remove order"
-msgstr "Supprimer la commande"
+msgstr "Retirer la commande"
 
 msgid "Remove pair"
-msgstr "Supprimer la paire"
+msgstr "Retirer la paire"
 
 msgid "Remove part"
-msgstr "Supprimer la pièce"
+msgstr "Retirer la pièce"
 
 msgid "Remove path"
-msgstr "Supprimer le chemin"
+msgstr "Retirer le chemin"
 
 msgid "Remove row"
-msgstr "Supprimer la ligne"
+msgstr "Retirer la ligne"
 
 msgid "Remove slide"
-msgstr "Supprimer la diapositive"
+msgstr "Retirer la diapositive"
 
 msgid "Remove slot"
-msgstr "Supprimer l'emplacement"
+msgstr "Retirer l'emplacement"
 
 msgid "Remove sort by column"
-msgstr "Supprimer le tri par colonne"
+msgstr "Retirer le tri par colonne"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Supprimez ce type de stockage de toutes les unités de stockage qui le référencent et supprimez-le. Cette action ne peut pas être annulée."
+msgstr "Retirer ce type de stockage de toutes les unités de stockage qui le référencent et le supprimer. Cela ne peut pas être annulé."
 
 msgid "Remove tool"
-msgstr "Supprimer l'outil"
+msgstr "Retirer l'outil"
 
 msgid "Remove two-factor authentication"
-msgstr "Supprimer l'authentification à deux facteurs"
+msgstr "Retirer l'authentification à deux facteurs"
 
 msgid "Removed"
 msgstr "Supprimé"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "Réorganiser le groupe"
 
 msgid "Reorder point"
-msgstr "Point de Réapprovisionnement"
+msgstr "Point de commande"
 
 msgid "Reorder Point"
-msgstr "Point de réapprovisionnement"
+msgstr "Point de commande"
 
 msgid "Reorder Point:"
-msgstr "Point de réapprovisionnement :"
+msgstr "Point de commande :"
 
 msgid "Reorder Policy"
 msgstr "Politique de réapprovisionnement"
@@ -12396,7 +12396,7 @@ msgid "Reordering Policy"
 msgstr "Politique de réapprovisionnement"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Réordonne uniquement la séquence d'expédition et le centre de travail — ne replanifie pas. Modifiez les dates sur le tableau des dates."
+msgstr "Réordonne uniquement la séquence d'intervention et le poste de travail — ne change pas la planification. Modifiez les dates sur le tableau des dates."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Se répète une fois pour chaque élément dans {inputLabel}"
@@ -12405,25 +12405,25 @@ msgid "Replace drawing?"
 msgstr "Remplacer le dessin ?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Remplacer les tarifs existants par les valeurs source"
+msgstr "Remplacer la tarification existante par les valeurs sources"
 
 msgid "Replace PDF"
 msgstr "Remplacer le PDF"
 
 msgid "Replace this company's data with a demo dataset — snapshotted first, so you can revert."
-msgstr "Remplacez les données de cette entreprise par un ensemble de données de démonstration — d'abord capturé, afin que vous puissiez revenir en arrière."
+msgstr "Remplacer les données de cette société par un ensemble de données de démonstration — d'abord enregistré, pour que vous puissiez annuler."
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "Le remplacement du PDF supprime tous les placements de bulles sur ce document. Les lignes de fonctionnalités et leurs valeurs restent ; vous pouvez placer à nouveau des bulles sur le nouveau dessin."
+msgstr "Le remplacement du PDF supprime tous les placements de bulles sur ce document. Les lignes de fonctionnalités et leurs valeurs restent ; vous pouvez placer à nouveau les bulles sur le nouveau dessin."
 
 msgid "Replenishment"
 msgstr "Réapprovisionnement"
 
 msgid "Replenishment system"
-msgstr "Système de réapprovisionnement"
+msgstr "Mode d'approvisionnement"
 
 msgid "Replenishment System"
-msgstr "Système de réapprovisionnement"
+msgstr "Mode d'approvisionnement"
 
 msgid "Report"
 msgstr "Rapport"
@@ -12432,7 +12432,7 @@ msgid "Reporting"
 msgstr "Rapports"
 
 msgid "Reporting dimension"
-msgstr "Dimension de rapports"
+msgstr "Axe analytique"
 
 msgid "Reports"
 msgstr "Rapports"
@@ -12456,13 +12456,13 @@ msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "Exiger un code à 6 chiffres d'une application d'authentification lors de la connexion."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
-msgstr "Exigez une application d'authentification avant que quiconque ne puisse ouvrir cette entreprise. Leurs autres entreprises ne sont pas affectées. Visitez la <0>page des comptes d'employés</0> pour voir le statut de chaque personne."
+msgstr "Exiger une application d'authentification avant que quiconque puisse ouvrir cette société. Leurs autres sociétés ne sont pas affectées. Visitez la <0>page des comptes employé</0> pour voir le statut de chaque personne."
 
 msgid "Require approval before suppliers can be set to Active"
 msgstr "Exiger une approbation avant que les fournisseurs puissent être définis comme Actifs"
 
 msgid "Require approval for purchase orders based on amount thresholds"
-msgstr "Exiger une approbation pour les commandes d'achat en fonction des seuils de montant"
+msgstr "Exiger une approbation pour les bons de commande en fonction des seuils de montant"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "Exiger une approbation pour les documents de qualité dans votre flux de travail"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "Actions Requises (par ordre)"
 
 msgid "Required Date"
-msgstr "Date requise"
+msgstr "Date de besoin"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Requis dans un environnement contrôlé — la journalisation d'audit ne peut pas être désactivée."
@@ -12547,7 +12547,7 @@ msgid "Residual Value %"
 msgstr "Valeur résiduelle %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "Résolvez ces problèmes avant de terminer l'NCR : chaque ligne doit avoir une disposition non-En attente, et les quantités des entités liées doivent correspondre à la quantité de la ligne."
+msgstr "Résolvez ceci avant de terminer le NCR : chaque ligne doit avoir un traitement non-Pending, et les quantités d'entités liées doivent correspondre à la quantité de la ligne."
 
 msgid "Resolved Price"
 msgstr "Prix résolu"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Restaurer à partir de la corbeille"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Restaurer cette entité au stock disponible dans le bac et au coût d'où elle a été mise au rebut."
+msgstr "Restaurer cette entité au stock disponible au casier et au coût à partir duquel elle a été mise au rebut."
 
 msgid "Restore tracked entities to available"
 msgstr "Restaurer les entités suivies en disponibles"
@@ -12583,10 +12583,10 @@ msgid "Resume Receiving"
 msgstr "Reprendre la réception"
 
 msgid "Retained Earnings"
-msgstr "Bénéfices non distribués"
+msgstr "Report à nouveau"
 
 msgid "Retained Earnings (default)"
-msgstr "Bénéfices non distribués (défaut)"
+msgstr "Report à nouveau (par défaut)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
 msgstr "Mise hors service d'un actif par mise au rebut ou par vente, en comptabilisant tout gain ou perte par rapport à la valeur nette comptable et en faisant passer son statut à Cédé."
@@ -12619,10 +12619,10 @@ msgid "Revenue"
 msgstr "Revenu"
 
 msgid "Revenue and expenses over a period"
-msgstr "Revenus et dépenses au cours d'une période"
+msgstr "Revenus et charges sur une période"
 
 msgid "Reverse all inventory adjustments"
-msgstr "Inverser tous les ajustements d'inventaire"
+msgstr "Extourner tous les ajustements de stock"
 
 msgid "Reverse all journal and cost ledger entries"
 msgstr "Inverser tous les écritures de journal et de grand livre des coûts"
@@ -12631,7 +12631,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Inverser les écritures de registre d'articles de cette facture"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Autofacture"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Taxe de vente d'autoliquidation"
@@ -12643,7 +12643,7 @@ msgid "Reverse the related journal entries"
 msgstr "Inverser les écritures comptables associées"
 
 msgid "Reversed"
-msgstr "Contrepassé"
+msgstr "Extourné"
 
 msgid "Revert"
 msgstr "Annuler"
@@ -12652,19 +12652,19 @@ msgid "Reverting"
 msgstr "Annulation en cours"
 
 msgid "Review"
-msgstr "Examiner"
+msgstr "Revue"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "Examinez les changements de chaque article, puis confirmez — la publication ne peut pas être annulée."
+msgstr "Examinez les modifications de chaque article, puis confirmez — la libération ne peut pas être annulée."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Examinez le bilan et le compte de résultat de la période et confirmez que les chiffres semblent corrects. Ceci est une approbation manuelle — marquez-la comme terminée une fois que vous les avez examinés."
+msgstr "Examinez le bilan et le compte de résultat de la période et confirmez que les chiffres semblent corrects. C'est une approbation manuelle — marquez-le comme fait une fois que vous les avez examinés."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
 msgstr "Passez en revue les correspondances suggérées avant d'appliquer. Ce sont une meilleure conjecture — confirmez que chacune est correcte."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Examinez les avertissements ci-dessous, puis validez le comptage pour appliquer les ajustements."
+msgstr "Examinez les avertissements ci-dessous, puis comptabilisez le décompte pour appliquer les ajustements."
 
 msgid "Revision"
 msgstr "Révision"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "Appels d'offres"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Faites voyager les dimensions Carbon sur les journaux poussés. Chaque emplacement mappe une dimension Carbon à une cible d'analyse du fournisseur ; le mappage des valeurs ci-dessous associe les valeurs de dimension individuelles aux options du fournisseur."
+msgstr "Envoyer les axes analytiques Carbon avec les écritures envoyées. Chaque emplacement mappe un axe analytique Carbon à une cible d'analytique du fournisseur ; le mappage de valeur ci-dessous associe les valeurs individuelles d'axe analytique aux options du fournisseur."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12753,7 +12753,7 @@ msgid "Roles and Responsibilities"
 msgstr "Rôles et responsabilités"
 
 msgid "Roles that set default permissions for new employees"
-msgstr "Les rôles qui définissent les permissions par défaut pour les nouveaux employés"
+msgstr "Rôles qui définissent les permissions par défaut pour les nouveaux employés"
 
 msgid "Room to grow without bolting on more tools"
 msgstr "Espace pour croître sans ajouter d'autres outils"
@@ -12765,10 +12765,10 @@ msgid "Rounding Account (default)"
 msgstr "Compte d'arrondi (défaut)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Acheminez toutes les factures AP vers une seule adresse (p. ex. siège social) au lieu de les envoyer à des acheteurs individuels."
+msgstr "Router toutes les factures des comptes fournisseurs vers une adresse (p. ex. siège social) au lieu d'acheteurs individuels."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Acheminez toutes les factures AR vers une seule adresse (p. ex. siège social) au lieu de lieux individuels."
+msgstr "Router toutes les factures des comptes clients vers une adresse (p. ex. siège social) au lieu de sites individuels."
 
 msgid "Routing"
 msgstr "Gamme opératoire"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Exécuter la liste de contrôle d'acceptation jusqu'à la réussite"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Gérer l'atelier sur tablettes : enregistrer le travail, signaler la progression, consulter les instructions"
+msgstr "Exécuter l'atelier sur des tablettes : enregistrer la main-d'œuvre, signaler la progression, voir les instructions"
 
 msgid "Run this workflow now?"
 msgstr "Exécuter ce flux de travail maintenant ?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "En cours d'exécution"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "Stocks renouvelés après l'offre et la demande de chaque semaine — la ligne."
+msgstr "Inventaire permanent après chaque semaine d'approvisionnement et de besoins — la ligne."
 
 msgid "Running Total"
 msgstr "Total cumulé"
@@ -12901,13 +12901,13 @@ msgid "Sales contact"
 msgstr "Contact commercial"
 
 msgid "Sales Contact"
-msgstr "Contact Commercial"
+msgstr "Contact commercial"
 
 msgid "Sales Discounts"
-msgstr "Rabais commerciaux"
+msgstr "Remises commerciales"
 
 msgid "Sales Discounts (default)"
-msgstr "Rabais commerciaux (défaut)"
+msgstr "Remises commerciales (par défaut)"
 
 msgid "Sales Funnel"
 msgstr "Entonnoir de ventes"
@@ -12928,22 +12928,22 @@ msgid "Sales Job Notifications"
 msgstr "Notifications de travaux de vente"
 
 msgid "Sales order"
-msgstr "Commande de vente"
+msgstr "Commande client"
 
 msgid "Sales Order"
-msgstr "Commande de vente"
+msgstr "Commande client"
 
 msgid "Sales Order ID"
 msgstr "Numéro de commande client"
 
 msgid "Sales order line"
-msgstr "Ligne de commande de vente"
+msgstr "Ligne de commande client"
 
 msgid "Sales Order Line"
 msgstr "Ligne de commande client"
 
 msgid "Sales Order Line (job)"
-msgstr "Ligne de commande de vente (travail)"
+msgstr "Ligne de commande client (ordre de fabrication)"
 
 msgid "Sales Order Location"
 msgstr "Localisation de la commande client"
@@ -12952,13 +12952,13 @@ msgid "Sales Order Number"
 msgstr "Numéro de commande client"
 
 msgid "Sales Orders"
-msgstr "Commandes de vente"
+msgstr "Commandes client"
 
 msgid "Sales Person"
-msgstr "Responsable commercial"
+msgstr "Vendeur"
 
 msgid "Sales Revenue"
-msgstr "Chiffre d'affaires"
+msgstr "Revenus des ventes"
 
 msgid "Sales Tax Payable"
 msgstr "Taxes de vente à payer"
@@ -12982,7 +12982,7 @@ msgid "Sample"
 msgstr "Échantillon"
 
 msgid "Sample Size"
-msgstr "Taille de l'échantillon"
+msgstr "Taille d'échantillon"
 
 msgid "Sampling"
 msgstr "Échantillonnage"
@@ -13012,7 +13012,7 @@ msgid "Save contacts"
 msgstr "Enregistrer les contacts"
 
 msgid "Save dimension settings"
-msgstr "Enregistrer les paramètres de dimension"
+msgstr "Enregistrer les paramètres d'axe analytique"
 
 msgid "Save Method"
 msgstr "Enregistrer la méthode"
@@ -13039,7 +13039,7 @@ msgid "Saving…"
 msgstr "Enregistrement…"
 
 msgid "Scan"
-msgstr "Numériser"
+msgstr "Scanner"
 
 msgid "Scan a label or search by item ID or tracking ID."
 msgstr "Scannez une étiquette ou recherchez par ID d'article ou ID de suivi."
@@ -13078,7 +13078,7 @@ msgid "Schedule"
 msgstr "Calendrier"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Planifier les travaux en fonction de la capacité du centre de travail"
+msgstr "Planifier les ordres de fabrication en fonction de la capacité du centre de travail"
 
 msgid "Schedule Name"
 msgstr "Nom de l'horaire"
@@ -13108,7 +13108,7 @@ msgid "Scopes"
 msgstr "Portées"
 
 msgid "Scrap"
-msgstr "Déchet"
+msgstr "Rebut"
 
 msgid "Scrap / Cost of Quality"
 msgstr "Rebut / Coût de la qualité"
@@ -13117,7 +13117,7 @@ msgid "Scrap Percent"
 msgstr "Pourcentage de rebut"
 
 msgid "Scrap percentage"
-msgstr "Pourcentage de rebut"
+msgstr "Taux de rebut"
 
 msgid "Scrap Qty"
 msgstr "Quantité de rebut"
@@ -13132,16 +13132,16 @@ msgid "Scrap Quantity Per Job"
 msgstr "Quantité de rebut par travail"
 
 msgid "scrap reason"
-msgstr "Motif de déchet"
+msgstr "Motif de rebut"
 
 msgid "Scrap Reason"
-msgstr "Raison de rebut"
+msgstr "Motif de rebut"
 
 msgid "scrap reasons"
-msgstr "Motifs de déchet"
+msgstr "Motifs de rebut"
 
 msgid "Scrap Reasons"
-msgstr "Raisons de rebut"
+msgstr "Motifs de rebut"
 
 msgid "Scrapped"
 msgstr "Mise au rebut"
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "Rechercher un existant ou en créer un nouveau"
 
 msgid "Search items or bins"
-msgstr "Rechercher des articles ou des bacs"
+msgstr "Rechercher des articles ou des casiers"
 
 msgid "Search Job"
 msgstr "Rechercher un travail"
@@ -13349,7 +13349,7 @@ msgid "Select customers"
 msgstr "Sélectionner les clients"
 
 msgid "Select dimension"
-msgstr "Sélectionner une dimension"
+msgstr "Sélectionner un axe analytique"
 
 msgid "Select Employee"
 msgstr "Sélectionner un employé"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Sélectionner un champ"
 
 msgid "Select Gauge"
-msgstr "Sélectionner un calibre"
+msgstr "Sélectionner un instrument de mesure"
 
 msgid "Select groups or individuals"
 msgstr "Sélectionner des groupes ou des individus"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Sélectionnez les groupes qui doivent suivre cette formation"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Sélectionnez les factures que ce paiement règle. La remise et la radiation sont en devise de facture."
+msgstr "Sélectionner les factures que ce paiement règle. La remise et le passage en perte sont à la devise de la facture."
 
 msgid "Select value"
 msgstr "Sélectionner une valeur"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Autogéré"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto-hébergé ou géré"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Intégration autonome"
 
 msgid "Self-paced"
 msgstr "Apprentissage autonome"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "Numéro de série / Lot"
 
 msgid "Serial items require a sales order"
-msgstr "Les articles en série nécessitent un bon de commande"
+msgstr "Les articles en série nécessitent une commande client"
 
 msgid "Serial Number"
 msgstr "Numéro de série"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Définir un objectif"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Configurez Carbon en fonction du fonctionnement de votre entreprise : sites, pièces, nomenclatures, processus de fabrication et flux que vous utilisez."
+msgstr "Configurer Carbon en fonction de votre fonctionnement : sites, pièces, BOM, liste des opérations et flux que vous utilisez."
 
 msgid "Set Clock Out"
-msgstr "Définir l'heure de départ"
+msgstr "Définir le pointage fin"
 
 msgid "Set clock-out time"
 msgstr "Définir l'heure de départ"
@@ -13575,7 +13575,7 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "Définir les pourcentages de majoration par défaut pour chaque catégorie de coûts sur les nouvelles lignes de devis"
 
 msgid "Set demand projection values for each week"
-msgstr "Définir les valeurs de projection de la demande pour chaque semaine"
+msgstr "Définir les valeurs de projection de besoins pour chaque semaine"
 
 msgid "Set due date"
 msgstr "Définir la date d'échéance"
@@ -13596,7 +13596,7 @@ msgid "Set up two-factor authentication"
 msgstr "Configurer l'authentification à deux facteurs"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "Configurez votre entreprise avec un plan d'implémentation étape par étape couvrant la configuration, les données, la formation et la mise en production."
+msgstr "Configurer votre société avec un plan de mise en œuvre étape par étape couvrant la configuration, les données, la formation et le lancement."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "Configurez vos propres données avec les outils d'importation et l'aide de l'IA"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Carte de Configuration"
 
 msgid "Setup time"
-msgstr "Temps de configuration"
+msgstr "Temps de réglage"
 
 msgid "Setup Time"
-msgstr "Temps de configuration"
+msgstr "Temps de réglage"
 
 msgid "Setup unit"
 msgstr "Unité de configuration"
@@ -13696,19 +13696,19 @@ msgid "Shelf-Life History"
 msgstr "Historique de la durée de conservation"
 
 msgid "shift"
-msgstr "quart"
+msgstr "Équipe"
 
 msgid "Shift"
-msgstr "Quart"
+msgstr "Équipe"
 
 msgid "Shift Name"
-msgstr "Nom du quart"
+msgstr "Nom de l'équipe"
 
 msgid "shifts"
-msgstr "quarts"
+msgstr "Équipes"
 
 msgid "Shifts"
-msgstr "Quarts"
+msgstr "Équipes"
 
 msgid "Ship"
 msgstr "Expédier"
@@ -13753,7 +13753,7 @@ msgid "Shipping Contact"
 msgstr "Contact d'expédition"
 
 msgid "Shipping Cost"
-msgstr "Coût d'expédition"
+msgstr "Frais de port"
 
 msgid "Shipping Customer"
 msgstr "Client de livraison"
@@ -13762,19 +13762,19 @@ msgid "Shipping Location"
 msgstr "Lieu d'expédition"
 
 msgid "shipping method"
-msgstr "méthode de livraison"
+msgstr "mode d'expédition"
 
 msgid "Shipping method"
 msgstr "Mode d'expédition"
 
 msgid "Shipping Method"
-msgstr "Méthode d'expédition"
+msgstr "Mode d'expédition"
 
 msgid "shipping methods"
-msgstr "méthodes de livraison"
+msgstr "modes d'expédition"
 
 msgid "Shipping Methods"
-msgstr "Méthodes d'expédition"
+msgstr "Modes d'expédition"
 
 msgid "Shipping Notes"
 msgstr "Notes d'expédition"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Affichage des 500 premières lignes"
 
 msgid "Showing the newest 200 journals"
-msgstr "Affichage des 200 journaux les plus récents"
+msgstr "Affichage des 200 dernières écritures"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Affichage des 1 000 meilleurs groupes par montant"
@@ -13868,10 +13868,10 @@ msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Affiché en arrière-plan discret sur chaque page des PDF générés"
 
 msgid "Shown to the user when this rule fails."
-msgstr "Affiché à l'utilisateur lorsque cette règle échoue."
+msgstr "Affiché à l'utilisateur quand cette règle échoue."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Se connecter à Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Connectez-vous avec la biométrie au lieu d'un lien magique. Les clés d'accès sont sécurisées par Face ID, Touch ID ou votre code PIN de l'appareil."
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "Se connecter avec Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Se connecter avec Passkey"
+msgstr "Se connecter avec Clé d'accès"
 
 msgid "Sign out"
 msgstr "Se déconnecter"
@@ -13898,7 +13898,7 @@ msgid "Sign out instead"
 msgstr "Se déconnecter à la place"
 
 msgid "Sign-off review before moving to the next step"
-msgstr "Examen de validation avant de passer à l'étape suivante"
+msgstr "Revue de validation avant de passer à l'étape suivante"
 
 msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
 msgstr "Autorisations qui doivent être enregistrées avant la fermeture de ce problème; en plus de celles requises par le flux de travail."
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "Sites et emplacements"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "Sites, emplacements, centres de travail, utilisateurs, fournisseurs et paramètres de votre entreprise — la base sur laquelle tout le reste s'appuie. Commencez par des modèles prêts à l'emploi."
+msgstr "Sites, emplacements, postes de travail, utilisateurs, fournisseurs et les paramètres de votre société — la base sur laquelle tout le reste repose. Commencez par des modèles prêts à l'emploi."
 
 msgid "Size"
 msgstr "Taille"
@@ -13943,7 +13943,7 @@ msgid "Skip scheduled maintenance on company holidays"
 msgstr "Ignorer la maintenance programmée lors des jours fériés de l'entreprise"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
-msgstr "Ignorer l'état libéré mais non démarré - le travail commence immédiatement à la numérisation."
+msgstr "Ignorer l'état libéré mais non démarré — l'ordre de fabrication démarre immédiatement lors du scan."
 
 msgid "Skipped"
 msgstr "Ignoré"
@@ -13952,25 +13952,25 @@ msgid "Slack"
 msgstr "Slack"
 
 msgid "Slice asset activity by location, item, or any dimension"
-msgstr "Segmenter l'activité des actifs par lieu, article ou toute dimension"
+msgstr "Ventiler l'activité des immobilisations par site, article ou axe analytique"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "Segmenter les dépenses par lieu, centre de coûts ou toute dimension"
+msgstr "Ventiler les charges par site, centre de coûts ou axe analytique"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Ventiler le chiffre d'affaires par client, type de client ou toute dimension"
+msgstr "Ventiler les revenus par client, type de client ou axe analytique"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Tester les flux quotidiens principaux de bout en bout"
 
 msgid "so you can assign it here."
-msgstr "pour que vous puissiez l'assigner ici."
+msgstr "pour que vous puissiez l'attribuer ici."
 
 msgid "Solutions Engineer"
 msgstr "Ingénieur Solutions"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "Certaines lignes extraites du PDF n'ont pas pu être automatiquement mappées à vos articles d'inventaire. Vérifiez et mappez chaque ligne ci-dessous."
+msgstr "Certaines lignes extraites du PDF n'ont pas pu être automatiquement associées à vos articles. Passez en revue et associez chaque ligne ci-dessous."
 
 msgid "Something went wrong. Please try again."
 msgstr "Quelque chose s'est mal passé. Veuillez réessayer."
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "Bientôt"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "L'expiration la plus proche parmi tous les matériaux détermine le produit fini."
+msgstr "La péremption la plus proche parmi toutes les matières détermine celle du produit fini."
 
 msgid "Sort"
 msgstr "Trier"
@@ -14000,19 +14000,19 @@ msgid "Source Analysis"
 msgstr "Analyse des sources"
 
 msgid "Source Company"
-msgstr "Entreprise source"
+msgstr "Société d'origine"
 
 msgid "Source document"
-msgstr "Document source"
+msgstr "document d'origine"
 
 msgid "Source Document"
-msgstr "Document source"
+msgstr "Document d'origine"
 
 msgid "Source Document ID"
-msgstr "ID du document source"
+msgstr "ID du document d'origine"
 
 msgid "Source document readable"
-msgstr "Document source lisible"
+msgstr "document d'origine lisible"
 
 msgid "Source Item"
 msgstr "Élément source"
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "Diviser la ligne d'expédition"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Mettre en place l'hébergement"
@@ -14087,7 +14087,7 @@ msgid "Standard"
 msgstr "Standard"
 
 msgid "Standard cloud Carbon fits how your company runs"
-msgstr "Carbon cloud standard s'adapte à la façon dont votre entreprise fonctionne"
+msgstr "Standard cloud Carbon s'adapte à la façon dont votre entreprise fonctionne"
 
 msgid "Standard Cost Variances"
 msgstr "Écarts de coûts standards"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "Facteur standard"
 
 msgid "Standard Lead Time"
-msgstr "Délai de livraison standard"
+msgstr "Délai d'approvisionnement standard"
 
 msgid "Start"
 msgstr "Démarrer"
@@ -14130,7 +14130,7 @@ msgid "Start Now"
 msgstr "Commencer maintenant"
 
 msgid "Start of Fiscal Year"
-msgstr "Début de l'exercice fiscal"
+msgstr "Début de l'exercice comptable"
 
 msgid "Start of Tax Year"
 msgstr "Début de l'année fiscale"
@@ -14202,7 +14202,7 @@ msgid "Steps are inherited from the assembly instruction."
 msgstr "Les étapes sont héritées de l'instruction d'assemblage."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "Les étapes sont héritées du plan d'inspection."
+msgstr "Les étapes sont héritées du plan de contrôle."
 
 msgid "Stock movement corrected"
 msgstr "Mouvement de stock corrigé"
@@ -14233,7 +14233,7 @@ msgid "Stockout"
 msgstr "Rupture de stock"
 
 msgid "Stop raising purchase orders after this date"
-msgstr "Arrêter de créer des commandes d'achat après cette date"
+msgstr "Cesser de lever des bons de commande après cette date"
 
 msgid "Stop Receiving"
 msgstr "Arrêter la réception"
@@ -14275,31 +14275,31 @@ msgid "Storage Units"
 msgstr "Unités de stockage"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "Stockez un nombre fixe de jours sur cet article. La date de début d'expiration est définie sur chaque lot ou numéro de série lors de sa création (ou lors de l'exécution du processus de déclenchement, le cas échéant)."
+msgstr "Stocker un nombre fixe de jours sur cet article. La date de début de péremption est définie sur chaque lot de production ou numéro de série lors de sa création (ou lorsque le processus déclencheur s'exécute, s'il est défini)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "Stockez un nombre fixe de jours sur cet article. La date de début d'expiration est définie sur chaque lot ou numéro de série lors de sa réception ou création (ou lors de l'exécution du processus de déclenchement, le cas échéant)."
+msgstr "Stocker un nombre fixe de jours sur cet article. La date de début de péremption est définie sur chaque lot de production ou numéro de série lors de sa réception ou sa création (ou lorsque le processus déclencheur s'exécute, s'il est défini)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Stockez un nombre fixe de jours sur cet article. La date de début d'expiration est définie sur chaque lot ou numéro de série lors de sa réception."
+msgstr "Stocker un nombre fixe de jours sur cet article. La date de début de péremption est définie sur chaque lot de production ou numéro de série lors de sa réception."
 
 msgid "Straight line"
 msgstr "Linéaire"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe possède déjà un client avec cet e-mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Date d'échéance Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe envoie par e-mail la facture au client, c'est pourquoi une adresse est requise. Cette adresse sera également enregistrée au contact dans Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe n'a pas encore de client pour ce client Carbon. La comptabilisation en créera un sur votre compte connecté."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Style de sortie kanban à afficher dans le tableau Kanban"
@@ -14311,7 +14311,7 @@ msgid "Sub-Departments"
 msgstr "Sous-départements"
 
 msgid "Subassembly"
-msgstr "Sous-assemblage"
+msgstr "Sous-ensemble"
 
 msgid "Subcontracting Variance"
 msgstr "Écart de Sous-Traitance"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "Soumettre pour approbation"
 
 msgid "Submit Inspection"
-msgstr "Soumettre l'inspection"
+msgstr "Soumettre le contrôle"
 
 msgid "Submitted By"
 msgstr "Soumis par"
@@ -14371,7 +14371,7 @@ msgid "Successfully created a new revision"
 msgstr "Révision créée avec succès"
 
 msgid "Successor effectivity"
-msgstr "Effectivité du successeur"
+msgstr "Date d'effet du successeur"
 
 msgid "Successor Effectivity Date"
 msgstr "Date d'effectivité du successeur"
@@ -14416,7 +14416,7 @@ msgid "Supersession"
 msgstr "Remplacement"
 
 msgid "Supersession chain detected"
-msgstr "Chaîne de succession détectée"
+msgstr "Chaîne de remplacement détectée"
 
 msgid "Supersession Mode"
 msgstr "Mode de remplacement"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Pièce Fournisseur"
 
 msgid "Supplier Part ID"
-msgstr "ID de pièce fournisseur"
+msgstr "Référence fournisseur"
 
 msgid "Supplier Part Number"
 msgstr "Numéro de pièce fournisseur"
@@ -14479,13 +14479,13 @@ msgid "Supplier Parts"
 msgstr "Pièces du fournisseur"
 
 msgid "Supplier Payment Discounts"
-msgstr "Escomptes de Paiement Fournisseur"
+msgstr "Remises de paiement fournisseur"
 
 msgid "Supplier Payment Discounts (default)"
-msgstr "Escomptes de Paiement Fournisseur (par défaut)"
+msgstr "Remises de paiement fournisseur (par défaut)"
 
 msgid "Supplier Prepayments"
-msgstr "Paiements anticipés aux fournisseurs"
+msgstr "Acomptes fournisseur"
 
 msgid "supplier process"
 msgstr "Processus Fournisseur"
@@ -14560,7 +14560,7 @@ msgid "Supply"
 msgstr "Approvisionnement"
 
 msgid "Supply & Demand"
-msgstr "Offre et demande"
+msgstr "Approvisionnement et Besoins"
 
 msgid "Support"
 msgstr "Support"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "Basculer"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "Désactivez un module pour le supprimer partout : Exigences, Données, Formation, Portée."
+msgstr "Désactiver un module le supprime partout : Exigences, Données, Formation, Portée."
 
 msgid "Switch to pan mode"
 msgstr "Passer en mode panoramique"
@@ -14591,7 +14591,7 @@ msgid "Switch users over and confirm access"
 msgstr "Basculer les utilisateurs et confirmer l'accès"
 
 msgid "Switching the employee's type here doesn't change their existing permissions; the modal that follows asks whether to overwrite the current set with the new type's defaults."
-msgstr "Changer le type d'employé ici ne change pas ses permissions existantes; le diálogui qui suit demande s'il faut remplacer l'ensemble actuel par les valeurs par défaut du nouveau type."
+msgstr "Modifier le type d'employé ici ne change pas ses autorisations existantes ; la fenêtre qui suit demande si vous souhaitez remplacer l'ensemble actuel par les paramètres par défaut du nouveau type."
 
 msgid "Sync"
 msgstr "Synchroniser"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "Personnalisez ce hub pour le client. Les modifications s'appliquent en direct pour tous ceux qui le consultent. Jamais affiché au client ici."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Prenez la durée de vie restante la plus courte parmi les matériaux consommés pour fabriquer cet article. À utiliser lorsque l'expiration du produit dépend de ses ingrédients."
+msgstr "Utiliser la durée de conservation la plus courte parmi les matières consommées pour fabriquer cet article. À utiliser lorsque la date d'expiration du produit dépend de ses ingrédients."
 
 msgid "taken"
 msgstr "prise"
@@ -14645,13 +14645,13 @@ msgid "Target an item group."
 msgstr "Ciblez un groupe d'articles."
 
 msgid "Target Company"
-msgstr "Entreprise Cible"
+msgstr "Société cible"
 
 msgid "Target customers by type."
-msgstr "Élément cible"
+msgstr "Cibler les clients par type."
 
 msgid "Target disposition row"
-msgstr "Ligne de disposition cible"
+msgstr "Ligne de traitement cible"
 
 msgid "Target go-live"
 msgstr "Cible de mise en ligne"
@@ -14696,7 +14696,7 @@ msgid "Tax"
 msgstr "Taxe"
 
 msgid "Tax & Additional Costs"
-msgstr "Taxe et frais supplémentaires"
+msgstr "Taxe et coûts supplémentaires"
 
 msgid "Tax & Shipping"
 msgstr "Taxe et expédition"
@@ -14708,31 +14708,31 @@ msgid "Tax codes, rates"
 msgstr "Codes fiscaux, taux"
 
 msgid "Tax Depreciation"
-msgstr "Dépréciation Fiscale"
+msgstr "Amortissement fiscal"
 
 msgid "Tax Depreciation Method"
-msgstr "Méthode de Dépréciation Fiscale"
+msgstr "Méthode d'amortissement fiscal"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Exonéré de taxe"
 
 msgid "Tax Exempt"
 msgstr "Exonéré de Taxe"
 
 msgid "Tax ID"
-msgstr "Numéro d'identification fiscale"
+msgstr "Numéro de taxe"
 
 msgid "Tax Information"
-msgstr "Informations Fiscales"
+msgstr "Informations fiscales"
 
 msgid "Tax liability for reverse-charge transactions"
-msgstr "Obligation Fiscale pour les Transactions d'Inversion du Mécanisme de Déductibilité"
+msgstr "Passif fiscal pour les transactions en autofacture"
 
 msgid "Tax Method"
-msgstr "Méthode Fiscale"
+msgstr "Méthode fiscale"
 
 msgid "Tax Method (default)"
-msgstr "Méthode Fiscale (par défaut)"
+msgstr "Méthode fiscale (par défaut)"
 
 msgid "Tax percent"
 msgstr "Pourcentage de taxe"
@@ -14741,16 +14741,16 @@ msgid "Tax Percent"
 msgstr "Pourcentage de taxe"
 
 msgid "Tax Residual Value %"
-msgstr "Valeur Résiduelle Fiscale %"
+msgstr "Valeur résiduelle fiscale %"
 
 msgid "Tax Useful Life (default)"
-msgstr "Durée de Vie Utile Fiscale (par défaut)"
+msgstr "Durée d'utilité fiscale (par défaut)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Durée de Vie Utile Fiscale (mois)"
+msgstr "Durée d'utilité fiscale (mois)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Durée de Vie Utile Fiscale (Mois)"
+msgstr "Durée d'utilité fiscale (Mois)"
 
 msgid "Tax:"
 msgstr "Taxe :"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Équipe formée"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Support technique"
 
 msgid "Temperature"
 msgstr "Température"
@@ -14805,7 +14805,7 @@ msgstr "Ce nom est déjà utilisé par une autre étape."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "La phase « {0} » se coche automatiquement une fois que toutes ses tâches du plan de projet sont terminées."
+msgstr "La phase « {0} » se valide automatiquement une fois que toutes ses tâches du plan de projet sont terminées."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
@@ -14817,22 +14817,22 @@ msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each tas
 msgstr "Les {0} phases pour le lancement, chacune se terminant à un point de contrôle. Cochez chaque tâche au fur et à mesure que vous la terminez."
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "La dimension comptable qui catégorise les articles pour la déclaration et l'analyse."
+msgstr "L'axe analytique comptable qui classe les articles pour les rapports et l'analyse."
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "Les comptes sur lesquels Carbon enregistre automatiquement"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "L'action qui copie une méthode enregistrée (ses matériaux, opérations et instructions de travail) sur une ligne de travail ou de devis."
+msgstr "L'action qui copie une méthode enregistrée (ses matières, opérations et modes opératoires) sur un ordre de fabrication ou une ligne de devis."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "Les valeurs autorisées pour un attribut de type liste; les utilisateurs choisissent parmi ceux-ci plutôt que de taper librement."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Les valeurs autorisées que les utilisateurs peuvent sélectionner lors du balisage des écritures avec cette dimension."
+msgstr "Les valeurs autorisées que les utilisateurs peuvent choisir lors du marquage des comptabilisations avec cet axe analytique."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "Le nombre de jours après la méthode de calcul pendant lesquels la remise au comptant est disponible"
+msgstr "Le nombre de jours après la méthode de calcul pour lequel la remise de trésorerie est disponible"
 
 msgid "The amount of days after the calculation method that the payment is due"
 msgstr "Le nombre de jours après la méthode de calcul que le paiement est dû"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "L'autorisation a été refusée dans Onshape. Réessayez de vous connecter."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Le livre de toutes les lignes de journal enregistrées, sommées par compte – écrit seulement si la comptabilité est activée pour l'entreprise."
+msgstr "Le registre de toutes les écritures comptabilisées, cumulées par compte — créé uniquement lorsque la comptabilité est activée pour la société."
 
 msgid "The buckets you track costs against"
 msgstr "Les compartiments par rapport auxquels vous suivez les coûts"
@@ -14853,7 +14853,7 @@ msgid "The capital assets you own and depreciate"
 msgstr "Les immobilisations que vous possédez et dépréciiez"
 
 msgid "The Carbon user currently responsible for working this record, set per record and independent of ownership fields like Account Manager or Sales Person."
-msgstr "L'utilisateur Carbon actuellement responsable du traitement de cet enregistrement, défini par enregistrement et indépendant des champs de propriété comme Gestionnaire de compte ou Représentant commercial."
+msgstr "L'utilisateur Carbon actuellement responsable du traitement de cet enregistrement, défini par enregistrement et indépendant des champs de propriété comme Gestionnaire de compte ou Commercial."
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
 msgstr "L'utilisateur Carbon responsable de cette relation client; les e-mails et les rappels à propos de ce client leur sont acheminés."
@@ -14877,16 +14877,16 @@ msgid "The carriers and methods you ship orders with"
 msgstr "Les transporteurs et méthodes avec lesquels vous expédiez les commandes"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "La remise en espèces que le client peut obtenir s'il paie dans la fenêtre de remise."
+msgstr "La remise de trésorerie que le client peut obtenir s'il paie dans la fenêtre de remise."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "La raison du catalogue qui explique cette ferraille; s'accumule dans les rapports de ferraille indexés par raison plutôt que par quantité."
+msgstr "La raison de catalogue qui explique ce rebut ; se cumule dans les rapports de rebut classés par raison plutôt que par quantité."
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "Le catalogue sur lequel vous travaillez. Se charge une fois la base en place."
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "Les catégories de stock autorisées dans cette unité; utilisées pour appliquer les règles de mise en place (par exemple, chaîne du froid, dangereux)."
+msgstr "Les catégories de stock autorisées dans cette unité ; utilisées pour renforcer les règles de rangement (ex. chaîne froide, dangereux)."
 
 msgid "The categories you group your suppliers into"
 msgstr "Les catégories dans lesquelles vous regroupez vos fournisseurs"
@@ -14913,7 +14913,7 @@ msgid "The code printed on the kanban card that operators scan to mark the job c
 msgstr "Le code imprimé sur la carte kanban que les opérateurs scannent pour marquer le travail comme terminé; généré automatiquement s'il est laissé vide."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "La disponibilité hebdomadaire prévue de l'entrepreneur; la planification l'utilise comme limite supérieure lors de l'affectation de cet entrepreneur à des opérations au cours de la semaine."
+msgstr "La disponibilité hebdomadaire attendue du prestataire ; la planification l'utilise comme limite supérieure lors de l'attribution de ce prestataire aux opérations de la semaine."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "La date d'expiration corrigée pour ce lot/numéro de série; l'inventaire existant est réévalué par rapport à la politique de durée de vie après la modification."
@@ -14949,22 +14949,22 @@ msgid "The date a job's quantity is needed, which together with Deadline Type se
 msgstr "La date à laquelle la quantité d'une commande de travail est nécessaire, qui définit conjointement avec Type d'échéance la place de la commande de travail dans la file d'attente de son emplacement."
 
 msgid "The date depreciation begins for this asset; usually the in-service date."
-msgstr "La date à laquelle la dépréciation de cet actif commence; généralement la date de mise en service."
+msgstr "La date à laquelle l'amortissement débute pour cet actif; généralement la date de mise en service."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "La date après laquelle les prix de cette devis ne sont plus valables; la conversion en commande après cette date peut nécessiter une re-cotation."
+msgstr "La date après laquelle les tarifs de ce devis ne sont plus honorés; la conversion en commande après cette date peut nécessiter un nouveau devis."
 
 msgid "The date the customer expects to receive the goods"
 msgstr "La date à laquelle le client s'attend à recevoir les marchandises"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "La date à laquelle les marchandises quittent réellement l'entrepôt; enregistrée sur l'affichage de la Expedition et utilisée pour la notation de l'expédition à temps."
+msgstr "La date à laquelle les marchandises quittent réellement l'entrepôt; enregistrée lors de la comptabilisation de l'expédition et utilisée pour l'évaluation du respect des délais d'expédition."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "La date à laquelle l'article doit être disponible sur site pour couvrir la demande projetée de la période."
+msgstr "La date à laquelle l'article est requis sur place pour couvrir les besoins projetés de la période."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "La date à laquelle cet actif est retiré du service; l'amortissement s'arrête à cette date et la valeur nette comptable restante est comptabilisée sur le compte de disposition."
+msgstr "La date à laquelle cet actif est retiré du service; l'amortissement s'arrête à cette date et la valeur nette comptable restante est comptabilisée au compte de cession."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "La date à laquelle cette écriture est enregistrée au grand livre; détermine la période comptable dans laquelle elle s'inscrit."
@@ -14979,13 +14979,13 @@ msgid "The deadline to send your quote to the customer."
 msgstr "Le délai pour envoyer votre devis au client."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "L'ordre de sélection par défaut utilise pour proposer des entités suivies: FEFO (expiration la plus tôt d'abord), FIFO (le plus ancien d'abord) ou LIFO (le plus nouveau d'abord)."
+msgstr "La méthode par défaut que le prélèvement utilise pour proposer les entités suivies: FEFO (première à expirer en premier), FIFO (le plus ancien en premier), ou LIFO (le plus récent en premier)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "La quantité de parcours par défaut lorsque cette pièce est fabriquée; les cycles de planification constituent le réapprovisionnement jusqu'à des multiples de ceci."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "Le taux d'imposition par défaut appliqué aux lignes de devis et de commande client de ce client, avant les remplacements par ligne; le calcul fiscal spécifique à la juridiction s'exécute par-dessus."
+msgstr "Le taux de taxe par défaut appliqué aux lignes de devis et de commande client de ce client, avant les substitutions par ligne; le calcul fiscal spécifique à la juridiction s'ajoute."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "Le département sous lequel celui-ci se cumule pour la déclaration et les hiérarchies de dénombrement; laisser vide pour un département au niveau supérieur."
@@ -15003,13 +15003,13 @@ msgid "The endpoint that receives a POST request with the updated data when the 
 msgstr "Le point de terminaison qui reçoit une requête POST avec les données mises à jour lorsque la table est mise à jour"
 
 msgid "The engineering drawing this inspection plan is tied to; inspections recorded against this part reference back to this drawing."
-msgstr "Le dessin d'ingénierie auquel ce plan d'inspection est lié ; les inspections enregistrées pour cette pièce font référence à ce dessin."
+msgstr "Le dessin technique auquel ce plan de contrôle est lié; les contrôles enregistrés contre cette pièce font référence à ce dessin."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "Le pourcentage attendu de la production de cet article perdu pendant la fabrication; la planification multiplie la demande par 1 / (1 − ferraille) pour compenser."
+msgstr "Le pourcentage attendu de la production de cet article perdu lors de la fabrication; la planification multiplie les besoins par 1 / (1 − rebut) pour compenser."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
-msgstr "Le compte de frais auquel cette ligne de dépenses indirectes est contabilisée; requis car les lignes indirectes n'ont pas d'écriture au journal des stocks à partir de laquelle dériver le compte."
+msgstr "Le compte de charge auquel cette ligne de dépenses indirectes se comptabilise; requis parce que les lignes indirectes n'ont pas d'entrée de livre comptable d'article à partir de laquelle dériver le compte."
 
 msgid "the first 3 to 4 weeks"
 msgstr "les 3 à 4 premières semaines"
@@ -15021,34 +15021,34 @@ msgid "The fixed-asset record this purchase capitalizes against; the line's rece
 msgstr "L'enregistrement d'actif fixe sur lequel cet achat est capitalisé; le reçu de la ligne crée une entrée d'actif plutôt qu'une entrée d'inventaire."
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "L'enregistrement d'actif fixe que cette vente aliène; l'expédition de la ligne contabilise l'écriture de disposition de la valeur nette comptable de l'actif au lieu de COGS."
+msgstr "L'enregistrement d'actif fixe que cette vente cède; l'expédition de la ligne comptabilise l'entrée de cession de la valeur nette comptable de l'actif plutôt que le COGS."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "Le plancher auquel un actif s'amortit; lorsque la valeur nette comptable l'atteint, l'actif bascule à Entièrement amorti."
+msgstr "Le plancher auquel un actif s'amortit; lorsque la valeur nette comptable l'atteint, l'actif bascule à Totalement amorti."
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "L'atelier et le bureau consultent les mêmes chiffres d'inventaire et de coûts."
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "Les assemblages suivants n'ont pas d'opérations. Veuillez assigner une opération à chacun avant de lancer."
+msgstr "Les assemblages suivants n'ont pas d'opération. Veuillez attribuer une opération à chacun avant de lancer."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "Les articles de ligne suivants n'ont pas de prix ou de délais de livraison :"
+msgstr "Les lignes suivantes n'ont pas de prix ou de délais d'approvisionnement:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Les tâches suivantes ne sont pas encore terminées :"
+msgstr "Les tâches suivantes ne sont pas encore faites:"
 
 msgid "The forms and shapes your raw materials come in"
 msgstr "Les formes et les formats de vos matières premières"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "La fraction de chaque lot à inspecter; le décompte réel est calculé à partir de la taille du lot au moment de l'inspection."
+msgstr "La fraction de chaque lot à contrôler; le nombre réel est calculé à partir de la taille de lot au moment du contrôle."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "L'écart entre le prix d'une commande d'achat et la facture du fournisseur, comptabilisé dans un compte d'écart lors de l'enregistrement de la facture."
+msgstr "L'écart entre le prix du bon de commande et la facture du fournisseur, comptabilisé sur un compte d'écart lors de la comptabilisation de la facture."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
-msgstr "Le compte GL auquel les frais de ce transporteur sont contabilisés (frais de transport, transport en/out)."
+msgstr "Le compte général sur lequel se comptabilisent les frais de ce transporteur (frais de transport, frais d'approvisionnement/frais d'expédition)."
 
 msgid "The goal"
 msgstr "L'objectif"
@@ -15060,13 +15060,13 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "Le compte de groupe auquel ce compte se résume; détermine son type, sa classe et son placement dans les états financiers."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "Le coût horaire de la main-d'œuvre opérationnelle à ce centre de travail; combiné avec les heures de travail enregistrées pour facturer le coût de la main-d'œuvre dans le WIP d'une tâche."
+msgstr "Le coût horaire de la main-d'œuvre sur ce poste de travail; combiné aux heures de main-d'œuvre enregistrées pour imputer le coût à l'en-cours de l'ordre de fabrication."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "Le coût horaire de fonctionnement de la machinerie à ce centre de travail; combiné avec les heures de machine enregistrées pour facturer le coût de la machine dans le WIP d'une tâche."
+msgstr "Le coût horaire d'utilisation de la machine sur ce poste de travail; combiné aux heures de machine enregistrées pour imputer le coût de la machine à l'en-cours de l'ordre de fabrication."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "La charge de coût indirect horaire appliquée à ce centre de travail; la différence entre main-d'œuvre + machine et le taux de devis complet est ce que les frais généraux absorbent."
+msgstr "La charge de frais indirects horaires appliquée à ce poste de travail; la différence entre la main-d'œuvre + machine et le tarif de devis complet est ce que les frais généraux absorbent."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "L'adresse https à laquelle une étape webhook du flux de travail envoie des messages — http simple, les redirections et les hôtes résolvant vers des adresses privées ou link-local sont refusés, et l'appel abandonne après dix secondes."
@@ -15087,7 +15087,7 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "L'évaluation d'impact si le risque est réalisé (1 = négligeable à 5 = catastrophique); associée à la probabilité pour calculer le score de risque."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "Le document d'enregistrement entrant qui reçoit les marchandises en stock (à partir d'une commande, transfert ou sortie de travail) et crée les entités suivi."
+msgstr "Le document de comptabilisation entrant qui prend les marchandises en stock (à partir d'un bon de commande, transfert, ou production d'ordre de fabrication) et crée les entités suivies."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
 msgstr "La règle Incoterms (FOB, DAP, EXW, CIF, ...) qui gouverne qui paie le fret, qui assume le risque et où le transfert de propriété se produit sur les expéditions de ce fournisseur."
@@ -15096,7 +15096,7 @@ msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight
 msgstr "La règle Incoterms (FOB, DAP, EXW, CIF, ...) qui gouverne qui paie le fret, qui assume le risque et où le transfert de propriété se produit sur les expéditions vers ce client."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Le coût de l'inventaire reconnu lors de l'enregistrement d'une expédition, évalué selon la méthode de coûtage de l'article."
+msgstr "Le coût reconnu lors de la comptabilisation d'une expédition, évalué selon la méthode de calcul des coûts de l'article."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "La classe de période de récupération IRS pour cet actif selon MACRS (3, 5, 7, 10, 15, 20, 27,5, 39 ans)."
@@ -15105,19 +15105,19 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "Le travail dont l'opération couvre cette ligne de traitement externe; le reçu de la ligne ferme l'opération contre ce travail."
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "La position de la commande de travail dans la file d'attente de son emplacement — un nombre fractionnaire que Carbon calcule à partir de la date d'échéance et du type d'échéance, et non une évaluation Bas/Haut."
+msgstr "La position de l'ordre de fabrication dans la file de planification de son site — un nombre fractionnaire que Carbon calcule à partir de la date d'échéance et du type d'échéance, pas une cote Faible/Élevé."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "Le type d'ajustement que cette règle applique - remise, majoration ou dépassement fixe; combiné avec Type de Montant pour calculer le delta réel sur chaque ligne."
+msgstr "Le type d'ajustement que cette règle applique — remise, surcharge, ou substitution fixe; combiné avec le type de montant pour calculer le delta réel sur chaque ligne."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
 msgstr "Le type de valeur que cet attribut accepte (texte, nombre, date, booléen, liste); verrouillé après que l'attribut ait des valeurs enregistrées."
 
 msgid "The label and document printers your company prints to"
-msgstr "Les imprimantes d'étiquettes et de documents sur lesquelles votre entreprise imprime"
+msgstr "Les imprimantes d'étiquettes et de documents vers lesquelles votre société imprime"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "La date limite pour passer cette commande afin qu'elle arrive à la date requise, compte tenu du délai de livraison du fournisseur."
+msgstr "La date la plus tardive pour passer ce bon de commande afin qu'il arrive à la date requise, compte tenu du délai d'approvisionnement du fournisseur."
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "L'entité juridique à facturer, quand elle est différente du client qui reçoit les marchandises - pour les arrangements de facturation parent/filiale ou tiers."
@@ -15135,13 +15135,13 @@ msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approv
 msgstr "L'état du cycle de vie de ce fournisseur - Actif, Inactif, Approbation en attente, etc.; seuls les fournisseurs Actifs apparaissent dans les sélecteurs PO/devis."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "Le fuseau horaire local dans lequel cet emplacement signale l'heure; les horaires, les feuilles de temps et les heures de quart à cet emplacement sont interprétés dans ce fuseau indépendamment de la locale du navigateur de l'utilisateur."
+msgstr "Le fuseau horaire local utilisé par ce site; la planification, les feuilles de temps, et les heures d'équipe sont interprétées dans cette zone indépendamment de la locale du navigateur de l'utilisateur."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "L'emplacement par défaut de cet employé; détermine l'interprétation du fuseau horaire sur ses feuilles de temps et les sélecteurs de quart par défaut sur son dossier de travail."
+msgstr "Le site par défaut pour cet employé; détermine l'interprétation du fuseau horaire sur ses feuilles de temps et les sélecteurs d'équipe par défaut sur ses ordres de fabrication."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "L'emplacement à partir duquel cette commande sera exécutée; les emplacements par ligne la remplacent lorsqu'ils sont définis."
+msgstr "Le site à partir duquel cette commande sera traitée; les sites par ligne le remplacent s'ils sont définis."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
 msgstr "L'emplacement à partir duquel ce devis sera exécuté s'il se convertit en commande; utilisé par la planification pour projeter l'approvisionnement au bon entrepôt."
@@ -15159,7 +15159,7 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "L'identifiant de lot pour ce stock; une ligne par lot, la quantité est celle en main pour ce lot."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "Le lot sera marqué comme Accepté. {fails} défaut(s) échantillonné(s) sont enregistrés pour vos dossiers."
+msgstr "Le lot sera marqué Réussi. {fails} défaut(s) d'échantillonnage sont enregistrés pour vos dossiers."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Le lot sera toujours rejeté, mais un NCR ne peut pas être créé tant qu'au moins un type de problème n'est pas configuré."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "Le plan d'échantillonnage par caractéristique du lot sera re-résolu à partir du document sélectionné."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "Le montant minimum que ce fournisseur facturera pour ce processus, quel que soit la quantité; les travaux en dessous du volume de seuil de rentabilité coûtent toujours au moins ce montant."
+msgstr "Le montant minimum que ce fournisseur facturera pour ce procédé, indépendamment de la quantité; les ordres de fabrication en dessous du volume de rentabilité coûtent au moins ce montant."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Les machines, cellules et postes par lesquels votre travail passe"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "Le mois où votre exercice financier commence; les périodes sont numérotées à partir de ce mois."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "Le mois où votre année fiscale commence; peut différer de l'exercice fiscal dans certaines juridictions."
+msgstr "Le mois où commence votre année fiscale; peut différer de l'exercice comptable dans certaines juridictions."
 
 msgid "The monthly periods you post into and close"
 msgstr "Les périodes mensuelles dans lesquelles vous comptabilisez et fermez"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "Le mode de défaillance le plus probable que le demandeur soupçonne; le technicien confirme ou remplace celui-ci à la fermeture, et la différence entre suspects et réelles alimente les rapports de fiabilité."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "Le prix unitaire négocié sur cette ligne; l'icône de traçage en ligne montre quelle règle de tarification ou remplacement l'a produit."
+msgstr "Le prix négocié par unité sur cette ligne; l'icône de traçabilité indique quelle règle de tarification ou substitution l'a produit."
 
 msgid "The new version number of the document"
 msgstr "Le nouveau numéro de version du document"
@@ -15207,16 +15207,16 @@ msgid "The new version number of the procedure"
 msgstr "Le nouveau numéro de version de la procédure"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Le nombre de jours entre le placement d'une PO avec le fournisseur préféré et l'arrivée des marchandises sur le quai; la planification compense la demande à rebours de ce montant."
+msgstr "Le nombre de jours entre la passation d'un bon de commande auprès du fournisseur préféré et l'arrivée des marchandises au quai; la planification décale les besoins en arrière de ce délai."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Le nombre de jours pour construire un lot de cet article, mesuré de la libération du travail à l'achèvement; la planification compense la demande à rebours de ce montant."
+msgstr "Le nombre de jours pour fabriquer un lot de production de cet article, mesuré de la mise en production à l'achèvement; la planification décale les besoins en arrière de ce délai."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "Le nombre d'unités supplémentaires à construire pour compenser la ferraille attendue; la planification la résume avec la quantité commandée lors de la réservation des matériaux."
+msgstr "Le nombre d'unités supplémentaires à fabriquer pour compenser le rebut prévu; la planification ajoute ce montant à la quantité commandée lors de la réservation de matières."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "Le nombre d'heures par semaine que l'entrepreneur est disponible pour travailler."
+msgstr "Le nombre d'heures par semaine que le prestataire est disponible pour travailler."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "Le nombre de mois sur lesquels cet actif sera amorti."
@@ -15240,7 +15240,7 @@ msgid "The outbound posting document that takes goods out of stock to a customer
 msgstr "Le document de comptabilisation sortante qui sort les marchandises du stock vers un client, en comptabilisant le COGS en cours de route."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Les fournisseurs externes qui effectuent ce processus; chacun obtient une ligne d'entrées de prix et de délais sur le formulaire de processus du fournisseur."
+msgstr "Les fournisseurs externes qui effectuent ce procédé; chacun reçoit une ligne de tarification et de délai d'approvisionnement sur le formulaire de procédé fournisseur."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "La chaîne parent-enfant des entités suivies - ce dont une unité a été construite et ce qu'elle est devenue."
@@ -15252,7 +15252,7 @@ msgid "The part is taken from existing stock when its parent is built — no new
 msgstr "La pièce est prélevée du stock existant lors de la construction de son parent - aucune nouvelle tâche ou bon de commande."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Les personnes du côté Carbon qui géreront votre implémentation et comment les contacter."
+msgstr "Les collaborateurs du côté Carbon qui exécuteront votre mise en œuvre, et comment les contacter."
 
 msgid "The people on your team and their access to Carbon"
 msgstr "Les personnes de votre équipe et leur accès à Carbon"
@@ -15264,7 +15264,7 @@ msgid "The per-item outcome recorded on a non-conformance's affected material �
 msgstr "Le résultat par article enregistré sur le matériel affecté d'une non-conformité — En attente, Retour au fournisseur, Retravail, Rebut ou Utiliser en l'état — décidé pour chaque lot ou numéro de série affecté individuellement."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "Le pourcentage de la remise en espèces. Utilisez 0 pour aucune remise."
+msgstr "Le pourcentage de remise en trésorerie. Utilisez 0 pour aucune remise."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "L'ensemble d'autorisations que les nouveaux employés de ce type reçoivent automatiquement; la modification ici change uniquement le modèle pour les embauches futures - les employés existants conservent ce qu'ils ont sauf s'ils sont explicitement mis à jour en masse."
@@ -15273,22 +15273,22 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Les usines, entrepôts et sites où se trouvent votre travail et vos stocks"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "Le bundle prédéfini de tâches et d'exigences d'approbation appliqués à ce problème; remplace le flux de travail par défaut du type de problème lorsqu'il est défini."
+msgstr "Le paquet prédéfini de tâches et d'exigences d'approbation appliqué à ce problème ; remplace le workflow par défaut du type de problème lorsqu'il est défini."
 
 msgid "The principle:"
 msgstr "Le principe :"
 
 msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
-msgstr "L'évaluation de probabilité que le risque se produit (1 = rare à 5 = presque certain); associée à la Sévérité pour calculer le score de risque."
+msgstr "L'évaluation de probabilité que le risque se manifeste (1 = rare à 5 = quasi certain) ; associée à la Gravité pour calculer le score de risque."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "La procédure que les techniciens suivent lors de l'exécution de cet entretien; la remplacer après que les calendriers aient déjà été générés n'affecte que les futures instances."
+msgstr "La procédure que les techniciens suivent lors de l'exécution de cette maintenance ; la remplacer après que les plannings aient déjà été générés n'affecte que les instances futures."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Les processus que ce centre de travail peut exécuter; apparaît dans les sélecteurs de processus lors de la planification des opérations, et limite les travaux qui peuvent traverser ce centre de travail."
+msgstr "Les procédés que ce poste de travail peut exécuter ; apparaît dans les sélecteurs de procédés lors de la planification des opérations et limite les ordres de fabrication qui peuvent être routés par ce poste de travail."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
-msgstr "Le fournisseur n'offre aucune cible de dimension. Activez d'abord la fonctionnalité dans le fournisseur (par exemple, les catégories de suivi, le suivi de classe ou les champs)."
+msgstr "Le fournisseur ne propose pas de cibles dimensionnelles. Activez la fonctionnalité chez le fournisseur d'abord (par exemple, catégories de suivi, suivi de classe ou champs)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
 msgstr "Les points d'arrêt de quantité à laquelle cette ligne est tarifée; chaque colonne porte son propre prix par unité pour la négociation acheteur-fournisseur et la conversion en documents aval."
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "L'enregistrement vers lequel une notification de flux de travail pointe, nommé comme un id plus son type ; laissez-le vide et la notification lien vers l'exécution du flux de travail elle-même."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "L'enregistrement qui applique un paiement ou une note à une facture, portant les montants appliqués, les remises et les annulations."
+msgstr "L'enregistrement qui applique un paiement ou un mémo à une facture, portant les montants appliqué, remise et passage en perte."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "La généalogie enregistrée des entités suivies - quelles entrées ont été consommées pour produire quelles sorties, réception à expédition."
@@ -15340,7 +15340,7 @@ msgid "The request body sent verbatim with a JSON content type after workflow va
 msgstr "Le corps de la demande envoyé tel quel avec un type de contenu JSON après que les variables du flux de travail soient substituées, sur les méthodes qui en contiennent."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "Le WIP résiduel qu'un travail a laissé à la fermeture, balayé sur un compte de variance de production - la seule variance que Carbon enregistre pour une tâche."
+msgstr "L'en-cours résiduel qu'un ordre de fabrication a laissé à la clôture, transféré à un compte Écart de production — le seul écart que Carbon comptabilise pour un ordre de fabrication."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "La réponse d'Onshape ne contenait pas les paramètres requis. Réessayez de vous connecter."
@@ -15352,13 +15352,13 @@ msgid "The revision number of the part"
 msgstr "Le numéro de révision de la pièce"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "La ligne de commande client que cette commande de travail a été créée pour fournir, liant la commande de travail à la demande client derrière elle."
+msgstr "La ligne de commande client pour laquelle cet ordre de fabrication a été créé, reliant l'ordre de fabrication aux besoins du client."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "L'échéance utilisée pour répartir le coût de cet actif sur sa durée de vie utile (ligne droite, solde décroissant, unités de production)."
+msgstr "Le planning utilisé pour étaler le coût de cet actif sur sa durée d'utilité (linéaire, dégressif, unités de production)."
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "Les étagères et bacs où le stock se trouve physiquement"
+msgstr "Les étagères et casiers où le stock se trouve physiquement"
 
 msgid "The shop supplies and consumables you keep on hand"
 msgstr "Les fournitures de magasin et les consommables que vous gardez à portée de main"
@@ -15370,7 +15370,7 @@ msgid "The size of the part"
 msgstr "La taille de la pièce"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Les compétences et aptitudes que vous suivez pour votre équipe"
+msgstr "Les compétences et aptitudes que vous suivez pour votre personnel"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "La quantité la plus petite que ce fournisseur acceptera sur une ligne de PO pour cette pièce; la planification s'arrondit à elle."
@@ -15382,25 +15382,25 @@ msgid "The specific contact on the selected supplier who will own this portal ac
 msgstr "Le contact spécifique sur le fournisseur sélectionné qui possédera ce compte de portail; son e-mail devient l'identifiant de connexion."
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "L'opération spécifique sur le travail ci-dessus que cette ligne de PO achète; seules les opérations marquées comme traitement externe sont sélectionnables."
+msgstr "L'opération spécifique sur l'ordre de fabrication ci-dessus que cette ligne de bon de commande achète ; seules les opérations marquées sous-traitance sont sélectionnables."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "Le PO, le retour ou le transfert spécifique sur lequel ce reçu est comptabilisé; les ID disponibles dépendent du type de document source ci-dessus."
+msgstr "Le bon de commande, retour ou transfert spécifique auquel cette réception est comptabilisée ; les ID disponibles dépendent du type de document d'origine ci-dessus."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "Le SO, le transfert ou l'RMA spécifique sur lequel cet envoi est comptabilisé; les ID disponibles dépendent du type de document source ci-dessus."
+msgstr "L'expédition, transfert ou RMA spécifique auquel cette expédition est comptabilisée ; les ID disponibles dépendent du type de document d'origine ci-dessus."
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "Les dimensions standard dans lesquelles vos matériaux sont stockés"
+msgstr "Les dimensions standard dans lesquelles vos matières sont stockées"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "Le facteur standard (heures, minutes, pièces) les opérations sur ce centre de travail sont mesurées par défaut; les remplacements par opération gagnent quand ils sont définis."
+msgstr "Le facteur standard (heures, minutes, pièces) dans lequel les opérations de ce poste de travail sont mesurées par défaut ; les remplacements par opération l'emportent lorsqu'ils sont définis."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
 msgstr "Le facteur standard utilisé pour mesurer ce processus - heures, minutes, pièces, pieds carrés - lorsque ses opérations sont estimées et cotées."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "L'état de cette ligne de devis - Brouillon, Pas de Devis, Complet; Pas de Devis révèle le champ Raison et exclut la ligne du total du devis."
+msgstr "L'état de cette ligne de devis — Brouillon, Refus de devis, Terminé ; Refus de devis révèle le champ Raison et exclut la ligne du total du devis."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Le groupe d'états que tous les comptes sous ce groupe utiliseront."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "Les paramètres de l'étape — cette exécution est antérieure à l'enregistrement des valeurs qu'elle a utilisées."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Les tailles de stock dans lesquelles ce matériau est acheté et stocké; chaque taille devient une variante sélectionnable distincte sur les travaux et les POs."
+msgstr "Les tailles de stock dans lesquelles cette matière est achetée et stockée ; chaque taille devient une variante sélectionnable distincte sur les ordres de fabrication et les bons de commande."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "Le bac de stockage à partir duquel cette ligne prélève; s'il est vide, le prélèvement utilise l'unité de stockage par défaut de l'article."
+msgstr "Le casier de stockage à partir duquel cette ligne est prélevée ; s'il est vide, le prélèvement utilise l'unité de stockage par défaut de l'article."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "Le service de stockage n'a pas répondu à temps. Veuillez réessayer."
@@ -15439,7 +15439,7 @@ msgid "The suppliers and vendors you buy from"
 msgstr "Les fournisseurs et vendeurs auprès desquels vous achetez"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Les fournisseurs recevant cette RFQ; chacun obtient sa propre ligne sur la RFQ à laquelle ils répondent avec leur propre prix."
+msgstr "Les fournisseurs recevant cette RFQ ; chacun reçoit sa propre ligne sur la RFQ à laquelle il répond avec sa propre tarification."
 
 msgid "The surface finishes available on your materials"
 msgstr "Les finitions de surface disponibles sur vos matériaux"
@@ -15457,22 +15457,22 @@ msgid "The timer starts manually"
 msgstr "Le chronomètre démarre manuellement"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Les outils et accessoires sur lesquels vos opérations comptent"
+msgstr "L'outillage et les montages d'usinage sur lesquels vos opérations reposent"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Le total à fabriquer sur tous les travaux créés dans ce lot en masse; combiné avec Quantité par Travail pour décider combien de travaux créer."
+msgstr "Le total à fabriquer pour tous les ordres de fabrication créés dans ce lot en masse ; combiné avec Quantité par ordre pour décider combien d'ordres créer."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "La référence traçable (par exemple, norme NIST, numéro de série du jauge maître) contre laquelle les valeurs d'étalonnage ont été comparées."
+msgstr "La référence traçable (par ex. norme NIST, numéro de série de l'étalon) sur laquelle les valeurs d'étalonnage ont été comparées."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "Le bon de travail liste chaque article de la nomenclature avec sa quantité."
+msgstr "La fiche suiveuse répertorie chaque article de la nomenclature avec sa quantité."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
-msgstr "Le type contrôle les permissions par défaut que reçoit le nouvel employé; le sélectionner ici remplit complètement la matrice des permissions à partir du modèle du type."
+msgstr "Le type contrôle les autorisations par défaut que le nouvel employé reçoit ; le sélectionner ici pré-remplit la matrice d'autorisations à partir du modèle du type."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Le nombre typique de jours entre l'envoi de travail à ce fournisseur pour ce processus et sa récupération; la planification compense la demande de ce montant lors de la sélection d'un fournisseur."
+msgstr "Le nombre typique de jours entre l'envoi du travail à ce fournisseur pour ce procédé et sa réception ; le décalage de planification décale les besoins de cette durée lors du choix d'un fournisseur."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "L'identifiant unique sur cette unité physique; une ligne par numéro de série, la quantité est toujours 1."
@@ -15493,10 +15493,10 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "Les unités de mesure dans lesquelles vous achetez, stockez et vendez"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "Le système d'amortissement fiscal américain avec des tableaux de classe de propriété IRS, exécuté en tant que programme fiscal séparé aux côtés du programme de livres."
+msgstr "Le système d'amortissement fiscal américain avec des tables de classe de propriété IRS, exécuté comme un planning fiscal distinct aux côtés du planning comptable."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
-msgstr "Les utilisateurs de ce groupe; les permissions et notifications en scope de groupe s'appliquent à chaque membre, et les utilisateurs peuvent appartenir à plusieurs groupes (les permissions effectives sont l'union)."
+msgstr "Les utilisateurs de ce groupe ; les autorisations et notifications de portée groupe s'appliquent à chaque membre, et les utilisateurs peuvent appartenir à plusieurs groupes (les autorisations effectives sont l'union)."
 
 msgid "The version of the new document"
 msgstr "La version du nouveau document"
@@ -15520,7 +15520,7 @@ msgid "The ways equipment fails, for maintenance and quality tracking"
 msgstr "Les façons dont l'équipement tombe en panne, pour le suivi de la maintenance et de la qualité"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Le bac propre du centre de travail où le matériel prélevé est préparé pour la production à consommer, par rapport à son étagère source d'entrepôt."
+msgstr "Le propre casier du poste de travail où le matériel prélevé est présenté pour la production à consommer, par opposition à son étagère source d'entrepôt."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Les heures de travail et les calendriers qui pilotent la planification"
@@ -15538,7 +15538,7 @@ msgid "There are no active supplier quotes to compare for this RFQ."
 msgstr "Il n'y a pas de devis fournisseurs actifs à comparer pour cette demande de prix."
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "Il y a des opérations externes associées à ce travail qui n'ont pas de fournisseurs. Veuillez assigner un fournisseur à chaque opération externe avant de le lancer."
+msgstr "Il existe des opérations sous-traitées associées à cet ordre de fabrication qui n'ont pas de fournisseur. Veuillez attribuer un fournisseur à chaque opération sous-traitée avant sa libération."
 
 msgid "There's nothing outstanding to apply these credits to."
 msgstr "Il n'y a rien d'impayé pour appliquer ces crédits."
@@ -15547,10 +15547,10 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "Ces champs personnalisés ne seront disponibles que pour les entités ayant les mêmes balises"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Ces documents n'ont pas été comptabilisés dans le grand livre, de sorte que leurs montants manquent à cette période. Comptabilisez ou annulez chacun — un document non daté reçoit la date du jour de comptabilisation lors de la comptabilisation."
+msgstr "Ces documents n'ont pas été comptabilisés au grand livre, donc leurs montants manquent de cette période. Comptabilisez ou invalides chacun — un document sans date reçoit la date du jour de comptabilisation lors de sa comptabilisation."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
-msgstr "Ces adresses e-mail seront automatiquement mises en copie sur tous les e-mails envoyés aux fournisseurs (devis, commandes d'achat, etc.)."
+msgstr "Ces adresses e-mail seront automatiquement mises en CC sur tous les e-mails envoyés aux fournisseurs (devis, bons de commande, etc.)."
 
 msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
 msgstr "Ces adresses e-mail seront automatiquement mises en copie sur tous les e-mails de devis envoyés aux clients."
@@ -15559,7 +15559,7 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Ces articles ont toujours du matériel à prélever. Terminer maintenant marque la liste comme Partielle."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Ces travaux ont des opérations assignées à ce centre de travail :"
+msgstr "Ces ordres de fabrication ont des opérations assignées à ce poste de travail :"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Ces écritures de journal sont encore Brouillon, de sorte que leurs débits et crédits ne se trouvent pas dans le grand livre pour cette période. Comptabilisez chacune ou redatez-la à une période ouverte ultérieure."
@@ -15568,16 +15568,16 @@ msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an adm
 msgstr "Cette instance Carbon n'a pas d'identifiants OAuth Onshape. Demandez à un administrateur de les configurer."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "Cette notice de modification est en cours de mise en œuvre, donc ses modifications sont verrouillées. Rouvrez-la pour la modifier."
+msgstr "Cet avis de modification est en cours de mise en œuvre, donc ses modifications sont verrouillées. Rouvrez-le pour le modifier."
 
 msgid "This change notice is closed, so its changes are read-only."
-msgstr "Cette notice de modification est fermée, donc ses modifications sont en lecture seule."
+msgstr "Cet avis de modification est clôturé, donc ses modifications sont en lecture seule."
 
 msgid "This completes the Discovery step."
 msgstr "Cela complète l'étape de découverte."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Ce contact n'a pas d'adresse e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Ce tiers n'a rien en suspens — le paiement sera enregistré en compte courant."
@@ -15586,10 +15586,10 @@ msgid "This download link is invalid or has been tampered with."
 msgstr "Ce lien de téléchargement est invalide ou a été modifié."
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "Ce fichier n'est plus disponible, ou vous n'avez pas la permission de le télécharger."
+msgstr "Ce fichier n'est plus disponible, ou vous n'avez pas l'autorisation de le télécharger."
 
 msgid "This Fiscal Year"
-msgstr "Cet exercice fiscal"
+msgstr "Cet exercice comptable"
 
 msgid "This information will be used on document headers"
 msgstr "Ces informations seront utilisées dans les en-têtes de document"
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Ces informations seront visibles par tous les utilisateurs, soyez donc prudent dans ce que vous partagez."
 
 msgid "this inspection plan"
-msgstr "ce plan d'inspection"
+msgstr "ce plan de contrôle"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Cette invitation pour rejoindre {0} a expiré. Vous pouvez demander une nouvelle invitation à envoyer à votre e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Cette facture n'a pas de date d'échéance utilisable — choisissez-en une pour Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Cette facture sera facturée au client Stripe déjà lié à ce client Carbon. Pour modifier ses détails, modifiez-le dans le tableau de bord Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "C'est un environnement contrôlé, donc une application d'authentification est requise."
@@ -15629,19 +15629,19 @@ msgid "This is taking longer than expected. It may still finish — if it doesn'
 msgstr "Cela prend plus de temps que prévu. Il peut encore finir — sinon, réessayez l'annulation pour restaurer vos données."
 
 msgid "This is the month your fiscal year starts."
-msgstr "C'est le mois où votre exercice fiscal commence."
+msgstr "C'est le mois où commence votre exercice comptable."
 
 msgid "This is the month your tax year starts."
-msgstr "C'est le mois où votre année fiscale commence."
+msgstr "C'est le mois où commence votre année fiscale."
 
 msgid "this item"
 msgstr "cet article"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Cet article est construit via un configurateur et résout ses composants par commande; les travaux créés pour lui héritent du BOM résolu du configurateur."
+msgstr "Cet article est construit via un configurateur et résout ses composants par commande ; les ordres de fabrication créés pour celui-ci héritent de la nomenclature résolue du configurateur."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "La nomenclature de cet article n'a aucune entrée avec la gestion de la durée de vie activée, donc aucune date d'expiration ne sera calculée à partir de la nomenclature."
+msgstr "La nomenclature de cet article n'a pas d'entrées avec une durée de vie activée, donc aucune péremption ne sera calculée à partir de la nomenclature."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
 msgstr "Ce travail sera reçu en inventaire. Il ne sera plus disponible sur l'atelier."
@@ -15665,7 +15665,7 @@ msgid "This Month"
 msgstr "Ce mois"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "Cette page de votre Implementation Hub est en cours de construction. Commencez par le centre de commande pendant que nous la finissons."
+msgstr "Cette page de votre hub de mise en œuvre est en construction. Commencez par le centre de commande en attendant que nous la terminions."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "Cette pièce a {quantityOnHand} en stock à cet endroit. Aucun stock signifie qu'elle ne sera ni planifiée ni consommée."
@@ -15680,7 +15680,7 @@ msgid "This part is obsolete (No Stock)."
 msgstr "Cette pièce est obsolète (Pas de stock)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "Cette pièce est obsolète et définie sur Stock Only — elle est réapprovisionnée jusqu'à son plancher de réserve de pièces de rechange, indépendamment de la demande."
+msgstr "Cette pièce est obsolète et définie sur Stock uniquement — elle est réapprovisionnée jusqu'à son plancher de réserve de pièces de rechange, indépendamment de la demande."
 
 msgid "This path only decides what runs next"
 msgstr "Ce chemin décide seulement de ce qui s'exécute ensuite"
@@ -15695,7 +15695,7 @@ msgid "This Quarter"
 msgstr "Ce trimestre"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "Cela supprime leur application d'authentification, donc leur prochaine connexion ne nécessite qu'un lien magique. Utilisez ceci quand ils ont perdu l'accès à leur authenticateur. Cela affecte leur connexion pour chaque entreprise à laquelle ils appartiennent."
+msgstr "Ceci supprime leur application d'authentification, de sorte que leur prochain accès ne nécessite qu'un lien magique. Utilisez cette option lorsqu'ils ont perdu l'accès à leur authentificateur. Cela affecte leur accès pour chaque société à laquelle ils appartiennent."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Cette révision est publiée (Production). Les modifications doivent normalement passer par un avis de modification."
@@ -15710,10 +15710,10 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Cela exécute le flux de travail pour de vrai. Cela créera des enregistrements, enverra des notifications et appellera tous les webhooks exactement comme le ferait une exécution en direct. Cela ne peut pas être annulé."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Cette commande client a des tâches associées. Choisissez ce que vous souhaitez en faire."
+msgstr "Cette commande client a des ordres de fabrication associés. Choisissez ce qu'en faire."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Cette commande client contient des lignes qui nécessitent la création de tâches"
+msgstr "Cette commande client a des lignes qui nécessitent la création d'ordres de fabrication."
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15726,7 +15726,7 @@ msgid "This tool is activated when change notice {activationLockId} is released.
 msgstr "Cet outil est activé lorsque l'avis de modification {activationLockId} est libéré."
 
 msgid "This updates the theme for all users of the application"
-msgstr "Cela met à jour le thème pour tous les utilisateurs de l'application"
+msgstr "Ceci met à jour le thème pour tous les utilisateurs de l'application."
 
 msgid "This user does not have two-factor authentication enabled."
 msgstr "Cet utilisateur n'a pas l'authentification à deux facteurs activée."
@@ -15735,20 +15735,20 @@ msgid "This usually takes a few seconds. You can leave the page — it keeps run
 msgstr "Cela prend généralement quelques secondes. Vous pouvez quitter la page — elle continue de s'exécuter."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
-msgstr "Cette version appartient à un <0>change notice</0> ouvert. Modifiez-le là."
+msgstr "Cette version appartient à un <0>avis de modification</0> ouvert. Modifiez-le là."
 
 #. placeholder {0}: lock.readableId
 msgid "This version belongs to change notice <0>{0}</0>. Edit it there."
-msgstr "Cette version appartient au change notice <0>{0}</0>. Modifiez-le là."
+msgstr "Cette version appartient à l'avis de modification <0>{0}</0>. Modifiez-le là."
 
 msgid "This version cannot be opened"
 msgstr "Cette version ne peut pas être ouverte"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Cette version est publiée."
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Cette version est publiée. Créez une nouvelle version pour la modifier."
 
 msgid "This version's definition could not be read."
 msgstr "La définition de cette version n'a pas pu être lue."
@@ -15760,7 +15760,7 @@ msgid "This will overwrite the existing job method"
 msgstr "Cela remplacera la méthode de travail existante"
 
 msgid "This will overwrite the existing manufacturing method and the latest versions of all subassemblies."
-msgstr "Cela remplacera la méthode de fabrication existante et les dernières versions de tous les sous-ensembles."
+msgstr "Ceci écrasera la méthode de production existante et les versions les plus récentes de tous les sous-ensembles."
 
 msgid "This will overwrite the existing quote method"
 msgstr "Cela remplacera la méthode de devis existante"
@@ -15771,7 +15771,7 @@ msgstr "Cela recalculera le coût unitaire à partir de la nomenclature et des p
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "Cela supprimera le lien de {0} vers {1}. Le travail n'apparaîtra plus sous la commande client et les expéditions ne le trouveront pas."
+msgstr "Ceci supprimera le lien {0} vers {1}. L'ordre de fabrication n'apparaîtra plus sous la commande client et les expéditions ne le trouveront pas."
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "Cela remplacera tous les matériaux de méthode des autres révisions par cette révision."
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Rapprochement indisponible"
 
 msgid "Tightened"
-msgstr "Serré"
+msgstr "Renforcé"
 
 msgid "Time of day"
 msgstr "Heure du jour"
@@ -15862,7 +15862,7 @@ msgid "To reactivate, use the row menu and choose Send Invite. The employee beco
 msgstr "Pour réactiver, utilisez le menu de ligne et choisissez Envoyer une invitation. L'employé devient actif dès qu'il accepte."
 
 msgid "To Receive"
-msgstr "À recevoir"
+msgstr "À réceptionner"
 
 msgid "To Ship"
 msgstr "À expédier"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "Basculer"
 
 msgid "Toggle Assignee"
-msgstr "Basculer le cessionnaire"
+msgstr "Basculer l'assigné"
 
 msgid "Toggle break active"
 msgstr "Activer/désactiver la tranche"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Outils"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Classification de niveau supérieur (actif/passif/capitaux propres/revenus/dépenses); défini uniquement sur les groupes racine, hérité par les enfants."
+msgstr "Classification de haut niveau (actif / passif / capitaux propres / revenus / charges) ; définie uniquement sur les groupes racines, héritée par les enfants."
 
 msgid "Topic"
 msgstr "Sujet"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "Quantité Totale"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Quantité totale disponible de l'article sur toutes les unités de stockage de cet emplacement. Devient rouge lorsque le disponible plus les entrées ne peuvent pas couvrir la demande totale."
+msgstr "Quantité totale en stock pour l'article sur toutes les unités de stockage à cet emplacement. Devient rouge lorsque le stock actuel plus les entrées en attente ne peuvent pas couvrir la demande totale."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Quantité totale requise sur toutes les tâches actives et commandes clients à cet emplacement — pas seulement cette tâche."
+msgstr "Quantité totale requise pour tous les ordres de fabrication et commandes clients actifs à cet emplacement — pas seulement cet ordre de fabrication."
 
 msgid "Total scrap quantity"
-msgstr "Quantité de déchet totale"
+msgstr "Quantité totale de rebut"
 
 msgid "Total tax"
 msgstr "Taxe totale"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "Valeur Totale"
 
 msgid "Total Variance"
-msgstr "Variance Totale"
+msgstr "Écart total"
 
 msgid "Total:"
 msgstr "Total :"
@@ -16015,16 +16015,16 @@ msgid "Track every change to your orders, invoices, customers, suppliers, and mo
 msgstr "Suivez chaque modification apportée à vos commandes, factures, clients, fournisseurs et bien d'autres."
 
 msgid "Track real-time inventory by location and bin"
-msgstr "Suivre l'inventaire en temps réel par emplacement et bac"
+msgstr "Suivre les stocks en temps réel par site et casier."
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "Suivre les numéros de série/lot et traiter les commandes de vente."
+msgstr "Suivre les numéros de série/lot et honorer les commandes clients."
 
 msgid "Track tax depreciation separately"
-msgstr "Suivre séparément l'amortissement fiscal"
+msgstr "Suivre l'amortissement fiscal séparément."
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "Suivre l'amortissement fiscal séparément de l'amortissement comptable et publier automatiquement les écritures de passif d'impôt différé."
+msgstr "Suivre l'amortissement fiscal séparément de l'amortissement comptable et comptabiliser automatiquement les écritures de passif d'impôt différé."
 
 msgid "Track transactions by segment (cost center, project, service line)"
 msgstr "Suivre les transactions par segment (centre de coûts, projet, ligne de service)"
@@ -16039,7 +16039,7 @@ msgid "Tracked entity"
 msgstr "Entité suivie"
 
 msgid "Tracked Entity"
-msgstr "Entité tracée"
+msgstr "Entité suivie"
 
 msgid "Tracked entity ID is required but none was found"
 msgstr "L'ID d'entité suivie est requis mais aucun n'a été trouvé"
@@ -16117,7 +16117,7 @@ msgid "Transfer Ownership"
 msgstr "Transférer la propriété"
 
 msgid "Transfer ownership of this company to another user"
-msgstr "Transférer la propriété de cette entreprise à un autre utilisateur"
+msgstr "Transférer la propriété de cette société à un autre utilisateur."
 
 msgid "Transfer To"
 msgstr "Transférer vers"
@@ -16180,7 +16180,7 @@ msgid "Type an email and press Enter to add an external recipient"
 msgstr "Tapez un e-mail et appuyez sur Entrée pour ajouter un destinataire externe"
 
 msgid "Type of Permission Update"
-msgstr "Type de mise à jour des permissions"
+msgstr "Type de mise à jour d'autorisation"
 
 msgid "Type to search across your workspace"
 msgstr "Tapez pour rechercher dans votre espace de travail"
@@ -16219,13 +16219,13 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Les lignes non comptabilisées restent inchangées à la publication — elles ne sont pas mises à zéro."
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "Sous Réapprovisionnement Basé sur la Demande, la planification additionne la demande dans cette fenêtre glissante lors du calcul d'une quantité de réapprovisionnement."
+msgstr "Sous le réapprovisionnement basé sur la demande, la planification additionne la demande dans cette fenêtre mobile lors du calcul d'une quantité de réapprovisionnement."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "Sous Quantité Fixe de Réapprovisionnement, les ordres de planification sont pour la quantité exacte à chaque activation du point de réapprovisionnement."
+msgstr "Sous quantité de réapprovisionnement fixe, la planification commande la quantité exacte chaque fois que le point de commande est atteint."
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "Sous Quantité Maximale, les ordres de planification montent jusqu'à ce niveau de stock à la main quand le point de réapprovisionnement s'active."
+msgstr "Selon la politique de quantité maximale, la planification commande jusqu'à ce niveau de stock lorsque le point de commande est atteint."
 
 msgid "Undo"
 msgstr "Annuler"
@@ -16279,7 +16279,7 @@ msgid "Units of measure"
 msgstr "Unités de mesure"
 
 msgid "Units reported as unrecoverable at an operation, with a reason — the alternative to rework."
-msgstr "Unités signalées comme irrécupérables à une opération, avec une raison — l'alternative au retravail."
+msgstr "Unités signalées comme irrécupérables à une opération, avec un motif — l'alternative à la retouche."
 
 msgid "Unknown"
 msgstr "Inconnu"
@@ -16291,10 +16291,10 @@ msgid "unknown location"
 msgstr "localisation inconnue"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Soutien fonctionnel illimité"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Enregistrements illimités"
 
 msgid "Unlink"
 msgstr "Dissocier"
@@ -16312,7 +16312,7 @@ msgid "Unmapped accounts"
 msgstr "Comptes non mappés"
 
 msgid "Unmapped dimension values"
-msgstr "Valeurs de dimension non mappées"
+msgstr "Valeurs d'axes analytiques non mappées"
 
 msgid "Unmapped Extracted Lines"
 msgstr "Lignes extraites non mappées"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Documents non comptabilisés"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Dépublier"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Dépublier {name} ?"
 
 msgid "Unreceived POs"
 msgstr "Bons de commande non reçus"
@@ -16360,7 +16360,7 @@ msgid "Unshipped orders"
 msgstr "Commandes non expédiées"
 
 msgid "Unsupported source document type: {sourceDocument}"
-msgstr "Type de document source non pris en charge : {sourceDocument}"
+msgstr "Type de document d'origine non pris en charge : {sourceDocument}"
 
 msgid "Untitled Diagram"
 msgstr "Diagramme sans titre"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "Ligne sans titre"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "Matériel prélevé inutilisé renvoyé du centre de travail à l'entrepôt."
+msgstr "Matière prélevée inutilisée renvoyée du poste de travail à l'entrepôt."
 
 msgid "UoM"
 msgstr "UoM"
@@ -16384,7 +16384,7 @@ msgid "Update a job"
 msgstr "Mettre à jour une commande de travail"
 
 msgid "Update a purchase order"
-msgstr "Mettre à jour une commande d'achat"
+msgstr "Mettre à jour un bon de commande"
 
 msgid "Update a quote"
 msgstr "Mettre à jour un devis"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Mettre à jour le problème Linear"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Mettre à jour les délais de livraison des pièces à partir des reçus d'achat validés."
+msgstr "Mettre à jour les délais d'approvisionnement des pièces à partir des réceptions comptabilisées."
 
 msgid "Update Password"
 msgstr "Mettre à jour le mot de passe"
@@ -16441,13 +16441,13 @@ msgid "Update Rule"
 msgstr "Mettre à jour la règle"
 
 msgid "Update source document quantities"
-msgstr "Mettre à jour les quantités du document source"
+msgstr "Mettre à jour les quantités du document d'origine"
 
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Mettez à jour les informations du kanban pour le réapprovisionnement basé sur le scan."
 
 msgid "Update the purchase order quantities"
-msgstr "Mettre à jour les quantités de la commande d'achat"
+msgstr "Mettre à jour les quantités du bon de commande"
 
 msgid "Updated"
 msgstr "Mis à jour"
@@ -16478,19 +16478,19 @@ msgid "Upgrade to unlock audit history"
 msgstr "Passez à la version supérieure pour déverrouiller l'historique d'audit"
 
 msgid "Upload"
-msgstr "Télécharger"
+msgstr "Téléverser"
 
 msgid "Upload a PDF first"
-msgstr "Téléchargez d'abord un PDF"
+msgstr "Téléversez d'abord un PDF"
 
 msgid "Upload completed but no file path returned"
-msgstr "Téléchargement terminé mais aucun chemin de fichier retourné"
+msgstr "Téléversement terminé mais aucun chemin d'accès au fichier retourné"
 
 msgid "Upload CSV"
-msgstr "Télécharger CSV"
+msgstr "Téléverser un CSV"
 
 msgid "Upload failed. Please try again."
-msgstr "Échec du téléchargement. Veuillez réessayer."
+msgstr "Le téléversement a échoué. Veuillez réessayer."
 
 msgid "Uploaded model"
 msgstr "Modèle téléchargé"
@@ -16549,13 +16549,13 @@ msgid "Use a different email"
 msgstr "Utiliser une adresse e-mail différente"
 
 msgid "Use metric system for default material dimensions."
-msgstr "Utiliser le système métrique pour les dimensions de matériau par défaut."
+msgstr "Utiliser le système métrique pour les dimensions de matière par défaut."
 
 msgid "Used In"
 msgstr "Utilisé dans"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "Utilisé dans la navigation et sur les documents comme les commandes de vente"
+msgstr "Utilisé dans la navigation et sur les documents comme les commandes clients"
 
 msgid "Used in the navigation in dark mode"
 msgstr "Utilisé dans la navigation en mode sombre"
@@ -16573,13 +16573,13 @@ msgid "Used when a cell is empty or doesn't match an option above. Clear it to l
 msgstr "Utilisé lorsqu'une cellule est vide ou ne correspond pas à une option ci-dessus. Effacez-la pour laisser ces lignes vierges."
 
 msgid "Useful Life (default)"
-msgstr "Durée de Vie Utile (par défaut)"
+msgstr "Durée d'utilité (par défaut)"
 
 msgid "Useful Life (months)"
-msgstr "Durée de Vie Utile (mois)"
+msgstr "Durée d'utilité (mois)"
 
 msgid "Useful Life (Months)"
-msgstr "Durée de Vie Utile (Mois)"
+msgstr "Durée d'utilité (Mois)"
 
 msgid "User"
 msgstr "Utilisateur"
@@ -16654,22 +16654,22 @@ msgid "Variance"
 msgstr "Écart"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Écart entre la consommation réelle et standard des composants de nomenclature"
+msgstr "Écart entre la consommation réelle et standard des composants du BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Écart entre les heures et les taux de routage réels et standard"
+msgstr "Écart entre les heures et les taux réels et standards de la gamme"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "Écart entre le prix d'achat réel et le coût standard"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Écart entre les frais généraux de fabrication appliqués et réels"
+msgstr "Écart entre les frais généraux de production appliqués et réels"
 
 msgid "Variance from physical inventory count adjustments"
 msgstr "Écart dû aux ajustements de comptage d'inventaire physique"
 
 msgid "Variance in outside processing costs"
-msgstr "Écart dans les coûts de traitement externe"
+msgstr "Écart dans les coûts de sous-traitance"
 
 msgid "Variance only"
 msgstr "Écarts uniquement"
@@ -16678,7 +16678,7 @@ msgid "VAT Number"
 msgstr "Numéro de TVA"
 
 msgid "Vendor Write-Off Income"
-msgstr "Revenu de Radiation Fournisseur"
+msgstr "Produits de passage en perte fournisseur"
 
 msgid "Verification Error"
 msgstr "Erreur de vérification"
@@ -16703,7 +16703,7 @@ msgstr "Version"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "La version {0} est publiée maintenant et sera remplacée."
 
 msgid "Version:"
 msgstr "Version :"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Afficher"
 
 msgid "View Active Jobs"
-msgstr "Afficher les tâches actives"
+msgstr "Afficher les ordres de fabrication actifs"
 
 msgid "View Active Quotes"
 msgstr "Afficher les devis actifs"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Afficher l'actif"
 
 msgid "View Assigned Jobs"
-msgstr "Afficher les tâches assignées"
+msgstr "Afficher les ordres de fabrication assignés"
 
 msgid "View Attachment"
 msgstr "Afficher la pièce jointe"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Afficher la fiche article"
 
 msgid "View Journal Entry"
-msgstr "Afficher l'écriture comptable"
+msgstr "Afficher la ligne d'écriture"
 
 msgid "View Lists"
 msgstr "Afficher les listes"
 
 msgid "View maintenance dispatch"
-msgstr "Afficher la dépêche de maintenance"
+msgstr "Afficher l'intervention de maintenance"
 
 msgid "View Memo"
 msgstr "Afficher le mémo"
@@ -16823,7 +16823,7 @@ msgid "View Open RFQs"
 msgstr "Afficher les demandes de devis ouvertes"
 
 msgid "View Payables"
-msgstr "Afficher les comptes créditeurs"
+msgstr "Afficher les dettes fournisseurs"
 
 msgid "View Payment"
 msgstr "Afficher le paiement"
@@ -16856,7 +16856,7 @@ msgid "View Receipt"
 msgstr "Afficher le reçu"
 
 msgid "View Receivables"
-msgstr "Afficher les créances"
+msgstr "Afficher les créances clients"
 
 msgid "View Run"
 msgstr "Afficher le passage"
@@ -16901,25 +16901,25 @@ msgid "Visible on a user's public profile"
 msgstr "Visible sur le profil public d'un utilisateur"
 
 msgid "Void"
-msgstr "Annuler"
+msgstr "Invalider"
 
 msgid "Void Invoice"
-msgstr "Annuler la facture"
+msgstr "Invalider la facture"
 
 msgid "Void Purchase Invoice"
-msgstr "Annuler la facture d'achat"
+msgstr "Invalider la facture d'achat"
 
 msgid "Void Receipt"
-msgstr "Annuler le reçu"
+msgstr "Invalider la réception"
 
 msgid "Void Sales Invoice"
-msgstr "Annuler la facture de vente"
+msgstr "Invalider la facture de vente"
 
 msgid "Void Shipment"
-msgstr "Annuler l'expédition"
+msgstr "Invalider l'expédition"
 
 msgid "Voided"
-msgstr "Annulé"
+msgstr "Invalidé"
 
 msgid "Voiding this purchase invoice will:"
 msgstr "L'annulation de cette facture d'achat aura pour effet :"
@@ -16928,10 +16928,10 @@ msgid "Voiding this receipt will:"
 msgstr "L'annulation de ce reçu va :"
 
 msgid "Voiding this shipment will:"
-msgstr "Annuler cet envoi va :"
+msgstr "L'invalidation de cette expédition :"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Parcourez chaque domaine avec votre champion et désactivez tout ce qui sort du périmètre. Les codes se lisent Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Parcourez chaque domaine avec votre responsable et désactivez tout ce qui est hors du champ. Les codes se lisent Module.Domaine.Numéro (ACC.GL.01 = Comptabilité, Grand livre, article 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Parcourez votre processus actuel, vos systèmes et vos données"
@@ -16958,7 +16958,7 @@ msgid "Warn but allow"
 msgstr "Avertir mais autoriser"
 
 msgid "Warn this many days before expiry"
-msgstr "Avertir ce nombre de jours avant expiration"
+msgstr "Avertir ce nombre de jours avant péremption"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Avertir lorsque la personne inspectant un article entrant est la même personne qui l'a reçu."
@@ -16973,7 +16973,7 @@ msgid "Watch full video"
 msgstr "Regarder la vidéo complète"
 
 msgid "We auto-matched each column. Review the values below before continuing."
-msgstr "Nous avons fait correspondre automatiquement chaque colonne. Vérifiez les valeurs ci-dessous avant de continuer."
+msgstr "Nous avons automatiquement mis en correspondance chaque colonne. Vérifiez les valeurs ci-dessous avant de continuer."
 
 msgid "We triage and fix issues fast while your team settles in"
 msgstr "Nous trions et résolvons les problèmes rapidement pendant que votre équipe s'adapte"
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "Hebdomadaire"
 
 msgid "Weekly demand"
-msgstr "Demande hebdomadaire"
+msgstr "Besoins hebdomadaires"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17089,10 +17089,10 @@ msgid "What data"
 msgstr "Quelles données"
 
 msgid "What drove inventory up or down, by any dimension"
-msgstr "Ce qui a poussé l'inventaire à la hausse ou à la baisse, par toute dimension"
+msgstr "Ce qui a fait monter ou descendre les stocks, selon un quelconque axe analytique"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Que se passe-t-il quand un journal est daté dans une période verrouillée ?"
+msgstr "Ce qui se passe quand une écriture est datée dans une période verrouillée."
 
 msgid "What is {translatedTerm}?"
 msgstr "Qu'est-ce que {translatedTerm} ?"
@@ -17101,19 +17101,19 @@ msgid "What it is"
 msgstr "Ce que c'est"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "Le type de changement : Version met à jour la façon dont la pièce est fabriquée, Révision révise ses détails et documents, Pièce de remplacement échange un nouveau numéro de pièce qui remplace l'ancien, et Nouvelle pièce introduit une pièce entièrement nouvelle sans prédécesseur."
+msgstr "Quel type de changement il s'agit : Version met à jour comment la pièce est fabriquée, Révision révise ses détails et documents, Pièce de remplacement remplace un nouveau numéro de pièce qui remplace l'ancien, et Nouvelle pièce introduit une pièce entièrement nouvelle sans prédécesseur."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Quel type de sortie cette entrée enregistre — Production (bonnes unités), Rebut (irrécupérable) ou Retravail (renvoyé pour correction) ; révèle Scrap Reason quand Rebut."
+msgstr "Quel type de résultat cette entrée enregistre — Production (bonnes unités), Rebut (irrécupérable), ou Retouche (renvoyée pour correction) ; révèle Motif de rebut quand Rebut."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Quel type de PO c'est — biens standard, services, traitement externe ou accord-cadre ; détermine la disposition de la ligne et les règles de comptabilisation GL."
+msgstr "Quel type de BC il s'agit — biens standard, prestations, sous-traitance, ou accord-cadre ; détermine la disposition de la ligne et les règles de comptabilisation du grand livre."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
 msgstr "Quel type de devis c'est — devis de fournisseur standard, devis à prix d'accord-cadre ou devis de fabrication contractuelle ; détermine la disposition de la ligne PO lors de la conversion."
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
-msgstr "De quelle source cette dimension tire ses valeurs autorisées (liste personnalisée ou une entité existante comme client, localisation, employé)."
+msgstr "D'où cet axe analytique tire ses valeurs autorisées (liste personnalisée ou une entité existante comme client, site, employé)."
 
 msgid "What the due-date countdown starts from (invoice date, end of month, etc.)."
 msgstr "À partir de quoi commence le compte à rebours de la date d'échéance (date de facture, fin du mois, etc.)."
@@ -17122,16 +17122,16 @@ msgid "What this field held before the change. Leave blank for nothing."
 msgstr "Ce que ce champ contenait avant la modification. Laissez vide pour rien."
 
 msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
-msgstr "Ce que ce reçu fulfille — une commande d'achat, un retour, un transfert entrant ou un reçu manuel sans parent."
+msgstr "Ce que cette réception remplit — un bon de commande, un retour, un transfert entrant, ou une réception manuelle sans parent."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "Ce que cet envoi fulfille — une commande client, un transfert sortant, une retour RMA ou un envoi manuel."
+msgstr "Ce que cette expédition remplit — une commande client, un transfert sortant, un retour RMA, ou une expédition manuelle."
 
 msgid "What this task means"
 msgstr "Ce que signifie cette tâche"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Ce que cette entrée de temps compte comme — Travail (temps opérateur), Machine (temps d'exécution) ou Configuration (temps de changement) ; chaque résumé sous un taux différent."
+msgstr "Ce que cette saisie de temps compte comme — Main-d'œuvre (temps opérateur), Machine (temps de production), ou Réglage (temps de changement) ; chacun s'accumule sous un taux différent."
 
 msgid "What to set up"
 msgstr "Quoi configurer"
@@ -17155,19 +17155,19 @@ msgid "When {name} changes"
 msgstr "Quand {name} change"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "Lorsque la durée de vie d'un produit fini est définie sur Calculée, choisissez les entrées consommées qui alimentent le calcul."
+msgstr "Quand la durée de conservation d'un produit fini est définie sur Calculée, choisissez quelles entrées consommées alimentent le calcul."
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
-msgstr "Quand un numéro de série ou un lot expire, et ce qui se passe s'il est utilisé après — une politique d'entreprise peut Avertir, Bloquer ou BloquerAvecOrsimplification."
+msgstr "Quand un numéro de série ou un lot de production expire, et ce qui se passe en cas d'utilisation après — une politique de société peut Avertir, Bloquer, ou Bloquer avec remplacement."
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
-msgstr "Quand Carbon s'est engagé à ce que les marchandises arrivent ; combiné avec les jours de transit de la méthode d'expédition, cela détermine le calcul rétroactif de la Date d'expédition."
+msgstr "Quand Carbon s'est engagé à ce que les marchandises arrivent ; combiné aux jours de transit du mode d'expédition, cela détermine le calcul à rebours de la date d'expédition."
 
 msgid "When expired stock is used"
 msgstr "Lorsque du stock expiré est utilisé"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "Quand MRP utilise le successeur pour la nouvelle demande"
+msgstr "Quand le MRP utilise le successeur pour les nouveaux besoins"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "Quand il est activé, les attributs de cette catégorie s'affichent dans le profil public d'une personne ; sinon, ils ne sont visibles que pour les administrateurs."
@@ -17176,16 +17176,16 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Quand il est activé, les employés peuvent modifier la valeur de cet attribut dans leur propre profil ; sinon, seuls les administrateurs peuvent le faire."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Quand il est activé, les règles de tarification (remises en volume, promotions) s'appliquent toujours en plus de ce remplacement ; quand il est désactivé, ce remplacement est le prix final."
+msgstr "Quand activé, les règles de tarification (remises de volume, promotions) s'appliquent toujours en plus de cette substitution ; quand désactivé, cette substitution est le prix final."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Quand il est activé, scanner le code à barres d'opération de ce processus signale toute la quantité ouverte restante comme complétée en une seule action ; désactiver quand les opérateurs rapportent régulièrement des partiels."
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
-msgstr "Quand il est activé, les factures de cette partie ignorent le calcul des impôts ; la partie est responsable de maintenir le certificat d'exemption à jour."
+msgstr "Quand activé, les factures de ce tiers ignorent le calcul de taxe ; le tiers est responsable de maintenir le certificat d'exonération à jour."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Quand il est activé, ce remplacement de prix s'applique aux commandes correspondantes ; quand il est désactivé, le remplacement est conservé sans suppression pour préserver l'historique d'audit."
+msgstr "Quand activé, cette substitution de prix s'applique aux commandes correspondantes ; désactiver sans supprimer préserve l'historique pour audit."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Lorsqu'elle est activée, cette règle s'applique à chaque cible de son type. Les lignes d'affectation sont ignorées mais conservées."
@@ -17203,10 +17203,10 @@ msgid "When the customer asked for delivery; the order commits to Promised Date,
 msgstr "Quand le client a demandé la livraison ; la commande s'engage à la Date Promise, qui peut être différente."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Quand le client souhaite recevoir les marchandises ; le devis s'engage à cette date si le client accepte."
+msgstr "Quand le client a demandé à recevoir les marchandises ; le devis s'engage sur cette date si le client accepte."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Quand le client souhaite recevoir les marchandises."
+msgstr "Quand le client a demandé à recevoir les marchandises."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "Quand le client a soumis cette RFQ ; l'horloge de réponse commence à partir de cette date."
@@ -17221,7 +17221,7 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Lorsque la carte kanban est scannée, le travail est automatiquement déplacé hors du brouillon et libéré à l'étage."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Quand le lieu de réception s'attend à l'arrivée du stock ; détermine la disponibilité MRP à la destination."
+msgstr "Quand le site de réception s'attend à la réception du stock ; détermine la disponibilité du MRP à destination."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Quand le fournisseur s'est engagé à livrer ; la planification utilise cette date pour la projection des stocks d'entrée."
@@ -17230,43 +17230,43 @@ msgid "When the supplier's pricing stops being honored; converting this quote to
 msgstr "Quand la tarification du fournisseur cesse d'être honorée ; convertir cette cotisation à un bon de commande après cette date peut nécessiter une nouvelle soumission."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Quand cette jauge est due pour étalonnage ; une fois en retard, elle affiche Hors-étalonnage."
+msgstr "Quand cet instrument de mesure doit être étalonné ; une fois en retard, il affiche Hors calibrage."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Quand cet appareil a été calibré avec succès pour la dernière fois ; la date de prochaine calibration est recalculée à partir de cette valeur plus l'intervalle."
+msgstr "Quand cet instrument de mesure a été étalonné la dernière fois avec succès ; la date du prochain étalonnage se recalcule à partir de cette valeur plus l'intervalle."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "Quand cela vous semble correct, marquez-le comme convenu. Cela complète l'étape Discovery de votre centre de commande."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Quand cette ligne spécifique est promise d'expédition ; remplacement par ligne de la Date Promise de l'en-tête de commande pour les envois fractionnés."
+msgstr "Quand cette ligne spécifique est promise à l'expédition ; substitution par ligne de la date promise de l'en-tête de la commande pour les expéditions fractionnées."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Quand ce lot/numéro de série spécifique expire ; détermine la sélection FEFO et la politique de durée de conservation à la consommation."
+msgstr "Quand ce lot/numéro de série spécifique expire ; détermine le prélèvement FEFO et la politique de durée de conservation sur la consommation."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Quand vous vous êtes engagé à livrer ; la planification traite ceci comme la date d'exigence de demande pour l'exécution."
 
 msgid "When your fiscal and tax years start"
-msgstr "Quand commencent vos exercices fiscal et fiscal"
+msgstr "Quand commencent vos années fiscales et fiscales"
 
 msgid "Where a workflow notification is delivered — in-app is always sent, while email needs a Business or Partner plan and Slack needs your Slack workspace connected."
 msgstr "Où une notification de workflow est livrée — in-app est toujours envoyé, tandis que l'email nécessite un plan Business ou Partner et Slack nécessite que votre espace de travail Slack soit connecté."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Où un opération s'exécute ; porte les taux de travail et de devis, avec frais généraux la différence entre eux."
+msgstr "Où une opération s'exécute ; porte les taux de main-d'œuvre et de devis, avec les frais généraux comme différence entre eux."
 
 msgid "Where and how you make things."
 msgstr "Où et comment vous fabriquez les choses."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Où les marchandises de cette PO sont expédiées par défaut par le fournisseur ; les localisations de livraison par ligne sur la PO remplacent ceci pour les scénarios drop-ship et livraison fractionnée."
+msgstr "Où les marchandises de ce BC sont expédiées par défaut ; les sites de livraison par ligne sur le BC remplacent ceci pour les scénarios de livraison directe et de livraison fractionnée."
 
 msgid "Where it lives today"
 msgstr "Où il se trouve aujourd'hui"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Où le nouveau stock de cet article se pose par défaut à la réception ; les sélections de stockage par ligne sur un reçu le remplacent."
+msgstr "Où le nouveau stock de cet article se place par défaut à la réception ; les sélections de stockage par ligne sur une réception la remplacent."
 
 msgid "Where stock lives and how it ships."
 msgstr "Où le stock se trouve et comment il est expédié."
@@ -17281,10 +17281,10 @@ msgid "Where this issue was raised from — internal QA, customer complaint, sup
 msgstr "D'où s'est posé ce problème — QA interne, plainte client, audit fournisseur, etc. ; utilisé pour la création de rapports, n'obstrue pas le flux de travail."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "Où les marchandises de cette ligne atterrissent dans le stock à la réception ; si vide, les reçus utilisent la localisation de stockage par défaut de l'article."
+msgstr "Où les marchandises de cette ligne se placent dans le stock à la réception ; si vide, les réceptions utilisent l'unité de stockage par défaut de l'article."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "D'où provient cette demande de maintenance — signalé par l'opérateur, programmé, déclencheur de surveillance d'état, inspection après-travail ; détermine la répartition des sources dans les rapports de maintenance."
+msgstr "D'où cette demande de maintenance est originaire — signalée par l'opérateur, planifiée, déclencheur de surveillance d'état, inspection post-travail ; détermine la répartition source dans les rapports de maintenance."
 
 msgid "Where you are today"
 msgstr "Où vous en êtes aujourd'hui"
@@ -17296,31 +17296,31 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Si le montant est interprété comme un pourcentage du prix de ligne ou comme un montant fixe en devise."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Si Carbon suit chaque unité (Serial), chaque lot (Batch), la quantité (Inventory) ou aucun suivi (Non-Inventory)."
+msgstr "Si Carbon suit chaque unité (Numéro de série), chaque lot de production (Lot de production), la quantité (Stocks), ou aucun suivi (Hors stock)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Si le chronomètre démarre lorsque le processus choisi commence ou lorsqu'il se termine."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Si ce lot/numéro de série réussit l'inspection (Pass) ou échoue (Fail) ; un Fail empêche la réception du stock dans l'inventaire disponible."
+msgstr "Si ce lot/numéro de série est conforme au contrôle (Conforme) ou non conforme (Non conforme) ; un résultat non conforme bloque la réception du stock dans les stocks disponibles."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Que ce processus s'exécute sur des centres de travail internes (Processus, Assemblage ou Inspection) ou chez des fournisseurs externes (Traitement extérieur) ; révèle différents champs en aval, change le fonctionnement des itinéraires de planification pour ce processus et définit par défaut le type d'opération sur les nouvelles opérations."
+msgstr "Si ce procédé s'exécute sur des postes de travail internes (Procédé, Assemblage, ou Contrôle) ou chez des fournisseurs externes (Sous-traitance) ; révèle différents champs en aval, change la façon dont les itinéraires de planification fonctionnent pour ce procédé, et définit par défaut le type d'opération sur les nouvelles opérations."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
 msgstr "Si ce travail bloque la production (Baisse), la dégrade (Impact), se situe dans une fenêtre de temps d'arrêt planifiée (Planifié) ou n'a aucun impact de production (Pas d'Impact) ; informe la planification et la communication d'arrêt orientée client."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
-msgstr "Si les autorisations sélectionnées sont Ajoutées au-dessus de ce que chaque utilisateur possède déjà, ou Mises à Jour en remplaçant l'ensemble des autorisations de chaque utilisateur par la sélection ci-dessous."
+msgstr "S'il faut ajouter les autorisations sélectionnées en plus de celles que chaque utilisateur possède déjà, ou mettre à jour en remplaçant entièrement l'ensemble d'autorisations de chaque utilisateur par la sélection ci-dessous."
 
 msgid "Which document drives each inspection flow for this item."
-msgstr "Quel document pilote chaque flux d'inspection pour cet article."
+msgstr "Quel document pilote chaque flux de contrôle pour cet article."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Quel type de requête envoyer : GET lit quelque chose, POST crée, PUT et PATCH mettent à jour, DELETE supprime. Une nouvelle étape commence par GET, et seuls POST, PUT et PATCH transportent un corps."
+msgstr "Quel type de requête envoyer : GET lit quelque chose, POST crée, PUT et PATCH mettent à jour, DELETE supprime. Une nouvelle étape commence par GET, et seuls POST, PUT et PATCH contiennent un corps."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
-msgstr "Quel événement de fabrication démarre l'horloge de durée de conservation — par exemple, remplissage, scellement ou CQ final."
+msgstr "Quel événement de production démarre l'horloge de durée de vie — par exemple, remplissage, scellage, ou QC final."
 
 msgid "Who Can Approve"
 msgstr "Qui peut approuver"
@@ -17338,22 +17338,22 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Qui doit approuver les devis, les commandes et les achats — et quand"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Qui devrait recevoir les notifications pour les dépêches liées à la maintenance ?"
+msgstr "Qui devrait recevoir des notifications pour les interventions de maintenance ?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Qui devrait recevoir les notifications pour les expéditions liées aux opérations ?"
+msgstr "Qui devrait recevoir des notifications pour les interventions liées aux opérations ?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "Qui devrait recevoir les notifications pour les autres dépêches ?"
+msgstr "Qui devrait recevoir des notifications pour les autres interventions ?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Qui devrait recevoir les notifications pour les expéditions liées à la qualité ?"
+msgstr "Qui devrait recevoir des notifications pour les interventions liées à la qualité ?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
 msgstr "Qui devrait recevoir des notifications lorsqu'un devis numérique est accepté ou expiré ?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Qui devrait recevoir des notifications lorsqu'une jauge sort de l'étalonnage ?"
+msgstr "Qui devrait recevoir des notifications quand un instrument de mesure sort d'étalonnage ?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "Qui devrait recevoir des notifications lorsqu'une nouvelle suggestion est soumise ?"
@@ -17401,10 +17401,10 @@ msgid "Window:"
 msgstr "Fenêtre :"
 
 msgid "WIP"
-msgstr "TEC"
+msgstr "En-cours"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Sans liste de prélèvement, les opérateurs prélèvent le matériel à partir de l'onglet Scan."
+msgstr "Sans liste de prélèvement, les opérateurs prélèvent les articles à partir de l'onglet Scan."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17424,28 +17424,28 @@ msgid "Wordmark Light Mode"
 msgstr "Wordmark Mode Clair"
 
 msgid "work center"
-msgstr "centre de travail"
+msgstr "poste de travail"
 
 msgid "Work center"
-msgstr "Centre de Travail"
+msgstr "Poste de travail"
 
 msgid "Work Center"
-msgstr "Centre de travail"
+msgstr "Poste de travail"
 
 msgid "Work Center Utilization"
-msgstr "Utilisation du centre de travail"
+msgstr "Utilisation du poste de travail"
 
 msgid "work centers"
-msgstr "centres de travail"
+msgstr "postes de travail"
 
 msgid "Work centers"
-msgstr "Centres de travail"
+msgstr "Postes de travail"
 
 msgid "Work Centers"
-msgstr "Centres de travail"
+msgstr "Postes de travail"
 
 msgid "Work in process (WIP)"
-msgstr "Travaux en cours (WIP)"
+msgstr "Travail en cours (En-cours)"
 
 msgid "Work in progress"
 msgstr "Travaux en cours"
@@ -17454,19 +17454,19 @@ msgid "Work in Progress (default)"
 msgstr "Travaux en Cours (par défaut)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Travaux en Cours (WIP)"
+msgstr "Travail en cours (En-cours)"
 
 msgid "Work instruction"
-msgstr "Instructions de travail"
+msgstr "Mode opératoire"
 
 msgid "Work Instructions"
-msgstr "Instructions de travail"
+msgstr "Modes opératoires"
 
 msgid "Work Phone"
 msgstr "Téléphone professionnel"
 
 msgid "Work shift tracking is active."
-msgstr "Le suivi des quarts de travail est actif."
+msgstr "Le suivi de l'équipe est actif."
 
 msgid "Workflow"
 msgstr "Flux de travail"
@@ -17487,26 +17487,26 @@ msgid "Worst Performing Machines"
 msgstr "Machines les plus défaillantes"
 
 msgid "Write-Down Account"
-msgstr "Compte de Dévaluation"
+msgstr "Compte de dépréciation"
 
 msgid "Write-off"
-msgstr "Radiation"
+msgstr "Passage en perte"
 
 msgid "Write-Off"
-msgstr "Radiation"
+msgstr "Passage en perte"
 
 msgid "Write-Off Account"
-msgstr "Compte de Radiation"
+msgstr "Compte de passage en perte"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Radiation pour {0}"
+msgstr "Passage en perte pour {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Radiation du stock mis au rebut ou retourné via les rejets d'inspection et les dispositions des rapports de non-conformité"
+msgstr "Passage en perte du stock mis au rebut ou retourné par les rejets de contrôle et les traitements de NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "Réduire la valeur d'un actif au cours de sa vie utile — un lot mensuel que vous créez, vérifiez en tant que brouillon, puis comptabilisez."
+msgstr "Réduire progressivement la valeur d'un bien sur sa durée de vie — un lot mensuel que vous créez, examinez en tant que brouillon, puis comptabilisez."
 
 msgid "Year"
 msgstr "Année"
@@ -17533,7 +17533,7 @@ msgid "You"
 msgstr "Vous"
 
 msgid "You belong to more than one company. Pick where to work."
-msgstr "Vous appartenez à plus d'une entreprise. Choisissez où travailler."
+msgstr "Vous appartenez à plus d'une société. Choisissez où travailler."
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Vous pouvez modifier le style de l'interface utilisateur à tout moment via les paramètres de thème"
@@ -17554,13 +17554,13 @@ msgid ""
 msgstr "Vous avez complété {leftoverQuantity} {0} de plus que la quantité commandée de {1}. Que souhaitez-vous faire avec les pièces supplémentaires ?"
 
 msgid "You do not have permission to edit workflows"
-msgstr "Vous n'avez pas la permission de modifier les flux de travail"
+msgstr "Vous n'avez pas l'autorisation de modifier les workflows"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "Vous n'avez pas la permission de modifier cette nomenclature."
+msgstr "Vous n'avez pas l'autorisation de modifier cette nomenclature."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Vous n'avez pas la permission de modifier ce bon de fabrication."
+msgstr "Vous n'avez pas l'autorisation de modifier cette liste des opérations."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
 msgstr "Vous pilotez ; nous veillons à ce que ce soit fait correctement. Un regard expert sur votre configuration, vos données et votre mise en ligne."
@@ -17576,7 +17576,7 @@ msgid "You lead"
 msgstr "Vous menez"
 
 msgid "You name a project owner with decision authority"
-msgstr "Vous nommez un responsable de projet ayant autorité décisionnelle"
+msgstr "Vous nommez un propriétaire de projet avec autorité décisionnelle."
 
 msgid "You received this item"
 msgstr "Vous avez reçu cet article"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Vous êtes en direct sur Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Vous êtes à une étape de votre espace de travail."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Vous configurez Carbon vous-même, à votre rythme"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Vous êtes connecté depuis {hoursElapsed} heures. Avez-vous oublié de vous déconnecter?"
+msgstr "Vous êtes pointé depuis {hoursElapsed} heures. Avez-vous oublié de pointer fin ?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Votre compte reste en sécurité même si votre identifiant est volé"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "vous-même"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Niveau d'inspection Z1.4 (I / II / III) ; les niveaux supérieurs signifient des tailles d'échantillon plus importantes pour le même lot."
+msgstr "Niveau de contrôle Z1.4 (I / II / III) ; les niveaux supérieurs signifient des tailles d'échantillon plus grandes pour le même lot."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Sévérité Z1.4 (Normal / Renforcé / Réduit) ; bascule par règle en fonction de l'historique d'acceptation de lot récent."
+msgstr "Gravité Z1.4 (Normal / Renforcé / Réduit) ; change selon la règle en fonction de l'historique d'acceptation récent des lots."
 
 msgid "Zoom Box"
 msgstr "Boîte de zoom"

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -532,7 +532,6 @@ msgstr "Revenir à l'opération"
 
 msgid "Go to onboarding"
 msgstr "Aller à l'onboarding"
-msgstr "Aller à l'intégration"
 
 msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
@@ -1515,7 +1514,6 @@ msgstr "Vous êtes pointé(e) depuis {hoursElapsed} heures. Avez-vous oublié le
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Votre compte ne fait pas encore partie d'une société. Terminez l'onboarding dans Carbon ERP pour continuer."
-msgstr "Votre compte n'est pas encore associé à une entreprise. Complétez l'intégration dans l'ERP Carbon pour continuer."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Votre organisation nécessite une application d'authentification. Configurez-la dans Carbon, puis revenez ici."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Rebuté(s)"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} unité(s) acceptée(s) sera/seront complétée(s)."
+msgstr "{completions} unité(s) conforme(s) vont être terminées."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} défaut(s) échantillonné(s) enregistré(s) et ne seront PAS complété(s) — résolvez-les à partir du menu des actions."
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Effacer la recherche"
 
 msgid "Clock In"
-msgstr "Pointer l'entrée"
+msgstr "Pointage début"
 
 msgid "Clock Out"
-msgstr "Pointer la sortie"
+msgstr "Pointage fin"
 
 msgid "Clocked in since <0/>"
 msgstr "Connecté depuis <0/>"
@@ -251,7 +251,7 @@ msgid "Columns"
 msgstr "Colonnes"
 
 msgid "Company"
-msgstr "Entreprise"
+msgstr "Société"
 
 msgid "Complete"
 msgstr "Terminé"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Détails"
 
 msgid "Dispatch not found"
-msgstr "Intervention non trouvée"
+msgstr "Intervention de maintenance non trouvée"
 
 msgid "Display"
 msgstr "Affichage"
@@ -398,10 +398,10 @@ msgid "Due today?"
 msgstr "Dû aujourd'hui ?"
 
 msgid "Duplicate batch number"
-msgstr "Numéro de lot en double"
+msgstr "Numéro de lot de production en doublon"
 
 msgid "Duplicate serial number"
-msgstr "Numéro de série en double"
+msgstr "Numéro de série en doublon"
 
 msgid "Duration"
 msgstr "Durée"
@@ -416,7 +416,7 @@ msgid "Email Address"
 msgstr "Adresse e-mail"
 
 msgid "Empty work centers"
-msgstr "Centres de travail vides"
+msgstr "Postes de travail vides"
 
 msgid "End Operations"
 msgstr "Arrêter les opérations"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Terminer quand même"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Terminez la configuration de votre compte"
 
 msgid "Finish with material unpicked?"
 msgstr "Terminer avec du matériel non prélevé?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Oubli de pointer la sortie ?"
+msgstr "Avez-vous oublié le pointage fin ?"
 
 msgid "Go back to operation"
 msgstr "Revenir à l'opération"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Aller à l'onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Combien ont réellement été prélevés ?"
@@ -619,7 +619,7 @@ msgid "Job Traveler"
 msgstr "Fiche suiveuse"
 
 msgid "Jobs"
-msgstr "Emplois"
+msgstr "Ordres de fabrication"
 
 msgid "Keep picking"
 msgstr "Continuer le prélèvement"
@@ -668,11 +668,11 @@ msgid "Log completed for {0}"
 msgstr "Enregistrer la production pour {0}"
 
 msgid "Log Rework"
-msgstr "Enregistrer la reprise"
+msgstr "Enregistrer une retouche"
 
 #. placeholder {0}: operation.itemReadableId
 msgid "Log rework for {0}"
-msgstr "Enregistrer la reprise pour {0}"
+msgstr "Enregistrer une retouche pour {0}"
 
 msgid "Log Scrap"
 msgstr "Enregistrer le rebut"
@@ -773,7 +773,7 @@ msgid "No"
 msgstr "Non"
 
 msgid "No active job at this work center"
-msgstr "Aucun travail actif à ce centre de travail"
+msgstr "Aucun ordre de fabrication actif à ce poste de travail"
 
 msgid "No active maintenance dispatches"
 msgstr "Aucune intervention de maintenance active"
@@ -782,7 +782,7 @@ msgid "No active operations"
 msgstr "Aucune opération active"
 
 msgid "No active work centers at this location."
-msgstr "Aucun centre de travail actif à cet emplacement."
+msgstr "Aucun poste de travail actif à ce site."
 
 msgid "No assigned operations"
 msgstr "Aucune opération assignée"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Aucune entité suivie disponible trouvée"
 
 msgid "No dispatches assigned to you"
-msgstr "Aucune intervention qui vous est assignée"
+msgstr "Aucune intervention de maintenance qui vous est assignée"
 
 msgid "No files"
 msgstr "Aucun fichier"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Aucun matériau"
 
 msgid "No open jobs"
-msgstr "Aucun travail ouvert"
+msgstr "Aucun ordre de fabrication ouvert"
 
 msgid "No open units to allocate"
 msgstr "Aucune unité ouverte à allouer"
@@ -896,7 +896,7 @@ msgid "Nothing running"
 msgstr "Rien en cours"
 
 msgid "Nothing scheduled at this work center"
-msgstr "Rien de planifié à ce centre de travail"
+msgstr "Rien de programmé à ce poste de travail"
 
 msgid "Nothing to scrap"
 msgstr "Rien à rebuter"
@@ -921,13 +921,13 @@ msgid "Open"
 msgstr "Ouvert"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "Ouvrez un affichage sur l'écran monté au centre de travail et laissez-le fonctionner. Chaque tableau s'actualise automatiquement."
+msgstr "Ouvrez un affichage sur l'écran installé au poste de travail et laissez-le fonctionner. Chaque tableau s'actualise automatiquement."
 
 msgid "Open an NCR for MRB disposition"
-msgstr "Ouvrir un NCR pour la disposition MRB"
+msgstr "Ouvrir une NCR pour le traitement du MRB"
 
 msgid "Open Jobs"
-msgstr "Emplois ouverts"
+msgstr "Ordres de fabrication ouverts"
 
 msgid "Operations"
 msgstr "Opérations"
@@ -963,7 +963,7 @@ msgid "Partial"
 msgstr "Partiel"
 
 msgid "Partial Disposition"
-msgstr "Disposition partielle"
+msgstr "Traitement partiel"
 
 msgid "Passed Inspection"
 msgstr "Inspection réussie"
@@ -972,7 +972,7 @@ msgid "Passkey unlock failed"
 msgstr "Le déverrouillage par clé d'accès a échoué"
 
 msgid "Pause"
-msgstr "Pause"
+msgstr "Mettre en pause"
 
 msgid "Pick"
 msgstr "Prélever"
@@ -1020,7 +1020,7 @@ msgid "Print"
 msgstr "Imprimer"
 
 msgid "Printer Settings"
-msgstr "Paramètres d'impression"
+msgstr "Paramètres de l'imprimante"
 
 msgid "Priority"
 msgstr "Priorité"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "File d'attente vide"
 
 msgid "Reason for rework"
-msgstr "Raison du rétravail"
+msgstr "Raison de la retouche"
 
 msgid "Recent"
 msgstr "Récent"
@@ -1102,7 +1102,7 @@ msgid "Rework"
 msgstr "Retouche"
 
 msgid "Rework created successfully"
-msgstr "Rework créé avec succès"
+msgstr "Retouche créée avec succès"
 
 msgid "Rework quantity"
 msgstr "Quantité de retouche"
@@ -1183,7 +1183,7 @@ msgid "Select a completion quantity"
 msgstr "Sélectionner une quantité de production"
 
 msgid "Select a rework quantity"
-msgstr "Sélectionner une quantité de reprise"
+msgstr "Sélectionnez une quantité de retouche"
 
 msgid "Select a scrap quantity and reason"
 msgstr "Sélectionner une quantité de rebut et un motif"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Session verrouillée"
 
 msgid "Set Clock Out"
-msgstr "Définir la sortie"
+msgstr "Définir le pointage fin"
 
 msgid "Set clock-out time"
 msgstr "Définir l'heure de sortie"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "Se connecter avec Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Se connecter avec Passkey"
+msgstr "Se connecter avec une clé d'accès"
 
 msgid "Sign out"
 msgstr "Se déconnecter"
@@ -1316,7 +1316,7 @@ msgstr "Poste : {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "L'acceptation statistique a échoué, de sorte que l'ensemble du lot de {0} est considéré comme non-conforme (ISO 9001:2015 §8.7) — {passes} passage(s) échantillonné(s) et {fails} défaillance(s). Acheminez les unités ci-dessous vers la rebut ou le retravail, ou enregistrez uniquement le verdict."
+msgstr "L'acceptation statistique a échoué, donc l'ensemble du lot de {0} est considéré comme non-conforme (ISO 9001:2015 §8.7) — {passes} conforme(s) et {fails} défaillance(s). Dirigez les unités ci-dessous vers le rebut ou la retouche, ou enregistrez uniquement le verdict."
 
 msgid "Status"
 msgstr "Statut"
@@ -1361,7 +1361,7 @@ msgid "The lot will still be dispositioned, but an NCR cannot be created until a
 msgstr "Le lot sera toujours dispositionné, mais un NCR ne peut pas être créé tant qu'au moins un type de problème n'est pas configuré."
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "Il n'y a aucun article suivi disponible ou consommé pour ce matériel."
+msgstr "Il n'y a aucune pièce traçable disponible ou consommée pour cette matière."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Il existe des matériaux suivis par numéro de série ou par lot dans la nomenclature qui n'ont pas été entièrement distribués. Terminer sans distribuer peut entraîner des enregistrements de traçabilité incorrects."
@@ -1373,10 +1373,10 @@ msgid "This lot is expired and can't be picked."
 msgstr "Ce lot est expiré et ne peut pas être prélevé."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Cette pièce a été fabriquée sur commande. Sa mise au rebut peut rouvrir son itinéraire pour créer un remplacement."
+msgstr "Cette pièce a été fabriquée sur commande. La mettre au rebut peut rouvrir sa gamme pour en fabriquer un remplacement."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "Cette pièce sera mise au rebut du stock. Son besoin reste ouvert pour que vous puissiez émettre un remplacement."
+msgstr "Cette pièce sera mise au rebut du stock. Son exigence reste ouverte pour que vous puissiez sortir un remplacement."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "Cette unité sera définitivement mise au rebut et un nouveau numéro de série de remplacement sera créé."
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "Dépicker {0}"
 
 msgid "Unplanned downtime"
-msgstr "Arrêt imprévu"
+msgstr "Temps d'arrêt non planifié"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1501,7 +1501,7 @@ msgid "Work Center"
 msgstr "Poste de travail"
 
 msgid "Work Center Displays"
-msgstr "Affichages du Centre de Travail"
+msgstr "Affichages des postes de travail"
 
 msgid "Yes"
 msgstr "Oui"
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Vous avez pointé à <0/>. Vous pouvez modifier votre heure de départ ci-dessous ou confirmer que vous travaillez toujours."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Vous êtes pointé depuis {hoursElapsed} heures. Avez-vous oublié de pointer la sortie ?"
+msgstr "Vous êtes pointé(e) depuis {hoursElapsed} heures. Avez-vous oublié le pointage fin ?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Votre compte ne fait pas encore partie d'une société. Terminez l'onboarding dans Carbon ERP pour continuer."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Votre organisation nécessite une application d'authentification. Configurez-la dans Carbon, puis revenez ici."

--- a/packages/locale/locales/glossary.json
+++ b/packages/locale/locales/glossary.json
@@ -1363,6 +1363,7 @@
       "term": "Total",
       "category": "accounting",
       "context": "The final amount including tax and shipping.",
+      "ambiguity": "Only a document total. Do NOT apply to 'total depreciation', 'MB total', or other adjective uses.",
       "translations": {
         "fr": "Total",
         "de": "Gesamtbetrag",
@@ -1783,6 +1784,7 @@
       "term": "Move",
       "category": "action",
       "context": "Relocate stock or a record.",
+      "ambiguity": "Only relocating stock or a record. Do NOT apply to 'status moves through' or 'moves Open → Locked'.",
       "translations": {
         "fr": "Déplacer",
         "de": "Umlagern",
@@ -2031,6 +2033,7 @@
       "term": "View",
       "category": "action",
       "context": "Open a record read-only.",
+      "ambiguity": "Only the read-only action. Do NOT apply to a saved 'view' (a table configuration) or to 'the operator view' (a screen).",
       "translations": {
         "fr": "Afficher",
         "de": "Anzeigen",
@@ -2318,6 +2321,7 @@
       "term": "Material",
       "category": "core",
       "context": "An item type: raw stock consumed by manufacturing (bar, sheet, resin), usually by dimension rather than by piece.",
+      "ambiguity": "Only the item TYPE (raw stock). Do NOT apply inside 'bill of materials', 'material ID', or a job's 'materials' generally — those are items, not raw stock.",
       "translations": {
         "fr": "Matière",
         "de": "Werkstoff",
@@ -2646,6 +2650,7 @@
       "term": "Inventory",
       "category": "inventory",
       "context": "The stock the company holds, and the module that manages it.",
+      "ambiguity": "Only the module name. Ordinary stock prose — 'inventory transactions', 'inventory value' — takes the plain word for stock, not the module title.",
       "translations": {
         "fr": "Stocks",
         "de": "Bestände",
@@ -2744,6 +2749,7 @@
       "term": "Pick",
       "category": "inventory",
       "context": "Taking stock off the shelf for a job or a shipment.",
+      "ambiguity": "Only taking stock off the shelf. Do NOT apply to 'pick another field', 'pick options', or 'the order the floor picks work up'.",
       "translations": {
         "fr": "Prélever",
         "de": "Kommissionieren",
@@ -3892,6 +3898,7 @@
       "term": "Setup",
       "category": "methods",
       "context": "Preparing a work center before running parts.",
+      "ambiguity": "Only work-center changeover. Do NOT apply to 'Setup Map', a setup checklist, or onboarding/configuration senses.",
       "translations": {
         "fr": "Réglage",
         "de": "Rüsten",
@@ -4044,6 +4051,7 @@
       "term": "Items",
       "category": "module",
       "context": "The item master: parts, materials, tools and their methods.",
+      "ambiguity": "Also used loosely as 'rows in a list'. Only the domain sense is fixed. Mirrors the note on 'Item' — singular and plural must not disagree on whether a miss is a defect.",
       "translations": {
         "fr": "Articles",
         "de": "Artikel",
@@ -4370,6 +4378,7 @@
       "term": "Person",
       "category": "people",
       "context": "An individual, as opposed to a company.",
+      "ambiguity": "Only the individual-vs-company distinction. Do NOT apply to 'a different person', 'the right person', or 'Sales Person'.",
       "translations": {
         "fr": "Personne",
         "de": "Person",
@@ -5874,6 +5883,7 @@
       "term": "Schedule",
       "category": "production",
       "context": "The planned timing of jobs and operations.",
+      "ambiguity": "Only job and operation timing. Do NOT apply to a calibration, maintenance, or depreciation schedule.",
       "translations": {
         "fr": "Planning",
         "de": "Terminplan",
@@ -7156,6 +7166,7 @@
       "term": "Standard",
       "category": "quality",
       "context": "The normal inspection level.",
+      "ambiguity": "Only the AQL inspection level. Do NOT apply to 'a traceable standard', 'reference standard', or 'sampling standard'.",
       "translations": {
         "fr": "Normal",
         "de": "Normal",
@@ -7827,6 +7838,7 @@
       "term": "Closed",
       "category": "status",
       "context": "Finished and no longer editable.",
+      "ambiguity": "Only the status. 'Closed at', 'Closed by' and 'Closed Date' are column labels and may inflect differently.",
       "translations": {
         "fr": "Clôturé",
         "de": "Abgeschlossen",
@@ -8208,6 +8220,7 @@
       "term": "Open",
       "category": "status",
       "context": "Still being worked on.",
+      "ambiguity": "Only the document status. Do NOT apply to 'open a record', 'open the document', or 'documents you open'.",
       "translations": {
         "fr": "Ouvert",
         "de": "Offen",
@@ -8341,6 +8354,7 @@
       "term": "Picked",
       "category": "status",
       "context": "Taken off the shelf.",
+      "ambiguity": "Same boundary as 'Pick' — only stock taken off the shelf.",
       "translations": {
         "fr": "Prélevé",
         "de": "Kommissioniert",
@@ -8360,6 +8374,7 @@
       "term": "Planned",
       "category": "status",
       "context": "Scheduled but not started.",
+      "ambiguity": "Only the status. Do NOT apply to 'planned quantity', 'planned end', or 'planned lot size' as an ordinary adjective.",
       "translations": {
         "fr": "Planifié",
         "de": "Geplant",
@@ -8379,6 +8394,7 @@
       "term": "Posted",
       "category": "status",
       "context": "Committed to the ledger.",
+      "ambiguity": "Only the ledger state. Many languages inflect the verb ('is posted') differently from the status adjective — do not force the status rendering onto the verb.",
       "translations": {
         "fr": "Comptabilisé",
         "de": "Gebucht",

--- a/packages/locale/locales/glossary.json
+++ b/packages/locale/locales/glossary.json
@@ -203,6 +203,7 @@
       "term": "Balance",
       "category": "accounting",
       "context": "What remains outstanding.",
+      "ambiguity": "Only the account/ledger balance. Do NOT apply to the verb ('the account balances when...', 'equal debits and credits') or to the compound 'Trial Balance', which is its own term.",
       "translations": {
         "fr": "Solde",
         "de": "Saldo",
@@ -279,6 +280,7 @@
       "term": "Cash",
       "category": "accounting",
       "context": "A posted receipt or disbursement of money.",
+      "ambiguity": "Only the cash account. Do NOT apply inside compounds — 'cash discount', 'Quote to cash'.",
       "translations": {
         "fr": "Trésorerie",
         "de": "Kasse",
@@ -470,6 +472,7 @@
       "term": "Debit",
       "category": "accounting",
       "context": "The left side of a posting.",
+      "ambiguity": "Only the ledger column/side (paired with Credit). Ordinary prose and compound names use the everyday word instead — 'debit memo', 'Credits & Debits'.",
       "translations": {
         "fr": "Débit",
         "de": "Soll",
@@ -717,6 +720,7 @@
       "term": "GL",
       "category": "accounting",
       "context": "Short form of General Ledger, used mainly in 'GL Account'.",
+      "ambiguity": "Only the general-ledger noun. English also uses 'GL' as a modifier ('Default GL expense account'), where most languages use an accounting adjective instead.",
       "translations": {
         "fr": "Grand livre",
         "de": "Hauptbuch",
@@ -813,6 +817,7 @@
       "term": "Income",
       "category": "accounting",
       "context": "Money earned, as an account category.",
+      "ambiguity": "Only the income account. Do NOT apply inside compounds that are their own terms — 'Income Tax', 'Net Income', 'interest income'.",
       "translations": {
         "fr": "Produits",
         "de": "Erträge",
@@ -1326,6 +1331,7 @@
       "term": "Tax",
       "category": "accounting",
       "context": "Tax charged or paid on a transaction.",
+      "ambiguity": "Only the tax charged or paid on a transaction. English also uses 'tax' as a modifier meaning 'relating to taxation' ('tax year', 'tax depreciation method', 'tax timing differences') — most languages need a different, adjectival word there.",
       "translations": {
         "fr": "Taxe",
         "de": "Steuer",
@@ -1615,6 +1621,7 @@
       "term": "Create",
       "category": "action",
       "context": "Make a new record.",
+      "ambiguity": "Only the create action. Do NOT apply to the ordinary verb in prose ('create a separate Stripe customer', 'failed to create asset class').",
       "translations": {
         "fr": "Créer",
         "de": "Erstellen",
@@ -1653,6 +1660,7 @@
       "term": "Delete",
       "category": "action",
       "context": "Remove permanently.",
+      "ambiguity": "Only the delete action. Do NOT apply to the HTTP method DELETE in an API/webhook context.",
       "translations": {
         "fr": "Supprimer",
         "de": "Löschen",
@@ -1691,6 +1699,7 @@
       "term": "Duplicate",
       "category": "action",
       "context": "Copy a record into a new one.",
+      "ambiguity": "Only the duplicate action. Do NOT apply to the adjective in an error message ('Duplicate batch number', 'Duplicate serial number').",
       "translations": {
         "fr": "Dupliquer",
         "de": "Duplizieren",
@@ -1902,6 +1911,7 @@
       "term": "Remove",
       "category": "action",
       "context": "Take a row out, without necessarily deleting the record.",
+      "ambiguity": "Only the remove action. Do NOT apply to the ordinary verb ('remove some attachments', 'to remove the asset's original cost').",
       "translations": {
         "fr": "Retirer",
         "de": "Entfernen",
@@ -1921,6 +1931,7 @@
       "term": "Reopen",
       "category": "action",
       "context": "Move a closed record back to open.",
+      "ambiguity": "Only the domain action on a closed record. Do NOT apply to ordinary re-opening described in prose.",
       "translations": {
         "fr": "Rouvrir",
         "de": "Wieder öffnen",
@@ -1997,6 +2008,7 @@
       "term": "Update",
       "category": "action",
       "context": "Apply changes to an existing record.",
+      "ambiguity": "Only the domain action. Do NOT apply to the ordinary verb ('failed to update batch property'), to a plural noun ('Automatic Cost Updates'), or inside a permission code ('inventory:update').",
       "translations": {
         "fr": "Mettre à jour",
         "de": "Aktualisieren",
@@ -2188,6 +2200,7 @@
       "term": "Review",
       "category": "changes",
       "context": "The stage where a change is examined before approval.",
+      "ambiguity": "Only the review record/step. Do NOT apply to the imperative verb ('Review each item's changes, then confirm').",
       "translations": {
         "fr": "Revue",
         "de": "Überprüfung",
@@ -2771,6 +2784,7 @@
       "term": "Picking",
       "category": "inventory",
       "context": "The activity of taking stock off the shelf for a job or shipment.",
+      "ambiguity": "Only warehouse picking. Do NOT apply to the ordinary verb ('sending work to a supplier and picking it back up').",
       "translations": {
         "fr": "Prélèvement",
         "de": "Kommissionierung",
@@ -2886,6 +2900,7 @@
       "term": "Shelf",
       "category": "inventory",
       "context": "A storage position inside a location.",
+      "ambiguity": "Only the physical storage shelf. Do NOT apply inside 'shelf life', which is a fixed idiom with its own wording in most languages.",
       "translations": {
         "fr": "Étagère",
         "de": "Regal",
@@ -4113,6 +4128,7 @@
       "term": "Manufacturing",
       "category": "module",
       "context": "The making module: methods, jobs, shop floor.",
+      "ambiguity": "Only the domain noun. Do NOT apply inside a company name ('e.g. Acme Manufacturing') or as a modifier of another term ('manufacturing method', 'manufacturing change').",
       "translations": {
         "fr": "Production",
         "de": "Fertigung",
@@ -4227,6 +4243,7 @@
       "term": "Sales",
       "category": "module",
       "context": "The selling module: quotes, sales orders, shipments.",
+      "ambiguity": "Only the sales module/domain noun. Do NOT apply as a modifier of another noun ('sales contact', 'sales request for quote').",
       "translations": {
         "fr": "Ventes",
         "de": "Vertrieb",
@@ -4246,6 +4263,7 @@
       "term": "Settings",
       "category": "module",
       "context": "Company configuration.",
+      "ambiguity": "Only the settings screen. Do NOT apply inside a URL path or code sample ('Link (optional) — e.g. /x/settings/…').",
       "translations": {
         "fr": "Paramètres",
         "de": "Einstellungen",
@@ -4707,6 +4725,7 @@
       "term": "Supply",
       "category": "planning",
       "context": "Everything that adds stock: purchase orders, jobs, on-hand quantity.",
+      "ambiguity": "Only the supply noun. Do NOT apply to the ordinary verb ('the sales order line this job was created to supply').",
       "translations": {
         "fr": "Approvisionnement",
         "de": "Deckung",
@@ -5126,6 +5145,7 @@
       "term": "Override",
       "category": "platform",
       "context": "Replacing an inherited or calculated value with a manual one.",
+      "ambiguity": "Only the override record/noun. Do NOT apply to the ordinary verb ('per-line locations override the default') — most languages use a different form there.",
       "translations": {
         "fr": "Substitution",
         "de": "Übersteuerung",
@@ -5145,6 +5165,7 @@
       "term": "Owner",
       "category": "platform",
       "context": "The person accountable for a record.",
+      "ambiguity": "Only the record owner. Do NOT apply to company/group ownership ('as the company owner, you can transfer ownership').",
       "translations": {
         "fr": "Propriétaire",
         "de": "Verantwortlicher",
@@ -5642,6 +5663,7 @@
       "term": "Dispatch",
       "category": "production",
       "context": "A maintenance dispatch — a scheduled or reactive maintenance task raised against equipment.",
+      "ambiguity": "Only the maintenance dispatch record. The app also uses 'dispatch' for operations-, quality- and other-category dispatches, and for the scheduling 'dispatch sequence' — do NOT force the maintenance wording there.",
       "translations": {
         "fr": "Intervention de maintenance",
         "de": "Instandhaltungsauftrag",
@@ -6388,6 +6410,7 @@
       "term": "To Receive",
       "category": "purchasing",
       "context": "Outstanding lines awaiting receipt.",
+      "ambiguity": "Only the quantity-to-receive column/status. Do NOT apply to the ordinary infinitive ('the date the customer expects to receive the goods').",
       "translations": {
         "fr": "À réceptionner",
         "de": "Zu empfangen",
@@ -6964,6 +6987,7 @@
       "term": "Reduced",
       "category": "quality",
       "context": "A looser inspection level after sustained passes.",
+      "ambiguity": "Only the domain status. Do NOT apply to the ordinary participle (\"when an asset's carrying value is reduced\").",
       "translations": {
         "fr": "Réduit",
         "de": "Reduziert",
@@ -7460,6 +7484,7 @@
       "term": "Pricing",
       "category": "sales",
       "context": "The activity and configuration of setting prices.",
+      "ambiguity": "Only the pricing feature/screen. Do NOT apply to ordinary use in prose ('contains pricing and lead times', 'a customer inquiry for pricing').",
       "translations": {
         "fr": "Tarification",
         "de": "Preisfindung",
@@ -7965,6 +7990,7 @@
       "term": "Done",
       "category": "status",
       "context": "Finished.",
+      "ambiguity": "Only the job/operation status. Do NOT apply to ordinary English use — 'all phases are done', 'an operation done by an outside supplier', 'we make sure it's done right'.",
       "translations": {
         "fr": "Fait",
         "de": "Erledigt",
@@ -8022,6 +8048,7 @@
       "term": "Fail",
       "category": "status",
       "context": "Did not meet the inspection requirement.",
+      "ambiguity": "Only the inspection/test result. Do NOT apply to the ordinary verb — 'shown when this rule fails', 'the ways equipment fails'.",
       "translations": {
         "fr": "Non conforme",
         "de": "Nicht bestanden",
@@ -8155,6 +8182,7 @@
       "term": "Lost",
       "category": "status",
       "context": "A quote or opportunity that did not convert.",
+      "ambiguity": "Only the quote/opportunity status. Do NOT apply to the ordinary participle ('output lost during production', 'Negative (lost/scrap)').",
       "translations": {
         "fr": "Perdu",
         "de": "Verloren",

--- a/packages/locale/locales/glossary.json
+++ b/packages/locale/locales/glossary.json
@@ -4335,9 +4335,7 @@
         "tr": "Yetkinlik",
         "ko": "역량"
       },
-      "englishVariants": [
-        "Abilities"
-      ]
+      "englishVariants": ["Abilities"]
     },
     {
       "term": "Contractor",
@@ -7864,9 +7862,7 @@
         "tr": "İptal edildi",
         "ko": "취소됨"
       },
-      "englishVariants": [
-        "Canceled"
-      ]
+      "englishVariants": ["Canceled"]
     },
     {
       "term": "Closed",

--- a/packages/locale/locales/glossary.json
+++ b/packages/locale/locales/glossary.json
@@ -1,0 +1,8607 @@
+{
+  "$comment": "Approved translation for every Carbon domain term. Fill `translations` per language, then every place that term appears must use it. Read `_readme` before editing.",
+  "_readme": {
+    "purpose": "Single source of truth for domain terminology across all locales. Every term here must render the SAME way everywhere it appears in the UI.",
+    "howToFill": "Fill `translations.<locale>` with the approved rendering for that language. Leave it blank if you are not sure — blank means 'not decided yet' and the translator falls back to the English meaning, which is safer than a wrong term spreading into thousands of strings. Blank never means 'translate freely'.",
+    "baseFormRule": "Write the BASE (dictionary) form here — singular, nominative, uninflected. It is a word CHOICE, not text to paste in. Translators are told to inflect it so the sentence is grammatical (German Auftrag → Aufträge, Polish zlecenie → zleceniu, Russian заказ → заказа, Turkish iş → işin), and the consistency check matches on the stem so those correct forms pass. What must stay constant across the app is which word is used, never the exact characters.",
+    "howToDecideATerm": "Read the term's `context` first — it says what the word means in Carbon, which is often not the everyday sense. Then pick the word a manufacturing ERP sold in that market actually uses, not a dictionary rendering. Common traps: 'Job' is a shop-floor work order, not employment; 'Receipt' is goods arriving from a supplier, not a payment slip; 'Operation' is a routing step, not an action.",
+    "doNotSeedFromExistingTranslations": "Do not take a term from what the .po catalogs already say, and do not treat the most common existing rendering as correct. Those were translated without domain context and the majority word is wrong for several terms — Chinese renders 'Job' as 工作 (employment) in 117 of 165 strings. Copying the majority makes a wrong word consistent everywhere, which is harder to spot than inconsistency.",
+    "ambiguityRule": "Entries with an `ambiguity` note have a non-domain English meaning too. The approved rendering applies ONLY to the domain sense — do not blanket-replace.",
+    "variantsRule": "`englishVariants` are alternate English spellings already present in the catalogs that mean the same thing and must share one translation.",
+    "seeAlso": "`seeAlso` links an abbreviation to its spelled-out entry. They are RELATED but translated independently — an abbreviation may stay Latin where the full form is translated.",
+    "verifyAfterFilling": "Run `node .claude/skills/translate/scripts/check-glossary.mjs --locale <code>` to see how far the filled terms disagree with what is already in the catalogs. A high count is expected on first fill and means the existing translations need correcting — it does NOT mean the new term is wrong.",
+    "editedBy": "Anyone — a person or a model. This file is edited directly and deliberately; the /translate skill only READS it and must never write to it.",
+    "locales": [
+      "fr",
+      "de",
+      "es",
+      "it",
+      "ja",
+      "pl",
+      "pt",
+      "ru",
+      "zh",
+      "hi",
+      "tr",
+      "ko"
+    ],
+    "notInScope": "`nl` is absent from `supportedLanguages` in packages/locale/src/config.ts and its catalog is stale; it is deliberately excluded.",
+    "doNotTranslate": [
+      "Carbon",
+      "PDF",
+      "CSV",
+      "QR",
+      "API",
+      "URL",
+      "ID",
+      "SKU",
+      "EAN",
+      "UPC",
+      "CAD",
+      "STEP",
+      "GLB",
+      "SSO",
+      "MFA",
+      "JSON",
+      "XML"
+    ]
+  },
+  "terms": [
+    {
+      "term": "AP",
+      "category": "accounting",
+      "context": "Short form of Accounts Payable.",
+      "translations": {
+        "fr": "Comptes fournisseurs",
+        "de": "Kreditoren",
+        "es": "Cuentas por pagar",
+        "it": "Debiti verso fornitori",
+        "ja": "買掛金",
+        "pl": "Zobowiązania",
+        "pt": "Contas a pagar",
+        "ru": "Кредиторская задолженность",
+        "zh": "应付账款",
+        "hi": "देय खाते",
+        "tr": "Borç hesapları",
+        "ko": "매입채무"
+      }
+    },
+    {
+      "term": "AR",
+      "category": "accounting",
+      "context": "Short form of Accounts Receivable.",
+      "translations": {
+        "fr": "Comptes clients",
+        "de": "Debitoren",
+        "es": "Cuentas por cobrar",
+        "it": "Crediti verso clienti",
+        "ja": "売掛金",
+        "pl": "Należności",
+        "pt": "Contas a receber",
+        "ru": "Дебиторская задолженность",
+        "zh": "应收账款",
+        "hi": "प्राप्य खाते",
+        "tr": "Alacak hesapları",
+        "ko": "매출채권"
+      }
+    },
+    {
+      "term": "Accounting Period",
+      "category": "accounting",
+      "context": "The period a transaction is booked into.",
+      "translations": {
+        "fr": "Période comptable",
+        "de": "Buchungsperiode",
+        "es": "Período contable",
+        "it": "Periodo contabile",
+        "ja": "会計期間",
+        "pl": "Okres księgowy",
+        "pt": "Período contábil",
+        "ru": "Учетный период",
+        "zh": "会计期间",
+        "hi": "लेखा अवधि",
+        "tr": "Muhasebe dönemi",
+        "ko": "회계 기간"
+      }
+    },
+    {
+      "term": "Accounts Payable",
+      "category": "accounting",
+      "context": "What the company owes suppliers.",
+      "translations": {
+        "fr": "Comptes fournisseurs",
+        "de": "Verbindlichkeiten",
+        "es": "Cuentas por pagar",
+        "it": "Debiti verso fornitori",
+        "ja": "買掛金",
+        "pl": "Zobowiązania",
+        "pt": "Contas a pagar",
+        "ru": "Кредиторская задолженность",
+        "zh": "应付账款",
+        "hi": "देय खाते",
+        "tr": "Borç hesapları",
+        "ko": "매입채무"
+      }
+    },
+    {
+      "term": "Accounts Receivable",
+      "category": "accounting",
+      "context": "What customers owe the company.",
+      "translations": {
+        "fr": "Comptes clients",
+        "de": "Forderungen",
+        "es": "Cuentas por cobrar",
+        "it": "Crediti verso clienti",
+        "ja": "売掛金",
+        "pl": "Należności",
+        "pt": "Contas a receber",
+        "ru": "Дебиторская задолженность",
+        "zh": "应收账款",
+        "hi": "प्राप्य खाते",
+        "tr": "Alacak hesapları",
+        "ko": "매출채권"
+      }
+    },
+    {
+      "term": "Accumulated Depreciation",
+      "category": "accounting",
+      "context": "Total depreciation charged against an asset so far.",
+      "translations": {
+        "fr": "Amortissements cumulés",
+        "de": "Kumulierte Abschreibung",
+        "es": "Depreciación acumulada",
+        "it": "Fondo ammortamento",
+        "ja": "減価償却累計額",
+        "pl": "Umorzenie",
+        "pt": "Depreciação acumulada",
+        "ru": "Накопленная амортизация",
+        "zh": "累计折旧",
+        "hi": "संचित मूल्यह्रास",
+        "tr": "Birikmiş amortisman",
+        "ko": "감가상각누계액"
+      }
+    },
+    {
+      "term": "Acquisition Cost",
+      "category": "accounting",
+      "context": "What a fixed asset originally cost.",
+      "translations": {
+        "fr": "Coût d'acquisition",
+        "de": "Anschaffungskosten",
+        "es": "Costo de adquisición",
+        "it": "Costo di acquisizione",
+        "ja": "取得原価",
+        "pl": "Cena nabycia",
+        "pt": "Custo de aquisição",
+        "ru": "Стоимость приобретения",
+        "zh": "购置成本",
+        "hi": "अधिग्रहण लागत",
+        "tr": "Edinme maliyeti",
+        "ko": "취득원가"
+      }
+    },
+    {
+      "term": "Asset Class",
+      "category": "accounting",
+      "context": "The grouping that sets how a fixed asset depreciates.",
+      "translations": {
+        "fr": "Catégorie d'immobilisation",
+        "de": "Anlagenklasse",
+        "es": "Clase de activo",
+        "it": "Classe di cespiti",
+        "ja": "資産クラス",
+        "pl": "Klasa środków trwałych",
+        "pt": "Classe de ativo",
+        "ru": "Класс основных средств",
+        "zh": "资产类别",
+        "hi": "परिसंपत्ति वर्ग",
+        "tr": "Varlık sınıfı",
+        "ko": "자산 클래스"
+      }
+    },
+    {
+      "term": "Balance",
+      "category": "accounting",
+      "context": "What remains outstanding.",
+      "translations": {
+        "fr": "Solde",
+        "de": "Saldo",
+        "es": "Saldo",
+        "it": "Saldo",
+        "ja": "残高",
+        "pl": "Saldo",
+        "pt": "Saldo",
+        "ru": "Остаток",
+        "zh": "余额",
+        "hi": "शेष राशि",
+        "tr": "Bakiye",
+        "ko": "잔액"
+      }
+    },
+    {
+      "term": "Balance Sheet",
+      "category": "accounting",
+      "context": "The statement of assets, liabilities and equity.",
+      "translations": {
+        "fr": "Bilan",
+        "de": "Bilanz",
+        "es": "Balance general",
+        "it": "Stato patrimoniale",
+        "ja": "貸借対照表",
+        "pl": "Bilans",
+        "pt": "Balanço patrimonial",
+        "ru": "Бухгалтерский баланс",
+        "zh": "资产负债表",
+        "hi": "तुलन पत्र",
+        "tr": "Bilanço",
+        "ko": "재무상태표"
+      }
+    },
+    {
+      "term": "Bank",
+      "category": "accounting",
+      "context": "A bank account money moves through.",
+      "translations": {
+        "fr": "Banque",
+        "de": "Bank",
+        "es": "Banco",
+        "it": "Banca",
+        "ja": "銀行",
+        "pl": "Bank",
+        "pt": "Banco",
+        "ru": "Банк",
+        "zh": "银行",
+        "hi": "बैंक",
+        "tr": "Banka",
+        "ko": "은행"
+      }
+    },
+    {
+      "term": "Book Value",
+      "category": "accounting",
+      "context": "An asset's cost less accumulated depreciation.",
+      "translations": {
+        "fr": "Valeur comptable",
+        "de": "Buchwert",
+        "es": "Valor en libros",
+        "it": "Valore contabile",
+        "ja": "帳簿価額",
+        "pl": "Wartość księgowa",
+        "pt": "Valor contábil",
+        "ru": "Балансовая стоимость",
+        "zh": "账面价值",
+        "hi": "बही मूल्य",
+        "tr": "Defter değeri",
+        "ko": "장부가액"
+      }
+    },
+    {
+      "term": "Cash",
+      "category": "accounting",
+      "context": "A posted receipt or disbursement of money.",
+      "translations": {
+        "fr": "Trésorerie",
+        "de": "Kasse",
+        "es": "Efectivo",
+        "it": "Cassa",
+        "ja": "現金",
+        "pl": "Gotówka",
+        "pt": "Caixa",
+        "ru": "Денежные средства",
+        "zh": "现金",
+        "hi": "नकद",
+        "tr": "Nakit",
+        "ko": "현금"
+      }
+    },
+    {
+      "term": "Chart of Accounts",
+      "category": "accounting",
+      "context": "The full structured list of GL accounts.",
+      "translations": {
+        "fr": "Plan comptable",
+        "de": "Kontenplan",
+        "es": "Plan de cuentas",
+        "it": "Piano dei conti",
+        "ja": "勘定科目表",
+        "pl": "Plan kont",
+        "pt": "Plano de contas",
+        "ru": "План счетов",
+        "zh": "会计科目表",
+        "hi": "खातों का चार्ट",
+        "tr": "Hesap planı",
+        "ko": "계정과목표"
+      }
+    },
+    {
+      "term": "Cost",
+      "category": "accounting",
+      "context": "What something costs the company.",
+      "translations": {
+        "fr": "Coût",
+        "de": "Kosten",
+        "es": "Costo",
+        "it": "Costo",
+        "ja": "原価",
+        "pl": "Koszt",
+        "pt": "Custo",
+        "ru": "Себестоимость",
+        "zh": "成本",
+        "hi": "लागत",
+        "tr": "Maliyet",
+        "ko": "원가"
+      }
+    },
+    {
+      "term": "Cost Center",
+      "category": "accounting",
+      "context": "The bucket that costs are collected against.",
+      "translations": {
+        "fr": "Centre de coûts",
+        "de": "Kostenstelle",
+        "es": "Centro de costos",
+        "it": "Centro di costo",
+        "ja": "原価センター",
+        "pl": "Miejsce powstawania kosztów",
+        "pt": "Centro de custo",
+        "ru": "Центр затрат",
+        "zh": "成本中心",
+        "hi": "लागत केंद्र",
+        "tr": "Maliyet merkezi",
+        "ko": "원가 센터"
+      }
+    },
+    {
+      "term": "Cost of Goods Sold",
+      "category": "accounting",
+      "context": "The cost of the products actually sold in a period.",
+      "translations": {
+        "fr": "Coût des marchandises vendues",
+        "de": "Umsatzkosten",
+        "es": "Costo de ventas",
+        "it": "Costo del venduto",
+        "ja": "売上原価",
+        "pl": "Koszt własny sprzedaży",
+        "pt": "Custo dos produtos vendidos",
+        "ru": "Себестоимость продаж",
+        "zh": "销售成本",
+        "hi": "बेचे गए माल की लागत",
+        "tr": "Satılan malın maliyeti",
+        "ko": "매출원가"
+      }
+    },
+    {
+      "term": "Costing",
+      "category": "accounting",
+      "context": "The configuration and activity of working out what items cost.",
+      "translations": {
+        "fr": "Calcul des coûts",
+        "de": "Kalkulation",
+        "es": "Costeo",
+        "it": "Calcolo dei costi",
+        "ja": "原価計算",
+        "pl": "Kalkulacja kosztów",
+        "pt": "Custeio",
+        "ru": "Калькуляция",
+        "zh": "成本核算",
+        "hi": "लागत निर्धारण",
+        "tr": "Maliyetlendirme",
+        "ko": "원가 계산"
+      }
+    },
+    {
+      "term": "Credit",
+      "category": "accounting",
+      "context": "The right side of a posting.",
+      "translations": {
+        "fr": "Crédit",
+        "de": "Haben",
+        "es": "Haber",
+        "it": "Avere",
+        "ja": "貸方",
+        "pl": "Ma",
+        "pt": "Crédito",
+        "ru": "Кредит",
+        "zh": "贷方",
+        "hi": "जमा",
+        "tr": "Alacak",
+        "ko": "대변"
+      }
+    },
+    {
+      "term": "Credit Memo",
+      "category": "accounting",
+      "context": "A document reducing what is owed.",
+      "translations": {
+        "fr": "Avoir",
+        "de": "Gutschrift",
+        "es": "Nota de crédito",
+        "it": "Nota di credito",
+        "ja": "クレジットメモ",
+        "pl": "Faktura korygująca",
+        "pt": "Nota de crédito",
+        "ru": "Кредит-нота",
+        "zh": "贷项凭证",
+        "hi": "क्रेडिट नोट",
+        "tr": "Alacak dekontu",
+        "ko": "대변전표"
+      }
+    },
+    {
+      "term": "Currency",
+      "category": "accounting",
+      "context": "The money a transaction is denominated in.",
+      "translations": {
+        "fr": "Devise",
+        "de": "Währung",
+        "es": "Moneda",
+        "it": "Valuta",
+        "ja": "通貨",
+        "pl": "Waluta",
+        "pt": "Moeda",
+        "ru": "Валюта",
+        "zh": "货币",
+        "hi": "मुद्रा",
+        "tr": "Para birimi",
+        "ko": "통화"
+      }
+    },
+    {
+      "term": "Currency Translation",
+      "category": "accounting",
+      "context": "Restating amounts from one currency into another.",
+      "translations": {
+        "fr": "Conversion de devises",
+        "de": "Währungsumrechnung",
+        "es": "Conversión de moneda",
+        "it": "Conversione valuta",
+        "ja": "通貨換算",
+        "pl": "Przeliczenie walut",
+        "pt": "Conversão de moeda",
+        "ru": "Пересчет валют",
+        "zh": "货币折算",
+        "hi": "मुद्रा रूपांतरण",
+        "tr": "Kur çevrimi",
+        "ko": "통화 환산"
+      }
+    },
+    {
+      "term": "Debit",
+      "category": "accounting",
+      "context": "The left side of a posting.",
+      "translations": {
+        "fr": "Débit",
+        "de": "Soll",
+        "es": "Debe",
+        "it": "Dare",
+        "ja": "借方",
+        "pl": "Winien",
+        "pt": "Débito",
+        "ru": "Дебет",
+        "zh": "借方",
+        "hi": "नामे",
+        "tr": "Borç",
+        "ko": "차변"
+      }
+    },
+    {
+      "term": "Declining Balance",
+      "category": "accounting",
+      "context": "A depreciation method charging more early and less later.",
+      "translations": {
+        "fr": "Dégressif",
+        "de": "Degressiv",
+        "es": "Saldo decreciente",
+        "it": "Quote decrescenti",
+        "ja": "定率法",
+        "pl": "Metoda degresywna",
+        "pt": "Saldo decrescente",
+        "ru": "Уменьшаемый остаток",
+        "zh": "余额递减法",
+        "hi": "ह्रासमान शेष",
+        "tr": "Azalan bakiye",
+        "ko": "정률법"
+      }
+    },
+    {
+      "term": "Deferred Tax",
+      "category": "accounting",
+      "context": "Tax recognised in a different period than the transaction.",
+      "translations": {
+        "fr": "Impôt différé",
+        "de": "Latente Steuern",
+        "es": "Impuesto diferido",
+        "it": "Imposte differite",
+        "ja": "繰延税金",
+        "pl": "Podatek odroczony",
+        "pt": "Imposto diferido",
+        "ru": "Отложенный налог",
+        "zh": "递延所得税",
+        "hi": "आस्थगित कर",
+        "tr": "Ertelenmiş vergi",
+        "ko": "이연법인세"
+      }
+    },
+    {
+      "term": "Depreciation",
+      "category": "accounting",
+      "context": "Spreading a fixed asset's cost over its life.",
+      "translations": {
+        "fr": "Amortissement",
+        "de": "Abschreibung",
+        "es": "Depreciación",
+        "it": "Ammortamento",
+        "ja": "減価償却",
+        "pl": "Amortyzacja",
+        "pt": "Depreciação",
+        "ru": "Амортизация",
+        "zh": "折旧",
+        "hi": "मूल्यह्रास",
+        "tr": "Amortisman",
+        "ko": "감가상각"
+      }
+    },
+    {
+      "term": "Depreciation Method",
+      "category": "accounting",
+      "context": "The formula spreading an asset's cost over its life (straight line, declining balance).",
+      "translations": {
+        "fr": "Méthode d'amortissement",
+        "de": "Abschreibungsmethode",
+        "es": "Método de depreciación",
+        "it": "Metodo di ammortamento",
+        "ja": "減価償却方法",
+        "pl": "Metoda amortyzacji",
+        "pt": "Método de depreciação",
+        "ru": "Метод амортизации",
+        "zh": "折旧方法",
+        "hi": "मूल्यह्रास विधि",
+        "tr": "Amortisman yöntemi",
+        "ko": "감가상각 방법"
+      }
+    },
+    {
+      "term": "Dimension",
+      "category": "accounting",
+      "context": "An extra reporting axis on a posting (department, project).",
+      "translations": {
+        "fr": "Axe analytique",
+        "de": "Dimension",
+        "es": "Dimensión",
+        "it": "Dimensione",
+        "ja": "ディメンション",
+        "pl": "Wymiar",
+        "pt": "Dimensão",
+        "ru": "Измерение",
+        "zh": "维度",
+        "hi": "आयाम",
+        "tr": "Boyut",
+        "ko": "차원"
+      }
+    },
+    {
+      "term": "Disbursement",
+      "category": "accounting",
+      "context": "Money paid out to a supplier.",
+      "translations": {
+        "fr": "Décaissement",
+        "de": "Auszahlung",
+        "es": "Desembolso",
+        "it": "Esborso",
+        "ja": "出金",
+        "pl": "Wypłata",
+        "pt": "Desembolso",
+        "ru": "Выплата",
+        "zh": "支付",
+        "hi": "संवितरण",
+        "tr": "Tediye",
+        "ko": "지급"
+      }
+    },
+    {
+      "term": "Disposal",
+      "category": "accounting",
+      "context": "Removing a fixed asset from the books by sale or scrapping.",
+      "translations": {
+        "fr": "Cession",
+        "de": "Abgang",
+        "es": "Baja",
+        "it": "Dismissione",
+        "ja": "除却",
+        "pl": "Likwidacja",
+        "pt": "Baixa",
+        "ru": "Выбытие",
+        "zh": "处置",
+        "hi": "निपटान",
+        "tr": "Elden çıkarma",
+        "ko": "처분"
+      }
+    },
+    {
+      "term": "Equity",
+      "category": "accounting",
+      "context": "Owners' residual interest in the business.",
+      "translations": {
+        "fr": "Capitaux propres",
+        "de": "Eigenkapital",
+        "es": "Patrimonio",
+        "it": "Patrimonio netto",
+        "ja": "純資産",
+        "pl": "Kapitał własny",
+        "pt": "Patrimônio líquido",
+        "ru": "Собственный капитал",
+        "zh": "所有者权益",
+        "hi": "इक्विटी",
+        "tr": "Özkaynak",
+        "ko": "자본"
+      }
+    },
+    {
+      "term": "Exchange Rate",
+      "category": "accounting",
+      "context": "The multiplier converting one currency to another.",
+      "translations": {
+        "fr": "Taux de change",
+        "de": "Wechselkurs",
+        "es": "Tipo de cambio",
+        "it": "Tasso di cambio",
+        "ja": "為替レート",
+        "pl": "Kurs wymiany",
+        "pt": "Taxa de câmbio",
+        "ru": "Валютный курс",
+        "zh": "汇率",
+        "hi": "विनिमय दर",
+        "tr": "Döviz kuru",
+        "ko": "환율"
+      }
+    },
+    {
+      "term": "Expense",
+      "category": "accounting",
+      "context": "A cost charged to the business rather than capitalised.",
+      "translations": {
+        "fr": "Charge",
+        "de": "Aufwand",
+        "es": "Gasto",
+        "it": "Spesa",
+        "ja": "費用",
+        "pl": "Wydatek",
+        "pt": "Despesa",
+        "ru": "Расход",
+        "zh": "费用",
+        "hi": "व्यय",
+        "tr": "Gider",
+        "ko": "비용"
+      }
+    },
+    {
+      "term": "Fiscal Year",
+      "category": "accounting",
+      "context": "The company's accounting year.",
+      "translations": {
+        "fr": "Exercice comptable",
+        "de": "Geschäftsjahr",
+        "es": "Ejercicio fiscal",
+        "it": "Esercizio fiscale",
+        "ja": "会計年度",
+        "pl": "Rok obrotowy",
+        "pt": "Ano fiscal",
+        "ru": "Финансовый год",
+        "zh": "会计年度",
+        "hi": "वित्तीय वर्ष",
+        "tr": "Mali yıl",
+        "ko": "회계연도"
+      }
+    },
+    {
+      "term": "Fixed Asset",
+      "category": "accounting",
+      "context": "Equipment owned and depreciated rather than consumed.",
+      "translations": {
+        "fr": "Immobilisation",
+        "de": "Anlagegut",
+        "es": "Activo fijo",
+        "it": "Cespite",
+        "ja": "固定資産",
+        "pl": "Środek trwały",
+        "pt": "Ativo fixo",
+        "ru": "Основное средство",
+        "zh": "固定资产",
+        "hi": "अचल संपत्ति",
+        "tr": "Sabit kıymet",
+        "ko": "고정자산"
+      }
+    },
+    {
+      "term": "GL",
+      "category": "accounting",
+      "context": "Short form of General Ledger, used mainly in 'GL Account'.",
+      "translations": {
+        "fr": "Grand livre",
+        "de": "Hauptbuch",
+        "es": "Libro mayor",
+        "it": "Contabilità generale",
+        "ja": "総勘定元帳",
+        "pl": "Księga główna",
+        "pt": "Razão",
+        "ru": "Главная книга",
+        "zh": "总账",
+        "hi": "सामान्य खाता बही",
+        "tr": "Büyük defter",
+        "ko": "총계정원장"
+      }
+    },
+    {
+      "term": "GL Account",
+      "category": "accounting",
+      "context": "A general-ledger account that postings land in.",
+      "ambiguity": "'Account' alone also means a login account — keep them distinct.",
+      "translations": {
+        "fr": "Compte général",
+        "de": "Sachkonto",
+        "es": "Cuenta contable",
+        "it": "Conto contabile",
+        "ja": "勘定科目",
+        "pl": "Konto księgowe",
+        "pt": "Conta contábil",
+        "ru": "Счет учета",
+        "zh": "总账科目",
+        "hi": "लेजर खाता",
+        "tr": "Muhasebe hesabı",
+        "ko": "계정과목"
+      }
+    },
+    {
+      "term": "GR/IR",
+      "category": "accounting",
+      "context": "Goods Received / Invoice Received — the clearing account between receipt and invoice.",
+      "translations": {
+        "fr": "GR/IR",
+        "de": "WE/RE",
+        "es": "GR/IR",
+        "it": "GR/IR",
+        "ja": "GR/IR",
+        "pl": "GR/IR",
+        "pt": "GR/IR",
+        "ru": "GR/IR",
+        "zh": "GR/IR",
+        "hi": "GR/IR",
+        "tr": "GR/IR",
+        "ko": "GR/IR"
+      }
+    },
+    {
+      "term": "General Ledger",
+      "category": "accounting",
+      "context": "The book of record for all financial postings.",
+      "translations": {
+        "fr": "Grand livre",
+        "de": "Hauptbuch",
+        "es": "Libro mayor",
+        "it": "Contabilità generale",
+        "ja": "総勘定元帳",
+        "pl": "Księga główna",
+        "pt": "Livro razão",
+        "ru": "Главная книга",
+        "zh": "总账",
+        "hi": "सामान्य खाता बही",
+        "tr": "Büyük defter",
+        "ko": "총계정원장"
+      }
+    },
+    {
+      "term": "Historical Rate",
+      "category": "accounting",
+      "context": "The exchange rate at the time of the original transaction.",
+      "translations": {
+        "fr": "Taux historique",
+        "de": "Historischer Kurs",
+        "es": "Tipo de cambio histórico",
+        "it": "Cambio storico",
+        "ja": "取得時レート",
+        "pl": "Kurs historyczny",
+        "pt": "Taxa histórica",
+        "ru": "Исторический курс",
+        "zh": "历史汇率",
+        "hi": "ऐतिहासिक दर",
+        "tr": "Tarihsel kur",
+        "ko": "역사적 환율"
+      }
+    },
+    {
+      "term": "Income",
+      "category": "accounting",
+      "context": "Money earned, as an account category.",
+      "translations": {
+        "fr": "Produits",
+        "de": "Erträge",
+        "es": "Ingresos",
+        "it": "Proventi",
+        "ja": "収益",
+        "pl": "Przychody",
+        "pt": "Receitas",
+        "ru": "Доходы",
+        "zh": "收益",
+        "hi": "आय",
+        "tr": "Gelir",
+        "ko": "수익"
+      }
+    },
+    {
+      "term": "Income Statement",
+      "category": "accounting",
+      "context": "The statement of revenue and expenses over a period.",
+      "translations": {
+        "fr": "Compte de résultat",
+        "de": "Gewinn- und Verlustrechnung",
+        "es": "Estado de resultados",
+        "it": "Conto economico",
+        "ja": "損益計算書",
+        "pl": "Rachunek zysków i strat",
+        "pt": "Demonstração de resultados",
+        "ru": "Отчет о прибылях и убытках",
+        "zh": "利润表",
+        "hi": "आय विवरण",
+        "tr": "Gelir tablosu",
+        "ko": "손익계산서"
+      }
+    },
+    {
+      "term": "Interest",
+      "category": "accounting",
+      "context": "A finance charge on an overdue balance.",
+      "translations": {
+        "fr": "Intérêts",
+        "de": "Zinsen",
+        "es": "Intereses",
+        "it": "Interessi",
+        "ja": "利息",
+        "pl": "Odsetki",
+        "pt": "Juros",
+        "ru": "Проценты",
+        "zh": "利息",
+        "hi": "ब्याज",
+        "tr": "Faiz",
+        "ko": "이자"
+      }
+    },
+    {
+      "term": "Invoice",
+      "category": "accounting",
+      "context": "A bill — sales or purchase depending on context.",
+      "translations": {
+        "fr": "Facture",
+        "de": "Rechnung",
+        "es": "Factura",
+        "it": "Fattura",
+        "ja": "請求書",
+        "pl": "Faktura",
+        "pt": "Fatura",
+        "ru": "Счет-фактура",
+        "zh": "发票",
+        "hi": "चालान",
+        "tr": "Fatura",
+        "ko": "송장"
+      }
+    },
+    {
+      "term": "Invoice Line",
+      "category": "accounting",
+      "context": "One charge row on an invoice.",
+      "translations": {
+        "fr": "Ligne de facture",
+        "de": "Rechnungsposition",
+        "es": "Línea de factura",
+        "it": "Riga fattura",
+        "ja": "請求書明細",
+        "pl": "Pozycja faktury",
+        "pt": "Linha da fatura",
+        "ru": "Строка счета-фактуры",
+        "zh": "发票行",
+        "hi": "चालान पंक्ति",
+        "tr": "Fatura satırı",
+        "ko": "송장 라인"
+      }
+    },
+    {
+      "term": "Journal",
+      "category": "accounting",
+      "context": "A group of balanced financial postings.",
+      "translations": {
+        "fr": "Écriture",
+        "de": "Buchungssatz",
+        "es": "Asiento",
+        "it": "Prima nota",
+        "ja": "仕訳",
+        "pl": "Dowód księgowy",
+        "pt": "Diário",
+        "ru": "Операция",
+        "zh": "凭证",
+        "hi": "जर्नल",
+        "tr": "Muhasebe fişi",
+        "ko": "전표"
+      }
+    },
+    {
+      "term": "Journal Entry",
+      "category": "accounting",
+      "context": "One line of a journal, debit or credit.",
+      "translations": {
+        "fr": "Ligne d'écriture",
+        "de": "Buchungszeile",
+        "es": "Apunte",
+        "it": "Riga di registrazione",
+        "ja": "仕訳行",
+        "pl": "Zapis księgowy",
+        "pt": "Lançamento",
+        "ru": "Проводка",
+        "zh": "分录",
+        "hi": "जर्नल प्रविष्टि",
+        "tr": "Yevmiye kaydı",
+        "ko": "분개"
+      }
+    },
+    {
+      "term": "Net Book Value",
+      "category": "accounting",
+      "context": "Acquisition cost less accumulated depreciation.",
+      "translations": {
+        "fr": "Valeur nette comptable",
+        "de": "Restbuchwert",
+        "es": "Valor neto en libros",
+        "it": "Valore contabile netto",
+        "ja": "未償却残高",
+        "pl": "Wartość księgowa netto",
+        "pt": "Valor contábil líquido",
+        "ru": "Остаточная стоимость",
+        "zh": "账面净值",
+        "hi": "शुद्ध बही मूल्य",
+        "tr": "Net defter değeri",
+        "ko": "순장부가액"
+      }
+    },
+    {
+      "term": "Other Expense",
+      "category": "accounting",
+      "context": "Cost outside normal trading.",
+      "translations": {
+        "fr": "Autres charges",
+        "de": "Sonstige Aufwendungen",
+        "es": "Otros gastos",
+        "it": "Altre spese",
+        "ja": "営業外費用",
+        "pl": "Pozostałe koszty",
+        "pt": "Outras despesas",
+        "ru": "Прочие расходы",
+        "zh": "营业外支出",
+        "hi": "अन्य व्यय",
+        "tr": "Diğer giderler",
+        "ko": "영업외비용"
+      }
+    },
+    {
+      "term": "Other Income",
+      "category": "accounting",
+      "context": "Income outside normal trading.",
+      "translations": {
+        "fr": "Autres produits",
+        "de": "Sonstige Erträge",
+        "es": "Otros ingresos",
+        "it": "Altri proventi",
+        "ja": "営業外収益",
+        "pl": "Pozostałe przychody",
+        "pt": "Outras receitas",
+        "ru": "Прочие доходы",
+        "zh": "营业外收入",
+        "hi": "अन्य आय",
+        "tr": "Diğer gelirler",
+        "ko": "영업외수익"
+      }
+    },
+    {
+      "term": "Overhead",
+      "category": "accounting",
+      "context": "Indirect cost applied to production.",
+      "translations": {
+        "fr": "Frais généraux",
+        "de": "Gemeinkosten",
+        "es": "Costos indirectos",
+        "it": "Costi generali",
+        "ja": "間接費",
+        "pl": "Koszty pośrednie",
+        "pt": "Custos indiretos",
+        "ru": "Накладные расходы",
+        "zh": "制造费用",
+        "hi": "उपरिव्यय",
+        "tr": "Genel üretim giderleri",
+        "ko": "간접비"
+      }
+    },
+    {
+      "term": "Overhead Absorption",
+      "category": "accounting",
+      "context": "Applying indirect cost to production output.",
+      "translations": {
+        "fr": "Imputation des frais généraux",
+        "de": "Gemeinkostenverrechnung",
+        "es": "Absorción de costos indirectos",
+        "it": "Assorbimento dei costi generali",
+        "ja": "間接費配賦",
+        "pl": "Rozliczenie kosztów pośrednich",
+        "pt": "Absorção de custos indiretos",
+        "ru": "Распределение накладных расходов",
+        "zh": "制造费用分配",
+        "hi": "उपरिव्यय अवशोषण",
+        "tr": "Genel üretim gideri dağıtımı",
+        "ko": "간접비 배부"
+      }
+    },
+    {
+      "term": "Payables",
+      "category": "accounting",
+      "context": "What the company owes suppliers.",
+      "translations": {
+        "fr": "Dettes fournisseurs",
+        "de": "Verbindlichkeiten",
+        "es": "Cuentas por pagar",
+        "it": "Debiti",
+        "ja": "買掛金",
+        "pl": "Zobowiązania",
+        "pt": "Contas a pagar",
+        "ru": "Кредиторская задолженность",
+        "zh": "应付款项",
+        "hi": "देय राशि",
+        "tr": "Borçlar",
+        "ko": "매입채무"
+      }
+    },
+    {
+      "term": "Payment",
+      "category": "accounting",
+      "context": "Money moving in or out against an invoice.",
+      "translations": {
+        "fr": "Paiement",
+        "de": "Zahlung",
+        "es": "Pago",
+        "it": "Pagamento",
+        "ja": "支払",
+        "pl": "Płatność",
+        "pt": "Pagamento",
+        "ru": "Платеж",
+        "zh": "付款",
+        "hi": "भुगतान",
+        "tr": "Ödeme",
+        "ko": "지불"
+      }
+    },
+    {
+      "term": "Payment Term",
+      "category": "accounting",
+      "context": "When an invoice is due.",
+      "translations": {
+        "fr": "Conditions de paiement",
+        "de": "Zahlungsbedingung",
+        "es": "Condiciones de pago",
+        "it": "Condizioni di pagamento",
+        "ja": "支払条件",
+        "pl": "Warunki płatności",
+        "pt": "Condição de pagamento",
+        "ru": "Условия оплаты",
+        "zh": "付款条件",
+        "hi": "भुगतान शर्तें",
+        "tr": "Ödeme koşulu",
+        "ko": "지불 조건"
+      }
+    },
+    {
+      "term": "Posting",
+      "category": "accounting",
+      "context": "Committing a transaction to the ledger.",
+      "translations": {
+        "fr": "Comptabilisation",
+        "de": "Buchung",
+        "es": "Contabilización",
+        "it": "Registrazione",
+        "ja": "転記",
+        "pl": "Księgowanie",
+        "pt": "Contabilização",
+        "ru": "Проведение",
+        "zh": "过账",
+        "hi": "पोस्टिंग",
+        "tr": "Muhasebeleştirme",
+        "ko": "전기"
+      }
+    },
+    {
+      "term": "Prepayment",
+      "category": "accounting",
+      "context": "Money paid before the goods or service arrive.",
+      "translations": {
+        "fr": "Acompte",
+        "de": "Anzahlung",
+        "es": "Anticipo",
+        "it": "Acconto",
+        "ja": "前払金",
+        "pl": "Zaliczka",
+        "pt": "Adiantamento",
+        "ru": "Предоплата",
+        "zh": "预付款",
+        "hi": "अग्रिम भुगतान",
+        "tr": "Avans",
+        "ko": "선급금"
+      }
+    },
+    {
+      "term": "Purchase Invoice",
+      "category": "accounting",
+      "context": "The bill received from a supplier.",
+      "translations": {
+        "fr": "Facture d'achat",
+        "de": "Eingangsrechnung",
+        "es": "Factura de compra",
+        "it": "Fattura di acquisto",
+        "ja": "仕入先請求書",
+        "pl": "Faktura zakupu",
+        "pt": "Fatura de compra",
+        "ru": "Счет-фактура полученный",
+        "zh": "采购发票",
+        "hi": "क्रय चालान",
+        "tr": "Alış faturası",
+        "ko": "매입 송장"
+      }
+    },
+    {
+      "term": "Receivables",
+      "category": "accounting",
+      "context": "What customers owe the company.",
+      "translations": {
+        "fr": "Créances clients",
+        "de": "Forderungen",
+        "es": "Cuentas por cobrar",
+        "it": "Crediti",
+        "ja": "売掛金",
+        "pl": "Należności",
+        "pt": "Contas a receber",
+        "ru": "Дебиторская задолженность",
+        "zh": "应收款项",
+        "hi": "प्राप्य राशि",
+        "tr": "Alacaklar",
+        "ko": "매출채권"
+      }
+    },
+    {
+      "term": "Residual Value",
+      "category": "accounting",
+      "context": "What an asset is expected to be worth at the end of its life.",
+      "translations": {
+        "fr": "Valeur résiduelle",
+        "de": "Restwert",
+        "es": "Valor residual",
+        "it": "Valore residuo",
+        "ja": "残存価額",
+        "pl": "Wartość rezydualna",
+        "pt": "Valor residual",
+        "ru": "Ликвидационная стоимость",
+        "zh": "残值",
+        "hi": "अवशिष्ट मूल्य",
+        "tr": "Kalıntı değer",
+        "ko": "잔존가액"
+      }
+    },
+    {
+      "term": "Retained Earnings",
+      "category": "accounting",
+      "context": "Accumulated profit not paid out.",
+      "translations": {
+        "fr": "Report à nouveau",
+        "de": "Gewinnvortrag",
+        "es": "Resultados acumulados",
+        "it": "Utili non distribuiti",
+        "ja": "利益剰余金",
+        "pl": "Zyski zatrzymane",
+        "pt": "Lucros acumulados",
+        "ru": "Нераспределенная прибыль",
+        "zh": "未分配利润",
+        "hi": "प्रतिधारित आय",
+        "tr": "Dağıtılmamış kârlar",
+        "ko": "이익잉여금"
+      }
+    },
+    {
+      "term": "Revenue",
+      "category": "accounting",
+      "context": "Income earned from sales.",
+      "translations": {
+        "fr": "Revenus",
+        "de": "Umsatzerlöse",
+        "es": "Ingresos por ventas",
+        "it": "Ricavi",
+        "ja": "売上高",
+        "pl": "Przychody ze sprzedaży",
+        "pt": "Receita",
+        "ru": "Выручка",
+        "zh": "收入",
+        "hi": "राजस्व",
+        "tr": "Hasılat",
+        "ko": "매출"
+      }
+    },
+    {
+      "term": "Sales Invoice",
+      "category": "accounting",
+      "context": "The bill sent to a customer.",
+      "translations": {
+        "fr": "Facture de vente",
+        "de": "Ausgangsrechnung",
+        "es": "Factura de venta",
+        "it": "Fattura di vendita",
+        "ja": "売上請求書",
+        "pl": "Faktura sprzedaży",
+        "pt": "Fatura de venda",
+        "ru": "Счет-фактура выданный",
+        "zh": "销售发票",
+        "hi": "विक्रय चालान",
+        "tr": "Satış faturası",
+        "ko": "매출 송장"
+      }
+    },
+    {
+      "term": "Service Charge",
+      "category": "accounting",
+      "context": "A fee added to a document.",
+      "translations": {
+        "fr": "Frais de service",
+        "de": "Servicegebühr",
+        "es": "Cargo por servicio",
+        "it": "Spese di servizio",
+        "ja": "サービス料",
+        "pl": "Opłata za usługę",
+        "pt": "Taxa de serviço",
+        "ru": "Сервисный сбор",
+        "zh": "服务费",
+        "hi": "सेवा शुल्क",
+        "tr": "Hizmet bedeli",
+        "ko": "서비스 요금"
+      }
+    },
+    {
+      "term": "Standard Cost",
+      "category": "accounting",
+      "context": "The planned cost used for valuation.",
+      "translations": {
+        "fr": "Coût standard",
+        "de": "Standardkosten",
+        "es": "Costo estándar",
+        "it": "Costo standard",
+        "ja": "標準原価",
+        "pl": "Koszt standardowy",
+        "pt": "Custo padrão",
+        "ru": "Нормативная себестоимость",
+        "zh": "标准成本",
+        "hi": "मानक लागत",
+        "tr": "Standart maliyet",
+        "ko": "표준원가"
+      }
+    },
+    {
+      "term": "Straight Line",
+      "category": "accounting",
+      "context": "A depreciation method charging an equal amount each period.",
+      "translations": {
+        "fr": "Linéaire",
+        "de": "Linear",
+        "es": "Línea recta",
+        "it": "Quote costanti",
+        "ja": "定額法",
+        "pl": "Metoda liniowa",
+        "pt": "Linear",
+        "ru": "Линейный метод",
+        "zh": "直线法",
+        "hi": "सीधी रेखा",
+        "tr": "Doğrusal",
+        "ko": "정액법"
+      }
+    },
+    {
+      "term": "Subtotal",
+      "category": "accounting",
+      "context": "The amount before tax and shipping.",
+      "translations": {
+        "fr": "Sous-total",
+        "de": "Zwischensumme",
+        "es": "Subtotal",
+        "it": "Subtotale",
+        "ja": "小計",
+        "pl": "Suma częściowa",
+        "pt": "Subtotal",
+        "ru": "Промежуточный итог",
+        "zh": "小计",
+        "hi": "उप-योग",
+        "tr": "Ara toplam",
+        "ko": "소계"
+      }
+    },
+    {
+      "term": "Tax",
+      "category": "accounting",
+      "context": "Tax charged or paid on a transaction.",
+      "translations": {
+        "fr": "Taxe",
+        "de": "Steuer",
+        "es": "Impuesto",
+        "it": "Imposta",
+        "ja": "税",
+        "pl": "Podatek",
+        "pt": "Imposto",
+        "ru": "Налог",
+        "zh": "税",
+        "hi": "कर",
+        "tr": "Vergi",
+        "ko": "세금"
+      }
+    },
+    {
+      "term": "Tax Exempt",
+      "category": "accounting",
+      "context": "Not subject to tax.",
+      "translations": {
+        "fr": "Exonéré de taxe",
+        "de": "Steuerbefreit",
+        "es": "Exento de impuestos",
+        "it": "Esente da imposta",
+        "ja": "非課税",
+        "pl": "Zwolniony z podatku",
+        "pt": "Isento de imposto",
+        "ru": "Не облагается налогом",
+        "zh": "免税",
+        "hi": "कर मुक्त",
+        "tr": "Vergiden muaf",
+        "ko": "면세"
+      }
+    },
+    {
+      "term": "Total",
+      "category": "accounting",
+      "context": "The final amount including tax and shipping.",
+      "translations": {
+        "fr": "Total",
+        "de": "Gesamtbetrag",
+        "es": "Total",
+        "it": "Totale",
+        "ja": "合計",
+        "pl": "Suma",
+        "pt": "Total",
+        "ru": "Итого",
+        "zh": "总计",
+        "hi": "कुल",
+        "tr": "Toplam",
+        "ko": "총계"
+      }
+    },
+    {
+      "term": "Useful Life",
+      "category": "accounting",
+      "context": "How long an asset is expected to be productive.",
+      "translations": {
+        "fr": "Durée d'utilité",
+        "de": "Nutzungsdauer",
+        "es": "Vida útil",
+        "it": "Vita utile",
+        "ja": "耐用年数",
+        "pl": "Okres użytkowania",
+        "pt": "Vida útil",
+        "ru": "Срок полезного использования",
+        "zh": "使用年限",
+        "hi": "उपयोगी जीवन",
+        "tr": "Faydalı ömür",
+        "ko": "내용연수"
+      }
+    },
+    {
+      "term": "VAT Number",
+      "category": "accounting",
+      "context": "The company's value-added-tax registration number.",
+      "translations": {
+        "fr": "Numéro de TVA",
+        "de": "USt-IdNr.",
+        "es": "Número de IVA",
+        "it": "Partita IVA",
+        "ja": "VAT番号",
+        "pl": "NIP",
+        "pt": "Número de IVA",
+        "ru": "ИНН",
+        "zh": "税号",
+        "hi": "वैट नंबर",
+        "tr": "Vergi numarası",
+        "ko": "사업자등록번호"
+      }
+    },
+    {
+      "term": "Variance",
+      "category": "accounting",
+      "context": "The difference between planned and actual cost or quantity.",
+      "translations": {
+        "fr": "Écart",
+        "de": "Abweichung",
+        "es": "Desviación",
+        "it": "Scostamento",
+        "ja": "差異",
+        "pl": "Odchylenie",
+        "pt": "Variação",
+        "ru": "Отклонение",
+        "zh": "差异",
+        "hi": "विचलन",
+        "tr": "Sapma",
+        "ko": "차이"
+      }
+    },
+    {
+      "term": "Write-Down",
+      "category": "accounting",
+      "context": "Reducing a carrying value without removing it.",
+      "translations": {
+        "fr": "Dépréciation",
+        "de": "Abwertung",
+        "es": "Deterioro",
+        "it": "Svalutazione",
+        "ja": "評価減",
+        "pl": "Odpis aktualizujący",
+        "pt": "Desvalorização",
+        "ru": "Уценка",
+        "zh": "减值",
+        "hi": "अवमूल्यन",
+        "tr": "Değer düşüklüğü",
+        "ko": "평가감"
+      }
+    },
+    {
+      "term": "Write-Off",
+      "category": "accounting",
+      "context": "Removing an uncollectable or worthless balance.",
+      "translations": {
+        "fr": "Passage en perte",
+        "de": "Ausbuchung",
+        "es": "Cancelación contable",
+        "it": "Stralcio",
+        "ja": "償却",
+        "pl": "Spisanie",
+        "pt": "Baixa contábil",
+        "ru": "Списание",
+        "zh": "核销",
+        "hi": "बट्टे खाते",
+        "tr": "Kayıttan düşme",
+        "ko": "대손 처리"
+      }
+    },
+    {
+      "term": "Accept",
+      "category": "action",
+      "context": "Agree to a suggestion, quote or lot disposition.",
+      "translations": {
+        "fr": "Accepter",
+        "de": "Annehmen",
+        "es": "Aceptar",
+        "it": "Accetta",
+        "ja": "承諾",
+        "pl": "Zaakceptuj",
+        "pt": "Aceitar",
+        "ru": "Принять",
+        "zh": "接受",
+        "hi": "स्वीकार करें",
+        "tr": "Kabul et",
+        "ko": "수락"
+      }
+    },
+    {
+      "term": "Add",
+      "category": "action",
+      "context": "Put a new row or record into something.",
+      "translations": {
+        "fr": "Ajouter",
+        "de": "Hinzufügen",
+        "es": "Agregar",
+        "it": "Aggiungi",
+        "ja": "追加",
+        "pl": "Dodaj",
+        "pt": "Adicionar",
+        "ru": "Добавить",
+        "zh": "添加",
+        "hi": "जोड़ें",
+        "tr": "Ekle",
+        "ko": "추가"
+      }
+    },
+    {
+      "term": "Approve",
+      "category": "action",
+      "context": "Sign off.",
+      "translations": {
+        "fr": "Approuver",
+        "de": "Genehmigen",
+        "es": "Aprobar",
+        "it": "Approva",
+        "ja": "承認",
+        "pl": "Zatwierdź",
+        "pt": "Aprovar",
+        "ru": "Утвердить",
+        "zh": "审批",
+        "hi": "अनुमोदित करें",
+        "tr": "Onayla",
+        "ko": "승인"
+      }
+    },
+    {
+      "term": "Assign",
+      "category": "action",
+      "context": "Give a record to a person.",
+      "translations": {
+        "fr": "Attribuer",
+        "de": "Zuweisen",
+        "es": "Asignar",
+        "it": "Assegna",
+        "ja": "割り当て",
+        "pl": "Przypisz",
+        "pt": "Atribuir",
+        "ru": "Назначить",
+        "zh": "分配",
+        "hi": "असाइन करें",
+        "tr": "Ata",
+        "ko": "할당"
+      }
+    },
+    {
+      "term": "Cancel",
+      "category": "action",
+      "context": "Abandon without saving.",
+      "ambiguity": "Distinct from the Cancelled status on a record.",
+      "translations": {
+        "fr": "Annuler",
+        "de": "Abbrechen",
+        "es": "Cancelar",
+        "it": "Annulla",
+        "ja": "キャンセル",
+        "pl": "Anuluj",
+        "pt": "Cancelar",
+        "ru": "Отмена",
+        "zh": "取消",
+        "hi": "रद्द करें",
+        "tr": "İptal",
+        "ko": "취소"
+      }
+    },
+    {
+      "term": "Close",
+      "category": "action",
+      "context": "Finish a record so it can no longer be edited.",
+      "translations": {
+        "fr": "Clôturer",
+        "de": "Abschließen",
+        "es": "Cerrar",
+        "it": "Chiudi",
+        "ja": "クローズ",
+        "pl": "Zamknij",
+        "pt": "Fechar",
+        "ru": "Закрыть",
+        "zh": "关闭",
+        "hi": "बंद करें",
+        "tr": "Kapat",
+        "ko": "마감"
+      }
+    },
+    {
+      "term": "Complete",
+      "category": "action",
+      "context": "Mark something as finished. This is the ACTION on a button, not the status.",
+      "translations": {
+        "fr": "Terminer",
+        "de": "Abschließen",
+        "es": "Completar",
+        "it": "Completa",
+        "ja": "完了する",
+        "pl": "Zakończ",
+        "pt": "Concluir",
+        "ru": "Завершить",
+        "zh": "完成",
+        "hi": "पूर्ण करें",
+        "tr": "Tamamla",
+        "ko": "완료 처리"
+      },
+      "ambiguity": "Many languages inflect the verb differently from the status adjective — do not reuse the Completed rendering here."
+    },
+    {
+      "term": "Create",
+      "category": "action",
+      "context": "Make a new record.",
+      "translations": {
+        "fr": "Créer",
+        "de": "Erstellen",
+        "es": "Crear",
+        "it": "Crea",
+        "ja": "作成",
+        "pl": "Utwórz",
+        "pt": "Criar",
+        "ru": "Создать",
+        "zh": "创建",
+        "hi": "बनाएँ",
+        "tr": "Oluştur",
+        "ko": "생성"
+      }
+    },
+    {
+      "term": "Deactivate",
+      "category": "action",
+      "context": "Make inactive without deleting.",
+      "translations": {
+        "fr": "Désactiver",
+        "de": "Deaktivieren",
+        "es": "Desactivar",
+        "it": "Disattiva",
+        "ja": "無効化",
+        "pl": "Dezaktywuj",
+        "pt": "Desativar",
+        "ru": "Деактивировать",
+        "zh": "停用",
+        "hi": "निष्क्रिय करें",
+        "tr": "Devre dışı bırak",
+        "ko": "비활성화"
+      }
+    },
+    {
+      "term": "Delete",
+      "category": "action",
+      "context": "Remove permanently.",
+      "translations": {
+        "fr": "Supprimer",
+        "de": "Löschen",
+        "es": "Eliminar",
+        "it": "Elimina",
+        "ja": "削除",
+        "pl": "Usuń",
+        "pt": "Excluir",
+        "ru": "Удалить",
+        "zh": "删除",
+        "hi": "हटाएँ",
+        "tr": "Sil",
+        "ko": "삭제"
+      }
+    },
+    {
+      "term": "Download",
+      "category": "action",
+      "context": "Retrieve a file from Carbon.",
+      "translations": {
+        "fr": "Télécharger",
+        "de": "Herunterladen",
+        "es": "Descargar",
+        "it": "Scarica",
+        "ja": "ダウンロード",
+        "pl": "Pobierz",
+        "pt": "Baixar",
+        "ru": "Скачать",
+        "zh": "下载",
+        "hi": "डाउनलोड करें",
+        "tr": "İndir",
+        "ko": "다운로드"
+      }
+    },
+    {
+      "term": "Duplicate",
+      "category": "action",
+      "context": "Copy a record into a new one.",
+      "translations": {
+        "fr": "Dupliquer",
+        "de": "Duplizieren",
+        "es": "Duplicar",
+        "it": "Duplica",
+        "ja": "複製",
+        "pl": "Duplikuj",
+        "pt": "Duplicar",
+        "ru": "Дублировать",
+        "zh": "复制",
+        "hi": "डुप्लिकेट करें",
+        "tr": "Çoğalt",
+        "ko": "복제"
+      }
+    },
+    {
+      "term": "Edit",
+      "category": "action",
+      "context": "Change an existing record.",
+      "translations": {
+        "fr": "Modifier",
+        "de": "Bearbeiten",
+        "es": "Editar",
+        "it": "Modifica",
+        "ja": "編集",
+        "pl": "Edytuj",
+        "pt": "Editar",
+        "ru": "Изменить",
+        "zh": "编辑",
+        "hi": "संपादित करें",
+        "tr": "Düzenle",
+        "ko": "편집"
+      }
+    },
+    {
+      "term": "Export",
+      "category": "action",
+      "context": "Send data out, usually as a file.",
+      "translations": {
+        "fr": "Exporter",
+        "de": "Exportieren",
+        "es": "Exportar",
+        "it": "Esporta",
+        "ja": "エクスポート",
+        "pl": "Eksportuj",
+        "pt": "Exportar",
+        "ru": "Экспортировать",
+        "zh": "导出",
+        "hi": "निर्यात करें",
+        "tr": "Dışa aktar",
+        "ko": "내보내기"
+      }
+    },
+    {
+      "term": "Filter",
+      "category": "action",
+      "context": "Narrow a list.",
+      "translations": {
+        "fr": "Filtrer",
+        "de": "Filtern",
+        "es": "Filtrar",
+        "it": "Filtra",
+        "ja": "絞り込み",
+        "pl": "Filtruj",
+        "pt": "Filtrar",
+        "ru": "Фильтровать",
+        "zh": "筛选",
+        "hi": "फ़िल्टर करें",
+        "tr": "Filtrele",
+        "ko": "필터"
+      }
+    },
+    {
+      "term": "Import",
+      "category": "action",
+      "context": "Bring data in from a file.",
+      "translations": {
+        "fr": "Importer",
+        "de": "Importieren",
+        "es": "Importar",
+        "it": "Importa",
+        "ja": "インポート",
+        "pl": "Importuj",
+        "pt": "Importar",
+        "ru": "Импортировать",
+        "zh": "导入",
+        "hi": "आयात करें",
+        "tr": "İçe aktar",
+        "ko": "가져오기"
+      }
+    },
+    {
+      "term": "Move",
+      "category": "action",
+      "context": "Relocate stock or a record.",
+      "translations": {
+        "fr": "Déplacer",
+        "de": "Umlagern",
+        "es": "Mover",
+        "it": "Sposta",
+        "ja": "移動",
+        "pl": "Przenieś",
+        "pt": "Mover",
+        "ru": "Переместить",
+        "zh": "移动",
+        "hi": "स्थानांतरित करें",
+        "tr": "Taşı",
+        "ko": "이동"
+      }
+    },
+    {
+      "term": "Pause",
+      "category": "action",
+      "context": "Temporarily stop a running job operation.",
+      "translations": {
+        "fr": "Mettre en pause",
+        "de": "Unterbrechen",
+        "es": "Pausar",
+        "it": "Sospendi",
+        "ja": "一時停止",
+        "pl": "Wstrzymaj",
+        "pt": "Pausar",
+        "ru": "Приостановить",
+        "zh": "暂停",
+        "hi": "रोकें",
+        "tr": "Duraklat",
+        "ko": "일시 중지"
+      }
+    },
+    {
+      "term": "Post",
+      "category": "action",
+      "context": "Commit to the ledger.",
+      "ambiguity": "Not a social post or an HTTP POST.",
+      "translations": {
+        "fr": "Comptabiliser",
+        "de": "Buchen",
+        "es": "Contabilizar",
+        "it": "Registra",
+        "ja": "転記する",
+        "pl": "Zaksięguj",
+        "pt": "Contabilizar",
+        "ru": "Провести",
+        "zh": "过账",
+        "hi": "पोस्ट करें",
+        "tr": "Muhasebeleştir",
+        "ko": "전기"
+      }
+    },
+    {
+      "term": "Print",
+      "category": "action",
+      "context": "Produce a printed or PDF output.",
+      "translations": {
+        "fr": "Imprimer",
+        "de": "Drucken",
+        "es": "Imprimir",
+        "it": "Stampa",
+        "ja": "印刷",
+        "pl": "Drukuj",
+        "pt": "Imprimir",
+        "ru": "Печать",
+        "zh": "打印",
+        "hi": "प्रिंट करें",
+        "tr": "Yazdır",
+        "ko": "인쇄"
+      }
+    },
+    {
+      "term": "Reject",
+      "category": "action",
+      "context": "Refuse.",
+      "translations": {
+        "fr": "Rejeter",
+        "de": "Ablehnen",
+        "es": "Rechazar",
+        "it": "Rifiuta",
+        "ja": "却下",
+        "pl": "Odrzuć",
+        "pt": "Rejeitar",
+        "ru": "Отклонить",
+        "zh": "拒绝",
+        "hi": "अस्वीकार करें",
+        "tr": "Reddet",
+        "ko": "거부"
+      }
+    },
+    {
+      "term": "Release",
+      "category": "action",
+      "context": "Authorise work to start.",
+      "translations": {
+        "fr": "Lancer",
+        "de": "Freigeben",
+        "es": "Liberar",
+        "it": "Rilascia",
+        "ja": "リリース",
+        "pl": "Zwolnij",
+        "pt": "Liberar",
+        "ru": "Запустить в работу",
+        "zh": "下达",
+        "hi": "जारी करें",
+        "tr": "Serbest bırak",
+        "ko": "릴리스"
+      }
+    },
+    {
+      "term": "Remove",
+      "category": "action",
+      "context": "Take a row out, without necessarily deleting the record.",
+      "translations": {
+        "fr": "Retirer",
+        "de": "Entfernen",
+        "es": "Quitar",
+        "it": "Rimuovi",
+        "ja": "除去",
+        "pl": "Usuń z listy",
+        "pt": "Remover",
+        "ru": "Убрать",
+        "zh": "移除",
+        "hi": "निकालें",
+        "tr": "Kaldır",
+        "ko": "제거"
+      }
+    },
+    {
+      "term": "Reopen",
+      "category": "action",
+      "context": "Move a closed record back to open.",
+      "translations": {
+        "fr": "Rouvrir",
+        "de": "Wieder öffnen",
+        "es": "Reabrir",
+        "it": "Riapri",
+        "ja": "再オープン",
+        "pl": "Otwórz ponownie",
+        "pt": "Reabrir",
+        "ru": "Открыть заново",
+        "zh": "重新打开",
+        "hi": "फिर से खोलें",
+        "tr": "Yeniden aç",
+        "ko": "다시 열기"
+      }
+    },
+    {
+      "term": "Save",
+      "category": "action",
+      "context": "Persist the current changes.",
+      "translations": {
+        "fr": "Enregistrer",
+        "de": "Speichern",
+        "es": "Guardar",
+        "it": "Salva",
+        "ja": "保存",
+        "pl": "Zapisz",
+        "pt": "Salvar",
+        "ru": "Сохранить",
+        "zh": "保存",
+        "hi": "सहेजें",
+        "tr": "Kaydet",
+        "ko": "저장"
+      }
+    },
+    {
+      "term": "Search",
+      "category": "action",
+      "context": "Find records.",
+      "translations": {
+        "fr": "Rechercher",
+        "de": "Suchen",
+        "es": "Buscar",
+        "it": "Cerca",
+        "ja": "検索",
+        "pl": "Szukaj",
+        "pt": "Pesquisar",
+        "ru": "Поиск",
+        "zh": "搜索",
+        "hi": "खोजें",
+        "tr": "Ara",
+        "ko": "검색"
+      }
+    },
+    {
+      "term": "Submit",
+      "category": "action",
+      "context": "Send for approval or processing.",
+      "translations": {
+        "fr": "Soumettre",
+        "de": "Einreichen",
+        "es": "Enviar",
+        "it": "Invia",
+        "ja": "提出",
+        "pl": "Prześlij",
+        "pt": "Enviar",
+        "ru": "Отправить",
+        "zh": "提交",
+        "hi": "सबमिट करें",
+        "tr": "Gönder",
+        "ko": "제출"
+      }
+    },
+    {
+      "term": "Update",
+      "category": "action",
+      "context": "Apply changes to an existing record.",
+      "translations": {
+        "fr": "Mettre à jour",
+        "de": "Aktualisieren",
+        "es": "Actualizar",
+        "it": "Aggiorna",
+        "ja": "更新",
+        "pl": "Aktualizuj",
+        "pt": "Atualizar",
+        "ru": "Обновить",
+        "zh": "更新",
+        "hi": "अपडेट करें",
+        "tr": "Güncelle",
+        "ko": "업데이트"
+      }
+    },
+    {
+      "term": "Upload",
+      "category": "action",
+      "context": "Send a file to Carbon.",
+      "translations": {
+        "fr": "Téléverser",
+        "de": "Hochladen",
+        "es": "Subir",
+        "it": "Carica",
+        "ja": "アップロード",
+        "pl": "Prześlij plik",
+        "pt": "Enviar arquivo",
+        "ru": "Загрузить",
+        "zh": "上传",
+        "hi": "अपलोड करें",
+        "tr": "Yükle",
+        "ko": "업로드"
+      }
+    },
+    {
+      "term": "View",
+      "category": "action",
+      "context": "Open a record read-only.",
+      "translations": {
+        "fr": "Afficher",
+        "de": "Anzeigen",
+        "es": "Ver",
+        "it": "Visualizza",
+        "ja": "表示",
+        "pl": "Wyświetl",
+        "pt": "Visualizar",
+        "ru": "Просмотр",
+        "zh": "查看",
+        "hi": "देखें",
+        "tr": "Görüntüle",
+        "ko": "보기"
+      }
+    },
+    {
+      "term": "Change Notice",
+      "category": "changes",
+      "context": "The controlled record for a design or process change.",
+      "translations": {
+        "fr": "Avis de modification",
+        "de": "Änderungsmitteilung",
+        "es": "Aviso de cambio",
+        "it": "Avviso di modifica",
+        "ja": "変更通知",
+        "pl": "Zawiadomienie o zmianie",
+        "pt": "Aviso de alteração",
+        "ru": "Извещение об изменении",
+        "zh": "变更通知",
+        "hi": "परिवर्तन सूचना",
+        "tr": "Değişiklik bildirimi",
+        "ko": "변경 통지"
+      }
+    },
+    {
+      "term": "Change Order",
+      "category": "changes",
+      "context": "The older name for a Change Notice; both appear.",
+      "translations": {
+        "fr": "Ordre de modification",
+        "de": "Änderungsauftrag",
+        "es": "Orden de cambio",
+        "it": "Ordine di modifica",
+        "ja": "変更指示",
+        "pl": "Zlecenie zmiany",
+        "pt": "Ordem de alteração",
+        "ru": "Приказ об изменении",
+        "zh": "变更单",
+        "hi": "परिवर्तन आदेश",
+        "tr": "Değişiklik emri",
+        "ko": "변경 오더"
+      }
+    },
+    {
+      "term": "ECO",
+      "category": "changes",
+      "context": "Short form of Engineering Change Order.",
+      "translations": {
+        "fr": "ECO",
+        "de": "ECO",
+        "es": "ECO",
+        "it": "ECO",
+        "ja": "ECO",
+        "pl": "ECO",
+        "pt": "ECO",
+        "ru": "ECO",
+        "zh": "ECO",
+        "hi": "ECO",
+        "tr": "ECO",
+        "ko": "ECO"
+      }
+    },
+    {
+      "term": "Effectivity",
+      "category": "changes",
+      "context": "The date from which a change or supersession applies.",
+      "translations": {
+        "fr": "Date d'effet",
+        "de": "Gültigkeit",
+        "es": "Efectividad",
+        "it": "Efficacia",
+        "ja": "有効日",
+        "pl": "Data obowiązywania",
+        "pt": "Efetividade",
+        "ru": "Дата вступления в силу",
+        "zh": "生效日期",
+        "hi": "प्रभावी तिथि",
+        "tr": "Geçerlilik",
+        "ko": "유효 시점"
+      }
+    },
+    {
+      "term": "Engineering Change",
+      "category": "changes",
+      "context": "A controlled change to an item's method, released as a set of affected items that supersede the versions they replace.",
+      "translations": {
+        "fr": "Modification technique",
+        "de": "Technische Änderung",
+        "es": "Cambio de ingeniería",
+        "it": "Modifica tecnica",
+        "ja": "設計変更",
+        "pl": "Zmiana konstrukcyjna",
+        "pt": "Alteração de engenharia",
+        "ru": "Конструкторское изменение",
+        "zh": "工程变更",
+        "hi": "इंजीनियरिंग परिवर्तन",
+        "tr": "Mühendislik değişikliği",
+        "ko": "설계 변경"
+      }
+    },
+    {
+      "term": "Impact",
+      "category": "changes",
+      "context": "What a change affects.",
+      "translations": {
+        "fr": "Impact",
+        "de": "Auswirkung",
+        "es": "Impacto",
+        "it": "Impatto",
+        "ja": "影響",
+        "pl": "Wpływ",
+        "pt": "Impacto",
+        "ru": "Влияние",
+        "zh": "影响",
+        "hi": "प्रभाव",
+        "tr": "Etki",
+        "ko": "영향"
+      }
+    },
+    {
+      "term": "Implementation",
+      "category": "changes",
+      "context": "The stage where an approved change is carried out.",
+      "translations": {
+        "fr": "Mise en œuvre",
+        "de": "Umsetzung",
+        "es": "Implementación",
+        "it": "Implementazione",
+        "ja": "実施",
+        "pl": "Wdrożenie",
+        "pt": "Implementação",
+        "ru": "Внедрение",
+        "zh": "实施",
+        "hi": "कार्यान्वयन",
+        "tr": "Uygulama",
+        "ko": "실행"
+      }
+    },
+    {
+      "term": "Review",
+      "category": "changes",
+      "context": "The stage where a change is examined before approval.",
+      "translations": {
+        "fr": "Revue",
+        "de": "Überprüfung",
+        "es": "Revisión",
+        "it": "Revisione",
+        "ja": "レビュー",
+        "pl": "Przegląd",
+        "pt": "Revisão",
+        "ru": "Рассмотрение",
+        "zh": "评审",
+        "hi": "समीक्षा",
+        "tr": "İnceleme",
+        "ko": "검토"
+      }
+    },
+    {
+      "term": "Consumable",
+      "category": "core",
+      "context": "An item type: a supply used up in production that is not part of the finished product.",
+      "translations": {
+        "fr": "Consommable",
+        "de": "Verbrauchsmaterial",
+        "es": "Consumible",
+        "it": "Materiale di consumo",
+        "ja": "消耗品",
+        "pl": "Materiał eksploatacyjny",
+        "pt": "Consumível",
+        "ru": "Расходный материал",
+        "zh": "耗材",
+        "hi": "उपभोग्य सामग्री",
+        "tr": "Sarf malzemesi",
+        "ko": "소모품"
+      }
+    },
+    {
+      "term": "Contact",
+      "category": "core",
+      "context": "A named person at a customer or supplier.",
+      "translations": {
+        "fr": "Contact",
+        "de": "Kontakt",
+        "es": "Contacto",
+        "it": "Contatto",
+        "ja": "担当者",
+        "pl": "Kontakt",
+        "pt": "Contato",
+        "ru": "Контактное лицо",
+        "zh": "联系人",
+        "hi": "संपर्क",
+        "tr": "İlgili kişi",
+        "ko": "담당자"
+      }
+    },
+    {
+      "term": "Customer",
+      "category": "core",
+      "context": "The company Carbon sells to.",
+      "translations": {
+        "fr": "Client",
+        "de": "Kunde",
+        "es": "Cliente",
+        "it": "Cliente",
+        "ja": "得意先",
+        "pl": "Klient",
+        "pt": "Cliente",
+        "ru": "Покупатель",
+        "zh": "客户",
+        "hi": "ग्राहक",
+        "tr": "Müşteri",
+        "ko": "고객"
+      }
+    },
+    {
+      "term": "Fixture",
+      "category": "core",
+      "context": "An item type: work-holding used to locate a part during an operation.",
+      "translations": {
+        "fr": "Montage d'usinage",
+        "de": "Vorrichtung",
+        "es": "Dispositivo de sujeción",
+        "it": "Attrezzatura di fissaggio",
+        "ja": "治具",
+        "pl": "Przyrząd obróbkowy",
+        "pt": "Dispositivo de fixação",
+        "ru": "Приспособление",
+        "zh": "工装夹具",
+        "hi": "फिक्स्चर",
+        "tr": "Bağlama aparatı",
+        "ko": "지그"
+      }
+    },
+    {
+      "term": "Item",
+      "category": "core",
+      "context": "The umbrella record for anything Carbon tracks and transacts: parts, materials, tools, consumables, services. Every part is an item; not every item is a part.",
+      "ambiguity": "Also used loosely as 'a row in a list'. Only the domain sense is fixed.",
+      "translations": {
+        "fr": "Article",
+        "de": "Artikel",
+        "es": "Artículo",
+        "it": "Articolo",
+        "ja": "品目",
+        "pl": "Artykuł",
+        "pt": "Item",
+        "ru": "Номенклатура",
+        "zh": "物料",
+        "hi": "आइटम",
+        "tr": "Stok kartı",
+        "ko": "품목"
+      }
+    },
+    {
+      "term": "Line",
+      "category": "core",
+      "context": "One row on a document: a quote line, order line, invoice line, shipment line. The core unit a document is built from.",
+      "ambiguity": "Do NOT apply to 'address line', 'a line of text', or 'product line'. Only the document-row sense is fixed.",
+      "translations": {
+        "fr": "Ligne",
+        "de": "Position",
+        "es": "Línea",
+        "it": "Riga",
+        "ja": "明細",
+        "pl": "Pozycja",
+        "pt": "Linha",
+        "ru": "Строка",
+        "zh": "行",
+        "hi": "पंक्ति",
+        "tr": "Satır",
+        "ko": "라인"
+      }
+    },
+    {
+      "term": "Material",
+      "category": "core",
+      "context": "An item type: raw stock consumed by manufacturing (bar, sheet, resin), usually by dimension rather than by piece.",
+      "translations": {
+        "fr": "Matière",
+        "de": "Werkstoff",
+        "es": "Material",
+        "it": "Materiale",
+        "ja": "材料",
+        "pl": "Materiał",
+        "pt": "Material",
+        "ru": "Материал",
+        "zh": "原材料",
+        "hi": "सामग्री",
+        "tr": "Malzeme",
+        "ko": "자재"
+      }
+    },
+    {
+      "term": "OEM",
+      "category": "core",
+      "context": "Original Equipment Manufacturer — a company that designs and builds its own finished products.",
+      "translations": {
+        "fr": "OEM",
+        "de": "OEM",
+        "es": "OEM",
+        "it": "OEM",
+        "ja": "OEM",
+        "pl": "OEM",
+        "pt": "OEM",
+        "ru": "OEM",
+        "zh": "OEM",
+        "hi": "OEM",
+        "tr": "OEM",
+        "ko": "OEM"
+      }
+    },
+    {
+      "term": "Part",
+      "category": "core",
+      "context": "An item type: a discrete manufactured or purchased component with a revision and a method.",
+      "ambiguity": "Never fix the rendering inside 'part of', 'partly', or 'take part'.",
+      "translations": {
+        "fr": "Pièce",
+        "de": "Teil",
+        "es": "Pieza",
+        "it": "Componente",
+        "ja": "部品",
+        "pl": "Część",
+        "pt": "Peça",
+        "ru": "Деталь",
+        "zh": "零件",
+        "hi": "पार्ट",
+        "tr": "Parça",
+        "ko": "부품"
+      }
+    },
+    {
+      "term": "Quantity",
+      "category": "core",
+      "context": "How many of an item — the number on a line, a receipt, a job or a stock record.",
+      "translations": {
+        "fr": "Quantité",
+        "de": "Menge",
+        "es": "Cantidad",
+        "it": "Quantità",
+        "ja": "数量",
+        "pl": "Ilość",
+        "pt": "Quantidade",
+        "ru": "Количество",
+        "zh": "数量",
+        "hi": "मात्रा",
+        "tr": "Miktar",
+        "ko": "수량"
+      }
+    },
+    {
+      "term": "Service",
+      "category": "core",
+      "context": "An item type: outside work bought or sold (plating, heat treat, inspection).",
+      "ambiguity": "Not a software service or a customer-service department.",
+      "translations": {
+        "fr": "Prestation",
+        "de": "Dienstleistung",
+        "es": "Servicio",
+        "it": "Servizio",
+        "ja": "外注サービス",
+        "pl": "Usługa",
+        "pt": "Serviço",
+        "ru": "Услуга",
+        "zh": "服务",
+        "hi": "सेवा",
+        "tr": "Hizmet",
+        "ko": "서비스"
+      }
+    },
+    {
+      "term": "Supplier",
+      "category": "core",
+      "context": "The company Carbon buys from.",
+      "translations": {
+        "fr": "Fournisseur",
+        "de": "Lieferant",
+        "es": "Proveedor",
+        "it": "Fornitore",
+        "ja": "仕入先",
+        "pl": "Dostawca",
+        "pt": "Fornecedor",
+        "ru": "Поставщик",
+        "zh": "供应商",
+        "hi": "आपूर्तिकर्ता",
+        "tr": "Tedarikçi",
+        "ko": "공급업체"
+      }
+    },
+    {
+      "term": "Tool",
+      "category": "core",
+      "context": "An item type: reusable tooling used to make a part; consumed by wear, not by unit.",
+      "ambiguity": "Not a software 'tool' or a toolbar.",
+      "translations": {
+        "fr": "Outil",
+        "de": "Werkzeug",
+        "es": "Herramienta",
+        "it": "Utensile",
+        "ja": "工具",
+        "pl": "Narzędzie",
+        "pt": "Ferramenta",
+        "ru": "Инструмент",
+        "zh": "刀具",
+        "hi": "टूल",
+        "tr": "Takım",
+        "ko": "공구"
+      }
+    },
+    {
+      "term": "Unit",
+      "category": "core",
+      "context": "A single countable piece of an item.",
+      "ambiguity": "Also appears in 'Unit of Measure' and 'Storage Unit', which are separate entries; and in 'unit price'. Fix only the standalone 'one piece' sense.",
+      "translations": {
+        "fr": "Unité",
+        "de": "Einheit",
+        "es": "Unidad",
+        "it": "Unità",
+        "ja": "個",
+        "pl": "Sztuka",
+        "pt": "Unidade",
+        "ru": "Единица",
+        "zh": "件",
+        "hi": "इकाई",
+        "tr": "Adet",
+        "ko": "개"
+      }
+    },
+    {
+      "term": "Adjustment",
+      "category": "inventory",
+      "context": "A manual correction to stock quantity.",
+      "translations": {
+        "fr": "Ajustement",
+        "de": "Korrektur",
+        "es": "Ajuste",
+        "it": "Rettifica",
+        "ja": "調整",
+        "pl": "Korekta",
+        "pt": "Ajuste",
+        "ru": "Корректировка",
+        "zh": "调整",
+        "hi": "समायोजन",
+        "tr": "Düzeltme",
+        "ko": "조정"
+      }
+    },
+    {
+      "term": "Batch",
+      "category": "inventory",
+      "context": "A produced group tracked together.",
+      "ambiguity": "Distinguish from Lot; do not use one word for both unless the language genuinely has one.",
+      "translations": {
+        "fr": "Lot de production",
+        "de": "Los",
+        "es": "Lote de producción",
+        "it": "Lotto di produzione",
+        "ja": "バッチ",
+        "pl": "Partia produkcyjna",
+        "pt": "Lote de produção",
+        "ru": "Серия",
+        "zh": "生产批次",
+        "hi": "बैच",
+        "tr": "Parti",
+        "ko": "배치"
+      }
+    },
+    {
+      "term": "Bin",
+      "category": "inventory",
+      "context": "A physical container stock sits in inside a location; nests inside a storage unit.",
+      "translations": {
+        "fr": "Casier",
+        "de": "Lagerplatz",
+        "es": "Contenedor",
+        "it": "Contenitore",
+        "ja": "ビン",
+        "pl": "Pojemnik",
+        "pt": "Compartimento",
+        "ru": "Ячейка",
+        "zh": "料箱",
+        "hi": "बिन",
+        "tr": "Göz",
+        "ko": "빈"
+      }
+    },
+    {
+      "term": "Cycle Count",
+      "category": "inventory",
+      "context": "A periodic physical count used to correct stock records.",
+      "translations": {
+        "fr": "Inventaire tournant",
+        "de": "Permanente Inventur",
+        "es": "Conteo cíclico",
+        "it": "Conteggio ciclico",
+        "ja": "循環棚卸",
+        "pl": "Inwentaryzacja ciągła",
+        "pt": "Contagem cíclica",
+        "ru": "Циклический пересчет",
+        "zh": "循环盘点",
+        "hi": "चक्रीय गणना",
+        "tr": "Periyodik sayım",
+        "ko": "순환 실사"
+      }
+    },
+    {
+      "term": "Expiration Date",
+      "category": "inventory",
+      "context": "When stock stops being usable.",
+      "translations": {
+        "fr": "Date d'expiration",
+        "de": "Verfallsdatum",
+        "es": "Fecha de caducidad",
+        "it": "Data di scadenza",
+        "ja": "有効期限",
+        "pl": "Data ważności",
+        "pt": "Data de validade",
+        "ru": "Дата истечения срока",
+        "zh": "到期日期",
+        "hi": "समाप्ति तिथि",
+        "tr": "Son kullanma tarihi",
+        "ko": "만료일"
+      }
+    },
+    {
+      "term": "Expiry",
+      "category": "inventory",
+      "context": "The date after which stock may no longer be used.",
+      "translations": {
+        "fr": "Péremption",
+        "de": "Verfall",
+        "es": "Caducidad",
+        "it": "Scadenza",
+        "ja": "使用期限",
+        "pl": "Termin ważności",
+        "pt": "Validade",
+        "ru": "Срок годности",
+        "zh": "有效期",
+        "hi": "समाप्ति",
+        "tr": "Son kullanma",
+        "ko": "유통기한"
+      }
+    },
+    {
+      "term": "FEFO",
+      "category": "inventory",
+      "context": "First Expired, First Out — consume the soonest-to-expire stock first.",
+      "translations": {
+        "fr": "FEFO",
+        "de": "FEFO",
+        "es": "FEFO",
+        "it": "FEFO",
+        "ja": "FEFO",
+        "pl": "FEFO",
+        "pt": "FEFO",
+        "ru": "FEFO",
+        "zh": "先到期先出",
+        "hi": "FEFO",
+        "tr": "FEFO",
+        "ko": "FEFO"
+      }
+    },
+    {
+      "term": "FIFO",
+      "category": "inventory",
+      "context": "First In, First Out — consume the oldest stock first.",
+      "translations": {
+        "fr": "FIFO",
+        "de": "FIFO",
+        "es": "FIFO",
+        "it": "FIFO",
+        "ja": "先入先出",
+        "pl": "FIFO",
+        "pt": "FIFO",
+        "ru": "ФИФО",
+        "zh": "先进先出",
+        "hi": "FIFO",
+        "tr": "FIFO",
+        "ko": "선입선출"
+      }
+    },
+    {
+      "term": "Finished Goods",
+      "category": "inventory",
+      "context": "Completed product ready to ship, as opposed to raw material or WIP.",
+      "translations": {
+        "fr": "Produits finis",
+        "de": "Fertigwaren",
+        "es": "Producto terminado",
+        "it": "Prodotti finiti",
+        "ja": "完成品",
+        "pl": "Wyroby gotowe",
+        "pt": "Produtos acabados",
+        "ru": "Готовая продукция",
+        "zh": "成品",
+        "hi": "तैयार माल",
+        "tr": "Mamul",
+        "ko": "완제품"
+      }
+    },
+    {
+      "term": "Inventory",
+      "category": "inventory",
+      "context": "The stock the company holds, and the module that manages it.",
+      "translations": {
+        "fr": "Stocks",
+        "de": "Bestände",
+        "es": "Inventario",
+        "it": "Magazzino",
+        "ja": "在庫管理",
+        "pl": "Zapasy",
+        "pt": "Inventário",
+        "ru": "Запасы",
+        "zh": "库存管理",
+        "hi": "इन्वेंटरी",
+        "tr": "Envanter",
+        "ko": "재고 관리"
+      }
+    },
+    {
+      "term": "Inventory Adjustment",
+      "category": "inventory",
+      "context": "A manual correction posting to stock quantity.",
+      "translations": {
+        "fr": "Ajustement de stock",
+        "de": "Bestandskorrektur",
+        "es": "Ajuste de inventario",
+        "it": "Rettifica di magazzino",
+        "ja": "在庫調整",
+        "pl": "Korekta zapasów",
+        "pt": "Ajuste de estoque",
+        "ru": "Корректировка запасов",
+        "zh": "库存调整",
+        "hi": "इन्वेंटरी समायोजन",
+        "tr": "Stok düzeltme",
+        "ko": "재고 조정"
+      }
+    },
+    {
+      "term": "Issue",
+      "category": "inventory",
+      "context": "Consuming material out of stock onto a job.",
+      "ambiguity": "COLLIDES with the quality 'Issue' record. Two different concepts — do not force one word for both.",
+      "translations": {
+        "fr": "Sortie de stock",
+        "de": "Materialentnahme",
+        "es": "Salida de material",
+        "it": "Scarico",
+        "ja": "出庫",
+        "pl": "Wydanie",
+        "pt": "Requisição",
+        "ru": "Списание в производство",
+        "zh": "领料",
+        "hi": "निर्गम",
+        "tr": "Malzeme çıkışı",
+        "ko": "불출"
+      }
+    },
+    {
+      "term": "Location",
+      "category": "inventory",
+      "context": "A site the company operates from; stock and jobs belong to one.",
+      "ambiguity": "Also used for a generic map/address location; only the ERP sense is fixed.",
+      "translations": {
+        "fr": "Site",
+        "de": "Standort",
+        "es": "Ubicación",
+        "it": "Ubicazione",
+        "ja": "拠点",
+        "pl": "Lokalizacja",
+        "pt": "Local",
+        "ru": "Площадка",
+        "zh": "地点",
+        "hi": "स्थान",
+        "tr": "Lokasyon",
+        "ko": "사업장"
+      }
+    },
+    {
+      "term": "Lot",
+      "category": "inventory",
+      "context": "A quantity of material made or received together, tracked as one unit for traceability.",
+      "ambiguity": "Must not use the word for 'a lot of' or 'batch size'.",
+      "translations": {
+        "fr": "Lot",
+        "de": "Charge",
+        "es": "Lote",
+        "it": "Lotto",
+        "ja": "ロット",
+        "pl": "Partia",
+        "pt": "Lote",
+        "ru": "Партия",
+        "zh": "批次",
+        "hi": "लॉट",
+        "tr": "Lot",
+        "ko": "로트"
+      }
+    },
+    {
+      "term": "Pick",
+      "category": "inventory",
+      "context": "Taking stock off the shelf for a job or a shipment.",
+      "translations": {
+        "fr": "Prélever",
+        "de": "Kommissionieren",
+        "es": "Picking",
+        "it": "Prelievo",
+        "ja": "ピッキング",
+        "pl": "Pobranie",
+        "pt": "Separar",
+        "ru": "Отбор",
+        "zh": "拣货",
+        "hi": "पिकिंग",
+        "tr": "Toplama",
+        "ko": "피킹"
+      }
+    },
+    {
+      "term": "Picking",
+      "category": "inventory",
+      "context": "The activity of taking stock off the shelf for a job or shipment.",
+      "translations": {
+        "fr": "Prélèvement",
+        "de": "Kommissionierung",
+        "es": "Picking",
+        "it": "Prelievo",
+        "ja": "ピッキング",
+        "pl": "Kompletacja",
+        "pt": "Separação",
+        "ru": "Отбор",
+        "zh": "拣货",
+        "hi": "पिकिंग",
+        "tr": "Toplama",
+        "ko": "피킹"
+      },
+      "seeAlso": "Pick"
+    },
+    {
+      "term": "Picking List",
+      "category": "inventory",
+      "context": "The list of stock to pull for a job or shipment.",
+      "translations": {
+        "fr": "Liste de prélèvement",
+        "de": "Kommissionierliste",
+        "es": "Lista de picking",
+        "it": "Lista di prelievo",
+        "ja": "ピッキングリスト",
+        "pl": "Lista kompletacyjna",
+        "pt": "Lista de separação",
+        "ru": "Лист отбора",
+        "zh": "拣货单",
+        "hi": "पिकिंग सूची",
+        "tr": "Toplama listesi",
+        "ko": "피킹 리스트"
+      }
+    },
+    {
+      "term": "Putaway",
+      "category": "inventory",
+      "context": "Placing received stock into its storage position.",
+      "translations": {
+        "fr": "Rangement",
+        "de": "Einlagerung",
+        "es": "Almacenamiento",
+        "it": "Stoccaggio",
+        "ja": "棚入れ",
+        "pl": "Odłożenie",
+        "pt": "Armazenagem",
+        "ru": "Размещение",
+        "zh": "上架",
+        "hi": "भंडारण",
+        "tr": "Yerleştirme",
+        "ko": "적치"
+      }
+    },
+    {
+      "term": "Quantity on Hand",
+      "category": "inventory",
+      "context": "How much is physically in stock right now.",
+      "translations": {
+        "fr": "Quantité en stock",
+        "de": "Istbestand",
+        "es": "Cantidad en existencia",
+        "it": "Quantità in giacenza",
+        "ja": "現在庫数",
+        "pl": "Stan magazynowy",
+        "pt": "Saldo em estoque",
+        "ru": "Остаток на складе",
+        "zh": "现有量",
+        "hi": "उपलब्ध मात्रा",
+        "tr": "Eldeki miktar",
+        "ko": "현재고"
+      }
+    },
+    {
+      "term": "Raw Materials",
+      "category": "inventory",
+      "context": "Unprocessed stock, as opposed to WIP or finished goods.",
+      "translations": {
+        "fr": "Matières premières",
+        "de": "Rohstoffe",
+        "es": "Materias primas",
+        "it": "Materie prime",
+        "ja": "原材料",
+        "pl": "Surowce",
+        "pt": "Matérias-primas",
+        "ru": "Сырье",
+        "zh": "原材料",
+        "hi": "कच्चा माल",
+        "tr": "Hammadde",
+        "ko": "원자재"
+      }
+    },
+    {
+      "term": "Serial Number",
+      "category": "inventory",
+      "context": "A unique identifier for one individual unit.",
+      "translations": {
+        "fr": "Numéro de série",
+        "de": "Seriennummer",
+        "es": "Número de serie",
+        "it": "Numero di serie",
+        "ja": "シリアル番号",
+        "pl": "Numer seryjny",
+        "pt": "Número de série",
+        "ru": "Серийный номер",
+        "zh": "序列号",
+        "hi": "सीरियल नंबर",
+        "tr": "Seri numarası",
+        "ko": "시리얼 번호"
+      }
+    },
+    {
+      "term": "Shelf",
+      "category": "inventory",
+      "context": "A storage position inside a location.",
+      "translations": {
+        "fr": "Étagère",
+        "de": "Regal",
+        "es": "Estante",
+        "it": "Scaffale",
+        "ja": "棚",
+        "pl": "Półka",
+        "pt": "Prateleira",
+        "ru": "Полка",
+        "zh": "货架",
+        "hi": "शेल्फ",
+        "tr": "Raf",
+        "ko": "선반"
+      }
+    },
+    {
+      "term": "Shelf Life",
+      "category": "inventory",
+      "context": "How long stock stays usable before it expires.",
+      "translations": {
+        "fr": "Durée de conservation",
+        "de": "Haltbarkeit",
+        "es": "Vida de anaquel",
+        "it": "Durata di conservazione",
+        "ja": "保存期間",
+        "pl": "Okres przydatności",
+        "pt": "Vida de prateleira",
+        "ru": "Срок хранения",
+        "zh": "保质期",
+        "hi": "शेल्फ लाइफ",
+        "tr": "Raf ömrü",
+        "ko": "보존 기간"
+      }
+    },
+    {
+      "term": "Split",
+      "category": "inventory",
+      "context": "Dividing a lot or line into smaller parts.",
+      "translations": {
+        "fr": "Fractionner",
+        "de": "Teilen",
+        "es": "Dividir",
+        "it": "Suddividi",
+        "ja": "分割",
+        "pl": "Podziel",
+        "pt": "Dividir",
+        "ru": "Разделить",
+        "zh": "拆分",
+        "hi": "विभाजित करें",
+        "tr": "Böl",
+        "ko": "분할"
+      }
+    },
+    {
+      "term": "Stock",
+      "category": "inventory",
+      "context": "Physical quantity on hand.",
+      "ambiguity": "Not the finance sense of shares.",
+      "translations": {
+        "fr": "Stock",
+        "de": "Bestand",
+        "es": "Existencias",
+        "it": "Giacenza",
+        "ja": "在庫",
+        "pl": "Zapas",
+        "pt": "Estoque",
+        "ru": "Запас",
+        "zh": "库存",
+        "hi": "स्टॉक",
+        "tr": "Stok",
+        "ko": "재고"
+      }
+    },
+    {
+      "term": "Storage Unit",
+      "category": "inventory",
+      "context": "A container or holder that stock sits in.",
+      "translations": {
+        "fr": "Unité de stockage",
+        "de": "Lagereinheit",
+        "es": "Unidad de almacenamiento",
+        "it": "Unità di stoccaggio",
+        "ja": "保管ユニット",
+        "pl": "Jednostka magazynowa",
+        "pt": "Unidade de armazenamento",
+        "ru": "Единица хранения",
+        "zh": "存储单元",
+        "hi": "भंडारण इकाई",
+        "tr": "Depolama birimi",
+        "ko": "보관 단위"
+      }
+    },
+    {
+      "term": "Tracked Entity",
+      "category": "inventory",
+      "context": "A lot or serial instance that Carbon follows through the shop.",
+      "translations": {
+        "fr": "Entité suivie",
+        "de": "Verfolgte Einheit",
+        "es": "Entidad rastreada",
+        "it": "Entità tracciata",
+        "ja": "追跡対象",
+        "pl": "Jednostka śledzona",
+        "pt": "Entidade rastreada",
+        "ru": "Отслеживаемый объект",
+        "zh": "追踪实体",
+        "hi": "ट्रैक की गई इकाई",
+        "tr": "İzlenen varlık",
+        "ko": "추적 대상"
+      }
+    },
+    {
+      "term": "Transfer",
+      "category": "inventory",
+      "context": "Moving stock between locations or shelves.",
+      "ambiguity": "Not a bank transfer or a file transfer.",
+      "translations": {
+        "fr": "Transfert",
+        "de": "Umlagerung",
+        "es": "Transferencia",
+        "it": "Trasferimento",
+        "ja": "転送",
+        "pl": "Przesunięcie",
+        "pt": "Transferência",
+        "ru": "Перемещение",
+        "zh": "调拨",
+        "hi": "स्थानांतरण",
+        "tr": "Transfer",
+        "ko": "이송"
+      }
+    },
+    {
+      "term": "Transfer Line",
+      "category": "inventory",
+      "context": "One item-and-quantity row on a stock transfer.",
+      "translations": {
+        "fr": "Ligne de transfert",
+        "de": "Umlagerungsposition",
+        "es": "Línea de transferencia",
+        "it": "Riga di trasferimento",
+        "ja": "転送明細",
+        "pl": "Pozycja przesunięcia",
+        "pt": "Linha de transferência",
+        "ru": "Строка перемещения",
+        "zh": "调拨行",
+        "hi": "स्थानांतरण पंक्ति",
+        "tr": "Transfer satırı",
+        "ko": "이송 라인"
+      }
+    },
+    {
+      "term": "Warehouse",
+      "category": "inventory",
+      "context": "A building or site holding stock.",
+      "translations": {
+        "fr": "Entrepôt",
+        "de": "Lager",
+        "es": "Almacén",
+        "it": "Deposito",
+        "ja": "倉庫",
+        "pl": "Magazyn",
+        "pt": "Armazém",
+        "ru": "Склад",
+        "zh": "仓库",
+        "hi": "गोदाम",
+        "tr": "Depo",
+        "ko": "창고"
+      }
+    },
+    {
+      "term": "Buy",
+      "category": "items",
+      "context": "A replenishment system: the item is purchased.",
+      "translations": {
+        "fr": "Achat",
+        "de": "Fremdbeschaffung",
+        "es": "Compra",
+        "it": "Acquisto",
+        "ja": "購入",
+        "pl": "Zakup",
+        "pt": "Compra",
+        "ru": "Закупка",
+        "zh": "采购",
+        "hi": "खरीद",
+        "tr": "Satın alma",
+        "ko": "구매"
+      }
+    },
+    {
+      "term": "Buy and Make",
+      "category": "items",
+      "context": "A replenishment system where an item can be both purchased and manufactured.",
+      "translations": {
+        "fr": "Achat et fabrication",
+        "de": "Fremdbeschaffung und Eigenfertigung",
+        "es": "Compra y fabricación",
+        "it": "Acquisto e produzione",
+        "ja": "購入・内製",
+        "pl": "Zakup i produkcja",
+        "pt": "Compra e fabricação",
+        "ru": "Закупка и производство",
+        "zh": "采购与自制",
+        "hi": "खरीद और निर्माण",
+        "tr": "Satın alma ve üretim",
+        "ko": "구매 및 사내 생산"
+      }
+    },
+    {
+      "term": "Consume First",
+      "category": "items",
+      "context": "A supersession mode: use up the old item before switching to the successor.",
+      "translations": {
+        "fr": "Consommer d'abord",
+        "de": "Zuerst verbrauchen",
+        "es": "Consumir primero",
+        "it": "Consumare prima",
+        "ja": "先に消費",
+        "pl": "Najpierw zużyj",
+        "pt": "Consumir primeiro",
+        "ru": "Сначала израсходовать",
+        "zh": "先消耗",
+        "hi": "पहले उपयोग करें",
+        "tr": "Önce tüket",
+        "ko": "우선 소진"
+      }
+    },
+    {
+      "term": "Drawing Number",
+      "category": "items",
+      "context": "The engineering drawing identifier for a part.",
+      "translations": {
+        "fr": "Numéro de plan",
+        "de": "Zeichnungsnummer",
+        "es": "Número de plano",
+        "it": "Numero disegno",
+        "ja": "図面番号",
+        "pl": "Numer rysunku",
+        "pt": "Número do desenho",
+        "ru": "Номер чертежа",
+        "zh": "图号",
+        "hi": "ड्राइंग नंबर",
+        "tr": "Resim numarası",
+        "ko": "도면 번호"
+      }
+    },
+    {
+      "term": "Item Type",
+      "category": "items",
+      "context": "Which kind of item a record is (Part, Material, Tool, Consumable, Service, Fixture).",
+      "translations": {
+        "fr": "Type d'article",
+        "de": "Artikelart",
+        "es": "Tipo de artículo",
+        "it": "Tipo articolo",
+        "ja": "品目タイプ",
+        "pl": "Typ artykułu",
+        "pt": "Tipo de item",
+        "ru": "Тип номенклатуры",
+        "zh": "物料类型",
+        "hi": "आइटम प्रकार",
+        "tr": "Stok kartı türü",
+        "ko": "품목 유형"
+      }
+    },
+    {
+      "term": "Kit",
+      "category": "items",
+      "context": "A group of items issued or sold together.",
+      "translations": {
+        "fr": "Kit",
+        "de": "Set",
+        "es": "Kit",
+        "it": "Kit",
+        "ja": "キット",
+        "pl": "Zestaw",
+        "pt": "Kit",
+        "ru": "Комплект",
+        "zh": "套件",
+        "hi": "किट",
+        "tr": "Set",
+        "ko": "키트"
+      }
+    },
+    {
+      "term": "Make",
+      "category": "items",
+      "context": "A replenishment system: the item is manufactured.",
+      "ambiguity": "Do NOT apply to 'make' as an ordinary verb ('nothing to make', 'make a change').",
+      "translations": {
+        "fr": "Fabrication",
+        "de": "Eigenfertigung",
+        "es": "Fabricación",
+        "it": "Produzione",
+        "ja": "内製",
+        "pl": "Produkcja",
+        "pt": "Fabricação",
+        "ru": "Производство",
+        "zh": "自制",
+        "hi": "निर्माण",
+        "tr": "Üretim",
+        "ko": "사내 생산"
+      }
+    },
+    {
+      "term": "Make to Order",
+      "category": "items",
+      "context": "The component is manufactured as its own job when the parent is built.",
+      "translations": {
+        "fr": "Fabrication à la commande",
+        "de": "Auftragsfertigung",
+        "es": "Fabricación bajo pedido",
+        "it": "Produzione su commessa",
+        "ja": "受注生産",
+        "pl": "Produkcja na zamówienie",
+        "pt": "Fabricação sob encomenda",
+        "ru": "Производство под заказ",
+        "zh": "按订单生产",
+        "hi": "ऑर्डर पर निर्माण",
+        "tr": "Siparişe göre üretim",
+        "ko": "주문 생산"
+      }
+    },
+    {
+      "term": "Material Finish",
+      "category": "items",
+      "context": "The surface treatment on a material.",
+      "translations": {
+        "fr": "Finition",
+        "de": "Oberflächenbehandlung",
+        "es": "Acabado",
+        "it": "Finitura",
+        "ja": "表面処理",
+        "pl": "Wykończenie",
+        "pt": "Acabamento",
+        "ru": "Обработка поверхности",
+        "zh": "表面处理",
+        "hi": "फिनिश",
+        "tr": "Yüzey işlemi",
+        "ko": "표면 처리"
+      }
+    },
+    {
+      "term": "Material Grade",
+      "category": "items",
+      "context": "The specification class of a material (304, 6061-T6).",
+      "translations": {
+        "fr": "Nuance",
+        "de": "Werkstoffgüte",
+        "es": "Grado",
+        "it": "Grado",
+        "ja": "グレード",
+        "pl": "Gatunek",
+        "pt": "Grau",
+        "ru": "Марка",
+        "zh": "牌号",
+        "hi": "ग्रेड",
+        "tr": "Malzeme kalitesi",
+        "ko": "재질 등급"
+      }
+    },
+    {
+      "term": "Material Shape",
+      "category": "items",
+      "context": "The stock form of a material (bar, sheet, tube).",
+      "translations": {
+        "fr": "Forme",
+        "de": "Form",
+        "es": "Forma",
+        "it": "Forma",
+        "ja": "形状",
+        "pl": "Kształt",
+        "pt": "Forma",
+        "ru": "Форма",
+        "zh": "形状",
+        "hi": "आकार",
+        "tr": "Şekil",
+        "ko": "형상"
+      }
+    },
+    {
+      "term": "Material Substance",
+      "category": "items",
+      "context": "What a material is made of (steel, aluminium, nylon).",
+      "translations": {
+        "fr": "Matériau",
+        "de": "Grundwerkstoff",
+        "es": "Material base",
+        "it": "Materiale base",
+        "ja": "素材",
+        "pl": "Tworzywo",
+        "pt": "Material base",
+        "ru": "Основной материал",
+        "zh": "材质",
+        "hi": "पदार्थ",
+        "tr": "Ana malzeme",
+        "ko": "재질"
+      }
+    },
+    {
+      "term": "Method Type",
+      "category": "items",
+      "context": "How a BOM line is sourced: Make to Order, Purchase to Order, or Pull from Inventory.",
+      "translations": {
+        "fr": "Type d'approvisionnement",
+        "de": "Bereitstellungsart",
+        "es": "Tipo de suministro",
+        "it": "Tipo di fornitura",
+        "ja": "供給方式",
+        "pl": "Typ zasilania",
+        "pt": "Tipo de suprimento",
+        "ru": "Способ обеспечения",
+        "zh": "供料方式",
+        "hi": "आपूर्ति प्रकार",
+        "tr": "Tedarik şekli",
+        "ko": "공급 방식"
+      }
+    },
+    {
+      "term": "Non-Inventory",
+      "category": "items",
+      "context": "An item that is not stocked or counted.",
+      "translations": {
+        "fr": "Hors stock",
+        "de": "Nicht lagergeführt",
+        "es": "No inventariable",
+        "it": "Non a magazzino",
+        "ja": "非在庫",
+        "pl": "Niemagazynowy",
+        "pt": "Não estocável",
+        "ru": "Нескладской",
+        "zh": "非库存",
+        "hi": "गैर-इन्वेंटरी",
+        "tr": "Stok dışı",
+        "ko": "비재고"
+      }
+    },
+    {
+      "term": "Pull from Inventory",
+      "category": "items",
+      "context": "The component is taken from existing stock when the parent is built.",
+      "translations": {
+        "fr": "Prélever du stock",
+        "de": "Aus Bestand entnehmen",
+        "es": "Tomar del inventario",
+        "it": "Preleva da magazzino",
+        "ja": "在庫から引当",
+        "pl": "Pobierz z magazynu",
+        "pt": "Retirar do estoque",
+        "ru": "Со склада",
+        "zh": "从库存领用",
+        "hi": "इन्वेंटरी से लें",
+        "tr": "Stoktan kullan",
+        "ko": "재고 사용"
+      }
+    },
+    {
+      "term": "Purchase to Order",
+      "category": "items",
+      "context": "The component is bought for that specific order rather than pulled from stock.",
+      "translations": {
+        "fr": "Achat à la commande",
+        "de": "Einzelbeschaffung",
+        "es": "Compra bajo pedido",
+        "it": "Acquisto su commessa",
+        "ja": "受注購買",
+        "pl": "Zakup pod zamówienie",
+        "pt": "Compra sob encomenda",
+        "ru": "Закупка под заказ",
+        "zh": "按订单采购",
+        "hi": "ऑर्डर पर खरीद",
+        "tr": "Siparişe göre satın alma",
+        "ko": "주문 구매"
+      }
+    },
+    {
+      "term": "Replenishment System",
+      "category": "items",
+      "context": "How an item is supplied overall: Buy, Make, or Buy and Make.",
+      "translations": {
+        "fr": "Mode d'approvisionnement",
+        "de": "Beschaffungsart",
+        "es": "Sistema de reposición",
+        "it": "Sistema di approvvigionamento",
+        "ja": "調達方式",
+        "pl": "System uzupełniania",
+        "pt": "Sistema de reposição",
+        "ru": "Способ пополнения",
+        "zh": "补货方式",
+        "hi": "पुनःपूर्ति प्रणाली",
+        "tr": "İkmal yöntemi",
+        "ko": "조달 방식"
+      }
+    },
+    {
+      "term": "Revision",
+      "category": "items",
+      "context": "A version of an item's design; a new revision is a controlled change, not an edit.",
+      "translations": {
+        "fr": "Révision",
+        "de": "Revision",
+        "es": "Revisión",
+        "it": "Revisione",
+        "ja": "リビジョン",
+        "pl": "Rewizja",
+        "pt": "Revisão",
+        "ru": "Ревизия",
+        "zh": "修订版",
+        "hi": "रिवीजन",
+        "tr": "Revizyon",
+        "ko": "리비전"
+      }
+    },
+    {
+      "term": "Successor",
+      "category": "items",
+      "context": "The item that replaces a superseded one.",
+      "translations": {
+        "fr": "Successeur",
+        "de": "Nachfolger",
+        "es": "Sucesor",
+        "it": "Successore",
+        "ja": "後継品目",
+        "pl": "Następnik",
+        "pt": "Sucessor",
+        "ru": "Преемник",
+        "zh": "后继物料",
+        "hi": "उत्तराधिकारी",
+        "tr": "Ardıl",
+        "ko": "후속 품목"
+      }
+    },
+    {
+      "term": "Supersession",
+      "category": "items",
+      "context": "A phase-out rule: this item is being replaced by a successor item.",
+      "translations": {
+        "fr": "Remplacement",
+        "de": "Ablösung",
+        "es": "Reemplazo",
+        "it": "Sostituzione",
+        "ja": "後継切替",
+        "pl": "Zastąpienie",
+        "pt": "Substituição",
+        "ru": "Замещение",
+        "zh": "替代",
+        "hi": "प्रतिस्थापन",
+        "tr": "İkame",
+        "ko": "대체"
+      }
+    },
+    {
+      "term": "Supersession Mode",
+      "category": "items",
+      "context": "Which rule governs a phase-out: No Stock, Stock Only, Prefer New or Consume First.",
+      "translations": {
+        "fr": "Mode de remplacement",
+        "de": "Ablösungsmodus",
+        "es": "Modo de reemplazo",
+        "it": "Modalità di sostituzione",
+        "ja": "後継切替モード",
+        "pl": "Tryb zastąpienia",
+        "pt": "Modo de substituição",
+        "ru": "Режим замещения",
+        "zh": "替代模式",
+        "hi": "प्रतिस्थापन मोड",
+        "tr": "İkame modu",
+        "ko": "대체 모드"
+      }
+    },
+    {
+      "term": "Thumbnail",
+      "category": "items",
+      "context": "The small preview image on an item.",
+      "translations": {
+        "fr": "Miniature",
+        "de": "Vorschaubild",
+        "es": "Miniatura",
+        "it": "Miniatura",
+        "ja": "サムネイル",
+        "pl": "Miniatura",
+        "pt": "Miniatura",
+        "ru": "Миниатюра",
+        "zh": "缩略图",
+        "hi": "थंबनेल",
+        "tr": "Küçük resim",
+        "ko": "썸네일"
+      }
+    },
+    {
+      "term": "Tracking Type",
+      "category": "items",
+      "context": "Whether an item is tracked by lot, by serial, or not at all.",
+      "translations": {
+        "fr": "Type de suivi",
+        "de": "Verfolgungsart",
+        "es": "Tipo de seguimiento",
+        "it": "Tipo di tracciabilità",
+        "ja": "追跡タイプ",
+        "pl": "Typ śledzenia",
+        "pt": "Tipo de rastreamento",
+        "ru": "Тип отслеживания",
+        "zh": "追踪类型",
+        "hi": "ट्रैकिंग प्रकार",
+        "tr": "İzleme türü",
+        "ko": "추적 유형"
+      }
+    },
+    {
+      "term": "Unit of Measure",
+      "category": "items",
+      "context": "How an item is counted or measured (each, kg, metre).",
+      "translations": {
+        "fr": "Unité de mesure",
+        "de": "Mengeneinheit",
+        "es": "Unidad de medida",
+        "it": "Unità di misura",
+        "ja": "単位",
+        "pl": "Jednostka miary",
+        "pt": "Unidade de medida",
+        "ru": "Единица измерения",
+        "zh": "计量单位",
+        "hi": "माप की इकाई",
+        "tr": "Ölçü birimi",
+        "ko": "단위"
+      }
+    },
+    {
+      "term": "Equipment",
+      "category": "maintenance",
+      "context": "A machine or asset that is maintained.",
+      "translations": {
+        "fr": "Équipement",
+        "de": "Anlage",
+        "es": "Equipo",
+        "it": "Impianto",
+        "ja": "設備",
+        "pl": "Urządzenie",
+        "pt": "Equipamento",
+        "ru": "Оборудование",
+        "zh": "设备",
+        "hi": "उपकरण",
+        "tr": "Ekipman",
+        "ko": "설비"
+      }
+    },
+    {
+      "term": "Maintenance",
+      "category": "maintenance",
+      "context": "Keeping equipment working — the module covering repairs and servicing.",
+      "translations": {
+        "fr": "Maintenance",
+        "de": "Instandhaltung",
+        "es": "Mantenimiento",
+        "it": "Manutenzione",
+        "ja": "保全",
+        "pl": "Utrzymanie ruchu",
+        "pt": "Manutenção",
+        "ru": "Техобслуживание",
+        "zh": "维护",
+        "hi": "रखरखाव",
+        "tr": "Bakım",
+        "ko": "유지보수"
+      }
+    },
+    {
+      "term": "Maintenance Dispatch",
+      "category": "maintenance",
+      "context": "A scheduled or reactive maintenance task raised against equipment.",
+      "translations": {
+        "fr": "Intervention de maintenance",
+        "de": "Instandhaltungsauftrag",
+        "es": "Orden de mantenimiento",
+        "it": "Intervento di manutenzione",
+        "ja": "保全指示",
+        "pl": "Zlecenie utrzymania ruchu",
+        "pt": "Ordem de manutenção",
+        "ru": "Заявка на техобслуживание",
+        "zh": "维护工单",
+        "hi": "रखरखाव कार्य",
+        "tr": "Bakım emri",
+        "ko": "유지보수 지시"
+      }
+    },
+    {
+      "term": "Spare Part",
+      "category": "maintenance",
+      "context": "A part held to repair equipment rather than to build product.",
+      "translations": {
+        "fr": "Pièce de rechange",
+        "de": "Ersatzteil",
+        "es": "Repuesto",
+        "it": "Ricambio",
+        "ja": "予備品",
+        "pl": "Część zamienna",
+        "pt": "Peça de reposição",
+        "ru": "Запасная часть",
+        "zh": "备件",
+        "hi": "स्पेयर पार्ट",
+        "tr": "Yedek parça",
+        "ko": "예비 부품"
+      }
+    },
+    {
+      "term": "BOM",
+      "category": "methods",
+      "context": "Short form of Bill of Materials. Most languages keep the Latin abbreviation — confirm per language.",
+      "translations": {
+        "fr": "BOM",
+        "de": "BOM",
+        "es": "BOM",
+        "it": "BOM",
+        "ja": "BOM",
+        "pl": "BOM",
+        "pt": "BOM",
+        "ru": "BOM",
+        "zh": "BOM",
+        "hi": "BOM",
+        "tr": "BOM",
+        "ko": "BOM"
+      },
+      "seeAlso": "Bill of Materials"
+    },
+    {
+      "term": "Bill of Materials",
+      "category": "methods",
+      "context": "The list of components that go into making an item.",
+      "translations": {
+        "fr": "Nomenclature",
+        "de": "Stückliste",
+        "es": "Lista de materiales",
+        "it": "Distinta base",
+        "ja": "部品表",
+        "pl": "Lista materiałowa",
+        "pt": "Lista de materiais",
+        "ru": "Спецификация",
+        "zh": "物料清单",
+        "hi": "सामग्री सूची",
+        "tr": "Ürün ağacı",
+        "ko": "자재 명세서"
+      }
+    },
+    {
+      "term": "Bill of Process",
+      "category": "methods",
+      "context": "The list of operations performed to make an item.",
+      "translations": {
+        "fr": "Liste des opérations",
+        "de": "Arbeitsgangliste",
+        "es": "Lista de operaciones",
+        "it": "Lista delle operazioni",
+        "ja": "工程表",
+        "pl": "Lista operacji",
+        "pt": "Lista de operações",
+        "ru": "Перечень операций",
+        "zh": "工序清单",
+        "hi": "प्रक्रिया सूची",
+        "tr": "Operasyon listesi",
+        "ko": "공정 목록"
+      }
+    },
+    {
+      "term": "Get Method",
+      "category": "methods",
+      "context": "Pulling a saved method onto a job, quote or BOM line.",
+      "translations": {
+        "fr": "Récupérer la méthode",
+        "de": "Methode übernehmen",
+        "es": "Obtener método",
+        "it": "Recupera metodo",
+        "ja": "製法を取得",
+        "pl": "Pobierz metodę",
+        "pt": "Obter método",
+        "ru": "Получить метод",
+        "zh": "获取方法",
+        "hi": "विधि प्राप्त करें",
+        "tr": "Yöntemi getir",
+        "ko": "방법 가져오기"
+      }
+    },
+    {
+      "term": "Labor Time",
+      "category": "methods",
+      "context": "Time a person is occupied.",
+      "translations": {
+        "fr": "Temps de main-d'œuvre",
+        "de": "Personalzeit",
+        "es": "Tiempo de mano de obra",
+        "it": "Tempo manodopera",
+        "ja": "労務時間",
+        "pl": "Czas robocizny",
+        "pt": "Tempo de mão de obra",
+        "ru": "Трудозатраты",
+        "zh": "人工工时",
+        "hi": "श्रम समय",
+        "tr": "İşçilik süresi",
+        "ko": "노무 시간"
+      }
+    },
+    {
+      "term": "Machine",
+      "category": "methods",
+      "context": "Equipment time on an operation, as opposed to Setup or Labor.",
+      "translations": {
+        "fr": "Machine",
+        "de": "Maschine",
+        "es": "Máquina",
+        "it": "Macchina",
+        "ja": "機械",
+        "pl": "Maszyna",
+        "pt": "Máquina",
+        "ru": "Станок",
+        "zh": "机器",
+        "hi": "मशीन",
+        "tr": "Makine",
+        "ko": "기계"
+      }
+    },
+    {
+      "term": "Machine Time",
+      "category": "methods",
+      "context": "Time the machine itself is occupied.",
+      "translations": {
+        "fr": "Temps machine",
+        "de": "Maschinenzeit",
+        "es": "Tiempo de máquina",
+        "it": "Tempo macchina",
+        "ja": "機械時間",
+        "pl": "Czas maszynowy",
+        "pt": "Tempo de máquina",
+        "ru": "Машинное время",
+        "zh": "机器工时",
+        "hi": "मशीन समय",
+        "tr": "Makine süresi",
+        "ko": "기계 시간"
+      }
+    },
+    {
+      "term": "Make Method",
+      "category": "methods",
+      "context": "The manufacturing method attached to a specific item revision.",
+      "translations": {
+        "fr": "Méthode de fabrication",
+        "de": "Fertigungsmethode",
+        "es": "Método de fabricación",
+        "it": "Metodo di produzione",
+        "ja": "製造方法",
+        "pl": "Metoda produkcji",
+        "pt": "Método de fabricação",
+        "ru": "Метод производства",
+        "zh": "制造方法",
+        "hi": "निर्माण विधि",
+        "tr": "Üretim yöntemi",
+        "ko": "생산 방법"
+      }
+    },
+    {
+      "term": "Method",
+      "category": "methods",
+      "context": "The saved recipe for making an item: its materials plus its operations.",
+      "ambiguity": "Not a programming method or a generic 'way of doing something'.",
+      "translations": {
+        "fr": "Méthode",
+        "de": "Methode",
+        "es": "Método",
+        "it": "Metodo",
+        "ja": "製法",
+        "pl": "Metoda",
+        "pt": "Método",
+        "ru": "Метод",
+        "zh": "方法",
+        "hi": "विधि",
+        "tr": "Yöntem",
+        "ko": "방법"
+      }
+    },
+    {
+      "term": "Operation",
+      "category": "methods",
+      "context": "One step in a routing, performed at a work center.",
+      "ambiguity": "Not a generic 'action' or 'operating the app'.",
+      "translations": {
+        "fr": "Opération",
+        "de": "Arbeitsgang",
+        "es": "Operación",
+        "it": "Operazione",
+        "ja": "工程",
+        "pl": "Operacja",
+        "pt": "Operação",
+        "ru": "Операция",
+        "zh": "工序",
+        "hi": "ऑपरेशन",
+        "tr": "Operasyon",
+        "ko": "공정"
+      }
+    },
+    {
+      "term": "Outside Processing",
+      "category": "methods",
+      "context": "An operation subcontracted to a supplier, which raises a purchase order.",
+      "translations": {
+        "fr": "Sous-traitance",
+        "de": "Fremdbearbeitung",
+        "es": "Subcontratación",
+        "it": "Conto lavoro",
+        "ja": "外注加工",
+        "pl": "Kooperacja",
+        "pt": "Beneficiamento externo",
+        "ru": "Кооперация",
+        "zh": "委外加工",
+        "hi": "बाहरी प्रसंस्करण",
+        "tr": "Fason işlem",
+        "ko": "외주 가공"
+      }
+    },
+    {
+      "term": "Process",
+      "category": "methods",
+      "context": "A named capability a work center can perform.",
+      "ambiguity": "Not 'processing' as a verb or a background process.",
+      "translations": {
+        "fr": "Procédé",
+        "de": "Verfahren",
+        "es": "Proceso",
+        "it": "Processo",
+        "ja": "工法",
+        "pl": "Proces",
+        "pt": "Processo",
+        "ru": "Процесс",
+        "zh": "工艺",
+        "hi": "प्रक्रिया",
+        "tr": "Proses",
+        "ko": "공법"
+      }
+    },
+    {
+      "term": "Quantity per Parent",
+      "category": "methods",
+      "context": "How many of a component go into one of the parent item.",
+      "translations": {
+        "fr": "Quantité par parent",
+        "de": "Einbaumenge",
+        "es": "Cantidad por padre",
+        "it": "Quantità per padre",
+        "ja": "員数",
+        "pl": "Ilość na wyrób nadrzędny",
+        "pt": "Quantidade por pai",
+        "ru": "Количество на изделие",
+        "zh": "单位用量",
+        "hi": "प्रति पैरेंट मात्रा",
+        "tr": "Birim başına miktar",
+        "ko": "모품목당 수량"
+      }
+    },
+    {
+      "term": "Routing",
+      "category": "methods",
+      "context": "The ordered sequence of operations an item goes through.",
+      "translations": {
+        "fr": "Gamme",
+        "de": "Arbeitsplan",
+        "es": "Ruta de fabricación",
+        "it": "Ciclo di lavorazione",
+        "ja": "工順",
+        "pl": "Marszruta",
+        "pt": "Roteiro de produção",
+        "ru": "Маршрут",
+        "zh": "工艺路线",
+        "hi": "रूटिंग",
+        "tr": "Rota",
+        "ko": "라우팅"
+      }
+    },
+    {
+      "term": "Run Time",
+      "category": "methods",
+      "context": "Time to produce the parts once setup is done.",
+      "translations": {
+        "fr": "Temps de production",
+        "de": "Bearbeitungszeit",
+        "es": "Tiempo de ejecución",
+        "it": "Tempo di lavorazione",
+        "ja": "加工時間",
+        "pl": "Czas obróbki",
+        "pt": "Tempo de execução",
+        "ru": "Время обработки",
+        "zh": "加工时间",
+        "hi": "रन समय",
+        "tr": "İşleme süresi",
+        "ko": "가공 시간"
+      }
+    },
+    {
+      "term": "Scrap Percentage",
+      "category": "methods",
+      "context": "The expected loss rate planned into a method.",
+      "translations": {
+        "fr": "Taux de rebut",
+        "de": "Ausschussanteil",
+        "es": "Porcentaje de desperdicio",
+        "it": "Percentuale di scarto",
+        "ja": "不良率",
+        "pl": "Procent braków",
+        "pt": "Percentual de refugo",
+        "ru": "Процент брака",
+        "zh": "报废率",
+        "hi": "स्क्रैप प्रतिशत",
+        "tr": "Fire oranı",
+        "ko": "불량률"
+      }
+    },
+    {
+      "term": "Setup",
+      "category": "methods",
+      "context": "Preparing a work center before running parts.",
+      "translations": {
+        "fr": "Réglage",
+        "de": "Rüsten",
+        "es": "Preparación",
+        "it": "Attrezzaggio",
+        "ja": "段取り",
+        "pl": "Przezbrojenie",
+        "pt": "Setup",
+        "ru": "Наладка",
+        "zh": "换型",
+        "hi": "सेटअप",
+        "tr": "Hazırlık",
+        "ko": "셋업"
+      }
+    },
+    {
+      "term": "Setup Time",
+      "category": "methods",
+      "context": "Time to prepare a work center before running parts, independent of quantity.",
+      "translations": {
+        "fr": "Temps de réglage",
+        "de": "Rüstzeit",
+        "es": "Tiempo de preparación",
+        "it": "Tempo di attrezzaggio",
+        "ja": "段取り時間",
+        "pl": "Czas przezbrojenia",
+        "pt": "Tempo de setup",
+        "ru": "Время наладки",
+        "zh": "换型时间",
+        "hi": "सेटअप समय",
+        "tr": "Hazırlık süresi",
+        "ko": "셋업 시간"
+      }
+    },
+    {
+      "term": "Subassembly",
+      "category": "methods",
+      "context": "A made component that has its own method and is built into a parent.",
+      "translations": {
+        "fr": "Sous-ensemble",
+        "de": "Baugruppe",
+        "es": "Subensamble",
+        "it": "Sottoassieme",
+        "ja": "サブアセンブリ",
+        "pl": "Podzespół",
+        "pt": "Subconjunto",
+        "ru": "Узел",
+        "zh": "子装配件",
+        "hi": "सब-असेंबली",
+        "tr": "Alt montaj",
+        "ko": "서브어셈블리"
+      }
+    },
+    {
+      "term": "Work Center",
+      "category": "methods",
+      "context": "Where an operation happens — a machine, cell, or bench.",
+      "translations": {
+        "fr": "Poste de travail",
+        "de": "Arbeitsplatz",
+        "es": "Centro de trabajo",
+        "it": "Centro di lavoro",
+        "ja": "作業区",
+        "pl": "Stanowisko robocze",
+        "pt": "Centro de trabalho",
+        "ru": "Рабочий центр",
+        "zh": "工作中心",
+        "hi": "वर्क सेंटर",
+        "tr": "İş merkezi",
+        "ko": "작업장"
+      }
+    },
+    {
+      "term": "Work Instruction",
+      "category": "methods",
+      "context": "The versioned ordered steps and parameters an operation is run to.",
+      "translations": {
+        "fr": "Mode opératoire",
+        "de": "Arbeitsanweisung",
+        "es": "Instrucción de trabajo",
+        "it": "Istruzione di lavoro",
+        "ja": "作業手順書",
+        "pl": "Instrukcja robocza",
+        "pt": "Instrução de trabalho",
+        "ru": "Рабочая инструкция",
+        "zh": "作业指导书",
+        "hi": "कार्य निर्देश",
+        "tr": "İş talimatı",
+        "ko": "작업 표준서"
+      }
+    },
+    {
+      "term": "Accounting",
+      "category": "module",
+      "context": "The finance module: ledger, invoices, payments, assets.",
+      "translations": {
+        "fr": "Comptabilité",
+        "de": "Buchhaltung",
+        "es": "Contabilidad",
+        "it": "Contabilità",
+        "ja": "会計",
+        "pl": "Księgowość",
+        "pt": "Contabilidade",
+        "ru": "Бухгалтерия",
+        "zh": "会计",
+        "hi": "लेखांकन",
+        "tr": "Muhasebe",
+        "ko": "회계"
+      }
+    },
+    {
+      "term": "Documents",
+      "category": "module",
+      "context": "Stored files and controlled documents.",
+      "translations": {
+        "fr": "Documents",
+        "de": "Dokumente",
+        "es": "Documentos",
+        "it": "Documenti",
+        "ja": "ドキュメント",
+        "pl": "Dokumenty",
+        "pt": "Documentos",
+        "ru": "Документы",
+        "zh": "文档",
+        "hi": "दस्तावेज़",
+        "tr": "Belgeler",
+        "ko": "문서"
+      }
+    },
+    {
+      "term": "Invoicing",
+      "category": "module",
+      "context": "The billing module: sales and purchase invoices.",
+      "translations": {
+        "fr": "Facturation",
+        "de": "Fakturierung",
+        "es": "Facturación",
+        "it": "Fatturazione",
+        "ja": "請求",
+        "pl": "Fakturowanie",
+        "pt": "Faturamento",
+        "ru": "Выставление счетов",
+        "zh": "开票",
+        "hi": "बिलिंग",
+        "tr": "Faturalama",
+        "ko": "송장 관리"
+      }
+    },
+    {
+      "term": "Items",
+      "category": "module",
+      "context": "The item master: parts, materials, tools and their methods.",
+      "translations": {
+        "fr": "Articles",
+        "de": "Artikel",
+        "es": "Artículos",
+        "it": "Articoli",
+        "ja": "品目",
+        "pl": "Artykuły",
+        "pt": "Itens",
+        "ru": "Номенклатура",
+        "zh": "物料",
+        "hi": "आइटम",
+        "tr": "Stok kartları",
+        "ko": "품목"
+      }
+    },
+    {
+      "term": "Jobs",
+      "category": "module",
+      "context": "The list of manufacturing jobs.",
+      "translations": {
+        "fr": "Ordres de fabrication",
+        "de": "Fertigungsaufträge",
+        "es": "Órdenes de trabajo",
+        "it": "Ordini di produzione",
+        "ja": "製造指図",
+        "pl": "Zlecenia produkcyjne",
+        "pt": "Ordens de produção",
+        "ru": "Производственные заказы",
+        "zh": "工单",
+        "hi": "जॉब",
+        "tr": "İş emirleri",
+        "ko": "작업 지시"
+      }
+    },
+    {
+      "term": "MES",
+      "category": "module",
+      "context": "Manufacturing Execution System — Carbon's shop-floor app.",
+      "translations": {
+        "fr": "MES",
+        "de": "MES",
+        "es": "MES",
+        "it": "MES",
+        "ja": "MES",
+        "pl": "MES",
+        "pt": "MES",
+        "ru": "MES",
+        "zh": "MES",
+        "hi": "MES",
+        "tr": "MES",
+        "ko": "MES"
+      }
+    },
+    {
+      "term": "Manufacturing",
+      "category": "module",
+      "context": "The making module: methods, jobs, shop floor.",
+      "translations": {
+        "fr": "Production",
+        "de": "Fertigung",
+        "es": "Manufactura",
+        "it": "Produzione",
+        "ja": "製造",
+        "pl": "Produkcja",
+        "pt": "Manufatura",
+        "ru": "Производство",
+        "zh": "制造",
+        "hi": "विनिर्माण",
+        "tr": "Üretim",
+        "ko": "제조"
+      }
+    },
+    {
+      "term": "Operations",
+      "category": "module",
+      "context": "Shop-floor operations and scheduling.",
+      "translations": {
+        "fr": "Opérations",
+        "de": "Arbeitsgänge",
+        "es": "Operaciones",
+        "it": "Operazioni",
+        "ja": "工程",
+        "pl": "Operacje",
+        "pt": "Operações",
+        "ru": "Операции",
+        "zh": "工序",
+        "hi": "ऑपरेशन",
+        "tr": "Operasyonlar",
+        "ko": "공정"
+      }
+    },
+    {
+      "term": "Parts",
+      "category": "module",
+      "context": "The parts list within Items.",
+      "translations": {
+        "fr": "Pièces",
+        "de": "Teile",
+        "es": "Piezas",
+        "it": "Componenti",
+        "ja": "部品",
+        "pl": "Części",
+        "pt": "Peças",
+        "ru": "Детали",
+        "zh": "零件",
+        "hi": "पार्ट्स",
+        "tr": "Parçalar",
+        "ko": "부품"
+      }
+    },
+    {
+      "term": "People",
+      "category": "module",
+      "context": "Employees, contractors and their abilities.",
+      "translations": {
+        "fr": "Personnel",
+        "de": "Personal",
+        "es": "Personal",
+        "it": "Personale",
+        "ja": "人員",
+        "pl": "Pracownicy",
+        "pt": "Pessoas",
+        "ru": "Сотрудники",
+        "zh": "人员",
+        "hi": "लोग",
+        "tr": "Personel",
+        "ko": "인원"
+      }
+    },
+    {
+      "term": "Purchasing",
+      "category": "module",
+      "context": "The buying module: RFQs, purchase orders, receipts.",
+      "translations": {
+        "fr": "Achats",
+        "de": "Einkauf",
+        "es": "Compras",
+        "it": "Acquisti",
+        "ja": "購買",
+        "pl": "Zakupy",
+        "pt": "Compras",
+        "ru": "Закупки",
+        "zh": "采购",
+        "hi": "क्रय",
+        "tr": "Satın alma",
+        "ko": "구매"
+      }
+    },
+    {
+      "term": "Resources",
+      "category": "module",
+      "context": "The module for people, equipment, work centers and abilities.",
+      "translations": {
+        "fr": "Ressources",
+        "de": "Ressourcen",
+        "es": "Recursos",
+        "it": "Risorse",
+        "ja": "リソース",
+        "pl": "Zasoby",
+        "pt": "Recursos",
+        "ru": "Ресурсы",
+        "zh": "资源",
+        "hi": "संसाधन",
+        "tr": "Kaynaklar",
+        "ko": "자원"
+      }
+    },
+    {
+      "term": "Sales",
+      "category": "module",
+      "context": "The selling module: quotes, sales orders, shipments.",
+      "translations": {
+        "fr": "Ventes",
+        "de": "Vertrieb",
+        "es": "Ventas",
+        "it": "Vendite",
+        "ja": "販売",
+        "pl": "Sprzedaż",
+        "pt": "Vendas",
+        "ru": "Продажи",
+        "zh": "销售",
+        "hi": "बिक्री",
+        "tr": "Satış",
+        "ko": "영업"
+      }
+    },
+    {
+      "term": "Settings",
+      "category": "module",
+      "context": "Company configuration.",
+      "translations": {
+        "fr": "Paramètres",
+        "de": "Einstellungen",
+        "es": "Configuración",
+        "it": "Impostazioni",
+        "ja": "設定",
+        "pl": "Ustawienia",
+        "pt": "Configurações",
+        "ru": "Настройки",
+        "zh": "设置",
+        "hi": "सेटिंग्स",
+        "tr": "Ayarlar",
+        "ko": "설정"
+      }
+    },
+    {
+      "term": "Timecards",
+      "category": "module",
+      "context": "Logged operator time.",
+      "translations": {
+        "fr": "Feuilles de temps",
+        "de": "Zeiterfassung",
+        "es": "Registro de tiempos",
+        "it": "Rilevazione tempi",
+        "ja": "タイムカード",
+        "pl": "Karty pracy",
+        "pt": "Apontamentos",
+        "ru": "Табели",
+        "zh": "工时记录",
+        "hi": "टाइमकार्ड",
+        "tr": "Puantaj",
+        "ko": "타임카드"
+      }
+    },
+    {
+      "term": "Users",
+      "category": "module",
+      "context": "Login accounts and their permissions.",
+      "translations": {
+        "fr": "Utilisateurs",
+        "de": "Benutzer",
+        "es": "Usuarios",
+        "it": "Utenti",
+        "ja": "ユーザー",
+        "pl": "Użytkownicy",
+        "pt": "Usuários",
+        "ru": "Пользователи",
+        "zh": "用户",
+        "hi": "उपयोगकर्ता",
+        "tr": "Kullanıcılar",
+        "ko": "사용자"
+      }
+    },
+    {
+      "term": "Ability",
+      "category": "people",
+      "context": "A skill an employee holds, used to assign work.",
+      "translations": {
+        "fr": "Compétence",
+        "de": "Qualifikation",
+        "es": "Habilidad",
+        "it": "Competenza",
+        "ja": "スキル",
+        "pl": "Umiejętność",
+        "pt": "Habilidade",
+        "ru": "Навык",
+        "zh": "技能",
+        "hi": "कौशल",
+        "tr": "Yetkinlik",
+        "ko": "역량"
+      },
+      "englishVariants": [
+        "Abilities"
+      ]
+    },
+    {
+      "term": "Contractor",
+      "category": "people",
+      "context": "An outside worker with abilities and available hours.",
+      "translations": {
+        "fr": "Prestataire",
+        "de": "Externer Mitarbeiter",
+        "es": "Contratista",
+        "it": "Collaboratore esterno",
+        "ja": "外部作業者",
+        "pl": "Pracownik zewnętrzny",
+        "pt": "Terceirizado",
+        "ru": "Подрядчик",
+        "zh": "外协人员",
+        "hi": "ठेकेदार",
+        "tr": "Taşeron",
+        "ko": "외주 인력"
+      }
+    },
+    {
+      "term": "Department",
+      "category": "people",
+      "context": "An organisational unit employees belong to.",
+      "translations": {
+        "fr": "Département",
+        "de": "Abteilung",
+        "es": "Departamento",
+        "it": "Reparto",
+        "ja": "部門",
+        "pl": "Dział",
+        "pt": "Departamento",
+        "ru": "Отдел",
+        "zh": "部门",
+        "hi": "विभाग",
+        "tr": "Departman",
+        "ko": "부서"
+      }
+    },
+    {
+      "term": "Employee",
+      "category": "people",
+      "context": "A person who works for the company and can be assigned work.",
+      "translations": {
+        "fr": "Employé",
+        "de": "Mitarbeiter",
+        "es": "Empleado",
+        "it": "Dipendente",
+        "ja": "従業員",
+        "pl": "Pracownik",
+        "pt": "Funcionário",
+        "ru": "Сотрудник",
+        "zh": "员工",
+        "hi": "कर्मचारी",
+        "tr": "Çalışan",
+        "ko": "직원"
+      }
+    },
+    {
+      "term": "Person",
+      "category": "people",
+      "context": "An individual, as opposed to a company.",
+      "translations": {
+        "fr": "Personne",
+        "de": "Person",
+        "es": "Persona",
+        "it": "Persona",
+        "ja": "個人",
+        "pl": "Osoba",
+        "pt": "Pessoa",
+        "ru": "Физическое лицо",
+        "zh": "个人",
+        "hi": "व्यक्ति",
+        "tr": "Kişi",
+        "ko": "개인"
+      }
+    },
+    {
+      "term": "Shift",
+      "category": "people",
+      "context": "A defined working period at a location.",
+      "translations": {
+        "fr": "Équipe",
+        "de": "Schicht",
+        "es": "Turno",
+        "it": "Turno",
+        "ja": "シフト",
+        "pl": "Zmiana",
+        "pt": "Turno",
+        "ru": "Смена",
+        "zh": "班次",
+        "hi": "शिफ्ट",
+        "tr": "Vardiya",
+        "ko": "교대조"
+      }
+    },
+    {
+      "term": "Team",
+      "category": "people",
+      "context": "A group of employees work is assigned to.",
+      "translations": {
+        "fr": "Groupe",
+        "de": "Team",
+        "es": "Equipo",
+        "it": "Squadra",
+        "ja": "チーム",
+        "pl": "Zespół",
+        "pt": "Equipe",
+        "ru": "Бригада",
+        "zh": "班组",
+        "hi": "टीम",
+        "tr": "Ekip",
+        "ko": "팀"
+      }
+    },
+    {
+      "term": "Training",
+      "category": "people",
+      "context": "Role-based material employees are trained on.",
+      "translations": {
+        "fr": "Formation",
+        "de": "Schulung",
+        "es": "Capacitación",
+        "it": "Formazione",
+        "ja": "教育訓練",
+        "pl": "Szkolenie",
+        "pt": "Treinamento",
+        "ru": "Обучение",
+        "zh": "培训",
+        "hi": "प्रशिक्षण",
+        "tr": "Eğitim",
+        "ko": "교육"
+      }
+    },
+    {
+      "term": "Demand",
+      "category": "planning",
+      "context": "Everything that consumes supply: orders, forecasts, job material needs.",
+      "translations": {
+        "fr": "Besoins",
+        "de": "Bedarf",
+        "es": "Demanda",
+        "it": "Fabbisogno",
+        "ja": "所要量",
+        "pl": "Zapotrzebowanie",
+        "pt": "Demanda",
+        "ru": "Потребность",
+        "zh": "需求",
+        "hi": "मांग",
+        "tr": "Talep",
+        "ko": "소요량"
+      }
+    },
+    {
+      "term": "Forecast",
+      "category": "planning",
+      "context": "An expectation of future demand, entered rather than ordered.",
+      "translations": {
+        "fr": "Prévision",
+        "de": "Prognose",
+        "es": "Pronóstico",
+        "it": "Previsione",
+        "ja": "予測",
+        "pl": "Prognoza",
+        "pt": "Previsão",
+        "ru": "Прогноз",
+        "zh": "预测",
+        "hi": "पूर्वानुमान",
+        "tr": "Tahmin",
+        "ko": "예측"
+      }
+    },
+    {
+      "term": "Lead Time",
+      "category": "planning",
+      "context": "How many days between ordering something and having it.",
+      "translations": {
+        "fr": "Délai d'approvisionnement",
+        "de": "Beschaffungszeit",
+        "es": "Plazo de entrega",
+        "it": "Lead time",
+        "ja": "リードタイム",
+        "pl": "Czas realizacji",
+        "pt": "Lead time",
+        "ru": "Срок поставки",
+        "zh": "提前期",
+        "hi": "लीड टाइम",
+        "tr": "Tedarik süresi",
+        "ko": "리드타임"
+      }
+    },
+    {
+      "term": "Lot Size",
+      "category": "planning",
+      "context": "The quantity ordered or made at a time.",
+      "translations": {
+        "fr": "Taille de lot",
+        "de": "Losgröße",
+        "es": "Tamaño de lote",
+        "it": "Dimensione del lotto",
+        "ja": "ロットサイズ",
+        "pl": "Wielkość partii",
+        "pt": "Tamanho do lote",
+        "ru": "Размер партии",
+        "zh": "批量",
+        "hi": "लॉट आकार",
+        "tr": "Parti büyüklüğü",
+        "ko": "로트 크기"
+      }
+    },
+    {
+      "term": "MRP",
+      "category": "planning",
+      "context": "Material Requirements Planning — the run that works out what to buy and make.",
+      "translations": {
+        "fr": "MRP",
+        "de": "MRP",
+        "es": "MRP",
+        "it": "MRP",
+        "ja": "MRP",
+        "pl": "MRP",
+        "pt": "MRP",
+        "ru": "MRP",
+        "zh": "MRP",
+        "hi": "MRP",
+        "tr": "MRP",
+        "ko": "MRP"
+      }
+    },
+    {
+      "term": "Planning",
+      "category": "planning",
+      "context": "Deciding what to make and buy, and when.",
+      "translations": {
+        "fr": "Planification",
+        "de": "Planung",
+        "es": "Planificación",
+        "it": "Pianificazione",
+        "ja": "計画",
+        "pl": "Planowanie",
+        "pt": "Planejamento",
+        "ru": "Планирование",
+        "zh": "计划",
+        "hi": "योजना",
+        "tr": "Planlama",
+        "ko": "계획"
+      }
+    },
+    {
+      "term": "Planning Offset",
+      "category": "planning",
+      "context": "Days planning shifts demand backward to allow for lead time.",
+      "translations": {
+        "fr": "Décalage de planification",
+        "de": "Planungsversatz",
+        "es": "Desfase de planificación",
+        "it": "Anticipo di pianificazione",
+        "ja": "計画オフセット",
+        "pl": "Przesunięcie planistyczne",
+        "pt": "Deslocamento de planejamento",
+        "ru": "Смещение планирования",
+        "zh": "计划偏移",
+        "hi": "योजना ऑफसेट",
+        "tr": "Planlama kaydırması",
+        "ko": "계획 오프셋"
+      }
+    },
+    {
+      "term": "Reorder Point",
+      "category": "planning",
+      "context": "The stock level at which more should be ordered.",
+      "translations": {
+        "fr": "Point de commande",
+        "de": "Meldebestand",
+        "es": "Punto de reorden",
+        "it": "Punto di riordino",
+        "ja": "発注点",
+        "pl": "Punkt zamawiania",
+        "pt": "Ponto de ressuprimento",
+        "ru": "Точка заказа",
+        "zh": "再订货点",
+        "hi": "पुनः ऑर्डर बिंदु",
+        "tr": "Yeniden sipariş noktası",
+        "ko": "재주문점"
+      }
+    },
+    {
+      "term": "Reordering Policy",
+      "category": "planning",
+      "context": "The rule deciding when and how much to reorder.",
+      "translations": {
+        "fr": "Politique de réapprovisionnement",
+        "de": "Dispositionsverfahren",
+        "es": "Política de reaprovisionamiento",
+        "it": "Politica di riordino",
+        "ja": "発注方針",
+        "pl": "Zasady zamawiania",
+        "pt": "Política de ressuprimento",
+        "ru": "Политика пополнения",
+        "zh": "补货策略",
+        "hi": "पुनः ऑर्डर नीति",
+        "tr": "Sipariş politikası",
+        "ko": "재주문 정책"
+      }
+    },
+    {
+      "term": "Required Date",
+      "category": "planning",
+      "context": "When something is needed by.",
+      "translations": {
+        "fr": "Date de besoin",
+        "de": "Bedarfstermin",
+        "es": "Fecha requerida",
+        "it": "Data fabbisogno",
+        "ja": "所要日",
+        "pl": "Data zapotrzebowania",
+        "pt": "Data de necessidade",
+        "ru": "Дата потребности",
+        "zh": "需求日期",
+        "hi": "आवश्यक तिथि",
+        "tr": "İhtiyaç tarihi",
+        "ko": "소요일"
+      }
+    },
+    {
+      "term": "Safety Stock",
+      "category": "planning",
+      "context": "Buffer stock held to absorb variability.",
+      "translations": {
+        "fr": "Stock de sécurité",
+        "de": "Sicherheitsbestand",
+        "es": "Stock de seguridad",
+        "it": "Scorta di sicurezza",
+        "ja": "安全在庫",
+        "pl": "Zapas bezpieczeństwa",
+        "pt": "Estoque de segurança",
+        "ru": "Страховой запас",
+        "zh": "安全库存",
+        "hi": "सुरक्षा स्टॉक",
+        "tr": "Emniyet stoku",
+        "ko": "안전 재고"
+      }
+    },
+    {
+      "term": "Stockout",
+      "category": "planning",
+      "context": "Projected on-hand stock falling below zero.",
+      "translations": {
+        "fr": "Rupture de stock",
+        "de": "Fehlbestand",
+        "es": "Rotura de stock",
+        "it": "Rottura di stock",
+        "ja": "欠品",
+        "pl": "Brak zapasu",
+        "pt": "Ruptura de estoque",
+        "ru": "Дефицит",
+        "zh": "缺货",
+        "hi": "स्टॉक आउट",
+        "tr": "Stoksuzluk",
+        "ko": "재고 부족"
+      }
+    },
+    {
+      "term": "Suggestion",
+      "category": "planning",
+      "context": "A proposed order or job that MRP produces for a planner to accept.",
+      "translations": {
+        "fr": "Suggestion",
+        "de": "Vorschlag",
+        "es": "Sugerencia",
+        "it": "Proposta",
+        "ja": "提案",
+        "pl": "Propozycja",
+        "pt": "Sugestão",
+        "ru": "Предложение",
+        "zh": "建议",
+        "hi": "सुझाव",
+        "tr": "Öneri",
+        "ko": "제안"
+      }
+    },
+    {
+      "term": "Supply",
+      "category": "planning",
+      "context": "Everything that adds stock: purchase orders, jobs, on-hand quantity.",
+      "translations": {
+        "fr": "Approvisionnement",
+        "de": "Deckung",
+        "es": "Suministro",
+        "it": "Copertura",
+        "ja": "供給",
+        "pl": "Pokrycie",
+        "pt": "Suprimento",
+        "ru": "Обеспечение",
+        "zh": "供应",
+        "hi": "आपूर्ति",
+        "tr": "Arz",
+        "ko": "공급"
+      }
+    },
+    {
+      "term": "API Key",
+      "category": "platform",
+      "context": "A credential letting an outside system call Carbon.",
+      "translations": {
+        "fr": "Clé API",
+        "de": "API-Schlüssel",
+        "es": "Clave de API",
+        "it": "Chiave API",
+        "ja": "APIキー",
+        "pl": "Klucz API",
+        "pt": "Chave de API",
+        "ru": "API-ключ",
+        "zh": "API密钥",
+        "hi": "API कुंजी",
+        "tr": "API anahtarı",
+        "ko": "API 키"
+      }
+    },
+    {
+      "term": "Address",
+      "category": "platform",
+      "context": "A postal address on a customer, supplier or location.",
+      "translations": {
+        "fr": "Adresse",
+        "de": "Adresse",
+        "es": "Dirección",
+        "it": "Indirizzo",
+        "ja": "住所",
+        "pl": "Adres",
+        "pt": "Endereço",
+        "ru": "Адрес",
+        "zh": "地址",
+        "hi": "पता",
+        "tr": "Adres",
+        "ko": "주소"
+      }
+    },
+    {
+      "term": "Approval Rule",
+      "category": "platform",
+      "context": "A rule deciding who must sign off and when.",
+      "translations": {
+        "fr": "Règle d'approbation",
+        "de": "Genehmigungsregel",
+        "es": "Regla de aprobación",
+        "it": "Regola di approvazione",
+        "ja": "承認ルール",
+        "pl": "Reguła zatwierdzania",
+        "pt": "Regra de aprovação",
+        "ru": "Правило утверждения",
+        "zh": "审批规则",
+        "hi": "अनुमोदन नियम",
+        "tr": "Onay kuralı",
+        "ko": "승인 규칙"
+      }
+    },
+    {
+      "term": "Assignee",
+      "category": "platform",
+      "context": "The person responsible for a record.",
+      "translations": {
+        "fr": "Assigné",
+        "de": "Bearbeiter",
+        "es": "Asignado",
+        "it": "Assegnatario",
+        "ja": "担当者",
+        "pl": "Osoba przypisana",
+        "pt": "Designado",
+        "ru": "Исполнитель",
+        "zh": "经办人",
+        "hi": "असाइनी",
+        "tr": "Atanan",
+        "ko": "담당자"
+      }
+    },
+    {
+      "term": "Attachment",
+      "category": "platform",
+      "context": "A file stored against a record.",
+      "translations": {
+        "fr": "Pièce jointe",
+        "de": "Anhang",
+        "es": "Adjunto",
+        "it": "Allegato",
+        "ja": "添付ファイル",
+        "pl": "Załącznik",
+        "pt": "Anexo",
+        "ru": "Вложение",
+        "zh": "附件",
+        "hi": "अनुलग्नक",
+        "tr": "Ek",
+        "ko": "첨부 파일"
+      }
+    },
+    {
+      "term": "Attribute",
+      "category": "platform",
+      "context": "A named property recorded against a person or record.",
+      "translations": {
+        "fr": "Attribut",
+        "de": "Attribut",
+        "es": "Atributo",
+        "it": "Attributo",
+        "ja": "属性",
+        "pl": "Atrybut",
+        "pt": "Atributo",
+        "ru": "Атрибут",
+        "zh": "属性",
+        "hi": "विशेषता",
+        "tr": "Öznitelik",
+        "ko": "속성"
+      }
+    },
+    {
+      "term": "Audit Log",
+      "category": "platform",
+      "context": "The record of who changed what and when.",
+      "translations": {
+        "fr": "Journal d'audit",
+        "de": "Änderungsprotokoll",
+        "es": "Registro de auditoría",
+        "it": "Registro di audit",
+        "ja": "監査ログ",
+        "pl": "Dziennik audytu",
+        "pt": "Log de auditoria",
+        "ru": "Журнал аудита",
+        "zh": "审计日志",
+        "hi": "ऑडिट लॉग",
+        "tr": "Denetim günlüğü",
+        "ko": "감사 로그"
+      }
+    },
+    {
+      "term": "Company",
+      "category": "platform",
+      "context": "One legal entity in Carbon; all data is scoped to it.",
+      "translations": {
+        "fr": "Société",
+        "de": "Unternehmen",
+        "es": "Empresa",
+        "it": "Azienda",
+        "ja": "会社",
+        "pl": "Firma",
+        "pt": "Empresa",
+        "ru": "Организация",
+        "zh": "公司",
+        "hi": "कंपनी",
+        "tr": "Şirket",
+        "ko": "회사"
+      }
+    },
+    {
+      "term": "Company Group",
+      "category": "platform",
+      "context": "A set of companies sharing accounting configuration.",
+      "translations": {
+        "fr": "Groupe de sociétés",
+        "de": "Unternehmensgruppe",
+        "es": "Grupo de empresas",
+        "it": "Gruppo aziendale",
+        "ja": "会社グループ",
+        "pl": "Grupa firm",
+        "pt": "Grupo de empresas",
+        "ru": "Группа организаций",
+        "zh": "公司集团",
+        "hi": "कंपनी समूह",
+        "tr": "Şirket grubu",
+        "ko": "회사 그룹"
+      }
+    },
+    {
+      "term": "Custom Field",
+      "category": "platform",
+      "context": "A user-defined field added to a record.",
+      "translations": {
+        "fr": "Champ personnalisé",
+        "de": "Benutzerdefiniertes Feld",
+        "es": "Campo personalizado",
+        "it": "Campo personalizzato",
+        "ja": "カスタムフィールド",
+        "pl": "Pole niestandardowe",
+        "pt": "Campo personalizado",
+        "ru": "Пользовательское поле",
+        "zh": "自定义字段",
+        "hi": "कस्टम फ़ील्ड",
+        "tr": "Özel alan",
+        "ko": "사용자 정의 필드"
+      }
+    },
+    {
+      "term": "Daily",
+      "category": "platform",
+      "context": "Once a day.",
+      "translations": {
+        "fr": "Quotidien",
+        "de": "Täglich",
+        "es": "Diario",
+        "it": "Giornaliero",
+        "ja": "毎日",
+        "pl": "Codziennie",
+        "pt": "Diário",
+        "ru": "Ежедневно",
+        "zh": "每日",
+        "hi": "दैनिक",
+        "tr": "Günlük",
+        "ko": "매일"
+      }
+    },
+    {
+      "term": "Document",
+      "category": "platform",
+      "context": "A file attached to or generated from a record.",
+      "translations": {
+        "fr": "Document",
+        "de": "Dokument",
+        "es": "Documento",
+        "it": "Documento",
+        "ja": "文書",
+        "pl": "Dokument",
+        "pt": "Documento",
+        "ru": "Документ",
+        "zh": "文件",
+        "hi": "दस्तावेज़",
+        "tr": "Belge",
+        "ko": "문서"
+      }
+    },
+    {
+      "term": "Due Date",
+      "category": "platform",
+      "context": "When something is expected to be finished.",
+      "translations": {
+        "fr": "Date d'échéance",
+        "de": "Fälligkeitsdatum",
+        "es": "Fecha de vencimiento",
+        "it": "Data di scadenza",
+        "ja": "期日",
+        "pl": "Termin",
+        "pt": "Data de vencimento",
+        "ru": "Срок выполнения",
+        "zh": "到期日",
+        "hi": "नियत तिथि",
+        "tr": "Son tarih",
+        "ko": "마감일"
+      }
+    },
+    {
+      "term": "External",
+      "category": "platform",
+      "context": "Visible outside the company.",
+      "translations": {
+        "fr": "Externe",
+        "de": "Extern",
+        "es": "Externo",
+        "it": "Esterno",
+        "ja": "社外",
+        "pl": "Zewnętrzny",
+        "pt": "Externo",
+        "ru": "Внешний",
+        "zh": "外部",
+        "hi": "बाहरी",
+        "tr": "Harici",
+        "ko": "외부"
+      }
+    },
+    {
+      "term": "History",
+      "category": "platform",
+      "context": "The past states or events on a record.",
+      "translations": {
+        "fr": "Historique",
+        "de": "Verlauf",
+        "es": "Historial",
+        "it": "Cronologia",
+        "ja": "履歴",
+        "pl": "Historia",
+        "pt": "Histórico",
+        "ru": "История",
+        "zh": "历史记录",
+        "hi": "इतिहास",
+        "tr": "Geçmiş",
+        "ko": "이력"
+      }
+    },
+    {
+      "term": "Integration",
+      "category": "platform",
+      "context": "A connection to an outside system.",
+      "translations": {
+        "fr": "Intégration",
+        "de": "Integration",
+        "es": "Integración",
+        "it": "Integrazione",
+        "ja": "連携",
+        "pl": "Integracja",
+        "pt": "Integração",
+        "ru": "Интеграция",
+        "zh": "集成",
+        "hi": "एकीकरण",
+        "tr": "Entegrasyon",
+        "ko": "연동"
+      }
+    },
+    {
+      "term": "Internal",
+      "category": "platform",
+      "context": "Visible only inside the company.",
+      "translations": {
+        "fr": "Interne",
+        "de": "Intern",
+        "es": "Interno",
+        "it": "Interno",
+        "ja": "社内",
+        "pl": "Wewnętrzny",
+        "pt": "Interno",
+        "ru": "Внутренний",
+        "zh": "内部",
+        "hi": "आंतरिक",
+        "tr": "Dahili",
+        "ko": "내부"
+      }
+    },
+    {
+      "term": "Module",
+      "category": "platform",
+      "context": "A top-level area of the app (Sales, Inventory, Production).",
+      "translations": {
+        "fr": "Module",
+        "de": "Modul",
+        "es": "Módulo",
+        "it": "Modulo",
+        "ja": "モジュール",
+        "pl": "Moduł",
+        "pt": "Módulo",
+        "ru": "Модуль",
+        "zh": "模块",
+        "hi": "मॉड्यूल",
+        "tr": "Modül",
+        "ko": "모듈"
+      }
+    },
+    {
+      "term": "Monthly",
+      "category": "platform",
+      "context": "Once a month.",
+      "translations": {
+        "fr": "Mensuel",
+        "de": "Monatlich",
+        "es": "Mensual",
+        "it": "Mensile",
+        "ja": "毎月",
+        "pl": "Co miesiąc",
+        "pt": "Mensal",
+        "ru": "Ежемесячно",
+        "zh": "每月",
+        "hi": "मासिक",
+        "tr": "Aylık",
+        "ko": "매월"
+      }
+    },
+    {
+      "term": "Note",
+      "category": "platform",
+      "context": "Free-text commentary on a record.",
+      "translations": {
+        "fr": "Note",
+        "de": "Notiz",
+        "es": "Nota",
+        "it": "Nota",
+        "ja": "メモ",
+        "pl": "Notatka",
+        "pt": "Observação",
+        "ru": "Примечание",
+        "zh": "备注",
+        "hi": "नोट",
+        "tr": "Not",
+        "ko": "메모"
+      }
+    },
+    {
+      "term": "Notification",
+      "category": "platform",
+      "context": "A message telling a user something happened.",
+      "translations": {
+        "fr": "Notification",
+        "de": "Benachrichtigung",
+        "es": "Notificación",
+        "it": "Notifica",
+        "ja": "通知",
+        "pl": "Powiadomienie",
+        "pt": "Notificação",
+        "ru": "Уведомление",
+        "zh": "通知",
+        "hi": "सूचना",
+        "tr": "Bildirim",
+        "ko": "알림"
+      }
+    },
+    {
+      "term": "Override",
+      "category": "platform",
+      "context": "Replacing an inherited or calculated value with a manual one.",
+      "translations": {
+        "fr": "Substitution",
+        "de": "Übersteuerung",
+        "es": "Sobrescritura",
+        "it": "Forzatura",
+        "ja": "上書き",
+        "pl": "Nadpisanie",
+        "pt": "Sobrescrita",
+        "ru": "Переопределение",
+        "zh": "覆盖",
+        "hi": "ओवरराइड",
+        "tr": "Geçersiz kılma",
+        "ko": "재정의"
+      }
+    },
+    {
+      "term": "Owner",
+      "category": "platform",
+      "context": "The person accountable for a record.",
+      "translations": {
+        "fr": "Propriétaire",
+        "de": "Verantwortlicher",
+        "es": "Propietario",
+        "it": "Responsabile",
+        "ja": "責任者",
+        "pl": "Właściciel",
+        "pt": "Responsável",
+        "ru": "Ответственный",
+        "zh": "负责人",
+        "hi": "स्वामी",
+        "tr": "Sahip",
+        "ko": "책임자"
+      }
+    },
+    {
+      "term": "Passkey",
+      "category": "platform",
+      "context": "A password-free login credential.",
+      "translations": {
+        "fr": "Clé d'accès",
+        "de": "Passkey",
+        "es": "Llave de acceso",
+        "it": "Passkey",
+        "ja": "パスキー",
+        "pl": "Klucz dostępu",
+        "pt": "Chave de acesso",
+        "ru": "Ключ доступа",
+        "zh": "通行密钥",
+        "hi": "पासकी",
+        "tr": "Geçiş anahtarı",
+        "ko": "패스키"
+      }
+    },
+    {
+      "term": "Permission",
+      "category": "platform",
+      "context": "What a user is allowed to do in a module.",
+      "translations": {
+        "fr": "Autorisation",
+        "de": "Berechtigung",
+        "es": "Permiso",
+        "it": "Autorizzazione",
+        "ja": "権限",
+        "pl": "Uprawnienie",
+        "pt": "Permissão",
+        "ru": "Право доступа",
+        "zh": "权限",
+        "hi": "अनुमति",
+        "tr": "İzin",
+        "ko": "권한"
+      }
+    },
+    {
+      "term": "Printer",
+      "category": "platform",
+      "context": "A configured output device for labels and documents.",
+      "translations": {
+        "fr": "Imprimante",
+        "de": "Drucker",
+        "es": "Impresora",
+        "it": "Stampante",
+        "ja": "プリンター",
+        "pl": "Drukarka",
+        "pt": "Impressora",
+        "ru": "Принтер",
+        "zh": "打印机",
+        "hi": "प्रिंटर",
+        "tr": "Yazıcı",
+        "ko": "프린터"
+      }
+    },
+    {
+      "term": "Quarterly",
+      "category": "platform",
+      "context": "Once a quarter.",
+      "translations": {
+        "fr": "Trimestriel",
+        "de": "Vierteljährlich",
+        "es": "Trimestral",
+        "it": "Trimestrale",
+        "ja": "四半期ごと",
+        "pl": "Co kwartał",
+        "pt": "Trimestral",
+        "ru": "Ежеквартально",
+        "zh": "每季度",
+        "hi": "त्रैमासिक",
+        "tr": "Üç aylık",
+        "ko": "분기별"
+      }
+    },
+    {
+      "term": "Readable ID",
+      "category": "platform",
+      "context": "The human-facing identifier on a record, as opposed to its internal id.",
+      "translations": {
+        "fr": "Identifiant lisible",
+        "de": "Lesbare ID",
+        "es": "ID legible",
+        "it": "ID leggibile",
+        "ja": "表示ID",
+        "pl": "Czytelny identyfikator",
+        "pt": "ID legível",
+        "ru": "Читаемый идентификатор",
+        "zh": "可读ID",
+        "hi": "पठनीय ID",
+        "tr": "Okunabilir kimlik",
+        "ko": "표시 ID"
+      }
+    },
+    {
+      "term": "Request Approval",
+      "category": "platform",
+      "context": "Ask the required approver to sign off.",
+      "translations": {
+        "fr": "Demander l'approbation",
+        "de": "Genehmigung anfordern",
+        "es": "Solicitar aprobación",
+        "it": "Richiedi approvazione",
+        "ja": "承認を依頼",
+        "pl": "Poproś o zatwierdzenie",
+        "pt": "Solicitar aprovação",
+        "ru": "Запросить утверждение",
+        "zh": "请求审批",
+        "hi": "अनुमोदन का अनुरोध करें",
+        "tr": "Onay iste",
+        "ko": "승인 요청"
+      }
+    },
+    {
+      "term": "Role",
+      "category": "platform",
+      "context": "A named set of permissions given to users.",
+      "translations": {
+        "fr": "Rôle",
+        "de": "Rolle",
+        "es": "Rol",
+        "it": "Ruolo",
+        "ja": "ロール",
+        "pl": "Rola",
+        "pt": "Função",
+        "ru": "Роль",
+        "zh": "角色",
+        "hi": "भूमिका",
+        "tr": "Rol",
+        "ko": "역할"
+      }
+    },
+    {
+      "term": "Rule",
+      "category": "platform",
+      "context": "A configured condition-and-action the system applies automatically.",
+      "translations": {
+        "fr": "Règle",
+        "de": "Regel",
+        "es": "Regla",
+        "it": "Regola",
+        "ja": "ルール",
+        "pl": "Reguła",
+        "pt": "Regra",
+        "ru": "Правило",
+        "zh": "规则",
+        "hi": "नियम",
+        "tr": "Kural",
+        "ko": "규칙"
+      }
+    },
+    {
+      "term": "Sequence",
+      "category": "platform",
+      "context": "The numbering rule that generates record IDs.",
+      "translations": {
+        "fr": "Séquence",
+        "de": "Nummernkreis",
+        "es": "Secuencia",
+        "it": "Sequenza",
+        "ja": "採番",
+        "pl": "Numeracja",
+        "pt": "Sequência",
+        "ru": "Нумерация",
+        "zh": "编号规则",
+        "hi": "अनुक्रम",
+        "tr": "Numaralandırma",
+        "ko": "채번 규칙"
+      }
+    },
+    {
+      "term": "Source Document",
+      "category": "platform",
+      "context": "The record a transaction posts against (the sales order behind a shipment, the PO behind a receipt).",
+      "translations": {
+        "fr": "Document d'origine",
+        "de": "Ursprungsbeleg",
+        "es": "Documento de origen",
+        "it": "Documento di origine",
+        "ja": "参照伝票",
+        "pl": "Dokument źródłowy",
+        "pt": "Documento de origem",
+        "ru": "Документ-основание",
+        "zh": "源单据",
+        "hi": "स्रोत दस्तावेज़",
+        "tr": "Kaynak belge",
+        "ko": "원본 문서"
+      }
+    },
+    {
+      "term": "Start Date",
+      "category": "platform",
+      "context": "When something is planned to begin.",
+      "translations": {
+        "fr": "Date de début",
+        "de": "Startdatum",
+        "es": "Fecha de inicio",
+        "it": "Data di inizio",
+        "ja": "開始日",
+        "pl": "Data rozpoczęcia",
+        "pt": "Data de início",
+        "ru": "Дата начала",
+        "zh": "开始日期",
+        "hi": "प्रारंभ तिथि",
+        "tr": "Başlangıç tarihi",
+        "ko": "시작일"
+      }
+    },
+    {
+      "term": "Status",
+      "category": "platform",
+      "context": "Where a record sits in its lifecycle.",
+      "translations": {
+        "fr": "Statut",
+        "de": "Status",
+        "es": "Estado",
+        "it": "Stato",
+        "ja": "ステータス",
+        "pl": "Status",
+        "pt": "Status",
+        "ru": "Статус",
+        "zh": "状态",
+        "hi": "स्थिति",
+        "tr": "Durum",
+        "ko": "상태"
+      }
+    },
+    {
+      "term": "Step",
+      "category": "platform",
+      "context": "One ordered stage in a work instruction, workflow or assembly.",
+      "translations": {
+        "fr": "Étape",
+        "de": "Schritt",
+        "es": "Paso",
+        "it": "Passo",
+        "ja": "ステップ",
+        "pl": "Krok",
+        "pt": "Etapa",
+        "ru": "Шаг",
+        "zh": "步骤",
+        "hi": "चरण",
+        "tr": "Adım",
+        "ko": "단계"
+      }
+    },
+    {
+      "term": "Task",
+      "category": "platform",
+      "context": "A unit of assigned work inside a record.",
+      "translations": {
+        "fr": "Tâche",
+        "de": "Aufgabe",
+        "es": "Tarea",
+        "it": "Attività",
+        "ja": "タスク",
+        "pl": "Zadanie",
+        "pt": "Tarefa",
+        "ru": "Задача",
+        "zh": "任务",
+        "hi": "कार्य",
+        "tr": "Görev",
+        "ko": "작업"
+      }
+    },
+    {
+      "term": "Two-Factor Authentication",
+      "category": "platform",
+      "context": "A second login step beyond the password.",
+      "translations": {
+        "fr": "Authentification à deux facteurs",
+        "de": "Zwei-Faktor-Authentifizierung",
+        "es": "Autenticación de dos factores",
+        "it": "Autenticazione a due fattori",
+        "ja": "二要素認証",
+        "pl": "Uwierzytelnianie dwuskładnikowe",
+        "pt": "Autenticação de dois fatores",
+        "ru": "Двухфакторная аутентификация",
+        "zh": "双因素认证",
+        "hi": "दो-कारक प्रमाणीकरण",
+        "tr": "İki faktörlü kimlik doğrulama",
+        "ko": "2단계 인증"
+      }
+    },
+    {
+      "term": "User",
+      "category": "platform",
+      "context": "A login account.",
+      "translations": {
+        "fr": "Utilisateur",
+        "de": "Benutzer",
+        "es": "Usuario",
+        "it": "Utente",
+        "ja": "ユーザー",
+        "pl": "Użytkownik",
+        "pt": "Usuário",
+        "ru": "Пользователь",
+        "zh": "用户",
+        "hi": "उपयोगकर्ता",
+        "tr": "Kullanıcı",
+        "ko": "사용자"
+      }
+    },
+    {
+      "term": "Version",
+      "category": "platform",
+      "context": "A numbered iteration of a workflow, work instruction or document.",
+      "ambiguity": "Distinct from item Revision — do not use one word for both.",
+      "translations": {
+        "fr": "Version",
+        "de": "Version",
+        "es": "Versión",
+        "it": "Versione",
+        "ja": "バージョン",
+        "pl": "Wersja",
+        "pt": "Versão",
+        "ru": "Версия",
+        "zh": "版本",
+        "hi": "संस्करण",
+        "tr": "Sürüm",
+        "ko": "버전"
+      }
+    },
+    {
+      "term": "Webhook",
+      "category": "platform",
+      "context": "An outbound HTTP call fired when something happens.",
+      "translations": {
+        "fr": "Webhook",
+        "de": "Webhook",
+        "es": "Webhook",
+        "it": "Webhook",
+        "ja": "Webhook",
+        "pl": "Webhook",
+        "pt": "Webhook",
+        "ru": "Вебхук",
+        "zh": "Webhook",
+        "hi": "वेबहुक",
+        "tr": "Webhook",
+        "ko": "웹훅"
+      }
+    },
+    {
+      "term": "Weekly",
+      "category": "platform",
+      "context": "Once a week.",
+      "translations": {
+        "fr": "Hebdomadaire",
+        "de": "Wöchentlich",
+        "es": "Semanal",
+        "it": "Settimanale",
+        "ja": "毎週",
+        "pl": "Co tydzień",
+        "pt": "Semanal",
+        "ru": "Еженедельно",
+        "zh": "每周",
+        "hi": "साप्ताहिक",
+        "tr": "Haftalık",
+        "ko": "매주"
+      }
+    },
+    {
+      "term": "Workflow",
+      "category": "platform",
+      "context": "A customer-configured automation rule that reacts to events.",
+      "ambiguity": "Carbon's product name for this feature — not a generic 'process flow'.",
+      "translations": {
+        "fr": "Workflow",
+        "de": "Workflow",
+        "es": "Flujo de trabajo",
+        "it": "Flusso di lavoro",
+        "ja": "ワークフロー",
+        "pl": "Przepływ pracy",
+        "pt": "Fluxo de trabalho",
+        "ru": "Рабочий процесс",
+        "zh": "工作流",
+        "hi": "वर्कफ़्लो",
+        "tr": "İş akışı",
+        "ko": "워크플로"
+      }
+    },
+    {
+      "term": "Backflush",
+      "category": "production",
+      "context": "Consuming material automatically when an operation is reported complete.",
+      "translations": {
+        "fr": "Post-consommation",
+        "de": "Retrograde Entnahme",
+        "es": "Consumo retroactivo",
+        "it": "Backflush",
+        "ja": "バックフラッシュ",
+        "pl": "Pobranie wsteczne",
+        "pt": "Baixa automática",
+        "ru": "Ретроградное списание",
+        "zh": "倒冲",
+        "hi": "बैकफ्लश",
+        "tr": "Geriye dönük tüketim",
+        "ko": "백플러시"
+      }
+    },
+    {
+      "term": "Clock In",
+      "category": "production",
+      "context": "An operator starting time against a job operation.",
+      "translations": {
+        "fr": "Pointage début",
+        "de": "Einstempeln",
+        "es": "Fichar entrada",
+        "it": "Timbra inizio",
+        "ja": "作業開始",
+        "pl": "Rozpoczęcie pracy",
+        "pt": "Apontar início",
+        "ru": "Начало работы",
+        "zh": "开工",
+        "hi": "कार्य प्रारंभ",
+        "tr": "İş başlangıcı",
+        "ko": "작업 시작"
+      }
+    },
+    {
+      "term": "Clock Out",
+      "category": "production",
+      "context": "An operator stopping time against a job operation.",
+      "translations": {
+        "fr": "Pointage fin",
+        "de": "Ausstempeln",
+        "es": "Fichar salida",
+        "it": "Timbra fine",
+        "ja": "作業終了",
+        "pl": "Zakończenie pracy",
+        "pt": "Apontar fim",
+        "ru": "Окончание работы",
+        "zh": "收工",
+        "hi": "कार्य समाप्त",
+        "tr": "İş bitişi",
+        "ko": "작업 종료"
+      }
+    },
+    {
+      "term": "Console Operator",
+      "category": "production",
+      "context": "A shared-terminal login used on the shop floor.",
+      "translations": {
+        "fr": "Opérateur console",
+        "de": "Konsolenbediener",
+        "es": "Operador de consola",
+        "it": "Operatore console",
+        "ja": "コンソールオペレーター",
+        "pl": "Operator konsoli",
+        "pt": "Operador de console",
+        "ru": "Оператор консоли",
+        "zh": "控制台操作员",
+        "hi": "कंसोल ऑपरेटर",
+        "tr": "Konsol operatörü",
+        "ko": "콘솔 작업자"
+      }
+    },
+    {
+      "term": "Consumption",
+      "category": "production",
+      "context": "Material being used up by a job.",
+      "translations": {
+        "fr": "Consommation",
+        "de": "Verbrauch",
+        "es": "Consumo",
+        "it": "Consumo",
+        "ja": "消費",
+        "pl": "Zużycie",
+        "pt": "Consumo",
+        "ru": "Потребление",
+        "zh": "消耗",
+        "hi": "खपत",
+        "tr": "Tüketim",
+        "ko": "소모"
+      }
+    },
+    {
+      "term": "Dispatch",
+      "category": "production",
+      "context": "A maintenance dispatch — a scheduled or reactive maintenance task raised against equipment.",
+      "translations": {
+        "fr": "Intervention de maintenance",
+        "de": "Instandhaltungsauftrag",
+        "es": "Orden de mantenimiento",
+        "it": "Intervento di manutenzione",
+        "ja": "保全指示",
+        "pl": "Zlecenie utrzymania ruchu",
+        "pt": "Ordem de manutenção",
+        "ru": "Заявка на техобслуживание",
+        "zh": "维护工单",
+        "hi": "रखरखाव कार्य",
+        "tr": "Bakım emri",
+        "ko": "유지보수 지시"
+      }
+    },
+    {
+      "term": "Downtime",
+      "category": "production",
+      "context": "Time a work center is unavailable.",
+      "translations": {
+        "fr": "Temps d'arrêt",
+        "de": "Stillstandszeit",
+        "es": "Tiempo de paro",
+        "it": "Fermo macchina",
+        "ja": "停止時間",
+        "pl": "Przestój",
+        "pt": "Tempo de parada",
+        "ru": "Простой",
+        "zh": "停机时间",
+        "hi": "डाउनटाइम",
+        "tr": "Duruş",
+        "ko": "비가동 시간"
+      }
+    },
+    {
+      "term": "Job",
+      "category": "production",
+      "context": "The manufacturing work order — the record that consumes materials, runs operations and produces a quantity of an item. Use the ERP work-order term, NOT the word for employment.",
+      "ambiguity": "Never fix the rendering inside 'job title' or 'job function' in HR-flavoured strings.",
+      "translations": {
+        "fr": "Ordre de fabrication",
+        "de": "Fertigungsauftrag",
+        "es": "Orden de trabajo",
+        "it": "Ordine di produzione",
+        "ja": "製造指図",
+        "pl": "Zlecenie produkcyjne",
+        "pt": "Ordem de produção",
+        "ru": "Производственный заказ",
+        "zh": "工单",
+        "hi": "जॉब",
+        "tr": "İş emri",
+        "ko": "작업 지시"
+      }
+    },
+    {
+      "term": "Job Material",
+      "category": "production",
+      "context": "One material line on a job — a snapshot of what that job consumes.",
+      "translations": {
+        "fr": "Composant d'OF",
+        "de": "Auftragsmaterial",
+        "es": "Material de la orden",
+        "it": "Materiale dell'ordine",
+        "ja": "指図材料",
+        "pl": "Materiał zlecenia",
+        "pt": "Material da ordem",
+        "ru": "Материал заказа",
+        "zh": "工单物料",
+        "hi": "जॉब सामग्री",
+        "tr": "İş emri malzemesi",
+        "ko": "작업 지시 자재"
+      }
+    },
+    {
+      "term": "Job Operation",
+      "category": "production",
+      "context": "One operation on a specific job — what an operator actually works on.",
+      "translations": {
+        "fr": "Opération d'OF",
+        "de": "Auftragsvorgang",
+        "es": "Operación de la orden",
+        "it": "Operazione dell'ordine",
+        "ja": "指図工程",
+        "pl": "Operacja zlecenia",
+        "pt": "Operação da ordem",
+        "ru": "Операция заказа",
+        "zh": "工单工序",
+        "hi": "जॉब ऑपरेशन",
+        "tr": "İş emri operasyonu",
+        "ko": "작업 지시 공정"
+      }
+    },
+    {
+      "term": "Kanban",
+      "category": "production",
+      "context": "A signal card that triggers replenishment of a part.",
+      "translations": {
+        "fr": "Kanban",
+        "de": "Kanban",
+        "es": "Kanban",
+        "it": "Kanban",
+        "ja": "かんばん",
+        "pl": "Kanban",
+        "pt": "Kanban",
+        "ru": "Канбан",
+        "zh": "看板",
+        "hi": "कानबान",
+        "tr": "Kanban",
+        "ko": "칸반"
+      }
+    },
+    {
+      "term": "Labor",
+      "category": "production",
+      "context": "Human work time logged against a job operation, as opposed to Setup or Machine time.",
+      "translations": {
+        "fr": "Main-d'œuvre",
+        "de": "Personal",
+        "es": "Mano de obra",
+        "it": "Manodopera",
+        "ja": "労務",
+        "pl": "Robocizna",
+        "pt": "Mão de obra",
+        "ru": "Труд",
+        "zh": "人工",
+        "hi": "श्रम",
+        "tr": "İşçilik",
+        "ko": "노무"
+      }
+    },
+    {
+      "term": "Lineside",
+      "category": "production",
+      "context": "Stock held at the point of use on the floor.",
+      "translations": {
+        "fr": "Bord de ligne",
+        "de": "Linienlager",
+        "es": "Pie de línea",
+        "it": "Bordo linea",
+        "ja": "ラインサイド",
+        "pl": "Magazyn przyliniowy",
+        "pt": "Borda de linha",
+        "ru": "Прилинейный запас",
+        "zh": "线边",
+        "hi": "लाइनसाइड",
+        "tr": "Hat yanı",
+        "ko": "라인사이드"
+      }
+    },
+    {
+      "term": "Operator",
+      "category": "production",
+      "context": "The person performing a job operation.",
+      "translations": {
+        "fr": "Opérateur",
+        "de": "Werker",
+        "es": "Operario",
+        "it": "Operatore",
+        "ja": "作業者",
+        "pl": "Operator",
+        "pt": "Operador",
+        "ru": "Оператор",
+        "zh": "操作员",
+        "hi": "ऑपरेटर",
+        "tr": "Operatör",
+        "ko": "작업자"
+      }
+    },
+    {
+      "term": "Priority",
+      "category": "production",
+      "context": "How urgent a job or task is relative to others.",
+      "translations": {
+        "fr": "Priorité",
+        "de": "Priorität",
+        "es": "Prioridad",
+        "it": "Priorità",
+        "ja": "優先度",
+        "pl": "Priorytet",
+        "pt": "Prioridade",
+        "ru": "Приоритет",
+        "zh": "优先级",
+        "hi": "प्राथमिकता",
+        "tr": "Öncelik",
+        "ko": "우선순위"
+      }
+    },
+    {
+      "term": "Production",
+      "category": "production",
+      "context": "The act of manufacturing, and the module that manages it.",
+      "translations": {
+        "fr": "Production",
+        "de": "Produktion",
+        "es": "Producción",
+        "it": "Produzione",
+        "ja": "生産",
+        "pl": "Produkcja",
+        "pt": "Produção",
+        "ru": "Производство",
+        "zh": "生产",
+        "hi": "उत्पादन",
+        "tr": "Üretim",
+        "ko": "생산"
+      }
+    },
+    {
+      "term": "Production Event",
+      "category": "production",
+      "context": "A recorded shop-floor occurrence: time, quantity, scrap or downtime.",
+      "translations": {
+        "fr": "Événement de production",
+        "de": "Produktionsereignis",
+        "es": "Evento de producción",
+        "it": "Evento di produzione",
+        "ja": "生産イベント",
+        "pl": "Zdarzenie produkcyjne",
+        "pt": "Evento de produção",
+        "ru": "Производственное событие",
+        "zh": "生产事件",
+        "hi": "उत्पादन इवेंट",
+        "tr": "Üretim olayı",
+        "ko": "생산 이벤트"
+      }
+    },
+    {
+      "term": "Scan",
+      "category": "production",
+      "context": "Reading a barcode or QR code to identify stock or work.",
+      "translations": {
+        "fr": "Scanner",
+        "de": "Scannen",
+        "es": "Escanear",
+        "it": "Scansiona",
+        "ja": "スキャン",
+        "pl": "Skanuj",
+        "pt": "Escanear",
+        "ru": "Сканировать",
+        "zh": "扫码",
+        "hi": "स्कैन करें",
+        "tr": "Tara",
+        "ko": "스캔"
+      }
+    },
+    {
+      "term": "Schedule",
+      "category": "production",
+      "context": "The planned timing of jobs and operations.",
+      "translations": {
+        "fr": "Planning",
+        "de": "Terminplan",
+        "es": "Programa",
+        "it": "Programma",
+        "ja": "スケジュール",
+        "pl": "Harmonogram",
+        "pt": "Programação",
+        "ru": "График",
+        "zh": "排程",
+        "hi": "शेड्यूल",
+        "tr": "Çizelge",
+        "ko": "일정"
+      }
+    },
+    {
+      "term": "Scrap",
+      "category": "production",
+      "context": "Material or parts lost or rejected during manufacturing.",
+      "translations": {
+        "fr": "Rebut",
+        "de": "Ausschuss",
+        "es": "Desperdicio",
+        "it": "Scarto",
+        "ja": "スクラップ",
+        "pl": "Braki",
+        "pt": "Refugo",
+        "ru": "Брак",
+        "zh": "报废",
+        "hi": "स्क्रैप",
+        "tr": "Fire",
+        "ko": "스크랩"
+      }
+    },
+    {
+      "term": "Scrap Reason",
+      "category": "production",
+      "context": "The configured cause recorded when parts are scrapped.",
+      "translations": {
+        "fr": "Motif de rebut",
+        "de": "Ausschussgrund",
+        "es": "Motivo de desperdicio",
+        "it": "Causale di scarto",
+        "ja": "不良理由",
+        "pl": "Przyczyna braku",
+        "pt": "Motivo de refugo",
+        "ru": "Причина брака",
+        "zh": "报废原因",
+        "hi": "स्क्रैप कारण",
+        "tr": "Fire nedeni",
+        "ko": "스크랩 사유"
+      }
+    },
+    {
+      "term": "Shop Floor",
+      "category": "production",
+      "context": "Where manufacturing physically happens; the MES app's domain.",
+      "translations": {
+        "fr": "Atelier",
+        "de": "Werkstatt",
+        "es": "Planta",
+        "it": "Officina",
+        "ja": "製造現場",
+        "pl": "Hala produkcyjna",
+        "pt": "Chão de fábrica",
+        "ru": "Цех",
+        "zh": "车间",
+        "hi": "शॉप फ्लोर",
+        "tr": "Atölye",
+        "ko": "현장"
+      }
+    },
+    {
+      "term": "Terminal",
+      "category": "production",
+      "context": "A shared shop-floor device operators sign into with a PIN.",
+      "translations": {
+        "fr": "Terminal",
+        "de": "Terminal",
+        "es": "Terminal",
+        "it": "Terminale",
+        "ja": "端末",
+        "pl": "Terminal",
+        "pt": "Terminal",
+        "ru": "Терминал",
+        "zh": "终端",
+        "hi": "टर्मिनल",
+        "tr": "Terminal",
+        "ko": "터미널"
+      }
+    },
+    {
+      "term": "Traveler",
+      "category": "production",
+      "context": "The printed packet that follows a job through the shop.",
+      "translations": {
+        "fr": "Fiche suiveuse",
+        "de": "Laufkarte",
+        "es": "Hoja viajera",
+        "it": "Cartellino di produzione",
+        "ja": "現品票",
+        "pl": "Przewodnik",
+        "pt": "Ficha de acompanhamento",
+        "ru": "Маршрутный лист",
+        "zh": "流转卡",
+        "hi": "ट्रैवलर",
+        "tr": "İş takip kartı",
+        "ko": "작업 이동표"
+      }
+    },
+    {
+      "term": "WIP",
+      "category": "production",
+      "context": "Work in Process — value or material part-way through manufacturing.",
+      "translations": {
+        "fr": "En-cours",
+        "de": "WIP",
+        "es": "Producto en proceso",
+        "it": "WIP",
+        "ja": "仕掛品",
+        "pl": "Produkcja w toku",
+        "pt": "Produto em processo",
+        "ru": "Незавершенное производство",
+        "zh": "在制品",
+        "hi": "WIP",
+        "tr": "Yarı mamul",
+        "ko": "재공품"
+      }
+    },
+    {
+      "term": "Buyer",
+      "category": "purchasing",
+      "context": "The person responsible for placing purchase orders.",
+      "translations": {
+        "fr": "Acheteur",
+        "de": "Einkäufer",
+        "es": "Comprador",
+        "it": "Buyer",
+        "ja": "購買担当者",
+        "pl": "Kupiec",
+        "pt": "Comprador",
+        "ru": "Закупщик",
+        "zh": "采购员",
+        "hi": "क्रेता",
+        "tr": "Satın almacı",
+        "ko": "구매 담당자"
+      }
+    },
+    {
+      "term": "Conversion Factor",
+      "category": "purchasing",
+      "context": "The multiplier between a supplier's unit of measure and ours.",
+      "translations": {
+        "fr": "Facteur de conversion",
+        "de": "Umrechnungsfaktor",
+        "es": "Factor de conversión",
+        "it": "Fattore di conversione",
+        "ja": "換算係数",
+        "pl": "Współczynnik przeliczeniowy",
+        "pt": "Fator de conversão",
+        "ru": "Коэффициент пересчета",
+        "zh": "换算系数",
+        "hi": "रूपांतरण कारक",
+        "tr": "Çevrim katsayısı",
+        "ko": "환산 계수"
+      }
+    },
+    {
+      "term": "Incoterm",
+      "category": "purchasing",
+      "context": "The standard code setting who pays freight and bears risk (EXW, DAP, FOB).",
+      "translations": {
+        "fr": "Incoterm",
+        "de": "Incoterm",
+        "es": "Incoterm",
+        "it": "Incoterm",
+        "ja": "インコタームズ",
+        "pl": "Incoterm",
+        "pt": "Incoterm",
+        "ru": "Инкотермс",
+        "zh": "贸易术语",
+        "hi": "इनकोटर्म",
+        "tr": "Incoterm",
+        "ko": "인코텀즈"
+      }
+    },
+    {
+      "term": "Minimum Order Quantity",
+      "category": "purchasing",
+      "context": "The smallest quantity a supplier will sell.",
+      "translations": {
+        "fr": "Quantité minimale de commande",
+        "de": "Mindestbestellmenge",
+        "es": "Cantidad mínima de pedido",
+        "it": "Quantità minima d'ordine",
+        "ja": "最小発注数量",
+        "pl": "Minimalna ilość zamówienia",
+        "pt": "Quantidade mínima de pedido",
+        "ru": "Минимальный объем заказа",
+        "zh": "最小起订量",
+        "hi": "न्यूनतम ऑर्डर मात्रा",
+        "tr": "Minimum sipariş miktarı",
+        "ko": "최소 주문 수량"
+      }
+    },
+    {
+      "term": "Order Multiple",
+      "category": "purchasing",
+      "context": "The increment an item must be ordered in.",
+      "translations": {
+        "fr": "Multiple de commande",
+        "de": "Bestellvielfaches",
+        "es": "Múltiplo de pedido",
+        "it": "Multiplo d'ordine",
+        "ja": "発注倍数",
+        "pl": "Wielokrotność zamówienia",
+        "pt": "Múltiplo de pedido",
+        "ru": "Кратность заказа",
+        "zh": "订购倍数",
+        "hi": "ऑर्डर गुणज",
+        "tr": "Sipariş katı",
+        "ko": "주문 배수"
+      }
+    },
+    {
+      "term": "Preferred Supplier",
+      "category": "purchasing",
+      "context": "The default supplier for an item.",
+      "translations": {
+        "fr": "Fournisseur préféré",
+        "de": "Bevorzugter Lieferant",
+        "es": "Proveedor preferido",
+        "it": "Fornitore preferenziale",
+        "ja": "優先仕入先",
+        "pl": "Preferowany dostawca",
+        "pt": "Fornecedor preferencial",
+        "ru": "Основной поставщик",
+        "zh": "首选供应商",
+        "hi": "पसंदीदा आपूर्तिकर्ता",
+        "tr": "Tercih edilen tedarikçi",
+        "ko": "우선 공급업체"
+      }
+    },
+    {
+      "term": "Price Break",
+      "category": "purchasing",
+      "context": "A quantity threshold at which the unit price changes.",
+      "translations": {
+        "fr": "Palier de prix",
+        "de": "Preisstaffel",
+        "es": "Escala de precios",
+        "it": "Scaglione di prezzo",
+        "ja": "価格スケール",
+        "pl": "Próg cenowy",
+        "pt": "Faixa de preço",
+        "ru": "Ценовая шкала",
+        "zh": "价格阶梯",
+        "hi": "मूल्य स्तर",
+        "tr": "Fiyat kademesi",
+        "ko": "가격 구간"
+      }
+    },
+    {
+      "term": "Promised Date",
+      "category": "purchasing",
+      "context": "The date a supplier committed to.",
+      "translations": {
+        "fr": "Date promise",
+        "de": "Zugesagter Termin",
+        "es": "Fecha prometida",
+        "it": "Data promessa",
+        "ja": "回答納期",
+        "pl": "Data potwierdzona",
+        "pt": "Data prometida",
+        "ru": "Подтвержденная дата",
+        "zh": "承诺日期",
+        "hi": "वादा की गई तिथि",
+        "tr": "Taahhüt tarihi",
+        "ko": "약속일"
+      }
+    },
+    {
+      "term": "Purchase Order",
+      "category": "purchasing",
+      "context": "A confirmed order placed on a supplier.",
+      "translations": {
+        "fr": "Bon de commande",
+        "de": "Bestellung",
+        "es": "Orden de compra",
+        "it": "Ordine di acquisto",
+        "ja": "発注書",
+        "pl": "Zamówienie zakupu",
+        "pt": "Pedido de compra",
+        "ru": "Заказ поставщику",
+        "zh": "采购订单",
+        "hi": "क्रय आदेश",
+        "tr": "Satın alma siparişi",
+        "ko": "발주서"
+      }
+    },
+    {
+      "term": "Quantity Break",
+      "category": "purchasing",
+      "context": "A quantity threshold at which pricing changes.",
+      "translations": {
+        "fr": "Palier de quantité",
+        "de": "Mengenstaffel",
+        "es": "Escala de cantidades",
+        "it": "Scaglione di quantità",
+        "ja": "数量スケール",
+        "pl": "Próg ilościowy",
+        "pt": "Faixa de quantidade",
+        "ru": "Шкала количества",
+        "zh": "数量阶梯",
+        "hi": "मात्रा स्तर",
+        "tr": "Miktar kademesi",
+        "ko": "수량 구간"
+      }
+    },
+    {
+      "term": "RFQ",
+      "category": "purchasing",
+      "context": "Short form of Request for Quote. Most languages keep the Latin abbreviation — confirm per language.",
+      "ambiguity": "Keep the abbreviation if the language normally keeps it.",
+      "translations": {
+        "fr": "RFQ",
+        "de": "Anfrage",
+        "es": "RFQ",
+        "it": "RdO",
+        "ja": "見積依頼",
+        "pl": "RFQ",
+        "pt": "RFQ",
+        "ru": "Запрос цен",
+        "zh": "询价单",
+        "hi": "RFQ",
+        "tr": "Teklif talebi",
+        "ko": "견적 요청"
+      },
+      "seeAlso": "Request for Quote"
+    },
+    {
+      "term": "Receipt",
+      "category": "purchasing",
+      "context": "Goods arriving from a supplier and being booked into stock. This is a GOODS receipt, not a payment receipt.",
+      "ambiguity": "Must not use the word for a payment/cash receipt.",
+      "translations": {
+        "fr": "Réception",
+        "de": "Wareneingang",
+        "es": "Recepción",
+        "it": "Entrata merci",
+        "ja": "入荷",
+        "pl": "Przyjęcie",
+        "pt": "Recebimento",
+        "ru": "Поступление",
+        "zh": "收货",
+        "hi": "प्राप्ति",
+        "tr": "Mal kabul",
+        "ko": "입고"
+      }
+    },
+    {
+      "term": "Receiving Location",
+      "category": "purchasing",
+      "context": "The location goods are received into.",
+      "translations": {
+        "fr": "Site de réception",
+        "de": "Empfangsort",
+        "es": "Ubicación de recepción",
+        "it": "Ubicazione di ricevimento",
+        "ja": "入荷拠点",
+        "pl": "Lokalizacja przyjęcia",
+        "pt": "Local de recebimento",
+        "ru": "Площадка приемки",
+        "zh": "收货地点",
+        "hi": "प्राप्ति स्थान",
+        "tr": "Mal kabul lokasyonu",
+        "ko": "입고 사업장"
+      }
+    },
+    {
+      "term": "Request for Quote",
+      "category": "purchasing",
+      "context": "The spelled-out form of RFQ.",
+      "translations": {
+        "fr": "Demande de devis",
+        "de": "Anfrage",
+        "es": "Solicitud de cotización",
+        "it": "Richiesta di offerta",
+        "ja": "見積依頼",
+        "pl": "Zapytanie ofertowe",
+        "pt": "Solicitação de cotação",
+        "ru": "Запрос цен",
+        "zh": "询价",
+        "hi": "कोटेशन अनुरोध",
+        "tr": "Teklif talebi",
+        "ko": "견적 요청"
+      }
+    },
+    {
+      "term": "Requested Date",
+      "category": "purchasing",
+      "context": "The date we asked for.",
+      "translations": {
+        "fr": "Date demandée",
+        "de": "Wunschtermin",
+        "es": "Fecha solicitada",
+        "it": "Data richiesta",
+        "ja": "希望納期",
+        "pl": "Data żądana",
+        "pt": "Data solicitada",
+        "ru": "Запрошенная дата",
+        "zh": "要求日期",
+        "hi": "अनुरोधित तिथि",
+        "tr": "Talep edilen tarih",
+        "ko": "요청일"
+      }
+    },
+    {
+      "term": "Supplier Part ID",
+      "category": "purchasing",
+      "context": "The supplier's own identifier for our item.",
+      "translations": {
+        "fr": "Référence fournisseur",
+        "de": "Lieferantenartikelnummer",
+        "es": "Referencia del proveedor",
+        "it": "Codice articolo fornitore",
+        "ja": "仕入先品番",
+        "pl": "Numer artykułu dostawcy",
+        "pt": "Referência do fornecedor",
+        "ru": "Артикул поставщика",
+        "zh": "供应商料号",
+        "hi": "आपूर्तिकर्ता पार्ट ID",
+        "tr": "Tedarikçi parça numarası",
+        "ko": "공급업체 품번"
+      }
+    },
+    {
+      "term": "Supplier Process",
+      "category": "purchasing",
+      "context": "A process a supplier can perform for us as outside work.",
+      "translations": {
+        "fr": "Procédé fournisseur",
+        "de": "Lieferantenverfahren",
+        "es": "Proceso del proveedor",
+        "it": "Processo del fornitore",
+        "ja": "仕入先工法",
+        "pl": "Proces dostawcy",
+        "pt": "Processo do fornecedor",
+        "ru": "Процесс поставщика",
+        "zh": "供应商工艺",
+        "hi": "आपूर्तिकर्ता प्रक्रिया",
+        "tr": "Tedarikçi prosesi",
+        "ko": "공급업체 공법"
+      }
+    },
+    {
+      "term": "Supplier Quote",
+      "category": "purchasing",
+      "context": "A supplier's priced response to an RFQ.",
+      "translations": {
+        "fr": "Devis fournisseur",
+        "de": "Lieferantenangebot",
+        "es": "Cotización del proveedor",
+        "it": "Offerta del fornitore",
+        "ja": "仕入先見積",
+        "pl": "Oferta dostawcy",
+        "pt": "Cotação do fornecedor",
+        "ru": "Предложение поставщика",
+        "zh": "供应商报价",
+        "hi": "आपूर्तिकर्ता कोटेशन",
+        "tr": "Tedarikçi teklifi",
+        "ko": "공급업체 견적"
+      }
+    },
+    {
+      "term": "Three-way match",
+      "category": "purchasing",
+      "context": "Checking purchase order, receipt and invoice agree before paying.",
+      "translations": {
+        "fr": "Rapprochement trois voies",
+        "de": "Dreiwege-Abgleich",
+        "es": "Conciliación de tres vías",
+        "it": "Riscontro a tre vie",
+        "ja": "三点照合",
+        "pl": "Uzgodnienie trójstronne",
+        "pt": "Conciliação de três vias",
+        "ru": "Трехстороннее сопоставление",
+        "zh": "三单匹配",
+        "hi": "थ्री-वे मिलान",
+        "tr": "Üçlü eşleştirme",
+        "ko": "3자 대사"
+      }
+    },
+    {
+      "term": "To Receive",
+      "category": "purchasing",
+      "context": "Outstanding lines awaiting receipt.",
+      "translations": {
+        "fr": "À réceptionner",
+        "de": "Zu empfangen",
+        "es": "Por recibir",
+        "it": "Da ricevere",
+        "ja": "入荷待ち",
+        "pl": "Do przyjęcia",
+        "pt": "A receber",
+        "ru": "Ожидает приемки",
+        "zh": "待收货",
+        "hi": "प्राप्त करने के लिए",
+        "tr": "Mal kabul bekleyen",
+        "ko": "입고 대기"
+      }
+    },
+    {
+      "term": "8D",
+      "category": "quality",
+      "context": "The eight-discipline structured problem-solving method.",
+      "translations": {
+        "fr": "8D",
+        "de": "8D",
+        "es": "8D",
+        "it": "8D",
+        "ja": "8D",
+        "pl": "8D",
+        "pt": "8D",
+        "ru": "8D",
+        "zh": "8D",
+        "hi": "8D",
+        "tr": "8D",
+        "ko": "8D"
+      }
+    },
+    {
+      "term": "AQL",
+      "category": "quality",
+      "context": "Acceptable Quality Limit — the sampling standard that sets how many to check.",
+      "translations": {
+        "fr": "AQL",
+        "de": "AQL",
+        "es": "AQL",
+        "it": "AQL",
+        "ja": "AQL",
+        "pl": "AQL",
+        "pt": "AQL",
+        "ru": "AQL",
+        "zh": "AQL",
+        "hi": "AQL",
+        "tr": "AQL",
+        "ko": "AQL"
+      }
+    },
+    {
+      "term": "Approval",
+      "category": "quality",
+      "context": "A required sign-off before something proceeds.",
+      "translations": {
+        "fr": "Approbation",
+        "de": "Genehmigung",
+        "es": "Aprobación",
+        "it": "Approvazione",
+        "ja": "承認",
+        "pl": "Zatwierdzenie",
+        "pt": "Aprovação",
+        "ru": "Утверждение",
+        "zh": "审批",
+        "hi": "अनुमोदन",
+        "tr": "Onay",
+        "ko": "승인"
+      }
+    },
+    {
+      "term": "CAPA",
+      "category": "quality",
+      "context": "Corrective and Preventive Action.",
+      "translations": {
+        "fr": "CAPA",
+        "de": "CAPA",
+        "es": "CAPA",
+        "it": "CAPA",
+        "ja": "CAPA",
+        "pl": "CAPA",
+        "pt": "CAPA",
+        "ru": "CAPA",
+        "zh": "CAPA",
+        "hi": "CAPA",
+        "tr": "CAPA",
+        "ko": "CAPA"
+      }
+    },
+    {
+      "term": "Calibration",
+      "category": "quality",
+      "context": "Verifying and adjusting a gauge against a standard.",
+      "translations": {
+        "fr": "Étalonnage",
+        "de": "Kalibrierung",
+        "es": "Calibración",
+        "it": "Taratura",
+        "ja": "校正",
+        "pl": "Wzorcowanie",
+        "pt": "Calibração",
+        "ru": "Калибровка",
+        "zh": "校准",
+        "hi": "अंशांकन",
+        "tr": "Kalibrasyon",
+        "ko": "교정"
+      }
+    },
+    {
+      "term": "Calibration Interval",
+      "category": "quality",
+      "context": "How often a gauge must be recalibrated.",
+      "translations": {
+        "fr": "Périodicité d'étalonnage",
+        "de": "Kalibrierintervall",
+        "es": "Intervalo de calibración",
+        "it": "Intervallo di taratura",
+        "ja": "校正周期",
+        "pl": "Okres wzorcowania",
+        "pt": "Intervalo de calibração",
+        "ru": "Интервал калибровки",
+        "zh": "校准周期",
+        "hi": "अंशांकन अंतराल",
+        "tr": "Kalibrasyon aralığı",
+        "ko": "교정 주기"
+      }
+    },
+    {
+      "term": "Calibration Record",
+      "category": "quality",
+      "context": "The logged result of calibrating a gauge.",
+      "translations": {
+        "fr": "Enregistrement d'étalonnage",
+        "de": "Kalibrierprotokoll",
+        "es": "Registro de calibración",
+        "it": "Registro di taratura",
+        "ja": "校正記録",
+        "pl": "Zapis wzorcowania",
+        "pt": "Registro de calibração",
+        "ru": "Запись о калибровке",
+        "zh": "校准记录",
+        "hi": "अंशांकन रिकॉर्ड",
+        "tr": "Kalibrasyon kaydı",
+        "ko": "교정 기록"
+      }
+    },
+    {
+      "term": "Containment",
+      "category": "quality",
+      "context": "Immediate action to stop bad material spreading.",
+      "translations": {
+        "fr": "Confinement",
+        "de": "Containment",
+        "es": "Contención",
+        "it": "Contenimento",
+        "ja": "封じ込め",
+        "pl": "Zabezpieczenie",
+        "pt": "Contenção",
+        "ru": "Локализация",
+        "zh": "围堵",
+        "hi": "नियंत्रण",
+        "tr": "Çevreleme",
+        "ko": "격리"
+      }
+    },
+    {
+      "term": "Corrective Action",
+      "category": "quality",
+      "context": "The work done to stop a problem recurring.",
+      "translations": {
+        "fr": "Action corrective",
+        "de": "Korrekturmaßnahme",
+        "es": "Acción correctiva",
+        "it": "Azione correttiva",
+        "ja": "是正処置",
+        "pl": "Działanie korygujące",
+        "pt": "Ação corretiva",
+        "ru": "Корректирующее действие",
+        "zh": "纠正措施",
+        "hi": "सुधारात्मक कार्रवाई",
+        "tr": "Düzeltici faaliyet",
+        "ko": "시정 조치"
+      }
+    },
+    {
+      "term": "Deviation",
+      "category": "quality",
+      "context": "Approved permission to depart from the specification.",
+      "translations": {
+        "fr": "Dérogation",
+        "de": "Sonderfreigabe",
+        "es": "Permiso de desviación",
+        "it": "Deroga",
+        "ja": "特別採用",
+        "pl": "Odstępstwo",
+        "pt": "Desvio",
+        "ru": "Разрешение на отклонение",
+        "zh": "偏差许可",
+        "hi": "विचलन अनुमति",
+        "tr": "Sapma izni",
+        "ko": "특채"
+      }
+    },
+    {
+      "term": "Disposition",
+      "category": "quality",
+      "context": "The decision on what happens to non-conforming material.",
+      "translations": {
+        "fr": "Traitement",
+        "de": "Verwendungsentscheid",
+        "es": "Disposición",
+        "it": "Disposizione",
+        "ja": "処置",
+        "pl": "Dyspozycja",
+        "pt": "Disposição",
+        "ru": "Решение",
+        "zh": "处置",
+        "hi": "निपटान",
+        "tr": "Karar",
+        "ko": "처분 결정"
+      }
+    },
+    {
+      "term": "Gauge",
+      "category": "quality",
+      "context": "A measuring instrument that must stay calibrated.",
+      "translations": {
+        "fr": "Instrument de mesure",
+        "de": "Prüfmittel",
+        "es": "Instrumento de medición",
+        "it": "Strumento di misura",
+        "ja": "測定器",
+        "pl": "Przyrząd pomiarowy",
+        "pt": "Instrumento de medição",
+        "ru": "Средство измерения",
+        "zh": "量具",
+        "hi": "गेज",
+        "tr": "Ölçüm aleti",
+        "ko": "계측기"
+      }
+    },
+    {
+      "term": "Gauge Type",
+      "category": "quality",
+      "context": "The classification of a measuring instrument.",
+      "translations": {
+        "fr": "Type d'instrument",
+        "de": "Prüfmittelart",
+        "es": "Tipo de instrumento",
+        "it": "Tipo di strumento",
+        "ja": "測定器タイプ",
+        "pl": "Typ przyrządu",
+        "pt": "Tipo de instrumento",
+        "ru": "Тип средства измерения",
+        "zh": "量具类型",
+        "hi": "गेज प्रकार",
+        "tr": "Ölçüm aleti türü",
+        "ko": "계측기 유형"
+      }
+    },
+    {
+      "term": "Genealogy",
+      "category": "quality",
+      "context": "The full parent-and-child history of a tracked lot or serial.",
+      "translations": {
+        "fr": "Généalogie",
+        "de": "Genealogie",
+        "es": "Genealogía",
+        "it": "Genealogia",
+        "ja": "系譜",
+        "pl": "Genealogia",
+        "pt": "Genealogia",
+        "ru": "Генеалогия",
+        "zh": "谱系",
+        "hi": "वंशावली",
+        "tr": "Soy ağacı",
+        "ko": "계보"
+      }
+    },
+    {
+      "term": "Inbound Inspection",
+      "category": "quality",
+      "context": "Checking goods on receipt from a supplier.",
+      "translations": {
+        "fr": "Contrôle à réception",
+        "de": "Wareneingangsprüfung",
+        "es": "Inspección de recepción",
+        "it": "Controllo in accettazione",
+        "ja": "受入検査",
+        "pl": "Kontrola dostaw",
+        "pt": "Inspeção de recebimento",
+        "ru": "Входной контроль",
+        "zh": "来料检验",
+        "hi": "इनबाउंड निरीक्षण",
+        "tr": "Girdi kontrolü",
+        "ko": "수입 검사"
+      }
+    },
+    {
+      "term": "Inspection",
+      "category": "quality",
+      "context": "Checking parts against requirements.",
+      "translations": {
+        "fr": "Contrôle",
+        "de": "Prüfung",
+        "es": "Inspección",
+        "it": "Controllo",
+        "ja": "検査",
+        "pl": "Kontrola",
+        "pt": "Inspeção",
+        "ru": "Контроль",
+        "zh": "检验",
+        "hi": "निरीक्षण",
+        "tr": "Muayene",
+        "ko": "검사"
+      }
+    },
+    {
+      "term": "Inspection Level",
+      "category": "quality",
+      "context": "How strict the sampling is: Normal, Tightened or Reduced.",
+      "translations": {
+        "fr": "Niveau de contrôle",
+        "de": "Prüfniveau",
+        "es": "Nivel de inspección",
+        "it": "Livello di controllo",
+        "ja": "検査水準",
+        "pl": "Poziom kontroli",
+        "pt": "Nível de inspeção",
+        "ru": "Уровень контроля",
+        "zh": "检验水平",
+        "hi": "निरीक्षण स्तर",
+        "tr": "Muayene seviyesi",
+        "ko": "검사 수준"
+      }
+    },
+    {
+      "term": "Inspection Plan",
+      "category": "quality",
+      "context": "The defined checks and sampling applied to an item or operation.",
+      "translations": {
+        "fr": "Plan de contrôle",
+        "de": "Prüfplan",
+        "es": "Plan de inspección",
+        "it": "Piano di controllo",
+        "ja": "検査計画",
+        "pl": "Plan kontroli",
+        "pt": "Plano de inspeção",
+        "ru": "План контроля",
+        "zh": "检验计划",
+        "hi": "निरीक्षण योजना",
+        "tr": "Kontrol planı",
+        "ko": "검사 계획"
+      }
+    },
+    {
+      "term": "Investigation",
+      "category": "quality",
+      "context": "The analysis of why a non-conformance happened.",
+      "translations": {
+        "fr": "Investigation",
+        "de": "Untersuchung",
+        "es": "Investigación",
+        "it": "Indagine",
+        "ja": "調査",
+        "pl": "Analiza przyczyn",
+        "pt": "Investigação",
+        "ru": "Расследование",
+        "zh": "调查",
+        "hi": "जांच",
+        "tr": "Araştırma",
+        "ko": "조사"
+      }
+    },
+    {
+      "term": "Likelihood",
+      "category": "quality",
+      "context": "How probable a risk is.",
+      "translations": {
+        "fr": "Probabilité",
+        "de": "Wahrscheinlichkeit",
+        "es": "Probabilidad",
+        "it": "Probabilità",
+        "ja": "発生可能性",
+        "pl": "Prawdopodobieństwo",
+        "pt": "Probabilidade",
+        "ru": "Вероятность",
+        "zh": "可能性",
+        "hi": "संभावना",
+        "tr": "Olasılık",
+        "ko": "발생 가능성"
+      }
+    },
+    {
+      "term": "Master",
+      "category": "quality",
+      "context": "A gauge used as the reference standard other gauges are calibrated against.",
+      "ambiguity": "Not 'master' as in a main/primary record; only the gauge role.",
+      "translations": {
+        "fr": "Étalon",
+        "de": "Normal",
+        "es": "Patrón",
+        "it": "Campione",
+        "ja": "標準器",
+        "pl": "Wzorzec",
+        "pt": "Padrão",
+        "ru": "Эталон",
+        "zh": "标准器",
+        "hi": "मास्टर",
+        "tr": "Mastar",
+        "ko": "표준기"
+      }
+    },
+    {
+      "term": "Material Review Board",
+      "category": "quality",
+      "context": "The group that decides what happens to non-conforming material.",
+      "translations": {
+        "fr": "Comité de revue des matériaux",
+        "de": "Material Review Board",
+        "es": "Junta de revisión de materiales",
+        "it": "Material Review Board",
+        "ja": "材料審査会",
+        "pl": "Komisja oceny materiałów",
+        "pt": "Comitê de análise de materiais",
+        "ru": "Комиссия по браку",
+        "zh": "材料评审委员会",
+        "hi": "सामग्री समीक्षा बोर्ड",
+        "tr": "Malzeme inceleme kurulu",
+        "ko": "MRB 위원회"
+      }
+    },
+    {
+      "term": "Measurement Standard",
+      "category": "quality",
+      "context": "The reference a gauge is calibrated against.",
+      "translations": {
+        "fr": "Étalon de mesure",
+        "de": "Messnormal",
+        "es": "Patrón de medición",
+        "it": "Campione di riferimento",
+        "ja": "計量標準",
+        "pl": "Wzorzec pomiarowy",
+        "pt": "Padrão de medição",
+        "ru": "Эталон измерений",
+        "zh": "测量标准",
+        "hi": "मापन मानक",
+        "tr": "Ölçüm standardı",
+        "ko": "측정 표준"
+      }
+    },
+    {
+      "term": "NCR",
+      "category": "quality",
+      "context": "Short form of Non-Conformance Report.",
+      "translations": {
+        "fr": "NCR",
+        "de": "NCR",
+        "es": "NCR",
+        "it": "NCR",
+        "ja": "NCR",
+        "pl": "NCR",
+        "pt": "NCR",
+        "ru": "NCR",
+        "zh": "NCR",
+        "hi": "NCR",
+        "tr": "NCR",
+        "ko": "NCR"
+      }
+    },
+    {
+      "term": "Non-Conformance",
+      "category": "quality",
+      "context": "A record that something did not meet requirements. The catalog spells this three ways; all three mean the same thing and must translate identically.",
+      "englishVariants": [
+        "Nonconformance",
+        "Non-conformance",
+        "Non conformance"
+      ],
+      "translations": {
+        "fr": "Non-conformité",
+        "de": "Nichtkonformität",
+        "es": "No conformidad",
+        "it": "Non conformità",
+        "ja": "不適合",
+        "pl": "Niezgodność",
+        "pt": "Não conformidade",
+        "ru": "Несоответствие",
+        "zh": "不合格",
+        "hi": "गैर-अनुरूपता",
+        "tr": "Uygunsuzluk",
+        "ko": "부적합"
+      }
+    },
+    {
+      "term": "Preventive",
+      "category": "quality",
+      "context": "Action taken to stop a problem occurring in the first place.",
+      "translations": {
+        "fr": "Préventif",
+        "de": "Vorbeugend",
+        "es": "Preventivo",
+        "it": "Preventivo",
+        "ja": "予防",
+        "pl": "Zapobiegawcze",
+        "pt": "Preventivo",
+        "ru": "Предупреждающее",
+        "zh": "预防",
+        "hi": "निवारक",
+        "tr": "Önleyici",
+        "ko": "예방"
+      }
+    },
+    {
+      "term": "Procedure",
+      "category": "quality",
+      "context": "A controlled written instruction.",
+      "translations": {
+        "fr": "Procédure",
+        "de": "Verfahrensanweisung",
+        "es": "Procedimiento",
+        "it": "Procedura",
+        "ja": "手順書",
+        "pl": "Procedura",
+        "pt": "Procedimento",
+        "ru": "Процедура",
+        "zh": "程序文件",
+        "hi": "कार्यविधि",
+        "tr": "Prosedür",
+        "ko": "절차서"
+      }
+    },
+    {
+      "term": "Quality",
+      "category": "quality",
+      "context": "Conformance to requirements, and the module that manages it.",
+      "translations": {
+        "fr": "Qualité",
+        "de": "Qualität",
+        "es": "Calidad",
+        "it": "Qualità",
+        "ja": "品質",
+        "pl": "Jakość",
+        "pt": "Qualidade",
+        "ru": "Качество",
+        "zh": "质量",
+        "hi": "गुणवत्ता",
+        "tr": "Kalite",
+        "ko": "품질"
+      }
+    },
+    {
+      "term": "RMA",
+      "category": "quality",
+      "context": "Return Merchandise Authorization — a customer returning goods.",
+      "translations": {
+        "fr": "RMA",
+        "de": "RMA",
+        "es": "RMA",
+        "it": "RMA",
+        "ja": "RMA",
+        "pl": "RMA",
+        "pt": "RMA",
+        "ru": "RMA",
+        "zh": "RMA",
+        "hi": "RMA",
+        "tr": "RMA",
+        "ko": "RMA"
+      }
+    },
+    {
+      "term": "Reduced",
+      "category": "quality",
+      "context": "A looser inspection level after sustained passes.",
+      "translations": {
+        "fr": "Réduit",
+        "de": "Reduziert",
+        "es": "Reducida",
+        "it": "Ridotto",
+        "ja": "ゆるい検査",
+        "pl": "Ulgowa",
+        "pt": "Atenuada",
+        "ru": "Ослабленный",
+        "zh": "放宽检验",
+        "hi": "शिथिल",
+        "tr": "Gevşetilmiş",
+        "ko": "수월한 검사"
+      }
+    },
+    {
+      "term": "Requirement",
+      "category": "quality",
+      "context": "A characteristic that must be met and checked.",
+      "translations": {
+        "fr": "Exigence",
+        "de": "Anforderung",
+        "es": "Requisito",
+        "it": "Requisito",
+        "ja": "要求事項",
+        "pl": "Wymaganie",
+        "pt": "Requisito",
+        "ru": "Требование",
+        "zh": "要求",
+        "hi": "आवश्यकता",
+        "tr": "Gereklilik",
+        "ko": "요구사항"
+      }
+    },
+    {
+      "term": "Rework",
+      "category": "quality",
+      "context": "Work redone to bring a non-conforming part into spec.",
+      "translations": {
+        "fr": "Retouche",
+        "de": "Nacharbeit",
+        "es": "Retrabajo",
+        "it": "Rilavorazione",
+        "ja": "手直し",
+        "pl": "Poprawka",
+        "pt": "Retrabalho",
+        "ru": "Доработка",
+        "zh": "返工",
+        "hi": "पुनः कार्य",
+        "tr": "Yeniden işleme",
+        "ko": "재작업"
+      }
+    },
+    {
+      "term": "Risk",
+      "category": "quality",
+      "context": "A logged potential problem tracked in the risk register.",
+      "translations": {
+        "fr": "Risque",
+        "de": "Risiko",
+        "es": "Riesgo",
+        "it": "Rischio",
+        "ja": "リスク",
+        "pl": "Ryzyko",
+        "pt": "Risco",
+        "ru": "Риск",
+        "zh": "风险",
+        "hi": "जोखिम",
+        "tr": "Risk",
+        "ko": "리스크"
+      }
+    },
+    {
+      "term": "Risk Register",
+      "category": "quality",
+      "context": "The log of tracked risks.",
+      "translations": {
+        "fr": "Registre des risques",
+        "de": "Risikoregister",
+        "es": "Registro de riesgos",
+        "it": "Registro dei rischi",
+        "ja": "リスク登録簿",
+        "pl": "Rejestr ryzyka",
+        "pt": "Registro de riscos",
+        "ru": "Реестр рисков",
+        "zh": "风险登记册",
+        "hi": "जोखिम रजिस्टर",
+        "tr": "Risk kaydı",
+        "ko": "리스크 등록부"
+      }
+    },
+    {
+      "term": "Root Cause",
+      "category": "quality",
+      "context": "The underlying reason a problem occurred.",
+      "translations": {
+        "fr": "Cause racine",
+        "de": "Grundursache",
+        "es": "Causa raíz",
+        "it": "Causa radice",
+        "ja": "根本原因",
+        "pl": "Przyczyna źródłowa",
+        "pt": "Causa raiz",
+        "ru": "Коренная причина",
+        "zh": "根本原因",
+        "hi": "मूल कारण",
+        "tr": "Kök neden",
+        "ko": "근본 원인"
+      }
+    },
+    {
+      "term": "SCAR",
+      "category": "quality",
+      "context": "Supplier Corrective Action Request.",
+      "translations": {
+        "fr": "SCAR",
+        "de": "SCAR",
+        "es": "SCAR",
+        "it": "SCAR",
+        "ja": "SCAR",
+        "pl": "SCAR",
+        "pt": "SCAR",
+        "ru": "SCAR",
+        "zh": "SCAR",
+        "hi": "SCAR",
+        "tr": "SCAR",
+        "ko": "SCAR"
+      }
+    },
+    {
+      "term": "Sample Size",
+      "category": "quality",
+      "context": "How many units a sampling plan requires be inspected.",
+      "translations": {
+        "fr": "Taille d'échantillon",
+        "de": "Stichprobenumfang",
+        "es": "Tamaño de muestra",
+        "it": "Dimensione del campione",
+        "ja": "サンプルサイズ",
+        "pl": "Wielkość próbki",
+        "pt": "Tamanho da amostra",
+        "ru": "Объем выборки",
+        "zh": "样本量",
+        "hi": "नमूना आकार",
+        "tr": "Örneklem büyüklüğü",
+        "ko": "샘플 크기"
+      }
+    },
+    {
+      "term": "Sampling",
+      "category": "quality",
+      "context": "Inspecting a subset instead of every piece.",
+      "translations": {
+        "fr": "Échantillonnage",
+        "de": "Stichprobenprüfung",
+        "es": "Muestreo",
+        "it": "Campionamento",
+        "ja": "抜取検査",
+        "pl": "Kontrola wyrywkowa",
+        "pt": "Amostragem",
+        "ru": "Выборочный контроль",
+        "zh": "抽样",
+        "hi": "नमूनाकरण",
+        "tr": "Örnekleme",
+        "ko": "샘플링"
+      }
+    },
+    {
+      "term": "Sampling Plan",
+      "category": "quality",
+      "context": "The rule setting how many units of a lot to inspect.",
+      "translations": {
+        "fr": "Plan d'échantillonnage",
+        "de": "Stichprobenplan",
+        "es": "Plan de muestreo",
+        "it": "Piano di campionamento",
+        "ja": "抜取検査方式",
+        "pl": "Plan kontroli wyrywkowej",
+        "pt": "Plano de amostragem",
+        "ru": "План выборочного контроля",
+        "zh": "抽样方案",
+        "hi": "नमूनाकरण योजना",
+        "tr": "Örnekleme planı",
+        "ko": "샘플링 계획"
+      }
+    },
+    {
+      "term": "Severity",
+      "category": "quality",
+      "context": "How serious a quality problem is.",
+      "translations": {
+        "fr": "Gravité",
+        "de": "Schweregrad",
+        "es": "Severidad",
+        "it": "Gravità",
+        "ja": "重大度",
+        "pl": "Waga",
+        "pt": "Severidade",
+        "ru": "Серьезность",
+        "zh": "严重度",
+        "hi": "गंभीरता",
+        "tr": "Şiddet",
+        "ko": "심각도"
+      }
+    },
+    {
+      "term": "Standard",
+      "category": "quality",
+      "context": "The normal inspection level.",
+      "translations": {
+        "fr": "Normal",
+        "de": "Normal",
+        "es": "Normal",
+        "it": "Normale",
+        "ja": "なみ検査",
+        "pl": "Normalna",
+        "pt": "Normal",
+        "ru": "Нормальный",
+        "zh": "正常检验",
+        "hi": "सामान्य",
+        "tr": "Normal",
+        "ko": "보통 검사"
+      }
+    },
+    {
+      "term": "Tightened",
+      "category": "quality",
+      "context": "A stricter inspection level after failures.",
+      "translations": {
+        "fr": "Renforcé",
+        "de": "Verschärft",
+        "es": "Rigurosa",
+        "it": "Rinforzato",
+        "ja": "きつい検査",
+        "pl": "Obostrzona",
+        "pt": "Severa",
+        "ru": "Усиленный",
+        "zh": "加严检验",
+        "hi": "कठोर",
+        "tr": "Sıkılaştırılmış",
+        "ko": "까다로운 검사"
+      }
+    },
+    {
+      "term": "Traceability",
+      "category": "quality",
+      "context": "The ability to follow material forward and backward through production.",
+      "translations": {
+        "fr": "Traçabilité",
+        "de": "Rückverfolgbarkeit",
+        "es": "Trazabilidad",
+        "it": "Tracciabilità",
+        "ja": "トレーサビリティ",
+        "pl": "Identyfikowalność",
+        "pt": "Rastreabilidade",
+        "ru": "Прослеживаемость",
+        "zh": "可追溯性",
+        "hi": "ट्रेसेबिलिटी",
+        "tr": "İzlenebilirlik",
+        "ko": "추적성"
+      }
+    },
+    {
+      "term": "Carrier",
+      "category": "sales",
+      "context": "The company physically transporting a shipment.",
+      "translations": {
+        "fr": "Transporteur",
+        "de": "Spediteur",
+        "es": "Transportista",
+        "it": "Vettore",
+        "ja": "運送業者",
+        "pl": "Przewoźnik",
+        "pt": "Transportadora",
+        "ru": "Перевозчик",
+        "zh": "承运商",
+        "hi": "वाहक",
+        "tr": "Nakliyeci",
+        "ko": "운송업체"
+      }
+    },
+    {
+      "term": "Convert",
+      "category": "sales",
+      "context": "Turning one document into the next (RFQ to quote, quote to order).",
+      "translations": {
+        "fr": "Convertir",
+        "de": "Umwandeln",
+        "es": "Convertir",
+        "it": "Converti",
+        "ja": "変換",
+        "pl": "Przekształć",
+        "pt": "Converter",
+        "ru": "Преобразовать",
+        "zh": "转换",
+        "hi": "परिवर्तित करें",
+        "tr": "Dönüştür",
+        "ko": "전환"
+      }
+    },
+    {
+      "term": "Customer Part ID",
+      "category": "sales",
+      "context": "The customer's own identifier for our item.",
+      "translations": {
+        "fr": "Référence client",
+        "de": "Kundenartikelnummer",
+        "es": "Referencia del cliente",
+        "it": "Codice articolo cliente",
+        "ja": "得意先品番",
+        "pl": "Numer artykułu klienta",
+        "pt": "Referência do cliente",
+        "ru": "Артикул покупателя",
+        "zh": "客户料号",
+        "hi": "ग्राहक पार्ट ID",
+        "tr": "Müşteri parça numarası",
+        "ko": "고객 품번"
+      }
+    },
+    {
+      "term": "Customer Portal",
+      "category": "sales",
+      "context": "The external site where a customer views their orders and quotes.",
+      "translations": {
+        "fr": "Portail client",
+        "de": "Kundenportal",
+        "es": "Portal del cliente",
+        "it": "Portale clienti",
+        "ja": "顧客ポータル",
+        "pl": "Portal klienta",
+        "pt": "Portal do cliente",
+        "ru": "Клиентский портал",
+        "zh": "客户门户",
+        "hi": "ग्राहक पोर्टल",
+        "tr": "Müşteri portalı",
+        "ko": "고객 포털"
+      }
+    },
+    {
+      "term": "Delivery Date",
+      "category": "sales",
+      "context": "When goods are due at the customer.",
+      "translations": {
+        "fr": "Date de livraison",
+        "de": "Liefertermin",
+        "es": "Fecha de entrega",
+        "it": "Data di consegna",
+        "ja": "納期",
+        "pl": "Data dostawy",
+        "pt": "Data de entrega",
+        "ru": "Дата поставки",
+        "zh": "交货日期",
+        "hi": "डिलीवरी तिथि",
+        "tr": "Teslim tarihi",
+        "ko": "납기일"
+      }
+    },
+    {
+      "term": "Discount",
+      "category": "sales",
+      "context": "A reduction from list price.",
+      "translations": {
+        "fr": "Remise",
+        "de": "Rabatt",
+        "es": "Descuento",
+        "it": "Sconto",
+        "ja": "値引",
+        "pl": "Rabat",
+        "pt": "Desconto",
+        "ru": "Скидка",
+        "zh": "折扣",
+        "hi": "छूट",
+        "tr": "İskonto",
+        "ko": "할인"
+      }
+    },
+    {
+      "term": "Drop-ship",
+      "category": "sales",
+      "context": "Shipping direct from the supplier to the customer.",
+      "translations": {
+        "fr": "Livraison directe",
+        "de": "Direktlieferung",
+        "es": "Envío directo",
+        "it": "Consegna diretta",
+        "ja": "直送",
+        "pl": "Dostawa bezpośrednia",
+        "pt": "Entrega direta",
+        "ru": "Прямая поставка",
+        "zh": "直发",
+        "hi": "ड्रॉप-शिप",
+        "tr": "Doğrudan sevkiyat",
+        "ko": "직송"
+      }
+    },
+    {
+      "term": "Fulfillment Location",
+      "category": "sales",
+      "context": "The location goods ship from.",
+      "translations": {
+        "fr": "Site d'expédition",
+        "de": "Versandstandort",
+        "es": "Ubicación de despacho",
+        "it": "Ubicazione di spedizione",
+        "ja": "出荷拠点",
+        "pl": "Lokalizacja realizacji",
+        "pt": "Local de expedição",
+        "ru": "Площадка отгрузки",
+        "zh": "发货地点",
+        "hi": "पूर्ति स्थान",
+        "tr": "Sevkiyat lokasyonu",
+        "ko": "출하 사업장"
+      }
+    },
+    {
+      "term": "New Part",
+      "category": "sales",
+      "context": "A quote line for a part Carbon has not made before.",
+      "translations": {
+        "fr": "Nouvelle pièce",
+        "de": "Neuteil",
+        "es": "Pieza nueva",
+        "it": "Nuovo componente",
+        "ja": "新規部品",
+        "pl": "Nowa część",
+        "pt": "Peça nova",
+        "ru": "Новая деталь",
+        "zh": "新零件",
+        "hi": "नया पार्ट",
+        "tr": "Yeni parça",
+        "ko": "신규 부품"
+      }
+    },
+    {
+      "term": "No Quote",
+      "category": "sales",
+      "context": "A decision not to bid on a requested part.",
+      "translations": {
+        "fr": "Refus de devis",
+        "de": "Kein Angebot",
+        "es": "Sin cotización",
+        "it": "Nessuna offerta",
+        "ja": "見積辞退",
+        "pl": "Odmowa oferty",
+        "pt": "Sem cotação",
+        "ru": "Отказ от предложения",
+        "zh": "不报价",
+        "hi": "कोई कोटेशन नहीं",
+        "tr": "Teklif yok",
+        "ko": "견적 거절"
+      }
+    },
+    {
+      "term": "Opportunity",
+      "category": "sales",
+      "context": "A potential sale being pursued before a quote exists.",
+      "translations": {
+        "fr": "Opportunité",
+        "de": "Verkaufschance",
+        "es": "Oportunidad",
+        "it": "Opportunità",
+        "ja": "商談",
+        "pl": "Szansa sprzedaży",
+        "pt": "Oportunidade",
+        "ru": "Сделка",
+        "zh": "商机",
+        "hi": "अवसर",
+        "tr": "Fırsat",
+        "ko": "영업 기회"
+      }
+    },
+    {
+      "term": "Price",
+      "category": "sales",
+      "context": "What an item is sold or bought for, per unit.",
+      "ambiguity": "Not 'pricing' as an activity, and not 'cost' — Carbon distinguishes price (what is charged) from cost (what it costs us).",
+      "translations": {
+        "fr": "Prix",
+        "de": "Preis",
+        "es": "Precio",
+        "it": "Prezzo",
+        "ja": "価格",
+        "pl": "Cena",
+        "pt": "Preço",
+        "ru": "Цена",
+        "zh": "价格",
+        "hi": "मूल्य",
+        "tr": "Fiyat",
+        "ko": "가격"
+      }
+    },
+    {
+      "term": "Pricing",
+      "category": "sales",
+      "context": "The activity and configuration of setting prices.",
+      "translations": {
+        "fr": "Tarification",
+        "de": "Preisfindung",
+        "es": "Fijación de precios",
+        "it": "Determinazione dei prezzi",
+        "ja": "価格設定",
+        "pl": "Ustalanie cen",
+        "pt": "Precificação",
+        "ru": "Ценообразование",
+        "zh": "定价",
+        "hi": "मूल्य निर्धारण",
+        "tr": "Fiyatlandırma",
+        "ko": "가격 책정"
+      }
+    },
+    {
+      "term": "Pricing Rule",
+      "category": "sales",
+      "context": "A configured rule that adjusts price by customer, quantity or date.",
+      "translations": {
+        "fr": "Règle de tarification",
+        "de": "Preisregel",
+        "es": "Regla de precios",
+        "it": "Regola di prezzo",
+        "ja": "価格設定ルール",
+        "pl": "Reguła cenowa",
+        "pt": "Regra de precificação",
+        "ru": "Правило ценообразования",
+        "zh": "定价规则",
+        "hi": "मूल्य नियम",
+        "tr": "Fiyatlandırma kuralı",
+        "ko": "가격 규칙"
+      }
+    },
+    {
+      "term": "Quote",
+      "category": "sales",
+      "context": "A priced offer to a customer, before it becomes a sales order.",
+      "ambiguity": "Not 'to quote' text.",
+      "translations": {
+        "fr": "Devis",
+        "de": "Angebot",
+        "es": "Cotización",
+        "it": "Offerta",
+        "ja": "見積",
+        "pl": "Oferta",
+        "pt": "Orçamento",
+        "ru": "Коммерческое предложение",
+        "zh": "报价单",
+        "hi": "कोटेशन",
+        "tr": "Teklif",
+        "ko": "견적서"
+      }
+    },
+    {
+      "term": "Quote Line",
+      "category": "sales",
+      "context": "One item-and-quantity row on a quote, with its own pricing.",
+      "translations": {
+        "fr": "Ligne de devis",
+        "de": "Angebotsposition",
+        "es": "Línea de cotización",
+        "it": "Riga offerta",
+        "ja": "見積明細",
+        "pl": "Pozycja oferty",
+        "pt": "Linha do orçamento",
+        "ru": "Строка предложения",
+        "zh": "报价行",
+        "hi": "कोटेशन पंक्ति",
+        "tr": "Teklif satırı",
+        "ko": "견적 라인"
+      }
+    },
+    {
+      "term": "Ready for Quote",
+      "category": "sales",
+      "context": "A line with everything needed to be priced.",
+      "translations": {
+        "fr": "Prêt pour devis",
+        "de": "Angebotsbereit",
+        "es": "Lista para cotizar",
+        "it": "Pronto per offerta",
+        "ja": "見積準備完了",
+        "pl": "Gotowe do oferty",
+        "pt": "Pronto para orçamento",
+        "ru": "Готово к предложению",
+        "zh": "可报价",
+        "hi": "कोटेशन के लिए तैयार",
+        "tr": "Teklife hazır",
+        "ko": "견적 준비 완료"
+      }
+    },
+    {
+      "term": "Sales Order",
+      "category": "sales",
+      "context": "A confirmed customer order to be fulfilled and invoiced.",
+      "translations": {
+        "fr": "Commande client",
+        "de": "Kundenauftrag",
+        "es": "Pedido de venta",
+        "it": "Ordine di vendita",
+        "ja": "受注",
+        "pl": "Zamówienie sprzedaży",
+        "pt": "Pedido de venda",
+        "ru": "Заказ покупателя",
+        "zh": "销售订单",
+        "hi": "विक्रय आदेश",
+        "tr": "Satış siparişi",
+        "ko": "수주"
+      }
+    },
+    {
+      "term": "Sales Order Line",
+      "category": "sales",
+      "context": "One item-and-quantity row on a sales order.",
+      "translations": {
+        "fr": "Ligne de commande client",
+        "de": "Kundenauftragsposition",
+        "es": "Línea de pedido de venta",
+        "it": "Riga ordine di vendita",
+        "ja": "受注明細",
+        "pl": "Pozycja zamówienia sprzedaży",
+        "pt": "Linha do pedido de venda",
+        "ru": "Строка заказа покупателя",
+        "zh": "销售订单行",
+        "hi": "विक्रय आदेश पंक्ति",
+        "tr": "Satış siparişi satırı",
+        "ko": "수주 라인"
+      }
+    },
+    {
+      "term": "Shipment",
+      "category": "sales",
+      "context": "Goods leaving to a customer.",
+      "translations": {
+        "fr": "Expédition",
+        "de": "Lieferung",
+        "es": "Envío",
+        "it": "Spedizione",
+        "ja": "出荷",
+        "pl": "Wysyłka",
+        "pt": "Remessa",
+        "ru": "Отгрузка",
+        "zh": "发货",
+        "hi": "शिपमेंट",
+        "tr": "Sevkiyat",
+        "ko": "출하"
+      }
+    },
+    {
+      "term": "Shipment Line",
+      "category": "sales",
+      "context": "One item-and-quantity row on a shipment.",
+      "translations": {
+        "fr": "Ligne d'expédition",
+        "de": "Lieferposition",
+        "es": "Línea de envío",
+        "it": "Riga spedizione",
+        "ja": "出荷明細",
+        "pl": "Pozycja wysyłki",
+        "pt": "Linha da remessa",
+        "ru": "Строка отгрузки",
+        "zh": "发货行",
+        "hi": "शिपमेंट पंक्ति",
+        "tr": "Sevkiyat satırı",
+        "ko": "출하 라인"
+      }
+    },
+    {
+      "term": "Shipping Cost",
+      "category": "sales",
+      "context": "Freight charged on a document.",
+      "translations": {
+        "fr": "Frais de port",
+        "de": "Versandkosten",
+        "es": "Costo de envío",
+        "it": "Spese di spedizione",
+        "ja": "送料",
+        "pl": "Koszt wysyłki",
+        "pt": "Frete",
+        "ru": "Стоимость доставки",
+        "zh": "运费",
+        "hi": "शिपिंग लागत",
+        "tr": "Nakliye bedeli",
+        "ko": "운송비"
+      }
+    },
+    {
+      "term": "Shipping Method",
+      "category": "sales",
+      "context": "How goods travel to the customer, and its transit days.",
+      "translations": {
+        "fr": "Mode d'expédition",
+        "de": "Versandart",
+        "es": "Método de envío",
+        "it": "Metodo di spedizione",
+        "ja": "出荷方法",
+        "pl": "Sposób wysyłki",
+        "pt": "Método de envio",
+        "ru": "Способ доставки",
+        "zh": "发货方式",
+        "hi": "शिपिंग विधि",
+        "tr": "Sevkiyat yöntemi",
+        "ko": "배송 방법"
+      }
+    },
+    {
+      "term": "To Ship",
+      "category": "sales",
+      "context": "Outstanding lines awaiting shipment.",
+      "translations": {
+        "fr": "À expédier",
+        "de": "Zu versenden",
+        "es": "Por enviar",
+        "it": "Da spedire",
+        "ja": "出荷待ち",
+        "pl": "Do wysyłki",
+        "pt": "A enviar",
+        "ru": "К отгрузке",
+        "zh": "待发货",
+        "hi": "भेजने के लिए",
+        "tr": "Sevk edilecek",
+        "ko": "출하 대기"
+      }
+    },
+    {
+      "term": "Unit Price",
+      "category": "sales",
+      "context": "The price for one unit, before quantity and discounts.",
+      "translations": {
+        "fr": "Prix unitaire",
+        "de": "Einzelpreis",
+        "es": "Precio unitario",
+        "it": "Prezzo unitario",
+        "ja": "単価",
+        "pl": "Cena jednostkowa",
+        "pt": "Preço unitário",
+        "ru": "Цена за единицу",
+        "zh": "单价",
+        "hi": "इकाई मूल्य",
+        "tr": "Birim fiyat",
+        "ko": "단가"
+      }
+    },
+    {
+      "term": "Accepted",
+      "category": "status",
+      "context": "A lot, quote or disposition agreed to. Distinct from Approved, which is a sign-off.",
+      "translations": {
+        "fr": "Accepté",
+        "de": "Angenommen",
+        "es": "Aceptado",
+        "it": "Accettato",
+        "ja": "承諾済",
+        "pl": "Zaakceptowano",
+        "pt": "Aceito",
+        "ru": "Принято",
+        "zh": "已接受",
+        "hi": "स्वीकृत",
+        "tr": "Kabul edildi",
+        "ko": "수락됨"
+      }
+    },
+    {
+      "term": "Active",
+      "category": "status",
+      "context": "In use.",
+      "translations": {
+        "fr": "Actif",
+        "de": "Aktiv",
+        "es": "Activo",
+        "it": "Attivo",
+        "ja": "有効",
+        "pl": "Aktywny",
+        "pt": "Ativo",
+        "ru": "Активный",
+        "zh": "启用",
+        "hi": "सक्रिय",
+        "tr": "Aktif",
+        "ko": "활성"
+      }
+    },
+    {
+      "term": "Approved",
+      "category": "status",
+      "context": "Signed off by a required approver.",
+      "translations": {
+        "fr": "Approuvé",
+        "de": "Genehmigt",
+        "es": "Aprobado",
+        "it": "Approvato",
+        "ja": "承認済",
+        "pl": "Zatwierdzono",
+        "pt": "Aprovado",
+        "ru": "Утверждено",
+        "zh": "已审批",
+        "hi": "अनुमोदित",
+        "tr": "Onaylandı",
+        "ko": "승인됨"
+      },
+      "ambiguity": "Distinct from Accepted — approval is a sign-off, acceptance is a disposition on a lot or quote."
+    },
+    {
+      "term": "Archived",
+      "category": "status",
+      "context": "Retained but hidden from normal use.",
+      "translations": {
+        "fr": "Archivé",
+        "de": "Archiviert",
+        "es": "Archivado",
+        "it": "Archiviato",
+        "ja": "アーカイブ済",
+        "pl": "Zarchiwizowano",
+        "pt": "Arquivado",
+        "ru": "В архиве",
+        "zh": "已归档",
+        "hi": "संग्रहीत",
+        "tr": "Arşivlendi",
+        "ko": "보관됨"
+      }
+    },
+    {
+      "term": "Assigned",
+      "category": "status",
+      "context": "Given to a person or resource.",
+      "translations": {
+        "fr": "Assigné",
+        "de": "Zugewiesen",
+        "es": "Asignado",
+        "it": "Assegnato",
+        "ja": "割当済",
+        "pl": "Przypisano",
+        "pt": "Atribuído",
+        "ru": "Назначено",
+        "zh": "已分配",
+        "hi": "असाइन किया गया",
+        "tr": "Atandı",
+        "ko": "할당됨"
+      }
+    },
+    {
+      "term": "Available",
+      "category": "status",
+      "context": "Stock free to be used or picked.",
+      "translations": {
+        "fr": "Disponible",
+        "de": "Verfügbar",
+        "es": "Disponible",
+        "it": "Disponibile",
+        "ja": "利用可能",
+        "pl": "Dostępny",
+        "pt": "Disponível",
+        "ru": "Доступно",
+        "zh": "可用",
+        "hi": "उपलब्ध",
+        "tr": "Kullanılabilir",
+        "ko": "가용"
+      }
+    },
+    {
+      "term": "Cancelled",
+      "category": "status",
+      "context": "Stopped deliberately before completion.",
+      "translations": {
+        "fr": "Annulé",
+        "de": "Storniert",
+        "es": "Cancelado",
+        "it": "Annullato",
+        "ja": "キャンセル済",
+        "pl": "Anulowano",
+        "pt": "Cancelado",
+        "ru": "Отменено",
+        "zh": "已取消",
+        "hi": "रद्द",
+        "tr": "İptal edildi",
+        "ko": "취소됨"
+      },
+      "englishVariants": [
+        "Canceled"
+      ]
+    },
+    {
+      "term": "Closed",
+      "category": "status",
+      "context": "Finished and no longer editable.",
+      "translations": {
+        "fr": "Clôturé",
+        "de": "Abgeschlossen",
+        "es": "Cerrado",
+        "it": "Chiuso",
+        "ja": "クローズ済",
+        "pl": "Zamknięto",
+        "pt": "Fechado",
+        "ru": "Закрыто",
+        "zh": "已关闭",
+        "hi": "बंद",
+        "tr": "Kapatıldı",
+        "ko": "마감됨"
+      }
+    },
+    {
+      "term": "Completed",
+      "category": "status",
+      "context": "Finished successfully.",
+      "translations": {
+        "fr": "Terminé",
+        "de": "Fertiggestellt",
+        "es": "Completado",
+        "it": "Completato",
+        "ja": "完了",
+        "pl": "Zakończono",
+        "pt": "Concluído",
+        "ru": "Завершено",
+        "zh": "已完成",
+        "hi": "पूर्ण",
+        "tr": "Tamamlandı",
+        "ko": "완료됨"
+      },
+      "ambiguity": "The STATUS. Distinct from the Complete button verb."
+    },
+    {
+      "term": "Confirmed",
+      "category": "status",
+      "context": "Agreed and locked in.",
+      "translations": {
+        "fr": "Confirmé",
+        "de": "Bestätigt",
+        "es": "Confirmado",
+        "it": "Confermato",
+        "ja": "確定済",
+        "pl": "Potwierdzono",
+        "pt": "Confirmado",
+        "ru": "Подтверждено",
+        "zh": "已确认",
+        "hi": "पुष्टि की गई",
+        "tr": "Teyit edildi",
+        "ko": "확정됨"
+      }
+    },
+    {
+      "term": "Consumed",
+      "category": "status",
+      "context": "Used up by a job.",
+      "translations": {
+        "fr": "Consommé",
+        "de": "Verbraucht",
+        "es": "Consumido",
+        "it": "Consumato",
+        "ja": "消費済",
+        "pl": "Zużyto",
+        "pt": "Consumido",
+        "ru": "Израсходовано",
+        "zh": "已消耗",
+        "hi": "उपयोग किया गया",
+        "tr": "Tüketildi",
+        "ko": "소모됨"
+      }
+    },
+    {
+      "term": "Critical",
+      "category": "status",
+      "context": "The most severe or most urgent level.",
+      "translations": {
+        "fr": "Critique",
+        "de": "Kritisch",
+        "es": "Crítico",
+        "it": "Critico",
+        "ja": "重大",
+        "pl": "Krytyczny",
+        "pt": "Crítico",
+        "ru": "Критический",
+        "zh": "严重",
+        "hi": "गंभीर",
+        "tr": "Kritik",
+        "ko": "심각"
+      }
+    },
+    {
+      "term": "Disposed",
+      "category": "status",
+      "context": "A fixed asset removed from the books.",
+      "translations": {
+        "fr": "Cédé",
+        "de": "Abgegangen",
+        "es": "Dado de baja",
+        "it": "Dismesso",
+        "ja": "除却済",
+        "pl": "Zlikwidowano",
+        "pt": "Baixado",
+        "ru": "Выбыло",
+        "zh": "已处置",
+        "hi": "निपटाया गया",
+        "tr": "Elden çıkarıldı",
+        "ko": "처분됨"
+      }
+    },
+    {
+      "term": "Done",
+      "category": "status",
+      "context": "Finished.",
+      "translations": {
+        "fr": "Fait",
+        "de": "Erledigt",
+        "es": "Hecho",
+        "it": "Fatto",
+        "ja": "完了",
+        "pl": "Gotowe",
+        "pt": "Feito",
+        "ru": "Готово",
+        "zh": "完成",
+        "hi": "हो गया",
+        "tr": "Bitti",
+        "ko": "완료"
+      }
+    },
+    {
+      "term": "Draft",
+      "category": "status",
+      "context": "Not yet submitted or confirmed.",
+      "translations": {
+        "fr": "Brouillon",
+        "de": "Entwurf",
+        "es": "Borrador",
+        "it": "Bozza",
+        "ja": "下書き",
+        "pl": "Wersja robocza",
+        "pt": "Rascunho",
+        "ru": "Черновик",
+        "zh": "草稿",
+        "hi": "ड्राफ्ट",
+        "tr": "Taslak",
+        "ko": "초안"
+      }
+    },
+    {
+      "term": "Expired",
+      "category": "status",
+      "context": "No longer valid because a date passed.",
+      "translations": {
+        "fr": "Expiré",
+        "de": "Abgelaufen",
+        "es": "Vencido",
+        "it": "Scaduto",
+        "ja": "期限切れ",
+        "pl": "Wygasły",
+        "pt": "Vencido",
+        "ru": "Истек срок",
+        "zh": "已过期",
+        "hi": "समाप्त",
+        "tr": "Süresi doldu",
+        "ko": "만료됨"
+      }
+    },
+    {
+      "term": "Fail",
+      "category": "status",
+      "context": "Did not meet the inspection requirement.",
+      "translations": {
+        "fr": "Non conforme",
+        "de": "Nicht bestanden",
+        "es": "No conforme",
+        "it": "Non conforme",
+        "ja": "不合格",
+        "pl": "Niezgodny",
+        "pt": "Reprovado",
+        "ru": "Не годен",
+        "zh": "不合格",
+        "hi": "अनुत्तीर्ण",
+        "tr": "Uygun değil",
+        "ko": "불합격"
+      }
+    },
+    {
+      "term": "Fully Depreciated",
+      "category": "status",
+      "context": "An asset whose cost is entirely written off.",
+      "translations": {
+        "fr": "Totalement amorti",
+        "de": "Vollständig abgeschrieben",
+        "es": "Totalmente depreciado",
+        "it": "Completamente ammortizzato",
+        "ja": "償却済",
+        "pl": "Całkowicie zamortyzowany",
+        "pt": "Totalmente depreciado",
+        "ru": "Полностью амортизировано",
+        "zh": "已提足折旧",
+        "hi": "पूर्ण मूल्यह्रासित",
+        "tr": "Amortismanı tamamlanmış",
+        "ko": "상각 완료"
+      }
+    },
+    {
+      "term": "High",
+      "category": "status",
+      "context": "An upper severity or priority level.",
+      "translations": {
+        "fr": "Élevé",
+        "de": "Hoch",
+        "es": "Alto",
+        "it": "Alto",
+        "ja": "高",
+        "pl": "Wysoki",
+        "pt": "Alto",
+        "ru": "Высокий",
+        "zh": "高",
+        "hi": "उच्च",
+        "tr": "Yüksek",
+        "ko": "높음"
+      }
+    },
+    {
+      "term": "In Progress",
+      "category": "status",
+      "context": "Started but not finished.",
+      "translations": {
+        "fr": "En cours",
+        "de": "In Bearbeitung",
+        "es": "En curso",
+        "it": "In corso",
+        "ja": "進行中",
+        "pl": "W toku",
+        "pt": "Em andamento",
+        "ru": "В работе",
+        "zh": "进行中",
+        "hi": "प्रगति में",
+        "tr": "Devam ediyor",
+        "ko": "진행 중"
+      }
+    },
+    {
+      "term": "Inactive",
+      "category": "status",
+      "context": "Not in use, but retained.",
+      "translations": {
+        "fr": "Inactif",
+        "de": "Inaktiv",
+        "es": "Inactivo",
+        "it": "Inattivo",
+        "ja": "無効",
+        "pl": "Nieaktywny",
+        "pt": "Inativo",
+        "ru": "Неактивный",
+        "zh": "已停用",
+        "hi": "निष्क्रिय",
+        "tr": "Pasif",
+        "ko": "비활성"
+      }
+    },
+    {
+      "term": "Invoiced",
+      "category": "status",
+      "context": "Billed.",
+      "translations": {
+        "fr": "Facturé",
+        "de": "Fakturiert",
+        "es": "Facturado",
+        "it": "Fatturato",
+        "ja": "請求済",
+        "pl": "Zafakturowano",
+        "pt": "Faturado",
+        "ru": "Выставлен счет",
+        "zh": "已开票",
+        "hi": "चालान किया गया",
+        "tr": "Faturalandı",
+        "ko": "송장 발행됨"
+      }
+    },
+    {
+      "term": "Locked",
+      "category": "status",
+      "context": "Closed to new postings but not yet finally closed.",
+      "translations": {
+        "fr": "Verrouillé",
+        "de": "Gesperrt",
+        "es": "Bloqueado",
+        "it": "Bloccato",
+        "ja": "ロック中",
+        "pl": "Zablokowany",
+        "pt": "Bloqueado",
+        "ru": "Заблокировано",
+        "zh": "已锁定",
+        "hi": "लॉक",
+        "tr": "Kilitli",
+        "ko": "잠김"
+      }
+    },
+    {
+      "term": "Lost",
+      "category": "status",
+      "context": "A quote or opportunity that did not convert.",
+      "translations": {
+        "fr": "Perdu",
+        "de": "Verloren",
+        "es": "Perdido",
+        "it": "Perso",
+        "ja": "失注",
+        "pl": "Przegrana",
+        "pt": "Perdido",
+        "ru": "Проиграно",
+        "zh": "丢单",
+        "hi": "खोया",
+        "tr": "Kaybedildi",
+        "ko": "실주"
+      }
+    },
+    {
+      "term": "Low",
+      "category": "status",
+      "context": "A lower severity or priority level.",
+      "translations": {
+        "fr": "Faible",
+        "de": "Niedrig",
+        "es": "Bajo",
+        "it": "Basso",
+        "ja": "低",
+        "pl": "Niski",
+        "pt": "Baixo",
+        "ru": "Низкий",
+        "zh": "低",
+        "hi": "निम्न",
+        "tr": "Düşük",
+        "ko": "낮음"
+      }
+    },
+    {
+      "term": "Medium",
+      "category": "status",
+      "context": "A middle severity or priority level.",
+      "translations": {
+        "fr": "Moyen",
+        "de": "Mittel",
+        "es": "Medio",
+        "it": "Medio",
+        "ja": "中",
+        "pl": "Średni",
+        "pt": "Médio",
+        "ru": "Средний",
+        "zh": "中",
+        "hi": "मध्यम",
+        "tr": "Orta",
+        "ko": "보통"
+      }
+    },
+    {
+      "term": "On Hold",
+      "category": "status",
+      "context": "Deliberately paused.",
+      "translations": {
+        "fr": "Suspendu",
+        "de": "Angehalten",
+        "es": "Suspendido",
+        "it": "Sospeso",
+        "ja": "保留中",
+        "pl": "Wstrzymano",
+        "pt": "Suspenso",
+        "ru": "Приостановлено",
+        "zh": "搁置",
+        "hi": "होल्ड पर",
+        "tr": "Askıda",
+        "ko": "보류"
+      }
+    },
+    {
+      "term": "Open",
+      "category": "status",
+      "context": "Still being worked on.",
+      "translations": {
+        "fr": "Ouvert",
+        "de": "Offen",
+        "es": "Abierto",
+        "it": "Aperto",
+        "ja": "オープン",
+        "pl": "Otwarte",
+        "pt": "Aberto",
+        "ru": "Открыто",
+        "zh": "未结",
+        "hi": "खुला",
+        "tr": "Açık",
+        "ko": "미결"
+      }
+    },
+    {
+      "term": "Ordered",
+      "category": "status",
+      "context": "A purchase or sales order exists for it.",
+      "translations": {
+        "fr": "Commandé",
+        "de": "Bestellt",
+        "es": "Pedido",
+        "it": "Ordinato",
+        "ja": "発注済",
+        "pl": "Zamówiono",
+        "pt": "Pedido emitido",
+        "ru": "Заказано",
+        "zh": "已订购",
+        "hi": "ऑर्डर किया गया",
+        "tr": "Sipariş edildi",
+        "ko": "발주됨"
+      }
+    },
+    {
+      "term": "Overdue",
+      "category": "status",
+      "context": "Past its due date.",
+      "translations": {
+        "fr": "En retard",
+        "de": "Überfällig",
+        "es": "Atrasado",
+        "it": "In ritardo",
+        "ja": "期限超過",
+        "pl": "Po terminie",
+        "pt": "Atrasado",
+        "ru": "Просрочено",
+        "zh": "已逾期",
+        "hi": "अतिदेय",
+        "tr": "Gecikmiş",
+        "ko": "기한 초과"
+      }
+    },
+    {
+      "term": "Partial",
+      "category": "status",
+      "context": "Some but not all of the quantity is done.",
+      "translations": {
+        "fr": "Partiel",
+        "de": "Teilweise",
+        "es": "Parcial",
+        "it": "Parziale",
+        "ja": "一部",
+        "pl": "Częściowy",
+        "pt": "Parcial",
+        "ru": "Частично",
+        "zh": "部分",
+        "hi": "आंशिक",
+        "tr": "Kısmi",
+        "ko": "부분"
+      }
+    },
+    {
+      "term": "Pass",
+      "category": "status",
+      "context": "Met the inspection requirement.",
+      "translations": {
+        "fr": "Conforme",
+        "de": "Bestanden",
+        "es": "Conforme",
+        "it": "Conforme",
+        "ja": "合格",
+        "pl": "Zgodny",
+        "pt": "Aprovado",
+        "ru": "Годен",
+        "zh": "合格",
+        "hi": "उत्तीर्ण",
+        "tr": "Uygun",
+        "ko": "합격"
+      }
+    },
+    {
+      "term": "Passed",
+      "category": "status",
+      "context": "Met the requirement.",
+      "translations": {
+        "fr": "Réussi",
+        "de": "Bestanden",
+        "es": "Superado",
+        "it": "Superato",
+        "ja": "合格",
+        "pl": "Zaliczony",
+        "pt": "Aprovado",
+        "ru": "Пройдено",
+        "zh": "已通过",
+        "hi": "उत्तीर्ण",
+        "tr": "Geçti",
+        "ko": "통과"
+      }
+    },
+    {
+      "term": "Pending",
+      "category": "status",
+      "context": "Waiting on something before it can proceed.",
+      "translations": {
+        "fr": "En attente",
+        "de": "Ausstehend",
+        "es": "Pendiente",
+        "it": "In attesa",
+        "ja": "待機中",
+        "pl": "Oczekujące",
+        "pt": "Pendente",
+        "ru": "В ожидании",
+        "zh": "待处理",
+        "hi": "लंबित",
+        "tr": "Beklemede",
+        "ko": "대기 중"
+      }
+    },
+    {
+      "term": "Picked",
+      "category": "status",
+      "context": "Taken off the shelf.",
+      "translations": {
+        "fr": "Prélevé",
+        "de": "Kommissioniert",
+        "es": "Preparado",
+        "it": "Prelevato",
+        "ja": "ピッキング済",
+        "pl": "Pobrano",
+        "pt": "Separado",
+        "ru": "Отобрано",
+        "zh": "已拣货",
+        "hi": "पिक किया गया",
+        "tr": "Toplandı",
+        "ko": "피킹 완료"
+      }
+    },
+    {
+      "term": "Planned",
+      "category": "status",
+      "context": "Scheduled but not started.",
+      "translations": {
+        "fr": "Planifié",
+        "de": "Geplant",
+        "es": "Planificado",
+        "it": "Pianificato",
+        "ja": "計画済",
+        "pl": "Zaplanowano",
+        "pt": "Planejado",
+        "ru": "Запланировано",
+        "zh": "已计划",
+        "hi": "योजनाबद्ध",
+        "tr": "Planlandı",
+        "ko": "계획됨"
+      }
+    },
+    {
+      "term": "Posted",
+      "category": "status",
+      "context": "Committed to the ledger.",
+      "translations": {
+        "fr": "Comptabilisé",
+        "de": "Gebucht",
+        "es": "Contabilizado",
+        "it": "Registrato",
+        "ja": "転記済",
+        "pl": "Zaksięgowano",
+        "pt": "Contabilizado",
+        "ru": "Проведено",
+        "zh": "已过账",
+        "hi": "पोस्ट किया गया",
+        "tr": "Muhasebeleştirildi",
+        "ko": "전기됨"
+      }
+    },
+    {
+      "term": "Published",
+      "category": "status",
+      "context": "Made visible to its audience.",
+      "translations": {
+        "fr": "Publié",
+        "de": "Veröffentlicht",
+        "es": "Publicado",
+        "it": "Pubblicato",
+        "ja": "公開済",
+        "pl": "Opublikowano",
+        "pt": "Publicado",
+        "ru": "Опубликовано",
+        "zh": "已发布",
+        "hi": "प्रकाशित",
+        "tr": "Yayınlandı",
+        "ko": "게시됨"
+      }
+    },
+    {
+      "term": "Queued",
+      "category": "status",
+      "context": "Waiting to run.",
+      "translations": {
+        "fr": "En file d'attente",
+        "de": "In Warteschlange",
+        "es": "En cola",
+        "it": "In coda",
+        "ja": "キュー待ち",
+        "pl": "W kolejce",
+        "pt": "Na fila",
+        "ru": "В очереди",
+        "zh": "排队中",
+        "hi": "कतार में",
+        "tr": "Kuyrukta",
+        "ko": "대기열"
+      }
+    },
+    {
+      "term": "Ready",
+      "category": "status",
+      "context": "Everything needed is available.",
+      "translations": {
+        "fr": "Prêt",
+        "de": "Bereit",
+        "es": "Listo",
+        "it": "Pronto",
+        "ja": "準備完了",
+        "pl": "Gotowy",
+        "pt": "Pronto",
+        "ru": "Готов",
+        "zh": "就绪",
+        "hi": "तैयार",
+        "tr": "Hazır",
+        "ko": "준비됨"
+      }
+    },
+    {
+      "term": "Registered",
+      "category": "status",
+      "context": "Recorded in the system.",
+      "translations": {
+        "fr": "Enregistré",
+        "de": "Registriert",
+        "es": "Registrado",
+        "it": "Registrato",
+        "ja": "登録済",
+        "pl": "Zarejestrowano",
+        "pt": "Registrado",
+        "ru": "Зарегистрировано",
+        "zh": "已登记",
+        "hi": "पंजीकृत",
+        "tr": "Kaydedildi",
+        "ko": "등록됨"
+      }
+    },
+    {
+      "term": "Rejected",
+      "category": "status",
+      "context": "Refused.",
+      "translations": {
+        "fr": "Rejeté",
+        "de": "Abgelehnt",
+        "es": "Rechazado",
+        "it": "Rifiutato",
+        "ja": "却下済",
+        "pl": "Odrzucono",
+        "pt": "Rejeitado",
+        "ru": "Отклонено",
+        "zh": "已拒绝",
+        "hi": "अस्वीकृत",
+        "tr": "Reddedildi",
+        "ko": "거부됨"
+      }
+    },
+    {
+      "term": "Released",
+      "category": "status",
+      "context": "Authorised to proceed to the floor.",
+      "translations": {
+        "fr": "Lancé",
+        "de": "Freigegeben",
+        "es": "Liberado",
+        "it": "Rilasciato",
+        "ja": "リリース済",
+        "pl": "Zwolniono",
+        "pt": "Liberado",
+        "ru": "Запущено",
+        "zh": "已下达",
+        "hi": "जारी",
+        "tr": "Serbest bırakıldı",
+        "ko": "릴리스됨"
+      }
+    },
+    {
+      "term": "Reserved",
+      "category": "status",
+      "context": "Held for a specific demand and not freely available.",
+      "translations": {
+        "fr": "Réservé",
+        "de": "Reserviert",
+        "es": "Reservado",
+        "it": "Impegnato",
+        "ja": "引当済",
+        "pl": "Zarezerwowano",
+        "pt": "Reservado",
+        "ru": "Зарезервировано",
+        "zh": "已预留",
+        "hi": "आरक्षित",
+        "tr": "Rezerve edildi",
+        "ko": "예약됨"
+      }
+    },
+    {
+      "term": "Reversed",
+      "category": "status",
+      "context": "Undone by an opposite posting.",
+      "translations": {
+        "fr": "Extourné",
+        "de": "Storniert",
+        "es": "Revertido",
+        "it": "Stornato",
+        "ja": "反対仕訳済",
+        "pl": "Wystornowano",
+        "pt": "Estornado",
+        "ru": "Сторнировано",
+        "zh": "已冲销",
+        "hi": "प्रतिवर्तित",
+        "tr": "Ters kayıt yapıldı",
+        "ko": "역분개됨"
+      }
+    },
+    {
+      "term": "Skipped",
+      "category": "status",
+      "context": "Deliberately not run.",
+      "translations": {
+        "fr": "Ignoré",
+        "de": "Übersprungen",
+        "es": "Omitido",
+        "it": "Saltato",
+        "ja": "スキップ済",
+        "pl": "Pominięto",
+        "pt": "Ignorado",
+        "ru": "Пропущено",
+        "zh": "已跳过",
+        "hi": "छोड़ा गया",
+        "tr": "Atlandı",
+        "ko": "건너뜀"
+      }
+    },
+    {
+      "term": "Void",
+      "category": "status",
+      "context": "Cancelled after posting, reversed rather than deleted.",
+      "translations": {
+        "fr": "Invalider",
+        "de": "Stornieren",
+        "es": "Anular",
+        "it": "Storna",
+        "ja": "取消",
+        "pl": "Unieważnij",
+        "pt": "Anular",
+        "ru": "Аннулировать",
+        "zh": "作废",
+        "hi": "अमान्य करें",
+        "tr": "Hükümsüz kıl",
+        "ko": "무효 처리"
+      }
+    },
+    {
+      "term": "Voided",
+      "category": "status",
+      "context": "Cancelled after posting, reversed rather than deleted. The status; Void is the action.",
+      "translations": {
+        "fr": "Invalidé",
+        "de": "Storniert",
+        "es": "Anulado",
+        "it": "Stornato",
+        "ja": "取消済",
+        "pl": "Unieważniono",
+        "pt": "Anulado",
+        "ru": "Аннулировано",
+        "zh": "已作废",
+        "hi": "अमान्य",
+        "tr": "Hükümsüz",
+        "ko": "무효 처리됨"
+      }
+    }
+  ]
+}

--- a/packages/locale/locales/glossary.json
+++ b/packages/locale/locales/glossary.json
@@ -393,6 +393,7 @@
       "term": "Credit",
       "category": "accounting",
       "context": "The right side of a posting.",
+      "ambiguity": "Only the ledger side. Do NOT apply to a credit memo, a customer's available credit, or credit terms.",
       "translations": {
         "fr": "Crédit",
         "de": "Haben",
@@ -1574,6 +1575,7 @@
       "term": "Close",
       "category": "action",
       "context": "Finish a record so it can no longer be edited.",
+      "ambiguity": "Only closing a record or period. Do NOT apply to 'month-end close' as a noun, 'closing balance', or 'close to'.",
       "translations": {
         "fr": "Clôturer",
         "de": "Abschließen",
@@ -2922,6 +2924,7 @@
       "term": "Split",
       "category": "inventory",
       "context": "Dividing a lot or line into smaller parts.",
+      "ambiguity": "Only dividing a lot or a line. Do NOT apply to the ordinary verb — 'status splits across ship and invoice'.",
       "translations": {
         "fr": "Fractionner",
         "de": "Teilen",
@@ -3057,6 +3060,7 @@
       "term": "Buy",
       "category": "items",
       "context": "A replenishment system: the item is purchased.",
+      "ambiguity": "Only the replenishment system. Do NOT apply to 'buy' as an ordinary verb — 'a customer who buys your parts'.",
       "translations": {
         "fr": "Achat",
         "de": "Fremdbeschaffung",
@@ -4417,6 +4421,7 @@
       "term": "Team",
       "category": "people",
       "context": "A group of employees work is assigned to.",
+      "ambiguity": "Only the shop-floor group work is assigned to. Do NOT apply to 'your team' meaning the company or the people reading the screen.",
       "translations": {
         "fr": "Groupe",
         "de": "Team",
@@ -5063,6 +5068,7 @@
       "term": "Monthly",
       "category": "platform",
       "context": "Once a month.",
+      "ambiguity": "Only the recurrence option. Do NOT apply to 'monthly periods' or 'monthly total', where the word is an ordinary adjective.",
       "translations": {
         "fr": "Mensuel",
         "de": "Monatlich",
@@ -5272,6 +5278,7 @@
       "term": "Role",
       "category": "platform",
       "context": "A named set of permissions given to users.",
+      "ambiguity": "Only the named permission set. Do NOT apply to 'a gauge whose role is Master' or other ordinary 'role/purpose' senses.",
       "translations": {
         "fr": "Rôle",
         "de": "Rolle",
@@ -7720,6 +7727,7 @@
       "term": "Active",
       "category": "status",
       "context": "In use.",
+      "ambiguity": "Only the record status. Do NOT apply to 'active jobs', 'active session', or other ordinary adjective uses.",
       "translations": {
         "fr": "Actif",
         "de": "Aktiv",
@@ -7778,6 +7786,7 @@
       "term": "Assigned",
       "category": "status",
       "context": "Given to a person or resource.",
+      "ambiguity": "Only the status. Do NOT apply to the ordinary verb — 'jobs assigned to me', 'work is assigned to a team'.",
       "translations": {
         "fr": "Assigné",
         "de": "Zugewiesen",
@@ -7897,6 +7906,7 @@
       "term": "Consumed",
       "category": "status",
       "context": "Used up by a job.",
+      "ambiguity": "Only material used up by a job. Do NOT apply to the ordinary verb — 'not consumed', 'consumes the allowance'.",
       "translations": {
         "fr": "Consommé",
         "de": "Verbraucht",
@@ -7935,6 +7945,7 @@
       "term": "Disposed",
       "category": "status",
       "context": "A fixed asset removed from the books.",
+      "ambiguity": "Only a fixed asset removed from the books. Do NOT apply to scrap or waste disposal.",
       "translations": {
         "fr": "Cédé",
         "de": "Abgegangen",
@@ -8240,6 +8251,7 @@
       "term": "Ordered",
       "category": "status",
       "context": "A purchase or sales order exists for it.",
+      "ambiguity": "Only the status meaning an order exists. Do NOT apply to 'ordered set', 'ordered list', or sequence senses.",
       "translations": {
         "fr": "Commandé",
         "de": "Bestellt",
@@ -8297,6 +8309,7 @@
       "term": "Pass",
       "category": "status",
       "context": "Met the inspection requirement.",
+      "ambiguity": "Only the inspection result. Do NOT apply to the verb 'it passes', or to a passing score, a pass-through, or a passkey.",
       "translations": {
         "fr": "Conforme",
         "de": "Bestanden",
@@ -8490,6 +8503,7 @@
       "term": "Rejected",
       "category": "status",
       "context": "Refused.",
+      "ambiguity": "Only the inspection or approval status. Do NOT apply to the ordinary verb — 'quote rejected by email'.",
       "translations": {
         "fr": "Rejeté",
         "de": "Abgelehnt",
@@ -8509,6 +8523,7 @@
       "term": "Released",
       "category": "status",
       "context": "Authorised to proceed to the floor.",
+      "ambiguity": "Only a job authorised to the floor. Do NOT apply to stock 'released to Available', or to a released revision or document.",
       "translations": {
         "fr": "Lancé",
         "de": "Freigegeben",

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -30,10 +30,10 @@ msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
 msgstr "\"{0}\" चयनित सतह(सतहों) पर उपलब्ध नहीं है। कोई अन्य फ़ील्ड चुनें।"
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "\"{storageUnitName}\" के {childCount} सीधे नेस्टेड स्टोरेज यूनिट हैं। इसे हटाने से वे और उनके अंदर की सभी चीजें भी हट जाएंगी। यह पूर्ववत नहीं किया जा सकता।"
+msgstr "\"{storageUnitName}\" के {childCount} प्रत्यक्ष नेस्टेड भंडारण इकाइयां हैं। इसे हटाने से वे भी हटाई जाएंगी और इसके नीचे कुछ भी हटाया जाएगा। इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "\"{storageUnitName}\" के पास 1 सीधी नेस्टेड स्टोरेज यूनिट है। इसे हटाने से वह यूनिट और इसके अंदर की कोई भी चीज़ भी हटा दी जाएगी। यह पूर्ववत नहीं किया जा सकता।"
+msgstr "\"{storageUnitName}\" के 1 प्रत्यक्ष नेस्टेड भंडारण इकाई है। इसे हटाने से वह इकाई भी हटाई जाएगी और इसके नीचे कुछ भी हटाया जाएगा। इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -66,7 +66,7 @@ msgstr "{0} अंतर वाली कोशिकाएँ"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
-msgstr "{0} ग्राहकों के साथ शेष"
+msgstr "{0} ग्राहक शेष राशि के साथ"
 
 #. placeholder {0}: rule.escalationDays
 msgid "{0} days"
@@ -83,7 +83,7 @@ msgstr "{0} ड्राफ्ट जर्नल प्रविष्टिय
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} नौकरियाँ बनाई गई"
+msgstr "{0} जॉब बनाए गए"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -116,7 +116,7 @@ msgstr "{0} पंजीकृत"
 
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
-msgstr "{0} आपूर्तिकर्ता शेष के साथ"
+msgstr "{0} आपूर्तिकर्ता शेष राशि के साथ"
 
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
@@ -145,13 +145,13 @@ msgid "{0} values missing"
 msgstr "{0} मान गायब हैं"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} भाग छोड़ दिए गए — उनके पास पहले से ही खुली नौकरियाँ हैं"
+msgstr "{alreadyPlannedItemCount} पार्ट्स छोड़ दिए गए — उनके पास पहले से ही खुली जॉब हैं"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% देय राशि का"
 
 msgid "{arOverduePct}% of receivables"
-msgstr "{arOverduePct}% प्राप्य"
+msgstr "प्राप्य राशि का {arOverduePct}%"
 
 msgid "{chainLabel}. Consider pointing this part directly at the final successor."
 msgstr "{chainLabel}. इस भाग को सीधे अंतिम उत्तराधिकारी की ओर इंगित करने पर विचार करें।"
@@ -166,15 +166,15 @@ msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} में से {count}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}–{to} में से {count} परिचालन"
+msgstr "{count} ऑपरेशन में से {from}–{to}"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "और {hiddenCount}: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
-msgstr "{inserted} डाले गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
+msgstr "{inserted} जोड़े गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# लाइन} other {# लाइनें}}"
@@ -186,20 +186,20 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} महीने बेमेल कुल के साथ"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} पत्रिकाएं प्रदाता में नहीं हैं"
+msgstr "प्रदाता में {missingCount} जर्नल गायब हैं"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} नहीं मिली पत्रिकाएं और {mismatchCount} बेमेल महीने"
+msgstr "{missingCount} गायब जर्नल और {mismatchCount} असमान महीने"
 
 msgid "{name} deleted"
 msgstr "{name} हटाया गया"
 
 msgid "{noDemandItemCount} parts skipped — nothing to make"
-msgstr "{noDemandItemCount} भाग छोड़ दिए गए — कुछ नहीं बनाना है"
+msgstr "{noDemandItemCount} पार्ट्स छोड़ दिए गए — निर्माण करने के लिए कुछ नहीं है"
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel} को संपादन के लिए संशोधन {0} के रूप में फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ जब तक आप इसे अंतिम रूप देते हैं और आदेश को फिर से भेजते हैं तब तक अपरिवर्तित रहता है।"
+msgstr "{orderLabel} को रिवीजन {0} के रूप में संपादन के लिए फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ अपरिवर्तित रहेगा जब तक आप क्रय आदेश को अंतिम रूप न दें और पुनः न भेजें।"
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# चरण बचा} other {# चरण बचे}}"
@@ -208,7 +208,7 @@ msgid "{scopeCount} permissions"
 msgstr "{scopeCount} अनुमतियाँ"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
+msgstr "आपकी कंपनी को Carbon पर लाइव करने के लिए {total} चरण। प्रत्येक एक चेकपॉइंट पर समाप्त होता है।"
 
 msgid "{total} phases to go live"
 msgstr "{total} चरण लाइव होने के लिए"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} नौकरियाँ अपडेट की गईं"
+msgstr "{updatedJobCount} जॉब अपडेट किए गए"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} अपलोड हो गया — दस्तावेज़ से फ़ील्ड भर दिए गए हैं।"
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "{variances, plural, one {# लाइन अपेक्षित मात्रा से भिन्न है} other {# लाइनें अपेक्षित मात्रा से भिन्न हैं}}"
+msgstr "{variances, plural, one {# पंक्ति अपेक्षित मात्रा से भिन्न है} other {# पंक्तियां अपेक्षित मात्रा से भिन्न हैं}}"
 
 msgid "{years}yr"
 msgstr "{years}वर्ष"
@@ -249,7 +249,7 @@ msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
 msgstr "<0>इस आइटम के लिए एक आपूर्तिकर्ता भाग जोड़ें</0> एक पसंदीदा आपूर्तिकर्ता सेट करने के लिए।"
 
 msgid "0 operations"
-msgstr "0 परिचालन"
+msgstr "0 ऑपरेशन"
 
 msgid "0-4 weeks"
 msgstr "0-4 सप्ताह"
@@ -267,10 +267,10 @@ msgid "1 job updated"
 msgstr "1 नौकरी अपडेट की गई"
 
 msgid "1 part skipped — it already has an open job"
-msgstr "1 भाग छोड़ दिया गया — इसके पास पहले से ही एक खुली नौकरी है"
+msgstr "1 पार्ट छोड़ दिया गया — इसके पास पहले से ही एक खुली जॉब है"
 
 msgid "1 part skipped — nothing to make"
-msgstr "1 भाग छोड़ दिया गया — कुछ नहीं बनाना है"
+msgstr "1 पार्ट छोड़ दिया गया — निर्माण करने के लिए कुछ नहीं है"
 
 msgid "1 problem — not published"
 msgstr "1 समस्या — प्रकाशित नहीं"
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4 घंटे"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "न्यूनतम 5 उपयोगकर्ता"
 
 msgid "5-8 weeks"
 msgstr "5-8 सप्ताह"
@@ -336,7 +336,7 @@ msgid "A clearing account holding the value of goods received but not yet billed
 msgstr "एक क्लीयरिंग खाता जो प्राप्त किए गए लेकिन अभी तक चालान नहीं किए गए सामान का मूल्य रखता है; आपूर्तिकर्ता चालान इसे साफ करता है।"
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
-msgstr "एक कंपनी जो अपने स्वयं के तैयार उत्पादों को अंत से अंत तक डिजाइन और निर्माण करती है (यहां, ह्यूमनॉइड रोबोट बनाने वाली दुकान) किसी अन्य कंपनी की विशेषताओं के अनुसार भाग बनाने के बजाय।"
+msgstr "एक कंपनी जो अपने स्वयं के तैयार उत्पादों को अंत तक डिजाइन और निर्मित करती है (यहां, मानवीय रोबोट बनाने वाली दुकान) बजाय किसी अन्य कंपनी के विनिर्देश के अनुसार पार्ट्स बनाने के।"
 
 msgid "A company that sits at or above selected companies in the group hierarchy and receives their intercompany cancelling entries for consolidated reporting; it is never a party to the trade itself."
 msgstr "एक कंपनी जो समूह पदानुक्रम में चयनित कंपनियों के समान या ऊपर स्थित है और समेकित रिपोर्टिंग के लिए उनकी इंटरकंपनी रद्दकरण प्रविष्टियां प्राप्त करती है; यह कभी भी व्यापार का पक्ष नहीं होती है।"
@@ -354,13 +354,13 @@ msgid "A completed job's output, received into inventory at the job's actual acc
 msgstr "एक पूर्ण नौकरी का आउटपुट, नौकरी की वास्तविक संचित WIP लागत पर इन्वेंटरी में प्राप्त।"
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "एक उपभोग्य एक भौतिक वस्तु है जिसका उपयोग एक भाग बनाने के लिए किया जाता है जिसे कई नौकरियों में उपयोग किया जा सकता है"
+msgstr "एक उपभोग्य सामग्री एक भौतिक आइटम है जो एक पार्ट बनाने के लिए उपयोग की जाती है जिसे कई जॉब में उपयोग किया जा सकता है"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "एक ठेकेदार एक आपूर्तिकर्ता संपर्क है जिसके पास विशेष क्षमताएं और उपलब्ध घंटे हैं"
+msgstr "एक ठेकेदार एक आपूर्तिकर्ता संपर्क है जिसके पास विशेष कौशल और उपलब्ध घंटे हैं"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "आपकी आवश्यकताओं को पूरा करने के लिए एक कस्टम समाधान"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "एक ग्राहक एक व्यवसाय या व्यक्ति है जो आपके पार्ट्स या सेवाएं खरीदता है।"
@@ -375,7 +375,7 @@ msgid "A customer's account manager changes"
 msgstr "किसी ग्राहक के खाता प्रबंधक में परिवर्तन"
 
 msgid "A customer's assignee changes"
-msgstr "किसी ग्राहक के प्रदायोजन में परिवर्तन"
+msgstr "ग्राहक का असाइनी बदल जाता है"
 
 msgid "A customer's currency changes"
 msgstr "किसी ग्राहक की मुद्रा में परिवर्तन"
@@ -399,10 +399,10 @@ msgid "A dated window postings fall into; its close status moves Open → Locked
 msgstr "एक दिनांकित विंडो जिसमें पोस्टिंग आती हैं; इसकी बंद स्थिति खुली → लॉक की गई → बंद चली जाती है, और एक बंद अवधि नई पोस्टिंग के विरुद्ध जमी हुई है।"
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
-msgstr "एक मूल्यह्रास पद्धति जो प्रत्येक अवधि में शेष पुस्तक मूल्य का एक निश्चित प्रतिशत लेती है — जल्दी भारी, बाद में हल्का।"
+msgstr "एक मूल्यह्रास विधि जो प्रत्येक अवधि में शेष बही मूल्य का एक निश्चित प्रतिशत चार्ज करती है — शुरुआत में भारी, बाद में हल्का।"
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
-msgstr "एक मूल्यह्रास पद्धति जो संपत्ति के उपयोगी जीवन में प्रत्येक अवधि में समान राशि लेती है।"
+msgstr "एक मूल्यह्रास विधि जो संपत्ति के उपयोगी जीवन में प्रत्येक अवधि में समान राशि चार्ज करती है।"
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
 msgstr "ग्राहक की एक मजबूत प्रतिबद्धता देने के लिए; पूरा होने की स्थिति पूर्ण तक पहुंचने से पहले शिपमेंट और चालान में विभाजित होती है।"
@@ -426,22 +426,22 @@ msgid "A job is deleted"
 msgstr "एक नौकरी हटाई गई है"
 
 msgid "A job is put on hold"
-msgstr "एक नौकरी को रोक दिया गया है"
+msgstr "एक जॉब को होल्ड पर रखा जाता है"
 
 msgid "A job is released"
 msgstr "एक नौकरी जारी की गई है"
 
 msgid "A job operation is completed"
-msgstr "एक नौकरी ऑपरेशन पूरा हो गया है"
+msgstr "एक जॉब ऑपरेशन पूर्ण किया गया है"
 
 msgid "A job's assignee changes"
-msgstr "किसी नौकरी के प्रदायोजन में परिवर्तन"
+msgstr "जॉब का असाइनी बदल जाता है"
 
 msgid "A job's deadline type changes"
 msgstr "किसी नौकरी की समय सीमा प्रकार में परिवर्तन"
 
 msgid "A job's due date changes"
-msgstr "किसी नौकरी की देय तिथि में परिवर्तन"
+msgstr "जॉब की नियत तिथि बदल जाती है"
 
 msgid "A job's priority changes"
 msgstr "किसी नौकरी की प्राथमिकता में परिवर्तन"
@@ -467,76 +467,76 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "एक सूची {0} में जुड़ी हुई है, इसलिए यह चरण इसमें प्रत्येक आइटम के लिए एक बार चलता है — {MAX_LIST_ITEMS} तक।"
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "एक ऑर्डर टू मेक घटक जो माता-पिता के बिल्ड के अंदर अपनी नौकरी और रूटिंग पाता है।"
+msgstr "एक ऑर्डर पर निर्माण घटक जिसे माता-पिता के निर्माण के भीतर अपना स्वयं का जॉब और रूटिंग मिलता है।"
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "एक ऑर्डर टू मेक घटक जिसके भाग माता-पिता की नौकरी में एक साथ जारी किए जाते हैं — कोई अलग बिल्ड नहीं।"
+msgstr "एक ऑर्डर पर निर्माण घटक जिसके पार्ट्स को माता-पिता की जॉब में एक साथ जारी किया जाता है — कोई अलग निर्माण नहीं।"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbon का एक प्रबंधित क्लाउड-होस्ट किया गया संस्करण"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "सभी उन्नत सुविधाओं के साथ एक प्रबंधित संस्करण"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "एक सामग्री एक भौतिक वस्तु है जिसका उपयोग एक भाग बनाने के लिए किया जाता है जिसे कई नौकरियों में उपयोग किया जा सकता है"
+msgstr "एक सामग्री एक भौतिक आइटम है जो एक पार्ट बनाने के लिए उपयोग की जाती है जिसे कई जॉब में उपयोग किया जा सकता है"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "एक मापन उपकरण (कैलिपर, माइक्रोमीटर, पिन गेज, सीएमएम) जो एक रिकॉर्ड के रूप में ट्रैक किया जाता है और एक आवर्ती कैलिब्रेशन शेड्यूल के लिए आयोजित किया जाता है।"
+msgstr "एक माप उपकरण (कैलिपर, माइक्रोमीटर, पिन गेज, CMM) जिसे एक रिकॉर्ड के रूप में ट्रैक किया जाता है और एक आवर्ती अंशांकन शेड्यूल का पालन किया जाता है।"
 
 msgid "A name is required to save a view"
 msgstr "एक दृश्य को सहेजने के लिए एक नाम आवश्यक है"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "एक विशिष्ट आइटम के लिए सहमत कीमत — ग्राहक, ग्राहक प्रकार, या सभी ग्राहकों द्वारा — जो आधार मूल्य को पूरी तरह से बदल देता है, वैकल्पिक रूप से मात्रा में छूट के साथ।"
+msgstr "एक समझौता किया गया मूल्य एक विशिष्ट आइटम के लिए तय किया गया — ग्राहक, ग्राहक प्रकार, या सभी ग्राहकों द्वारा — जो मूल मूल्य को पूरी तरह से प्रतिस्थापित करता है, वैकल्पिक रूप से मात्रा स्तर के साथ।"
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "प्रत्येक आपूर्तिकर्ता के लिए एक नया क्रय आदेश बनाया जाएगा। वैकल्पिक रूप से, आप आपूर्तिकर्ता के लिए एक मौजूदा ड्राफ्ट क्रय आदेश चुन सकते हैं और बाहरी संचालन जोड़ सकते हैं।"
+msgstr "प्रत्येक आपूर्तिकर्ता के लिए एक नया क्रय आदेश बनाया जाएगा। वैकल्पिक रूप से, आप आपूर्तिकर्ता के लिए एक मौजूदा ड्राफ्ट क्रय आदेश चुन सकते हैं जिसमें बाहरी ऑपरेशन जोड़ने हैं।"
 
 msgid "A new revision will be created using a copy of the current revision"
-msgstr "एक नया संशोधन वर्तमान संशोधन की प्रतिलिपि का उपयोग करके बनाया जाएगा"
+msgstr "वर्तमान रिवीजन की एक प्रति का उपयोग करके एक नई रिवीजन बनाई जाएगी"
 
 msgid "A new size will be created using a copy of the current size"
 msgstr "एक नया आकार वर्तमान आकार की प्रतिलिपि का उपयोग करके बनाया जाएगा"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "एक नया Stripe ग्राहक बनाया जाएगा"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "एक गैर-नकद दस्तावेज जो एक कारण खाते के विरुद्ध एक चालान को निपटाता है: एक क्रेडिट बकाया राशि को कम करता है, एक डेबिट इसे बढ़ाता है।"
+msgstr "एक गैर-नकद दस्तावेज़ जो एक कारण खाते के विरुद्ध चालान को निपटाता है: जमा देय राशि को कम करता है, नामे इसे बढ़ाता है।"
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
-msgstr "एक गैर-अनुरूपता जो एक आपूर्तिकर्ता के साथ एक लॉगिन-मुक्त /share/scar लिंक के माध्यम से साझा की जाती है, ताकि वे समस्या का जवाब दे सकें और कार्बन के बाहर से इसके कार्यों को अपडेट कर सकें।"
+msgstr "एक गैर-अनुरूपता जो आपूर्तिकर्ता के साथ एक लॉगिन-मुक्त /share/scar लिंक पर साझा की गई है, ताकि वे Carbon के बाहर से समस्या का जवाब दे सकें और इसके कार्य अपडेट कर सकें।"
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "एक गैर-कर योग्य अधिभार (जैसे पुनः प्राप्य खर्च जैसे परमिट शुल्क) जो पंक्ति में जोड़ा जाता है और कर आधार से बाहर रखा जाता है।"
+msgstr "एक गैर-कर योग्य अतिरिक्त शुल्क (जैसे recoverable खर्च जैसे परमिट शुल्क) पंक्ति में जोड़ा गया; कर आधार से बाहर रखा गया।"
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "एक अनुरूपता कार्य जो एक पुष्टि मूल कारण को ठीक करता है — एक निवारक या तत्काल निहितार्थ कार्रवाई के विपरीत।"
+msgstr "एक गैर-अनुरूपता कार्य जो एक पुष्टि किए गए मूल कारण को ठीक करता है — एक निवारक या तत्काल नियंत्रण कार्रवाई के विपरीत।"
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "एक अनुरूपता कार्य जो समस्या को कहीं और दोहराने से रोकता है — सुधारात्मक सुधार और निहितार्थ से अलग।"
+msgstr "एक गैर-अनुरूपता कार्य जो समस्या को अन्य स्थानों पर फिर से होने से रोकता है — सुधारात्मक सुधार और नियंत्रण से अलग।"
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "एक पार्ट में एक विशिष्ट आइटम की जानकारी होती है जिसे खरीदा या निर्मित किया जा सकता है।"
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "एक भौतिक पुल सिग्नल — एक मुद्रित कार्ड या क्यूआर कोड जो स्टॉक के साथ रहता है — जो एक खरीद आदेश या नौकरी को उठाता है जैसे ही इसे बिन को फिर से भरने के लिए स्कैन किया जाता है।"
+msgstr "एक भौतिक खींचने का संकेत — एक मुद्रित कार्ड या QR कोड जो स्टॉक के साथ रहता है — जो क्रय आदेश या जॉब बढ़ाता है जिस क्षण इसे बिन को भरने के लिए स्कैन किया जाता है।"
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
 msgstr "कार्बन के अपने प्रवाह में एक बिंदु जिसे एक वर्कफ़्लो देख सकता है — एक नौकरी जारी की गई, एक उद्धरण स्वीकार किया गया, एक शिपमेंट पोस्ट किया गया — एक कच्चे क्षेत्र परिवर्तन के विपरीत; यह वर्कफ़्लो को आईडी द्वारा शामिल रिकॉर्ड देता है।"
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "एक पोस्ट की गई लेखांकन प्रविष्टि: एक हेडर प्लस GL खातों के विरुद्ध संतुलित डेबिट और क्रेडिट लाইनें।"
+msgstr "एक पोस्ट किया गया लेखांकन प्रविष्टि: एक शीर्षलेख प्लस संतुलित नामे और जमा पंक्तियां लेजर खातों के विरुद्ध।"
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "एक पोस्ट किया गया नकद लेनदेन — एक ग्राहक से एक रसीद या एक आपूर्तिकर्ता को एक वितरण — निपटान के माध्यम से चालान पर लागू, ड्राफ्ट → पोस्ट किया गया → रद्द चल रहा है।"
+msgstr "एक पोस्ट किया गया नकद लेनदेन — ग्राहक से एक प्राप्ति या आपूर्तिकर्ता को एक संवितरण — चालानों पर निपटान के माध्यम से लागू, ड्राफ्ट → पोस्ट किया गया → अमान्य में स्थानांतरित।"
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "इस वर्कफ़्लो का उपयोग करने वाली प्रत्येक समस्या में डाला गया एक पूर्व-लिखित विवरण; {itemId} और {location} जैसे प्लेसहोल्डर बनाते समय प्रतिस्थापित किए जाते हैं।"
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "एक मूल्यवान बिक्रय उद्धरण; मसौदा → भेजा → आदेशित, या खो, समाप्त, या रद्द अंत।"
+msgstr "एक मूल्यवान बिक्री कोटेशन; ड्राफ्ट → भेजा गया → ऑर्डर किया गया, या खोया, समाप्त, या रद्द में समाप्त होता है।"
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
 msgstr "एक क्रय चालान एक दस्तावेज है जो किसी ग्राहक द्वारा खरीदे गए उत्पादों या सेवाओं और संबंधित लागत को निर्दिष्ट करता है।"
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "एक क्रय आदेश हटाया गया है"
 
 msgid "A purchase order's assignee changes"
-msgstr "किसी क्रय आदेश के प्रदायोजन में परिवर्तन"
+msgstr "क्रय आदेश के असाइनी में परिवर्तन"
 
 msgid "A purchase order's order date changes"
 msgstr "किसी क्रय आदेश की आदेश तिथि में परिवर्तन"
@@ -575,13 +575,13 @@ msgid "A purchase order's type changes"
 msgstr "किसी क्रय आदेश के प्रकार में परिवर्तन"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "एक गुणवत्ता समस्या — एक लॉग किया गया विचलन या दोष जिसमें जांच और कार्य कार्यों की एक कॉन्फ़िगरेबल वर्कफ़्लो है।"
+msgstr "एक गुणवत्ता समस्या — एक लॉग किया गया विचलन अनुमति या दोष जांच और कार्य कार्य की एक कॉन्फ़िगरेबल वर्कफ़्लो के साथ।"
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "समान इकाइयों की एक मात्रा एक ट्रैक की गई इकाई और बैच संख्या साझा करती है — एक इकाई, कई इकाइयां।"
 
 msgid "A quote is a set of prices for specific parts and quantities."
-msgstr "एक उद्धरण विशिष्ट भागों और मात्राओं के लिए कीमतों का एक समूह है।"
+msgstr "एक कोटेशन विशिष्ट पार्ट्स और मात्राओं के लिए मूल्यों का एक समूह है।"
 
 msgid "A quote is accepted"
 msgstr "एक उद्धरण स्वीकार किया गया है"
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "एक उद्धरण भेजा गया है"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "एक उद्धरण पंक्ति में किसी विशेष भाग के लिए मूल्य निर्धारण और लीड समय शामिल होते हैं"
+msgstr "एक कोटेशन पंक्ति एक विशेष पार्ट के लिए मूल्य निर्धारण और लीड टाइम शामिल करती है"
 
 msgid "A quote's assignee changes"
-msgstr "किसी उद्धरण के नियुक्त व्यक्ति में परिवर्तन होता है"
+msgstr "कोटेशन के असाइनी में परिवर्तन"
 
 msgid "A quote's completed date changes"
 msgstr "किसी उद्धरण की पूर्ण तारीख में परिवर्तन होता है"
@@ -608,13 +608,13 @@ msgid "A quote's customer changes"
 msgstr "किसी उद्धरण के ग्राहक में परिवर्तन होता है"
 
 msgid "A quote's due date changes"
-msgstr "किसी उद्धरण की देय तारीख में परिवर्तन होता है"
+msgstr "कोटेशन की नियत तिथि में परिवर्तन"
 
 msgid "A quote's estimator changes"
 msgstr "किसी उद्धरण के अनुमानकर्ता में परिवर्तन होता है"
 
 msgid "A quote's expiration date changes"
-msgstr "किसी उद्धरण की समाप्ति तारीख में परिवर्तन होता है"
+msgstr "कोटेशन की समाप्ति तिथि में परिवर्तन"
 
 msgid "A quote's salesperson changes"
 msgstr "किसी उद्धरण के विक्रय प्रतिनिधि में परिवर्तन होता है"
@@ -632,10 +632,10 @@ msgid "A receipt is posted"
 msgstr "एक रसीद पोस्ट की गई है"
 
 msgid "A receipt's assignee changes"
-msgstr "किसी रसीद के नियुक्त व्यक्ति में परिवर्तन होता है"
+msgstr "प्राप्ति के असाइनी में परिवर्तन"
 
 msgid "A receipt's invoiced changes"
-msgstr "किसी रसीद के बिल योग्य में परिवर्तन होता है"
+msgstr "प्राप्ति का चालान किया गया स्थिति परिवर्तन"
 
 msgid "A receipt's location changes"
 msgstr "किसी रसीद के स्थान में परिवर्तन होता है"
@@ -656,22 +656,22 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "एक पुनः प्रयोग योग्य, संस्करण युक्त कार्य निर्देशों का समूह जो एक प्रक्रिया से जुड़ा होता है, जो एक ऑपरेशन को रिकॉर्ड और जांच के लिए क्रमबद्ध चरण प्रदान करता है साथ ही वह पैरामीटर भी प्रदान करता है जिस पर यह चलता है।"
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "एक रिलीज़ की गई जॉब पर एक रूटिंग स्टेप, जॉब की अपनी ऑपरेशन की कॉपी, जिसमें एक स्थिति है जो फ्लोर Todo से Done तक चलाता है।"
+msgstr "एक जारी जॉब पर एक रूटिंग चरण, जॉब की अपनी ऑपरेशन की प्रति, एक स्थिति ले जाता है जो फ़्लोर को करने के लिए कार्य करता है।"
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "एक बिक्री चालान (आप एक ग्राहक को बिल भेजते हैं) या एक खरीद चालान (एक आपूर्तिकर्ता आपको बिल भेजता है), भुगतान और क्रेडिट या डेबिट मेमो लागू करके निपटाया जाता है।"
+msgstr "एक विक्रय चालान (आप ग्राहक को बिल करते हैं) या क्रय चालान (एक आपूर्तिकर्ता आपको बिल करता है), भुगतान और जमा या नामे मेमो लागू करके निपटाया गया।"
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
-msgstr "एक बिक्रय चालान एक दस्तावेज है जो किसी ग्राहक को बेचे गए उत्पादों या सेवाओं और संबंधित लागत को निर्दिष्ट करता है।"
+msgstr "एक विक्रय चालान एक दस्तावेज़ है जो ग्राहक को बेची गई उत्पादों या सेवाओं और संबंधित लागत को निर्दिष्ट करता है।"
 
 msgid "A sales invoice is posted"
 msgstr "एक विक्रय चालान पोस्ट किया गया है"
 
 msgid "A sales invoice line contains invoice details for a particular item"
-msgstr "एक बिक्रय चालान पंक्ति में किसी विशेष आइटम के लिए चालान विवरण होते हैं"
+msgstr "एक विक्रय चालान पंक्ति एक विशेष आइटम के लिए चालान विवरण शामिल करती है"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "एक बिक्रय आदेश कंपनी और एक विशिष्ट ग्राहक के बीच भागों और सेवाओं के लिए समझौते की जानकारी रखता है।"
+msgstr "एक विक्रय आदेश कंपनी और पार्ट्स और सेवाओं के लिए एक विशिष्ट ग्राहक के बीच समझौते के बारे में जानकारी शामिल करता है।"
 
 msgid "A sales order is created"
 msgstr "एक विक्रय आदेश बनाया गया है"
@@ -680,10 +680,10 @@ msgid "A sales order is deleted"
 msgstr "एक विक्रय आदेश हटाया गया है"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "एक बिक्रय आदेश पंक्ति किसी विशेष आइटम के लिए आदेश विवरण रखती है"
+msgstr "एक विक्रय आदेश पंक्ति एक विशेष आइटम के लिए आदेश विवरण शामिल करती है"
 
 msgid "A sales order's assignee changes"
-msgstr "किसी विक्रय आदेश के नियुक्त व्यक्ति में परिवर्तन होता है"
+msgstr "विक्रय आदेश के असाइनी में परिवर्तन"
 
 msgid "A sales order's completed date changes"
 msgstr "किसी विक्रय आदेश की पूर्ण तारीख में परिवर्तन होता है"
@@ -707,7 +707,7 @@ msgid "A sales order's status changes"
 msgstr "किसी विक्रय आदेश की स्थिति में परिवर्तन होता है"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "एक बिक्रय उद्धरण अनुरोध (RFQ) भागों और मात्राओं के एक सेट पर मूल्य निर्धारण के लिए एक ग्राहक पूछताछ है। इसके परिणामस्वरूप एक उद्धरण हो सकता है।"
+msgstr "एक विक्रय कोटेशन अनुरोध (RFQ) पार्ट्स और मात्राओं के एक समूह पर मूल्य निर्धारण के लिए एक ग्राहक पूछताछ है। यह एक कोटेशन में परिणाम दे सकता है।"
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "एक बिक्रय RFQ (एक ग्राहक आपको उद्धृत करने के लिए कहता है) या खरीद RFQ (आप आपूर्तिकर्ताओं से पूछते हैं); दोनों अवसर धागे को खिलाते हैं।"
@@ -722,10 +722,10 @@ msgid "A service is a billable activity that is bought or performed — it is ne
 msgstr "एक सेवा एक बिलयोग्य गतिविधि है जो खरीदी या प्रदर्शन की जाती है — इसे कभी भेजा नहीं जाता, प्राप्त नहीं किया जाता, या स्टॉक नहीं किया जाता"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "एक ही मालिक के अधीन कंपनियों का समूह जो समूह-स्तरीय कॉन्फ़िगरेशन साझा करती हैं — खातों का चार्ट, मुद्राएँ और आयाम — ताकि वही लेखांकन सेटअप समूह की हर कंपनी पर लागू हो।"
+msgstr "एक मालिक के तहत कंपनियों का एक समूह जो समूह-scoped कॉन्फ़िगरेशन साझा करते हैं — खातों का चार्ट, मुद्राएं, और आयाम — ताकि समान लेखांकन सेटअप समूह में प्रत्येक कंपनी को span करता है।"
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "गोदाम से एक नौकरी की बकाया सामग्री को खींचने और उन्हें लाइन के किनारे स्थापित करने के लिए निर्देशों का एक सेट; एक पिक स्टॉक को उपयोग के बिंदु तक ले जाता है न कि इसे खपत करता है।"
+msgstr "एक जॉब की बकाया सामग्री को गोदाम से खींचने और उन्हें लाइनसाइड में चरण देने के निर्देशों का एक समूह; एक पिकिंग स्टॉक को उपयोग के बिंदु पर स्थानांतरित करता है बजाय इसे खपत करने के।"
 
 msgid "A shipment is created"
 msgstr "एक शिपमेंट बनाया गया है"
@@ -737,10 +737,10 @@ msgid "A shipment is posted"
 msgstr "एक शिपमेंट पोस्ट किया गया है"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "एक शिपमेंट लाइन जो सीधे आपूर्तिकर्ता से ग्राहक को भेजी जाती है, आपके गोदाम को दरकिनार करते हुए — प्रति लाइन सेट, हेडर पर नहीं।"
+msgstr "एक शिपमेंट पंक्ति आपूर्तिकर्ता से सीधे ग्राहक को भेजी गई, आपके गोदाम को bypass करते हुए — प्रति पंक्ति सेट, शीर्षलेख पर नहीं।"
 
 msgid "A shipment's assignee changes"
-msgstr "किसी शिपमेंट के नियुक्त व्यक्ति में परिवर्तन होता है"
+msgstr "शिपमेंट के असाइनी में परिवर्तन"
 
 msgid "A shipment's customer changes"
 msgstr "किसी शिपमेंट के ग्राहक में परिवर्तन होता है"
@@ -773,7 +773,7 @@ msgid "A supplier's account manager changes"
 msgstr "एक आपूर्तिकर्ता के खाता प्रबंधक में परिवर्तन"
 
 msgid "A supplier's assignee changes"
-msgstr "एक आपूर्तिकर्ता के निर्दिष्ट व्यक्ति में परिवर्तन"
+msgstr "आपूर्तिकर्ता के असाइनी में परिवर्तन"
 
 msgid "A supplier's currency changes"
 msgstr "एक आपूर्तिकर्ता की मुद्रा में परिवर्तन"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "एक आपूर्तिकर्ता का नाम बदल जाता है"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "एक आपूर्तिकर्ता की खरीद RFQ का मूल्य निर्धारण प्रतिक्रिया — एक प्रति आपूर्तिकर्ता; ड्राफ्ट → सक्रिय जब वे जमा करते हैं, या अस्वीकार।"
+msgstr "एक खरीद कोटेशन अनुरोध के लिए एक आपूर्तिकर्ता की मूल्य वाली प्रतिक्रिया — प्रति आपूर्तिकर्ता एक; ड्राफ्ट → सक्रिय जब वे सबमिट करते हैं, या अस्वीकृत।"
 
 msgid "A supplier's status changes"
 msgstr "एक आपूर्तिकर्ता की स्थिति में परिवर्तन"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "एक कर योग्य अधिभार (हैंडलिंग, सेटअप, ईंधन) जो पंक्ति में जोड़ा जाता है और कर आधार में शामिल किया जाता है।"
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "एक समय-निर्धारित रिकॉर्ड जो किसी जॉब ऑपरेशन के विरुद्ध लॉग किए गए सेटअप, लेबर या मशीन कार्य का है, जिसकी अवधि ऑपरेशन की वास्तविक लागत में जोड़ी जाती है।"
+msgstr "एक जॉब ऑपरेशन के विरुद्ध लॉग किए गए सेटअप, श्रम, या मशीन काम का एक समयबद्ध रिकॉर्ड, जिसकी अवधि ऑपरेशन की वास्तविक लागत में rolled up।"
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "एक उपकरण एक भौतिक वस्तु है जिसका उपयोग एक भाग बनाने के लिए किया जाता है जिसे कई कार्यों में उपयोग किया जा सकता है"
+msgstr "एक टूल एक भौतिक आइटम है जिसका उपयोग एक पार्ट बनाने के लिए किया जाता है जिसे कई जॉब में उपयोग किया जा सकता है"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
 msgstr "एक उपयोगकर्ता प्रत्येक बैच या सीरीज पर समाप्ति तिथि दर्ज करता है जब माल प्राप्त होता है। जब आपूर्तिकर्ता विभिन्न समाप्ति तिथियों के साथ लॉट भेजते हैं तो इसका उपयोग करें।"
 
 msgid "abilities"
-msgstr "क्षमताओं"
+msgstr "कौशल"
 
 msgid "Abilities"
-msgstr "क्षमताएं"
+msgstr "कौशल"
 
 msgid "ability"
-msgstr "क्षमता"
+msgstr "कौशल"
 
 msgid "About"
 msgstr "के बारे में"
@@ -842,7 +842,7 @@ msgid "Acceptance"
 msgstr "स्वीकृति"
 
 msgid "Acceptance passed"
-msgstr "स्वीकृति पारित"
+msgstr "स्वीकृति उत्तीर्ण"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
@@ -855,7 +855,7 @@ msgid "Account & Details"
 msgstr "खाता और विवरण"
 
 msgid "Account balances with debits and credits"
-msgstr "डेबिट और क्रेडिट के साथ खाता शेष"
+msgstr "नामे और जमा के साथ खाता शेष राशि"
 
 msgid "Account for advance payments made before goods or services are received"
 msgstr "माल या सेवाएं प्राप्त होने से पहले किए गए अग्रिम भुगतान के लिए खाता।"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "लेखांकन अवधि"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "लेखांकन: GL, AR, AP, और महीने के अंत का समापन"
+msgstr "लेखांकन: सामान्य खाता बही, प्राप्य खाते, देय खाते, और माह-अंत बंद"
 
 msgid "Accounts"
 msgstr "खाते"
@@ -942,22 +942,22 @@ msgid "Accounts referenced by posting defaults or journal history that have no p
 msgstr "पोस्टिंग डिफ़ॉल्ट या जर्नल इतिहास द्वारा संदर्भित खाते जिनके पास अभी तक कोई प्रदाता मानचित्रण नहीं है।"
 
 msgid "Accumulated Depreciation"
-msgstr "संचयी मूल्यह्रास"
+msgstr "संचित मूल्यह्रास"
 
 msgid "Accumulated Depreciation (default)"
-msgstr "संचयी मूल्यह्रास (डिफ़ॉल्ट)"
+msgstr "संचित मूल्यह्रास (डिफ़ॉल्ट)"
 
 msgid "Accumulated Depreciation (opening)"
-msgstr "संचयी मूल्यह्रास (खोलना)"
+msgstr "संचित मूल्यह्रास (शुरुआती)"
 
 msgid "Accumulated Depreciation Account"
-msgstr "संचयी मूल्यह्रास खाता"
+msgstr "संचित मूल्यह्रास खाता"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "निपटान पर संचयी मूल्यह्रास"
+msgstr "संचित मूल्यह्रास निपटान पर"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "निपटान पर संचयी मूल्यह्रास (डिफ़ॉल्ट)"
+msgstr "संचित मूल्यह्रास निपटान पर (डिफ़ॉल्ट)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "संचय अवधि (सप्ताह)"
@@ -1011,13 +1011,13 @@ msgid "Active"
 msgstr "सक्रिय"
 
 msgid "Active Jobs"
-msgstr "सक्रिय नौकरियां"
+msgstr "सक्रिय जॉब"
 
 msgid "Active Statuses"
 msgstr "सक्रिय स्थितियाँ"
 
 msgid "Active Supplier Quotes"
-msgstr "सक्रिय आपूर्तिकर्ता उद्धरण"
+msgstr "सक्रिय आपूर्तिकर्ता कोटेशन"
 
 msgid "Activity"
 msgstr "गतिविधि"
@@ -1053,13 +1053,13 @@ msgid "Add a comment..."
 msgstr "एक टिप्पणी जोड़ें..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "मात्रा, मूल्य, शिपिंग, लीड समय और कर को ओवरराइड करने के लिए एक कस्टम मूल्य निर्धारण पंक्ति जोड़ें"
+msgstr "मात्रा, मूल्य, शिपिंग, लीड टाइम, और कर को ओवरराइड करने के लिए एक कस्टम मूल्य निर्धारण पंक्ति जोड़ें"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "बिल ऑफ मेटेरियल्स पर प्रत्येक आइटम और उसकी मात्रा को सूचीबद्ध करने वाली एक सामग्री अनुभाग जोड़ें।"
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "प्रिंटिंग सेटिंग्स में एक प्रिंटर जोड़ें ताकि लेबल सीधे प्रिंट कर सकें।"
+msgstr "लेबल सीधे प्रिंट करने के लिए प्रिंटिंग सेटिंग्स में एक प्रिंटर जोड़ें।"
 
 msgid "Add a requirement"
 msgstr "एक आवश्यकता जोड़ें"
@@ -1092,7 +1092,7 @@ msgid "Add Authenticator App"
 msgstr "ऑथेंटिकेटर ऐप जोड़ें"
 
 msgid "Add Calibration Record"
-msgstr "कैलिब्रेशन रिकॉर्ड जोड़ें"
+msgstr "अंशांकन रिकॉर्ड जोड़ें"
 
 msgid "Add Child Storage Unit"
 msgstr "बाल भंडारण इकाई जोड़ें"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "नोट जोड़ें"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "इस रखरखाव डिस्पैच के लिए नोट्स और दस्तावेज़ जोड़ें"
+msgstr "इस रखरखाव कार्य के लिए नोट्स और दस्तावेज़ जोड़ें"
 
 msgid "Add Operation"
 msgstr "ऑपरेशन जोड़ें"
@@ -1167,7 +1167,7 @@ msgid "Add Partner"
 msgstr "पार्टनर जोड़ें"
 
 msgid "Add parts"
-msgstr "पुर्जे जोड़ें"
+msgstr "पार्ट्स जोड़ें"
 
 msgid "Add Passkey"
 msgstr "पासकी जोड़ें"
@@ -1218,10 +1218,10 @@ msgid "Add Spare Part"
 msgstr "स्पेयर पार्ट जोड़ें"
 
 msgid "Add Step"
-msgstr "स्टेप जोड़ें"
+msgstr "चरण जोड़ें"
 
 msgid "Add steps to preview the operator view."
-msgstr "ऑपरेटर व्यू की प्रीव्यू के लिए कदम जोड़ें।"
+msgstr "ऑपरेटर दृश्य का पूर्वावलोकन करने के लिए चरण जोड़ें।"
 
 msgid "Add Stock Transfer"
 msgstr "स्टॉक ट्रांसफर जोड़ें"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "सभी {0} कोशिकाएँ मेल खाती हैं"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "सभी {total} चरण पूरे हो गए। शानदार काम — आपकी टीम चल रही है।"
+msgstr "सभी {total} चरण पूर्ण हो गए हैं। बहुत अच्छा काम — आपकी टीम चल रही है।"
 
 msgid "All accounts"
 msgstr "सभी खाते"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "सभी कार्य चयनित"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "सभी उन्नत विशेषताएं उपलब्ध हैं"
 
 msgid "All Audit Logs"
 msgstr "सभी ऑडिट लॉग"
@@ -1361,7 +1361,7 @@ msgid "All Locations"
 msgstr "सभी स्थान"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
-msgstr "चयनित समूहों के सभी सदस्य और चयनित व्यक्ति अनुरोधों को मंजूरी दे सकेंगे"
+msgstr "सभी चुने गए समूहों के सदस्य और चुने गए व्यक्ति अनुरोधों को अनुमोदित कर सकेंगे"
 
 msgid "All posting accounts are mapped"
 msgstr "सभी पोस्टिंग खाते मैप किए गए हैं"
@@ -1388,7 +1388,7 @@ msgid "All users"
 msgstr "सभी उपयोगकर्ता"
 
 msgid "All Work Centers"
-msgstr "सभी कार्य केंद्र"
+msgstr "सभी वर्क सेंटर"
 
 msgid "Allows acknowledge & continue"
 msgstr "स्वीकार करने और जारी रखने की अनुमति देता है"
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "राशि प्रकार"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "एक लेखांकन बाल्टी जो विभाग या कार्य द्वारा व्यय को समूहबद्ध करती है ताकि GL खाते द्वारा नहीं बल्कि समूह द्वारा व्यय की रिपोर्ट कर सके।"
+msgstr "एक लेखांकन बकेट जो विभाग या कार्य द्वारा व्यय को समूहित करता है ताकि सामान्य खाता बही समूह द्वारा व्यय की रिपोर्ट कर सकें, केवल खाता द्वारा नहीं।"
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "एक पूंजीकृत वस्तु के लिए एक लेखांकन रिकॉर्ड जिसे आप खर्च करने के बजाय मूल्यह्रास करते हैं; मसौदा → सक्रिय → पूर्ण रूप से मूल्यह्रास → निपटान।"
+msgstr "एक पूंजीकृत आइटम के लिए एक लेखांकन रिकॉर्ड जिसे आप व्यय की बजाय मूल्यह्रास करते हैं; ड्राफ्ट → सक्रिय → पूर्ण मूल्यह्रासित → निपटाया गया।"
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "एक सतर्कता कि कुछ को एक व्यक्ति के ध्यान की आवश्यकता है, कार्बन/सूचित करें घटना से इन-ऐप इनबॉक्स और वैकल्पिक ईमेल और स्लैक में फैला हुआ, प्रति विषय प्रति उपयोगकर्ता म्यूट करने योग्य।"
@@ -1434,7 +1434,7 @@ msgid "An approval requirement on a non-conformance whose reviewers (seeded Engi
 msgstr "एक गैर-अनुरूपता पर एक अनुमोदन आवश्यकता जिसके समीक्षकों (सीडेड इंजीनियरिंग और गुणवत्ता) को समस्या बंद होने से पहले हस्ताक्षर करने चाहिए।"
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "एक संपत्ति की अधिग्रहण लागत माइनस संचयी मूल्यह्रास — यह किताबों पर अभी भी क्या मूल्य है और राशि जिस पर इसे निपटाया जाता है।"
+msgstr "किसी संपत्ति की अधिग्रहण लागत घटा संचित मूल्यह्रास — यह पुस्तकों पर अभी भी क्या मूल्य का है, और वह आंकड़ा जिस पर इसे निपटाया गया है।"
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "एक स्वचालन जो आप कैनवास पर बनाते हैं: एक ट्रिगर, फिर चरण जो शर्तों की जांच करते हैं, रिकॉर्ड देखते हैं, और कार्य करते हैं — किसी को सूचित करना, एक रिकॉर्ड बनाना या अपडेट करना, या बाहरी URL को कॉल करना।"
@@ -1449,7 +1449,7 @@ msgid "An integration or a custom change — the small slice that's actually cus
 msgstr "एक एकीकरण या एक कस्टम परिवर्तन — वह छोटा हिस्सा जो वास्तव में कस्टम है।"
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "एक आमंत्रण लंबित है। वे इसे स्वीकार करने के बाद सक्रिय हो जाते हैं।"
+msgstr "एक आमंत्रण लंबित है। वे सक्रिय हो जाते हैं एक बार जब वे इसे स्वीकार कर लेते हैं।"
 
 msgid "An issue is created"
 msgstr "एक समस्या बनाई गई है"
@@ -1458,13 +1458,13 @@ msgid "An issue is deleted"
 msgstr "एक समस्या हटा दी गई है"
 
 msgid "An issue's assignee changes"
-msgstr "एक समस्या के निर्दिष्ट व्यक्ति में परिवर्तन"
+msgstr "एक समस्या के असाइनी में परिवर्तन"
 
 msgid "An issue's close date changes"
 msgstr "एक समस्या की बंद करने की तारीख में परिवर्तन"
 
 msgid "An issue's due date changes"
-msgstr "एक समस्या की देय तारीख में परिवर्तन"
+msgstr "एक समस्या की नियत तिथि में परिवर्तन"
 
 msgid "An issue's location changes"
 msgstr "एक समस्या के स्थान में परिवर्तन"
@@ -1500,7 +1500,7 @@ msgid "An item's assignee changes"
 msgstr "किसी आइटम का असाइनी बदलता है"
 
 msgid "An item's default method type changes"
-msgstr "किसी आइटम का डिफ़ॉल्ट विधि प्रकार बदलता है"
+msgstr "एक आइटम के डिफ़ॉल्ट आपूर्ति प्रकार में परिवर्तन"
 
 msgid "An item's name changes"
 msgstr "किसी आइटम का नाम बदलता है"
@@ -1509,7 +1509,7 @@ msgid "An item's replenishment system changes"
 msgstr "किसी आइटम की पुनःपूर्ति प्रणाली बदलती है"
 
 msgid "An item's revision status changes"
-msgstr "किसी आइटम की संशोधन स्थिति बदलती है"
+msgstr "एक आइटम की रिवीजन स्थिति में परिवर्तन"
 
 msgid "An item's tracking type changes"
 msgstr "किसी आइटम का ट्रैकिंग प्रकार बदलता है"
@@ -1518,10 +1518,10 @@ msgid "An item's unit of measure changes"
 msgstr "किसी आइटम की माप की इकाई बदलती है"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "एक आंतरिक कार्य केंद्र के बजाय बाहरी आपूर्तिकर्ता द्वारा किया गया ऑपरेशन, जिसे एक उप-अनुबंध खरीद आदेश द्वारा कवर किया जाता है।"
+msgstr "एक आपूर्तिकर्ता द्वारा किया गया एक ऑपरेशन एक इन-हाउस वर्क सेंटर के बजाय, एक उप-अनुबंध क्रय आदेश द्वारा कवर किया गया।"
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "एक ऑपरेशन की अपने कार्य केंद्र की कतार में स्थिति — वह क्रम जिससे मंजिल काम उठाती है — कार्य केंद्र बोर्ड पर कार्डों को पुनः सूचीबद्ध करके किसी भी तारीखों को बदले बिना सेट किया जाता है।"
+msgstr "एक ऑपरेशन की अपने वर्क सेंटर की कतार में स्थिति — वह क्रम जिसमें फर्श काम उठाता है — वर्क सेंटर बोर्ड पर कार्ड को पुनः क्रमित करके सेट किया गया है बिना किसी तारीख को बदले।"
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Onshape से कनेक्ट करते समय एक अनपेक्षित त्रुटि हुई। दोबारा कनेक्ट करने का प्रयास करें।"
@@ -1576,19 +1576,19 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "स्कोप में ऊपर स्पष्ट रूप से सूचीबद्ध कुछ भी नहीं"
 
 msgid "AP"
-msgstr "AP"
+msgstr "देय खाते"
 
 msgid "AP Aging"
-msgstr "AP एजिंग"
+msgstr "देय खाते की आयु"
 
 msgid "AP Clerk"
-msgstr "AP क्लर्क"
+msgstr "देय खाते क्लर्क"
 
 msgid "AP Outstanding"
-msgstr "AP बकाया"
+msgstr "देय खाते शेष राशि"
 
 msgid "AP Overdue"
-msgstr "AP देय"
+msgstr "देय खाते अतिदेय"
 
 msgid "API Docs"
 msgstr "API डॉक्स"
@@ -1597,19 +1597,19 @@ msgid "API Documentation"
 msgstr "API दस्तावेज़"
 
 msgid "API key"
-msgstr "एपीआई कुंजी"
+msgstr "API कुंजी"
 
 msgid "API Key"
-msgstr "एपीआई कुंजी"
+msgstr "API कुंजी"
 
 msgid "API Keys"
-msgstr "एपीआई कुंजियाँ"
+msgstr "API कुंजियाँ"
 
 msgid "API keys for programmatic access to your Carbon data."
 msgstr "आपके Carbon डेटा के लिए प्रोग्रामेटिक एक्सेस के लिए API कुंजियाँ।"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, वेबहुक, और एकीकरण"
 
 msgid "Applied"
 msgstr "लागू"
@@ -1631,7 +1631,7 @@ msgid "Applies to all"
 msgstr "सभी पर लागू होता है"
 
 msgid "Applies to all work centers"
-msgstr "सभी कार्य केंद्रों पर लागू होता है"
+msgstr "सभी वर्क सेंटर पर लागू होता है"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
 msgstr "उन सुविधाओं पर लागू होता है जिनके अपने नियम नहीं हैं, और जब यह योजना निरीक्षण चलाती है तो लॉट पर लागू होता है।"
@@ -1697,7 +1697,7 @@ msgid "Approvals"
 msgstr "अनुमोदन"
 
 msgid "Approve"
-msgstr "मंजूरी दें"
+msgstr "अनुमोदित करें"
 
 msgid "Approved By"
 msgstr "द्वारा अनुमोदित"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "प्राप्य खाते"
 
 msgid "AR / AP representation"
-msgstr "AR / AP प्रतिनिधित्व"
+msgstr "प्राप्य खाते / देय खाते प्रतिनिधित्व"
 
 msgid "AR Aging"
-msgstr "AR एजिंग"
+msgstr "प्राप्य खाते पुरानिता"
 
 msgid "AR Clerk"
-msgstr "AR क्लर्क"
+msgstr "प्राप्य खाते लिपिक"
 
 msgid "AR Outstanding"
-msgstr "AR बकाया"
+msgstr "प्राप्य खाते बकाया"
 
 msgid "AR Overdue"
-msgstr "AR अतिदेय"
+msgstr "प्राप्य खाते अतिदेय"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "प्राप्य खाते / देय खाते"
 
 msgid "Archive"
 msgstr "संग्रह"
@@ -1744,7 +1744,7 @@ msgstr "संग्रहीत लॉग"
 #. placeholder {0}: getQuoteDisplayId(quote)
 #. placeholder {1}: formatter.format(total)
 msgid "Are you sure you want to accept quote {0} for {1}?"
-msgstr "क्या आप सुनिश्चित हैं कि आप उद्धरण {0} को {1} के लिए स्वीकार करना चाहते हैं?"
+msgstr "क्या आप कोटेशन {0} को {1} के लिए स्वीकार करना चाहते हैं?"
 
 msgid "Are you sure you want to activate the process: {name}? It will appear in dropdowns again."
 msgstr "क्या आप सुनिश्चित हैं कि आप प्रक्रिया को सक्रिय करना चाहते हैं: {name}? यह ड्रॉपडाउन में फिर से दिखाई देगा।"
@@ -1754,11 +1754,11 @@ msgstr "क्या आप सुनिश्चित हैं कि आप 
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} को रद्द करना चाहते हैं? यह बंद हो जाएगा और जब तक आप इसे फिर से नहीं खोलते तब तक यह केवल पढ़ने के लिए होगा।"
+msgstr "क्या आप {0} को रद्द करना चाहते हैं? यह बंद हो जाएगी और पढ़ने के लिए केवल तब तक होगी जब तक आप इसे फिर से खोलेंगे।"
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} को रद्द करना चाहते हैं? यह सभी संबंधित आपूर्तिकर्ता उद्धरणों को भी रद्द कर देगा।"
+msgstr "क्या आप {0} को रद्द करना चाहते हैं? यह सभी संबंधित आपूर्तिकर्ता कोटेशन को भी रद्द कर देगा।"
 
 msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "क्या आप सुनिश्चित हैं कि आप {orderLabel} को रद्द करना चाहते हैं? यह आदेश को बंद कर देगा।"
@@ -1767,325 +1767,325 @@ msgid "Are you sure you want to cancel this job? It will no longer be available 
 msgstr "क्या आप सुनिश्चित हैं कि आप इस कार्य को रद्द करना चाहते हैं? यह अब शॉप फ्लोर पर उपलब्ध नहीं होगा।"
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
-msgstr "क्या आप सुनिश्चित हैं कि आप {propertyName} प्रॉपर्टी को बदलना चाहते हैं? चूंकि आप जेनरेट की गई मटेरियल आईडी का उपयोग करते हैं, यह इस पार्ट की पार्ट आईडी और सभी संबंधित संशोधनों को बदल देगा।"
+msgstr "क्या आप {propertyName} संपत्ति को बदलना चाहते हैं? चूंकि आप उत्पन्न सामग्री आईडी का उपयोग करते हैं, यह इस पार्ट की पार्ट आईडी और सभी संबंधित रिवीजन को बदल देगा।"
 
 msgid "Are you sure you want to complete this stock transfer?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस स्टॉक ट्रांसफर को पूरा करना चाहते हैं?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस बिक्रय आदेश की पुष्टि करना चाहते हैं? आदेश की पुष्टि करने से आपूर्ति और मांग की गणना के लिए उपयोग की जाने वाली आदेश मात्रा प्रभावित होगी।"
+msgstr "क्या आप इस विक्रय आदेश की पुष्टि करना चाहते हैं? आदेश की पुष्टि करने से आपूर्ति और मांग की गणना के लिए उपयोग किए जाने वाले ऑर्डर मात्राओं पर प्रभाव पड़ेगा।"
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
-msgstr "क्या आप सुनिश्चित हैं कि आप RFQ को उद्धरण में परिवर्तित करना चाहते हैं?"
+msgstr "क्या आप RFQ को कोटेशन में परिवर्तित करना चाहते हैं?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस बिक्रय आदेश के लिए नौकरियां बनाना चाहते हैं? यह उन सभी पंक्तियों के लिए नौकरियां बनाएगा जिनके पास पहले से नौकरियां नहीं हैं।"
+msgstr "क्या आप इस विक्रय आदेश के लिए जॉब बनाना चाहते हैं? यह उन सभी पंक्तियों के लिए जॉब बनाएगा जिनके पास पहले से जॉब नहीं हैं।"
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप {0} को निष्क्रिय करना चाहते हैं?"
 
 #. placeholder {0}: selectedCategory?.name
 msgid "Are you sure you want to deactivate the {0} attribute category?"
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} विशेषता श्रेणी को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप {0} विशेषता श्रेणी को निष्क्रिय करना चाहते हैं?"
 
 #. placeholder {0}: selectedAttribute?.name
 msgid "Are you sure you want to deactivate the {0} attribute?"
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} विशेषता को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप {0} विशेषता को निष्क्रिय करना चाहते हैं?"
 
 msgid "Are you sure you want to deactivate the {label} configuration rule?"
-msgstr "क्या आप सुनिश्चित हैं कि आप {label} कॉन्फ़िगरेशन नियम को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप {label} कॉन्फ़िगरेशन नियम को निष्क्रिय करना चाहते हैं?"
 
 msgid "Are you sure you want to deactivate the process: {name}? It will no longer appear in dropdowns."
-msgstr "क्या आप सुनिश्चित हैं कि आप प्रक्रिया को निष्क्रिय करना चाहते हैं: {name}? यह अब ड्रॉपडाउन में दिखाई नहीं देगा।"
+msgstr "क्या आप प्रक्रिया को निष्क्रिय करना चाहते हैं: {name}? यह ड्रॉपडाउन में अब दिखाई नहीं देगा।"
 
 msgid "Are you sure you want to deactivate these users?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इन उपयोगकर्ताओं को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप इन उपयोगकर्ताओं को निष्क्रिय करना चाहते हैं?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस गेज को निष्क्रिय करना चाहते हैं?."
+msgstr "क्या आप इस गेज को निष्क्रिय करना चाहते हैं?."
 
 msgid "Are you sure you want to deactivate this user?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस उपयोगकर्ता को निष्क्रिय करना चाहते हैं?"
+msgstr "क्या आप इस उपयोगकर्ता को निष्क्रिय करना चाहते हैं?"
 
 #. placeholder {0}: tool.readableIdWithRevision
 msgid "Are you sure you want to delete {0} from this operation? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस ऑपरेशन से {0} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस ऑपरेशन से {0} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: selectedEntry.journalEntryId
 #. placeholder {0}: selectedGroup.name
 msgid "Are you sure you want to delete {0}?"
-msgstr "क्या आप {0} को हटाना सुनिश्चित हैं?"
+msgstr "क्या आप {0} को हटाना चाहते हैं?"
 
 #. placeholder {0}: getQuoteDisplayId( routeData?.quote )
 #. placeholder {0}: getQuoteDisplayId( selectedQuotation )
 #. placeholder {0}: initialValues.memoId
 msgid "Are you sure you want to delete {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {0} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {name} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {name} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete {orderLabel}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {orderLabel} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {orderLabel} को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: activeView.name
 #. placeholder {0}: viewPendingDelete.name
 msgid "Are you sure you want to delete the \"{0}\" view? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप \"{0}\" दृश्य को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप \"{0}\" देखें को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: selectedCustomField?.name
 msgid "Are you sure you want to delete the {0} field?"
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} फ़ील्ड को हटाना चाहते हैं?"
+msgstr "क्या आप {0} फ़ील्ड को हटाना चाहते हैं?"
 
 #. placeholder {0}: parameter.label
 msgid "Are you sure you want to delete the {0} parameter? This will not update any formulas that are using this parameter."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} पैरामीटर को हटाना चाहते हैं? यह किसी भी सूत्र को अपडेट नहीं करेगा जो इस पैरामीटर का उपयोग कर रहे हैं।"
+msgstr "क्या आप {0} पैरामीटर को हटाना चाहते हैं? यह इस पैरामीटर का उपयोग करने वाले किसी भी सूत्र को अपडेट नहीं करेगा।"
 
 msgid "Are you sure you want to delete the {key} parameter from this operation? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस ऑपरेशन से {key} पैरामीटर को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस ऑपरेशन से {key} पैरामीटर को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the {name} attribute from this operation? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस ऑपरेशन से {name} विशेषता को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस ऑपरेशन से {name} विशेषता को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: account.name
 #. placeholder {1}: account.number ? ` (${account.number})` : ""
 msgid "Are you sure you want to delete the account: {0}{1}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप खाता हटाना चाहते हैं: {0}{1}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप खाता हटाना चाहते हैं: {0}{1}? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: apiKey.name
 msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप API कुंजी को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप API कुंजी को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "क्या आप निश्चित हैं कि आप परिसंपत्ति वर्ग हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप परिसंपत्ति वर्ग को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "क्या आप परिवर्तन सूचना कार्रवाई को हटाना सुनिश्चित हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप परिवर्तन सूचना क्रिया को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "क्या आप परिवर्तन सूचना श्रेणी को हटाना सुनिश्चित हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप परिवर्तन सूचना श्रेणी को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप ठेकेदार को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप ठेकेदार को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} के लिए ग्राहक भाग को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {0} के लिए ग्राहक पार्ट को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the customer portal for: {customerName}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {customerName} के लिए ग्राहक पोर्टल को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {customerName} के लिए ग्राहक पोर्टल को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: customerStatus.name
 msgid "Are you sure you want to delete the customer status: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप ग्राहक स्थिति को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप ग्राहक स्थिति {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: customerType.name
 msgid "Are you sure you want to delete the customer type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप ग्राहक प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप ग्राहक प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप विभाग को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप विभाग {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: employeeType.name
 msgid "Are you sure you want to delete the employee type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप कर्मचारी प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप कर्मचारी प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the failure mode: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप विफलता मोड को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप विफलता मोड {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप गेज प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप गेज प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप समूह को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप समूह {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the holiday: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप छुट्टी को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप छुट्टी {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: nonConformanceType.name
 msgid "Are you sure you want to delete the issue type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप समस्या प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप समस्या प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: itemPostingGroup.name
 msgid "Are you sure you want to delete the item group: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप आइटम समूह को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप आइटम समूह {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: line.customerPartId
 #. placeholder {0}: line.description
 #. placeholder {0}: line.itemReadableId
 msgid "Are you sure you want to delete the line: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप लाइन को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप पंक्ति {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the line: {itemReadableId}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप लाइन को हटाना चाहते हैं: {itemReadableId}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप पंक्ति {itemReadableId} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the location: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप स्थान को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप स्थान {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप रखरखाव शेड्यूल को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप रखरखाव शेड्यूल {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री आयाम को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप सामग्री आयाम {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री फिनिश को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप फिनिश {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री फॉर्म को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप सामग्री रूप {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री ग्रेड को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप ग्रेड {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री पदार्थ को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप पदार्थ {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप सामग्री प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप सामग्री प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप नो कोट कारण को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप बिना कोटेशन कारण {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप पार्टनर को हटाना चाहते हैं: {name}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप भागीदार {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप भुगतान अवधि को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप भुगतान शर्तें {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप मूल्य निर्धारण नियम को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप मूल्य नियम {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: printerToDelete.name
 msgid "Are you sure you want to delete the printer \"{0}\"? Any assignments referencing this printer will be cleared. This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप प्रिंटर \"{0}\" को हटाना चाहते हैं? इस प्रिंटर को संदर्भित करने वाले किसी भी असाइनमेंट को साफ़ किया जाएगा। इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप प्रिंटर \"{0}\" को हटाना चाहते हैं? इस प्रिंटर की सभी असाइनमेंट हटा दी जाएंगी। इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} {1} के लिए खरीद चालान लाइन को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {0} {1} के लिए क्रय चालान पंक्ति को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} {1} के लिए बिक्री चालान लाइन को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {0} {1} के लिए विक्रय चालान पंक्ति को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप {0} {1} के लिए बिक्रय आदेश लाइन को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {0} {1} के लिए विक्रय आदेश पंक्ति को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप स्क्रैप कारण को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप स्क्रैप कारण {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "क्या आप {itemLabel} के लिए सीरियल नंबर अनुक्रम को हटाना निश्चित हैं? इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {itemLabel} के लिए सीरियल नंबर अनुक्रम को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप शिफ्ट को हटाना चाहते हैं: {name} से {locationName}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप {locationName} से शिफ्ट {name} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप शिपिंग विधि को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप शिपिंग विधि {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप स्टोरेज प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप भंडारण प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप स्टोरेज यूनिट को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप भंडारण इकाई {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप आपूर्तिकर्ता प्रकार को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप आपूर्तिकर्ता प्रकार {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: unitOfMeasure.name
 msgid "Are you sure you want to delete the unit of measure: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप माप की इकाई को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप माप की इकाई {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 #. placeholder {0}: selectedView.name
 msgid "Are you sure you want to delete the view \"{0}\"?"
-msgstr "क्या आप सुनिश्चित हैं कि आप दृश्य \"{0}\" को हटाना चाहते हैं?"
+msgstr "क्या आप दृश्य \"{0}\" को हटाना चाहते हैं?"
 
 #. placeholder {0}: webhook.name
 msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप वेबहुक को हटाना चाहते हैं: {0}? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप वेबहुक {0} को हटाना चाहते हैं? इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this approval rule? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस अनुमोदन नियम को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस अनुमोदन नियम को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "क्या आप इस परिवर्तन सूचना को हटाना सुनिश्चित हैं?"
+msgstr "क्या आप इस परिवर्तन सूचना को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस गेज को हटाना चाहते हैं?"
+msgstr "क्या आप इस गेज को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "क्या आप निश्चित हैं कि आप इस निरीक्षण योजना को हटाना चाहते हैं?"
+msgstr "क्या आप इस निरीक्षण योजना को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस निरीक्षण योजना को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस निरीक्षण योजना को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this issue workflow?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस समस्या वर्कफ़्लो को हटाना चाहते हैं?"
+msgstr "क्या आप इस समस्या वर्कफ़्लो को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this issue?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस समस्या को हटाना चाहते हैं?"
+msgstr "क्या आप इस समस्या को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this kanban card? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस कनबन कार्ड को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस कानबान कार्ड को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस रखरखाव प्रेषण को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस रखरखाव कार्य को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
-msgstr "क्या आप वाकई इस पासकी को हटाना चाहते हैं? आप इसे फिर से साइन इन करने के लिए उपयोग नहीं कर पाएंगे।"
+msgstr "क्या आप इस पासकी को हटाना चाहते हैं? आप इसे साइन इन करने के लिए अब उपयोग नहीं कर पाएँगे।"
 
 msgid "Are you sure you want to delete this quality document?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस गुणवत्ता दस्तावेज़ को हटाना चाहते हैं?"
+msgstr "क्या आप इस गुणवत्ता दस्तावेज़ को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this record?"
 msgstr "क्या आप इस रिकॉर्ड को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this required action?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस आवश्यक कार्रवाई को हटाना चाहते हैं?"
+msgstr "क्या आप इस आवश्यक कार्य को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this risk?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस जोखिम को हटाना चाहते हैं?"
+msgstr "क्या आप इस जोखिम को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this risk? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस जोखिम को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस जोखिम को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this suggestion? This action cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस सुझाव को हटाना चाहते हैं? यह कार्रवाई पूर्ववत नहीं की जा सकती।"
+msgstr "क्या आप इस सुझाव को हटाना चाहते हैं? यह क्रिया वापस नहीं की जा सकती।"
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस टाइमकार्ड को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस समय कार्ड को हटाना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to delete this workflow? Its versions and run history go with it."
-msgstr "क्या आप इस वर्कफ़्लो को हटाना सुनिश्चित हैं? इसके संस्करण और रन इतिहास इसके साथ जाते हैं।"
+msgstr "क्या आप इस वर्कफ़्लो को हटाना चाहते हैं? इसके संस्करण और रन इतिहास इसके साथ चले जाएँगे।"
 
 msgid "Are you sure you want to finalize the quote?"
 msgstr "क्या आप सुनिश्चित हैं कि आप उद्धरण को अंतिम रूप देना चाहते हैं?"
 
 msgid "Are you sure you want to finalize the supplier quote?"
-msgstr "क्या आप सुनिश्चित हैं कि आप आपूर्तिकर्ता उद्धरण को अंतिम रूप देना चाहते हैं?"
+msgstr "क्या आप आपूर्तिकर्ता कोटेशन को अंतिम रूप देना चाहते हैं?"
 
 msgid "Are you sure you want to leave this page?"
 msgstr "क्या आप वाकई इस पृष्ठ को छोड़ना चाहते हैं?"
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "क्या आप {0} को स्थायी रूप से हटाना चाहते हैं?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "क्या आप सुनिश्चित हैं कि आप आपूर्तिकर्ता प्रक्रिया को स्थायी रूप से हटाना चाहते हैं?"
+msgstr "क्या आप आपूर्तिकर्ता प्रक्रिया को स्थायी रूप से हटाना चाहते हैं?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस रसीद को पोस्ट करना चाहते हैं?"
@@ -2109,20 +2109,20 @@ msgid "Are you sure you want to post this shipment?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस शिपमेंट को पोस्ट करना चाहते हैं?"
 
 msgid "Are you sure you want to reject this quote?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस उद्धरण को अस्वीकार करना चाहते हैं?"
+msgstr "क्या आप इस कोटेशन को अस्वीकार करना चाहते हैं?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस कार्य को जारी करना चाहते हैं? यह शॉप फ्लोर पर उपलब्ध हो जाएगा, और खरीद और उत्पादन को चलाएगा।"
+msgstr "क्या आप इस जॉब को जारी करना चाहते हैं? यह शॉप फ्लोर पर उपलब्ध हो जाएगी, और क्रय एवं उत्पादन को चलाएगी।"
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस आइटम के लिए {0} को आपूर्तिकर्ता के रूप में हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस आइटम के लिए {0} को आपूर्तिकर्ता के रूप में निकालना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस आइटम के लिए {supplierName} को आपूर्तिकर्ता के रूप में हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस आइटम के लिए {supplierName} को आपूर्तिकर्ता के रूप में निकालना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस आइटम को मूल्य सूची से हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस आइटम को मूल्य सूची से निकालना चाहते हैं? यह वापस नहीं किया जा सकता।"
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस उपयोगकर्ता के लिए आमंत्रण को रद्द करना चाहते हैं?"
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "क्या आप सुनिश्चित हैं कि आप इस उपयोगकर्ता को आमंत्रण भेजना चाहते हैं?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस खरीद चालान को रद्द करना चाहते हैं? यह कार्रवाई सभी वित्तीय लेनदेन को उलट देगी और इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस क्रय चालान को अमान्य करना चाहते हैं? यह क्रिया सभी वित्तीय लेनदेन को उलट देगी और वापस नहीं की जा सकती।"
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस रसीद को रद्द करना चाहते हैं? यह कार्रवाई सभी इन्वेंटरी लेनदेन को उलट देगी और इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस प्राप्ति को अमान्य करना चाहते हैं? यह क्रिया सभी इन्वेंटरी लेनदेन को उलट देगी और वापस नहीं की जा सकती।"
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस बिक्रय चालान को रद्द करना चाहते हैं? यह कार्रवाई सभी वित्तीय लेनदेन को उलट देगी और इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस विक्रय चालान को अमान्य करना चाहते हैं? यह क्रिया सभी वित्तीय लेनदेन को उलट देगी और वापस नहीं की जा सकती।"
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस शिपमेंट को रद्द करना चाहते हैं? यह कार्रवाई सभी इन्वेंटरी लेनदेन को उलट देगी और इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप इस शिपमेंट को अमान्य करना चाहते हैं? यह क्रिया सभी इन्वेंटरी लेनदेन को उलट देगी और वापस नहीं की जा सकती।"
 
 msgid "Are you sure?"
 msgstr "क्या आप सुनिश्चित हैं?"
@@ -2173,7 +2173,7 @@ msgstr "आरोही"
 #. placeholder {0}: copy.moduleLabel
 #. placeholder {1}: copy.noun
 msgid "Ask an admin with {0} permission to add the first {1}."
-msgstr "{0} अनुमति वाले व्यवस्थापक से पहली {1} जोड़ने के लिए कहें।"
+msgstr "पहला {1} जोड़ने के लिए {0} अनुमति वाले प्रशासक से पूछें।"
 
 msgid "Assemblies"
 msgstr "असेंबलीज"
@@ -2206,19 +2206,19 @@ msgid "Asset Acquisition Cost (default)"
 msgstr "परिसंपत्ति अधिग्रहण लागत (डिफ़ॉल्ट)"
 
 msgid "asset class"
-msgstr "संपत्ति वर्ग"
+msgstr "परिसंपत्ति वर्ग"
 
 msgid "Asset class"
-msgstr "संपत्ति वर्ग"
+msgstr "परिसंपत्ति वर्ग"
 
 msgid "Asset Class"
-msgstr "संपत्ति वर्ग"
+msgstr "परिसंपत्ति वर्ग"
 
 msgid "asset classes"
-msgstr "संपत्ति वर्ग"
+msgstr "परिसंपत्ति वर्गों"
 
 msgid "Asset Classes"
-msgstr "संपत्ति वर्ग"
+msgstr "परिसंपत्ति वर्गों"
 
 msgid "Asset Cost on Disposal"
 msgstr "निपटान पर संपत्ति लागत"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "असाइनमेंट"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "इस स्टोरेज यूनिट को एक वर्क सेंटर (लाइनसाइड) को असाइन करता है"
+msgstr "इस भंडारण इकाई को वर्क सेंटर (लाइनसाइड) को असाइन करता है"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "इस इकाई को लाइनसाइड सामग्री के लिए एक कार्य केंद्र को निर्दिष्ट करता है, इसलिए ऑपरेटर इसे उत्पादन दृश्य में देखते हैं; जब वहां सेट किया जाता है तो माता-पिता की इकाई से विरासत में।"
+msgstr "इस इकाई को लाइनसाइड सामग्री के लिए वर्क सेंटर को असाइन करता है, ताकि ऑपरेटर इसे उत्पादन दृश्य पर देखें; मूल इकाई से विरासत में मिला जब वहाँ सेट किया जाता है।"
 
 msgid "At each gate"
 msgstr "हर गेट पर"
@@ -2281,10 +2281,10 @@ msgid "Attach File"
 msgstr "फ़ाइल संलग्न करें"
 
 msgid "Attachment"
-msgstr "संलग्नक"
+msgstr "अनुलग्नक"
 
 msgid "Attachments"
-msgstr "संलग्नताएं"
+msgstr "अनुलग्नक"
 
 msgid "Attempts"
 msgstr "प्रयास"
@@ -2293,19 +2293,19 @@ msgid "Attribute"
 msgstr "विशेषता"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "इनबाउंड निरीक्षणों पर लॉट नमूना आकार और स्वीकार/अस्वीकार संख्याओं की गणना करने के लिए उपयोग किया जाने वाला विशेषता नमूनाकरण मानक।"
+msgstr "विशेषता नमूनाकरण मानदंड लॉट नमूना आकार और इनबाउंड निरीक्षण पर स्वीकार/अस्वीकार संख्याओं की गणना के लिए उपयोग किया जाता है।"
 
 msgid "Attributes"
 msgstr "विशेषताएं"
 
 msgid "Attributes are inherited from the procedure."
-msgstr "प्रक्रिया से विशेषताएं विरासत में मिली हैं।"
+msgstr "विशेषताएँ कार्यविधि से विरासत में मिली हैं।"
 
 msgid "Audit Log"
 msgstr "ऑडिट लॉग"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "ऑडिट लॉगिंग"
 
 msgid "Audit Logging"
 msgstr "ऑडिट लॉगिंग"
@@ -2338,10 +2338,10 @@ msgid "Auto arrange"
 msgstr "ऑटो व्यवस्था"
 
 msgid "Auto Release"
-msgstr "ऑटो रिलीज़"
+msgstr "स्वचालित जारी करना"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "नौकरी को स्वचालित रूप से शुरू करने के लिए स्वचालित रिलीज़ सक्षम होना चाहिए"
+msgstr "जॉब को स्वचालित रूप से शुरू करने के लिए स्वचालित जारी करना सक्षम होना चाहिए"
 
 msgid "Auto Start Job"
 msgstr "ऑटो स्टार्ट जॉब"
@@ -2377,16 +2377,16 @@ msgid "Automatic Updates"
 msgstr "स्वचालित अपडेट"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "स्वचालित अपडेट और बैकअप"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "आउटपुट की रिपोर्ट करते समय एक कार्य की गैर-ट्रैक की गई सामग्री की स्वचालित, आनुपातिक खपत — ट्रैक की गई सामग्री को मैन्युअल रूप से जारी किया जाता है।"
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "कनबन स्कैन किए जाने पर जॉब को स्वचालित रूप से रिलीज़ करें"
+msgstr "कानबान स्कैन किए जाने पर जॉब को स्वचालित रूप से जारी करें"
 
 msgid "Automatically start the job when the kanban is scanned"
-msgstr "कनबन स्कैन किए जाने पर जॉब को स्वचालित रूप से शुरू करें"
+msgstr "कानबान स्कैन किए जाने पर जॉब को स्वचालित रूप से शुरू करें"
 
 msgid "available"
 msgstr "उपलब्ध"
@@ -2395,7 +2395,7 @@ msgid "Available"
 msgstr "उपलब्ध"
 
 msgid "Available Actions (click to add)"
-msgstr "उपलब्ध कार्य (जोड़ने के लिए क्लिक करें)"
+msgstr "उपलब्ध क्रियाएँ (जोड़ने के लिए क्लिक करें)"
 
 #. placeholder {0}: port.label
 msgid "Available after {0}"
@@ -2423,10 +2423,10 @@ msgid "Backups"
 msgstr "बैकअप"
 
 msgid "Balance"
-msgstr "शेष"
+msgstr "शेष राशि"
 
 msgid "Balance Sheet"
-msgstr "बैलेंस शीट"
+msgstr "तुलन पत्र"
 
 msgid "Balanced"
 msgstr "संतुलित"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "आधार मूल्य"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "मूल ERP, MES और QMS कार्यक्षमता"
 
 msgid "Basic Information"
 msgstr "बुनियादी जानकारी"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "बैच / सीरीज़"
 
 msgid "Batch items require a sales order"
-msgstr "बैच आइटम के लिए बिक्री आदेश आवश्यक है"
+msgstr "बैच आइटम को विक्रय आदेश की आवश्यकता है"
 
 msgid "Batch number"
 msgstr "बैच नंबर"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "बीटा"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "कारण, आइटम, या कार्य केंद्र द्वारा स्क्रैप के सबसे बड़े कारण"
+msgstr "कारण, आइटम या वर्क सेंटर के अनुसार स्क्रैप के सबसे बड़े कारण"
 
 msgid "Bill of Material"
 msgstr "सामग्री की बिल"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "सामग्री की सूची"
 
 msgid "Bill of Process"
-msgstr "प्रक्रिया का विधेयक"
+msgstr "प्रक्रिया सूची"
 
 msgid "Bill To"
 msgstr "बिल प्राप्तकर्ता"
@@ -2581,7 +2581,7 @@ msgid "BOM synced successfully"
 msgstr "BOM सफलतापूर्वक सिंक हो गया"
 
 msgid "BOMs"
-msgstr "बीओएम"
+msgstr "BOMs"
 
 msgid "Bonus Depreciation %"
 msgstr "बोनस मूल्यह्रास %"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "ब्रेडक्रम्ब"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "अपने पार्ट्स, BOMs, Bill of Process, और कोस्टिंग लाएं — Carbon के इम्पोर्ट टूल्स, CSV, या LLM हेल्प के साथ।"
+msgstr "अपने पार्ट्स, BOMs, प्रक्रिया सूची और लागत निर्धारण को लाएँ — Carbon के आयात उपकरण, CSV या LLM सहायता के साथ।"
 
 msgid "Browse library"
 msgstr "लाइब्रेरी ब्राउज़ करें"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "प्रकाशित संस्करण को केवल पढ़ने के लिए ब्राउज़ करें। आप अभी भी लेआउट को साफ करने के लिए चरणों को पुनर्व्यवस्थित कर सकते हैं।"
 
 msgid "Bucket"
 msgstr "बकेट"
@@ -2626,7 +2626,7 @@ msgid "Bugs and changes"
 msgstr "बग और परिवर्तन"
 
 msgid "Build any net-new integrations or customizations"
-msgstr "किसी भी नए इंटीग्रेशन या कस्टमाइजेशन बनाएं"
+msgstr "कोई भी नया एकीकरण या अनुकूलन बनाएँ"
 
 msgid "Build any net-new work"
 msgstr "कोई भी नया काम बनाएं"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "एकीकरण और अनुकूलन बनाएं"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "लाइव पार्ट, लागत और बिल ऑफ प्रोसेस डेटा खींचकर कोट्स बनाएं"
+msgstr "लाइव पार्ट, लागत और प्रक्रिया सूची डेटा खींचकर कोटेशन बनाएँ"
 
 msgid "Build role-based training materials"
 msgstr "भूमिका-आधारित प्रशिक्षण सामग्री बनाएं"
@@ -2662,7 +2662,7 @@ msgid "Buy"
 msgstr "खरीदें"
 
 msgid "Buy and Make"
-msgstr "खरीदें और बनाएं"
+msgstr "खरीद और निर्माण"
 
 msgid "Buyer"
 msgstr "क्रेता"
@@ -2683,7 +2683,7 @@ msgid "By Document Date"
 msgstr "दस्तावेज़ तारीख के अनुसार"
 
 msgid "By Due Date"
-msgstr "देय तारीख के अनुसार"
+msgstr "नियत तिथि के अनुसार"
 
 msgid "By field"
 msgstr "क्षेत्र द्वारा"
@@ -2713,19 +2713,19 @@ msgid "Calibration"
 msgstr "अंशांकन"
 
 msgid "Calibration Attempts"
-msgstr "कैलिब्रेशन प्रयास"
+msgstr "अंशांकन प्रयास"
 
 msgid "Calibration Expiration Notifications"
-msgstr "कैलिब्रेशन समाप्ति सूचनाएं"
+msgstr "अंशांकन समाप्ति सूचनाएँ"
 
 msgid "Calibration Interval (Months)"
 msgstr "अंशांकन अंतराल (महीने)"
 
 msgid "Calibration Record"
-msgstr "कैलिब्रेशन रिकॉर्ड"
+msgstr "अंशांकन रिकॉर्ड"
 
 msgid "Calibration Records"
-msgstr "कैलिब्रेशन रिकॉर्ड"
+msgstr "अंशांकन रिकॉर्ड"
 
 msgid "Calibration Status"
 msgstr "अंशांकन स्थिति"
@@ -2740,7 +2740,7 @@ msgid "Call an outside URL"
 msgstr "बाहरी URL को कॉल करें"
 
 msgid "Called a method in Carbon — the components plus operations that produce a part."
-msgstr "कार्बन में एक विधि कहा जाता है — घटक और संचालन जो एक हिस्सा तैयार करते हैं।"
+msgstr "Carbon में एक विधि कहा जाता है — घटक साथ ऑपरेशन जो एक पार्ट का उत्पादन करते हैं।"
 
 msgid "Can't delete this period"
 msgstr "इस अवधि को हटाया नहीं जा सकता"
@@ -2749,7 +2749,7 @@ msgid "Can't disable the only active break. Add another break or toggle the over
 msgstr "केवल सक्रिय ब्रेक को अक्षम नहीं कर सकते। एक और ब्रेक जोड़ें या ओवरराइड के सक्रिय को टॉगल करें।"
 
 msgid "Can't download this file"
-msgstr "इस फ़ाइल को डाउनलोड नहीं कर सकते"
+msgstr "इस फ़ाइल को डाउनलोड नहीं किया जा सकता"
 
 msgid "Cancel"
 msgstr "रद्द करें"
@@ -2767,10 +2767,10 @@ msgid "Cancel Order"
 msgstr "ऑर्डर रद्द करें"
 
 msgid "Cancel Purchase Order"
-msgstr "क्रय ऑर्डर रद्द करें"
+msgstr "क्रय आदेश रद्द करें"
 
 msgid "Cancel Sales Order"
-msgstr "बिक्रय आदेश रद्द करें"
+msgstr "विक्रय आदेश रद्द करें"
 
 msgid "Cancel SO"
 msgstr "SO को रद्द करें"
@@ -2794,19 +2794,19 @@ msgid "Cancelled"
 msgstr "रद्द किया गया"
 
 msgid "Cannot add parameters to unsaved operation"
-msgstr "असहेजे ऑपरेशन में पैरामीटर नहीं जोड़ सकते"
+msgstr "असहेजे गए ऑपरेशन में पैरामीटर नहीं जोड़े जा सकते"
 
 msgid "Cannot add steps to unsaved operation"
-msgstr "असहेजे ऑपरेशन में चरण नहीं जोड़ सकते"
+msgstr "असहेजे गए ऑपरेशन में चरण नहीं जोड़े जा सकते"
 
 msgid "Cannot add tools to unsaved operation"
-msgstr "असहेजे ऑपरेशन में उपकरण नहीं जोड़ सकते"
+msgstr "असहेजे गए ऑपरेशन में टूल नहीं जोड़े जा सकते"
 
 msgid "Cannot close yet"
 msgstr "अभी बंद नहीं कर सकते"
 
 msgid "Cannot convert RFQ to quote"
-msgstr "RFQ को उद्धरण में परिवर्तित नहीं कर सकते"
+msgstr "RFQ को कोटेशन में परिवर्तित नहीं किया जा सकता"
 
 msgid "Cannot move to parts bucket without item ID"
 msgstr "आइटम आईडी के बिना पार्ट्स बकेट में नहीं जा सकते"
@@ -2821,13 +2821,13 @@ msgid "Cannot send RFQ"
 msgstr "RFQ नहीं भेज सकते"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe के माध्यम से भेजा नहीं जा सकता"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "अपलोड नहीं कर सकते — आपूर्तिकर्ता इंटरैक्शन अभी तक बनाया नहीं गया"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "आइटम आईडी के बिना पार्ट्स बकेट में अपलोड नहीं कर सकते"
+msgstr "आइटम ID के बिना पार्ट्स बकेट में अपलोड नहीं कर सकते"
 
 msgid "Caption"
 msgstr "कैप्शन"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Carbon-only · ग्राहक यह पाठ देखता है, लॉक किया गया।"
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "सामग्री की सूची और प्रक्रिया सूची (रूटिंग) के लिए कार्बन का नाम: घटक और संचालन जो एक हिस्सा बनाते हैं।"
+msgstr "Carbon का BOM और प्रक्रिया सूची (रूटिंग) के लिए नाम: पार्ट्स बनाने वाले घटक और ऑपरेशन।"
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "कार्बन का योजना रन आपूर्ति को मांग के विरुद्ध नेट करता है और विधियों को विस्फोट करता है, कमियों को दिखाता है — लेकिन यह स्वयं कोई आदेश नहीं बनाता।"
+msgstr "Carbon की योजना आपूर्ति को मांग के विरुद्ध नेट करती है और विधि को विस्तृत करती है, कमियों को उजागर करती है — लेकिन यह स्वयं कोई आदेश नहीं बनाती।"
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
 msgstr "कार्बन का उत्पादन आदेश — एक कार्य अपनी प्रतिलिपि की गई विधि और रूटिंग से एक आइटम की मात्रा बनाता है।"
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "कार्बन का शॉप-फ्लोर ऐप जहां ऑपरेटर ऑपरेशन चलाते हैं, मात्रा की रिपोर्ट करते हैं, सामग्री जारी करते हैं, और रिलीज की गई नौकरियों के विरुद्ध रीयल टाइम में समय लॉग करते हैं।"
+msgstr "Carbon का शॉप फ्लोर ऐप जहां ऑपरेटर ऑपरेशन चलाते हैं, मात्रा की रिपोर्ट करते हैं, सामग्री निर्गम करते हैं, और जारी जॉब के विरुद्ध रीयल टाइम में समय दर्ज करते हैं।"
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "कार्बन का किसी भी भाग संख्या वाली चीज के लिए एक एकल रिकॉर्ड — भाग, सामग्री, उपकरण, सेवा, खपत योग्य, या फिक्स्चर — जो नौकरियां, विधियां, आदेश, और इन्वेंटरी सभी इंगित करते हैं।"
+msgstr "Carbon का एकल रिकॉर्ड किसी भी चीज़ के लिए जिसका पार्ट नंबर है — पार्ट, सामग्री, टूल, सेवा, उपभोग्य सामग्री, या फिक्स्चर — जिस पर जॉब, विधि, आदेश और इन्वेंटरी सभी इंगित करते हैं।"
 
 msgid "Cards"
 msgstr "कार्ड"
@@ -2981,7 +2981,7 @@ msgid "Change Notices"
 msgstr "परिवर्तन सूचनाएं"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "परिवर्तन सूचनाएँ लोड नहीं की जा सकीं, इसलिए नए संस्करण और संशोधन अवरुद्ध हैं। फिर से प्रयास करने के लिए पुनः लोड करें।"
+msgstr "परिवर्तन सूचना को लोड नहीं किया जा सका, इसलिए नए संस्करण और रिवीजन अवरुद्ध हैं। पुनः प्रयास करने के लिए फिर से लोड करें।"
 
 msgid "Change order"
 msgstr "परिवर्तन आदेश"
@@ -3008,7 +3008,7 @@ msgid "Changing this will overwrite the existing method"
 msgstr "इसे बदलने से मौजूदा विधि अधिलेखित हो जाएगी"
 
 msgid "Changing this will update the part ID"
-msgstr "इसे बदलने से पार्ट ID अपडेट हो जाएगा"
+msgstr "इसे बदलने से पार्ट ID अपडेट हो जाएगी"
 
 msgid "Changing type resets this item's draft edits."
 msgstr "प्रकार बदलने से इस आइटम के ड्राफ्ट संपादन रीसेट हो जाते हैं।"
@@ -3017,19 +3017,19 @@ msgid "Chart of accounts"
 msgstr "खातों की चार्ट"
 
 msgid "Chart of Accounts"
-msgstr "खातों की सूची"
+msgstr "खातों का चार्ट"
 
 msgid "Chat"
 msgstr "चैट"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "अवधि के अंत तक नकारात्मक मौजूदा मात्रा वाली किसी भी वस्तु के लिए वस्तु खाता बही की जाँच करें — आमतौर पर एक लापता प्राप्ति या एक गलत-क्रम में पोस्टिंग जो इन्वेंटरी मूल्य और बेचे गए सामान की लागत को विकृत करती है। एक बार समीक्षा करने के बाद इसे पूर्ण चिह्नित करें, या एक कारण के साथ छोड़ दें।"
+msgstr "अवधि के अंत तक किसी भी आइटम के लिए आइटम लेजर की जांच करें जिसमें नकारात्मक ऑन-हैंड मात्रा है — आमतौर पर एक लापता प्राप्ति या एक गलत क्रम में पोस्टिंग जो इन्वेंटरी मूल्य और बेचे गए माल की लागत को विकृत करती है। एक बार समीक्षा के बाद इसे हो गया के रूप में चिह्नित करें, या कारण के साथ छोड़ दें।"
 
 msgid "Check your email"
 msgstr "अपना ईमेल जांचें"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "इस ग्राहक के लिए Stripe की जांच की जा रही है…"
 
 msgid "Checkpoint ·"
 msgstr "चेकपॉइंट ·"
@@ -3071,25 +3071,25 @@ msgid "Class (inherited)"
 msgstr "वर्ग (विरासत में मिला)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "एक रूटिंग ऑपरेशन को वर्गीकृत करता है: प्रक्रिया, असेंबली, और निरीक्षण ऑपरेशन MES में आपके खुद के शॉप फ्लोर पर चलते हैं - असेंबली को निर्देशित असेंबली दृश्य मिलता है और निरीक्षण को गुणवत्ता जांच - जबकि एक बाहरी प्रसंस्करण ऑपरेशन एक आपूर्तिकर्ता को आउटसोर्स किया जाता है और एक खरीद आदेश बनाता है; प्रक्रिया समान प्रकार को लागू करती है और इसे नए ऑपरेशन पर डिफ़ॉल्ट करती है।"
+msgstr "रूटिंग ऑपरेशन को वर्गीकृत करता है: प्रक्रिया, असेंबली, और निरीक्षण ऑपरेशन आपके अपने शॉप फ्लोर पर MES में चलते हैं — असेंबली को गाइडेड असेंबली दृश्य मिलता है और निरीक्षण को गुणवत्ता जांच मिलती है — जबकि बाहरी प्रसंस्करण ऑपरेशन एक आपूर्तिकर्ता को आउटसोर्स किया जाता है और एक क्रय आदेश बनाता है; प्रक्रिया एक ही प्रकार को ले जाती है और नए ऑपरेशन पर इसे डिफ़ॉल्ट करती है।"
 
 msgid "Clean and approve the migrated data"
-msgstr "माइग्रेट किए गए डेटा को साफ करें और मंजूरी दें"
+msgstr "माइग्रेट किए गए डेटा को साफ करें और अनुमोदित करें"
 
 msgid "Clear"
 msgstr "साफ़ करें"
 
 msgid "Clear due date"
-msgstr "देय तारीख साफ़ करें"
+msgstr "नियत तिथि साफ करें"
 
 msgid "Clear Filters"
 msgstr "फ़िल्टर साफ़ करें"
 
 msgid "Clear search"
-msgstr "खोज साफ़ करें"
+msgstr "खोज साफ करें"
 
 msgid "Clear search query"
-msgstr "खोज क्वेरी साफ़ करें"
+msgstr "खोज क्वेरी साफ करें"
 
 msgid "Clear selection"
 msgstr "चयन साफ करें"
@@ -3101,7 +3101,7 @@ msgid "Clear value"
 msgstr "मान साफ़ करें"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "माल की प्राप्ति और आपूर्तिकर्ता चालान के बीच समाशोधन खाता; जब दोनों को पोस्ट किया जाता है तो संतुलन होता है।"
+msgstr "माल प्राप्ति और आपूर्तिकर्ता चालान के बीच क्लीयरिंग खाता; दोनों के पोस्ट करने पर संतुलन होता है।"
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "माल की प्राप्ति / चालान प्राप्ति मिलान के लिए समाशोधन खाता"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "PDF ड्राइंग अपलोड करने के लिए क्लिक करें"
 
 msgid "Clock In"
-msgstr "घड़ी में"
+msgstr "कार्य प्रारंभ"
 
 msgid "Clock Out"
-msgstr "घड़ी बंद करें"
+msgstr "कार्य समाप्त"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/> से काम में आए"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "क्लाउड, या आपका स्व-होस्ट किया गया वातावरण।"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC अनुपालन"
 
 msgid "Code"
 msgstr "कोड"
@@ -3188,7 +3188,7 @@ msgid "Collapse features table"
 msgstr "फीचर्स टेबल को संक्षिप्त करें"
 
 msgid "Collapse Labor"
-msgstr "Labor को संक्षिप्त करें"
+msgstr "श्रम को संक्षिप्त करें"
 
 msgid "Collapse Machine"
 msgstr "मशीन को संक्षिप्त करें"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "एक प्राप्ति, शिपमेंट या चालान की प्रतिबद्धता: मात्रा चलती है, जर्नल प्रविष्टियां बहीखाता को मारती हैं, और स्थिति पोस्ट की जाती है।"
 
 msgid "Community support"
-msgstr ""
+msgstr "सामुदायिक समर्थन"
 
 msgid "Companies"
 msgstr "कंपनियां"
@@ -3266,7 +3266,7 @@ msgid "Compare Quotes"
 msgstr "उद्धरणों की तुलना करें"
 
 msgid "Compare Supplier Quotes"
-msgstr "आपूर्तिकर्ता उद्धरणों की तुलना करें"
+msgstr "आपूर्तिकर्ता कोटेशन की तुलना करें"
 
 msgid "Complete"
 msgstr "पूर्ण करें"
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "आइटम कॉन्फ़िगर करें"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "गेज कैलिब्रेशन से बाहर जाने पर सूचनाएं कॉन्फ़िगर करें।"
+msgstr "इसके लिए सूचनाएं कॉन्फ़िगर करें कि जब गेज अंशांकन से बाहर हो जाएं।"
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "जब नौकरियां पूरी हो जाएं तो सूचनाएं कॉन्फ़िगर करें।"
+msgstr "यह कॉन्फ़िगर करें कि जब जॉब पूर्ण हों तो सूचनाएं भेजी जाएं।"
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "दुकान के फर्श से रखरखाव डिस्पैच बनाए जाने पर सूचनाएं कॉन्फ़िगर करें। सूचनाएं विफलता मोड प्रकार के आधार पर रूट की जाती हैं।"
+msgstr "इसके लिए सूचनाएं कॉन्फ़िगर करें कि जब शॉप फ्लोर से रखरखाव कार्य बनाए जाएं। सूचनाएं विफलता मोड प्रकार के आधार पर रूट की जाती हैं।"
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "नए सुझाव जमा किए जाने पर सूचनाएं कॉन्फ़िगर करें।"
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "साइटें, कार्य केंद्र, प्रक्रिया बिल, BOMs, लागत, भूमिकाएं कॉन्फ़िगर करें"
+msgstr "साइटें, वर्क सेंटर, प्रक्रिया सूची, BOM, लागत निर्धारण, भूमिका कॉन्फ़िगर करें"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "विभिन्न लेनदेन प्रकारों के लिए आपके सिस्टम में उपयोग किए जाने वाले डिफ़ॉल्ट खातों को कॉन्फ़िगर करें"
@@ -3381,7 +3381,7 @@ msgid "Configure when purchased item costs should be updated from supplier trans
 msgstr "खरीदी गई वस्तु की लागत को आपूर्तिकर्ता लेनदेन से कब अपडेट किया जाना चाहिए, इसे कॉन्फ़िगर करें।"
 
 msgid "Configure who should receive notifications when a supplier submits a quote."
-msgstr "सप्लायर द्वारा कोट सबमिट करने पर कौन सूचनाएं प्राप्त करेगा, इसे कॉन्फ़िगर करें।"
+msgstr "कॉन्फ़िगर करें कि जब कोई आपूर्तिकर्ता कोटेशन जमा करे तो किसे सूचनाएं मिलनी चाहिए।"
 
 msgid "Configure-to-order"
 msgstr "कॉन्फ़िगर-टू-ऑर्डर"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "पुष्टि की गई आने वाली स्टॉक — खरीद और उत्पादन आदेश (बार शून्य से ऊपर)।"
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "पुष्टि की गई आने वाली स्टॉक — बिक्री आदेश और नौकरी सामग्री (बार शून्य से नीचे)।"
+msgstr "पुष्टि की गई बाहरी स्टॉक — विक्रय आदेश और जॉब सामग्री (शून्य से नीचे की पट्टियां)।"
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "पुष्टि करता है कि अवधि में हर पोस्ट की गई जर्नल प्रविष्टि में बराबर डेबिट और क्रेडिट हैं। यदि कोई प्रविष्टि असंतुलित है तो ट्रायल बैलेंस मेल नहीं खाएगा, इसलिए अवधि बंद होने से पहले इसे ठीक किया जाना चाहिए।"
+msgstr "पुष्टि करता है कि अवधि में प्रत्येक पोस्ट किए गए जर्नल प्रविष्टि में समान नामे और जमा हैं। यदि कोई प्रविष्टि असंतुलित है तो ट्रायल बैलेंस संतुलित नहीं होगा, इसलिए अवधि को बंद करने से पहले इसे सुधारा जाना चाहिए।"
 
 msgid "Conflict reason"
 msgstr "संघर्ष कारण"
@@ -3466,7 +3466,7 @@ msgid "Connect Linear issue"
 msgstr "Linear समस्या से कनेक्ट करें"
 
 msgid "Connect Slack under Settings → Integrations first."
-msgstr "पहले सेटिंग्स → इंटीग्रेशन के तहत Slack को जोड़ें।"
+msgstr "पहले सेटिंग्स → एकीकरण के तहत Slack कनेक्ट करें।"
 
 msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "कोई शर्त मेल नहीं खाने पर चलाने के लिए हैंडल को एक नोड से कनेक्ट करें।"
@@ -3493,22 +3493,22 @@ msgid "Console Operator"
 msgstr "कंसोल ऑपरेटर"
 
 msgid "consumable"
-msgstr "उपभोग्य"
+msgstr "उपभोग्य सामग्री"
 
 msgid "Consumable"
-msgstr "उपभोग्य"
+msgstr "उपभोग्य सामग्री"
 
 msgid "Consumable Details"
-msgstr "उपभोग्य विवरण"
+msgstr "उपभोग्य सामग्री विवरण"
 
 msgid "Consumable ID"
-msgstr "उपभोग्य ID"
+msgstr "उपभोग्य सामग्री ID"
 
 msgid "consumables"
-msgstr "उपभोग्य"
+msgstr "उपभोग्य सामग्री"
 
 msgid "Consumables"
-msgstr "उपभोग्य"
+msgstr "उपभोग्य सामग्री"
 
 msgid "Consumed"
 msgstr "उपभोग किया गया"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "संपर्क (वैकल्पिक)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "हमसे संपर्क करें"
 
 msgid "contacts"
 msgstr "संपर्क"
@@ -3538,10 +3538,10 @@ msgid "Contained"
 msgstr "नियंत्रित"
 
 msgid "Containment"
-msgstr "समावेशन"
+msgstr "नियंत्रण"
 
 msgid "Containment action"
-msgstr "निरोध कार्रवाई"
+msgstr "नियंत्रण कार्रवाई"
 
 msgid "Content"
 msgstr "सामग्री"
@@ -3565,7 +3565,7 @@ msgid "Contractors"
 msgstr "ठेकेदार"
 
 msgid "Control design changes with revisions / ECOs"
-msgstr "संशोधन / ECOs के साथ डिज़ाइन परिवर्तनों को नियंत्रित करें"
+msgstr "रिवीजन / ECO के साथ डिज़ाइन परिवर्तनों को नियंत्रित करें"
 
 msgid "Control how operators pick material and track time on the shop floor."
 msgstr "नियंत्रित करें कि ऑपरेटर शॉप फ्लोर पर सामग्री कैसे चुनते हैं और समय कैसे ट्रैक करते हैं।"
@@ -3574,10 +3574,10 @@ msgid "Controller, Accountant"
 msgstr "नियंत्रक, लेखाकार"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "नियंत्रित करता है कि योजना एक बंद की गई वस्तु को कैसे संभालती है: पहले उपभोग करें हाथ पर स्टॉक को समाप्त करता है फिर उत्तराधिकारी पर स्विच करता है, नई को प्राथमिकता दें नई मांग को तुरंत उत्तराधिकारी को पुनर्निर्देशित करता है, केवल स्टॉक केवल न्यूनतम सेवा रिजर्व रखता है, और कोई स्टॉक नहीं वस्तु को योजना से पूरी तरह हटा देता है।"
+msgstr "यह नियंत्रित करता है कि योजना एक बंद की गई आइटम को कैसे संभालती है: पहले उपयोग करें ऑन-हैंड स्टॉक को समाप्त करता है फिर उत्तराधिकारी पर स्विच करता है; नई को प्राथमिकता तुरंत नई मांग को उत्तराधिकारी पर पुनर्निर्देशित करती है; केवल स्टॉक न्यूनतम सेवा रिज़र्व रखता है; कोई स्टॉक आइटम को पूरी तरह योजना से हटा देता है।"
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "नियंत्रित करता है कि क्या जारी (उत्पादन) संशोधन के सामग्री बिल और प्रक्रिया बिल को परिवर्तन आदेश के बाहर संपादित किया जा सकता है।"
+msgstr "यह नियंत्रित करता है कि जारी किया गया (उत्पादन) रिवीजन की सामग्री सूची और प्रक्रिया सूची को परिवर्तन आदेश के बाहर संपादित किया जा सकता है या नहीं।"
 
 msgid "Convention"
 msgstr "अभिसम्मति"
@@ -3598,16 +3598,16 @@ msgid "Convert"
 msgstr "परिवर्तित करें"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "उद्धरण को बिना पुनः-कुंजीयन के बिक्रय आदेश में परिवर्तित करें"
+msgstr "बिना पुनः-प्रविष्टि के कोटेशन को विक्रय आदेश में परिवर्तित करें"
 
 msgid "Convert Line to Job"
-msgstr "लाइन को जॉब में कनवर्ट करें"
+msgstr "पंक्ति को जॉब में परिवर्तित करें"
 
 msgid "Convert Lines to Jobs"
-msgstr "लाइनों को जॉब में कनवर्ट करें"
+msgstr "पंक्तियों को जॉब में परिवर्तित करें"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "MRP सुझावों को खरीद आदेशों और कार्यों में परिवर्तित करें।"
+msgstr "MRP सुझावों को क्रय आदेश और जॉब में परिवर्तित करें।"
 
 msgid "Convert to Quote"
 msgstr "उद्धरण में परिवर्तित करें"
@@ -3628,19 +3628,19 @@ msgid "Copy all items and pricing to another customer or type."
 msgstr "सभी आइटम और मूल्य निर्धारण को किसी अन्य ग्राहक या प्रकार में कॉपी करें।"
 
 msgid "Copy API Key"
-msgstr "API Key कॉपी करें"
+msgstr "API कुंजी की नकल करें"
 
 msgid "Copy company unique identifier"
 msgstr "कंपनी के अद्वितीय पहचानकर्ता की प्रतिलिपि बनाएं"
 
 msgid "Copy consumable number"
-msgstr "उपभोग्य संख्या कॉपी करें"
+msgstr "उपभोग्य सामग्री संख्या की नकल करें"
 
 msgid "Copy dispatch ID"
-msgstr "डिस्पैच आईडी कॉपी करें"
+msgstr "रखरखाव कार्य ID की नकल करें"
 
 msgid "Copy dispatch number"
-msgstr "डिस्पैच नंबर कॉपी करें"
+msgstr "रखरखाव कार्य संख्या की नकल करें"
 
 msgid "Copy document name"
 msgstr "दस्तावेज़ का नाम कॉपी करें"
@@ -3667,10 +3667,10 @@ msgid "Copy link to change notice"
 msgstr "परिवर्तन सूचना के लिंक की प्रतिलिपि बनाएं"
 
 msgid "Copy link to consumable"
-msgstr "उपभोग्य के लिए लिंक कॉपी करें"
+msgstr "उपभोग्य सामग्री के लिए लिंक की नकल करें"
 
 msgid "Copy link to dispatch"
-msgstr "डिस्पैच के लिए लिंक कॉपी करें"
+msgstr "रखरखाव कार्य के लिए लिंक की नकल करें"
 
 msgid "Copy link to document"
 msgstr "दस्तावेज़ की लिंक कॉपी करें"
@@ -3688,7 +3688,7 @@ msgid "Copy link to part"
 msgstr "भाग के लिए लिंक कॉपी करें"
 
 msgid "Copy link to procedure"
-msgstr "प्रक्रिया के लिए लिंक कॉपी करें"
+msgstr "कार्यविधि के लिए लिंक की नकल करें"
 
 msgid "Copy link to service"
 msgstr "सेवा के लिए लिंक कॉपी करें"
@@ -3724,13 +3724,13 @@ msgid "Copy pricing to all customers of a type"
 msgstr "एक प्रकार के सभी ग्राहकों को मूल्य निर्धारण कॉपी करें"
 
 msgid "Copy Procedure"
-msgstr "प्रक्रिया कॉपी करें"
+msgstr "कार्यविधि की नकल करें"
 
 msgid "Copy procedure name"
-msgstr "प्रक्रिया का नाम कॉपी करें"
+msgstr "कार्यविधि का नाम नकल करें"
 
 msgid "Copy procedure unique identifier"
-msgstr "प्रक्रिया अद्वितीय पहचानकर्ता की प्रतिलिपि बनाएं"
+msgstr "कार्यविधि की अद्वितीय पहचान की नकल करें"
 
 msgid "Copy Quality Document"
 msgstr "गुणवत्ता दस्तावेज़ कॉपी करें"
@@ -3754,7 +3754,7 @@ msgid "Copy this link to share the quote with a customer"
 msgstr "इस लिंक को कॉपी करें ताकि आप ग्राहक के साथ उद्धरण साझा कर सकें"
 
 msgid "Copy this link to share the quote with a supplier"
-msgstr "इस लिंक को कॉपी करें सप्लायर के साथ कोट साझा करने के लिए"
+msgstr "कोटेशन को आपूर्तिकर्ता के साथ साझा करने के लिए इस लिंक की नकल करें"
 
 msgid "Copy tool number"
 msgstr "टूल नंबर कॉपी करें"
@@ -3820,22 +3820,22 @@ msgid "Cost History"
 msgstr "लागत इतिहास"
 
 msgid "Cost of Goods Sold"
-msgstr "बेची गई वस्तुओं की लागत"
+msgstr "बेचे गए माल की लागत"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "बेची गई वस्तुओं की लागत (COGS)"
+msgstr "बेचे गए माल की लागत (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "बेची गई वस्तुओं की लागत (डिफ़ॉल्ट)"
+msgstr "बेचे गए माल की लागत (डिफ़ॉल्ट)"
 
 msgid "Cost of Sales"
 msgstr "बिक्री की लागत"
 
 msgid "Costing"
-msgstr "लागत"
+msgstr "लागत निर्धारण"
 
 msgid "Costing & Posting"
-msgstr "लागत और पोस्टिंग"
+msgstr "लागत निर्धारण और पोस्टिंग"
 
 msgid "Costing method"
 msgstr "लागत निर्धारण विधि"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "दस्तावेज़ लोड नहीं हो सके"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "संबंधित दस्तावेज़ लोड नहीं हो सके। डुप्लीकेट से बचने के लिए नया बनाने से पहले रीफ्रेश करें।"
+msgstr "संबंधित दस्तावेज़ लोड नहीं किए जा सके। डुप्लिकेट से बचने के लिए एक नया बनाने से पहले रीफ़्रेश करें।"
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "प्रदाता के आयाम लक्ष्य लोड नहीं कर सके — कनेक्शन जांचें और फिर से लोड करें।"
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "बनाएं और स्नैपशॉट लें"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "नई संशोधन के लिए एक परिवर्तन सूचना बनाएं और इसे खोलें"
+msgstr "नए रिवीजन के लिए एक परिवर्तन सूचना बनाएँ और इसे खोलें"
 
 msgid "Create a job"
 msgstr "एक नौकरी बनाएँ"
@@ -3930,25 +3930,25 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "स्कैन-आधारित पुनःपूर्ति के लिए एक नया कानबन कार्ड बनाएं।"
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "उपकरण मरम्मत और रखरखाव गतिविधियों को ट्रैक करने के लिए एक नया रखरखाव प्रेषण बनाएं"
+msgstr "उपकरण की मरम्मत और रखरखाव गतिविधियों को ट्रैक करने के लिए एक नया रखरखाव कार्य बनाएँ"
 
 msgid "Create a new production job to fulfill the sales order"
-msgstr "बिक्रय आदेश को पूरा करने के लिए एक नई उत्पादन नौकरी बनाएं"
+msgstr "विक्रय आदेश को पूरा करने के लिए एक नया उत्पादन जॉब बनाएँ"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "इसके बजाय एक नया Stripe ग्राहक बनाएँ"
 
 msgid "Create a new version"
 msgstr "एक नया संस्करण बनाएं"
 
 msgid "Create a purchase order"
-msgstr "एक खरीद आदेश बनाएँ"
+msgstr "एक क्रय आदेश बनाएँ"
 
 msgid "Create a quote with a new quote ID"
 msgstr "एक नई उद्धरण ID के साथ एक उद्धरण बनाएं"
 
 msgid "Create a sales order"
-msgstr "एक बिक्रय आदेश बनाएँ"
+msgstr "एक विक्रय आदेश बनाएँ"
 
 msgid "Create Account"
 msgstr "खाता बनाएं"
@@ -3963,7 +3963,7 @@ msgid "Create an issue"
 msgstr "एक समस्या बनाएँ"
 
 msgid "Create and approve purchase orders"
-msgstr "क्रय आदेश बनाएं और मंजूरी दें"
+msgstr "क्रय आदेश बनाएँ और अनुमोदित करें"
 
 msgid "Create audit trail entries"
 msgstr "ऑडिट ट्रेल प्रविष्टियां बनाएं"
@@ -3975,19 +3975,19 @@ msgid "Create Issue"
 msgstr "समस्या बनाएं"
 
 msgid "Create Jobs"
-msgstr "नौकरियां बनाएं"
+msgstr "जॉब बनाएँ"
 
 msgid "Create Kanban"
-msgstr "कनबन बनाएं"
+msgstr "कानबान बनाएँ"
 
 msgid "Create new rule"
 msgstr "नया नियम बनाएं"
 
 msgid "Create PO Revision"
-msgstr "PO संशोधन बनाएं"
+msgstr "क्रय आदेश रिवीजन बनाएँ"
 
 msgid "Create Production Event"
-msgstr "उत्पादन घटना बनाएं"
+msgstr "उत्पादन इवेंट बनाएँ"
 
 msgid "Create Production Quantity"
 msgstr "उत्पादन मात्रा बनाएं"
@@ -3996,10 +3996,10 @@ msgid "Create Projection"
 msgstr "प्रक्षेपण बनाएं"
 
 msgid "Create Quote Revision"
-msgstr "उद्धरण संशोधन बनाएं"
+msgstr "कोटेशन रिवीजन बनाएँ"
 
 msgid "Create Revision"
-msgstr "संशोधन बनाएं"
+msgstr "रिवीजन बनाएँ"
 
 msgid "Create Rule"
 msgstr "नियम बनाएं"
@@ -4014,7 +4014,7 @@ msgid "Create Version"
 msgstr "संस्करण बनाएं"
 
 msgid "Create Work Center"
-msgstr "कार्य केंद्र बनाएं"
+msgstr "वर्क सेंटर बनाएँ"
 
 msgid "Created"
 msgstr "बनाया गया"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "खाता बनाया गया"
 
 msgid "Created asset class"
-msgstr "संपत्ति वर्ग बनाया गया"
+msgstr "परिसंपत्ति वर्ग बनाया गया"
 
 msgid "Created at"
 msgstr "पर बनाया गया"
@@ -4044,7 +4044,7 @@ msgid "Created change notice type"
 msgstr "परिवर्तन सूचना प्रकार बनाया गया"
 
 msgid "Created consumable"
-msgstr "उपभोग्य बनाया गया"
+msgstr "उपभोग्य सामग्री बनाई गई"
 
 msgid "Created cost center"
 msgstr "लागत केंद्र बनाया गया"
@@ -4102,10 +4102,10 @@ msgid "Created material type"
 msgstr "सामग्री प्रकार बनाया गया"
 
 msgid "Created no quote reason"
-msgstr "कोई उद्धरण कारण नहीं बनाया गया"
+msgstr "कोई कोटेशन नहीं देने का कारण बनाया गया"
 
 msgid "Created non conformance type"
-msgstr "गैर अनुरूपता प्रकार बनाया गया"
+msgstr "गैर-अनुरूपता प्रकार बनाया गया"
 
 msgid "Created part"
 msgstr "भाग बनाया गया"
@@ -4129,7 +4129,7 @@ msgid "Created shipping method"
 msgstr "शिपिंग विधि बनाई गई"
 
 msgid "Created stock transfer line"
-msgstr "स्टॉक ट्रांसफर लाइन बनाई गई"
+msgstr "स्टॉक स्थानांतरण पंक्ति बनाई गई"
 
 msgid "Created storage type"
 msgstr "भंडारण प्रकार बनाया गया"
@@ -4148,10 +4148,10 @@ msgid "Created webhook"
 msgstr "वेबहुक बनाया गया"
 
 msgid "Created work center"
-msgstr "कार्य केंद्र बनाया गया"
+msgstr "वर्क सेंटर बनाया गया"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "एक वित्तीय वर्ष के लिए 12 मासिक अवधियाँ बनाता है। जो अवधियाँ पहले से मौजूद हैं वे रखी जाती हैं।"
+msgstr "एक वित्तीय वर्ष के लिए 12 मासिक अवधियों को बनाता है। जो अवधियां पहले से मौजूद हैं उन्हें रखा जाता है।"
 
 msgid "Creating part..."
 msgstr "भाग बनाया जा रहा है..."
@@ -4164,10 +4164,10 @@ msgid "Credit ({0})"
 msgstr "जमा ({0})"
 
 msgid "Credit / debit memo"
-msgstr "क्रेडिट / डेबिट मेमो"
+msgstr "क्रेडिट / डेबिट नोट"
 
 msgid "Credit / Debit Memos"
-msgstr "क्रेडिट / डेबिट मेमो"
+msgstr "क्रेडिट / डेबिट नोट"
 
 msgid "Credit Account"
 msgstr "क्रेडिट खाता"
@@ -4176,25 +4176,25 @@ msgid "Credit account when labor/machine time is absorbed into WIP"
 msgstr "क्रेडिट खाता जब श्रम / मशीन समय WIP में अवशोषित होता है"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "जब ओवरहेड को WIP में अवशोषित किया जाता है तो क्रेडिट खाता"
+msgstr "जब उपरिव्यय WIP में अवशोषित होता है तो खाते को जमा करें"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
 msgstr "जब विनिर्माण लागत को WIP में अवशोषित किया जाता है तब उपयोग किए जाने वाले क्रेडिट खाते"
 
 msgid "Credit Memo"
-msgstr "क्रेडिट मेमो"
+msgstr "क्रेडिट नोट"
 
 msgid "Credits"
 msgstr "जमा"
 
 msgid "Credits & Debits"
-msgstr "क्रेडिट और डेबिट"
+msgstr "जमा और नामे"
 
 msgid "Credits applied"
 msgstr "क्रेडिट लागू किए गए"
 
 msgid "Critical"
-msgstr "महत्वपूर्ण"
+msgstr "गंभीर"
 
 msgid "CSV column"
 msgstr "CSV कॉलम"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "मुद्रा कोड"
 
 msgid "Currency Translation"
-msgstr "मुद्रा अनुवाद"
+msgstr "मुद्रा रूपांतरण"
 
 msgid "Currency Translation (default)"
-msgstr "मुद्रा अनुवाद (डिफ़ॉल्ट)"
+msgstr "मुद्रा रूपांतरण (डिफ़ॉल्ट)"
 
 msgid "current"
 msgstr "वर्तमान"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "वर्तमान"
 
 msgid "Current Net Book Value:"
-msgstr "वर्तमान नेट बुक वैल्यू:"
+msgstr "वर्तमान शुद्ध बही मूल्य:"
 
 msgid "Current Password"
 msgstr "वर्तमान पासवर्ड"
@@ -4260,7 +4260,7 @@ msgid "Custom development, integrations, or self-hosting"
 msgstr "कस्टम विकास, एकीकरण, या स्व-होस्टिंग"
 
 msgid "Custom field"
-msgstr "कस्टम क्षेत्र"
+msgstr "कस्टम फ़ील्ड"
 
 msgid "Custom Field"
 msgstr "कस्टम फील्ड"
@@ -4332,7 +4332,7 @@ msgid "Customer Part Number"
 msgstr "ग्राहक भाग संख्या"
 
 msgid "Customer Part Revision"
-msgstr "ग्राहक भाग संशोधन"
+msgstr "ग्राहक पार्ट रिवीजन"
 
 msgid "Customer Parts"
 msgstr "ग्राहक पार्ट्स"
@@ -4365,7 +4365,7 @@ msgid "Customer Reference"
 msgstr "ग्राहक संदर्भ"
 
 msgid "Customer Revision"
-msgstr "ग्राहक संशोधन"
+msgstr "ग्राहक रिवीजन"
 
 msgid "Customer RFQ"
 msgstr "ग्राहक RFQ"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "ग्राहक प्रकार"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "ग्राहक राइट-ऑफ (बुरा कर्ज)"
+msgstr "ग्राहक बट्टे खाते (बुरा ऋण)"
 
 msgid "customers"
 msgstr "ग्राहकों"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "ग्राहक"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "कस्टमाइज़ेशन, प्रशिक्षण और एकीकरण"
 
 msgid "Customize"
 msgstr "अनुकूलित करें"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "कटओवर सहायता"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "चक्र गणना करें और ऑडिट ट्रेल के साथ समायोजित करें"
+msgstr "चक्रीय गणना करें और ऑडिट ट्रेल के साथ समायोजित करें"
 
 msgid "Daily"
 msgstr "दैनिक"
@@ -4571,17 +4571,17 @@ msgid "Deadline Type"
 msgstr "समय सीमा प्रकार"
 
 msgid "Debit"
-msgstr "डेबिट"
+msgstr "नामे"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
 msgstr "नामे ({0})"
 
 msgid "Debit Account"
-msgstr "डेबिट खाता"
+msgstr "नामे खाता"
 
 msgid "Debit Memo"
-msgstr "डेबिट मेमो"
+msgstr "डेबिट नोट"
 
 msgid "Debits"
 msgstr "नामे"
@@ -4599,7 +4599,7 @@ msgid "Decimal Places"
 msgstr "दशमलव स्थान"
 
 msgid "Declining balance"
-msgstr "घटती शेष राशि"
+msgstr "ह्रासमान शेष"
 
 msgid "Default"
 msgstr "डिफ़ॉल्ट"
@@ -4614,7 +4614,7 @@ msgid "Default accounts for business expenses"
 msgstr "व्यावसायिक व्यय के लिए डिफ़ॉल्ट खाते"
 
 msgid "Default accounts for customer transactions and receivables"
-msgstr "ग्राहक लेनदेन और प्राप्य के लिए डिफ़ॉल्ट खाते"
+msgstr "ग्राहक लेनदेन और प्राप्य राशि के लिए डिफ़ॉल्ट खाते"
 
 msgid "Default accounts for long-term assets and depreciation"
 msgstr "दीर्घकालिक संपत्ति और मूल्यह्रास के लिए डिफ़ॉल्ट खाते"
@@ -4626,13 +4626,13 @@ msgid "Default accounts for tax-related transactions"
 msgstr "कर संबंधी लेनदेन के लिए डिफ़ॉल्ट खाते"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "बेचे गए सामानों की लागत और अप्रत्यक्ष खरीद के लिए डिफ़ॉल्ट खाते"
+msgstr "बेचे गए माल की लागत और अप्रत्यक्ष खरीद के लिए डिफ़ॉल्ट खाते"
 
 msgid "Default Approver"
 msgstr "डिफ़ॉल्ट अनुमोदक"
 
 msgid "Default Attachments"
-msgstr "डिफ़ॉल्ट अटैचमेंट"
+msgstr "डिफ़ॉल्ट अनुलग्नक"
 
 msgid "Default cash account for transactions in non-base currencies."
 msgstr "गैर-आधार मुद्राओं में लेनदेन के लिए डिफ़ॉल्ट नकद खाता।"
@@ -4656,10 +4656,10 @@ msgid "Default GL account used for cash transactions when no specific bank accou
 msgstr "जब कोई विशिष्ट बैंक खाता नहीं चुना जाता है तो नकद लेनदेन के लिए उपयोग किया जाने वाला डिफ़ॉल्ट GL खाता।"
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "उपकरण और सुविधा रखरखाव के लिए डिफ़ॉल्ट GL व्यय खाता।"
+msgstr "उपकरण और सुविधा रखरखाव के लिए डिफ़ॉल्ट सामान्य खाता बही व्यय खाता।"
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "आवधिक मूल्यह्रास रन के लिए डिफ़ॉल्ट GL व्यय खाता।"
+msgstr "आवधिक मूल्यह्रास रन के लिए डिफ़ॉल्ट सामान्य खाता बही व्यय खाता।"
 
 msgid "Default Method"
 msgstr "डिफ़ॉल्ट विधि"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "डिफ़ॉल्ट विधि जो इस वर्ग में नई संपत्तियों पर पूर्व-भर जाती है (प्रति संपत्ति अभी भी संपादन योग्य)।"
 
 msgid "Default method type"
-msgstr "डिफ़ॉल्ट विधि प्रकार"
+msgstr "डिफ़ॉल्ट आपूर्ति प्रकार"
 
 msgid "Default Method Type"
-msgstr "डिफ़ॉल्ट विधि प्रकार"
+msgstr "डिफ़ॉल्ट आपूर्ति प्रकार"
 
 msgid "Default Permissions"
 msgstr "डिफ़ॉल्ट अनुमतियाँ"
@@ -4680,7 +4680,7 @@ msgid "Default Priority"
 msgstr "डिफ़ॉल्ट प्राथमिकता"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "डिफ़ॉल्ट राजस्व GL खाता जब बिक्री चालान पोस्ट किया जाता है तो क्रेडिट किया जाता है।"
+msgstr "जब विक्रय चालान पोस्ट होता है तो डिफ़ॉल्ट राजस्व लेजर खाता जमा किया जाता है।"
 
 msgid "Default Sampling"
 msgstr "डिफ़ॉल्ट नमूनाकरण"
@@ -4692,7 +4692,7 @@ msgid "Default Source"
 msgstr "डिफ़ॉल्ट स्रोत"
 
 msgid "Default Storage Unit"
-msgstr "डिफ़ॉल्ट स्टोरेज यूनिट"
+msgstr "डिफ़ॉल्ट भंडारण इकाई"
 
 msgid "Default tax depreciation method for new assets in this class."
 msgstr "इस वर्ग में नई संपत्तियों के लिए डिफ़ॉल्ट कर मूल्यह्रास विधि।"
@@ -4710,22 +4710,22 @@ msgid "Defaults"
 msgstr "डिफ़ॉल्ट"
 
 msgid "Deferred Tax Expense"
-msgstr "स्थगित कर व्यय"
+msgstr "आस्थगित कर व्यय"
 
 msgid "Deferred Tax Expense (default)"
-msgstr "स्थगित कर व्यय (डिफ़ॉल्ट)"
+msgstr "आस्थगित कर व्यय (डिफ़ॉल्ट)"
 
 msgid "Deferred Tax Liability"
-msgstr "स्थगित कर दायित्व"
+msgstr "आस्थगित कर दायित्व"
 
 msgid "Deferred Tax Liability (default)"
-msgstr "स्थगित कर दायित्व (डिफ़ॉल्ट)"
+msgstr "आस्थगित कर देयता (डिफ़ॉल्ट)"
 
 msgid "Define a manufacturing operation first."
 msgstr "पहले एक विनिर्माण ऑपरेशन को परिभाषित करें।"
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "बहु-स्तरीय BOMs और Bill of Process (make methods) को परिभाषित करें"
+msgstr "बहु-स्तरीय BOMs और प्रक्रिया सूची (निर्माण विधि) को परिभाषित करें"
 
 msgid "Delete"
 msgstr "हटाएं"
@@ -4750,7 +4750,7 @@ msgid "Delete Action"
 msgstr "कार्रवाई हटाएं"
 
 msgid "Delete API Key"
-msgstr "API Key हटाएं"
+msgstr "API कुंजी हटाएँ"
 
 msgid "Delete Asset"
 msgstr "परिसंपत्ति हटाएं"
@@ -4774,7 +4774,7 @@ msgid "Delete Change Notice"
 msgstr "परिवर्तन सूचना हटाएं"
 
 msgid "Delete Consumable"
-msgstr "उपभोग्य हटाएं"
+msgstr "उपभोग्य सामग्री हटाएँ"
 
 msgid "Delete Contact"
 msgstr "संपर्क हटाएं"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "आयाम हटाएं"
 
 msgid "Delete Dispatch"
-msgstr "डिस्पैच हटाएं"
+msgstr "रखरखाव कार्य हटाएँ"
 
 msgid "Delete Document"
 msgstr "दस्तावेज़ हटाएं"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "आइटम समूह हटाएं"
 
 msgid "Delete Journal Entry"
-msgstr "पत्रिका प्रविष्टि हटाएं"
+msgstr "जर्नल प्रविष्टि हटाएँ"
 
 msgid "Delete line"
 msgstr "पंक्ति हटाएं"
@@ -4882,7 +4882,7 @@ msgid "Delete Payment"
 msgstr "भुगतान हटाएं"
 
 msgid "Delete Payment Term"
-msgstr "भुगतान अवधि हटाएं"
+msgstr "भुगतान शर्तें हटाएँ"
 
 msgid "Delete Period"
 msgstr "अवधि हटाएँ"
@@ -4894,25 +4894,25 @@ msgid "Delete Portal"
 msgstr "पोर्टल हटाएं"
 
 msgid "Delete Price Break"
-msgstr "मूल्य ब्रेक हटाएं"
+msgstr "मूल्य स्तर हटाएँ"
 
 msgid "Delete Pricing Rule"
 msgstr "मूल्य निर्धारण नियम हटाएं"
 
 msgid "Delete Procedure"
-msgstr "प्रक्रिया हटाएं"
+msgstr "कार्यविधि हटाएँ"
 
 msgid "Delete Process"
 msgstr "प्रक्रिया हटाएं"
 
 msgid "Delete Purchase Invoice"
-msgstr "खरीद चालान हटाएं"
+msgstr "क्रय चालान हटाएँ"
 
 msgid "Delete Purchase Order"
 msgstr "क्रय आदेश हटाएं"
 
 msgid "Delete Purchase Orders"
-msgstr "खरीद आदेश हटाएं"
+msgstr "क्रय आदेशों को हटाएँ"
 
 msgid "Delete Question"
 msgstr "प्रश्न हटाएं"
@@ -4945,10 +4945,10 @@ msgid "Delete Rule"
 msgstr "नियम हटाएं"
 
 msgid "Delete Sales Invoice"
-msgstr "बिक्रय चालान हटाएं"
+msgstr "विक्रय चालान हटाएँ"
 
 msgid "Delete Sales Order"
-msgstr "बिक्रय आदेश हटाएं"
+msgstr "विक्रय आदेश हटाएँ"
 
 msgid "Delete Schedule"
 msgstr "शेड्यूल हटाएं"
@@ -4963,7 +4963,7 @@ msgid "Delete Shipment"
 msgstr "शिपमेंट हटाएं"
 
 msgid "Delete shipment line"
-msgstr "शिपमेंट लाइन हटाएं"
+msgstr "शिपमेंट पंक्ति हटाएँ"
 
 msgid "Delete Shipping Method"
 msgstr "शिपिंग विधि हटाएं"
@@ -4972,7 +4972,7 @@ msgid "Delete step"
 msgstr "चरण हटाएं"
 
 msgid "Delete Step"
-msgstr "स्टेप हटाएं"
+msgstr "चरण हटाएँ"
 
 msgid "Delete Stock Transfer"
 msgstr "स्टॉक ट्रांसफर हटाएं"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "स्टोरेज प्रकार हटाएं"
 
 msgid "Delete Storage Unit"
-msgstr "स्टोरेज यूनिट हटाएं"
+msgstr "भंडारण इकाई हटाएँ"
 
 msgid "Delete Substance"
 msgstr "पदार्थ हटाएं"
@@ -4996,14 +4996,14 @@ msgid "Delete Supplier"
 msgstr "आपूर्तिकर्ता हटाएं"
 
 msgid "Delete Supplier Quote"
-msgstr "आपूर्तिकर्ता उद्धरण हटाएं"
+msgstr "आपूर्तिकर्ता कोटेशन हटाएँ"
 
 msgid "Delete Supplier Type"
 msgstr "आपूर्तिकर्ता प्रकार हटाएं"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "मात्रा {0} के लिए मूल्य ब्रेक हटाएं? इसे पूर्ववत नहीं किया जा सकता।"
+msgstr "मात्रा {0} के लिए मूल्य स्तर हटाएँ? यह पूर्ववत नहीं किया जा सकता।"
 
 msgid "Delete Timecard"
 msgstr "टाइमकार्ड हटाएं"
@@ -5018,7 +5018,7 @@ msgid "Delete Transfer"
 msgstr "स्थानांतरण हटाएं"
 
 msgid "Delete Transfer Line"
-msgstr "स्थानांतरण लाइन हटाएं"
+msgstr "स्थानांतरण पंक्ति हटाएँ"
 
 msgid "Delete Type"
 msgstr "प्रकार हटाएं"
@@ -5042,7 +5042,7 @@ msgid "Delete Workflow"
 msgstr "वर्कफ़्लो हटाएँ"
 
 msgid "Delivery Date"
-msgstr "डिलीवरी तारीख"
+msgstr "डिलीवरी तिथि"
 
 msgid "Delivery Location"
 msgstr "डिलीवरी स्थान"
@@ -5060,7 +5060,7 @@ msgid "Demand Forecast — Driven by"
 msgstr "मांग पूर्वानुमान — द्वारा संचालित"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "मांग पूर्वानुमान = खुले बिक्रय आदेशों, सक्रिय कार्यों और उत्पादन प्रक्षेपणों से BOM-विस्फोटित मांग।"
+msgstr "मांग पूर्वानुमान = खुले विक्रय आदेश, प्रगति में जॉब, और उत्पादन प्रक्षेपण से BOM-विस्फोटित मांग।"
 
 msgid "Demand projection"
 msgstr "मांग प्रक्षेपण"
@@ -5117,13 +5117,13 @@ msgid "Depreciation Method (default)"
 msgstr "मूल्यह्रास विधि (डिफ़ॉल्ट)"
 
 msgid "Depreciation reversal when a fixed asset is disposed"
-msgstr "जब एक निश्चित संपत्ति का निपटान किया जाता है तो मूल्यह्रास उलट"
+msgstr "जब अचल संपत्ति निपटाई जाती है तो मूल्यह्रास का उलट"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
 msgstr "इस अवधि में समाप्त होने वाले मूल्यह्रास चलान जो अभी भी ड्राफ्ट हैं, पोस्ट किए जाने चाहिए ताकि अवधि सही मूल्यह्रास व्यय और संचित मूल्यह्रास को दर्शाए। यदि इस अवधि में मूल्यह्रास लागू नहीं होता है तो एक कारण के साथ छोड़ दें।"
 
 msgid "Depreciation Start Date"
-msgstr "मूल्यह्रास शुरुआत की तारीख"
+msgstr "मूल्यह्रास प्रारंभ तिथि"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
 msgstr "इस आइटम की शेल्फ लाइफ को इसके घटकों की सबसे कम शेल्फ लाइफ से निकालें, ऊपर दिए गए डेज़ फील्ड को अनदेखा करते हुए।"
@@ -5180,7 +5180,7 @@ msgid "Dimension slots"
 msgstr "आयाम स्लॉट"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "पोस्ट की गई पत्रिकाओं पर आयाम मान जिनके पास अभी तक कोई प्रदाता मैपिंग नहीं है।"
+msgstr "पोस्ट किए गए जर्नल पर आयाम मान जिनके पास अभी तक कोई प्रदाता मैपिंग नहीं है।"
 
 msgid "dimensions"
 msgstr "आयाम"
@@ -5247,16 +5247,16 @@ msgid "Dismiss"
 msgstr "खारिज करें"
 
 msgid "Dispatch"
-msgstr "डिस्पैच"
+msgstr "रखरखाव कार्य"
 
 msgid "Dispatch ID"
-msgstr "डिस्पैच आईडी"
+msgstr "रखरखाव कार्य ID"
 
 msgid "Dispatch priority"
-msgstr "डिस्पैच प्राथमिकता"
+msgstr "रखरखाव कार्य की प्राथमिकता"
 
 msgid "Dispatches"
-msgstr "प्रेषण"
+msgstr "रखरखाव कार्य"
 
 msgid "Display Settings"
 msgstr "प्रदर्शन सेटिंग्स"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "दस्तावेज़"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "दस्तावेज़ चालान, बिल और भुगतान को मूल प्रदाता दस्तावेज़ के रूप में धकेलता है; उनकी पत्रिकाओं को दस्तावेज़ द्वारा कवर किए गए के रूप में दर्ज किया जाता है। यह प्रदाता में दर्ज भुगतान को वापस Carbon में खींचता है, मिलान वाले चालान या बिल को बंद करता है और एक Carbon GL पत्रिका पोस्ट करता है। बंद उन्हें जानबूझकर बाहर रखे गए के रूप में दर्ज करता है।"
+msgstr "दस्तावेज़ प्रणाली चालान, बिल और भुगतान को मूल प्रदाता दस्तावेज़ के रूप में भेजती है; उनकी जर्नल को दस्तावेज़ द्वारा कवर के रूप में दर्ज किया जाता है। यह प्रदाता में दर्ज भुगतान को कार्बन में वापस भी खींचता है, मिलान करने वाले चालान या बिल को बंद करता है और कार्बन GL जर्नल पोस्ट करता है। बंद उन्हें जानबूझकर बाहर रखे गए के रूप में दर्ज करता है।"
 
 msgid "Documents you open will show up here for quick access."
 msgstr "जो दस्तावेज़ आप खोलेंगे वह तेज़ पहुंच के लिए यहां दिखाई देंगे।"
@@ -5322,13 +5322,13 @@ msgid "Don't Cancel"
 msgstr "रद्द न करें"
 
 msgid "done"
-msgstr "पूर्ण"
+msgstr "हो गया"
 
 msgid "Done"
-msgstr "पूर्ण"
+msgstr "हो गया"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "दिन-प्रतिदिन की कार्यप्रणाली बिना हमारे कमरे में चले तो पूरी हो जाएगी"
+msgstr "दिन-प्रतिदिन हमारे बिना कमरे में चले तब हो गया"
 
 msgid "Download"
 msgstr "डाउनलोड करें"
@@ -5365,7 +5365,7 @@ msgid "Drag & drop files, or click to browse"
 msgstr "फ़ाइलों को ड्रैग और ड्रॉप करें, या ब्राउज़ करने के लिए क्लिक करें"
 
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
-msgstr "यहाँ एक खरीद आदेश PDF को ड्रैग और ड्रॉप करें, या एक फ़ाइल चुनने के लिए क्लिक करें"
+msgstr "एक क्रय आदेश PDF को यहाँ खींचें और छोड़ें, या एक फ़ाइल चुनने के लिए क्लिक करें"
 
 msgid "Drag handle"
 msgstr "ड्रैग हैंडल"
@@ -5417,25 +5417,25 @@ msgid "Due {0}"
 msgstr "Due {0}"
 
 msgid "Due date"
-msgstr "देय तारीख"
+msgstr "नियत तिथि"
 
 msgid "Due Date"
-msgstr "देय तारीख"
+msgstr "नियत तिथि"
 
 msgid "Due Date (job)"
-msgstr "देय तारीख (नौकरी)"
+msgstr "नियत तिथि (जॉब)"
 
 msgid "Due Date of First Job"
-msgstr "पहली जॉब की देय तारीख"
+msgstr "प्रथम जॉब की नियत तिथि"
 
 msgid "Due Date of Last Job"
-msgstr "अंतिम जॉब की देय तारीख"
+msgstr "अंतिम जॉब की नियत तिथि"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "बल्क बैच में सबसे पहली नौकरी की देय तारीख; बाद की नौकरियां इस तारीख और अंतिम नौकरी की देय तारीख के बीच समान रूप से दूरी पर होती हैं।"
+msgstr "बल्क बैच में सबसे पहली जॉब की नियत तिथि; बाद की जॉब को इस तिथि और अंतिम जॉब की नियत तिथि के बीच समान अंतराल पर रखा जाता है।"
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "बल्क बैच में अंतिम नौकरी की देय तारीख; नौकरियों को समान रूप से दूरी देने के लिए पहली नौकरी की देय तारीख के साथ मिलाया जाता है।"
+msgstr "बल्क बैच में अंतिम जॉब की नियत तिथि; पहली जॉब की नियत तिथि के साथ जॉब को समान रूप से रखने के लिए संयुक्त किया जाता है।"
 
 msgid "Due Days"
 msgstr "देय दिन"
@@ -5444,13 +5444,13 @@ msgid "Due Days after {selectedCalculationMethod}"
 msgstr "{selectedCalculationMethod} के बाद देय दिन"
 
 msgid "Duplicate"
-msgstr "डुप्लिकेट"
+msgstr "डुप्लिकेट करें"
 
 msgid "Duplicate Item"
-msgstr "डुप्लिकेट आइटम"
+msgstr "आइटम डुप्लिकेट करें"
 
 msgid "Duplicate Price List"
-msgstr "डुप्लिकेट प्राइस लिस्ट"
+msgstr "मूल्य सूची डुप्लिकेट करें"
 
 msgid "Duplicate Pricing Rule"
 msgstr "मूल्य निर्धारण नियम डुप्लिकेट करें"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "उदाहरण के लिए Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "प्रत्येक ऑपरेशन की अप्रयुक्त सामग्री ऑपरेशन पूरी होते ही वापस आती है।"
+msgstr "प्रत्येक ऑपरेशन की अप्रयुक्त सामग्री जैसे ही ऑपरेशन हो जाता है तुरंत वापस आती है।"
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "प्रत्येक भौतिक इकाई को अपनी खुद की ट्रैक की गई इकाई और अद्वितीय संख्या मिलती है — एक इकाई, एक इकाई।"
@@ -5534,7 +5534,7 @@ msgid "Easier to extend"
 msgstr "विस्तार करना आसान"
 
 msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
-msgstr "आर्थिक संचालकों पंजीकरण और पहचान संख्या; EU/UK में सीमा शुल्क सीमाओं को पार करने वाली वस्तुओं के लिए आवश्यक।"
+msgstr "आर्थिक ऑपरेटर पंजीकरण और पहचान संख्या; EU / UK में सीमा शुल्क सीमाओं को पार करने वाले सामानों के लिए आवश्यक।"
 
 msgid "Edit"
 msgstr "संपादित करें"
@@ -5549,7 +5549,7 @@ msgid "Edit Action"
 msgstr "कार्रवाई संपादित करें"
 
 msgid "Edit API Key"
-msgstr "API Key संपादित करें"
+msgstr "API कुंजी संपादित करें"
 
 msgid "Edit Approval Rule"
 msgstr "अनुमोदन नियम संपादित करें"
@@ -5558,7 +5558,7 @@ msgid "Edit Asset"
 msgstr "परिसंपत्ति संपादित करें"
 
 msgid "Edit Asset Class"
-msgstr "संपत्ति वर्ग संपादित करें"
+msgstr "परिसंपत्ति वर्ग संपादित करें"
 
 msgid "Edit Assignment"
 msgstr "असाइनमेंट संपादित करें"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "आयाम संपादित करें"
 
 msgid "Edit Dispatch"
-msgstr "डिस्पैच संपादित करें"
+msgstr "रखरखाव कार्य संपादित करें"
 
 msgid "Edit Employee"
 msgstr "कर्मचारी संपादित करें"
@@ -5627,7 +5627,7 @@ msgid "Edit Employee Type"
 msgstr "कर्मचारी प्रकार संपादित करें"
 
 msgid "Edit expiration date"
-msgstr "समाप्ति तारीख संपादित करें"
+msgstr "समाप्ति तिथि संपादित करें"
 
 msgid "Edit Expiry"
 msgstr "समाप्ति तिथि संपादित करें"
@@ -5636,10 +5636,10 @@ msgid "Edit Failure Mode"
 msgstr "विफलता मोड संपादित करें"
 
 msgid "Edit Fixed Asset"
-msgstr "निश्चित संपत्ति संपादित करें"
+msgstr "अचल संपत्ति संपादित करें"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "गेज कैलिब्रेशन रिकॉर्ड संपादित करें"
+msgstr "गेज अंशांकन रिकॉर्ड संपादित करें"
 
 msgid "Edit Gauge Type"
 msgstr "गेज प्रकार संपादित करें"
@@ -5657,10 +5657,10 @@ msgid "Edit Item Group"
 msgstr "आइटम ग्रुप संपादित करें"
 
 msgid "Edit Journal Entry"
-msgstr "पत्रिका प्रविष्टि संपादित करें"
+msgstr "जर्नल प्रविष्टि संपादित करें"
 
 msgid "Edit Kanban"
-msgstr "कनबन संपादित करें"
+msgstr "कानबान संपादित करें"
 
 msgid "Edit Line"
 msgstr "लाइन संपादित करें"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "स्थान संपादित करें"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "रखरखाव डिस्पैच संपादित करें"
+msgstr "रखरखाव कार्य संपादित करें"
 
 msgid "Edit Material"
 msgstr "सामग्री संपादित करें"
@@ -5696,7 +5696,7 @@ msgid "Edit Memo"
 msgstr "मेमो संपादित करें"
 
 msgid "Edit Non Conformance Type"
-msgstr "गैर अनुरूपता प्रकार संपादित करें"
+msgstr "गैर-अनुरूपता प्रकार संपादित करें"
 
 msgid "Edit Part"
 msgstr "भाग संपादित करें"
@@ -5711,10 +5711,10 @@ msgid "Edit Payment"
 msgstr "भुगतान संपादित करें"
 
 msgid "Edit Payment Term"
-msgstr "भुगतान शर्त संपादित करें"
+msgstr "भुगतान शर्तें संपादित करें"
 
 msgid "Edit permissions"
-msgstr "संपादन की अनुमतियाँ"
+msgstr "अनुमतियाँ संपादित करें"
 
 msgid "Edit Permissions"
 msgstr "अनुमतियों को संपादित करें"
@@ -5738,7 +5738,7 @@ msgid "Edit Process"
 msgstr "प्रक्रिया संपादित करें"
 
 msgid "Edit Production Event"
-msgstr "उत्पादन घटना संपादित करें"
+msgstr "उत्पादन इवेंट संपादित करें"
 
 msgid "Edit Production Projection"
 msgstr "उत्पादन प्रक्षेपण संपादित करें"
@@ -5759,7 +5759,7 @@ msgid "Edit Receipt"
 msgstr "रसीद संपादित करें"
 
 msgid "Edit Revision"
-msgstr "संशोधन संपादित करें"
+msgstr "रिवीजन संपादित करें"
 
 msgid "Edit rule"
 msgstr "नियम संपादित करें"
@@ -5798,7 +5798,7 @@ msgid "Edit Size"
 msgstr "आकार संपादित करें"
 
 msgid "Edit Step"
-msgstr "स्टेप संपादित करें"
+msgstr "चरण संपादित करें"
 
 msgid "Edit Stock Transfer"
 msgstr "स्टॉक ट्रांसफर संपादित करें"
@@ -5807,7 +5807,7 @@ msgid "Edit Storage Type"
 msgstr "स्टोरेज प्रकार संपादित करें"
 
 msgid "Edit Storage Unit"
-msgstr "स्टोरेज यूनिट संपादित करें"
+msgstr "भंडारण इकाई संपादित करें"
 
 msgid "Edit Substance"
 msgstr "पदार्थ संपादित करें"
@@ -5825,7 +5825,7 @@ msgid "Edit Supplier Type"
 msgstr "आपूर्तिकर्ता प्रकार संपादित करें"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "नियम को संपादित करें \"सभी पर लागू करें\" फ़्लैग को हटाने के लिए"
+msgstr "\"सभी पर लागू\" फ़्लैग को निकालने के लिए नियम संपादित करें"
 
 msgid "Edit Timecard"
 msgstr "टाइमकार्ड संपादित करें"
@@ -5840,7 +5840,7 @@ msgid "Edit Transfer"
 msgstr "ट्रांसफर संपादित करें"
 
 msgid "Edit Transfer Line"
-msgstr "स्थानांतरण लाइन संपादित करें"
+msgstr "स्थानांतरण पंक्ति संपादित करें"
 
 msgid "Edit Type"
 msgstr "प्रकार संपादित करें"
@@ -5855,7 +5855,7 @@ msgid "Edit Webhook"
 msgstr "वेबहुक संपादित करें"
 
 msgid "Edit Work Center"
-msgstr "कार्य केंद्र संपादित करें"
+msgstr "वर्क सेंटर संपादित करें"
 
 msgid "Eliminated"
 msgstr "समाप्त किया गया"
@@ -5876,7 +5876,7 @@ msgid "Email Address"
 msgstr "ईमेल पता"
 
 msgid "Email notifications are not included in your company's current plan; email preferences will apply if they are enabled."
-msgstr "ईमेल नोटिफिकेशन आपकी कंपनी की वर्तमान योजना में शामिल नहीं हैं; यदि वे सक्षम हैं तो ईमेल प्राथमिकताएं लागू होंगी।"
+msgstr "ईमेल सूचनाएँ आपकी कंपनी की वर्तमान योजना में शामिल नहीं हैं; ईमेल प्राथमिकताएँ लागू होंगी यदि वे सक्षम हैं।"
 
 msgid "Email notifications not configured"
 msgstr "ईमेल सूचनाएं कॉन्फ़िगर नहीं की गई हैं"
@@ -5918,7 +5918,7 @@ msgid "Empty list"
 msgstr "खाली सूची"
 
 msgid "Empty work centers"
-msgstr "खाली कार्य केंद्र"
+msgstr "खाली वर्क सेंटर"
 
 msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "अपने डेटा में परिवर्तनों को ट्रैक करना शुरू करने के लिए सेटिंग्स में ऑडिट लॉगिंग सक्षम करें।"
@@ -5933,7 +5933,7 @@ msgid "Enable in Settings"
 msgstr "सेटिंग्स में सक्षम करें"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "जब कोई RFQ उद्धरण के लिए तैयार के रूप में चिह्नित किया जाता है तो सूचनाएं सक्षम करें।"
+msgstr "जब RFQ को कोटेशन के लिए तैयार के रूप में चिह्नित किया जाए तो सूचनाएँ सक्षम करें।"
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
 msgstr "MES टर्मिनल के लिए साझा वर्कस्टेशन मोड सक्षम करें। ऑपरेटर काम करने से पहले PIN के माध्यम से स्वयं की पहचान करते हैं।"
@@ -5951,16 +5951,16 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "सामान्य खाता बही में लेनदेन को स्वचालित रूप से पोस्ट करने के लिए सक्षम करें।"
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "कर-विशिष्ट मूल्यह्रास विधियों को संपत्ति वर्गों पर कॉन्फ़िगर करने के लिए सक्षम करें (उदाहरण के लिए, MACRS, त्वरित)।"
+msgstr "परिसंपत्ति वर्गों पर कर-विशिष्ट मूल्यह्रास विधियों को कॉन्फ़िगर करने के लिए सक्षम करें (उदा., MACRS, त्वरित)।"
 
 msgid "Enable to generate IDs and descriptions for raw materials."
-msgstr "कच्चे माल के लिए आईडी और विवरण उत्पन्न करने के लिए सक्षम करें।"
+msgstr "कच्चे माल के लिए ID और विवरण उत्पन्न करने के लिए सक्षम करें।"
 
 msgid "Enable to start tracking changes to your data."
 msgstr "अपने डेटा में परिवर्तन ट्रैक करना शुरू करने के लिए सक्षम करें।"
 
 msgid "Enable to start tracking work shifts."
-msgstr "कार्य पारियों को ट्रैक करना शुरू करने के लिए सक्षम करें।"
+msgstr "कार्य शिफ्ट को ट्रैक करना शुरू करने के लिए सक्षम करें।"
 
 msgid "Enable to use metric units for material dimensions."
 msgstr "सामग्री आयामों के लिए मीट्रिक इकाइयों का उपयोग करने के लिए सक्षम करें।"
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "नामांकन करें"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "समाप्ति तारीख सेट करने से पहले एक बैच नंबर दर्ज करें"
+msgstr "समाप्ति तिथि सेट करने से पहले बैच संख्या दर्ज करें"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "1 और {0} के बीच मात्रा दर्ज करें।"
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "विक्रेता बिलों को PO के विरुद्ध दर्ज करें और अनुमोदित करें (तीन-तरफा मिलान)"
+msgstr "PO के विरुद्ध विक्रेता बिलों को दर्ज करें और अनुमोदित करें (थ्री-वे मिलान)"
 
 msgid "Enter number…"
 msgstr "संख्या दर्ज करें…"
@@ -6091,7 +6091,7 @@ msgid "Equity account for accumulated profits or losses"
 msgstr "संचित लाभ या हानि के लिए इक्विटी खाता"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "मुद्रा अनुवाद समायोजन (CTA) के लिए इक्विटी खाता"
+msgstr "मुद्रा रूपांतरण समायोजन के लिए इक्विटी खाता (CTA)"
 
 msgid "Error"
 msgstr "त्रुटि"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "आपूर्तिकर्ता डेटा प्राप्त करने में त्रुटि"
 
 msgid "Error loading assigned dispatches"
-msgstr "असाइन किए गए डिस्पैच लोड करने में त्रुटि"
+msgstr "असाइन किए गए रखरखाव कार्य लोड करने में त्रुटि"
 
 msgid "Error loading assigned documents"
 msgstr "असाइन किए गए दस्तावेज़ लोड करने में त्रुटि"
@@ -6121,7 +6121,7 @@ msgid "Error loading job tree."
 msgstr "जॉब ट्री लोड करने में त्रुटि।"
 
 msgid "Error loading make method"
-msgstr "मेक विधि लोड करने में त्रुटि"
+msgstr "निर्माण विधि लोड करने में त्रुटि"
 
 msgid "Error moving file"
 msgstr "फ़ाइल स्थानांतरित करने में त्रुटि"
@@ -6139,16 +6139,16 @@ msgid "Error removing model from job"
 msgstr "जॉब से मॉडल हटाने में त्रुटि"
 
 msgid "Error removing model from quote line"
-msgstr "उद्धरण पंक्ति से मॉडल हटाने में त्रुटि"
+msgstr "कोटेशन पंक्ति से मॉडल निकालने में त्रुटि"
 
 msgid "Error removing model from RFQ line"
 msgstr "RFQ लाइन से मॉडल हटाने में त्रुटि"
 
 msgid "Error removing model from sales invoice line"
-msgstr "बिक्री चालान लाइन से मॉडल हटाने में त्रुटि"
+msgstr "विक्रय चालान पंक्ति से मॉडल निकालने में त्रुटि"
 
 msgid "Error removing model from sales order line"
-msgstr "बिक्रय आदेश लाइन से मॉडल हटाने में त्रुटि"
+msgstr "विक्रय आदेश पंक्ति से मॉडल निकालने में त्रुटि"
 
 msgid "Escalate to the project leads"
 msgstr "परियोजना नेताओं को बढ़ाएं"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "हर मेल"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "अवधि बंद करने से पहले प्रत्येक आवश्यक कार्य को पूर्ण या छोड़ा जाना चाहिए।"
+msgstr "अवधि को बंद करने से पहले प्रत्येक आवश्यक कार्य को हो गया या छोड़ा गया होना चाहिए।"
 
 msgid "Every row was imported successfully."
 msgstr "हर पंक्ति सफलतापूर्वक आयात की गई।"
@@ -6211,10 +6211,10 @@ msgid "Everything else"
 msgstr "बाकी सब कुछ"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "बाकी सब कुछ लोगों, आयातों, एकीकरण और API को कवर करता है — कुछ भी जो आपके वर्कफ़्लो में से एक नहीं है।"
+msgstr "बाकी सब कुछ लोग, आयात, एकीकरण और API को कवर करता है — कुछ भी जो आपके वर्कफ़्लो में से एक नहीं है।"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MB से अधिक है — भेजने के लिए कुछ अटैचमेंट हटाएं।"
+msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MB कुल से अधिक है — भेजने के लिए कुछ अनुलग्नक निकालें।"
 
 msgid "Exchange rate"
 msgstr "विनिमय दर"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "मौजूदा मैपिंग। पुनः-मैप करने के लिए एक अलग प्रदाता विकल्प चुनें।"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "मौजूदा Stripe ग्राहक"
 
 msgid "Expand"
 msgstr "विस्तार करें"
@@ -6281,7 +6281,7 @@ msgid "Expand subtree"
 msgstr "सबट्री को विस्तृत करें"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "एक निर्माण भाग के लिए अपेक्षित भविष्य की मांग सप्ताह दर सप्ताह किसी भी बिक्री आदेश के अस्तित्व से पहले; योजना इसे आपूर्ति के विरुद्ध शुद्ध करती है और घटकों को आदेश देने के लिए विधि को विस्फोट करती है।"
+msgstr "एक निर्माण पार्ट के लिए अपेक्षित भविष्य मांग को किसी भी विक्रय आदेश के मौजूद होने से पहले सप्ताह दर सप्ताह दर्ज किया जाता है; योजना इसे आपूर्ति के विरुद्ध नेट करती है और घटकों को आगे के लिए आदेश देने के लिए विधि को विस्तृत करती है।"
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
 msgstr "किसी वस्तु के लिए अपेक्षित भविष्य की मांग, अवधि द्वारा बकेटेड, वास्तविक मांग के साथ योजना चलाने द्वारा भरी हुई।"
@@ -6293,10 +6293,10 @@ msgid "Expected Receipt Date"
 msgstr "अपेक्षित प्राप्ति तारीख"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "AR निपटान पर अनिर्धारणीय के रूप में लिखे गए ग्राहक शेष के लिए व्यय खाता"
+msgstr "ग्राहक शेष राशि के लिए व्यय खाता जो प्राप्य खाते समझौते पर अनिर्धारक के रूप में लिखा गया है"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
-msgstr "मूल्यह्रास पर स्थगित कर समायोजन के लिए व्यय खाता"
+msgstr "मूल्यह्रास पर आस्थगित कर समायोजन के लिए व्यय खाता"
 
 msgid "Expense account for equipment and facility maintenance"
 msgstr "उपकरण और सुविधा रखरखाव के लिए व्यय खाता"
@@ -6308,28 +6308,28 @@ msgid "Expense account for non-inventory purchases (services, supplies)"
 msgstr "गैर-इन्वेंटरी खरीद (सेवाएं, आपूर्ति) के लिए व्यय खाता"
 
 msgid "Expense account for the cost of items sold"
-msgstr "व्यय GL खाता जब इन्वेंटरी बिक्री के विरुद्ध भेजी/जारी की जाती है तो डेबिट किया जाता है।"
+msgstr "बेचे गए आइटम की लागत के लिए व्यय खाता"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "स्थगित कर आंदोलन का व्यय पक्ष (स्थगित कर देयता के साथ युग्मित)।"
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "संपत्ति वर्ग बनाने में विफल: {0}"
+msgstr "आस्थगित कर आंदोलनों की व्यय पक्ष (आस्थगित कर दायित्व के साथ जोड़ी गई)।"
 
 msgid "Expenses"
-msgstr "खर्च"
+msgstr "व्यय"
 
 msgid "Expert guidance"
 msgstr "विशेषज्ञ मार्गदर्शन"
 
 msgid "Expiration date"
-msgstr "समाप्ति तारीख"
+msgstr "समाप्ति तिथि"
 
 msgid "Expiration Date"
-msgstr "समाप्ति तारीख"
+msgstr "समाप्ति तिथि"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "समाप्ति तारीख (इस लाइन पर सभी सीरीज़ पर लागू होता है)"
+msgstr "समाप्ति तिथि (इस पंक्ति के सभी सीरीज़ पर लागू होता है)"
 
 msgid "Expired"
 msgstr "समाप्त"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "अनुरोध के साथ भेजी गई अतिरिक्त जानकारी, जैसे कि एक प्राधिकरण कुंजी; हेडर मान चलाने के इतिहास में छिपे हुए हैं, हालांकि नाम पठनीय रहते हैं।"
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "आपकी GL रिपोर्टिंग को स्लाइस करने के लिए अतिरिक्त टैग"
+msgstr "आपकी सामान्य खाता बही रिपोर्टिंग को स्लाइस करने के लिए अतिरिक्त टैग"
 
 msgid "Fail"
-msgstr "विफल"
+msgstr "अनुत्तीर्ण"
 
 msgid "Failed"
 msgstr "विफल"
@@ -6432,11 +6432,11 @@ msgstr "विफल विशेषताएँ"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (पहले समाप्त होने वाले को पहले बाहर करना)"
+msgstr "परिसंपत्ति वर्ग बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
-msgstr "उपभोग्य बनाने में विफल: {0}"
+msgstr "उपभोग्य सामग्री बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create cost center: {0}"
@@ -6464,7 +6464,7 @@ msgstr "विभाग बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create failure mode: {0}"
-msgstr "विफल रहा विफलता मोड बनाने में: {0}"
+msgstr "विफलता मोड बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
@@ -6472,7 +6472,7 @@ msgstr "गेज प्रकार बनाने में विफल: {0}
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
-msgstr "आइटम ग्रुप बनाने में विफल: {0}"
+msgstr "आइटम समूह बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create location: {0}"
@@ -6492,7 +6492,7 @@ msgstr "सामग्री फिनिश बनाने में वि�
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
-msgstr "सामग्री फॉर्म बनाने में विफल: {0}"
+msgstr "सामग्री रूप बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
@@ -6512,15 +6512,15 @@ msgstr "सामग्री बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "कोई उद्धरण कारण बनाने में विफल: {0}"
+msgstr "कोई कोटेशन नहीं कारण बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
-msgstr "भाग बनाने में विफल: {0}"
+msgstr "पार्ट बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "भुगतान शर्त बनाने में विफल: {0}"
+msgstr "भुगतान शर्तें बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6536,11 +6536,11 @@ msgstr "शिपिंग विधि बनाने में विफल: 
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "स्टॉक ट्रांसफर लाइन बनाने में विफल: {0}"
+msgstr "स्टॉक स्थानांतरण पंक्ति बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
-msgstr "भंडारण प्रकार बनाने में विफल: {0}"
+msgstr "स्टोरेज प्रकार बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create supplier: {0}"
@@ -6556,10 +6556,10 @@ msgstr "वेबहुक बनाने में विफल: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
-msgstr "कार्य केंद्र बनाने में विफल: {0}"
+msgstr "वर्क सेंटर बनाने में विफल: {0}"
 
 msgid "Failed to delete file from old location"
-msgstr "पुरानी स्थान से फ़ाइल हटाने में विफल"
+msgstr "पुराने स्थान से फ़ाइल हटाने में विफल"
 
 msgid "Failed to download file for moving"
 msgstr "स्थानांतरण के लिए फ़ाइल डाउनलोड करने में विफल"
@@ -6583,10 +6583,10 @@ msgid "Failed to initialize Carbon client"
 msgstr "Carbon क्लाइंट को इनिशियलाइज़ करने में विफल"
 
 msgid "Failed to insert quote line"
-msgstr "उद्धरण पंक्ति सम्मिलित करने में विफल"
+msgstr "कोटेशन पंक्ति जोड़ने में विफल"
 
 msgid "Failed to insert supplier quote line"
-msgstr "आपूर्तिकर्ता उद्धरण लाइन सम्मिलित करने में विफल"
+msgstr "आपूर्तिकर्ता कोटेशन पंक्ति जोड़ने में विफल"
 
 msgid "Failed to load configuration parameters"
 msgstr "कॉन्फ़िगरेशन पैरामीटर लोड करने में विफल"
@@ -6610,13 +6610,13 @@ msgid "Failed to load job operations"
 msgstr "जॉब ऑपरेशन लोड करने में विफल"
 
 msgid "Failed to load jobs"
-msgstr "नौकरियां लोड करने में विफल"
+msgstr "जॉब लोड करने में विफल"
 
 msgid "Failed to load purchase order lines"
 msgstr "क्रय आदेश लाइनें लोड करने में विफल"
 
 msgid "Failed to load purchase orders"
-msgstr "खरीद आदेश लोड करने में विफल"
+msgstr "क्रय आदेश लोड करने में विफल"
 
 msgid "Failed to load receipt lines"
 msgstr "रसीद लाइनें लोड करने में विफल"
@@ -6625,13 +6625,13 @@ msgid "Failed to load receipts"
 msgstr "रसीदें लोड करने में विफल"
 
 msgid "Failed to load sales order lines"
-msgstr "बिक्रय आदेश लाइनें लोड करने में विफल"
+msgstr "विक्रय आदेश पंक्ति लोड करने में विफल"
 
 msgid "Failed to load sales orders"
-msgstr "बिक्रय आदेश लोड करने में विफल"
+msgstr "विक्रय आदेश लोड करने में विफल"
 
 msgid "Failed to load shipment lines"
-msgstr "शिपमेंट लाइनें लोड करने में विफल"
+msgstr "शिपमेंट पंक्ति लोड करने में विफल"
 
 msgid "Failed to load shipments"
 msgstr "शिपमेंट लोड करने में विफल"
@@ -6653,16 +6653,16 @@ msgid "Failed to register passkey"
 msgstr "पासकी को पंजीकृत करने में विफल"
 
 msgid "Failed to remove image: {errorMessage}"
-msgstr "छवि हटाने में विफल: {errorMessage}"
+msgstr "छवि निकालने में विफल: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "मॉडल थंबनेल हटाने में विफल"
+msgstr "मॉडल थंबनेल निकालने में विफल"
 
 msgid "Failed to remove purchase order"
-msgstr "खरीद आदेश हटाने में विफल"
+msgstr "क्रय आदेश निकालने में विफल"
 
 msgid "Failed to remove thumbnail"
-msgstr "थंबनेल हटाने में विफल"
+msgstr "थंबनेल निकालने में विफल"
 
 msgid "Failed to resize image"
 msgstr "छवि को पुनः आकार देने में विफल"
@@ -6683,7 +6683,7 @@ msgid "Failed to save measurement"
 msgstr "माप को सहेजने में विफल"
 
 msgid "Failed to save parts"
-msgstr "पुर्जों को सहेजने में विफल"
+msgstr "पार्ट्स सहेजने में विफल"
 
 msgid "Failed to save result"
 msgstr "परिणाम को सहेजने में विफल रहा"
@@ -6695,35 +6695,35 @@ msgid "Failed to save tools"
 msgstr "उपकरणों को सहेजने में विफल"
 
 msgid "Failed to update batch property"
-msgstr "बैच प्रॉपर्टी अपडेट करने में विफल"
+msgstr "बैच गुण अपडेट करने में विफल"
 
 msgid "Failed to update category markups"
 msgstr "श्रेणी मार्कअप अपडेट करने में विफल"
 
 msgid "Failed to update configuration parameter"
-msgstr "कॉन्फ़िगरेशन पैरामीटर को अपडेट करने में विफल"
+msgstr "कॉन्फ़िगरेशन पैरामीटर अपडेट करने में विफल"
 
 msgid "Failed to update count"
-msgstr "गिनती अपडेट करने में विफल"
+msgstr "गणना अपडेट करने में विफल"
 
 msgid "Failed to update item cost"
 msgstr "आइटम लागत अपडेट करने में विफल"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "क्रय आदेश के साथ अवसर को अपडेट करने में विफल"
+msgstr "क्रय आदेश के साथ अवसर अपडेट करने में विफल"
 
 msgid "Failed to update quote line"
-msgstr "उद्धरण पंक्ति को अपडेट करने में विफल"
+msgstr "कोटेशन पंक्ति अपडेट करने में विफल"
 
 msgid "Failed to update supplier quote line"
-msgstr "आपूर्तिकर्ता उद्धरण लाइन को अपडेट करने में विफल"
+msgstr "आपूर्तिकर्ता कोटेशन पंक्ति अपडेट करने में विफल"
 
 msgid "Failed to update thumbnail path"
 msgstr "थंबनेल पथ अपडेट करने में विफल"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
-msgstr "अपलोड करने में विफल {0}"
+msgstr "{0} अपलोड करने में विफल"
 
 msgid "Failed to upload certificate"
 msgstr "प्रमाणपत्र अपलोड करने में विफल"
@@ -6735,7 +6735,7 @@ msgid "Failed to upload file"
 msgstr "फ़ाइल अपलोड करने में विफल"
 
 msgid "Failed to upload file to new location"
-msgstr "नई स्थिति में फ़ाइल अपलोड करने में विफल"
+msgstr "फ़ाइल को नए स्थान में अपलोड करने में विफल"
 
 #. placeholder {0}: file.name
 #. placeholder {0}: fileUpload.name
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "शुल्क"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "फिनिश"
+msgstr "FEFO (प्रथम समाप्ति प्रथम निकली)"
 
 msgid "Fetch"
 msgstr "लाएं"
@@ -6835,7 +6835,7 @@ msgid "Files"
 msgstr "फ़ाइलें"
 
 msgid "Files attached here ride along on every purchase order email by default. Suppliers will receive them alongside the PO PDF."
-msgstr "यहां संलग्न की गई फाइलें डिफ़ॉल्ट रूप से हर खरीद आदेश ईमेल के साथ जाती हैं। आपूर्तिकर्ताओं को उन्हें PO PDF के साथ प्राप्त होगा।"
+msgstr "यहां संलग्न फाइलें डिफ़ॉल्ट रूप से हर क्रय आदेश ईमेल के साथ भेजी जाती हैं। आपूर्तिकर्ताओं को उन्हें PO PDF के साथ प्राप्त होगा।"
 
 msgid "Files attached here ride along on every purchase order email sent to this supplier (in addition to company-wide defaults)."
 msgstr "यहां संलग्न की गई फाइलें इस आपूर्तिकर्ता को भेजे गए प्रत्येक क्रय आदेश ईमेल के साथ जाती हैं (कंपनी-व्यापी डिफ़ॉल्ट के अतिरिक्त)।"
@@ -6844,13 +6844,13 @@ msgid "Fill this company with a realistic industry story so every screen has som
 msgstr "इस कंपनी को एक यथार्थवादी उद्योग की कहानी से भरें ताकि हर स्क्रीन में कुछ न कुछ हो। आप पहले जो यहां था उसे वापस डाल सकते हैं।"
 
 msgid "Filter"
-msgstr "फ़िल्टर"
+msgstr "फ़िल्टर करें"
 
 msgid "Finalize"
 msgstr "अंतिम रूप दें"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "खुली → लॉक की गई → बंद जीवनचक्र के माध्यम से एक वित्तीय माह को अंतिम रूप देना; एक बंद अवधि जमी हुई है और इसके संतुलन को स्नैपशॉट किया गया है, केवल स्पष्ट पुनः खुलने से उलटा है।"
+msgstr "एक वित्तीय महीने को खुला → लॉक → बंद जीवनचक्र के माध्यम से अंतिम रूप देना; एक बंद अवधि जमी हुई है और इसकी शेष राशि स्नैपशॉट की गई है, केवल स्पष्ट पुनः खोलने द्वारा प्रतिवर्ती है।"
 
 msgid "Financial Statements"
 msgstr "वित्तीय विवरण"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "सामग्री अनचुनी के साथ समाप्त करें?"
 
 msgid "Finished goods"
-msgstr "फिनिशें"
+msgstr "तैयार माल"
 
 msgid "Finished Goods"
 msgstr "तैयार माल"
@@ -6928,16 +6928,16 @@ msgid "Fixed"
 msgstr "निश्चित"
 
 msgid "Fixed asset"
-msgstr "जब बैच आकार मानक से अलग हो तो निश्चित लागत परिशोधन विचरण"
+msgstr "अचल संपत्ति"
 
 msgid "Fixed Asset"
-msgstr "स्थिर संपत्ति"
+msgstr "अचल संपत्ति"
 
 msgid "Fixed Assets"
-msgstr "स्थिर संपत्ति"
+msgstr "अचल संपत्तियाँ"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "लाभ और हानि"
+msgstr "निर्धारित लागत परिशोधन विचलन जब बैच आकार सामान्य से भिन्न हो"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "एक बार लेखा अवधियों को पोस्ट किया जाने या बंद किए जाने के बाद निर्धारित। इसे बदलने के लिए सभी खुली अवधियों को हटाएँ।"
@@ -6946,7 +6946,7 @@ msgid "Fixed Reorder"
 msgstr "निश्चित पुनः ऑर्डर"
 
 msgid "Fixed Shelf Life"
-msgstr "निश्चित शेल्फ जीवन"
+msgstr "निर्धारित शेल्फ लाइफ"
 
 msgid "Fixture"
 msgstr "फिक्सचर"
@@ -6962,16 +6962,16 @@ msgstr "किसी भी चीज़ के लिए। वे सही �
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "पूर्वानुमान विधि: <0>{0}</0>. यह पंक्ति सक्रिय कार्यों से प्राप्त नहीं की गई थी, इसलिए कोई मूल स्रोत उपलब्ध नहीं हैं।"
+msgstr "पूर्वानुमान विधि: <0>{0}</0>। यह पंक्ति कार्यरत जॉब से व्युत्पन्न नहीं की गई थी, इसलिए कोई मूल स्रोत उपलब्ध नहीं है।"
 
 msgid "Forgot to Clock Out?"
-msgstr "क्या आप क्लॉक आउट करना भूल गए?"
+msgstr "कार्य समाप्त करना भूल गए?"
 
 msgid "Format"
 msgstr "प्रारूप"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "अग्रपंक्ति में तैनात इंजीनियर"
 
 msgid "Foundation"
 msgstr "आधार"
@@ -6983,10 +6983,10 @@ msgid "Freeze the old system, no new transactions"
 msgstr "पुरानी प्रणाली को फ्रीज करें, कोई नया लेनदेन नहीं"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "इस लाइन के लिए ग्राहक को बिल किया जाने वाला माल, लाइन की इकाई कीमत से अलग।"
+msgstr "इस पंक्ति के लिए ग्राहक को बिल किया गया माल भाड़ा, पंक्ति की इकाई मूल्य से अलग।"
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
-msgstr "इस आपूर्तिकर्ता द्वारा इस लाइन के लिए लगाया गया माल, जब वह इकाई कीमत में शामिल करने के बजाय शिपिंग की आइटम बनाता है।"
+msgstr "इस आपूर्तिकर्ता द्वारा इस पंक्ति के लिए चार्ज किया गया माल भाड़ा, जब यह शिपिंग को अलग से सूचीबद्ध करता है बजाय इकाई मूल्य में शामिल करने के।"
 
 msgid "Frequencies"
 msgstr "आवृत्तियाँ"
@@ -7018,19 +7018,19 @@ msgid "from on-account credit"
 msgstr "खाता-पर क्रेडिट से"
 
 msgid "From Storage Unit"
-msgstr "स्टोरेज यूनिट से"
+msgstr "भंडारण इकाई से"
 
 msgid "Fulfillment Location"
-msgstr "पूरा करने का स्थान"
+msgstr "पूर्ति स्थान"
 
 msgid "Full name"
 msgstr "पूरा नाम"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "पूर्ण सेटअप और माइग्रेशन"
 
 msgid "Fully Depreciated"
-msgstr "पूरी तरह से मूल्यह्रास"
+msgstr "पूर्ण मूल्यह्रासित"
 
 msgid "Fully trained for"
 msgstr "पूरी तरह प्रशिक्षित"
@@ -7048,7 +7048,7 @@ msgid "Gain on Disposal Account"
 msgstr "निपटान पर लाभ खाता"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "स्थिर संपत्तियों के निपटान पर मान्यता प्राप्त लाभ"
+msgstr "अचल संपत्तियों के निपटान पर स्वीकृत लाभ"
 
 msgid "gauge"
 msgstr "गेज"
@@ -7057,7 +7057,7 @@ msgid "Gauge"
 msgstr "गेज"
 
 msgid "Gauge Calibration Notifications"
-msgstr "गेज कैलिब्रेशन सूचनाएं"
+msgstr "गेज अंशांकन सूचनाएँ"
 
 msgid "Gauge ID"
 msgstr "गेज आईडी"
@@ -7072,19 +7072,19 @@ msgid "Gauge Types"
 msgstr "गेज प्रकार"
 
 msgid "gauges"
-msgstr "वंशावली"
+msgstr "गेज"
 
 msgid "Gauges"
 msgstr "गेज"
 
 msgid "Genealogy"
-msgstr "सामान्य बहीखाता"
+msgstr "वंशावली"
 
 msgid "General"
 msgstr "सामान्य"
 
 msgid "General ledger"
-msgstr "GL खाता बाहरी प्रसंस्करण संचालन पर लागत अंतर को कैप्चर करता है।"
+msgstr "सामान्य खाता बही"
 
 msgid "General Ledger"
 msgstr "सामान्य खाता बही"
@@ -7126,7 +7126,7 @@ msgid "Generating suggestions…"
 msgstr "सुझाव उत्पन्न जा रहे हैं…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "Carbon पर लाइव जाएं: एक सिस्टम जो कोटिंग, खरीद, शॉप फ्लोर, इन्वेंटरी और वित्त चलाता है, वर्तमान उपकरणों को प्रतिस्थापित करता है।"
+msgstr "Carbon पर लाइव जाएं: एक प्रणाली जो उद्धरण, क्रय, शॉप फ्लोर, इन्वेंटरी और वित्त चला रही है, वर्तमान उपकरणों को प्रतिस्थापित करती है।"
 
 msgid "Get Method"
 msgstr "विधि प्राप्त करें"
@@ -7144,19 +7144,19 @@ msgid "Getting set up"
 msgstr "सेटअप हो रहा है"
 
 msgid "Give it an owner and a date"
-msgstr "इसे एक मालिक और एक तारीख दें"
+msgstr "इसे एक स्वामी और एक तारीख दें"
 
 msgid "GL"
-msgstr "GL"
+msgstr "सामान्य खाता बही"
 
 msgid "GL Account"
 msgstr "जीएल खाता"
 
 msgid "GL account capturing cost differences on outside-processing operations."
-msgstr "GL खाता जो बाह्य-प्रसंस्करण (आउटसोर्स प्रोसेसिंग) संचालन पर लागत अंतर को कैप्चर करता है।"
+msgstr "लेजर खाता बाहरी-प्रसंस्करण संचालन पर लागत अंतर को कैप्चर करता है।"
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "GL खाता लागू और वास्तविक विनिर्माण ओवरहेड के बीच अंतर को कैप्चर करता है।"
+msgstr "लेजर खाता लागू और वास्तविक विनिर्माण उपरिव्यय के बीच अंतर को कैप्चर करता है।"
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "GL खाता BOM-अपेक्षित और वास्तविक सामग्री खपत के बीच अंतर को कैप्चर करता है।"
@@ -7168,25 +7168,25 @@ msgid "GL account capturing fixed-cost differences when actual lot size differs 
 msgstr "GL खाता निश्चित-लागत अंतर को कैप्चर करता है जब वास्तविक लॉट आकार योजना से अलग होता है।"
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "GL खाता इसके निपटान के समय संपत्ति की मूल लागत को हटाने के लिए जमा किया जाता है।"
+msgstr "लेजर खाता संपत्ति की मूल लागत को हटाने के लिए जमा किया जाता है जब इसे निपटाया जाता है।"
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "GL खाता जब एक आपूर्तिकर्ता चालान पोस्ट किया जाता है तो जमा किया जाता है (AP बैलेंस)।"
+msgstr "लेजर खाता जमा किया जाता है जब आपूर्तिकर्ता चालान पोस्ट किया जाता है (देय खाते शेष राशि)।"
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
 msgstr "GL खाता जब श्रम या मशीन लागत एक उत्पादन कार्य में अवशोषित की जाती है तो जमा किया जाता है।"
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
-msgstr "जब विनिर्माण ओवरहेड को एक उत्पादन कार्य में अवशोषित किया जाता है तो GL खाता क्रेडिट किया जाता है।"
+msgstr "लेजर खाता जमा किया जाता है जब विनिर्माण उपरिव्यय एक उत्पादन जॉब में अवशोषित होता है।"
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "GL खाता जब एक संपत्ति का निपटान किया जाता है तो जमा किए गए मूल्यह्रास को साफ करने के लिए डेबिट किया जाता है।"
+msgstr "लेजर खाता डेबिट किया जाता है संचित मूल्यह्रास को साफ करने के लिए जब एक संपत्ति को निपटाया जाता है।"
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
 msgstr "GL खाता जब ग्राहक चालान पोस्ट किया जाता है तो डेबिट किया जाता है; जब ग्राहक भुगतान करता है तो साफ किया जाता है।"
 
 msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
-msgstr "GL खाता जब एक स्थिर संपत्ति प्राप्त की जाती है तो डेबिट किया जाता है (खरीद या पूंजीकृत लागत)।"
+msgstr "लेजर खाता डेबिट किया जाता है जब एक अचल संपत्ति प्राप्त की जाती है (क्रय या पूंजीकृत लागत)।"
 
 msgid "GL account for bank service charges and similar fees."
 msgstr "बैंक सेवा शुल्क और समान शुल्कों के लिए GL खाता।"
@@ -7198,7 +7198,7 @@ msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "आपूर्तिकर्ताओं को भुगतान किया गया खरीद कर के लिए GL खाता (या वसूली योग्य)।"
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "GL खाता रिवर्स चार्ज नियमों के तहत अर्जित कर के लिए जहां खरीदार स्व-मूल्यांकन करता है।"
+msgstr "लेजर खाता रिवर्स-चार्ज नियमों के तहत अर्जित कर के लिए जहां क्रेता स्वयं मूल्यांकन करता है।"
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "कर समय अंतर के लिए GL खाता (जैसे त्वरित कर मूल्यह्रास बनाम पुस्तक मूल्यह्रास)।"
@@ -7207,7 +7207,7 @@ msgid "GL account hit when physical counts differ from system inventory."
 msgstr "GL खाता जो प्रभावित होता है जब भौतिक गणना प्रणाली की इन्वेंटरी से भिन्न होती है।"
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "इस अंतरकंपनी लेनदेन के लिए डेबिट करने के लिए स्रोत कंपनी में GL खाता।"
+msgstr "स्रोत कंपनी में लेजर खाता इस अंतःकंपनी लेनदेन के लिए डेबिट करने के लिए।"
 
 msgid "GL account in the target company to credit for this intercompany transaction."
 msgstr "इस अंतरकंपनी लेनदेन के लिए क्रेडिट करने के लिए लक्ष्य कंपनी में GL खाता।"
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "GL खाता जो संपत्ति की मूल अधिग्रहण लागत वहन करता है — अधिग्रहण पर डेबिट किया जाता है और निपटान या बिक्री होने पर पूर्ण सकल लागत पर क्रेडिट किया जाता है।"
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "GL खाता जो उत्पादन में कार्यों का मान रखता है जब तक वे तैयार माल को पोस्ट नहीं करते।"
+msgstr "लेजर खाता जो उत्पादन में जॉब के मूल्य को धारण करता है जब तक वे तैयार माल में पोस्ट नहीं करते।"
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "GL खाता जो निर्मित माल का मूल्य रखता है (Make आइटम); नौकरी पूरी होने पर डेबिट किया जाता है, शिपमेंट पर क्रेडिट किया जाता है।"
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "GL खाता जहां आपूर्तिकर्ताओं से ली गई जल्दी भुगतान छूट दर्ज की जाती है।"
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "GL विरोधी-संपत्ति खाता जो हर अवधि में मूल्यह्रास पोस्ट होने पर क्रेडिट किया जाता है और संपत्ति बेची या स्क्रैप किए जाने पर पूर्ण रूप से डेबिट किया जाता है।"
+msgstr "लेजर विरोधी-संपत्ति खाता जमा किया जाता है जब प्रत्येक अवधि में मूल्यह्रास पोस्ट होता है और पूरी तरह से डेबिट किया जाता है जब संपत्ति को बेचा या स्क्रैप किया जाता है।"
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "GL विरोधी-संपत्ति खाता जो निश्चित संपत्तियों के खिलाफ बुक किए गए मूल्यह्रास को जमा करता है।"
+msgstr "लेजर विरोधी-संपत्ति खाता जो अचल संपत्तियों के विरुद्ध बुक किए गए मूल्यह्रास को जमा करता है।"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "GL इक्विटी खाता (CTA रिजर्व) जो विदेशी मुद्रा की शेष राशि को पुनः अनुवाद करने से अवास्तविक विदेशी मुद्रा अंतर रखता है अवधि के अंत में; P&L में महसूस की गई विदेशी मुद्रा लाभ/हानि से अलग।"
+msgstr "सामान्य खाता बही इक्विटी खाता (CTA रिजर्व) जो विदेशी मुद्रा शेषों को अवधि-अंत में पुनः-अनुवाद करने से अप्राप्त FX अंतर रखता है; P&L में साकार FX लाभ/हानि से अलग।"
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "GL इक्विटी खाता जहां वित्तीय वर्ष के अंत में शुद्ध आय बंद होती है।"
+msgstr "सामान्य खाता बही इक्विटी खाता जहां शुद्ध आय वित्तीय वर्ष-अंत में बंद होती है।"
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "GL व्यय खाता जब मूल्यह्रास पोस्ट किया जाता है तो हर अवधि में डेबिट किया जाता है।"
+msgstr "सामान्य खाता बही व्यय खाता जिसे प्रत्येक अवधि में मूल्यह्रास पोस्ट करने पर डेबिट किया जाता है।"
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "GL व्यय खाता जो तब डेबिट किया जाता है जब हानि (इम्पेयरमेंट) के कारण संपत्ति का वहन मूल्य घटाया जाता है, अर्थात जब इसकी वसूली योग्य राशि निवल बही मूल्य (नेट बुक वैल्यू) से कम हो जाती है।"
+msgstr "सामान्य खाता बही व्यय खाता जिसे किसी परिसंपत्ति के वहन मूल्य को अवमूल्यन से कम किए जाने पर डेबिट किया जाता है, अर्थात जब इसकी वसूल योग्य राशि शुद्ध बही मूल्य से कम हो जाती है।"
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "गैर-इन्वेंटरी खरीद के लिए GL व्यय खाता (आपूर्ति, सेवाएं)।"
+msgstr "गैर-इन्वेंटरी खरीद (आपूर्ति, सेवाएं) के लिए सामान्य खाता बही व्यय खाता।"
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "ग्राहकों से एकत्र किए गए बिक्री कर के लिए GL देयता खाता।"
+msgstr "ग्राहकों से एकत्र किए गए बिक्री कर के लिए सामान्य खाता बही देयता खाता जमा किया गया।"
 
 msgid "GL tie-out"
-msgstr "GL समाधान"
+msgstr "सामान्य खाता बही समन्वय"
 
 msgid "GL Tie-Out"
-msgstr "GL टाई-आउट"
+msgstr "सामान्य खाता बही समन्वय"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "पहली बार ही सही तरीके से लाइव जाएं — हमारी टीम आपके साथ है"
@@ -7310,10 +7310,10 @@ msgid "Good morning, {0}"
 msgstr "शुभ प्रभात, {0}"
 
 msgid "Google Places API key not configured"
-msgstr "Google Places API key कॉन्फ़िगर नहीं है"
+msgstr "Google Places API कुंजी कॉन्फ़िगर नहीं की गई"
 
 msgid "GR/IR (goods received, not invoiced)"
-msgstr "GR/IR (माल प्राप्त, अचालान)"
+msgstr "GR/IR (प्राप्त सामान, चालान नहीं किया गया)"
 
 msgid "GR/IR Clearing"
 msgstr "GR/IR समाशोधन"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "घंटे/टुकड़ा"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "कोई वस्तु कैसे पूरी तरह से भरी जाती है (खरीद, बनाना, या खरीद और बनाना), प्रति आइटम सेट, प्रति-पंक्ति विधि प्रकार के विपरीत।"
+msgstr "किसी आइटम को समग्र रूप से कैसे आपूर्ति किया जाता है (खरीद, निर्माण, या खरीद और निर्माण), प्रति आइटम सेट किया जाता है, प्रति-पंक्ति आपूर्ति प्रकार के विपरीत।"
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "एक आइटम कैसे भरी जाती है: मैनुअल पुनरावृत्ति, मांग-आधारित पुनरावृत्ति, निर्धारित पुनरावृत्ति मात्रा, या अधिकतम मात्रा।"
@@ -7475,10 +7475,10 @@ msgid "How many days after the calculation date the full amount is due."
 msgstr "गणना की तारीख के बाद कितने दिनों में पूरी राशि देय है।"
 
 msgid "How many days from invoice date this customer is given to pay; drives the default due date on customer invoices."
-msgstr "इस ग्राहक को चालान की तारीख से भुगतान करने के लिए कितने दिन मिलते हैं; ग्राहक चालान पर डिफ़ॉल्ट देय तारीख निर्धारित करता है।"
+msgstr "यह ग्राहक को चालान तारीख से भुगतान करने के लिए कितने दिन दिए जाते हैं; ग्राहक चालान पर डिफ़ॉल्ट नियत तिथि निर्धारित करता है।"
 
 msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
-msgstr "इस आपूर्तिकर्ता को चालान की तारीख से भुगतान की अपेक्षा कितने दिन है; चालान पर डिफ़ॉल्ट देय तारीख निर्धारित करता है।"
+msgstr "यह आपूर्तिकर्ता को चालान तारीख से भुगतान की अपेक्षा कितने दिन की है; बिलों पर डिफ़ॉल्ट नियत तिथि निर्धारित करता है।"
 
 msgid "How many fractional digits to keep when rounding amounts in this currency."
 msgstr "इस मुद्रा में राशि को गोल करते समय कितने आंशिक अंकों को रखना है।"
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "कितने वास्तव में चुने गए?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "इस गेज को कितनी बार पुनः कैलिब्रेट किया जाना चाहिए; अगली कैलिब्रेशन तारीख को स्वचालित रूप से पुनः गणना करने के लिए अंतिम कैलिब्रेशन तारीख के साथ संयुक्त।"
+msgstr "यह गेज कितनी बार पुनः-अंशांकन किया जाना चाहिए; अंतिम अंशांकन तारीख के साथ मिलाकर अगली अंशांकन तारीख को स्वचालित रूप से पुनः-गणना करने के लिए।"
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "यह रखरखाव कितनी बार पुनरावृत्ति करता है — दैनिक, साप्ताहिक, मासिक, चक्र गणना पर; दैनिक सप्ताह के दिन का चयनकर्ता प्रकट करता है, अन्य सरल अंतराल गणित का उपयोग करते हैं।"
+msgstr "यह रखरखाव कितनी बार दोहराया जाता है — दैनिक, साप्ताहिक, मासिक, चक्रीय गणना पर; दैनिक सप्ताह-की-दिन चयनकर्ता को प्रकट करता है, अन्य सरल अंतराल गणित का उपयोग करते हैं।"
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
-msgstr "देय तारीख कितनी सख्त है — कठिन समय सीमा निर्धारण को ब्लॉक करता है, नरम समय सीमा योजना को चेतावनी के साथ धकेलने देता है, कोई समय सीमा नहीं इसे पूरी तरह से नजरअंदाज करता है।"
+msgstr "नियत तिथि कितनी कठोर है — कठोर समयसीमा इसके बाद शेड्यूलिंग को ब्लॉक करती है, नरम समयसीमा योजना को चेतावनी के साथ आगे बढ़ने देती है, कोई समयसीमा नहीं इसे पूरी तरह अनदेखा करती है।"
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "सामग्री कैसे प्राप्त की जाती है (बनाना, खरीदना, या इन्वेंट्री से लेना) और वह भंडारण इकाई जहाँ से इसे लिया जाता है।"
+msgstr "सामग्री को कैसे आपूर्ति किया जाता है (निर्माण, खरीद, या इन्वेंटरी से लें) और भंडारण इकाई जहां से इसे लिया जाता है।"
 
 msgid "How the resolved price was calculated."
 msgstr "हल की गई कीमत की गणना कैसे की गई।"
@@ -7526,10 +7526,10 @@ msgid "How to read this chart"
 msgstr "इस चार्ट को कैसे पढ़ें"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "यह डिस्पैच कितना जरूरी है — कम / मध्यम / उच्च / महत्वपूर्ण; शेड्यूल स्लॉट तय करने के लिए प्राथमिकता और OEE प्रभाव के साथ संयुक्त।"
+msgstr "यह रखरखाव कार्य कितना तत्काल है — निम्न / मध्यम / उच्च / गंभीर; प्राथमिकता और OEE प्रभाव के साथ मिलाकर शेड्यूल स्लॉट तय करने के लिए।"
 
 msgid "How we know we're done"
-msgstr "हम कैसे जानते हैं कि हम पूरा कर चुके हैं"
+msgstr "हम कैसे जानते हैं कि हम तैयार हैं"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
 msgstr "हम कैसे संरेखित रहते हैं और समस्याओं का समाधान कैसे होता है। आपकी भूमिका: साप्ताहिक कॉल में शामिल हों और बाधाओं को जल्दी उठाएं, इससे पहले कि वे देरी बन जाएं।"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "हाइपरकेयर: पहले हफ्तों के लिए गहन समर्थन"
 
 msgid "I (reduced)"
-msgstr "I (कम किया गया)"
+msgstr "I (शिथिल)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "मेरे पास यह मानने का उचित आधार है कि यह व्यक्ति 22 CFR 120.62 में परिभाषित अनुसार एक U.S. व्यक्ति है"
@@ -7586,7 +7586,7 @@ msgid "Identifiers"
 msgstr "पहचानकर्ता"
 
 msgid "IDs and descriptions are generated for raw materials."
-msgstr "कच्चे माल के लिए आईडी और विवरण उत्पन्न किए जाते हैं।"
+msgstr "कच्चे माल के लिए IDs और विवरण उत्पन्न किए जाते हैं।"
 
 msgid "If"
 msgstr "यदि"
@@ -7595,7 +7595,7 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "अगर यह अगली कॉल तक इंतज़ार नहीं कर सकता, तो दोनों तरफ के लीड फैसला लेते हैं।"
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "अगर यह अवरुद्ध है या कोई तारीख जोखिम में है, तो इसे एक मालिक मिलता है और इसे ट्रैक किया जाता है।"
+msgstr "यदि यह अवरुद्ध है या एक तारीख जोखिम में है, तो इसे एक स्वामी मिलता है और इसका ट्रैक किया जाता है।"
 
 msgid "If items already exist"
 msgstr "अगर आइटम पहले से मौजूद हैं"
@@ -7607,13 +7607,13 @@ msgid "If something is off track"
 msgstr "अगर कुछ गलत रास्ते पर है"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "यदि आप भाग संख्याओं को बदलना चाहते हैं, तो कृपया Cancel पर क्लिक करें और रूपांतरण से पहले प्रत्येक लाइन आइटम के लिए भागों को मैन्युअल रूप से असाइन करें।"
+msgstr "यदि आप पार्ट नंबर बदलना चाहते हैं, तो कृपया रद्द करें पर क्लिक करें और परिवर्तित करने से पहले प्रत्येक पंक्ति आइटम के लिए पार्ट्स को मैन्युअल रूप से असाइन करें।"
 
 msgid "II (normal default)"
 msgstr "II (सामान्य डिफ़ॉल्ट)"
 
 msgid "III (tightened)"
-msgstr "III (कसा हुआ)"
+msgstr "III (कठोर)"
 
 msgid "Impact"
 msgstr "प्रभाव"
@@ -7644,19 +7644,19 @@ msgid "in {0}"
 msgstr "{0} में"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "Onshape में, इस OAuth ऐप्लिकेशन की अनुमतियों में \"Application can write to your documents\" शामिल करें, फिर दोबारा कनेक्ट करें।"
+msgstr "Onshape में, इस OAuth एप्लिकेशन की अनुमतियों को संपादित करें ताकि „एप्लिकेशन आपके दस्तावेज़ों में लिख सके”, फिर फिर से कनेक्ट करें।"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
-msgstr "इस RFQ को उद्धरण में परिवर्तित करने के लिए, सभी पंक्तियों के पास एक आंतरिक भाग संख्या होनी चाहिए।"
+msgstr "इस RFQ को कोटेशन में परिवर्तित करने के लिए, सभी पंक्तियों के पास एक आंतरिक पार्ट नंबर होना चाहिए।"
 
 msgid "In order to convert this RFQ to a quote, it must be associated with a customer."
-msgstr "इस RFQ को उद्धरण में परिवर्तित करने के लिए, इसे एक ग्राहक के साथ जुड़ा होना चाहिए।"
+msgstr "इस RFQ को कोटेशन में परिवर्तित करने के लिए, इसे एक ग्राहक के साथ जुड़ा होना चाहिए।"
 
 msgid "In order to convert this RFQ to a quote, it must have a customer."
-msgstr "इस RFQ को उद्धरण में परिवर्तित करने के लिए, इसके पास एक ग्राहक होना चाहिए।"
+msgstr "इस RFQ को कोटेशन में परिवर्तित करने के लिए, इसके पास एक ग्राहक होना चाहिए।"
 
 msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
-msgstr "इस RFQ को आपूर्तिकर्ताओं को भेजने के लिए, आपको पहले RFQ में आपूर्तिकर्ता जोड़ने होंगे।"
+msgstr "इस RFQ को आपूर्तिकर्ताओं को भेजने के लिए, आपको पहले RFQ में आपूर्तिकर्ता जोड़ने चाहिए।"
 
 msgid "In Process Only"
 msgstr "केवल प्रक्रिया में"
@@ -7689,10 +7689,10 @@ msgid "In-app"
 msgstr "ऐप में"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email or Slack."
-msgstr "इन-ऐप नोटिफिकेशन हमेशा डिलीवर किए जाते हैं। चुनें कि कौन से विषय आपको ईमेल या Slack के माध्यम से भी पहुंचते हैं।"
+msgstr "इन-ऐप सूचनाएं हमेशा दी जाती हैं। चुनें कि कौन से विषय आपको ईमेल या Slack द्वारा भी पहुंचें।"
 
 msgid "In-app notifications are always delivered. Choose which topics also reach you by email."
-msgstr "इन-ऐप नोटिफिकेशन हमेशा डिलीवर किए जाते हैं। चुनें कि कौन से विषय आपको ईमेल के माध्यम से भी पहुंचते हैं।"
+msgstr "इन-ऐप सूचनाएं हमेशा दी जाती हैं। चुनें कि कौन से विषय आपको ईमेल द्वारा भी पहुंचें।"
 
 msgid "Inactive"
 msgstr "निष्क्रिय"
@@ -7719,7 +7719,7 @@ msgid "Includes tax and shipping costs"
 msgstr "कर और शिपिंग लागत शामिल है"
 
 msgid "Income / Balance (inherited)"
-msgstr "आय / बैलेंस (विरासत में मिला)"
+msgstr "आय / शेष राशि (विरासत में मिली)"
 
 msgid "Income Statement"
 msgstr "आय विवरण"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "आयकर"
 
 msgid "Income/Balance"
-msgstr "आय/शेष"
+msgstr "आय/शेष राशि"
 
 msgid "incoming"
 msgstr "आने वाला"
@@ -7737,7 +7737,7 @@ msgid "Incoming"
 msgstr "आने वाली"
 
 msgid "Incoterm"
-msgstr "Incoterm"
+msgstr "इनकोटर्म"
 
 msgid "Incoterm Location"
 msgstr "इनकोटर्म स्थान"
@@ -7776,7 +7776,7 @@ msgid "Inherited from the group: where this account appears on financial stateme
 msgstr "समूह से विरासत में मिला: यह खाता वित्तीय विवरणों में कहाँ दिखाई देता है।"
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "समूह से विरासत में मिला: क्या यह खाता बरकरार आय (आय) या वहन (संतुलन) को बंद करता है।"
+msgstr "समूह से विरासत में मिली: क्या यह खाता प्रतिधारित आय (आय) में बंद होता है या आगे ले जाता है (शेष राशि)।"
 
 msgid "Inherited from the parent group."
 msgstr "मूल समूह से विरासत में मिला।"
@@ -7827,10 +7827,10 @@ msgid "Inspections"
 msgstr "निरीक्षण"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "निरीक्षण, असंगति, और CAPA"
+msgstr "निरीक्षण, गैर-अनुरूपता, और CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "निरीक्षण, असंगति, CAPA"
+msgstr "निरीक्षण, गैर-अनुरूपता, और CAPA"
 
 msgid "Inspections: Require Different Inspector"
 msgstr "निरीक्षण: विभिन्न निरीक्षक की आवश्यकता है"
@@ -7845,7 +7845,7 @@ msgid "Instructions"
 msgstr "निर्देश"
 
 msgid "Instructions are inherited from the procedure."
-msgstr "निर्देश प्रक्रिया से विरासत में मिले हैं।"
+msgstr "निर्देश कार्यविधि से विरासत में मिले हैं।"
 
 msgid "Integration"
 msgstr "एकीकरण"
@@ -7857,13 +7857,13 @@ msgid "Integrations"
 msgstr "एकीकरण"
 
 msgid "Integrations not named here"
-msgstr "यहाँ नाम न किए गए इंटीग्रेशन"
+msgstr "यहां नामित नहीं किए गए एकीकरण"
 
 msgid "Intercompany"
 msgstr "अंतरकंपनी"
 
 msgid "Intercompany Balances"
-msgstr "अंतरकंपनी शेष"
+msgstr "अंतर-कंपनी शेष राशि"
 
 msgid "Intercompany company"
 msgstr "इंटरकंपनी कंपनी"
@@ -7923,10 +7923,10 @@ msgid "Inventory Adjustment (default)"
 msgstr "इन्वेंटरी समायोजन (डिफ़ॉल्ट)"
 
 msgid "Inventory and purchasing, with automated planning"
-msgstr "इन्वेंटरी और खरीद, स्वचालित योजना के साथ"
+msgstr "इन्वेंटरी और क्रय, स्वचालित योजना के साथ"
 
 msgid "Inventory balances"
-msgstr "इन्वेंटरी बैलेंस"
+msgstr "इन्वेंटरी शेष राशि"
 
 msgid "Inventory Control"
 msgstr "इन्वेंटरी नियंत्रण"
@@ -7941,7 +7941,7 @@ msgid "Inventory History"
 msgstr "इन्वेंटरी इतिहास"
 
 msgid "Inventory Job Notifications"
-msgstr "इन्वेंटरी जॉब नोटिफिकेशन"
+msgstr "इन्वेंटरी जॉब सूचनाएँ"
 
 msgid "Inventory Movements"
 msgstr "इन्वेंटरी मूवमेंट्स"
@@ -8031,7 +8031,7 @@ msgid "Invoiced Amount:"
 msgstr "चालान की गई राशि:"
 
 msgid "Invoiced Statuses"
-msgstr "चालान किए गए स्थितियां"
+msgstr "चालान की गई स्थितियाँ"
 
 msgid "Invoices"
 msgstr "चालान"
@@ -8040,7 +8040,7 @@ msgid "Invoices this memo has been applied to. Click a row to open the document.
 msgstr "इस मेमो को लागू किए गए चालान। दस्तावेज़ खोलने के लिए एक पंक्ति पर क्लिक करें।"
 
 msgid "Invoicing"
-msgstr "चालान"
+msgstr "बिलिंग"
 
 msgid "is"
 msgstr "है"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "समस्या वर्कफ़्लो"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "समस्या वर्कफ़्लो ने किसी समस्या के लिए पूर्वनिर्धारित मान परिभाषित किए। उदाहरण के लिए, आपके पास 8D वर्कफ़्लो या निरोध वर्कफ़्लो हो सकता है।"
+msgstr "समस्या वर्कफ़्लो ने किसी समस्या के लिए पूर्वनिर्धारित मूल्यों को परिभाषित किया। उदाहरण के लिए, आपके पास 8D वर्कफ़्लो या नियंत्रण वर्कफ़्लो हो सकता है।"
 
 msgid "Issued"
 msgstr "जारी किया गया"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "समस्याएं"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "यह तब तक चलना बंद कर देगा जब तक आप फिर से एक संस्करण प्रकाशित नहीं करते। कुछ भी हटाया नहीं गया है।"
 
 msgid "ITAR Certifications"
 msgstr "ITAR प्रमाणपत्र"
@@ -8166,10 +8166,10 @@ msgid "Item Master"
 msgstr "आइटम मास्टर"
 
 msgid "Item Master and Make Methods"
-msgstr "आइटम मास्टर और मेक मेथड्स"
+msgstr "आइटम मास्टर और निर्माण विधियाँ"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "आइटम मास्टर, BOMs और बिल ऑफ प्रोसेस"
+msgstr "आइटम मास्टर, BOM और प्रक्रिया सूची"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "आइटम को एक चयनित प्रकार और एक चयनित समूह से मेल खाना चाहिए"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "इस विंडो के अंदर आइटम को एक पीला बैज मिलता है।"
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "आइटम: आइटम मास्टर, BOMs, बिल ऑफ प्रोसेस, इंजीनियरिंग परिवर्तन, CAD"
+msgstr "आइटम: आइटम मास्टर, BOM, प्रक्रिया सूची, इंजीनियरिंग परिवर्तन, CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "इसकी डिजाइन परिवर्तन सूचना जारी होने से पहले बदल सकती है।"
@@ -8217,16 +8217,16 @@ msgid "Job ID"
 msgstr "जॉब आईडी"
 
 msgid "Job in progress"
-msgstr "कार्य प्रगति पर"
+msgstr "प्रगति में जॉब"
 
 msgid "Job Location"
 msgstr "जॉब स्थान"
 
 msgid "Job make method"
-msgstr "नौकरी बनाने की विधि"
+msgstr "जॉब निर्माण विधि"
 
 msgid "Job Materials"
-msgstr "कार्य सामग्री"
+msgstr "जॉब सामग्री"
 
 msgid "Job operation"
 msgstr "जॉब ऑपरेशन"
@@ -8235,7 +8235,7 @@ msgid "Job Operation"
 msgstr "जॉब ऑपरेशन"
 
 msgid "Job Operations"
-msgstr "कार्य संचालन"
+msgstr "जॉब ऑपरेशन"
 
 msgid "Job Priority"
 msgstr "नौकरी प्राथमिकता"
@@ -8247,16 +8247,16 @@ msgid "Job Traveler"
 msgstr "जॉब ट्रैवलर"
 
 msgid "Jobs"
-msgstr "नौकरियां"
+msgstr "जॉब"
 
 msgid "Jobs Assigned to Me"
-msgstr "मुझे सौंपी गई नौकरियां"
+msgstr "मुझे असाइन किए गए जॉब"
 
 msgid "Jobs Required"
-msgstr "नौकरियां आवश्यक हैं"
+msgstr "आवश्यक जॉब"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "जिन कार्यों की सामग्री सूची में यह आइटम है"
+msgstr "जॉब जिनकी सामग्री सूची में यह आइटम है"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
@@ -8269,19 +8269,19 @@ msgid "Journal Entries"
 msgstr "जर्नल प्रविष्टियां"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "इस अवधि में दिनांकित जर्नल प्रविष्टियाँ जो अभी भी ड्राफ्ट हैं, पोस्ट की जानी चाहिए, या बाद की खुली अवधि में पुनः दिनांकित की जानी चाहिए। ड्राफ्ट प्रविष्टियाँ लेजर का हिस्सा नहीं हैं, इसलिए उनके डेबिट और क्रेडिट बंद होने से गायब हो जाएंगे।"
+msgstr "इस अवधि में दिनांकित जर्नल प्रविष्टियाँ जो अभी ड्राफ्ट में हैं, को पोस्ट किया जाना चाहिए या बाद की खुली अवधि में पुनः दिनांकित किया जाना चाहिए। ड्राफ्ट प्रविष्टियाँ जर्नल का हिस्सा नहीं हैं, इसलिए बंद करते समय उनके नामे और जमा राशि छूट जाएगी।"
 
 msgid "Journal Entry"
 msgstr "जर्नल प्रविष्टि"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "इस तारीख को या उससे पहले की तारीख वाली पत्रिकाओं को लॉक किए गए के रूप में माना जाता है। प्रदाता द्वारा रिपोर्ट की गई लॉक तारीख के साथ विलय किया जाता है जब दोनों मौजूद हों।"
+msgstr "इस तारीख को या इससे पहले दिनांकित जर्नल को लॉक माना जाता है। दोनों मौजूद होने पर प्रदाता द्वारा रिपोर्ट की गई लॉक तारीख के साथ मर्ज किया जाता है।"
 
 msgid "Just one"
 msgstr "बस एक"
 
 msgid "Kanban"
-msgstr "कनबन"
+msgstr "कानबान"
 
 msgid "Kanban for {kanbanName}"
 msgstr "{kanbanName} के लिए कानबन"
@@ -8290,7 +8290,7 @@ msgid "Kanban Output"
 msgstr "कानबन आउटपुट"
 
 msgid "Kanbans"
-msgstr "कनबन्स"
+msgstr "कानबान"
 
 msgid "Keep"
 msgstr "रखें"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "खुला रखें"
 
 msgid "Keep picking"
-msgstr "चुनते रहें"
+msgstr "पिकिंग जारी रखें"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "ऑर्डर, कोट्स और सेटिंग्स को एक दूसरी जांच के पीछे रखता है"
@@ -8329,14 +8329,14 @@ msgid "Label"
 msgstr "लेबल"
 
 msgid "Label to complete the current operation for this kanban"
-msgstr "इस कनबन के लिए वर्तमान ऑपरेशन को पूरा करने के लिए लेबल"
+msgstr "इस कानबान के लिए वर्तमान ऑपरेशन पूर्ण करें"
 
 #. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
 msgid "Label to create a {0} for this kanban"
-msgstr "इस कनबन के लिए {0} बनाने के लिए लेबल"
+msgstr "इस कानबान के लिए एक {0} बनाएँ"
 
 msgid "Label to start the next operation for this kanban"
-msgstr "इस कनबन के लिए अगली ऑपरेशन शुरू करने के लिए लेबल"
+msgstr "इस कानबान के लिए अगला ऑपरेशन शुरू करें"
 
 msgid "Labels"
 msgstr "लेबल"
@@ -8351,10 +8351,10 @@ msgid "Labor & Machine Absorption (default)"
 msgstr "श्रम और मशीन अवशोषण (डिफ़ॉल्ट)"
 
 msgid "Labor & Machine Variance"
-msgstr "श्रम और मशीन भिन्नता"
+msgstr "श्रम और मशीन विचलन"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "श्रम और मशीन भिन्नता (डिफ़ॉल्ट)"
+msgstr "श्रम और मशीन विचलन (डिफ़ॉल्ट)"
 
 msgid "Labor rate"
 msgstr "श्रम दर"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "अक्षांश"
 
 msgid "Lead time"
-msgstr "लीड समय"
+msgstr "लीड टाइम"
 
 msgid "Lead Time"
 msgstr "लीड टाइम"
 
 msgid "Lead time (days)"
-msgstr "लीड समय (दिन)"
+msgstr "लीड टाइम (दिन)"
 
 msgid "Lead Time (Days)"
 msgstr "लीड टाइम (दिन)"
 
 msgid "Lead Time:"
-msgstr "लीड समय:"
+msgstr "लीड टाइम:"
 
 msgid "Learn"
 msgstr "सीखें"
@@ -8459,7 +8459,7 @@ msgid "Leave blank for built-in"
 msgstr "बिल्ट-इन के लिए खाली छोड़ें"
 
 msgid "Leave blank to use the next revision automatically"
-msgstr "अगले संशोधन को स्वचालित रूप से उपयोग करने के लिए खाली छोड़ें"
+msgstr "अगले रिवीजन को स्वचालित रूप से उपयोग करने के लिए खाली छोड़ें"
 
 msgid "Leave empty for exact match"
 msgstr "सटीक मिलान के लिए खाली छोड़ें"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "कम मैनुअल काम, कम त्रुटियां"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "चलिए निर्माण करें"
 
 msgid "Let's build something"
 msgstr "चलिए कुछ बनाते हैं"
@@ -8501,7 +8501,7 @@ msgid "Letter"
 msgstr "अक्षर"
 
 msgid "Liability account for deferred taxes from accelerated depreciation"
-msgstr "त्वरित मूल्यह्रास से स्थगित कर के लिए दायित्व खाता"
+msgstr "त्वरित मूल्यह्रास से आस्थगित कर के लिए देयता खाता"
 
 msgid "Liability account for sales tax collected from customers"
 msgstr "ग्राहकों से एकत्र किए गए बिक्री कर के लिए दायित्व खाता"
@@ -8549,10 +8549,10 @@ msgid "Lines need internal part numbers"
 msgstr "लाइनों को आंतरिक भाग संख्याओं की आवश्यकता है"
 
 msgid "Lines need prices or lead times"
-msgstr "लाइनों को कीमतों या लीड समय की आवश्यकता है"
+msgstr "पंक्तियों को मूल्य या लीड टाइम की आवश्यकता है"
 
 msgid "Lineside"
-msgstr "लाइन के किनारे"
+msgstr "लाइनसाइड"
 
 msgid "Link"
 msgstr "लिंक"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Linear समस्या को लिंक करें"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "इस Carbon ग्राहक को इनमें से किसी एक से जोड़ें, या एक अलग Stripe ग्राहक बनाएँ।"
 
 msgid "Link to sales order line"
-msgstr "बिक्रय आदेश पंक्ति से लिंक करें"
+msgstr "विक्रय आदेश पंक्ति से जोड़ें"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8604,16 +8604,16 @@ msgid "Load newer"
 msgstr "नया लोड करें"
 
 msgid "Load open transactions (orders, POs, inventory, balances)"
-msgstr "खुले लेनदेन लोड करें (ऑर्डर, POs, इन्वेंटरी, बैलेंस)"
+msgstr "खुले लेनदेन लोड करें (आदेश, PO, इन्वेंटरी, शेष राशि)"
 
 msgid "Load Templates"
 msgstr "टेम्पलेट लोड करें"
 
 msgid "Loaded last, right at cutover, so balances are current."
-msgstr "अंत में लोड किया गया, कटओवर के दौरान, इसलिए शेष वर्तमान हैं।"
+msgstr "अंतिम रूप से लोड किया गया, कटओवर पर, इसलिए शेष राशि वर्तमान है।"
 
 msgid "Loading associated jobs..."
-msgstr "संबंधित कार्य लोड हो रहे हैं..."
+msgstr "संबंधित जॉब लोड हो रहे हैं..."
 
 msgid "Loading current quantity…"
 msgstr "वर्तमान मात्रा लोड हो रही है…"
@@ -8622,7 +8622,7 @@ msgid "Loading item details..."
 msgstr "आइटम विवरण लोड हो रहे हैं..."
 
 msgid "Loading your own data with Carbon's import tools"
-msgstr "Carbon के आयात उपकरणों के साथ अपना डेटा लोड करना"
+msgstr "Carbon के आयात उपकरणों के साथ अपने डेटा को लोड करना"
 
 msgid "Loading..."
 msgstr "लोड हो रहा है..."
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "लॉक किया गया"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "लॉकिंग अवधि को परिचालन दस्तावेज़ों (रसीदें, शिपमेंट, चालान) के लिए केवल-पढ़ने योग्य बनाता है जबकि मूल्यह्रास और निस्तारण जैसे लेखा समायोजन की अनुमति देता है। अवधि को बंद किए जाने से पहले उसे लॉक किया जाना चाहिए।"
+msgstr "लॉक करने से अवधि ऑपरेशनल दस्तावेज़ (प्राप्ति, शिपमेंट, चालान) के लिए केवल पढ़ने योग्य बन जाती है, जबकि अभी भी लेखांकन समायोजन जैसे मूल्यह्रास और निपटान की अनुमति है। अवधि को बंद किए जाने से पहले लॉक किया जाना चाहिए।"
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "गैर-अनुरूपताओं को लॉग करें और CAPA चलाएं"
@@ -8704,10 +8704,10 @@ msgid "Loss on Disposal Account"
 msgstr "निपटान पर हानि खाता"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "स्थिर संपत्तियों के निपटान पर मान्यता प्राप्त हानि"
+msgstr "अचल संपत्ति के निपटान पर मान्यता प्राप्त हानियाँ"
 
 msgid "Lost"
-msgstr "खो गया"
+msgstr "खोया"
 
 msgid "Lot"
 msgstr "लॉट"
@@ -8719,19 +8719,19 @@ msgid "Lot Size"
 msgstr "लॉट आकार"
 
 msgid "Lot Size Variance"
-msgstr "बहुत आकार विचरण"
+msgstr "लॉट आकार विचलन"
 
 msgid "Lot Size Variance (default)"
-msgstr "बहुत आकार विचरण (डिफ़ॉल्ट)"
+msgstr "लॉट आकार विचलन (डिफ़ॉल्ट)"
 
 msgid "Lot Size:"
-msgstr "लॉट साइज:"
+msgstr "लॉट आकार:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "एक नमूने योजना के विरुद्ध प्राप्त माल का लॉट-आधारित निरीक्षण; इकाइयां रसीद पर होल्ड पर पोस्ट करती हैं और केवल उपलब्ध को रिलीज करती हैं जब लॉट स्वीकृत के रूप में निपटाया जाता है।"
+msgstr "नमूनाकरण योजना के विरुद्ध प्राप्त माल की लॉट-आधारित निरीक्षण; इकाइयाँ प्राप्ति पर होल्ड पर पोस्ट होती हैं और केवल लॉट को स्वीकृत के रूप में निपटाए जाने के बाद उपलब्ध होती हैं।"
 
 msgid "Low"
-msgstr "कम"
+msgstr "निम्न"
 
 msgid "Machine"
 msgstr "मशीन"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "रखरखाव"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "रखरखाव डिस्पैच सूचनाएं"
+msgstr "रखरखाव कार्य सूचनाएँ"
 
 msgid "Maintenance Dispatches"
-msgstr "रखरखाव प्रेषण"
+msgstr "रखरखाव कार्य"
 
 msgid "Maintenance Expense"
 msgstr "रखरखाव व्यय"
@@ -8809,10 +8809,10 @@ msgid "Make Inactive"
 msgstr "निष्क्रिय करें"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "Make आइटम्स को सीधे इनवॉइस नहीं किया जा सकता। जारी रखने के लिए विधि को Pick में बदलें।"
+msgstr "निर्माण आइटम को सीधे चालान नहीं किया जा सकता। जारी रखने के लिए विधि को पिकिंग में बदलें।"
 
 msgid "Make Method Version"
-msgstr "मेक मेथड संस्करण"
+msgstr "निर्माण विधि संस्करण"
 
 msgid "Make Payment"
 msgstr "भुगतान करें"
@@ -8823,7 +8823,7 @@ msgstr "भुगतान करें · {0} चालान"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make revision {0} default?"
-msgstr "संशोधन {0} को डिफ़ॉल्ट बनाएं?"
+msgstr "क्या रिवीजन {0} को डिफ़ॉल्ट बनाएँ?"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make size {0} default?"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "जाएं / न जाएं का निर्णय लें"
 
 msgid "Make to Order"
-msgstr "ऑर्डर के अनुसार बनाएं"
+msgstr "ऑर्डर पर निर्माण"
 
 msgid "Make tracked entities available again"
 msgstr "ट्रैक किए गए इकाइयों को फिर से उपलब्ध करें"
@@ -8884,7 +8884,7 @@ msgid "Map accounts"
 msgstr "खातों को मैप करें"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "कार्बन खातों को प्रदाता के खातों के चार्ट से मैप करें। पोस्ट की गई पत्रिकाएं मैप किए गए प्रदाता खाता कोड का उपयोग करके धकेली जाती हैं।"
+msgstr "Carbon खातों को प्रदाता के खातों का चार्ट से मैप करें। पोस्ट किए गए जर्नल मैप किए गए प्रदाता खाता कोड का उपयोग करके पुश करते हैं।"
 
 msgid "Map Extracted Invoice Lines"
 msgstr "निकाली गई चालान पंक्तियों को मैप करें"
@@ -8906,7 +8906,7 @@ msgstr "मैप किए गए मान"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "\"{0}\" को पास के रूप में चिह्नित करें?"
+msgstr "क्या \"{0}\" को उत्तीर्ण के रूप में चिह्नित करें?"
 
 msgid "Mark all as configured"
 msgstr "सभी को कॉन्फ़िगर किए गए के रूप में चिह्नित करें"
@@ -8924,7 +8924,7 @@ msgid "Mark as Unpaid"
 msgstr "अदा न किए गए के रूप में चिह्नित करें"
 
 msgid "Mark checkpoint passed"
-msgstr "चेकपॉइंट पास किया गया चिह्नित करें"
+msgstr "चेकपॉइंट को उत्तीर्ण चिह्नित करें"
 
 msgid "Mark Complete"
 msgstr "पूर्ण चिह्नित करें"
@@ -8936,7 +8936,7 @@ msgid "Mark done"
 msgstr "पूर्ण चिह्नित करें"
 
 msgid "Mark Done"
-msgstr "पूर्ण के रूप में चिह्नित करें"
+msgstr "पूर्ण चिह्नित करें"
 
 msgid "Mark Light Mode"
 msgstr "मार्क लाइट मोड"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "सामग्री प्रकार"
 
 msgid "Material Usage Variance"
-msgstr "सामग्री उपयोग विचरण"
+msgstr "सामग्री उपयोग विचलन"
 
 msgid "Material Usage Variance (default)"
-msgstr "सामग्री उपयोग विचरण (डिफ़ॉल्ट)"
+msgstr "सामग्री उपयोग विचलन (डिफ़ॉल्ट)"
 
 msgid "materials"
 msgstr "सामग्रियां"
@@ -9152,13 +9152,13 @@ msgid "Method Materials"
 msgstr "विधि सामग्री"
 
 msgid "Method Operations"
-msgstr "विधि संचालन"
+msgstr "विधि ऑपरेशन"
 
 msgid "Method type"
-msgstr "विधि प्रकार"
+msgstr "आपूर्ति प्रकार"
 
 msgid "Method Type"
-msgstr "विधि प्रकार"
+msgstr "आपूर्ति प्रकार"
 
 msgid "Methods"
 msgstr "तरीके"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "आइटम को स्थानांतरित करें"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "मात्रा का कुछ हिस्सा एक नई डिस्पोजिशन पंक्ति में स्थानांतरित करें ताकि MRB प्रत्येक भाग पर अलग से निर्णय ले सके (उदाहरण के लिए कुछ को स्क्रैप करें, कुछ को रीवर्क करें)।"
+msgstr "कुछ मात्रा को एक नई निपटान पंक्ति में स्थानांतरित करें ताकि MRB प्रत्येक भाग का अलग से निर्णय ले सके (जैसे कुछ स्क्रैप करें, कुछ पुनः कार्य करें)।"
 
 msgid "Move to"
 msgstr "को स्थानांतरित करें"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "नाम"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "निर्णय लेने के अधिकार के साथ एक आंतरिक परियोजना मालिक नामित करें"
+msgstr "निर्णय लेने के अधिकार के साथ एक आंतरिक परियोजना मालिक का नाम रखें"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "नाम हब भर में जहां भी उन भूमिकाओं का संदर्भ दिया जाता है वहां भरे जाते हैं।"
@@ -9388,10 +9388,10 @@ msgid "Negative Adjustment"
 msgstr "नकारात्मक समायोजन"
 
 msgid "Net book value"
-msgstr "शुद्ध पुस्तक मूल्य"
+msgstr "शुद्ध बही मूल्य"
 
 msgid "Net Book Value"
-msgstr "नेट बुक वैल्यू"
+msgstr "शुद्ध बही मूल्य"
 
 msgid "Net Change"
 msgstr "शुद्ध परिवर्तन"
@@ -9439,7 +9439,7 @@ msgid "New Change Notice Type"
 msgstr "नई परिवर्तन सूचना प्रकार"
 
 msgid "New Consumable"
-msgstr "नया उपभोग्य"
+msgstr "नई उपभोग्य सामग्री"
 
 msgid "New Contractor"
 msgstr "नया ठेकेदार"
@@ -9448,7 +9448,7 @@ msgid "New Cost Center"
 msgstr "नया लागत केंद्र"
 
 msgid "New Credit / Debit Memo"
-msgstr "नया क्रेडिट / डेबिट मेमो"
+msgstr "नया जमा / नामे मेमो"
 
 msgid "New Custom Field"
 msgstr "नया कस्टम फील्ड"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "नया कर्मचारी प्रकार"
 
 msgid "New expiration date"
-msgstr "नई समाप्ति तारीख"
+msgstr "नई समाप्ति तिथि"
 
 msgid "New Failure Mode"
 msgstr "नई विफलता मोड"
@@ -9484,7 +9484,7 @@ msgid "New Gauge"
 msgstr "नया गेज"
 
 msgid "New Gauge Calibration Record"
-msgstr "नया गेज कैलिब्रेशन रिकॉर्ड"
+msgstr "नया गेज अंशांकन रिकॉर्ड"
 
 msgid "New Gauge Type"
 msgstr "नया गेज प्रकार"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "नया स्थान"
 
 msgid "New Maintenance Dispatch"
-msgstr "नया रखरखाव प्रेषण"
+msgstr "नया रखरखाव कार्य"
 
 msgid "New Material"
 msgstr "नई सामग्री"
@@ -9550,10 +9550,10 @@ msgid "New Material Type"
 msgstr "नई सामग्री प्रकार"
 
 msgid "New Non Conformance Type"
-msgstr "नया गैर अनुरूपता प्रकार"
+msgstr "नई गैर-अनुरूपता प्रकार"
 
 msgid "New Owner"
-msgstr "नया मालिक"
+msgstr "नया स्वामी"
 
 msgid "New Part"
 msgstr "नया पार्ट"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "नया भुगतान"
 
 msgid "New Payment Term"
-msgstr "नया भुगतान शर्त"
+msgstr "नई भुगतान शर्तें"
 
 msgid "New Picking List"
 msgstr "नई पिकिंग सूची"
@@ -9583,7 +9583,7 @@ msgid "New Pricing Rule"
 msgstr "नया मूल्य निर्धारण नियम"
 
 msgid "New Procedure"
-msgstr "नई प्रक्रिया"
+msgstr "नई कार्यविधि"
 
 msgid "New Process"
 msgstr "नई प्रक्रिया"
@@ -9598,7 +9598,7 @@ msgid "New Quote"
 msgstr "नया उद्धरण"
 
 msgid "New Quote Line"
-msgstr "नई उद्धरण पंक्ति"
+msgstr "नई कोटेशन पंक्ति"
 
 msgid "New Receipt"
 msgstr "नई रसीद"
@@ -9607,7 +9607,7 @@ msgid "New record created"
 msgstr "नया रिकॉर्ड बनाया गया"
 
 msgid "New Revision"
-msgstr "नया संस्करण"
+msgstr "नया रिवीजन"
 
 msgid "New RFQ"
 msgstr "नया RFQ"
@@ -9619,16 +9619,16 @@ msgid "New Rule"
 msgstr "नया नियम"
 
 msgid "New Sales Invoice"
-msgstr "नया बिक्रय चालान"
+msgstr "नया विक्रय चालान"
 
 msgid "New Sales Invoice Line"
-msgstr "नई बिक्रय चालान पंक्ति"
+msgstr "नई विक्रय चालान पंक्ति"
 
 msgid "New Sales Order"
-msgstr "नया बिक्रय आदेश"
+msgstr "नया विक्रय आदेश"
 
 msgid "New Sales Order Line"
-msgstr "नई बिक्रय आदेश पंक्ति"
+msgstr "नई विक्रय आदेश पंक्ति"
 
 msgid "New Scheduled Maintenance"
 msgstr "नया निर्धारित रखरखाव"
@@ -9655,7 +9655,7 @@ msgid "New Storage Type"
 msgstr "नया स्टोरेज प्रकार"
 
 msgid "New Storage Unit"
-msgstr "नया स्टोरेज यूनिट"
+msgstr "नई भंडारण इकाई"
 
 msgid "New Supplier"
 msgstr "नया आपूर्तिकर्ता"
@@ -9676,7 +9676,7 @@ msgid "New Transfer"
 msgstr "नया स्थानांतरण"
 
 msgid "New Transfer Line"
-msgstr "नई ट्रांसफर लाइन"
+msgstr "नई स्थानांतरण पंक्ति"
 
 msgid "New Unit of Measure"
 msgstr "नई माप की इकाई"
@@ -9688,7 +9688,7 @@ msgid "New Warehouse Transfer"
 msgstr "नया गोदाम स्थानांतरण"
 
 msgid "New Webhook"
-msgstr "नया Webhook"
+msgstr "नया वेबहुक"
 
 msgid "New Work Center"
 msgstr "नया वर्क सेंटर"
@@ -9715,16 +9715,16 @@ msgid "Next Due"
 msgstr "अगला देय"
 
 msgid "Next Due Date"
-msgstr "अगली देय तारीख"
+msgstr "अगली नियत तिथि"
 
 msgid "Next page"
 msgstr "अगला पृष्ठ"
 
 msgid "Next Sequence"
-msgstr "अगला क्रम"
+msgstr "अगला अनुक्रम"
 
 msgid "Next step"
-msgstr "अगला कदम"
+msgstr "अगला चरण"
 
 msgid "Next:"
 msgstr "अगला:"
@@ -9738,14 +9738,14 @@ msgstr "कोई {0} नहीं मिला"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "{0} सिंक परिचालन नहीं हैं"
+msgstr "कोई {0} सिंक ऑपरेशन नहीं"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
 msgstr "अभी कोई {0} नहीं"
 
 msgid "No abilities added"
-msgstr "कोई क्षमता जोड़ी नहीं गई"
+msgstr "कोई कौशल जोड़ा नहीं गया"
 
 msgid "No Access"
 msgstr "कोई एक्सेस नहीं"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "कोई क्रिया चयनित नहीं"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "इस बिक्रय आदेश के लिए कोई सक्रिय कार्य नहीं मिला। आदेश सीधे रद्द कर दिया जाएगा।"
+msgstr "इस विक्रय आदेश के लिए कोई चालू जॉब नहीं मिला। आदेश सीधे रद्द कर दिया जाएगा।"
 
 msgid "No active plan"
 msgstr "कोई सक्रिय योजना नहीं"
@@ -9785,7 +9785,7 @@ msgstr "कोई आवेदन नहीं। भुगतान खात�
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "अभी तक कोई संग्रहीत लॉग नहीं है। {0} दिन से पुराने लॉग स्वचालित रूप से संग्रहीत किए जाएंगे और यहां डाउनलोड के लिए उपलब्ध होंगे।"
+msgstr "अभी तक कोई संग्रहीत लॉग नहीं हैं। {0} दिनों से पुराने लॉग स्वचालित रूप से संग्रहीत किए जाएंगे और यहाँ डाउनलोड के लिए उपलब्ध होंगे।"
 
 msgid "No attachments."
 msgstr "कोई अनुलग्नक नहीं।"
@@ -9812,13 +9812,13 @@ msgid "No changes yet."
 msgstr "अभी तक कोई परिवर्तन नहीं।"
 
 msgid "No clauses yet. Use Add clause above."
-msgstr "अभी तक कोई खंड नहीं। ऊपर Add clause का उपयोग करें।"
+msgstr "अभी तक कोई खंड नहीं है। ऊपर ‟खंड जोड़ें„ का उपयोग करें।"
 
 msgid "No comments yet. Be the first to add a comment."
-msgstr "अभी तक कोई टिप्पणी नहीं है। टिप्पणी जोड़ने वाले पहले व्यक्ति बनें।"
+msgstr "अभी तक कोई टिप्पणी नहीं है। पहले एक टिप्पणी जोड़ने वाले बनें।"
 
 msgid "No completed jobs within range"
-msgstr "निर्धारित सीमा के भीतर कोई पूर्ण किए गए कार्य नहीं"
+msgstr "रेंज में कोई पूर्ण जॉब नहीं"
 
 msgid "No condition may match"
 msgstr "कोई भी शर्त मेल नहीं खा सकती"
@@ -9839,7 +9839,7 @@ msgid "No days off scheduled"
 msgstr "कोई दिन बंद निर्धारित नहीं है"
 
 msgid "No default attachments yet."
-msgstr "अभी तक कोई डिफ़ॉल्ट अटैचमेंट नहीं है।"
+msgstr "अभी तक कोई डिफ़ॉल्ट अनुलग्नक नहीं है।"
 
 msgid "No dimension slots configured"
 msgstr "कोई आयाम स्लॉट कॉन्फ़िगर नहीं किया गया"
@@ -9848,13 +9848,13 @@ msgid "No dimension values mapped yet"
 msgstr "अभी तक कोई आयाम मान मैप नहीं किया गया"
 
 msgid "No draft make method for this item yet."
-msgstr "इस आइटम के लिए अभी तक कोई ड्राफ्ट विधि नहीं।"
+msgstr "इस आइटम के लिए अभी तक कोई ड्राफ्ट निर्माण विधि नहीं है।"
 
 msgid "No draft versions available"
 msgstr "कोई ड्राफ्ट संस्करण उपलब्ध नहीं है"
 
 msgid "No due date"
-msgstr "कोई नियत तारीख नहीं"
+msgstr "कोई नियत तिथि नहीं"
 
 msgid "No editable properties for this item."
 msgstr "इस आइटम के लिए कोई संपादन योग्य गुण नहीं।"
@@ -9920,7 +9920,7 @@ msgid "No items have inventory activity here yet."
 msgstr "अभी तक यहाँ कोई आइटम इन्वेंटरी गतिविधि नहीं है।"
 
 msgid "No jobs were created"
-msgstr "कोई नौकरी नहीं बनाई गई"
+msgstr "कोई जॉब नहीं बनाया गया"
 
 msgid "No journal lines in scope for this period"
 msgstr "इस अवधि के लिए दायरे में कोई जर्नल लाइन नहीं"
@@ -9944,10 +9944,10 @@ msgid "No matches"
 msgstr "कोई मेल नहीं"
 
 msgid "No matches for \"{query}\". Try a different search term."
-msgstr "\"{query}\" के लिए कोई मिलान नहीं। एक अलग खोज शब्द आजमाएं।"
+msgstr "‟{query}„ के लिए कोई मेल नहीं मिला। एक अलग खोज शब्द आजमाएँ।"
 
 msgid "No matches. Type to create one."
-msgstr "कोई मेल नहीं। एक बनाने के लिए टाइप करें।"
+msgstr "कोई मेल नहीं। बनाने के लिए टाइप करें।"
 
 msgid "No matching bins"
 msgstr "कोई मिलान बिन नहीं"
@@ -9965,7 +9965,7 @@ msgid "No open orders for this item are available to link."
 msgstr "इस आइटम के लिए लिंक करने के लिए कोई खुले ऑर्डर उपलब्ध नहीं हैं।"
 
 msgid "No open sales order lines"
-msgstr "कोई खुली बिक्रय ऑर्डर लाइनें नहीं"
+msgstr "कोई खुली विक्रय आदेश पंक्ति नहीं"
 
 msgid "No operations found."
 msgstr "कोई ऑपरेशन नहीं मिला।"
@@ -10001,13 +10001,13 @@ msgid "No part ID"
 msgstr "कोई भाग ID नहीं"
 
 msgid "No parts"
-msgstr "कोई पुर्जे नहीं"
+msgstr "कोई पार्ट्स नहीं"
 
 msgid "No passkeys registered yet."
 msgstr "अभी तक कोई पासकी पंजीकृत नहीं है।"
 
 msgid "No payables"
-msgstr "कोई देय नहीं"
+msgstr "कोई देय राशि नहीं"
 
 msgid "No payments yet."
 msgstr "अभी तक कोई भुगतान नहीं।"
@@ -10028,28 +10028,28 @@ msgid "No printer configured"
 msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया"
 
 msgid "No printers configured. Click \"Add Printer\" to create one."
-msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया है। एक बनाने के लिए \"प्रिंटर जोड़ें\" पर क्लिक करें।"
+msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया है। ‟प्रिंटर जोड़ें„ पर क्लिक करें।"
 
 msgid "No process selected"
 msgstr "कोई प्रक्रिया चयनित नहीं है"
 
 msgid "No production events recorded for this operation yet"
-msgstr "इस ऑपरेशन के लिए अभी तक कोई उत्पादन घटना रिकॉर्ड नहीं की गई है"
+msgstr "इस ऑपरेशन के लिए अभी तक कोई उत्पादन इवेंट दर्ज नहीं किया गया है"
 
 msgid "No purchases in this period"
 msgstr "इस अवधि में कोई खरीद नहीं"
 
 msgid "No Quote"
-msgstr "कोई उद्धरण नहीं"
+msgstr "कोई कोटेशन नहीं"
 
 msgid "No Quote Reason"
-msgstr "कोई उद्धरण कारण नहीं"
+msgstr "कोई कोटेशन कारण नहीं"
 
 msgid "No Quote Reasons"
-msgstr "कोई उद्धरण कारण नहीं"
+msgstr "कोई कोटेशन कारण नहीं"
 
 msgid "No receivables"
-msgstr "कोई प्राप्य नहीं"
+msgstr "कोई प्राप्य राशि नहीं"
 
 msgid "No records found"
 msgstr "कोई रिकॉर्ड नहीं मिला"
@@ -10061,10 +10061,10 @@ msgid "No remaining entities to inspect."
 msgstr "निरीक्षण के लिए कोई शेष इकाई नहीं है।"
 
 msgid "No reports match your search."
-msgstr "कोई रिपोर्ट आपकी खोज से मेल नहीं खाती।"
+msgstr "कोई रिपोर्ट आपकी खोज से मेल नहीं खाती है।"
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "इस कंपनी के किसी भी प्रतिनिधि ने अभी तक Carbon GovCloud Rider स्वीकार नहीं किया है। किसी के भी Carbon तक पहुँचने से पहले इस कंपनी के एक व्यवस्थापक को इसे स्वीकार करना होगा — Carbon कर्मचारी इसे आपकी ओर से स्वीकार नहीं कर सकते।"
+msgstr "इस कंपनी का कोई प्रतिनिधि अभी तक Carbon GovCloud Rider को स्वीकार नहीं किया है। इस कंपनी के एक प्रशासक को यह स्वीकार करना चाहिए ताकि कोई भी Carbon का उपयोग कर सके — Carbon स्टाफ आपकी ओर से इसे स्वीकार नहीं कर सकता है।"
 
 msgid "No results"
 msgstr "कोई परिणाम नहीं"
@@ -10094,13 +10094,13 @@ msgid "No stockout projected in the next 48 weeks"
 msgstr "अगले 48 सप्ताह में कोई स्टॉकआउट प्रक्षेपित नहीं है"
 
 msgid "No storage unit"
-msgstr "कोई स्टोरेज यूनिट नहीं"
+msgstr "कोई भंडारण इकाई नहीं"
 
 msgid "No suppliers yet"
 msgstr "अभी तक कोई आपूर्तिकर्ता नहीं"
 
 msgid "No sync operations yet"
-msgstr "अभी तक कोई सिंक परिचालन नहीं है"
+msgstr "अभी तक कोई सिंक ऑपरेशन नहीं"
 
 msgid "No time entries for this week"
 msgstr "इस सप्ताह के लिए कोई समय प्रविष्टि नहीं"
@@ -10109,7 +10109,7 @@ msgid "No tools"
 msgstr "कोई उपकरण नहीं"
 
 msgid "No tools for this step"
-msgstr "इस कदम के लिए कोई उपकरण नहीं"
+msgstr "इस चरण के लिए कोई टूल नहीं"
 
 msgid "No transactions in this period"
 msgstr "इस अवधि में कोई लेनदेन नहीं"
@@ -10136,10 +10136,10 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "इस आइटम के लिए कोई गोदाम स्टॉक रिकॉर्ड पर नहीं है। आप इसे अभी भी चुन सकते हैं — गणना के समाधान तक हाथ पर नकारात्मक हो जाएगा।"
 
 msgid "No work center utilization data within range"
-msgstr "रेंज के भीतर कोई कार्य केंद्र उपयोग डेटा नहीं"
+msgstr "सीमा के भीतर कोई वर्क सेंटर उपयोग डेटा नहीं"
 
 msgid "No work centers exist"
-msgstr "कोई कार्य केंद्र मौजूद नहीं है"
+msgstr "कोई वर्क सेंटर मौजूद नहीं है"
 
 msgid "Nom"
 msgstr "नाम"
@@ -10151,13 +10151,13 @@ msgid "Non conformance"
 msgstr "गैर-अनुरूपता"
 
 msgid "Non Conformance Type"
-msgstr "गैर अनुरूपता प्रकार"
+msgstr "गैर-अनुरूपता प्रकार"
 
 msgid "Non conformance workflow"
 msgstr "गैर-अनुरूपता वर्कफ़्लो"
 
 msgid "Non-conformance (issue)"
-msgstr "गैर-अनुकूलता (समस्या)"
+msgstr "गैर-अनुरूपता (निर्गम)"
 
 msgid "Non-Inventory"
 msgstr "गैर-इन्वेंटरी"
@@ -10166,10 +10166,10 @@ msgid "Non-Inventory Tracking"
 msgstr "गैर-इन्वेंटरी ट्रैकिंग"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
-msgstr "गैर-परिचालन व्यय खाता जिसमें इस वर्ग की एक संपत्ति को इसके शुद्ध पुस्तक मूल्य से कम पर बेचा या स्क्रैप किया जाता है तो डेबिट किया जाता है।"
+msgstr "गैर-संचालन व्यय खाता डेबिट किया जाता है जब इस वर्ग की एक संपत्ति इसके शुद्ध बही मूल्य से कम पर बेची या नष्ट की जाती है।"
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "गैर-परिचालन आय खाता जिसमें इस वर्ग की एक संपत्ति को इसके शुद्ध पुस्तक मूल्य से अधिक पर बेचा जाता है तो क्रेडिट किया जाता है।"
+msgstr "गैर-संचालन आय खाता जमा किया जाता है जब इस वर्ग की एक संपत्ति इसके शुद्ध बही मूल्य से अधिक पर बेची जाती है।"
 
 msgid "Non-Taxable Add-On Cost"
 msgstr "गैर-कर योग्य ऐड-ऑन लागत"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "सामान्य"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "एक तालिका नहीं बल्कि एक सामान्य-बहीखाता संतुलन: काम की सामग्री जारी होने पर लागत जमा होती है और जब काम स्टॉक में प्राप्त होता है तो स्पष्ट हो जाता है।"
+msgstr "एक तालिका नहीं बल्कि एक सामान्य खाता बही शेष: लागत जमा होती है जब जॉब सामग्री जारी की जाती है और साफ़ होती है जब जॉब स्टॉक में प्राप्त होता है।"
 
 msgid "Not certified"
 msgstr "प्रमाणित नहीं"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "पर्याप्त नौकरियां नहीं हैं मात्रा को कवर करने के लिए"
+msgstr "मात्रा को कवर करने के लिए पर्याप्त जॉबें नहीं हैं"
 
 msgid "Not reached"
 msgstr "प्राप्त नहीं"
@@ -10245,7 +10245,7 @@ msgid "Nothing in the archive"
 msgstr "आर्काइव में कुछ नहीं है"
 
 msgid "Nothing yet. A step only offers values once it is configured."
-msgstr "अभी कुछ नहीं। एक स्टेप केवल तभी मूल्य प्रदान करता है जब इसे कॉन्फ़िगर किया जाता है।"
+msgstr "अभी कुछ नहीं। एक चरण केवल तभी मान प्रदान करता है जब इसे कॉन्फ़िगर किया जाता है।"
 
 msgid "Notification"
 msgstr "सूचना"
@@ -10299,7 +10299,7 @@ msgid "Off — handled outside the sync"
 msgstr "बंद — सिंक के बाहर संभाला गया"
 
 msgid "Off — released revisions stay editable"
-msgstr "बंद — जारी किए गए संशोधन संपादन योग्य रहते हैं"
+msgstr "बंद — जारी किए गए रिवीजन संपादन योग्य रहते हैं"
 
 msgid "OK"
 msgstr "ठीक है"
@@ -10329,7 +10329,7 @@ msgid "On Hold"
 msgstr "होल्ड पर"
 
 msgid "On Jobs"
-msgstr "नौकरियों पर"
+msgstr "जॉब पर"
 
 msgid "On order"
 msgstr "ऑर्डर पर"
@@ -10338,13 +10338,13 @@ msgid "On Production Demand"
 msgstr "उत्पादन मांग पर"
 
 msgid "On Purchase Order"
-msgstr "खरीद आदेश पर"
+msgstr "क्रय आदेश पर"
 
 msgid "On Sales Order"
-msgstr "बिक्रय आदेश पर"
+msgstr "विक्रय आदेश पर"
 
 msgid "On Storage Unit"
-msgstr "स्टोरेज यूनिट पर"
+msgstr "भंडारण इकाई पर"
 
 msgid "On this operation"
 msgstr "इस ऑपरेशन पर"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "हाथ में इन्वेंटरी बची है"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "स्थान या आइटम के अनुसार हाथ में मूल्य, GL टाई-आउट के साथ"
+msgstr "स्थान या आइटम के अनुसार हाथ पर मूल्य, सामान्य खाता बही समन्वय के साथ"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "निर्मित माल का मौजूदा मूल्य (Make आइटम)"
@@ -10374,7 +10374,7 @@ msgid "On-time delivery"
 msgstr "समय पर डिलीवरी"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "एक वर्कफ़्लो का एक एक्सीक्यूशन, जो कदम दर कदम दर्ज किया जाता है, प्रत्येक कदम द्वारा उपयोग किए गए और उत्पन्न मूल्यों के साथ, वर्कफ़्लो के मालिक की अनुमतियों के साथ काम करते हुए।"
+msgstr "एक वर्कफ़्लो का एक निष्पादन, चरण दर चरण रिकॉर्ड किया गया जिसमें प्रत्येक चरण द्वारा उपयोग किए गए और उत्पादित मान शामिल हैं, वर्कफ़्लो के स्वामी की अनुमतियों के साथ पूरे समय कार्य करते हुए।"
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
 msgstr "एक सीरीज यूनिट या एक बैच जो Carbon व्यक्तिगत रूप से अनुसरण करता है, अपनी स्वयं की स्थिति और विशेषताएं जैसे समाप्ति तिथि ले जाता है।"
@@ -10383,13 +10383,13 @@ msgid "One set of numbers"
 msgstr "एक ही संख्या का सेट"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "एक काम के मार्ग में एक कदम, एक प्रक्रिया और एक कार्य केंद्र का नाम देता है और अपने स्वयं के सेटअप, श्रम और मशीन समय और दरें लेता है।"
+msgstr "एक जॉब की रूटिंग में एक चरण, एक प्रक्रिया और एक वर्क सेंटर का नाम देते हुए और अपने स्वयं के सेटअप, श्रम, मशीन समय और दरें शामिल करते हुए।"
 
 msgid "One system from quote to cash"
 msgstr "उद्धरण से नकद तक एक प्रणाली"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "केवल ड्राफ्ट प्रक्रियाएं संपादन योग्य हैं। किसी सक्रिय या संग्रहीत प्रक्रिया को बदलने के लिए नया संस्करण बनाएं।"
+msgstr "केवल ड्राफ्ट कार्यविधियाँ संपादन योग्य हैं। सक्रिय या संग्रहीत कार्यविधि को बदलने के लिए एक नया संस्करण बनाएँ।"
 
 msgid "Only empty, open periods can be deleted."
 msgstr "केवल खाली, खुली अवधियों को हटाया जा सकता है।"
@@ -10431,10 +10431,10 @@ msgid "Open an NCR for MRB disposition"
 msgstr "MRB निपटान के लिए एक NCR खोलें"
 
 msgid "Open AP"
-msgstr "खुला AP"
+msgstr "खुले देय खाते"
 
 msgid "Open AR"
-msgstr "खुला AR"
+msgstr "खुले प्राप्य खाते"
 
 msgid "Open Audit Log"
 msgstr "ऑडिट लॉग खोलें"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "खुली तारीख"
 
 msgid "Open Dispatches"
-msgstr "खुली डिस्पैच"
+msgstr "खुले रखरखाव कार्य"
 
 msgid "Open in Carbon"
 msgstr "Carbon में खोलें"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "परिवर्तन सूचना {ids} में खोलें। नए संस्करण या संशोधन बनाने के लिए इसे जारी करें।"
+msgstr "परिवर्तन सूचना {ids} में खुला है। नए संस्करण या रिवीजन बनाने के लिए इसे जारी करें।"
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "परिवर्तन सूचनाओं {ids} में खोलें। नए संस्करण या संशोधन बनाने के लिए उन्हें जारी करें।"
+msgstr "परिवर्तन सूचनाओं {ids} में खुले हैं। नए संस्करण या रिवीजन बनाने के लिए उन्हें जारी करें।"
 
 msgid "Open in MES"
 msgstr "MES में खोलें"
@@ -10467,13 +10467,13 @@ msgid "Open job demand plus outstanding transfers out of this bin"
 msgstr "खुली नौकरी की मांग प्लस इस बिन से बकाया ट्रांसफर"
 
 msgid "Open jobs"
-msgstr "खुली नौकरियां"
+msgstr "खुली जॉबें"
 
 msgid "Open menu"
 msgstr "मेनू खोलें"
 
 msgid "Open payables by supplier and age"
-msgstr "आपूर्तिकर्ता और आयु द्वारा खुले देनदारी"
+msgstr "आपूर्तिकर्ता और आयु के अनुसार खुली देय राशि"
 
 msgid "Open Purchase Invoices"
 msgstr "खुले क्रय चालान"
@@ -10491,16 +10491,16 @@ msgid "Open Reactive"
 msgstr "खुली प्रतिक्रियाशील"
 
 msgid "Open receivables by customer and age"
-msgstr "ग्राहक और आयु द्वारा खुली प्राप्य"
+msgstr "ग्राहक और आयु के अनुसार खुली प्राप्य राशि"
 
 msgid "Open RFQs"
 msgstr "खुले RFQ"
 
 msgid "Open sales orders"
-msgstr "खुले बिक्रय आदेश"
+msgstr "खुले विक्रय आदेश"
 
 msgid "Open Sales Orders"
-msgstr "खुले बिक्रय आदेश"
+msgstr "खुले विक्रय आदेश"
 
 msgid "Open Scheduled"
 msgstr "खुली अनुसूचित"
@@ -10527,7 +10527,7 @@ msgid "Opening an operation starts its timer, so time is tracked from the moment
 msgstr "किसी ऑपरेशन को खोलने से इसका टाइमर शुरू हो जाता है, इसलिए काम शुरू होने के समय से समय ट्रैक किया जाता है।"
 
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
-msgstr "अवक्षयण का खाता खोलने के संतुलन को पहले ही बुक किया गया है इससे पहले कि यह संपत्ति Carbon में जोड़ी गई थी (नई खरीद के लिए 0 का उपयोग करें)।"
+msgstr "इस संपत्ति को Carbon में जोड़े जाने से पहले दर्ज मूल्यह्रास का प्रारंभिक शेष (नई खरीद के लिए 0 का उपयोग करें)।"
 
 msgid "Operating Expenses"
 msgstr "परिचालन व्यय"
@@ -10566,13 +10566,13 @@ msgid "Operation unit cost"
 msgstr "ऑपरेशन यूनिट लागत"
 
 msgid "Operations"
-msgstr "संचालन"
+msgstr "ऑपरेशन"
 
 msgid "Operations / steps"
-msgstr "संचालन / चरण"
+msgstr "ऑपरेशन / चरण"
 
 msgid "Operations Type"
-msgstr "संचालन प्रकार"
+msgstr "ऑपरेशन प्रकार"
 
 msgid "Operator"
 msgstr "ऑपरेटर"
@@ -10602,7 +10602,7 @@ msgid "Opportunity"
 msgstr "अवसर"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr "तेज़ पूर्वावलोकन के लिए अनुकूलित — डाउनलोड हमेशा मूल अपलोड की गई फ़ाइल देते हैं"
+msgstr "तेज़ पूर्वावलोकन के लिए अनुकूलित — डाउनलोड हमेशा मूल अपलोड की गई फाइल प्रदान करते हैं"
 
 msgid "Optional"
 msgstr "वैकल्पिक"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "इस नियम के लिए वैकल्पिक संदर्भ"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "वैकल्पिक निर्धारित दर का उपयोग IAS 21 के अनुसार इक्विटी शेष का अनुवाद करते समय (अवधि दर के बजाय)।"
+msgstr "IAS 21 के अनुसार इक्विटी शेष को परिवर्तित करते समय उपयोग की जाने वाली वैकल्पिक निश्चित दर (अवधि दर के बजाय)।"
 
 msgid "Optional pages & sections"
 msgstr "वैकल्पिक पृष्ठ और अनुभाग"
@@ -10645,7 +10645,7 @@ msgid "Order Date"
 msgstr "ऑर्डर तारीख"
 
 msgid "Order Multiple"
-msgstr "ऑर्डर मल्टीपल"
+msgstr "ऑर्डर गुणज"
 
 msgid "Order Parts"
 msgstr "पार्ट्स ऑर्डर करें"
@@ -10693,7 +10693,7 @@ msgid "Other Income account for FX gains when a payment settles a foreign-curren
 msgstr "विदेशी मुद्रा लाभ के लिए अन्य आय खाता जब कोई भुगतान विदेशी-मुद्रा चालान को अधिक अनुकूल दर पर निपटाता है"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "विक्रेता शेष राशि के लिए अन्य आय खाता जो AP निपटान पर पूर्ण भुगतान के बिना साफ़ किया गया है"
+msgstr "अन्य आय खाता विक्रेता शेष राशि के लिए जो देय खाते निपटान पर पूर्ण भुगतान के बिना स्पष्ट किए जाते हैं"
 
 msgid "Other Type"
 msgstr "अन्य प्रकार"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "आउटपुट"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "आउटपुट कभी भी अपनी कच्ची सामग्री से अधिक समय तक नहीं रहता। जब किसी इनपुट की समाप्ति तारीख नहीं होती है तो निर्धारित अवधि पर वापस आता है।"
+msgstr "आउटपुट कभी भी अपने कच्चे माल से आगे नहीं जा सकता। जब कोई इनपुट की समाप्ति तारीख नहीं होती है तो निश्चित अवधि का उपयोग करता है।"
 
 msgid "Outside operation"
 msgstr "ओवरहेड विचरण"
@@ -10726,28 +10726,28 @@ msgid "Overdue"
 msgstr "अतिदेय"
 
 msgid "Overhead Absorption"
-msgstr "ओवरहेड अवशोषण"
+msgstr "उपरिव्यय अवशोषण"
 
 msgid "Overhead Absorption (default)"
-msgstr "ओवरहेड अवशोषण (डिफ़ॉल्ट)"
+msgstr "उपरिव्यय अवशोषण (डिफ़ॉल्ट)"
 
 msgid "Overhead rate"
-msgstr "ओवरहेड दर"
+msgstr "उपरिव्यय दर"
 
 msgid "Overhead Rate"
-msgstr "ओवरहेड दर"
+msgstr "उपरिव्यय दर"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "ओवरहेड दर (प्रति घंटा)"
+msgstr "उपरिव्यय दर (प्रति घंटा)"
 
 msgid "Overhead Variance"
-msgstr "ओवरहेड विचरण (डिफ़ॉल्ट)"
+msgstr "उपरिव्यय विचलन"
 
 msgid "Overhead Variance (default)"
-msgstr "स्वामी (लागत केंद्र)"
+msgstr "उपरिव्यय विचलन (डिफ़ॉल्ट)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "ओवरराइड के लिए inventory:update अनुमति और एक कारण की आवश्यकता है।"
+msgstr "ओवरराइड के लिए inventory:update अनुमति और कारण की आवश्यकता है।"
 
 msgid "Override Price"
 msgstr "ओवरराइड मूल्य"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "उद्धरण विधि के साथ लक्ष्य विनिर्माण विधि को अधिलेखित करें"
 
 msgid "Owner"
-msgstr "मालिक"
+msgstr "स्वामी"
 
 msgid "Owner (cost center)"
-msgstr "मूल लागत केंद्र"
+msgstr "स्वामी (लागत केंद्र)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10808,13 +10808,13 @@ msgid "Parameters"
 msgstr "पैरामीटर"
 
 msgid "Parameters are inherited from the procedure."
-msgstr "प्रक्रिया से पैरामीटर विरासत में मिले हैं।"
+msgstr "पैरामीटर कार्यविधि से विरासत में मिलते हैं।"
 
 msgid "Params"
 msgstr "पैरामीटर"
 
 msgid "Parent cost center"
-msgstr "भाग"
+msgstr "मूल लागत केंद्र"
 
 msgid "Parent Cost Center"
 msgstr "पैरेंट लागत केंद्र"
@@ -10829,10 +10829,10 @@ msgid "Parent Item"
 msgstr "मूल आइटम"
 
 msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
-msgstr "मूल वस्तुएं। (यदि आप नीचे दिए गए मूल पुर्जों में से किसी एक पर क्लिक करते हैं, तो आप इस आइटम को सामग्री सूची पर एक घटक के रूप में शामिल देखेंगे।)"
+msgstr "मूल आइटम। (यदि आप नीचे दिए गए मूल पार्ट्स में से किसी एक पर क्लिक करते हैं, तो आप इस आइटम को सामग्री की बिल पर एक घटक के रूप में देखेंगे।)"
 
 msgid "Parent Storage Unit"
-msgstr "पैरेंट स्टोरेज यूनिट"
+msgstr "मूल भंडारण इकाई"
 
 msgid "Pareto by Type"
 msgstr "प्रकार के अनुसार पेरेटो"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "त्रुटि के रूप में पार्क करें"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "पत्रिका को चेतावनी के साथ पार्क करें जब तक मान मैप न हो जाए"
+msgstr "मान मैप किए जाने तक चेतावनी के साथ जर्नल को पार्क करें।"
 
 msgid "part"
 msgstr "भाग"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "भागीदार"
 
 msgid "parts"
-msgstr "देय खाते"
+msgstr "पार्ट्स"
 
 msgid "Parts"
 msgstr "पार्ट्स"
@@ -10892,7 +10892,7 @@ msgid "Pass"
 msgstr "पास"
 
 msgid "Passed"
-msgstr "पास किया गया"
+msgstr "उत्तीर्ण"
 
 msgid "Passkey name"
 msgstr "पासकी का नाम"
@@ -10913,13 +10913,13 @@ msgid "Pay Rate"
 msgstr "भुगतान दर"
 
 msgid "Payables"
-msgstr "देय खाते (डिफ़ॉल्ट)"
+msgstr "देय राशि"
 
 msgid "Payables (AP)"
-msgstr "देय (AP)"
+msgstr "देय राशि (देय खाते)"
 
 msgid "Payables (default)"
-msgstr "भुगतान अवधि"
+msgstr "देय राशि (डिफ़ॉल्ट)"
 
 msgid "Payables aging"
 msgstr "देय राशि की आयु"
@@ -10937,16 +10937,16 @@ msgid "Payment ID"
 msgstr "भुगतान ID"
 
 msgid "payment term"
-msgstr "भुगतान अवधि"
+msgstr "भुगतान शर्तें"
 
 msgid "Payment term"
-msgstr "भुगतान शर्त"
+msgstr "भुगतान शर्तें"
 
 msgid "Payment Term"
-msgstr "भुगतान अवधि"
+msgstr "भुगतान शर्तें"
 
 msgid "payment terms"
-msgstr "लोग"
+msgstr "भुगतान शर्तें"
 
 msgid "Payment Terms"
 msgstr "भुगतान शर्तें"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "लंबित"
 
 msgid "people"
-msgstr "स्थिर संपत्ति के लिए आवधिक मूल्यह्रास व्यय"
+msgstr "लोग"
 
 msgid "People"
 msgstr "लोग"
@@ -10991,7 +10991,7 @@ msgid "Per Unit"
 msgstr "प्रति यूनिट"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "ऑर्डर हेडर के पूर्ण स्थान का प्रति-पंक्ति ओवरराइड; विभाजित शिपमेंट और ड्रॉप-शिप के लिए उपयोग किया जाता है।"
+msgstr "ऑर्डर हेडर के पूर्ति स्थान का प्रति-पंक्ति ओवरराइड; विभाजित शिपमेंट और ड्रॉप-शिप के लिए उपयोग किया जाता है।"
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
 msgstr "PO हेडर के डिलीवरी स्थान का प्रति-पंक्ति ओवरराइड; एकाधिक गोदाम या ड्रॉप-शिपमेंट के लिए विभाजित डिलीवरी के लिए उपयोग किया जाता है।"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "अवधि लॉक नीति"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "पिकिंग ट्रैक किए गए इकाइयों को सबसे पहले समाप्ति के क्रम में प्रदान करती है, इसलिए सबसे जल्दी समाप्त होने वाला स्टॉक डिफ़ॉल्ट रूप से पहले छोड़ा जाता है।"
+msgstr "अचल संपत्ति के लिए आवधिक मूल्यह्रास व्यय"
 
 msgid "Permanently Delete"
 msgstr "स्थायी रूप से हटाएं"
@@ -11054,7 +11054,7 @@ msgid "Pick"
 msgstr "चुनें"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "एक Carbon आयाम चुनें और प्रदाता लक्ष्य चुनें जहां यह पोस्ट करता है। स्वचालित-निर्माण पुश समय पर नाम से लापता प्रदाता विकल्प जोड़ता है।"
+msgstr "एक Carbon आयाम चुनें और प्रदाता लक्ष्य जहां यह पोस्ट करता है। ऑटो-बनाना पुश समय पर नाम से गायब प्रदाता विकल्प जोड़ता है।"
 
 msgid "Pick a column to sort by"
 msgstr "सॉर्ट करने के लिए एक कॉलम चुनें"
@@ -11078,7 +11078,7 @@ msgid "Pick a record type…"
 msgstr "एक रिकॉर्ड प्रकार चुनें…"
 
 msgid "Pick a value from an earlier step"
-msgstr "पहले के स्टेप से एक मूल्य चुनें"
+msgstr "पहले के एक चरण से मान चुनें"
 
 msgid "Pick a variable…"
 msgstr "एक वेरिएबल चुनें…"
@@ -11111,16 +11111,16 @@ msgid "Picking List"
 msgstr "पिकिंग सूची"
 
 msgid "Picking List ID"
-msgstr "पिकिंग लिस्ट आईडी"
+msgstr "पिकिंग सूची ID"
 
 msgid "Picking List Notes"
-msgstr "पिकिंग लिस्ट नोट्स"
+msgstr "पिकिंग सूची नोट्स"
 
 msgid "Picking Lists"
 msgstr "पिकिंग सूचियाँ"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "नियोजित"
+msgstr "पिकिंग सबसे पहले समाप्त होने वाली ट्रैक की गई वस्तुओं को प्राथमिकता देता है, इसलिए डिफ़ॉल्ट रूप से सबसे जल्द समाप्त होने वाला स्टॉक पहले निकलता है।"
 
 msgid "Pieces/Hour"
 msgstr "Pieces/Hour"
@@ -11167,7 +11167,7 @@ msgid "Planned order = MRP suggestion to cover projected demand based on the ite
 msgstr "नियोजित आदेश = अनुमानित मांग को कवर करने के लिए MRP सुझाव आइटम की पुनः आदेश नीति के आधार पर (या मैन्युअल रूप से जोड़ा गया)।"
 
 msgid "Planned purchase order"
-msgstr "नियोजित खरीद आदेश"
+msgstr "योजनाबद्ध क्रय आदेश"
 
 msgid "Planned Start"
 msgstr "नियोजित प्रारंभ"
@@ -11230,7 +11230,7 @@ msgid "Policy"
 msgstr "नीति"
 
 msgid "Policy & Procedure"
-msgstr "नीति और प्रक्रिया"
+msgstr "नीति और कार्यविधि"
 
 msgid "Portal Link"
 msgstr "पोर्टल लिंक"
@@ -11290,7 +11290,7 @@ msgid "Posted once, no corrections."
 msgstr "एक बार पोस्ट किया गया, कोई सुधार नहीं।"
 
 msgid "Posting"
-msgstr "अग्रिम भुगतान"
+msgstr "पोस्टिंग"
 
 msgid "Posting date"
 msgstr "पोस्टिंग तारीख"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "अग्रिम भुगतान (डिफ़ॉल्ट)"
 
 msgid "Prepayments (default)"
-msgstr "निवारक कार्रवाई"
+msgstr "अग्रिम भुगतान (डिफ़ॉल्ट)"
 
 msgid "Present Week"
 msgstr "वर्तमान सप्ताह"
@@ -11323,7 +11323,7 @@ msgid "Prev"
 msgstr "पिछला"
 
 msgid "Preventive action"
-msgstr "उपलब्ध इन्वेंटरी मूल्यांकन के लिए प्राथमिक खाता"
+msgstr "निवारक कार्रवाई"
 
 msgid "Preventive maintenance schedules for your equipment"
 msgstr "आपकी उपकरण के लिए निवारक रखरखाव शेड्यूल"
@@ -11347,20 +11347,20 @@ msgid "Previous page"
 msgstr "पिछला पृष्ठ"
 
 msgid "Previous step"
-msgstr "पिछला कदम"
+msgstr "पिछला चरण"
 
 #. placeholder {0}: humanizeField(watchedField)
 msgid "Previous value of {0}"
 msgstr "{0} का पिछला मूल्य"
 
 msgid "Price break actions"
-msgstr "मूल्य विराम क्रियाएं"
+msgstr "मूल्य स्तर की क्रियाएँ"
 
 msgid "Price Break History"
-msgstr "मूल्य ब्रेक इतिहास"
+msgstr "मूल्य स्तर इतिहास"
 
 msgid "Price Breaks"
-msgstr "मूल्य ब्रेक"
+msgstr "मूल्य स्तर"
 
 msgid "Price List"
 msgstr "मूल्य सूची"
@@ -11393,7 +11393,7 @@ msgid "Pricing Trace"
 msgstr "मूल्य निर्धारण ट्रेस"
 
 msgid "Primary cash account for bank transactions"
-msgstr "प्रक्रिया"
+msgstr "बैंक लेनदेन के लिए प्राथमिक नकद खाता"
 
 msgid "Print"
 msgstr "प्रिंट करें"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "{0} लेबल प्रिंट करें"
 
 msgid "Print Jobs"
-msgstr "प्रिंट जॉब्स"
+msgstr "प्रिंट जॉब"
 
 msgid "Print Label"
 msgstr "लेबल प्रिंट करें"
@@ -11437,16 +11437,16 @@ msgid "Private"
 msgstr "निजी"
 
 msgid "procedure"
-msgstr "प्रक्रियाएं"
+msgstr "कार्यविधि"
 
 msgid "Procedure"
-msgstr "प्रक्रिया"
+msgstr "कार्यविधि"
 
 msgid "procedures"
-msgstr "प्रक्रिया"
+msgstr "कार्यविधियाँ"
 
 msgid "Procedures"
-msgstr "प्रक्रियाएं"
+msgstr "कार्यविधियाँ"
 
 msgid "process"
 msgstr "प्रक्रियाएं"
@@ -11482,13 +11482,13 @@ msgid "Production"
 msgstr "उत्पादन"
 
 msgid "Production event"
-msgstr "उत्पादन घटना"
+msgstr "उत्पादन इवेंट"
 
 msgid "Production Event"
-msgstr "उत्पादन घटना"
+msgstr "उत्पादन इवेंट"
 
 msgid "Production Events"
-msgstr "उत्पादन घटनाएं"
+msgstr "उत्पादन इवेंट"
 
 msgid "Production planning"
 msgstr "उत्पादन योजना"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "उत्पादन मात्रा"
 
 msgid "Production variance"
-msgstr "BOMs और पूर्वानुमान से विस्फोटित अनुमानित मांग।"
+msgstr "उत्पादन विचलन"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "उत्पादन: शॉप-फ्लोर ऐप और शेड्यूलिंग"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "प्रोजेक्ट"
 
 msgid "Project owner"
-msgstr "प्रोजेक्ट मालिक"
+msgstr "परियोजना स्वामी"
 
 msgid "Project Plan"
 msgstr "प्रोजेक्ट प्लान"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "प्रोजेक्ट शुरुआत"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "अनुमानित इन्वेंटरी"
+msgstr "BOM और पूर्वानुमान से विस्फोटित अनुमानित मांग।"
 
 msgid "Projected inventory"
 msgstr "अनुमानित उपलब्ध"
@@ -11543,14 +11543,14 @@ msgstr "अनुमानित स्टॉक"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "{0} के सप्ताह में सुरक्षा स्टॉक से नीचे गिरने का अनुमान"
+msgstr "सप्ताह {0} में अनुमानित स्टॉक आउट"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "सुरक्षा स्टॉक के ऊपर रहने का अनुमान"
 
 msgid "Projected to stay above safety stock"
-msgstr "क्रय आदेश"
+msgstr "सुरक्षा स्टॉक से ऊपर रहने का अनुमान"
 
 msgid "Projection"
 msgstr "प्रक्षेपण"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "अनुमान"
 
 msgid "Promised Date"
-msgstr "वादा की गई तारीख"
+msgstr "वादा की गई तिथि"
 
 msgid "Properties"
 msgstr "गुण"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Carbon द्वारा प्रकाशित"
 
 msgid "Published Version"
-msgstr ""
+msgstr "प्रकाशित संस्करण"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "प्रकाशित संस्करणों को संपादित नहीं किया जा सकता। केवल-पठन के लिए देखें, या परिवर्तन करने के लिए एक नया संस्करण शाखा करें।"
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "लेखांकन से खींचें"
 
 msgid "Pull from Inventory"
-msgstr "इन्वेंटरी से खींचें"
+msgstr "इन्वेंटरी से लें"
 
 msgid "Pull, map, and load your data"
 msgstr "अपना डेटा खींचें, मैप करें, और लोड करें"
@@ -11647,13 +11647,13 @@ msgid "Purchase Invoice Amount"
 msgstr "क्रय चालान राशि"
 
 msgid "Purchase Invoice Line"
-msgstr "खरीद चालान पंक्ति"
+msgstr "क्रय चालान पंक्ति"
 
 msgid "Purchase Invoices"
-msgstr "खरीद चालान"
+msgstr "क्रय चालान"
 
 msgid "Purchase order"
-msgstr "खरीद मूल्य विचरण"
+msgstr "क्रय आदेश"
 
 msgid "Purchase Order"
 msgstr "क्रय आदेश"
@@ -11692,13 +11692,13 @@ msgid "Purchase planning"
 msgstr "खरीद योजना"
 
 msgid "Purchase price variance"
-msgstr "खरीद मूल्य विचरण"
+msgstr "क्रय मूल्य विचलन"
 
 msgid "Purchase Price Variance"
-msgstr "खरीद मूल्य विचरण (डिफ़ॉल्ट)"
+msgstr "क्रय मूल्य विचलन"
 
 msgid "Purchase Price Variance (default)"
-msgstr "खरीद कर देय"
+msgstr "क्रय मूल्य विचलन (डिफ़ॉल्ट)"
 
 msgid "Purchase Qty"
 msgstr "खरीद मात्रा"
@@ -11737,13 +11737,13 @@ msgid "Purchasing and auto-planning"
 msgstr "क्रय और स्वचालित योजना"
 
 msgid "Purchasing contact"
-msgstr "खरीद संपर्क"
+msgstr "क्रय संपर्क"
 
 msgid "Purchasing Contact"
 msgstr "क्रय संपर्क"
 
 msgid "Purchasing Invoices"
-msgstr "खरीद चालान"
+msgstr "क्रय चालान"
 
 msgid "Purchasing Unit of Measure"
 msgstr "क्रय माप की इकाई"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "रिकॉर्ड परिवर्तनों को बाहरी सिस्टम में तुरंत भेजें जब वे होते हैं।"
 
 msgid "Push the journal without the dimension"
-msgstr "आयाम के बिना पत्रिका को पुश करें"
+msgstr "आयाम के बिना जर्नल पुश करें"
 
 msgid "Push to accounting"
 msgstr "लेखांकन को धकेलें"
@@ -11768,10 +11768,10 @@ msgstr "आपका डेटा वापस डाल रहे हैं"
 
 #. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
 msgid "QR Code to create a {0} for this kanban"
-msgstr "इस कनबन के लिए {0} बनाने के लिए QR कोड"
+msgstr "इस कानबान के लिए एक {0} बनाने के लिए QR कोड"
 
 msgid "QR Code to start the next operation for this kanban"
-msgstr "इस कनबन के लिए अगली ऑपरेशन शुरू करने के लिए QR कोड"
+msgstr "इस कानबान के लिए अगला ऑपरेशन शुरू करने के लिए QR कोड"
 
 msgid "Qty"
 msgstr "मात्रा"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "मात्रा। स्क्रैप किया गया"
 
 msgid "quality"
-msgstr "उद्धरण से नकद तक"
+msgstr "गुणवत्ता"
 
 msgid "Quality"
 msgstr "गुणवत्ता"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "गुणवत्ता प्रकार"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "गुणवत्ता: निरीक्षण, असंगति, CAPA"
+msgstr "गुणवत्ता: निरीक्षण, गैर-अनुरूपता, CAPA"
 
 msgid "Quantities"
 msgstr "मात्रा"
@@ -11819,10 +11819,10 @@ msgid "Quantity"
 msgstr "मात्रा"
 
 msgid "Quantity arriving — on open purchase orders plus on production (make) orders."
-msgstr "आने वाली मात्रा — खुले खरीद आदेशों के साथ-साथ उत्पादन (निर्माण) आदेशों पर।"
+msgstr "आने वाली मात्रा — खुले क्रय आदेशों पर साथ ही उत्पादन (निर्माण) आदेशों पर।"
 
 msgid "Quantity Breaks"
-msgstr "मात्रा विघ्न"
+msgstr "मात्रा स्तर"
 
 msgid "Quantity complete"
 msgstr "पूर्ण मात्रा"
@@ -11840,19 +11840,19 @@ msgid "Quantity must be greater than 0"
 msgstr "मात्रा 0 से अधिक होनी चाहिए"
 
 msgid "Quantity on hand"
-msgstr "हाथ में मात्रा"
+msgstr "उपलब्ध मात्रा"
 
 msgid "Quantity on Hand"
-msgstr "हाथ में मात्रा"
+msgstr "उपलब्ध मात्रा"
 
 msgid "Quantity on Jobs"
-msgstr "नौकरियों पर मात्रा"
+msgstr "जॉब पर मात्रा"
 
 msgid "Quantity on Purchase Order"
 msgstr "क्रय आदेश पर मात्रा"
 
 msgid "Quantity on Sales Order"
-msgstr "बिक्रय आदेश पर मात्रा"
+msgstr "विक्रय आदेश पर मात्रा"
 
 msgid "Quantity Per Job"
 msgstr "प्रति जॉब मात्रा"
@@ -11913,13 +11913,13 @@ msgid "Quote ID"
 msgstr "उद्धरण ID"
 
 msgid "Quote line"
-msgstr "उद्धरण लाइन"
+msgstr "कोटेशन पंक्ति"
 
 msgid "Quote Line"
-msgstr "उद्धरण पंक्ति"
+msgstr "कोटेशन पंक्ति"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "उद्धरण पंक्तियां जिनकी सामग्री सूची में यह आइटम शामिल है"
+msgstr "कोटेशन पंक्तियाँ जिनकी सामग्री सूची इस आइटम को शामिल करती है"
 
 msgid "Quote Location"
 msgstr "उद्धरण स्थान"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "उद्धरण संख्या"
 
 msgid "Quote to cash"
-msgstr "प्राप्य खाते"
+msgstr "कोटेशन से नकद तक"
 
 msgid "Quote Type"
 msgstr "उद्धरण प्रकार"
@@ -11949,7 +11949,7 @@ msgid "Quotes"
 msgstr "उद्धरण"
 
 msgid "Quoting and sales orders"
-msgstr "उद्धरण और बिक्रय आदेश"
+msgstr "कोटेशन और विक्रय आदेश"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "उद्धरण, आदेश, कॉन्फ़िगर-टू-ऑर्डर"
@@ -11997,7 +11997,7 @@ msgid "Readable ID"
 msgstr "पठनीय ID"
 
 msgid "Readable id with revision"
-msgstr "संशोधन के साथ पठनीय आईडी"
+msgstr "रिवीजन के साथ पठनीय ID"
 
 msgid "Reading the document..."
 msgstr "दस्तावेज़ पढ़ा जा रहा है..."
@@ -12006,7 +12006,7 @@ msgid "Ready"
 msgstr "तैयार"
 
 msgid "Ready for Quote"
-msgstr "उद्धरण के लिए तैयार"
+msgstr "कोटेशन के लिए तैयार"
 
 msgid "ready to keep or revert"
 msgstr "रखने या पूर्ववत् करने के लिए तैयार"
@@ -12048,7 +12048,7 @@ msgid "Recalculate"
 msgstr "पुनः गणना करें"
 
 msgid "Recalculate Unit Cost"
-msgstr "यूनिट कॉस्ट की पुनः गणना करें"
+msgstr "इकाई लागत की पुनः गणना करें"
 
 msgid "Recalculating…"
 msgstr "पुनः गणना की जा रही है…"
@@ -12066,28 +12066,28 @@ msgid "Receipt Lines"
 msgstr "रसीद लाइनें"
 
 msgid "Receipt Promised Date"
-msgstr "प्राप्ति वादा तारीख"
+msgstr "प्राप्ति वादा की गई तिथि"
 
 msgid "Receipt Requested Date"
-msgstr "प्राप्ति अनुरोधित तारीख"
+msgstr "प्राप्ति अनुरोधित तिथि"
 
 msgid "Receipts"
 msgstr "रसीदें"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "रसीदें, शिपमेंट, बिक्रय चालान, खरीद चालान, भुगतान, और क्रेडिट/डेबिट मेमो जो अभी भी ड्राफ्ट या लंबित हैं, पोस्ट किए जाने चाहिए या रद्द किए जाने चाहिए — दोनों दस्तावेज़ जो इस अवधि में दिनांकित हैं और दस्तावेज़ जो पोस्ट किए जाने पर इसमें दिनांक प्राप्त करेंगे। जब तक वे पोस्ट न हों, उनकी राशि सामान्य लेजर में नहीं होती है, इसलिए अवधि को कम आंका जाएगा।"
+msgstr "प्राप्ति, शिपमेंट, विक्रय चालान, क्रय चालान, भुगतान, और जमा/नामे ज्ञापन जो अभी भी ड्राफ्ट या लंबित हैं, उन्हें पोस्ट किया जाना चाहिए या अमान्य किया जाना चाहिए — दोनों दस्तावेज़ इस अवधि में दिनांकित और बिना दिनांक के दस्तावेज़ जो पोस्ट होने पर इसमें एक तिथि प्राप्त करेंगे। जब तक वे पोस्ट नहीं होते, उनकी राशियाँ सामान्य खाता बही में नहीं हैं, इसलिए अवधि को कम दिखाया जाएगा।"
 
 msgid "Receivables"
-msgstr "प्राप्य खाते (डिफ़ॉल्ट)"
+msgstr "प्राप्य राशि"
 
 msgid "Receivables (AR)"
-msgstr "प्राप्य (AR)"
+msgstr "प्राप्य राशि (प्राप्य खाते)"
 
 msgid "Receivables (default)"
-msgstr "एक क्रय आदेश को प्राप्त और चालान किए गए के साथ समेटना — Carbon में निहित, लाइन मात्रा और GR/IR शेष के माध्यम से।"
+msgstr "प्राप्य राशि (डिफ़ॉल्ट)"
 
 msgid "Receivables aging"
-msgstr "प्राप्य उम्र बढ़ना"
+msgstr "प्राप्य राशि की आयु"
 
 msgid "Receive"
 msgstr "प्राप्त करें"
@@ -12145,16 +12145,16 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "समन्वय ने प्रदाता के साथ विसंगतियां पाईं"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "वसूली अवधि"
+msgstr "एक क्रय आदेश को प्राप्त और चालान किए गए के विरुद्ध समन्वय करना — Carbon में अंतर्निहित, पंक्ति मात्रा और GR/IR शेष राशि के माध्यम से।"
 
 msgid "Record"
 msgstr "रिकॉर्ड करें"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "एक ग्राहक या आपूर्तिकर्ता के विरुद्ध क्रेडिट या डेबिट मेमो रिकॉर्ड करें। विशिष्ट चालानों के लिए आवेदन मेमो बनाने के बाद जोड़े जाते हैं।"
+msgstr "एक ग्राहक या आपूर्तिकर्ता के विरुद्ध एक जमा या नामे ज्ञापन दर्ज करें। विशिष्ट चालान के लिए आवेदन ज्ञापन बनाए जाने के बाद जोड़े जाते हैं।"
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "ग्राहक से प्राप्त नकद (रसीद) या आपूर्तिकर्ता को दिया गया नकद (वितरण) दर्ज करें। विशिष्ट चालानों के लिए आवेदन भुगतान बनाने के बाद जोड़े जाते हैं।"
+msgstr "एक ग्राहक से प्राप्त नकद (प्राप्ति) या एक आपूर्तिकर्ता को भुगतान की गई नकद (संवितरण) को दर्ज करें। विशिष्ट चालान के लिए आवेदन भुगतान बनाए जाने के बाद जोड़े जाते हैं।"
 
 msgid "Record deleted"
 msgstr "रिकॉर्ड हटाया गया"
@@ -12166,7 +12166,7 @@ msgid "Record type"
 msgstr "रिकॉर्ड प्रकार"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "कैलिब्रेशन पर दर्ज किया गया है कि गेज को मरम्मत की आवश्यकता है इससे पहले कि इसकी रीडिंग पर विश्वास किया जा सके।"
+msgstr "अंशांकन पर दर्ज किया गया कि गेज को मरम्मत की आवश्यकता है इससे पहले कि इसकी रीडिंग पर भरोसा किया जा सके।"
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
 msgstr "दर्ज किया गया कि इस अंशांकन के बाद अनुवर्ती कार्रवाई की आवश्यकता है; खुली कार्रवाइयों की कतार में इस गेज को सामने लाता है।"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "सत्यापन पृष्ठ पर पुनः निर्देशित किया जा रहा है..."
 
 msgid "Reduced"
-msgstr "कम किया गया"
+msgstr "शिथिल"
 
 msgid "Reference"
 msgstr "संदर्भ"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "पंजीकृत"
 
 msgid "Registered"
-msgstr "पुन: आदेश बिंदु"
+msgstr "पंजीकृत"
 
 msgid "Registration failed"
 msgstr "पंजीकरण विफल"
@@ -12244,19 +12244,19 @@ msgid "Relative timeline · dates to be confirmed"
 msgstr "सापेक्ष समयरेखा · तारीखें पुष्टि की जानी हैं"
 
 msgid "Release"
-msgstr "रिलीज़"
+msgstr "जारी करें"
 
 msgid "Release change notice"
 msgstr "परिवर्तन सूचना जारी करें"
 
 msgid "Release control"
-msgstr "जारी करने का नियंत्रण"
+msgstr "जारी नियंत्रण"
 
 msgid "Release Control"
-msgstr "जारी करने का नियंत्रण"
+msgstr "जारी नियंत्रण"
 
 msgid "Release Job"
-msgstr "जॉब रिलीज़ करें"
+msgstr "जॉब जारी करें"
 
 msgid "Released"
 msgstr "जारी किया गया"
@@ -12265,10 +12265,10 @@ msgid "Released date"
 msgstr "जारी की गई तारीख"
 
 msgid "Released revision"
-msgstr "जारी किया गया संशोधन"
+msgstr "जारी रिवीजन"
 
 msgid "Released revision is locked"
-msgstr "जारी किया गया संशोधन लॉक किया गया है"
+msgstr "जारी रिवीजन लॉक है"
 
 msgid "Remaining"
 msgstr "शेष"
@@ -12280,68 +12280,68 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "इस PIN को याद रखें। MES टर्मिनल पर कंसोल मोड से बाहर निकलने के लिए आपको इसकी आवश्यकता होगी।"
 
 msgid "Remove"
-msgstr "हटाएं"
+msgstr "निकालें"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "{0} को हटाएं"
+msgstr "निकालें {0}"
 
 msgid "Remove {label}"
-msgstr "हटाएँ {label}"
+msgstr "निकालें {label}"
 
 msgid "Remove authenticator app"
-msgstr "ऑथेंटिकेटर ऐप हटाएं"
+msgstr "प्रमाणकर्ता ऐप्लिकेशन निकालें"
 
 msgid "Remove clause"
-msgstr "खंड हटाएं"
+msgstr "खंड निकालें"
 
 msgid "Remove condition"
-msgstr "शर्त हटाएं"
+msgstr "शर्त निकालें"
 
 msgid "Remove filter"
-msgstr "फ़िल्टर हटाएं"
+msgstr "फ़िल्टर निकालें"
 
 msgid "Remove Filters"
-msgstr "फ़िल्टर हटाएं"
+msgstr "फ़िल्टर निकालें"
 
 msgid "Remove from Price List"
-msgstr "मूल्य सूची से हटाएं"
+msgstr "मूल्य सूची से निकालें"
 
 msgid "Remove line"
-msgstr "लाइन हटाएं"
+msgstr "पंक्ति निकालें"
 
 msgid "Remove order"
-msgstr "ऑर्डर हटाएं"
+msgstr "आदेश निकालें"
 
 msgid "Remove pair"
-msgstr "जोड़ी हटाएं"
+msgstr "जोड़ी निकालें"
 
 msgid "Remove part"
-msgstr "पुर्जा हटाएँ"
+msgstr "पार्ट निकालें"
 
 msgid "Remove path"
-msgstr "पथ हटाएं"
+msgstr "पथ निकालें"
 
 msgid "Remove row"
-msgstr "पंक्ति हटाएं"
+msgstr "पंक्ति निकालें"
 
 msgid "Remove slide"
-msgstr "स्लाइड हटाएँ"
+msgstr "स्लाइड निकालें"
 
 msgid "Remove slot"
-msgstr "स्लॉट हटाएं"
+msgstr "स्लॉट निकालें"
 
 msgid "Remove sort by column"
-msgstr "कॉलम द्वारा सॉर्ट हटाएं"
+msgstr "कॉलम के अनुसार क्रमबद्धता निकालें"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "इस स्टोरेज प्रकार को सभी संदर्भित स्टोरेज इकाइयों से हटाएं और इसे हटाएं। यह पूर्ववत नहीं किया जा सकता।"
+msgstr "इस भंडारण प्रकार को सभी संदर्भित भंडारण इकाइयों से निकालें और इसे हटाएँ। इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "Remove tool"
-msgstr "उपकरण हटाएँ"
+msgstr "टूल निकालें"
 
 msgid "Remove two-factor authentication"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण हटाएं"
+msgstr "दो-कारक प्रमाणीकरण निकालें"
 
 msgid "Removed"
 msgstr "हटाया गया"
@@ -12366,7 +12366,7 @@ msgid "Reorder Group"
 msgstr "समूह को पुनः क्रमित करें"
 
 msgid "Reorder point"
-msgstr "पुन: आदेश बिंदु"
+msgstr "पुनः ऑर्डर बिंदु"
 
 msgid "Reorder Point"
 msgstr "पुनः ऑर्डर बिंदु"
@@ -12396,7 +12396,7 @@ msgid "Reordering Policy"
 msgstr "पुनः ऑर्डर करने की नीति"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "केवल प्रेषण अनुक्रम और कार्य केंद्र को पुनः क्रमबद्ध करता है — पुनर्निर्धारण नहीं करता। तिथि बोर्ड पर तिथियां बदलें।"
+msgstr "केवल प्रेषण अनुक्रम और वर्क सेंटर को पुनः क्रमित करता है — समय सारणी में परिवर्तन नहीं करता है। तिथि बोर्ड पर तिथियां बदलें।"
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "{inputLabel} में प्रत्येक आइटम के लिए एक बार दोहराएं"
@@ -12414,13 +12414,13 @@ msgid "Replace this company's data with a demo dataset — snapshotted first, so
 msgstr "इस कंपनी के डेटा को डेमो डेटासेट से बदलें — पहले स्नैपशॉट लिया जाता है, ताकि आप पूर्ववत् कर सकें।"
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "पीडीएफ को बदलने से इस दस्तावेज़ पर सभी बैलून प्लेसमेंट हटा दिए जाएंगे। फीचर पंक्तियाँ और उनके मान बने रहते हैं; आप नई ड्राइंग पर फिर से बैलून रख सकते हैं।"
+msgstr "इस दस्तावेज़ पर PDF को बदलने से सभी बैलून प्लेसमेंट हटा दिए जाते हैं। सुविधा पंक्तियां और उनके मान रहते हैं; आप नई ड्राइंग पर फिर से बैलून रख सकते हैं।"
 
 msgid "Replenishment"
 msgstr "पुनःपूर्ति"
 
 msgid "Replenishment system"
-msgstr "पूरक प्रणाली"
+msgstr "पुनःपूर्ति प्रणाली"
 
 msgid "Replenishment System"
 msgstr "पुनःपूर्ति प्रणाली"
@@ -12450,7 +12450,7 @@ msgid "Request Approval"
 msgstr "अनुमोदन का अनुरोध करें"
 
 msgid "Requested Date"
-msgstr "अनुरोधित तारीख"
+msgstr "अनुरोधित तिथि"
 
 msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "साइन इन करते समय ऑथेंटिकेटर ऐप से 6-अंकीय कोड की आवश्यकता है।"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "आवश्यक क्रियाएं (क्रम में)"
 
 msgid "Required Date"
-msgstr "आवश्यक तारीख"
+msgstr "आवश्यक तिथि"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "नियंत्रित वातावरण में आवश्यक — ऑडिट लॉगिंग को बंद नहीं किया जा सकता।"
@@ -12583,13 +12583,13 @@ msgid "Resume Receiving"
 msgstr "प्राप्ति को फिर से शुरू करें"
 
 msgid "Retained Earnings"
-msgstr "संचित मुनाफा"
+msgstr "प्रतिधारित आय"
 
 msgid "Retained Earnings (default)"
-msgstr "संचित मुनाफा (डिफ़ॉल्ट)"
+msgstr "प्रतिधारित आय (डिफ़ॉल्ट)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
-msgstr "स्क्रैपिंग या बिक्री द्वारा किसी संपत्ति को सेवा से सेवानिवृत्त करना, जिसमें निवल बही मूल्य (नेट बुक वैल्यू) के विरुद्ध कोई भी लाभ या हानि दर्ज की जाती है और इसकी स्थिति 'निपटान किया गया' (Disposed) पर सेट कर दी जाती है।"
+msgstr "किसी संपत्ति को स्क्रैपिंग या विक्रय द्वारा सेवा से सेवामुक्त करना, किसी भी लाभ या हानि को शुद्ध बही मूल्य के विरुद्ध दर्ज करना और इसकी स्थिति को निपटाया गया पर सेट करना।"
 
 msgid "Retry"
 msgstr "पुनः प्रयास करें"
@@ -12631,7 +12631,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "इस चालान से किसी भी आइटम लेजर प्रविष्टियों को उलट दें"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "रिवर्स चार्ज"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "रिवर्स चार्ज बिक्रय कर"
@@ -12643,7 +12643,7 @@ msgid "Reverse the related journal entries"
 msgstr "संबंधित जर्नल प्रविष्टियों को उलट दें"
 
 msgid "Reversed"
-msgstr "उलट दिया गया"
+msgstr "प्रतिवर्तित"
 
 msgid "Revert"
 msgstr "पूर्ववत् करें"
@@ -12658,7 +12658,7 @@ msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "प्रत्येक आइटम के परिवर्तनों की समीक्षा करें, फिर पुष्टि करें — जारी करना वापस नहीं किया जा सकता।"
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "अवधि की बैलेंस शीट और आय विवरण की समीक्षा करें और पुष्टि करें कि आंकड़े सही लगते हैं। यह एक मैनुअल साइन-ऑफ है — एक बार समीक्षा करने के बाद इसे पूर्ण चिह्नित करें।"
+msgstr "अवधि के तुलन पत्र और आय विवरण की समीक्षा करें और पुष्टि करें कि आंकड़े सही दिखते हैं। यह एक मैनुअल हस्ताक्षर बंद है — समीक्षा के बाद इसे पूरा करें।"
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
 msgstr "लागू करने से पहले सुझाए गए मिलानों की समीक्षा करें। ये एक सर्वोत्तम अनुमान हैं — प्रत्येक की पुष्टि करें कि यह सही है।"
@@ -12667,17 +12667,17 @@ msgid "Review the warnings below, then post the count to apply the adjustments."
 msgstr "नीचे दी गई चेतावनियों की समीक्षा करें, फिर समायोजन लागू करने के लिए गणना पोस्ट करें।"
 
 msgid "Revision"
-msgstr "संस्करण"
+msgstr "रिवीजन"
 
 #. placeholder {0}: revision.revision
 msgid "Revision {0}"
-msgstr "संस्करण {0}"
+msgstr "रिवीजन {0}"
 
 msgid "Revision status"
-msgstr "संशोधन स्थिति"
+msgstr "रिवीजन स्थिति"
 
 msgid "Revisions"
-msgstr "संशोधन"
+msgstr "रिवीजन"
 
 msgid "Revoke"
 msgstr "रद्द करें"
@@ -12695,7 +12695,7 @@ msgid "RFQ"
 msgstr "RFQ"
 
 msgid "RFQ (request for quote)"
-msgstr "आरएफक्यू (उद्धरण के लिए अनुरोध)"
+msgstr "RFQ (कोटेशन अनुरोध)"
 
 msgid "RFQ Date"
 msgstr "RFQ तारीख"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "आरएफक्यू"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "पुश की गई पत्रिकाओं पर Carbon आयाम साथ रखें। प्रत्येक स्लॉट एक Carbon आयाम को एक प्रदाता विश्लेषण लक्ष्य के लिए मैप करता है; नीचे मान मैपिंग व्यक्तिगत आयाम मान को प्रदाता विकल्प के साथ जोड़ता है।"
+msgstr "कार्बन आयामों को पुश किए गए जर्नल के साथ ले जाएँ। प्रत्येक स्लॉट एक कार्बन आयाम को एक प्रदाता विश्लेषण लक्ष्य से मैप करता है; नीचे दिया गया मूल्य मैपिंग व्यक्तिगत आयाम मानों को प्रदाता विकल्पों के साथ जोड़ता है।"
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,10 +12765,10 @@ msgid "Rounding Account (default)"
 msgstr "राउंडिंग खाता (डिफ़ॉल्ट)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "सभी AP चालानों को एक पते पर भेजें (जैसे कॉर्पोरेट मुख्यालय) व्यक्तिगत खरीदारों के बजाय।"
+msgstr "सभी देय खाते चालानों को एक पते (जैसे कॉर्पोरेट मुख्यालय) पर रूट करें, बजाय व्यक्तिगत क्रेताओं के।"
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "सभी AR चालानों को एक पते पर भेजें (जैसे कॉर्पोरेट मुख्यालय) व्यक्तिगत स्थानों के बजाय।"
+msgstr "सभी प्राप्य खाते चालानों को एक पते (जैसे कॉर्पोरेट मुख्यालय) पर रूट करें, बजाय व्यक्तिगत स्थानों के।"
 
 msgid "Routing"
 msgstr "रूटिंग"
@@ -12913,49 +12913,49 @@ msgid "Sales Funnel"
 msgstr "बिक्रय फनल"
 
 msgid "Sales invoice"
-msgstr "बिक्रय चालान"
+msgstr "विक्रय चालान"
 
 msgid "Sales Invoice"
-msgstr "बिक्रय चालान"
+msgstr "विक्रय चालान"
 
 msgid "Sales Invoice Line"
-msgstr "बिक्रय चालान पंक्ति"
+msgstr "विक्रय चालान पंक्ति"
 
 msgid "Sales Invoices"
-msgstr "बिक्रय चालान"
+msgstr "विक्रय चालान"
 
 msgid "Sales Job Notifications"
 msgstr "बिक्रय कार्य सूचनाएं"
 
 msgid "Sales order"
-msgstr "बिक्रय आदेश"
+msgstr "विक्रय आदेश"
 
 msgid "Sales Order"
 msgstr "विक्रय आदेश"
 
 msgid "Sales Order ID"
-msgstr "बिक्रय आदेश ID"
+msgstr "विक्रय आदेश ID"
 
 msgid "Sales order line"
-msgstr "बिक्रय आदेश लाइन"
+msgstr "विक्रय आदेश पंक्ति"
 
 msgid "Sales Order Line"
-msgstr "बिक्रय आदेश पंक्ति"
+msgstr "विक्रय आदेश पंक्ति"
 
 msgid "Sales Order Line (job)"
-msgstr "बिक्रय आदेश लाइन (कार्य)"
+msgstr "विक्रय आदेश पंक्ति (जॉब)"
 
 msgid "Sales Order Location"
-msgstr "बिक्रय आदेश स्थान"
+msgstr "विक्रय आदेश स्थान"
 
 msgid "Sales Order Number"
-msgstr "बिक्रय आदेश संख्या"
+msgstr "विक्रय आदेश संख्या"
 
 msgid "Sales Orders"
-msgstr "बिक्रय आदेश"
+msgstr "विक्रय आदेश"
 
 msgid "Sales Person"
-msgstr "विक्रय व्यक्ति"
+msgstr "विक्रय प्रतिनिधि"
 
 msgid "Sales Revenue"
 msgstr "बिक्रय राजस्व"
@@ -13060,7 +13060,7 @@ msgid "Scan or search..."
 msgstr "स्कैन या खोजें..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "इस लॉट से एक ट्रैक की गई इकाई को स्कैन या चुनें इसे एक नमूना कॉलम के रूप में जोड़ने के लिए, फिर ग्रिड में इसके परिणाम को रिकॉर्ड करें।"
+msgstr "इस लॉट से ट्रैक की गई इकाई को स्कैन करें या चुनें ताकि इसे नमूना कॉलम के रूप में जोड़ा जा सके, फिर ग्रिड में इसका परिणाम दर्ज करें।"
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
 msgstr "अपने ऑथेंटिकेटर ऐप (जैसे Google Authenticator या 1Password) के साथ इस QR कोड को स्कैन करें, फिर यह जो 6-अंकीय कोड दिखाता है उसे दर्ज करें।"
@@ -13078,7 +13078,7 @@ msgid "Schedule"
 msgstr "शेड्यूल"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "कार्य-केंद्र क्षमता के विरुद्ध नौकरियों को शेड्यूल करें"
+msgstr "वर्क सेंटर क्षमता के विरुद्ध जॉब को शेड्यूल करें"
 
 msgid "Schedule Name"
 msgstr "शेड्यूल नाम"
@@ -13147,7 +13147,7 @@ msgid "Scrapped"
 msgstr "स्क्रैप किया गया"
 
 msgid "Search"
-msgstr "खोज"
+msgstr "खोजें"
 
 msgid "Search accounts..."
 msgstr "खातों को खोजें..."
@@ -13156,7 +13156,7 @@ msgid "Search across your workspace..."
 msgstr "अपने कार्यक्षेत्र में खोजें..."
 
 msgid "Search actions…"
-msgstr "क्रियाओं की खोज करें…"
+msgstr "कार्यों को खोजें…"
 
 msgid "Search by Jira issue title..."
 msgstr "Jira समस्या शीर्षक द्वारा खोजें..."
@@ -13174,7 +13174,7 @@ msgid "Search employees..."
 msgstr "कर्मचारियों को खोजें..."
 
 msgid "Search events…"
-msgstr "घटनाओं की खोज करें…"
+msgstr "घटनाओं को खोजें…"
 
 msgid "Search fields..."
 msgstr "फ़ील्ड खोजें..."
@@ -13192,13 +13192,13 @@ msgid "Search list variables…"
 msgstr "सूची चर खोजें…"
 
 msgid "Search operations…"
-msgstr "संचालन खोजें…"
+msgstr "ऑपरेशन को खोजें…"
 
 msgid "Search operators..."
 msgstr "ऑपरेटर खोजें..."
 
 msgid "Search parts..."
-msgstr "पुर्जे खोजें..."
+msgstr "पार्ट्स को खोजें..."
 
 msgid "Search processes..."
 msgstr "प्रक्रियाओं को खोजें..."
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "एक दस्तावेज़ चुनें"
 
 msgid "Select a new owner"
-msgstr "एक नया मालिक चुनें"
+msgstr "एक नया स्वामी चुनें"
 
 msgid "Select a new parent group for this account."
 msgstr "इस खाते के लिए एक नया पैरेंट समूह चुनें।"
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "एक उद्धरण चुनें"
 
 msgid "Select a quote line"
-msgstr "एक उद्धरण लाइन चुनें"
+msgstr "एक कोटेशन पंक्ति चुनें"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "उद्धरण क्यों नहीं बनाया गया इसका कारण चुनें।"
@@ -13331,7 +13331,7 @@ msgid "Select an option"
 msgstr "एक विकल्प चुनें"
 
 msgid "Select at least one line to convert"
-msgstr "परिवर्तित करने के लिए कम से कम एक पंक्ति चुनें"
+msgstr "रूपांतरण के लिए कम से कम एक पंक्ति चुनें"
 
 msgid "Select Contact"
 msgstr "संपर्क चुनें"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "उन समूहों का चयन करें जिन्हें इस प्रशिक्षण को पूरा करना चाहिए"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "इस भुगतान को निपटाने वाले चालान चुनें। छूट और राइट-ऑफ चालान मुद्रा में हैं।"
+msgstr "वह चालान चुनें जो यह भुगतान निपटाता है। छूट और बट्टे खाते चालान मुद्रा में हैं।"
 
 msgid "Select value"
 msgstr "मान चुनें"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "स्व प्रबंधित"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "स्व-होस्टेड या प्रबंधित"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "स्व-ऑनबोर्डिंग"
 
 msgid "Self-paced"
 msgstr "स्व-गति"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "सीरियल / बैच"
 
 msgid "Serial items require a sales order"
-msgstr "सीरियल आइटम के लिए बिक्री आदेश आवश्यक है"
+msgstr "सीरियल आइटम को विक्रय आदेश की आवश्यकता है"
 
 msgid "Serial Number"
 msgstr "सीरियल नंबर"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "लक्ष्य निर्धारित करें"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Carbon को अपनी कंपनी के संचालन के अनुसार सेट करें: साइट्स, पार्ट्स, BOMs, बिल ऑफ प्रोसेस, और आप जो फ्लो उपयोग करते हैं।"
+msgstr "Carbon को अपनी कंपनी के संचालन के अनुसार सेट अप करें: साइटें, पार्ट्स, BOM, प्रक्रिया सूची, और जिन प्रवाहों का आप उपयोग करते हैं।"
 
 msgid "Set Clock Out"
-msgstr "क्लॉक आउट सेट करें"
+msgstr "कार्य समाप्त सेट करें"
 
 msgid "Set clock-out time"
 msgstr "घड़ी बंद करने का समय सेट करें"
@@ -13572,13 +13572,13 @@ msgid "Set Console PIN"
 msgstr "कंसोल पिन सेट करें"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "प्रत्येक लागत श्रेणी के लिए नई उद्धरण पंक्तियों पर डिफ़ॉल्ट मार्कअप प्रतिशत सेट करें"
+msgstr "नई कोटेशन पंक्तियों पर प्रत्येक लागत श्रेणी के लिए डिफ़ॉल्ट मार्कअप प्रतिशत सेट करें"
 
 msgid "Set demand projection values for each week"
 msgstr "प्रत्येक सप्ताह के लिए मांग प्रक्षेपण मान निर्धारित करें"
 
 msgid "Set due date"
-msgstr "देय तारीख सेट करें"
+msgstr "नियत तिथि सेट करें"
 
 msgid "Set Pricing"
 msgstr "मूल्य निर्धारण सेट करें"
@@ -13593,7 +13593,7 @@ msgid "Set up the right way"
 msgstr "सही तरीके से सेटअप करें"
 
 msgid "Set up two-factor authentication"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण सेट करें"
+msgstr "दो-कारक प्रमाणीकरण सेट अप करें"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
 msgstr "सेटअप, डेटा, प्रशिक्षण और go-live को कवर करने वाली चरण-दर-चरण कार्यान्वयन योजना के साथ अपनी कंपनी सेट करें।"
@@ -13609,7 +13609,7 @@ msgid "Set Version {0} as Active Version?"
 msgstr "संस्करण {0} को सक्रिय संस्करण के रूप में सेट करें?"
 
 msgid "Set your default location in profile settings to pick a storage unit."
-msgstr "अपनी डिफ़ॉल्ट स्थान को प्रोफ़ाइल सेटिंग्स में सेट करें स्टोरेज यूनिट चुनने के लिए।"
+msgstr "एक भंडारण इकाई चुनने के लिए प्रोफ़ाइल सेटिंग्स में अपना डिफ़ॉल्ट स्थान सेट करें।"
 
 msgid "Settings"
 msgstr "सेटिंग्स"
@@ -13696,7 +13696,7 @@ msgid "Shelf-Life History"
 msgstr "शेल्फ-लाइफ इतिहास"
 
 msgid "shift"
-msgstr "पाली"
+msgstr "शिफ्ट"
 
 msgid "Shift"
 msgstr "शिफ्ट"
@@ -13705,7 +13705,7 @@ msgid "Shift Name"
 msgstr "शिफ्ट का नाम"
 
 msgid "shifts"
-msgstr "पालियां"
+msgstr "शिफ्ट"
 
 msgid "Shifts"
 msgstr "शिफ्ट"
@@ -13732,10 +13732,10 @@ msgid "Shipment ID"
 msgstr "शिपमेंट आईडी"
 
 msgid "Shipment Line"
-msgstr "शिपमेंट लाइन"
+msgstr "शिपमेंट पंक्ति"
 
 msgid "Shipment Lines"
-msgstr "शिपमेंट लाइनें"
+msgstr "शिपमेंट पंक्ति"
 
 msgid "Shipment Location"
 msgstr "शिपमेंट स्थान"
@@ -13850,7 +13850,7 @@ msgstr "अनुगामी शून्य दिखाएं"
 
 #. placeholder {0}: data.length
 msgid "Showing {0} of {totalCount} — refine your search"
-msgstr "दिखा रहा है {0} का {totalCount} — अपनी खोज को परिष्कृत करें"
+msgstr "{0} में से {totalCount} दिखा रहा है — अपनी खोज को परिष्कृत करें"
 
 msgid "Showing in {parentCurrency}"
 msgstr "में दिखाई दे रहा है {parentCurrency}"
@@ -13868,10 +13868,10 @@ msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "जनरेट की गई PDF के हर पेज के पीछे हल्की पृष्ठभूमि के रूप में दिखाया जाता है"
 
 msgid "Shown to the user when this rule fails."
-msgstr "जब यह नियम विफल हो तो उपयोगकर्ता को दिखाया जाता है।"
+msgstr "जब यह नियम विफल हो तब उपयोगकर्ता को दिखाया जाता है।"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon में साइन इन करें"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "जादुई लिंक के बजाय बायोमेट्रिक्स के साथ साइन इन करें। पासकीज़ Face ID, Touch ID, या आपकी डिवाइस PIN द्वारा सुरक्षित हैं।"
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "साइटें और स्थान"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "साइट्स, स्थान, कार्य केंद्र, उपयोगकर्ता, आपूर्तिकर्ता, और आपकी कंपनी सेटिंग्स — वह आधार जिस पर बाकी सब कुछ बनता है। तैयार टेम्पलेट से शुरू करें।"
+msgstr "साइटें, स्थान, वर्क सेंटर, उपयोगकर्ता, आपूर्तिकर्ता, और आपकी कंपनी की सेटिंग्स — वह आधार जिस पर बाकी सब कुछ बनता है। तैयार टेम्पलेट से शुरू करें।"
 
 msgid "Size"
 msgstr "आकार"
@@ -13943,7 +13943,7 @@ msgid "Skip scheduled maintenance on company holidays"
 msgstr "कंपनी की छुट्टियों पर निर्धारित रखरखाव को छोड़ें"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
-msgstr "जारी-लेकिन-शुरू नहीं की गई स्थिति को छोड़ें - स्कैन पर काम तुरंत शुरू होता है।"
+msgstr "रिलीज़ किए गए लेकिन शुरू न किए गए स्थिति को छोड़ दें — जॉब स्कैन पर तुरंत शुरू हो जाता है।"
 
 msgid "Skipped"
 msgstr "छोड़ा गया"
@@ -13955,7 +13955,7 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "स्थान, आइटम, या किसी भी आयाम द्वारा संपत्ति गतिविधि को स्लाइस करें"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "स्थान, लागत केंद्र, या किसी भी आयाम द्वारा खर्चों को स्लाइस करें"
+msgstr "स्थान, लागत केंद्र, या किसी भी आयाम द्वारा व्यय को विभाजित करें"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
 msgstr "ग्राहक, ग्राहक प्रकार, या किसी भी आयाम द्वारा राजस्व को स्लाइस करें"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "रसीद लाइन को विभाजित करें"
 
 msgid "Split shipment line"
-msgstr "शिपमेंट लाइन को विभाजित करें"
+msgstr "शिपमेंट पंक्ति को विभाजित करें"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "होस्टिंग सेट अप करें"
@@ -14090,13 +14090,13 @@ msgid "Standard cloud Carbon fits how your company runs"
 msgstr "मानक क्लाउड कार्बन आपकी कंपनी के संचालन के तरीके के अनुरूप है"
 
 msgid "Standard Cost Variances"
-msgstr "मानक लागत विचरण"
+msgstr "मानक लागत विचलन"
 
 msgid "Standard factor"
 msgstr "मानक कारक"
 
 msgid "Standard Lead Time"
-msgstr "मानक लीड समय"
+msgstr "मानक लीड टाइम"
 
 msgid "Start"
 msgstr "शुरू करें"
@@ -14112,7 +14112,7 @@ msgid "Start date"
 msgstr "प्रारंभ तिथि"
 
 msgid "Start Date"
-msgstr "शुरुआत तारीख"
+msgstr "प्रारंभ तिथि"
 
 msgid "Start Expiration"
 msgstr "समाप्ति शुरू करें"
@@ -14166,7 +14166,7 @@ msgid "Status"
 msgstr "स्थिति"
 
 msgid "Status call: progress, blockers, what's next"
-msgstr "स्टेटस कॉल: प्रगति, बाधाएं, आगे क्या है"
+msgstr "स्थिति कॉल: प्रगति, रुकावटें, आगे क्या है"
 
 msgid "Status Distribution"
 msgstr "स्थिति वितरण"
@@ -14193,7 +14193,7 @@ msgid "Step removed — pick a new value"
 msgstr "चरण हटाया गया — एक नया मान चुनें"
 
 msgid "steps"
-msgstr "कदम"
+msgstr "चरण"
 
 msgid "Steps"
 msgstr "चरण"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "स्टॉक ट्रांसफर आईडी"
 
 msgid "Stock Transfer Lines"
-msgstr "स्टॉक ट्रांसफर लाइनें"
+msgstr "स्टॉक स्थानांतरण पंक्तियाँ"
 
 msgid "Stock Transfer Notes"
 msgstr "स्टॉक ट्रांसफर नोट्स"
@@ -14230,7 +14230,7 @@ msgid "Stocked for spares only."
 msgstr "केवल स्पेयर के लिए स्टॉक किया गया।"
 
 msgid "Stockout"
-msgstr "स्टॉक समाप्त"
+msgstr "स्टॉक आउट"
 
 msgid "Stop raising purchase orders after this date"
 msgstr "इस तारीख के बाद क्रय आदेश जारी करना बंद करें"
@@ -14266,43 +14266,43 @@ msgid "Storage Unit"
 msgstr "भंडारण इकाई"
 
 msgid "Storage Unit (optional)"
-msgstr "स्टोरेज यूनिट (वैकल्पिक)"
+msgstr "भंडारण इकाई (वैकल्पिक)"
 
 msgid "storage units"
-msgstr "भंडारण इकाइयां"
+msgstr "भंडारण इकाइयाँ"
 
 msgid "Storage Units"
 msgstr "भंडारण इकाइयाँ"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "इस आइटम पर दिनों की एक निश्चित संख्या स्टोर करें। समाप्ति शुरुआत तारीख प्रत्येक बैच या सीरियल पर सेट की जाती है जब इसे बनाया जाता है (या जब ट्रिगर प्रक्रिया चलती है, यदि सेट है)।"
+msgstr "इस आइटम पर निश्चित संख्या के दिनों के लिए भंडारण करें। समाप्ति प्रारंभ तिथि प्रत्येक बैच या सीरीयल पर सेट की जाती है जब यह बनाया जाता है (या जब ट्रिगर प्रक्रिया चलती है, यदि सेट है)।"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "इस आइटम पर दिनों की एक निश्चित संख्या स्टोर करें। समाप्ति शुरुआत तारीख प्रत्येक बैच या सीरियल पर सेट की जाती है जब इसे प्राप्त या बनाया जाता है (या जब ट्रिगर प्रक्रिया चलती है, यदि सेट है)।"
+msgstr "इस आइटम पर निश्चित संख्या के दिनों के लिए भंडारण करें। समाप्ति प्रारंभ तिथि प्रत्येक बैच या सीरीयल पर सेट की जाती है जब यह प्राप्त किया जाता है या बनाया जाता है (या जब ट्रिगर प्रक्रिया चलती है, यदि सेट है)।"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "इस आइटम पर दिनों की एक निश्चित संख्या स्टोर करें। प्रत्येक बैच या सीरीज़ के लिए समाप्ति प्रारंभ तारीख प्राप्त होने पर सेट की जाती है।"
+msgstr "इस आइटम पर निश्चित संख्या के दिनों के लिए भंडारण करें। समाप्ति प्रारंभ तिथि प्रत्येक बैच या सीरीयल पर सेट की जाती है जब यह प्राप्त किया जाता है।"
 
 msgid "Straight line"
 msgstr "सीधी रेखा"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe के पास पहले से इस ईमेल के साथ एक ग्राहक है"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe नियत तिथि"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe चालान को ग्राहक को ईमेल करता है, इसलिए एक पता आवश्यक है। यह Carbon में संपर्क के लिए भी सहेजा जाएगा।"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी तक कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक बनाएगी।"
 
 msgid "Style of kanban output to show in the Kanban table"
-msgstr "Kanban तालिका में दिखाने के लिए kanban आउटपुट की शैली"
+msgstr "कानबान तालिका में दिखाने के लिए कानबान आउटपुट की शैली"
 
 msgid "Sub-assembly expiries only"
 msgstr "उप-विधानसभा समाप्ति केवल"
@@ -14311,7 +14311,7 @@ msgid "Sub-Departments"
 msgstr "उप-विभाग"
 
 msgid "Subassembly"
-msgstr "उप-विधानसभा"
+msgstr "सब-असेंबली"
 
 msgid "Subcontracting Variance"
 msgstr "उप-अनुबंध विचलन"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "अनुमोदन के लिए सबमिट करें"
 
 msgid "Submit Inspection"
-msgstr "निरीक्षण जमा करें"
+msgstr "निरीक्षण सबमिट करें"
 
 msgid "Submitted By"
 msgstr "द्वारा प्रस्तुत"
@@ -14353,10 +14353,10 @@ msgid "substituted from"
 msgstr "से प्रतिस्थापित"
 
 msgid "Subtotal"
-msgstr "उप-कुल"
+msgstr "उप-योग"
 
 msgid "Subtotal:"
-msgstr "उप-कुल:"
+msgstr "उप-योग:"
 
 msgid "Succeeded"
 msgstr "सफल"
@@ -14368,13 +14368,13 @@ msgid "Successfully copied quote"
 msgstr "सफलतापूर्वक उद्धरण की प्रतिलिपि बनाई गई"
 
 msgid "Successfully created a new revision"
-msgstr "सफलतापूर्वक एक नया संशोधन बनाया गया"
+msgstr "नया रिवीजन सफलतापूर्वक बनाया गया"
 
 msgid "Successor effectivity"
-msgstr "उत्तराधिकारी प्रभावशीलता"
+msgstr "उत्तराधिकारी प्रभावी तिथि"
 
 msgid "Successor Effectivity Date"
-msgstr "उत्तराधिकारी प्रभावी तारीख"
+msgstr "उत्तराधिकारी प्रभावी तिथि"
 
 msgid "Successor Part"
 msgstr "उत्तराधिकारी भाग"
@@ -14416,10 +14416,10 @@ msgid "Supersession"
 msgstr "प्रतिस्थापन"
 
 msgid "Supersession chain detected"
-msgstr "सुपरसेशन चेन का पता चला"
+msgstr "प्रतिस्थापन श्रृंखला का पता चला"
 
 msgid "Supersession Mode"
-msgstr "सुपरसेशन मोड"
+msgstr "प्रतिस्थापन मोड"
 
 msgid "supplier"
 msgstr "आपूर्तिकर्ता"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "आपूर्तिकर्ता भाग"
 
 msgid "Supplier Part ID"
-msgstr "आपूर्तिकर्ता भाग ID"
+msgstr "आपूर्तिकर्ता पार्ट ID"
 
 msgid "Supplier Part Number"
 msgstr "आपूर्तिकर्ता भाग संख्या"
@@ -14500,19 +14500,19 @@ msgid "Supplier Quality"
 msgstr "आपूर्तिकर्ता गुणवत्ता"
 
 msgid "Supplier quote"
-msgstr "आपूर्तिकर्ता उद्धरण"
+msgstr "आपूर्तिकर्ता कोटेशन"
 
 msgid "Supplier Quote"
-msgstr "आपूर्तिकर्ता उद्धरण"
+msgstr "आपूर्तिकर्ता कोटेशन"
 
 msgid "Supplier Quote ID"
-msgstr "आपूर्तिकर्ता उद्धरण ID"
+msgstr "आपूर्तिकर्ता कोटेशन ID"
 
 msgid "Supplier Quote Notifications"
-msgstr "आपूर्तिकर्ता उद्धरण सूचनाएं"
+msgstr "आपूर्तिकर्ता कोटेशन सूचनाएँ"
 
 msgid "Supplier Quotes"
-msgstr "आपूर्तिकर्ता उद्धरण"
+msgstr "आपूर्तिकर्ता कोटेशन"
 
 msgid "Supplier Ref."
 msgstr "आपूर्तिकर्ता संदर्भ"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "स्विच करें"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "एक मॉड्यूल को बंद करें इसे हर जगह हटाने के लिए: आवश्यकताएं, डेटा, प्रशिक्षण, दायरा।"
+msgstr "मॉड्यूल को बंद करने से यह हर जगह हटा दिया जाता है: आवश्यकताएँ, डेटा, प्रशिक्षण, दायरा।"
 
 msgid "Switch to pan mode"
 msgstr "पैन मोड में स्विच करें"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "लक्ष्य कंपनी"
 
 msgid "Target customers by type."
-msgstr "लक्ष्य आइटम"
+msgstr "ग्राहकों को प्रकार से लक्ष्य करें।"
 
 msgid "Target disposition row"
 msgstr "लक्ष्य निपटान पंक्ति"
@@ -14690,7 +14690,7 @@ msgid "Tasks still open"
 msgstr "अभी भी खुले कार्य"
 
 msgid "Tasks that must be completed before this issue can be closed; selecting actions here adds them on top of whatever the workflow specifies."
-msgstr "कार्य जो इस समस्या को बंद करने से पहले पूरे किए जाने चाहिए; यहाँ क्रियाओं का चयन करने से वर्कफ़्लो जो निर्दिष्ट करता है उसके ऊपर उन्हें जोड़ा जाता है।"
+msgstr "इस निर्गम को बंद करने से पहले पूर्ण किए जाने वाले कार्य; यहाँ कार्य चुनने से वह वर्कफ़्लो जो भी निर्दिष्ट करता है उसके शीर्ष पर जोड़े जाते हैं।"
 
 msgid "Tax"
 msgstr "कर"
@@ -14711,13 +14711,13 @@ msgid "Tax Depreciation"
 msgstr "कर मूल्यह्रास"
 
 msgid "Tax Depreciation Method"
-msgstr "कर मूल्यह्रास पद्धति"
+msgstr "कर मूल्यह्रास विधि"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "कर मुक्त"
 
 msgid "Tax Exempt"
-msgstr "कर छूट"
+msgstr "कर मुक्त"
 
 msgid "Tax ID"
 msgstr "टैक्स आईडी"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "टीम प्रशिक्षित"
 
 msgid "Technical support"
-msgstr ""
+msgstr "तकनीकी समर्थन"
 
 msgid "Temperature"
 msgstr "तापमान"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "टेम्पलेट्स"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "अस्थायी निपटान-समाशोधन (क्लियरिंग) खाता जो शिपमेंट पर संपत्ति के निवल बही मूल्य के लिए डेबिट किया जाता है और चालान पर निवल बही मूल्य के लिए क्रेडिट किया जाता है, जो बिक्री चक्र के दौरान शून्य हो जाता है।"
+msgstr "अस्थायी निपटान-समाशोधन खाता जिसे शिपमेंट पर एक संपत्ति के शुद्ध बही मूल्य के लिए डेबिट किया जाता है और बिलिंग पर इसके शुद्ध बही मूल्य के लिए क्रेडिट किया जाता है, बिक्रय चक्र पर शून्य तक नेट किया जाता है।"
 
 msgid "Terms and Privacy"
 msgstr "शर्तें और गोपनीयता"
@@ -14805,25 +14805,25 @@ msgstr "वह नाम पहले से ही एक अन्य चर�
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "\"{0}\" चरण अपने आप को बंद कर देता है जब इसके सभी कार्य प्रोजेक्ट योजना में पूरे हो जाते हैं।"
+msgstr "चरण \"{0}\" अपने आप को बंद कर देता है जब इसके प्रोजेक्ट योजना में सभी कार्य पूर्ण हो जाते हैं।"
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "\"{0}\" चरण पूरा हो गया है — इसका \"{1}\" चेकपॉइंट पास हो गया है।"
+msgstr "यह \"{0}\" चरण पूर्ण हो गया — इसकी \"{1}\" चेकपॉइंट उत्तीर्ण हो गई।"
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
 msgstr "{0} चरणों को लाइव करने के लिए, प्रत्येक एक चेकपॉइंट पर समाप्त होता है। जैसे ही आप प्रत्येक कार्य को पूरा करते हैं, उसे टिक करें।"
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "लेखा आयाम जो रिपोर्टिंग और विश्लेषण के लिए वस्तुओं को वर्गीकृत करता है।"
+msgstr "लेखांकन आयाम जो रिपोर्टिंग और विश्लेषण के लिए आइटम को वर्गीकृत करता है।"
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "वे खाते जो Carbon स्वचालित रूप से पोस्ट करता है"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "वह कार्रवाई जो एक सहेजी गई विधि (इसकी सामग्री, संचालन और कार्य निर्देश) को एक कार्य या उद्धरण पंक्ति पर कॉपी करती है।"
+msgstr "किसी सहेजी गई विधि (इसकी सामग्री, ऑपरेशन और कार्य निर्देश) को किसी जॉब या कोटेशन पंक्ति पर प्रतिलिपि करने की कार्रवाई।"
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "एक सूची-प्रकार की विशेषता के लिए अनुमत मान; उपयोगकर्ता स्वतंत्र रूप से टाइप करने के बजाय इन में से चुनते हैं।"
@@ -14886,16 +14886,16 @@ msgid "The catalog you run on. Loads once foundation is in."
 msgstr "वह कैटलॉग जिस पर आप चलते हैं। फाउंडेशन के बाद लोड होता है।"
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "इस इकाई में अनुमत स्टॉक की श्रेणियां; इकाई नियमों को लागू करने के लिए उपयोग किया जाता है (उदाहरण के लिए, ठंडी श्रृंखला, खतरनाक)।"
+msgstr "इस इकाई में अनुमत स्टॉक की श्रेणियाँ; भंडारण नियमों को लागू करने के लिए उपयोग की जाती हैं (जैसे कोल्ड चेन, खतरनाक)।"
 
 msgid "The categories you group your suppliers into"
 msgstr "वे श्रेणियां जिनमें आप अपने आपूर्तिकर्ताओं को समूहित करते हैं"
 
 msgid "The categories your fixed assets fall into"
-msgstr "आपकी निश्चित संपत्तियां जिन श्रेणियों में आती हैं"
+msgstr "वह श्रेणियाँ जिनमें आपकी अचल संपत्ति आती है"
 
 msgid "The category a fixed asset belongs to, carrying the GL accounts every asset of that kind posts to."
-msgstr "अनिवार्य संपत्ति की श्रेणी, जो मुख्य खाता खातों को ले जाती है जिनमें उस प्रकार की प्रत्येक संपत्ति बुक की जाती है।"
+msgstr "वह श्रेणी जिससे अचल संपत्ति संबंधित है, जिसमें लेजर खाते होते हैं जहाँ उस प्रकार की प्रत्येक संपत्ति पोस्ट होती है।"
 
 msgid "The category of risk (operational, strategic, financial, compliance, etc.); drives which reports the risk rolls into."
 msgstr "जोखिम की श्रेणी (परिचालन, रणनीतिक, वित्तीय, अनुपालन, आदि); यह निर्धारित करता है कि जोखिम किन रिपोर्टों में जाता है।"
@@ -14910,10 +14910,10 @@ msgid "The category this supplier belongs to (raw-material, services, contract-m
 msgstr "वह श्रेणी जिससे यह आपूर्तिकर्ता संबंधित है (कच्चा माल, सेवाएं, अनुबंध निर्माता); डिफ़ॉल्ट GL खातों और रिपोर्टिंग समूहीकरण को निर्धारित करता है।"
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "कन्बन कार्ड पर मुद्रित कोड जिसे ऑपरेटर नौकरी को पूर्ण के रूप में चिह्नित करने के लिए स्कैन करते हैं; यदि खाली छोड़ा जाता है तो स्वचालित रूप से उत्पन्न होता है।"
+msgstr "कानबान कार्ड पर मुद्रित कोड जिसे ऑपरेटर जॉब को पूर्ण करने के लिए स्कैन करते हैं; खाली छोड़ने पर स्वचालित रूप से उत्पन्न।"
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "ठेकेदार की अपेक्षित साप्ताहिक उपलब्धता; शेड्यूलिंग इसे ऊपरी सीमा के रूप में उपयोग करता है जब इस ठेकेदार को सप्ताह भर के संचालन को असाइन करता है।"
+msgstr "ठेकेदार की अपेक्षित साप्ताहिक उपलब्धता; शेड्यूलिंग इसे इस सप्ताह भर में इस ठेकेदार को ऑपरेशन के लिए असाइन करते समय ऊपरी सीमा के रूप में उपयोग करती है।"
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "इस लॉट/सीरीज़ के लिए सही की गई समाप्ति तिथि; परिवर्तन के बाद मौजूदा ऑन-हैंड स्टॉक को शेल्फ-लाइफ नीति के विरुद्ध पुनः मूल्यांकन किया जाता है।"
@@ -14925,16 +14925,16 @@ msgid "The customer record this portal account links to; only contacts already o
 msgstr "ग्राहक रिकॉर्ड जिससे यह पोर्टल खाता जुड़ा है; केवल वे संपर्क जो उस ग्राहक के साथ पहले से हैं, नीचे खाता धारक के रूप में चुने जा सकते हैं।"
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "वह ग्राहक जिसे माल वितरित किया जाता है, जब यह बिल किए जाने वाले ग्राहक से अलग होता है (जैसे मुख्यालय को बिल भेजें, शाखा को शिप करें)।"
+msgstr "ग्राहक जिसे माल वितरित किया जाता है, जब वह चालान किए जाने वाले ग्राहक से अलग हो (जैसे मुख्यालय को चालान, शाखा को शिपमेंट)।"
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
 msgstr "वह ग्राहक जिसके लिए यह पोर्टल लिंक प्रदान किया जाता है; केवल इस ग्राहक के संपर्क लिंक के माध्यम से साइन इन कर सकते हैं।"
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "इस दस्तावेज़ के लिए ग्राहक का अपना संदर्भ - आमतौर पर उनके सिस्टम पर उनकी RFQ या PO संख्या; मुद्रण योग्य आउटपुट पर प्रदर्शित और किसी भी दस्तावेज़ में आगे किया गया जिसमें यह परिवर्तित होता है।"
+msgstr "इस दस्तावेज़ का ग्राहक का अपना संदर्भ — आमतौर पर उनके सिस्टम पर उनका RFQ या PO नंबर; मुद्रणीय आउटपुट पर दिखाया जाता है और इस दस्तावेज़ से किसी भी दस्तावेज़ में ले जाया जाता है जिसमें यह रूपांतरित होता है।"
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
-msgstr "उनके भाग ID के लिए ग्राहक का संशोधन टैग, जब यह हमारे से अलग होता है; क्रॉस-संदर्भ स्तर पर पिन किया गया, हमारे संशोधन पर नहीं।"
+msgstr "उनके पार्ट ID के लिए ग्राहक का रिवीजन टैग, जब यह हमारे से भिन्न हो; क्रॉस-रेफरेंस स्तर पर लॉक किया जाता है, हमारे रिवीजन पर नहीं।"
 
 msgid "The customers who go live fastest own these well. The full ours/yours split is below."
 msgstr "जो ग्राहक सबसे तेजी से लाइव होते हैं वे इन्हें अच्छी तरह से संभालते हैं। पूरा हमारा/आपका विभाजन नीचे है।"
@@ -14952,10 +14952,10 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "वह तारीख जब इस संपत्ति के लिए मूल्यह्रास शुरू होता है; आमतौर पर सेवा शुरुआत की तारीख।"
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "वह तारीख जिसके बाद इस उद्धरण की कीमत अब सम्मानित नहीं है; इस तारीख के बाद ऑर्डर में रूपांतरण को पुनः-उद्धरण की आवश्यकता हो सकती है।"
+msgstr "वह नियत तिथि जिसके बाद इस कोटेशन की मूल्य निर्धारण अब सम्मानित नहीं है; इस तिथि के बाद आदेश में रूपांतरण के लिए पुनः कोटेशन की आवश्यकता हो सकती है।"
 
 msgid "The date the customer expects to receive the goods"
-msgstr "वह तारीख जिस दिन ग्राहक को सामान प्राप्त होने की उम्मीद है"
+msgstr "वह नियत तिथि जिस पर ग्राहक को माल प्राप्त होने की अपेक्षा है"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
 msgstr "वह तारीख जब सामान वास्तव में गोदाम से बाहर निकलते हैं; शिपमेंट पोस्टिंग पर दर्ज किया जाता है और समय पर शिपिंग स्कोरिंग के लिए उपयोग किया जाता है।"
@@ -14964,7 +14964,7 @@ msgid "The date the item is required on-site to cover the period's projected dem
 msgstr "वह तारीख जिस दिन आइटम साइट पर आवश्यक है ताकि अवधि की अनुमानित मांग को पूरा किया जा सके।"
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "वह तारीख जब यह संपत्ति सेवा से सेवानिवृत्त होती है; इस तारीख पर मूल्यह्रास बंद हो जाता है और शेष शुद्ध बुक मूल्य निपटान खाते में बुक किया जाता है।"
+msgstr "वह तिथि जिस पर यह अचल संपत्ति सेवा से सेवानिवृत्त हो जाती है; इस तिथि पर मूल्यह्रास रुक जाता है और शेष शुद्ध बही मूल्य निपटान खाते में दर्ज किया जाता है।"
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "वह तारीख जब यह प्रविष्टि खाता बही में दर्ज होती है; वह लेखांकन अवधि निर्धारित करता है जिसमें यह आता है।"
@@ -14991,13 +14991,13 @@ msgid "The department this one rolls up under for reporting and headcount hierar
 msgstr "विभाग जिसके अंतर्गत यह रिपोर्टिंग और हेडकाउंट पदानुक्रमों के लिए रोल अप करता है; शीर्ष स्तरीय विभाग के लिए खाली छोड़ें।"
 
 msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
-msgstr "आठ अनुशासन गुणवत्ता विधि, अनुरूपता रहित वर्कफ़्लो के कार्यों के साथ मॉडल किया गया है, न कि कठोर कोडित।"
+msgstr "आठ-अनुशासन गुणवत्ता विधि, गैर-अनुरूपता वर्कफ़्लो के कार्यों के साथ मॉडल किया गया, हार्ड-कोडेड नहीं।"
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "इस लागत केंद्र के लिए जिम्मेदार कर्मचारी — जब खरीद आदेश अनुमोदन चालू हों, तो वह इसके विरुद्ध खाते में व्यय के लिए अनुमोदक है।"
+msgstr "वह कर्मचारी जो इस लागत केंद्र के लिए जिम्मेदार है — जब क्रय आदेश अनुमोदन चालू होते हैं, तो वे इसके विरुद्ध पोस्ट किए गए खर्च के लिए अनुमोदक होते हैं।"
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "ग्राहक को उद्धृत करने से भुगतान एकत्र करने तक का अंत-से-अंत व्यावसायिक प्रवाह: RFQ से उद्धरण से बिक्रय आदेश, फिर शिपमेंट, चालान और निपटाए गए भुगतान।"
+msgstr "एक ग्राहक को कोटेशन देने से भुगतान एकत्र करने तक अंत से अंत तक व्यावसायिक प्रवाह: RFQ से कोटेशन से विक्रय आदेश, फिर शिपमेंट, चालान और निपटारा भुगतान।"
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "वह एंडपॉइंट जो तालिका अपडेट होने पर अपडेट किए गए डेटा के साथ POST अनुरोध प्राप्त करता है"
@@ -15006,7 +15006,7 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "इंजीनियरिंग ड्राइंग जिसे यह निरीक्षण योजना बंधी है; इस हिस्से के विरुद्ध दर्ज निरीक्षण इस ड्राइंग को वापस संदर्भित करते हैं।"
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "उत्पादन के दौरान इस आइटम के उत्पादन का अपेक्षित प्रतिशत खो गया; योजना नुकसान की भरपाई के लिए मांग को 1 / (1 - स्क्रैप) से गुणा करता है।"
+msgstr "इस आइटम के आउटपुट का अपेक्षित प्रतिशत जो उत्पादन के दौरान खो जाता है; योजना मांग को 1 / (1 − स्क्रैप) से गुणा करती है मुआवजा देने के लिए।"
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "व्यय खाता जिस पर यह अप्रत्यक्ष-खर्च लाइन पोस्ट करता है; आवश्यक है क्योंकि अप्रत्यक्ष लाइनों के पास खाता प्राप्त करने के लिए कोई वस्तु बही प्रविष्टि नहीं है।"
@@ -15018,13 +15018,13 @@ msgid "The fixed number of units to inspect from the front of each lot, regardle
 msgstr "लॉट के आगे से निरीक्षण करने के लिए इकाइयों की निश्चित संख्या, लॉट के आकार की परवाह किए बिना।"
 
 msgid "The fixed-asset record this purchase capitalizes against; the line's receipt creates the asset entry rather than an inventory entry."
-msgstr "अचल संपत्ति रिकॉर्ड जिसके विरुद्ध यह खरीद पूंजीकृत है; लाइन की रसीद इन्वेंटरी प्रविष्टि के बजाय संपत्ति प्रविष्टि बनाती है।"
+msgstr "अचल संपत्ति का रिकॉर्ड जिसके विरुद्ध यह खरीद पूंजीकृत की जाती है; पंक्ति की प्राप्ति अचल संपत्ति प्रविष्टि बनाती है, इन्वेंटरी प्रविष्टि नहीं।"
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
 msgstr "अचल संपत्ति रिकॉर्ड जिसे यह बिक्रय निपटान करती है; लाइन की शिपमेंट संपत्ति की शुद्ध पुस्तक मूल्य निपटान प्रविष्टि को COGS के बजाय पोस्ट करती है।"
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "वह न्यूनतम मूल्य जिस तक एक संपत्ति का मूल्यह्रास होता है; जब शुद्ध बुक मूल्य इसे पहुंचता है, तो संपत्ति पूरी तरह से मूल्यहृास हो जाती है।"
+msgstr "वह न्यूनतम मूल्य जिसके लिए अचल संपत्ति का मूल्यह्रास होता है; जब शुद्ध बही मूल्य इस पर पहुँचता है, तो संपत्ति पूर्ण मूल्यह्रासित में परिवर्तित हो जाती है।"
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "फर्श और कार्यालय समान इन्वेंटरी और लागत आंकड़े पढ़ते हैं।"
@@ -15033,19 +15033,19 @@ msgid "The following assemblies have no operations. Please assign an operation t
 msgstr "निम्नलिखित असेंबलियों के पास कोई ऑपरेशन नहीं है। रिलीज़ करने से पहले प्रत्येक को एक ऑपरेशन असाइन करें।"
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "निम्नलिखित लाइन आइटम कीमतें या लीड समय गायब हैं:"
+msgstr "निम्नलिखित पंक्ति वस्तुओं के मूल्य या लीड टाइम नहीं हैं:"
 
 msgid "The following tasks are not done yet:"
-msgstr "निम्नलिखित कार्य अभी तक पूरे नहीं हुए हैं:"
+msgstr "निम्नलिखित कार्य अभी तक हो नहीं गए हैं:"
 
 msgid "The forms and shapes your raw materials come in"
-msgstr "आपकी कच्ची सामग्री जिन रूपों और आकारों में आती है"
+msgstr "वे रूप और आकार जिनमें आपका कच्चा माल आता है"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
 msgstr "प्रत्येक लॉट का अंश निरीक्षण के लिए; वास्तविक गणना निरीक्षण के समय लॉट आकार से की जाती है।"
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "खरीद आदेश की कीमत और आपूर्तिकर्ता के बिल के बीच का अंतर, जब चालान पोस्ट होता है तो एक विचलन खाते में पोस्ट किया जाता है।"
+msgstr "क्रय आदेश के मूल्य और आपूर्तिकर्ता के बिल के बीच अंतर, जो चालान पोस्ट होने पर विचलन खाते में पोस्ट किया जाता है।"
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "GL खाता जिस पर इस वाहक के लिए शुल्क पोस्ट करते हैं (माल ढुलाई व्यय, माल ढुलाई में/बाहर)।"
@@ -15060,43 +15060,43 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "वह समूह खाता जिसमें यह खाता जोड़ा जाता है; इसका प्रकार, वर्ग और विवरण प्लेसमेंट निर्धारित करता है।"
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "इस कार्य केंद्र पर ऑपरेटर श्रम की प्रति घंटा लागत; एक काम के WIP में श्रम लागत चार्ज करने के लिए दर्ज श्रम घंटों के साथ संयुक्त।"
+msgstr "इस वर्क सेंटर पर ऑपरेटर श्रम की प्रति घंटा लागत; दर्ज श्रम घंटों के साथ संयुक्त होकर श्रम लागत को जॉब के WIP में चार्ज करने के लिए।"
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "इस कार्य केंद्र पर मशीनरी चलाने की प्रति घंटा लागत; एक काम के WIP में मशीन लागत चार्ज करने के लिए दर्ज मशीन घंटों के साथ संयुक्त।"
+msgstr "इस वर्क सेंटर पर मशीनरी चलाने की प्रति घंटा लागत; दर्ज मशीन घंटों के साथ संयुक्त होकर मशीन लागत को जॉब के WIP में चार्ज करने के लिए।"
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "इस कार्य केंद्र पर लागू प्रति घंटा अप्रत्यक्ष-लागत बोझ; श्रम + मशीन और पूर्ण उद्धरण दर के बीच का अंतर वह है जो ओवरहेड अवशोषित करता है।"
+msgstr "इस वर्क सेंटर पर लागू अप्रत्यक्ष लागत का प्रति घंटा भार; श्रम + मशीन और पूर्ण कोटेशन दर के बीच अंतर वह है जो उपरिव्यय ले लेता है।"
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
-msgstr "वह https पता जिसमें एक workflow के webhook step को भेजा जाता है — plain http, redirects, और private या link-local addresses को resolve करने वाले hosts को अस्वीकार किया जाता है, और कॉल दस सेकंड के बाद रुक जाती है।"
+msgstr "वह https पता जहाँ वर्कफ़्लो का वेबहुक चरण पोस्ट करता है — सादा HTTP, रीडायरेक्ट और निजी या लिंक-लोकल पते पर रिज़ॉल्व होने वाले होस्ट अस्वीकार किए जाते हैं, और कॉल दस सेकंड के बाद हार मान जाता है।"
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
 msgstr "मानव-पठनीय दस्तावेज़ संख्या (जैसे J000001 या ECO-000001) जो एक अनुक्रम से बनाई गई है और रिकॉर्ड पर संग्रहीत है, इसके आंतरिक id से अलग।"
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "पहचानकर्ता जो ग्राहक इस भाग के लिए अपने POs पर उपयोग करता है; Carbon आदेश आयात पर इसे हमारे आंतरिक भाग ID में हल करता है।"
+msgstr "वह पहचानकर्ता जिसका ग्राहक अपने PO पर इस पार्ट के लिए उपयोग करता है; Carbon इसे ऑर्डर इंपोर्ट पर हमारे आंतरिक पार्ट ID में रिज़ॉल्व करता है।"
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
 msgstr "पहचानकर्ता जो आपूर्तिकर्ता इस भाग के लिए अपने उद्धरणों और चालानों पर उपयोग करता है; Carbon इसे हमारे आंतरिक भाग ID में हल करता है।"
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
-msgstr "तत्काल अनुरूपता कार्य जो प्रभावित स्टॉक या कार्य को अलग रखता है इससे पहले कि मूल कारण ज्ञात हो।"
+msgstr "तत्काल गैर-अनुरूपता कार्य जो प्रभावित स्टॉक या काम को संगरोध करता है इससे पहले कि मूल कारण ज्ञात हो।"
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
 msgstr "प्रभाव रेटिंग यदि जोखिम महसूस किया जाता है (1 = नगण्य से 5 = विनाशकारी); जोखिम स्कोर की गणना के लिए संभावना के साथ जोड़ी गई।"
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "आने वाली पोस्टिंग दस्तावेज जो माल को स्टॉक में लेता है (एक PO, स्थानांतरण, या कार्य आउटपुट से) और कोई भी ट्रैक किए गए संस्थाएं बनाता है।"
+msgstr "आंतरिक आगमन पोस्टिंग दस्तावेज़ जो माल को स्टॉक में ले लेता है (PO, स्थानांतरण या जॉब आउटपुट से) और कोई भी ट्रैक किए गए इकाइयों को बनाता है।"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "Incoterm नियम (FOB, DAP, EXW, CIF, ...) जो नियंत्रित करता है कि इस आपूर्तिकर्ता से माल भेजने पर कौन माल ढुलाई का भुगतान करता है, जोखिम कौन लेता है और शीर्षक का हस्तांतरण कहां होता है।"
+msgstr "इनकोटर्म नियम (FOB, DAP, EXW, CIF, …) जो निर्धारित करता है कि कौन माल भाड़ा भुगतान करता है, कौन जोखिम वहन करता है, और इस आपूर्तिकर्ता से शिपमेंट पर मालिकाना हक का स्थानांतरण कहाँ होता है।"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "Incoterm नियम (FOB, DAP, EXW, CIF, ...) जो नियंत्रित करता है कि इस ग्राहक को माल भेजने पर कौन माल ढुलाई का भुगतान करता है, जोखिम कौन लेता है और शीर्षक का हस्तांतरण कहां होता है।"
+msgstr "इनकोटर्म नियम (FOB, DAP, EXW, CIF, …) जो निर्धारित करता है कि कौन माल भाड़ा भुगतान करता है, कौन जोखिम वहन करता है, और इस ग्राहक को शिपमेंट पर मालिकाना हक का स्थानांतरण कहाँ होता है।"
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "इन्वेंटरी लागत जो शिपमेंट पोस्ट होने पर पहचानी जाती है, वस्तु की लागत पद्धति द्वारा मूल्यांकित।"
+msgstr "शिपमेंट पोस्ट होने पर मान्यता दी गई इन्वेंटरी लागत, जिसका मूल्यांकन आइटम की लागत निर्धारण विधि के द्वारा किया गया है।"
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "MACRS के तहत इस संपत्ति के लिए IRS पुनर्प्राप्ति-अवधि वर्ग (3, 5, 7, 10, 15, 20, 27.5, 39-वर्ष)।"
@@ -15105,19 +15105,19 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "वह काम जिसका संचालन यह बाहरी-प्रसंस्करण लाइन कवर करता है; लाइन की रसीद इस काम के विरुद्ध संचालन को बंद करती है।"
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "स्थान की शेड्यूल कतार में नौकरी की स्थिति — एक आंशिक संख्या जो Carbon due date और deadline type से गणना करता है, Low/High रेटिंग नहीं।"
+msgstr "जॉब की अपने स्थान की शेड्यूल पंक्ति में स्थिति — एक अंशीय संख्या जो Carbon नियत तिथि और समय सीमा प्रकार से परिकलित करता है, कोई निम्न/उच्च रेटिंग नहीं।"
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
 msgstr "प्रकार का समायोजन जो यह नियम लागू करता है - छूट, अधिभार, या निश्चित ओवरराइड; प्रत्येक पंक्ति पर वास्तविक डेल्टा की गणना करने के लिए राशि प्रकार के साथ संयुक्त।"
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "मान का प्रकार जो यह विशेषता स्वीकार करता है (पाठ, संख्या, तारीख, बूलियन, सूची); विशेषता के दर्ज किए गए मान होने के बाद लॉक किया गया।"
+msgstr "जिस मूल्य का प्रकार यह विशेषता स्वीकार करती है (पाठ, संख्या, तिथि, बूलियन, सूची); जब विशेषता के पास कोई दर्ज मूल्य हो जाता है तो लॉक कर दिया जाता है।"
 
 msgid "The label and document printers your company prints to"
-msgstr "वह लेबल और दस्तावेज़ प्रिंटर जिन पर आपकी कंपनी प्रिंट करती है"
+msgstr "लेबल और दस्तावेज़ प्रिंटर जिनमें आपकी कंपनी प्रिंट करती है"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "इस PO को रखने की नवीनतम तारीख ताकि यह आवश्यकता की तारीख तक पहुंचे, आपूर्तिकर्ता के लीड समय को देखते हुए।"
+msgstr "इस PO को रखने की सबसे हाल की तिथि ताकि यह प्राप्ति की आवश्यकता तिथि तक पहुँचे, आपूर्तिकर्ता की लीड टाइम दी गई।"
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "कानूनी इकाई जिसे चालान भेजा जाता है, जब यह उस ग्राहक से अलग होता है जो माल प्राप्त करता है - माता-पिता / सहायक या तीसरे पक्ष के बिलिंग व्यवस्था के लिए।"
@@ -15132,22 +15132,22 @@ msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.
 msgstr "इस ग्राहक की जीवन चक्र स्थिति - सक्रिय, संभावना, निष्क्रिय, आदि; केवल सक्रिय ग्राहक बिक्री-आदेश चयनकर्ताओं में दिखाई देते हैं।"
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "इस आपूर्तिकर्ता की जीवन चक्र स्थिति - सक्रिय, निष्क्रिय, अनुमोदन अप्रबंधित, आदि; केवल सक्रिय आपूर्तिकर्ता PO / उद्धरण चयनकर्ताओं में दिखाई देते हैं।"
+msgstr "इस आपूर्तिकर्ता की जीवन चक्र स्थिति — सक्रिय, निष्क्रिय, अनुमोदन लंबित, आदि; केवल सक्रिय आपूर्तिकर्ता PO/कोटेशन चयनकर्ता में दिखाई देते हैं।"
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "स्थानीय समय क्षेत्र जिसमें यह स्थान समय की रिपोर्ट करता है; इस स्थान पर शेड्यूल, समयपत्र और शिफ्ट के घंटों की व्याख्या उपयोगकर्ता के ब्राउज़र स्थान की परवाह किए बिना इस क्षेत्र में की जाती है।"
+msgstr "स्थानीय समय क्षेत्र जिसमें यह स्थान समय रिपोर्ट करता है; इस स्थान पर शेड्यूल, टाइमकार्ड और शिफ्ट घंटों की व्याख्या इस क्षेत्र में की जाती है, भले ही उपयोगकर्ता के ब्राउज़र लोकेल की परवाह किए बिना।"
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "वह स्थान जिसके लिए यह कर्मचारी डिफ़ॉल्ट रूप से; उनके समयपत्र पर समय क्षेत्र व्याख्या और उनके काम के रिकॉर्ड पर डिफ़ॉल्ट शिफ्ट सेलेक्टर को चलाता है।"
+msgstr "यह स्थान जिसके लिए यह कर्मचारी डिफ़ॉल्ट रूप से सेट है; उनके टाइमकार्ड पर टाइमज़ोन व्याख्या को चलाता है और उनके जॉब रिकॉर्ड पर डिफ़ॉल्ट शिफ्ट चयनकर्ता को चलाता है।"
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
 msgstr "वह स्थान जिससे इस आदेश को पूरा किया जाएगा; प्रति-पंक्ति स्थान इसे ओवरराइड करते हैं जब सेट किया जाता है।"
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "वह स्थान जिससे यह उद्धरण पूरा किया जाएगा यदि इसे आदेश में परिवर्तित किया जाता है; योजना द्वारा सही गोदाम में आपूर्ति के प्रक्षेपण के लिए उपयोग किया जाता है।"
+msgstr "यह स्थान जहाँ से यह कोटेशन पूरा होगा यदि यह एक आदेश में परिवर्तित होता है; योजना द्वारा सही गोदाम में आपूर्ति प्रोजेक्ट करने के लिए उपयोग किया जाता है।"
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
-msgstr "वह स्थान जिससे यह अनुरोध पूरा किया जाएगा यदि यह एक उद्धरण में और फिर एक आदेश में परिवर्तित होता है।"
+msgstr "यह स्थान जहाँ से यह RFQ पूरा होगा यदि यह एक कोटेशन में परिवर्तित होता है और फिर एक आदेश में।"
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
 msgstr "किसी भी इकाई के खिलाफ उठाए गए जोखिमों और अवसरों का लॉग, प्रत्येक को स्वतंत्र 1–5 गंभीरता और संभावना द्वारा दर्जांकित और समाधान के लिए संचालित।"
@@ -15159,7 +15159,7 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "इस स्टॉक के लिए लॉट पहचानकर्ता; प्रति बैच एक पंक्ति, मात्रा उस लॉट के लिए हाथ पर है।"
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "लॉट को पास के रूप में चिह्नित किया जाएगा। {fails} नमूना विफलता(एं) आपके रिकॉर्ड के लिए दर्ज की गई हैं।"
+msgstr "लॉट को उत्तीर्ण के रूप में चिह्नित किया जाएगा। {fails} नमूना की गई विफलता(एँ) आपके रिकॉर्ड के लिए दर्ज की गई हैं।"
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "लॉट अभी भी अस्वीकृत कर दिया जाएगा, लेकिन कम से कम एक Issue Type कॉन्फ़िगर होने तक NCR नहीं बनाया जा सकता।"
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "चयनित दस्तावेज़ से लॉट की प्रति-विशेषता नमूनाकरण योजना को पुनः निर्धारित किया जाएगा।"
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "सबसे कम राशि जो यह आपूर्तिकर्ता इस प्रक्रिया के लिए चार्ज करेगा, मात्रा की परवाह किए बिना; संतुलन मात्रा के नीचे नौकरियां अभी भी कम से कम इतनी अधिक लागत करती हैं।"
+msgstr "यह न्यूनतम राशि जो यह आपूर्तिकर्ता इस प्रक्रिया के लिए चार्ज करेगा, मात्रा की परवाह किए बिना; ब्रेकइवन वॉल्यूम के नीचे जॉब की लागत कम से कम यह राशि ही होगी।"
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "वे मशीनें, सेल और स्टेशन जिनके माध्यम से आपका काम चलता है"
@@ -15204,13 +15204,13 @@ msgid "The new version number of the method"
 msgstr "विधि का नया संस्करण संख्या"
 
 msgid "The new version number of the procedure"
-msgstr "प्रक्रिया की नई संस्करण संख्या"
+msgstr "कार्यविधि की नई संस्करण संख्या"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
 msgstr "पसंदीदा आपूर्तिकर्ता के साथ एक PO देने और सामान डॉक पर पहुंचने के बीच दिनों की संख्या; योजना इस राशि से मांग को पीछे की ओर ऑफसेट करता है।"
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "इस आइटम का एक बैच बनाने के लिए दिनों की संख्या, नौकरी की रिहाई से समाप्ति तक मापी गई; योजना इस राशि से मांग को पीछे की ओर ऑफसेट करता है।"
+msgstr "इस आइटम का एक बैच बनाने के दिनों की संख्या, जॉब रिलीज़ से पूरा होने तक मापी गई; योजना इस मात्रा से पीछे की ओर मांग को ऑफसेट करती है।"
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
 msgstr "अपेक्षित स्क्रैप के लिए क्षतिपूर्ति करने के लिए बनाने के लिए अतिरिक्त इकाइयों की संख्या; योजना सामग्री को आरक्षित करते समय इसे आदेश मात्रा के साथ जोड़ता है।"
@@ -15225,13 +15225,13 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "हाथ पर रखी गई स्तर जो मात्रा-आधारित नीतियों के तहत एक नई पुनः भरण आदेश को ट्रिगर करता है।"
 
 msgid "The operations and steps your parts move through"
-msgstr "वह संचालन और चरण जिनके माध्यम से आपके पार्ट्स गुजरते हैं"
+msgstr "ऑपरेशन और चरण जिनके माध्यम से आपके पार्ट्स आगे बढ़ते हैं"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
 msgstr "कार्यों की क्रमित सूची जो इस वर्कफ़्लो का उपयोग करने वाली समस्याओं को पूरा करना चाहिए; यहाँ का क्रम वह क्रम है जिसमें वे समस्या पर दिखाई देते हैं।"
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "संचालन का क्रमित क्रम जो एक काम चलाता है, विधि के बिल ऑफ प्रोसेस से कॉपी किया गया।"
+msgstr "ऑपरेशन का क्रमबद्ध अनुक्रम जिसके माध्यम से एक जॉब चलता है, विधि की प्रक्रिया सूची से कॉपी किया गया।"
 
 msgid "The original model file is no longer available"
 msgstr "मूल मॉडल फ़ाइल अब उपलब्ध नहीं है"
@@ -15240,7 +15240,7 @@ msgid "The outbound posting document that takes goods out of stock to a customer
 msgstr "बाहरी पोस्टिंग दस्तावेज़ जो स्टॉक से माल को ग्राहक के पास ले जाता है, रास्ते में COGS पोस्ट करता है।"
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "बाहरी आपूर्तिकर्ता जो इस प्रक्रिया को करते हैं; प्रत्येक को आपूर्तिकर्ता प्रक्रिया फॉर्म पर मूल्य और लीड-टाइम इनपुट की एक पंक्ति मिलती है।"
+msgstr "बाहरी आपूर्तिकर्ता जो इस प्रक्रिया को करते हैं; प्रत्येक को आपूर्तिकर्ता प्रक्रिया फॉर्म पर मूल्य निर्धारण और लीड समय इनपुट की एक पंक्ति मिलती है।"
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "ट्रैक किए गए इकाइयों की मातृ-बाल श्रृंखला - एक इकाई किस चीज़ से बनाई गई थी और यह क्या बन गई।"
@@ -15249,7 +15249,7 @@ msgid "The part is manufactured as its own job when the parent that needs it is 
 msgstr "जब माता-पिता जो इसकी आवश्यकता है वह बनाया जाता है तब भाग अपनी स्वयं की नौकरी के रूप में निर्मित होता है।"
 
 msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
-msgstr "जब इसके माता-पिता को बनाया जाता है तब भाग मौजूदा स्टॉक से लिया जाता है - कोई नई नौकरी या खरीद आदेश नहीं।"
+msgstr "पार्ट को मौजूदा स्टॉक से लिया जाता है जब इसका मूल आइटम बनाया जाता है — कोई नया जॉब या क्रय आदेश नहीं।"
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
 msgstr "कार्बन की ओर से वे लोग जो आपके कार्यान्वयन को चलाएंगे, और उन तक कैसे पहुंचें।"
@@ -15261,7 +15261,7 @@ msgid "The per-company counter behind a document type's readable number, assembl
 msgstr "प्रति-कंपनी काउंटर जो एक दस्तावेज़ प्रकार की पठनीय संख्या के अंतर्गत काम करता है, जो उपसर्ग, शून्य-पैडित अगली मान, और प्रत्यय को एकत्रित करता है, और हर नए दस्तावेज़ के निर्माण के साथ आगे बढ़ता है।"
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "प्रत्येक आइटम का परिणाम एक गैर-अनुरूपता की प्रभावित सामग्री पर दर्ज किया गया — प्रतीक्षित, आपूर्तिकर्ता को वापस, पुनः कार्य, स्क्रैप, या जैसा है वैसा उपयोग करें — प्रत्येक प्रभावित लॉट या सीरियल के लिए अपने आप पर निर्णय लिया गया।"
+msgstr "गैर-अनुरूपता की प्रभावित सामग्री पर दर्ज किया गया प्रति-आइटम परिणाम — लंबित, आपूर्तिकर्ता को वापसी, पुनः कार्य, स्क्रैप, या जैसा है उपयोग करें — प्रत्येक प्रभावित लॉट या सीरीज के लिए अलग से तय किया गया।"
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
 msgstr "नकद छूट का प्रतिशत। कोई छूट नहीं के लिए 0 का उपयोग करें।"
@@ -15282,10 +15282,10 @@ msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certa
 msgstr "संभाव्यता रेटिंग कि जोखिम होता है (1 = दुर्लभ से 5 = लगभग निश्चित); जोखिम स्कोर की गणना के लिए गंभीरता के साथ जोड़ी गई।"
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "प्रक्रिया जो तकनीशियन इस रखरखाव के दौरान अनुसरण करते हैं; समय सारणी पहले से ही उत्पन्न होने के बाद इसे प्रतिस्थापित करना केवल भविष्य के उदाहरणों को प्रभावित करता है।"
+msgstr "कार्यविधि जिसका पालन तकनीशियन इस रखरखाव को करते समय करते हैं; इसे उसके बाद बदलना जब शेड्यूल पहले से ही तैयार हो गए हों केवल भविष्य के उदाहरणों को प्रभावित करता है।"
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "प्रक्रियाएं जो यह कार्य केंद्र चला सकता है; संचालन निर्धारण करते समय प्रक्रिया-पिकर्स में दिखाई देता है, और इस कार्य केंद्र के माध्यम से कौन से नौकरियां रूट कर सकती हैं।"
+msgstr "प्रक्रियाएँ जो यह वर्क सेंटर चला सकता है; ऑपरेशन शेड्यूल करते समय प्रक्रिया-पिकर में दिखाई देता है, और यह सीमित करता है कि कौन से जॉब इस वर्क सेंटर के माध्यम से रूट हो सकते हैं।"
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "प्रदाता कोई आयाम लक्ष्य प्रदान नहीं करता है। पहले प्रदाता में सुविधा सक्षम करें (जैसे ट्रैकिंग श्रेणियां, कक्षा ट्रैकिंग, या फ़ील्ड)।"
@@ -15303,7 +15303,7 @@ msgid "The quote has been created"
 msgstr "उद्धरण बनाया जा चुका है"
 
 msgid "The quote will be copied with a revision suffix"
-msgstr "उद्धरण को एक संशोधन प्रत्यय के साथ कॉपी किया जाएगा"
+msgstr "कोटेशन को एक रिवीजन प्रत्यय के साथ कॉपी किया जाएगा"
 
 msgid "The raw stock and material master you buy and consume"
 msgstr "कच्चा स्टॉक और सामग्री मास्टर जो आप खरीदते और उपभोग करते हैं"
@@ -15315,10 +15315,10 @@ msgid "The reasons you record when you decline an RFQ"
 msgstr "वह कारण जो आप RFQ को अस्वीकार करते समय दर्ज करते हैं"
 
 msgid "The record a workflow notification points at, named as an id plus its kind; leave it empty and the notification links to the workflow run itself."
-msgstr "वह रिकॉर्ड जिसकी ओर एक workflow notification इशारा करता है, एक id और इसके प्रकार के रूप में नाम दिया गया है; इसे खाली छोड़ दें और notification workflow run से स्वयं को link करता है।"
+msgstr "रिकॉर्ड जिस पर एक वर्कफ़्लो सूचना इंगित करती है, एक आईडी प्लस इसकी तरह के रूप में नामित; इसे खाली छोड़ दें और सूचना वर्कफ़्लो रन को स्वयं जोड़ती है।"
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "वह रिकॉर्ड जो एक भुगतान या ज्ञापन को एक चालान पर लागू करता है, लागू, छूट और लिखित-बंद राशि ले जाता है।"
+msgstr "रिकॉर्ड जो एक चालान पर भुगतान या नोट को लागू करता है, लागू, छूट, और बट्टे खाते की राशि को ले जाता है।"
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "ट्रैक किए गए इकाइयों का रिकॉर्ड किया गया वंशावली - कौन से इनपुट का उपभोग किया गया था कौन से आउटपुट का उत्पादन करने के लिए, रसीद से शिपमेंट।"
@@ -15340,7 +15340,7 @@ msgid "The request body sent verbatim with a JSON content type after workflow va
 msgstr "वह request body जिसे JSON content type के साथ ज्यों का त्यों भेजा जाता है इसके अंदर के workflow variables को substitute करने के बाद, उन methods पर जो इसे carry करते हैं।"
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "अवशिष्ट WIP जो एक काम को बंद करने पर छोड़ गया है, उत्पादन विचरण खाते में स्वेप किया गया - एक काम के लिए कार्बन पुस्तकें का एकमात्र विचरण।"
+msgstr "अवशिष्ट WIP जो एक जॉब के पास बंद करते समय बचा है, एक उत्पादन विचलन खाते में स्वीप किया गया — एक जॉब के लिए कार्बन बुक का एकमात्र विचलन।"
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "Onshape की प्रतिक्रिया में आवश्यक पैरामीटर नहीं थे। दोबारा कनेक्ट करने का प्रयास करें।"
@@ -15349,19 +15349,19 @@ msgid "The result will not appear on the Runs page."
 msgstr "परिणाम Runs page पर प्रदर्शित नहीं होगा।"
 
 msgid "The revision number of the part"
-msgstr "भाग की संशोधन संख्या"
+msgstr "पार्ट की रिवीजन संख्या"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "वह sales order line जिसे पूरा करने के लिए यह नौकरी बनाई गई थी, नौकरी को इसके पीछे की customer demand से जोड़ता है।"
+msgstr "विक्रय आदेश पंक्ति जिसे आपूर्ति के लिए यह जॉब बनाया गया था, जॉब को इसके पीछे ग्राहक मांग से जोड़ता है।"
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "अनुसूची का उपयोग इस संपत्ति की लागत को इसके उपयोगी जीवन पर फैलाने के लिए (सीधी पंक्ति, घटता शेष, उत्पादन की इकाइयां)।"
+msgstr "यह शेड्यूल जिसका उपयोग इस संपत्ति की लागत को इसके उपयोगी जीवन (सीधी लाइन मूल्यह्रास, ह्रासमान शेष, उत्पादन की इकाई) पर फैलाने के लिए किया जाता है।"
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "वह शेल्फ और बिन जहां स्टॉक भौतिक रूप से रखा जाता है"
 
 msgid "The shop supplies and consumables you keep on hand"
-msgstr "दुकान की आपूर्ति और उपभोग्य वस्तुएं जो आप हाथ में रखते हैं"
+msgstr "दुकान की आपूर्ति और उपभोग्य सामग्री जो आप हाथ में रखते हैं"
 
 msgid "The sign-offs every issue using this workflow needs before it can be closed."
 msgstr "साइन-ऑफ जो इस वर्कफ़्लो का उपयोग करने वाली प्रत्येक समस्या को बंद करने से पहले चाहिए।"
@@ -15373,7 +15373,7 @@ msgid "The skills and abilities you track for your people"
 msgstr "आपके लोगों के लिए आप जो कौशल और क्षमताओं को ट्रैक करते हैं"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "सबसे छोटी मात्रा जो यह आपूर्तिकर्ता इस भाग के लिए एक PO लाइन पर स्वीकार करेगा; योजना इसे गोल करती है।"
+msgstr "यह सबसे छोटी मात्रा जो यह आपूर्तिकर्ता इस पार्ट के लिए एक क्रय आदेश पंक्ति पर स्वीकार करेगा; योजना इसे गोल करती है।"
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
 msgstr "चयनित ग्राहक पर विशेष संपर्क जो इस पोर्टल खाते का मालिक होगा; उनका ईमेल साइन-इन पहचानकर्ता बन जाता है।"
@@ -15382,7 +15382,7 @@ msgid "The specific contact on the selected supplier who will own this portal ac
 msgstr "चयनित आपूर्तिकर्ता पर विशेष संपर्क जो इस पोर्टल खाते का मालिक होगा; उनका ईमेल साइन-इन पहचानकर्ता बन जाता है।"
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "उपरोक्त नौकरी पर विशेष संचालन जो यह PO लाइन खरीद रही है; केवल बाहरी-प्रसंस्करण के रूप में चिह्नित संचालन चयनयोग्य हैं।"
+msgstr "ऊपर दिए गए जॉब पर विशिष्ट ऑपरेशन जो यह क्रय आदेश पंक्ति खरीद रही है; केवल बाहरी प्रसंस्करण के रूप में चिह्नित ऑपरेशन चयनयोग्य हैं।"
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
 msgstr "विशिष्ट PO, रिटर्न, या ट्रांसफर जिसके विरुद्ध यह रसीद पोस्ट करता है; उपलब्ध आईडी ऊपर स्रोत दस्तावेज़ प्रकार पर निर्भर करती हैं।"
@@ -15394,25 +15394,25 @@ msgid "The standard dimensions your materials are stocked in"
 msgstr "आपकी सामग्री जिन मानक आयामों में स्टॉक की जाती है"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "मानक कारक (घंटे, मिनट, टुकड़े) इस कार्य केंद्र पर संचालन डिफ़ॉल्ट रूप से मापा जाता है; प्रति-संचालन ओवरराइड जीतते हैं जब सेट किया जाता है।"
+msgstr "मानक कारक (घंटे, मिनट, टुकड़े) जिसमें इस वर्क सेंटर पर ऑपरेशन डिफ़ॉल्ट रूप से मापे जाते हैं; प्रति-ऑपरेशन ओवरराइड जब सेट किए जाते हैं तो जीत जाते हैं।"
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
-msgstr "इस प्रक्रिया को मापने के लिए उपयोग की जाने वाली मानक कारक – घंटे, मिनट, टुकड़े, वर्ग फुट – जब इसके संचालन का अनुमान और मूल्य निर्धारण किया जाता है।"
+msgstr "मानक कारक जिसका उपयोग इस प्रक्रिया को मापने के लिए किया जाता है — घंटे, मिनट, टुकड़े, वर्ग फुट — जब इसके ऑपरेशन का अनुमान लगाया और लागत दी जाती है।"
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "इस उद्धरण पंक्ति की स्थिति - ड्राफ्ट, कोई उद्धरण नहीं, पूर्ण; कोई उद्धरण नहीं कारण क्षेत्र प्रकट करता है और उद्धरण कुल से पंक्ति को बाहर करता है।"
+msgstr "इस कोटेशन पंक्ति की स्थिति — ड्राफ्ट, कोई कोटेशन नहीं, पूर्ण; कोई कोटेशन नहीं कारण क्षेत्र को प्रकट करता है और पंक्ति को कोटेशन कुल से बाहर करता है।"
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "विवरण बाल्टी जो इस समूह के सभी खाते उपयोग करेंगे।"
 
 msgid "The step's settings — this run predates recording the values it used."
-msgstr "step की सेटिंग्स — यह run उन मानों को record करने से पहले का है जिनका उपयोग इसने किया था।"
+msgstr "चरण की सेटिंग — यह रन उन मानों को रिकॉर्ड करने से पहले का है जो इसने उपयोग किए।"
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "स्टॉक आकार जिनमें यह सामग्री खरीदी और आयोजित की जाती है; प्रत्येक आकार नौकरियों और POs पर एक अलग चयनयोग्य संस्करण बन जाता है।"
+msgstr "स्टॉक आकार जिसमें यह सामग्री खरीदी और रखी जाती है; प्रत्येक आकार जॉब और क्रय आदेश पर एक अलग चयनयोग्य वेरिएंट बन जाता है।"
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "भंडारण डिब्बे जिससे यह पंक्ति चुनती है; यदि खाली है, तो चुनना वस्तु की डिफ़ॉल्ट स्टोरेज इकाई का उपयोग करता है।"
+msgstr "भंडारण बिन जिससे यह पंक्ति पिकिंग करती है; यदि खाली है, तो पिकिंग आइटम की डिफ़ॉल्ट भंडारण इकाई का उपयोग करती है।"
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "स्टोरेज सेवा समय पर प्रतिक्रिया नहीं दे सकी। कृपया पुनः प्रयास करें।"
@@ -15427,7 +15427,7 @@ msgid "The supplier record this portal account links to; only contacts already o
 msgstr "आपूर्तिकर्ता रिकॉर्ड जिससे यह पोर्टल खाता जुड़ा है; केवल वे संपर्क जो उस आपूर्तिकर्ता के साथ पहले से हैं, नीचे खाता धारक के रूप में चुने जा सकते हैं।"
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "आपूर्तिकर्ता का स्वयं का उद्धरण / प्रस्ताव संख्या; इस उद्धरण से परिवर्तित PO पर ट्रैसेबिलिटी के लिए दर्ज किया गया।"
+msgstr "आपूर्तिकर्ता का अपना कोटेशन / प्रस्ताव संख्या; इस कोटेशन से परिवर्तित होने वाले क्रय आदेश पर ट्रेसेबिलिटी के लिए दर्ज किया गया।"
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "इस ऑर्डर के लिए आपूर्तिकर्ता का अपना संदर्भ (उनके सिस्टम पर उनकी SO संख्या); ऑडिट के लिए दर्ज और रसीद पर सामने आया।"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "सिस्टम आपके कॉन्फ़िगर किए गए सिस्टम में हर इन-स्कोप स्वीकृति परीक्षा पास करता है, आपके डेटा के साथ; डेटा सत्यापित है; और आप साइन ऑफ करते हैं। फिर लाइव जाएं।"
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "धागा जो बिक्रय RFQ, इसकी उद्धरण, और परिणामी बिक्रय आदेश को जोड़ता है – एक जुड़ाव, अपनी स्थिति के साथ एक दस्तावेज़ नहीं।"
+msgstr "बिक्री RFQ, इसके कोटेशन, और परिणामी विक्रय आदेश को जोड़ने वाली श्रृंखला — एक संबंध, अपनी स्थिति के साथ एक दस्तावेज़ नहीं।"
 
 msgid "The timer starts automatically"
 msgstr "टाइमर स्वचालित रूप से शुरू होता है"
@@ -15457,22 +15457,22 @@ msgid "The timer starts manually"
 msgstr "टाइमर मैन्युअल रूप से शुरू होता है"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "वह उपकरण और फिक्सचर जिन पर आपकी कार्यप्रणाली निर्भर करती है"
+msgstr "उपकरण और फिक्स्चर जिन पर आपके ऑपरेशन निर्भर करते हैं"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "इस बल्क बैच में बनाई गई सभी नौकरियों में कुल बनाना; कितनी नौकरियां बनाने के लिए तय करने के लिए प्रति नौकरी मात्रा के साथ संयुक्त।"
+msgstr "इस बल्क बैच में बनाए गए सभी जॉब में बनाने के लिए कुल; प्रति जॉब मात्रा के साथ संयुक्त यह तय करने के लिए कि कितने जॉब बनाए जाएँ।"
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
 msgstr "पता लगाने योग्य संदर्भ (उदाहरण के लिए, NIST मानक, मास्टर गेज सीरीज़ नंबर) जिसके विरुद्ध अंशांकन मान की तुलना की गई थी।"
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "ट्रैवलर बिल ऑफ मेटेरियल्स पर प्रत्येक आइटम और उसकी मात्रा को सूचीबद्ध करता है।"
+msgstr "ट्रैवलर सामग्री सूची पर प्रत्येक आइटम को इसकी मात्रा के साथ सूचीबद्ध करता है।"
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "प्रकार नियंत्रित करता है कि नया कर्मचारी कौन सी डिफ़ॉल्ट अनुमतियां प्राप्त करता है; यहाँ इसे चुनने से प्रकार के टेम्पलेट से अनुमति मैट्रिक्स पूर्व-भर जाता है।"
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "इस आपूर्तिकर्ता को इस प्रक्रिया के लिए काम भेजने और वापस पाने के बीच दिनों की विशिष्ट संख्या; एक आपूर्तिकर्ता चुनते समय योजना इस राशि से मांग को ऑफसेट करती है।"
+msgstr "इस प्रक्रिया के लिए इस आपूर्तिकर्ता को काम भेजने और इसे वापस पाने के बीच दिनों की विशिष्ट संख्या; योजना आपूर्तिकर्ता चुनते समय इस मात्रा से मांग को ऑफसेट करती है।"
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "इस भौतिक इकाई पर अद्वितीय पहचानकर्ता; प्रति सीरीज़ नंबर एक पंक्ति, मात्रा हमेशा 1 होती है।"
@@ -15481,7 +15481,7 @@ msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hou
 msgstr "वह इकाई जिसमें रूटिंग समय व्यक्त किया जाता है, जैसे घंटे/टुकड़ा या कुल घंटे, कार्बन को बताता है कि समय मात्रा के साथ बढ़ता है या प्रति रन निश्चित है।"
 
 msgid "The unit price of the item at the time of the purchase"
-msgstr "खरीद के समय आइटम की यूनिट कीमत"
+msgstr "खरीद के समय आइटम की इकाई मूल्य"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
 msgstr "इकाई जिसमें आपूर्तिकर्ता इस आइटम की कीमत निर्धारण और शिपिंग करते हैं, जब यह इन्वेंटरी इकाई से अलग होता है (जैसे केस बनाम प्रत्येक); रूपांतरण कारक के साथ जोड़ी गई।"
@@ -15502,13 +15502,13 @@ msgid "The version of the new document"
 msgstr "नई दस्तावेज़ का संस्करण"
 
 msgid "The version of the new procedure"
-msgstr "नई प्रक्रिया का संस्करण"
+msgstr "नई कार्यविधि का संस्करण"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "इस दस्तावेज़ के लिए संस्करण स्टैम्प; नए संस्करण एक प्रति बनाते हैं जो पिछले को हटाए बिना प्रतिस्थापित करता है।"
+msgstr "इस दस्तावेज़ के लिए संस्करण स्टैम्प; नए संस्करण एक कॉपी बनाते हैं जो पिछले को बिना हटाए बदल देती है।"
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "इस प्रक्रिया के लिए संस्करण स्टैम्प; नए संस्करण एक प्रति बनाते हैं जो पिछले को हटाए बिना प्रतिस्थापित करता है।"
+msgstr "इस कार्यविधि के लिए संस्करण स्टैम्प; नए संस्करण एक कॉपी बनाते हैं जो पिछले को बिना हटाए बदल देती है।"
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
 msgstr "गोदाम जिससे इस आदेश पर सामान भेज दिया जाएगा; ग्राहक का शिप स्थान वह जगह है जहां वे पहुंचेंगे।"
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "गोदाम जिससे इस उद्धरण पर सामान भेज दिया जाएगा; ग्राहक का शिप स्थान वह जगह है जहां वे पहुंचेंगे।"
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "उपकरण विफल होने के तरीके, रखरखाव और गुणवत्ता ट्रैकिंग के लिए"
+msgstr "उपकरण की विफलता के तरीके, रखरखाव और गुणवत्ता ट्रैकिंग के लिए"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "कार्य केंद्र का अपना बिन जहां चुनी गई सामग्री उत्पादन के लिए तैयार की जाती है, इसके गोदाम स्रोत शेल्फ के विपरीत।"
+msgstr "वर्क सेंटर की अपनी बिन जहां पिक की गई सामग्री उत्पादन के लिए रखी जाती है, इसके गोदाम स्रोत शेल्फ के विपरीत।"
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "कार्य घंटे और कैलेंडर जो शेड्यूलिंग को संचालित करते हैं"
@@ -15535,10 +15535,10 @@ msgid "Then by"
 msgstr "फिर द्वारा"
 
 msgid "There are no active supplier quotes to compare for this RFQ."
-msgstr "इस RFQ के लिए तुलना करने के लिए कोई सक्रिय आपूर्तिकर्ता उद्धरण नहीं हैं।"
+msgstr "इस RFQ के लिए तुलना करने के लिए कोई सक्रिय आपूर्तिकर्ता कोटेशन नहीं हैं।"
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "इस नौकरी से जुड़े बाहरी संचालन हैं जिनके पास कोई आपूर्तिकर्ता नहीं है। इसे जारी करने से पहले कृपया प्रत्येक बाहरी संचालन को एक आपूर्तिकर्ता असाइन करें।"
+msgstr "इस जॉब से जुड़े बाहरी ऑपरेशन हैं जिनके पास कोई आपूर्तिकर्ता नहीं है। कृपया इसे जारी करने से पहले प्रत्येक बाहरी ऑपरेशन के लिए एक आपूर्तिकर्ता असाइन करें।"
 
 msgid "There's nothing outstanding to apply these credits to."
 msgstr "इन क्रेडिट्स को लागू करने के लिए कुछ भी बकाया नहीं है।"
@@ -15547,28 +15547,28 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "ये कस्टम फ़ील्ड केवल समान टैग वाली संस्थाओं के लिए उपलब्ध होंगी"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "ये दस्तावेज़ सामान्य लेजर में पोस्ट नहीं हुए हैं, इसलिए उनकी राशि इस अवधि से गायब है। प्रत्येक को पोस्ट करें या रद्द करें — एक दस्तावेज़ जिसमें तारीख नहीं है, पोस्ट किए जाने पर पोस्टिंग दिन की तारीख प्राप्त करता है।"
+msgstr "ये दस्तावेज़ सामान्य खाता बही में पोस्ट नहीं किए गए हैं, इसलिए इस अवधि में उनकी राशि नहीं है। प्रत्येक को पोस्ट करें या अमान्य करें — एक अनंकित दस्तावेज़ पोस्ट करते समय पोस्टिंग दिन की तारीख प्राप्त करता है।"
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
-msgstr "ये ईमेल पते सभी आपूर्तिकर्ताओं को भेजे गए ईमेल पर स्वचालित रूप से CC किए जाएंगे (उद्धरण, क्रय आदेश, आदि)।"
+msgstr "ये ईमेल पते आपूर्तिकर्ताओं को भेजे गए सभी ईमेल पर स्वचालित रूप से CC किए जाएंगे (कोटेशन, क्रय आदेश, आदि)।"
 
 msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
-msgstr "ये ईमेल पते सभी ग्राहकों को भेजे गए उद्धरण ईमेल पर स्वचालित रूप से CC किए जाएंगे।"
+msgstr "ये ईमेल पते ग्राहकों को भेजे गए सभी कोटेशन ईमेल पर स्वचालित रूप से CC किए जाएंगे।"
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
 msgstr "इन आइटमों में अभी भी सामग्री चुनने के लिए है। अभी समाप्त करने से सूची को आंशिक चिह्नित किया जाता है।"
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "इन कार्यों के पास इस कार्य केंद्र को सौंपे गए संचालन हैं:"
+msgstr "ये जॉब इस वर्क सेंटर को असाइन किए गए ऑपरेशन हैं:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "ये जर्नल प्रविष्टियाँ अभी भी ड्राफ्ट हैं, इसलिए उनके डेबिट और क्रेडिट इस अवधि के लिए लेजर में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में पुनः दिनांकित करें।"
+msgstr "ये जर्नल प्रविष्टियां अभी भी ड्राफ्ट हैं, इसलिए उनके नामे और जमा इस अवधि के लिए खाता बही में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में फिर से दिनांकित करें।"
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "इस Carbon इंस्टेंस में Onshape OAuth क्रेडेंशियल नहीं हैं। किसी व्यवस्थापक से उन्हें सेट करने के लिए कहें।"
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "यह परिवर्तन सूचना लागू की जा रही है, इसलिए इसके परिवर्तन लॉक हैं। इसे संपादित करने के लिए फिर से खोलें।"
+msgstr "यह परिवर्तन सूचना कार्यान्वित की जा रही है, इसलिए इसके परिवर्तन लॉक हैं। इसे संपादित करने के लिए इसे फिर से खोलें।"
 
 msgid "This change notice is closed, so its changes are read-only."
 msgstr "यह परिवर्तन सूचना बंद है, इसलिए इसके परिवर्तन केवल पढ़ने के लिए हैं।"
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "यह Discovery चरण को पूरा करता है।"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "इस संपर्क के पास कोई ईमेल पता नहीं है"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "यह प्रतिपक्ष के पास कुछ भी बकाया नहीं है — भुगतान खाते पर दर्ज किया जाएगा।"
@@ -15586,7 +15586,7 @@ msgid "This download link is invalid or has been tampered with."
 msgstr "यह डाउनलोड लिंक अमान्य है या इसमें छेड़छाड़ की गई है।"
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "यह फ़ाइल अब उपलब्ध नहीं है, या आपके पास इसे डाउनलोड करने की अनुमति नहीं है।"
+msgstr "यह फाइल अब उपलब्ध नहीं है, या आपके पास इसे डाउनलोड करने की अनुमति नहीं है।"
 
 msgid "This Fiscal Year"
 msgstr "यह वित्तीय वर्ष"
@@ -15605,10 +15605,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "यह आमंत्रण {0} में शामिल होने के लिए समाप्त हो गया है। आप अपने ईमेल पर भेजने के लिए नया आमंत्रण का अनुरोध कर सकते हैं।"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "इस चालान के पास कोई उपयोगी नियत तिथि नहीं है — Stripe के लिए एक चुनें।"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "यह चालान इस Carbon ग्राहक के लिए पहले से जुड़े Stripe ग्राहक को बिल किया जाएगा। इसके विवरण को बदलने के लिए, इसे Stripe डैशबोर्ड में संपादित करें।"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "यह एक नियंत्रित वातावरण है, इसलिए एक प्रमाणकर्ता ऐप की आवश्यकता है।"
@@ -15638,10 +15638,10 @@ msgid "this item"
 msgstr "यह आइटम"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "इस आइटम को एक कॉन्फ़िगरेटर के माध्यम से बनाया जाता है और प्रति-आदेश अपने घटकों को हल करता है; इसके लिए बनाई गई नौकरियां कॉन्फ़िगरेटर के हल बिल को विरासत में पाती हैं।"
+msgstr "यह आइटम एक कॉन्फ़िगरेटर के माध्यम से बनाया गया है और अपने घटकों को प्रति-ऑर्डर के आधार पर हल करता है; इसके लिए बनाई गई जॉब कॉन्फ़िगरेटर के हल किए गए BOM को प्राप्त करती हैं।"
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "इस आइटम के बिल ऑफ मेटेरियल्स में शेल्फ-लाइफ सक्षम इनपुट नहीं हैं, इसलिए BOM से कोई एक्सपायरी की गणना नहीं की जाएगी।"
+msgstr "इस आइटम की सामग्री सूची में शेल्फ-लाइफ सक्षम कोई इनपुट नहीं हैं, इसलिए BOM से कोई समाप्ति की गणना नहीं की जाएगी।"
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
 msgstr "यह जॉब इन्वेंटरी में प्राप्त किया जाएगा। यह शॉप फ्लोर पर अब उपलब्ध नहीं होगा।"
@@ -15665,7 +15665,7 @@ msgid "This Month"
 msgstr "इस महीने"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "आपके Implementation Hub का यह पृष्ठ बनाया जा रहा है। जब तक हम इसे पूरा करते हैं, command center से शुरू करें।"
+msgstr "आपके कार्यान्वयन हब के इस पृष्ठ को बनाया जा रहा है। कमांड सेंटर से शुरू करें जबकि हम इसे पूरा करते हैं।"
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "यह पार्ट इस स्थान पर {quantityOnHand} की मात्रा में उपलब्ध है। No Stock का अर्थ है कि इसकी न तो योजना बनाई जाएगी और न ही इसका उपयोग किया जाएगा।"
@@ -15695,29 +15695,29 @@ msgid "This Quarter"
 msgstr "इस त्रैमासिक"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "यह उनके प्रमाणकर्ता ऐप को हटा देता है, इसलिए उनके अगले साइन-इन के लिए केवल एक जादुई लिंक की आवश्यकता है। इसका उपयोग तब करें जब उन्होंने अपने प्रमाणकर्ता तक पहुंच खो दी हो। यह उनकी प्रत्येक कंपनी के लिए उनके साइन-इन को प्रभावित करता है जिससे वे संबंधित हैं।"
+msgstr "यह उनके प्रमाणीकरणकर्ता ऐप को निकालता है, इसलिए उनके अगले साइन-इन के लिए केवल एक जादुई लिंक की आवश्यकता होती है। जब वे अपने प्रमाणीकरणकर्ता तक पहुंच खो गए हों तो इसका उपयोग करें। यह उनके साइन-इन को उन सभी कंपनियों के लिए प्रभावित करता है जिनसे वे संबंधित हैं।"
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "यह संशोधन जारी किया गया है (उत्पादन)। परिवर्तन सामान्यतः एक परिवर्तन सूचना के माध्यम से होने चाहिए।"
+msgstr "यह रिवीजन जारी है (उत्पादन)। परिवर्तन आमतौर पर एक परिवर्तन सूचना के माध्यम से प्रवाहित होने चाहिए।"
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "यह संशोधन जारी किया गया है (उत्पादन)। इसे संशोधित करने के लिए एक परिवर्तन सूचना खोलें।"
+msgstr "यह रिवीजन जारी है (उत्पादन)। इसे संशोधित करने के लिए एक परिवर्तन सूचना खोलें।"
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
-msgstr "इस run में यहाँ दिखाए जाने से अधिक steps हैं। केवल पहले {MAX_RUN_STEPS} सूचीबद्ध हैं।"
+msgstr "यह रन हमारे यहां दिखाए गए की तुलना में अधिक चरण हैं। केवल पहले {MAX_RUN_STEPS} सूचीबद्ध हैं।"
 
 msgid "This runs the workflow for real. It will create records, send notifications and call any webhooks exactly as a live run would. This cannot be undone."
-msgstr "यह workflow को वास्तविक रूप से चलाता है। यह रिकॉर्ड बनाएगा, notifications भेजेगा और किसी भी webhooks को ठीक वैसे ही कॉल करेगा जैसे एक live run करेगा। यह अपरिवर्तनीय है।"
+msgstr "यह वर्कफ़्लो को वास्तव में चलाता है। यह रिकॉर्ड बनाएगा, सूचनाएं भेजेगा और किसी भी वेबहुक को कॉल करेगा जैसे एक लाइव रन करता है। इसे पूर्ववत नहीं किया जा सकता।"
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "इस बिक्रय आदेश के संबंधित कार्य हैं। उनके साथ क्या करना है यह चुनें।"
+msgstr "इस विक्रय आदेश के पास जुड़ी जॉब हैं। उनके साथ क्या करना है यह चुनें।"
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "इस बिक्रय आदेश में ऐसी पंक्तियाँ हैं जिनके लिए नौकरियाँ बनाई जानी आवश्यक हैं"
+msgstr "इस विक्रय आदेश के पास पंक्तियां हैं जिनके लिए जॉब बनाने की आवश्यकता है"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "यह स्टोरेज प्रकार वर्तमान में {usageCount} स्टोरेज यूनिट{0} द्वारा उपयोग किया जा रहा है।"
+msgstr "यह भंडारण प्रकार वर्तमान में {usageCount} भंडारण इकाई{0} द्वारा उपयोग किया जा रहा है।"
 
 msgid "this supplier"
 msgstr "यह आपूर्तिकर्ता"
@@ -15726,7 +15726,7 @@ msgid "This tool is activated when change notice {activationLockId} is released.
 msgstr "यह उपकरण तब सक्रिय होता है जब परिवर्तन सूचना {activationLockId} जारी की जाती है।"
 
 msgid "This updates the theme for all users of the application"
-msgstr "यह एप्लिकेशन के सभी उपयोगकर्ताओं के लिए थीम को अपडेट करता है"
+msgstr "यह एप्लिकेशन के सभी उपयोगकर्ताओं के लिए थीम अपडेट करता है"
 
 msgid "This user does not have two-factor authentication enabled."
 msgstr "इस उपयोगकर्ता के पास दो-कारक प्रमाणीकरण सक्षम नहीं है।"
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "यह version खोला नहीं जा सकता"
 
 msgid "This version is published"
-msgstr ""
+msgstr "यह संस्करण प्रकाशित है"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "यह संस्करण प्रकाशित है। संपादित करने के लिए एक नया संस्करण बनाएं।"
 
 msgid "This version's definition could not be read."
 msgstr "इस version की परिभाषा को पढ़ा नहीं जा सका।"
@@ -15766,27 +15766,27 @@ msgid "This will overwrite the existing quote method"
 msgstr "यह मौजूदा उद्धरण विधि को अधिलेखित करेगा"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "यह सक्रिय निर्माण विधि के सामग्री विवरण और प्रक्रियाओं से बैच आकार का उपयोग करके इकाई लागत की पुनः गणना करेगा। वर्तमान लागत को अधिलेखित किया जाएगा। क्या आप जारी रखना चाहते हैं?"
+msgstr "यह बैच आकार का उपयोग करके सक्रिय निर्माण विधि की सामग्री सूची और प्रक्रियाओं से इकाई लागत की पुनः गणना करेगा। वर्तमान लागत अधिलेखित की जाएगी। क्या आप जारी रखना चाहते हैं?"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "यह {0} का {1} से लिंक हटा देगा। यह जॉब अब बिक्री आदेश के तहत दिखाई नहीं देगा और शिपमेंट इसे नहीं खोज पाएंगे।"
+msgstr "यह {0} के लिंक को {1} से निकालेगा। जॉब अब विक्रय आदेश के तहत नहीं दिखाई देगा और शिपमेंट इसे नहीं ढूंढेंगे।"
 
 msgid "This will replace all method materials of other revisions with this revision."
-msgstr "यह अन्य संशोधनों की सभी विधि सामग्री को इस संशोधन से बदल देगा।"
+msgstr "यह अन्य रिवीजन की सभी विधि सामग्री को इस रिवीजन के साथ प्रतिस्थापित करेगा।"
 
 msgid "This will replace all method materials of other sizes with this size."
 msgstr "यह अन्य आकारों की सभी विधि सामग्रियों को इस आकार से बदल देगा।"
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "यह make विधि के वर्तमान संस्करण को सक्रिय के रूप में सेट करेगा, जिससे यह केवल-पढ़ने योग्य हो जाएगा।"
+msgstr "यह निर्माण विधि के वर्तमान संस्करण को सक्रिय सेट करेगा, इसे पढ़ने के लिए केवल बनाता है।"
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "यह संपत्ति के शेष बही मूल्य को लिख देगा।"
 
 msgid "Three-way match"
-msgstr "तीन-तरफा मेल"
+msgstr "थ्री-वे मिलान"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Tie-Out उपलब्ध नहीं है"
 
 msgid "Tightened"
-msgstr "कड़ा"
+msgstr "कठोर"
 
 msgid "Time of day"
 msgstr "दिन का समय"
@@ -15871,7 +15871,7 @@ msgid "To Ship and Receive"
 msgstr "भेजने और प्राप्त करने के लिए"
 
 msgid "To Storage Unit"
-msgstr "स्टोरेज यूनिट को"
+msgstr "भंडारण इकाई के लिए"
 
 msgid "To supplier"
 msgstr "आपूर्तिकर्ता को"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "कुल मात्रा"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "इस स्थान पर सभी भंडारण इकाइयों में आइटम की कुल उपलब्ध मात्रा। जब उपलब्ध मात्रा और आने वाली मात्रा कुल मांग को पूरा नहीं कर पाती तो लाल हो जाती है।"
+msgstr "इस स्थान पर सभी भंडारण इकाइयों के पार आइटम के लिए कुल मात्रा। जब हाथ पर मात्रा प्लस आने वाली कुल मांग को कवर नहीं कर सकती तब लाल हो जाती है।"
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "इस स्थान पर सभी सक्रिय कार्यों और बिक्री आदेशों में आवश्यक कुल मात्रा — केवल इस कार्य के लिए नहीं।"
+msgstr "इस स्थान पर सभी सक्रिय जॉब और विक्रय आदेशों के पार कुल मात्रा की आवश्यकता है — केवल इस जॉब नहीं।"
 
 msgid "Total scrap quantity"
-msgstr "कुल scrap मात्रा"
+msgstr "कुल स्क्रैप मात्रा"
 
 msgid "Total tax"
 msgstr "कुल कर"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "कुल मूल्य"
 
 msgid "Total Variance"
-msgstr "कुल भिन्नता"
+msgstr "कुल विचलन"
 
 msgid "Total:"
 msgstr "कुल:"
@@ -16009,16 +16009,16 @@ msgid "Track changes to key business entities including invoices, orders, custom
 msgstr "चालान, ऑर्डर, ग्राहक, आपूर्तिकर्ता और अन्य सहित मुख्य व्यावसायिक संस्थाओं में परिवर्तन को ट्रैक करें।"
 
 msgid "Track every change to your orders, invoices, customers, and more."
-msgstr "अपने ऑर्डर, इनवॉइस, ग्राहकों और बहुत कुछ में हर परिवर्तन को ट्रैक करें।"
+msgstr "आपके आदेश, चालान, ग्राहक और बहुत कुछ का हर परिवर्तन ट्रैक करें।"
 
 msgid "Track every change to your orders, invoices, customers, suppliers, and more."
-msgstr "अपने ऑर्डर, इनवॉइस, ग्राहकों, आपूर्तिकर्ताओं और अन्य सभी परिवर्तनों को ट्रैक करें।"
+msgstr "आपके आदेश, चालान, ग्राहक, आपूर्तिकर्ता और बहुत कुछ का हर परिवर्तन ट्रैक करें।"
 
 msgid "Track real-time inventory by location and bin"
 msgstr "स्थान और बिन के अनुसार रीयल-टाइम इन्वेंटरी ट्रैक करें"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "सीरियल/लॉट नंबर ट्रैक करें और बिक्री आदेश पूरे करें।"
+msgstr "क्रम संख्या/लॉट संख्या को ट्रैक करें और विक्रय आदेश पूरा करें।"
 
 msgid "Track tax depreciation separately"
 msgstr "कर मूल्यह्रास को अलग से ट्रैक करें"
@@ -16045,7 +16045,7 @@ msgid "Tracked entity ID is required but none was found"
 msgstr "ट्रैक किया गया इकाई ID आवश्यक है लेकिन कोई नहीं मिला"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "ट्रैक की गई सामग्री पिक ऑर्डर (FEFO) द्वारा पूर्व-चयनित है, यहां तक कि बिना पिकिंग लिस्ट के भी।"
+msgstr "ट्रैक की गई सामग्री को पिकिंग क्रम (FEFO) द्वारा पूर्व-चयनित किया जाता है, भले ही पिकिंग सूची के बिना।"
 
 msgid "Tracking"
 msgstr "ट्रैकिंग"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "ट्रांसफर आईडी"
 
 msgid "Transfer Lines"
-msgstr "स्थानांतरण लाइनें"
+msgstr "स्थानांतरण पंक्तियाँ"
 
 msgid "Transfer Ownership"
 msgstr "स्वामित्व हस्तांतरित करें"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "ट्रैश"
 
 msgid "Trial Balance"
-msgstr "ट्रायल बैलेंस"
+msgstr "परीक्षण शेष"
 
 msgid "Trigger"
 msgstr "ट्रिगर"
@@ -16153,16 +16153,16 @@ msgid "Two-factor authentication"
 msgstr "दो-कारक प्रमाणीकरण"
 
 msgid "Two-factor authentication disabled"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण अक्षम"
+msgstr "दो-कारक प्रमाणीकरण अक्षम किया गया"
 
 msgid "Two-factor authentication enabled"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण सक्षम"
+msgstr "दो-कारक प्रमाणीकरण सक्षम किया गया"
 
 msgid "Two-Factor Authentication Enforcement"
 msgstr "दो-कारक प्रमाणीकरण प्रवर्तन"
 
 msgid "Two-factor authentication is not enabled."
-msgstr "दो-फ़ैक्टर प्रमाणीकरण सक्षम नहीं है।"
+msgstr "दो-कारक प्रमाणीकरण सक्षम नहीं है।"
 
 msgid "Type"
 msgstr "प्रकार"
@@ -16177,13 +16177,13 @@ msgid "Type a message..."
 msgstr "एक संदेश लिखें..."
 
 msgid "Type an email and press Enter to add an external recipient"
-msgstr "ईमेल टाइप करें और बाहरी प्राप्तकर्ता जोड़ने के लिए Enter दबाएं"
+msgstr "एक ईमेल टाइप करें और बाहरी प्राप्तकर्ता जोड़ने के लिए Enter दबाएँ"
 
 msgid "Type of Permission Update"
 msgstr "अनुमति अपडेट का प्रकार"
 
 msgid "Type to search across your workspace"
-msgstr "अपने वर्कस्पेस में खोजने के लिए टाइप करें"
+msgstr "अपने कार्यक्षेत्र में खोजने के लिए टाइप करें"
 
 msgid "Type:"
 msgstr "प्रकार:"
@@ -16222,10 +16222,10 @@ msgid "Under Demand-Based Reorder, planning sums demand inside this rolling wind
 msgstr "Demand-आधारित पुनः आदेश के तहत, योजना एक पुनः भरण मात्रा की गणना करते समय इस रोलिंग विंडो के भीतर मांग को जोड़ता है।"
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "निर्धारित पुनः क्रय मात्रा के तहत, पुनः क्रय बिंदु सक्रिय होने पर प्रत्येक बार सटीक मात्रा की योजना बनाई जाती है।"
+msgstr "निश्चित पुनः आदेश मात्रा के तहत, योजना हर बार जब पुनः ऑर्डर बिंदु सक्रिय होता है सटीक मात्रा का आदेश देता है।"
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "अधिकतम मात्रा नीति के तहत, पुनः क्रय बिंदु सक्रिय होने पर इस हाथ पर मौजूद स्तर तक योजना बनाई जाती है।"
+msgstr "अधिकतम मात्रा नीति के तहत, योजना जब पुनः ऑर्डर बिंदु सक्रिय होता है इस हाथ में स्तर तक का आदेश देता है।"
 
 msgid "Undo"
 msgstr "पूर्ववत करें"
@@ -16261,7 +16261,7 @@ msgid "Unit price"
 msgstr "इकाई मूल्य"
 
 msgid "Unit Price"
-msgstr "यूनिट मूल्य"
+msgstr "इकाई मूल्य"
 
 msgid "Unit Sale Price"
 msgstr "यूनिट विक्रय मूल्य"
@@ -16291,16 +16291,16 @@ msgid "unknown location"
 msgstr "अज्ञात स्थान"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "असीमित कार्यात्मक समर्थन"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "असीमित रिकॉर्ड"
 
 msgid "Unlink"
 msgstr "अनलिंक करें"
 
 msgid "Unlink job from sales order?"
-msgstr "बिक्रय आदेश से नौकरी को अनलिंक करें?"
+msgstr "जॉब को विक्रय आदेश से अलग करें?"
 
 msgid "Unlock"
 msgstr "अनलॉक करें"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "अपोस्ट किए गए दस्तावेज़"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "अप्रकाशित करें"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "अप्रकाशित करें {name}?"
 
 msgid "Unreceived POs"
 msgstr "अप्राप्त POs"
@@ -16378,13 +16378,13 @@ msgid "Update"
 msgstr "अपडेट करें"
 
 msgid "Update a customer"
-msgstr "एक customer को अपडेट करें"
+msgstr "एक ग्राहक को अपडेट करें"
 
 msgid "Update a job"
 msgstr "एक नौकरी को अपडेट करें"
 
 msgid "Update a purchase order"
-msgstr "एक purchase order को अपडेट करें"
+msgstr "एक क्रय आदेश को अपडेट करें"
 
 msgid "Update a quote"
 msgstr "एक quote को अपडेट करें"
@@ -16393,13 +16393,13 @@ msgid "Update a receipt"
 msgstr "एक receipt को अपडेट करें"
 
 msgid "Update a sales order"
-msgstr "एक sales order को अपडेट करें"
+msgstr "एक विक्रय आदेश को अपडेट करें"
 
 msgid "Update a shipment"
-msgstr "एक shipment को अपडेट करें"
+msgstr "एक शिपमेंट को अपडेट करें"
 
 msgid "Update a supplier"
-msgstr "एक supplier को अपडेट करें"
+msgstr "एक आपूर्तिकर्ता को अपडेट करें"
 
 msgid "Update an issue"
 msgstr "एक issue को अपडेट करें"
@@ -16417,13 +16417,13 @@ msgid "Update Jira issue"
 msgstr "Jira समस्या को अपडेट करें"
 
 msgid "Update Kanban"
-msgstr "कनबन अपडेट करें"
+msgstr "कानबान को अपडेट करें"
 
 msgid "Update Linear issue"
 msgstr "Linear समस्या को अपडेट करें"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "पोस्ट किए गए खरीद रसीदों से भाग लीड समय अपडेट करें।"
+msgstr "पोस्ट किए गए क्रय प्राप्तियों से पार्ट लीड टाइम को अपडेट करें।"
 
 msgid "Update Password"
 msgstr "पासवर्ड अपडेट करें"
@@ -16432,7 +16432,7 @@ msgid "Update Permissions"
 msgstr "अनुमतियों को अपडेट करें"
 
 msgid "Update Projection"
-msgstr "प्रक्षेपण अद्यतन करें"
+msgstr "प्रक्षेपण को अपडेट करें"
 
 msgid "Update Quantity"
 msgstr "मात्रा अपडेट करें"
@@ -16444,7 +16444,7 @@ msgid "Update source document quantities"
 msgstr "स्रोत दस्तावेज़ मात्रा अपडेट करें"
 
 msgid "Update the kanban information for scan-based replenishment."
-msgstr "कनबन जानकारी को स्कैन-आधारित पुनःपूर्ति के लिए अपडेट करें।"
+msgstr "स्कैन-आधारित पुनः भरण के लिए कानबान जानकारी को अपडेट करें।"
 
 msgid "Update the purchase order quantities"
 msgstr "क्रय आदेश मात्रा अपडेट करें"
@@ -16484,7 +16484,7 @@ msgid "Upload a PDF first"
 msgstr "पहले एक PDF अपलोड करें"
 
 msgid "Upload completed but no file path returned"
-msgstr "अपलोड पूर्ण हुआ लेकिन कोई फ़ाइल पथ नहीं मिला"
+msgstr "अपलोड पूरा हुआ लेकिन कोई फ़ाइल पथ वापस नहीं किया गया"
 
 msgid "Upload CSV"
 msgstr "CSV अपलोड करें"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "अपलोड हो रहा है…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "Convert पर क्लिक करने पर, निम्नलिखित आंतरिक भाग संख्याओं के साथ भाग बनाए जाएंगे:"
+msgstr "परिवर्तित करें क्लिक करने पर, पार्ट्स निम्नलिखित आंतरिक पार्ट संख्या के साथ बनाए जाएंगे:"
 
 msgid "URL"
 msgstr "यूआरएल"
@@ -16528,7 +16528,7 @@ msgid "Usage/Day (90d)"
 msgstr "उपयोग/दिन (90d)"
 
 msgid "Use ... to get the next consumable ID"
-msgstr "अगला उपभोग्य ID प्राप्त करने के लिए ... का उपयोग करें"
+msgstr "अगला उपभोग्य सामग्री ID प्राप्त करने के लिए ... का उपयोग करें"
 
 msgid "Use ... to get the next material ID"
 msgstr "अगली सामग्री ID प्राप्त करने के लिए ... का उपयोग करें"
@@ -16555,7 +16555,7 @@ msgid "Used In"
 msgstr "में उपयोग किया गया"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "नेविगेशन में और बिक्री आदेश जैसे दस्तावेजों पर उपयोग किया जाता है"
+msgstr "नेविगेशन में और विक्रय आदेश जैसे दस्तावेज़ों पर उपयोग किया जाता है"
 
 msgid "Used in the navigation in dark mode"
 msgstr "डार्क मोड में नेविगेशन में उपयोग किया जाता है"
@@ -16594,13 +16594,13 @@ msgid "Users"
 msgstr "उपयोगकर्ता"
 
 msgid "Users and groups allowed to open or download this document; the uploader is always included."
-msgstr "इस दस्तावेज़ को खोलने या डाउनलोड करने की अनुमति प्राप्त उपयोगकर्ता और समूह; अपलोडर हमेशा शामिल होता है।"
+msgstr "इस दस्तावेज़ को खोलने या डाउनलोड करने की अनुमति वाले उपयोगकर्ता और समूह; अपलोडकर्ता हमेशा शामिल है।"
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "इस दस्तावेज़ का नाम बदलने, उसे बदलने या फिर से लेबल करने की अनुमति प्राप्त उपयोगकर्ता और समूह; अपलोडर हमेशा शामिल होता है, और संपादन अनुमति में देखने की अनुमति शामिल है।"
+msgstr "इस दस्तावेज़ का नाम बदलने, बदलने, या फिर से लेबल करने की अनुमति वाले उपयोगकर्ता और समूह; अपलोडकर्ता हमेशा शामिल है, और संपादित करने की पहुँच का मतलब देखने की पहुँच है।"
 
 msgid "Users can update this value for themselves"
-msgstr "उपयोगकर्ता स्वयं के लिए इस मान को अपडेट कर सकते हैं"
+msgstr "उपयोगकर्ता अपने लिए इस मान को अपडेट कर सकते हैं"
 
 msgid "Users to Update"
 msgstr "अपडेट करने के लिए उपयोगकर्ता"
@@ -16615,7 +16615,7 @@ msgid "Valid To"
 msgstr "वैध तक"
 
 msgid "Validate a sample and approve the migrated data"
-msgstr "नमूने को मान्य करें और माइग्रेट किए गए डेटा को मंजूरी दें"
+msgstr "एक नमूने को सत्यापित करें और माइग्रेट किए गए डेटा को अनुमोदित करें"
 
 msgid "validated"
 msgstr "सत्यापित"
@@ -16651,34 +16651,34 @@ msgid "Variables"
 msgstr "चर"
 
 msgid "Variance"
-msgstr "विचरण"
+msgstr "विचलन"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "वास्तविक और मानक बीओएम घटक खपत के बीच विचरण"
+msgstr "वास्तविक और मानक BOM घटक खपत के बीच विचलन"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "वास्तविक और मानक रूटिंग घंटे और दरों के बीच विचरण"
+msgstr "वास्तविक और मानक रूटिंग घंटे और दरों के बीच विचलन"
 
 msgid "Variance between actual purchase price and standard cost"
-msgstr "वास्तविक खरीद मूल्य और मानक लागत के बीच विचरण"
+msgstr "वास्तविक क्रय मूल्य और मानक लागत के बीच विचलन"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "लागू और वास्तविक विनिर्माण ओवरहेड के बीच विचरण"
+msgstr "लागू और वास्तविक विनिर्माण उपरिव्यय के बीच विचलन"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "भौतिक इन्वेंटरी गणना समायोजन से विचरण"
+msgstr "भौतिक इन्वेंटरी गणना समायोजन से विचलन"
 
 msgid "Variance in outside processing costs"
-msgstr "बाहरी प्रसंस्करण लागत में विचरण"
+msgstr "बाहरी प्रसंस्करण लागत में विचलन"
 
 msgid "Variance only"
-msgstr "केवल भिन्नता"
+msgstr "केवल विचलन"
 
 msgid "VAT Number"
-msgstr "VAT संख्या"
+msgstr "वैट नंबर"
 
 msgid "Vendor Write-Off Income"
-msgstr "विक्रेता राइट-ऑफ आय"
+msgstr "विक्रेता बट्टे खाते आय"
 
 msgid "Verification Error"
 msgstr "सत्यापन त्रुटि"
@@ -16703,7 +16703,7 @@ msgstr "संस्करण"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "संस्करण {0} अभी प्रकाशित है और प्रतिस्थापित किया जाएगा।"
 
 msgid "Version:"
 msgstr "संस्करण:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "देखें"
 
 msgid "View Active Jobs"
-msgstr "सक्रिय नौकरियां देखें"
+msgstr "सक्रिय जॉब देखें"
 
 msgid "View Active Quotes"
 msgstr "सक्रिय उद्धरण देखें"
@@ -16739,7 +16739,7 @@ msgid "View Assigned Jobs"
 msgstr "असाइन किए गए जॉब्स देखें"
 
 msgid "View Attachment"
-msgstr "संलग्नक देखें"
+msgstr "अनुलग्नक देखें"
 
 msgid "View Attributes"
 msgstr "विशेषताएं देखें"
@@ -16787,7 +16787,7 @@ msgid "View Lists"
 msgstr "सूचियाँ देखें"
 
 msgid "View maintenance dispatch"
-msgstr "रखरखाव डिस्पैच देखें"
+msgstr "रखरखाव कार्य देखें"
 
 msgid "View Memo"
 msgstr "मेमो देखें"
@@ -16844,10 +16844,10 @@ msgid "View Prints"
 msgstr "प्रिंट देखें"
 
 msgid "View Production Events"
-msgstr "उत्पादन घटनाएं देखें"
+msgstr "उत्पादन इवेंट देखें"
 
 msgid "View Purchase Invoice"
-msgstr "खरीद चालान देखें"
+msgstr "क्रय चालान देखें"
 
 msgid "View Reactive"
 msgstr "प्रतिक्रियाशील देखें"
@@ -16856,7 +16856,7 @@ msgid "View Receipt"
 msgstr "रसीद देखें"
 
 msgid "View Receivables"
-msgstr "प्राप्य देखें"
+msgstr "प्राप्य राशि देखें"
 
 msgid "View Run"
 msgstr "रन देखें"
@@ -16901,25 +16901,25 @@ msgid "Visible on a user's public profile"
 msgstr "उपयोगकर्ता की सार्वजनिक प्रोफ़ाइल पर दृश्यमान"
 
 msgid "Void"
-msgstr "रद्द करें"
+msgstr "अमान्य करें"
 
 msgid "Void Invoice"
-msgstr "चालान रद्द करें"
+msgstr "चालान अमान्य करें"
 
 msgid "Void Purchase Invoice"
-msgstr "खरीद चालान रद्द करें"
+msgstr "क्रय चालान अमान्य करें"
 
 msgid "Void Receipt"
-msgstr "रसीद रद्द करें"
+msgstr "प्राप्ति अमान्य करें"
 
 msgid "Void Sales Invoice"
-msgstr "बिक्री चालान को रद्द करें"
+msgstr "विक्रय चालान अमान्य करें"
 
 msgid "Void Shipment"
-msgstr "शिपमेंट रद्द करें"
+msgstr "शिपमेंट अमान्य करें"
 
 msgid "Voided"
-msgstr "रद्द किया गया"
+msgstr "अमान्य"
 
 msgid "Voiding this purchase invoice will:"
 msgstr "इस क्रय चालान को रद्द करने से:"
@@ -16931,7 +16931,7 @@ msgid "Voiding this shipment will:"
 msgstr "इस शिपमेंट को रद्द करने से:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "अपने चैंपियन के साथ प्रत्येक क्षेत्र को देखें और स्कोप से बाहर कुछ भी टॉगल करें। कोड Module.Area.Number पढ़ते हैं (ACC.GL.01 = Accounting, General Ledger, item 1)।"
+msgstr "अपने चैंपियन के साथ प्रत्येक क्षेत्र में चलें और दायरे से बाहर कुछ भी टॉगल करें। कोड Module.Area.Number पढ़ें (ACC.GL.01 = लेखांकन, सामान्य खाता बही, आइटम 1)।"
 
 msgid "Walk your current process, systems, and data"
 msgstr "अपनी वर्तमान प्रक्रिया, सिस्टम और डेटा को देखें"
@@ -16952,7 +16952,7 @@ msgid "Warn"
 msgstr "चेतावनी"
 
 msgid "Warn — edits succeed with a warning"
-msgstr "चेतावनी — संपादन एक चेतावनी के साथ सफल होता है"
+msgstr "चेतावनी दें — संपादन चेतावनी के साथ सफल होते हैं"
 
 msgid "Warn but allow"
 msgstr "चेतावनी दें लेकिन अनुमति दें"
@@ -17101,16 +17101,16 @@ msgid "What it is"
 msgstr "यह क्या है"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "यह किस प्रकार का परिवर्तन है: संस्करण अपडेट करता है कि भाग कैसे बनाया जाता है, संशोधन अपने विवरण और दस्तावेज़ को संशोधित करता है, प्रतिस्थापन भाग एक नई भाग संख्या में स्वैप करता है जो पुरानी को प्रतिस्थापित करता है, और नया भाग एक शुद्ध-नया भाग पेश करता है जिसका कोई पूर्ववर्ती नहीं है।"
+msgstr "यह किस प्रकार का परिवर्तन है: संस्करण अपडेट कैसे पार्ट बनाया जाता है, रिवीजन इसके विवरण और दस्तावेज़ों को संशोधित करता है, प्रतिस्थापन पार्ट एक नए पार्ट नंबर में स्वैप करता है जो पुराने को प्रतिस्थापित करता है, और नया पार्ट बिना पूर्ववर्ती के एक बिल्कुल नया पार्ट पेश करता है।"
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
 msgstr "यह प्रविष्टि किस प्रकार का आउटपुट रिकॉर्ड करती है — उत्पादन (अच्छी इकाइयाँ), स्क्रैप (अपूरणीय) या पुनः कार्य (सुधार के लिए वापस भेजा गया); जब स्क्रैप हो तो स्क्रैप कारण प्रकट करता है।"
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "यह किस प्रकार का पीओ है — मानक सामान, सेवाएँ, बाहरी प्रसंस्करण, या खाता समझौता; लाइन लेआउट और जीएल पोस्टिंग नियमों को चलाता है।"
+msgstr "यह किस प्रकार का PO है — मानक माल, सेवा, बाहरी प्रसंस्करण, या व्यापक समझौता; पंक्ति लेआउट और सामान्य खाता बही पोस्टिंग नियमों को संचालित करता है।"
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
-msgstr "यह किस प्रकार का उद्धरण है — मानक आपूर्तिकर्ता उद्धरण, खाता-समझौता मूल्य वाला उद्धरण, या अनुबंध विनिर्माण उद्धरण; रूपांतरण के समय पीओ लाइन लेआउट को चलाता है।"
+msgstr "यह किस प्रकार का कोटेशन है — मानक आपूर्तिकर्ता कोटेशन, व्यापक समझौता मूल्य वाला कोटेशन, या अनुबंध विनिर्माण कोटेशन; रूपांतरण के समय PO पंक्ति लेआउट को संचालित करता है।"
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
 msgstr "यह आयाम अपने स्वीकृत मानों को किस स्रोत से खींचता है (कस्टम सूची या मौजूदा इकाई जैसे ग्राहक, स्थान, कर्मचारी)।"
@@ -17122,10 +17122,10 @@ msgid "What this field held before the change. Leave blank for nothing."
 msgstr "यह फील्ड परिवर्तन से पहले क्या रखता था। कुछ नहीं के लिए खाली छोड़ दें।"
 
 msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
-msgstr "यह रसीद क्या पूरी कर रही है — एक खरीद आदेश, एक रिटर्न, एक आवक हस्तांतरण, या कोई मूल के बिना मैनुअल रसीद।"
+msgstr "यह प्राप्ति क्या पूरी कर रही है — एक क्रय आदेश, एक वापसी, एक इनबाउंड स्थानांतरण, या कोई पैरेंट नहीं है ऐसी एक मैनुअल प्राप्ति।"
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "यह शिपमेंट क्या पूरी कर रहा है — एक बिक्रय आदेश, एक आउटबाउंड स्थानांतरण, एक आरएमए रिटर्न, या एक मैनुअल शिपमेंट।"
+msgstr "यह शिपमेंट क्या पूरी कर रहा है — एक विक्रय आदेश, एक आउटबाउंड स्थानांतरण, एक RMA रिटर्न, या एक मैनुअल शिपमेंट।"
 
 msgid "What this task means"
 msgstr "इस कार्य का मतलब क्या है"
@@ -17155,7 +17155,7 @@ msgid "When {name} changes"
 msgstr "जब {name} परिवर्तन होता है"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "जब किसी तैयार उत्पाद का शेल्फ जीवन Calculated पर सेट किया जाता है, तो चुनें कि कौन से उपभोग किए गए इनपुट गणना को खिलाते हैं।"
+msgstr "जब किसी तैयार उत्पाद की शेल्फ लाइफ को गणना के लिए सेट किया जाता है, तो चुनें कि गणना को कौन सी उपयोग की गई इनपुट प्रदान करती हैं।"
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
 msgstr "जब एक सीरियल या बैच समाप्त हो जाता है, और उपयोग के बाद क्या होता है — एक कंपनी नीति सतर्क, अवरुद्ध, या ब्लॉकविदअधिग्रहण हो सकती है।"
@@ -17173,10 +17173,10 @@ msgid "When on, attributes in this category show up on a person's public profile
 msgstr "जब सक्षम हो, तो इस श्रेणी की विशेषताएँ किसी के सार्वजनिक प्रोफ़ाइल पर दिखाई देती हैं; अन्यथा वे केवल व्यवस्थापकों के लिए दृश्यमान हैं।"
 
 msgid "When on, employees can edit this attribute's value on their own profile; otherwise only admins can."
-msgstr "जब सक्षम हो, तो कर्मचारी अपनी स्वयं की प्रोफ़ाइल पर इस विशेषता का मान संपादित कर सकते हैं; अन्यथा केवल व्यवस्थापक ऐसा कर सकते हैं।"
+msgstr "जब चालू हो, तो कर्मचारी अपनी प्रोफाइल पर इस विशेषता का मान संपादित कर सकते हैं; अन्यथा केवल प्रशासक ही कर सकते हैं।"
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "जब सक्षम हो, तो मूल्य निर्धारण नियम (वॉल्यूम डिस्काउंट, प्रचार) इस ओवरराइड के शीर्ष पर लागू होते रहते हैं; जब अक्षम हो, तो यह ओवरराइड अंतिम मूल्य है।"
+msgstr "जब चालू हो, तो मूल्य नियम (मात्रा छूट, प्रचार) इस ओवरराइड के शीर्ष पर अभी भी लागू होते हैं; जब बंद हो, तो यह ओवरराइड अंतिम मूल्य है।"
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "जब सक्षम हो, तो इस प्रक्रिया की ऑपरेशन बारकोड स्कैन करने से सभी शेष खुली मात्रा एक कार्रवाई में पूर्ण के रूप में रिपोर्ट होती है; जब ऑपरेटर नियमित रूप से आंशिक रिपोर्ट करते हैं तो अक्षम करें।"
@@ -17194,25 +17194,25 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "जब आपूर्तिकर्ता प्रतिक्रिया की उम्मीद की जाती है; आपूर्तिकर्ता आरएफक्यू पोर्टल पर यह तारीख देखते हैं और कार्बन इसके बाद देर से प्रतिक्रिया स्वीकार नहीं करता है (कॉन्फ़िगर करने योग्य)।"
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "जब खरीदार ने माल की मांग की; आपूर्तिकर्ता वादा किए गए तारीख को कुछ और का वचन दे सकता है और डिलीवरी की तारीख को फिर से कुछ और बुक कर सकता है।"
+msgstr "जब क्रेता ने माल के लिए अनुरोध किया; आपूर्तिकर्ता वादा की गई तिथि पर कुछ और वादा कर सकता है और डिलीवरी तिथि पर फिर से कुछ और पोस्ट कर सकता है।"
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "जब खरीदार को इस पंक्ति की वस्तुओं की डॉक पर आवश्यकता है; योजना स्टॉक-उपलब्धता और बाहरी-प्रसंस्करण शेड्यूलिंग के लिए इस तारीख का उपयोग करती है।"
+msgstr "जब क्रेता को इस पंक्ति के माल की डॉक पर आवश्यकता हो; योजना स्टॉक-उपलब्धता और बाहरी प्रसंस्करण शेड्यूलिंग के लिए इस तिथि का उपयोग करती है।"
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "जब ग्राहक ने डिलीवरी की मांग की; आदेश वादा किए गए तारीख के लिए प्रतिबद्ध है, जो अलग हो सकता है।"
+msgstr "जब ग्राहक ने डिलीवरी के लिए अनुरोध किया; आदेश वादा की गई तिथि के लिए प्रतिबद्ध होता है, जो भिन्न हो सकती है।"
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "जब ग्राहक माल प्राप्त करना चाहता है; उद्धरण इस तारीख के लिए प्रतिबद्ध है यदि ग्राहक स्वीकार करता है।"
+msgstr "जब ग्राहक को माल प्राप्त करने के लिए अनुरोध किया; कोटेशन इस तिथि के लिए प्रतिबद्ध होता है यदि ग्राहक स्वीकार करता है।"
 
 msgid "When the customer asked to receive the goods."
-msgstr "जब ग्राहक माल प्राप्त करना चाहता है।"
+msgstr "जब ग्राहक को माल प्राप्त करने के लिए अनुरोध किया।"
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "जब ग्राहक ने यह आरएफक्यू जमा किया; प्रतिक्रिया की घड़ी इस तारीख से शुरू होती है।"
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "जब ग्राहक का अनुरोध वर्तमान नहीं रह जाता है; इस तारीख के बाद आरएफक्यू स्वचालित रूप से बंद हो जाता है और यदि पुनः न खोला जाए तो उद्धरण प्रतिक्रिया स्वीकार नहीं करता है।"
+msgstr "जब ग्राहक का अनुरोध वर्तमान होना बंद हो जाता है; इस तिथि के बाद RFQ स्वचालित रूप से बंद हो जाता है और कोटेशन प्रतिक्रियाओं को स्वीकार नहीं करेगा जब तक कि फिर से खोला न जाए।"
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
 msgstr "जब सामान वास्तव में आ गए; रसीद पर दर्ज किए गए और आपूर्तिकर्ता की समय पर डिलीवरी स्कोरिंग के लिए उपयोग किए गए।"
@@ -17221,7 +17221,7 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "जब कानबान कार्ड को स्कैन किया जाता है, तो नौकरी स्वचालित रूप से ड्राफ्ट से बाहर चली जाती है और फर्श पर रिलीज के लिए जारी की जाती है।"
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "जब प्राप्तकर्ता स्थान स्टॉक के आगमन की प्रत्याशा करता है; गंतव्य पर एमआरपी उपलब्धता चलाता है।"
+msgstr "प्राप्ति स्थान को स्टॉक के आने की उम्मीद कब है; गंतव्य पर MRP उपलब्धता को संचालित करता है।"
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "जब आपूर्तिकर्ता डिलीवरी के लिए प्रतिबद्ध हुआ; योजना आवक-स्टॉक आगमन प्रक्षेपण के लिए इस तारीख का उपयोग करती है।"
@@ -17230,7 +17230,7 @@ msgid "When the supplier's pricing stops being honored; converting this quote to
 msgstr "जब आपूर्तिकर्ता की मूल्य निर्धारण सम्मानित नहीं रह जाती है; इस तारीख के बाद इस उद्धरण को एक पीओ में परिवर्तित करने के लिए पुनः-उद्धरण की आवश्यकता हो सकती है।"
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "जब यह गेज कैलिब्रेशन के लिए देय हो जाता है; एक बार अतिदेय होने के बाद यह Out-of-Calibration पढ़ता है।"
+msgstr "जब यह गेज अंशांकन के लिए देय हो जाता है; एक बार देय होने के बाद यह Out-of-Calibration पढ़ता है।"
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
 msgstr "जब यह गेज पिछली बार सफलतापूर्वक अंशांकित किया गया था; अगली-कैलिब्रेशन तारीख इस मूल्य और अंतराल से फिर से गणना की जाती है।"
@@ -17239,10 +17239,10 @@ msgid "When this looks right, mark it agreed. That completes the Discovery step 
 msgstr "जब यह सही लगे, तो इसे सहमत के रूप में चिह्नित करें। यह आपके कमांड सेंटर पर डिस्कवरी चरण को पूरा करता है।"
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "जब यह विशिष्ट पंक्ति भेजने के लिए वादा की जाती है; आदेश शीर्ष की वादा की गई तारीख का प्रति-पंक्ति ओवरराइड विभाजित शिपमेंट के लिए।"
+msgstr "जब यह विशिष्ट पंक्ति शिपमेंट के लिए वादा की जाती है; विभाजित शिपमेंट के लिए ऑर्डर हेडर के वादा की गई तिथि की प्रति-पंक्ति ओवरराइड।"
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "जब यह विशिष्ट लॉट/सीरीज समाप्त हो जाता है; एफईएफओ चुनने और खपत पर शेल्फ-जीवन नीति को चलाता है।"
+msgstr "जब यह विशिष्ट लॉट/सीरियल समाप्त हो जाता है; FEFO पिकिंग और खपत पर शेल्फ-लाइफ नीति को संचालित करता है।"
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "जब आप डिलीवरी के लिए प्रतिबद्ध हुए; योजना इसे पूरा करने के लिए मांग-देय-तारीख के रूप में मानती है।"
@@ -17254,7 +17254,7 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "वह जगह जहां वर्कफ़्लो सूचना दी जाती है — ऐप में हमेशा भेजा जाता है, जबकि ईमेल को एक बिजनेस या पार्टनर प्लान की आवश्यकता है और Slack को आपके Slack वर्कस्पेस को जोड़ने की आवश्यकता है।"
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "जहां एक ऑपरेशन चलता है; श्रम और उद्धरण दरें ले जाता है, ओवरहेड उनके बीच अंतर के साथ।"
+msgstr "ऑपरेशन कहाँ चलता है; श्रम और कोटिंग दरें रखता है, उपरिव्यय उनके बीच का अंतर है।"
 
 msgid "Where and how you make things."
 msgstr "जहां और कैसे आप चीजें बनाते हैं।"
@@ -17281,7 +17281,7 @@ msgid "Where this issue was raised from — internal QA, customer complaint, sup
 msgstr "यह समस्या कहाँ से उठी — आंतरिक क्यूए, ग्राहक शिकायत, आपूर्तिकर्ता ऑडिट आदि; रिपोर्टिंग के लिए उपयोग किया जाता है, वर्कफ़्लो को अवरुद्ध नहीं करता है।"
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "जहां इस पंक्ति की वस्तुएँ प्राप्ति पर स्टॉक में उतरती हैं; यदि खाली है, तो रसीदें आइटम के डिफ़ॉल्ट स्टोरेज यूनिट का उपयोग करती हैं।"
+msgstr "प्राप्ति पर इस पंक्ति के सामान स्टॉक में कहाँ आते हैं; यदि रिक्त है, तो प्राप्तियाँ आइटम की डिफ़ॉल्ट भंडारण इकाई का उपयोग करती हैं।"
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
 msgstr "यह रखरखाव अनुरोध कहाँ से आया — ऑपरेटर द्वारा रिपोर्ट किया गया, शेड्यूल किया गया, स्थिति-निगरानी ट्रिगर, पोस्ट-जॉब निरीक्षण; रखरखाव रिपोर्टों में स्रोत ब्रेकडाउन को चलाता है।"
@@ -17296,34 +17296,34 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "क्या राशि को लाइन मूल्य के प्रतिशत के रूप में या एक निश्चित मुद्रा राशि के रूप में समझा जाता है।"
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "क्या Carbon प्रत्येक इकाई (Serial), प्रत्येक लॉट (Batch), मात्रा (Inventory), या कोई ट्रैकिंग नहीं (Non-Inventory) को ट्रैक करता है।"
+msgstr "क्या Carbon प्रत्येक इकाई (Serial), प्रत्येक बैच (Batch), मात्रा (Inventory), या कोई ट्रैकिंग नहीं (गैर-इन्वेंटरी) का पालन करता है।"
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "क्या घड़ी तब शुरू होती है जब चुनी गई प्रक्रिया शुरू होती है या जब वह पूरी होती है।"
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "क्या यह लॉट/सीरियल निरीक्षण पास करता है (Pass) या विफल होता है (Fail); एक Fail स्टॉक को उपलब्ध इन्वेंट्री में प्राप्त होने से रोकता है।"
+msgstr "क्या यह लॉट/सीरियल निरीक्षण पास करता है (Pass) या अनुत्तीर्ण होता है (Fail); एक Fail स्टॉक को उपलब्ध इन्वेंटरी में प्राप्त होने से रोकता है।"
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "क्या यह प्रक्रिया आंतरिक कार्य केंद्रों (प्रक्रिया, असेंबली, या निरीक्षण) पर चलती है या बाहरी आपूर्तिकर्ताओं (बाहरी प्रसंस्करण) पर; विभिन्न डाउनस्ट्रीम फ़ील्ड्स को प्रकट करता है, इस प्रक्रिया के लिए योजना मार्गों का काम करने का तरीका बदलता है, और नए ऑपरेशन पर ऑपरेशन प्रकार को डिफ़ॉल्ट करता है।"
+msgstr "क्या यह प्रक्रिया आंतरिक वर्क सेंटर पर चलती है (Process, Assembly, या Inspection) या बाहरी आपूर्तिकर्ता पर (बाहरी प्रसंस्करण); विभिन्न डाउनस्ट्रीम फील्ड्स को प्रकट करता है, इस प्रक्रिया के लिए योजना कैसे काम करती है इसे बदलता है, और नए ऑपरेशन पर ऑपरेशन प्रकार को डिफ़ॉल्ट करता है।"
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
 msgstr "यह कार्य उत्पादन को अवरुद्ध करता है (डाउन), इसे नीचा दिखाता है (प्रभाव), एक नियोजित डाउनटाइम विंडो (योजनाबद्ध) में है, या कोई उत्पादन प्रभाव नहीं है (कोई प्रभाव नहीं); शेड्यूलिंग और ग्राहक-सामना डाउनटाइम संचार को सूचित करता है।"
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
-msgstr "चाहे चयनित अनुमतियां जोड़ी जाएं कि प्रत्येक उपयोगकर्ता के पास पहले से क्या है, या अपडेट द्वारा नीचे दिए गए चयन के साथ प्रत्येक उपयोगकर्ता की अनुमति सेट को प्रतिस्थापित करें।"
+msgstr "क्या जोड़ें चयनित अनुमतियों को प्रत्येक उपयोगकर्ता के पास पहले से है उसके ऊपर, या अपडेट करें प्रत्येक उपयोगकर्ता की अनुमति सेट को नीचे चयन के साथ थोक में प्रतिस्थापित करके।"
 
 msgid "Which document drives each inspection flow for this item."
 msgstr "कौन सा दस्तावेज़ इस आइटम के लिए प्रत्येक निरीक्षण प्रवाह को चलाता है।"
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "किस प्रकार का अनुरोध भेजना है: GET कुछ पढ़ता है, POST बनाता है, PUT और PATCH अपडेट करते हैं, DELETE हटाता है। एक नया कदम GET पर शुरू होता है, और केवल POST, PUT, और PATCH बॉडी ले जाते हैं।"
+msgstr "किस प्रकार का अनुरोध भेजना है: GET कुछ पढ़ता है, POST बनाता है, PUT और PATCH अपडेट करते हैं, DELETE हटाता है। एक नया चरण GET से शुरू होता है, और केवल POST, PUT, और PATCH body ले जाते हैं।"
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "कौन सी विनिर्माण घटना शेल्फ-जीवन घड़ी शुरू करती है — उदाहरण के लिए, भरना, सील करना, या अंतिम क्यूसी।"
 
 msgid "Who Can Approve"
-msgstr "कौन अनुमोदन कर सकता है"
+msgstr "कौन अनुमोदित कर सकता है"
 
 msgid "Who can do what"
 msgstr "कौन क्या कर सकता है"
@@ -17335,37 +17335,37 @@ msgid "Who gets trained on what, in what format. Your part: protect the hands-on
 msgstr "कौन किस पर प्रशिक्षण पाता है, किस प्रारूप में। आपका हिस्सा: अपने चैंपियन के कैलेंडर पर हाथों-हाथ सत्र का समय जल्दी सुरक्षित रखें। यह वह है जो कंपनियों के व्यस्त होने पर सबसे अधिक फिसलता है।"
 
 msgid "Who has to approve quotes, orders, and purchases — and when"
-msgstr "जिसे उद्धरण, आदेश और खरीद को मंजूरी देनी है — और कब"
+msgstr "कोटेशन, ऑर्डर और खरीद को अनुमोदित करने के लिए कौन है — और कब"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "रखरखाव से संबंधित डिस्पैच के लिए सूचनाएं कौन प्राप्त करनी चाहिए?"
+msgstr "रखरखाव कार्य के लिए सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "संचालन-संबंधित डिस्पैच के लिए सूचनाएं कौन प्राप्त करनी चाहिए?"
+msgstr "ऑपरेशन कार्य के लिए सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "अन्य डिस्पैच के लिए सूचनाएं कौन प्राप्त करना चाहिए?"
+msgstr "अन्य कार्य के लिए सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "गुणवत्ता से संबंधित डिस्पैच के लिए सूचनाएं कौन प्राप्त करनी चाहिए?"
+msgstr "गुणवत्ता कार्य के लिए सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
 msgstr "डिजिटल उद्धरण स्वीकार या समाप्त होने पर कौन सूचनाएं प्राप्त करना चाहिए?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "गेज कैलिब्रेशन से बाहर जाने पर किसे सूचनाएं प्राप्त करनी चाहिए?"
+msgstr "जब कोई गेज अंशांकन से बाहर चला जाता है तो सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "नया सुझाव जमा किए जाने पर किसे सूचनाएं प्राप्त करनी चाहिए?"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "जब कोई RFQ उद्धरण के लिए तैयार के रूप में चिह्नित किया जाता है तो किसे सूचनाएं प्राप्त करनी चाहिए?"
+msgstr "जब कोई RFQ कोटेशन के लिए तैयार चिह्नित किया जाता है तो सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications when a sales job is completed?"
 msgstr "बिक्रय कार्य पूर्ण होने पर कौन सूचनाएं प्राप्त करनी चाहिए?"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
-msgstr "जब कोई आपूर्तिकर्ता उद्धरण जमा करे तो किसे सूचनाएं प्राप्त करनी चाहिए?"
+msgstr "जब कोई आपूर्तिकर्ता कोटेशन प्रस्तुत किया जाता है तो सूचना कौन प्राप्त करे?"
 
 msgid "Who should receive notifications when an inventory job is completed?"
 msgstr "इन्वेंटरी जॉब पूरा होने पर कौन सूचनाएं प्राप्त करना चाहिए?"
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "WIP"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "बिना पिकिंग लिस्ट के, ऑपरेटर स्कैन टैब से सामग्री चुनते हैं।"
+msgstr "पिकिंग सूची के बिना, ऑपरेटर Scan टैब से सामग्री पिकिंग करते हैं।"
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17424,37 +17424,37 @@ msgid "Wordmark Light Mode"
 msgstr "वर्डमार्क लाइट मोड"
 
 msgid "work center"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work center"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work Center"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work Center Utilization"
-msgstr "कार्य केंद्र उपयोग"
+msgstr "वर्क सेंटर उपयोग"
 
 msgid "work centers"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work centers"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work Centers"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work in process (WIP)"
 msgstr "प्रक्रिया में कार्य (WIP)"
 
 msgid "Work in progress"
-msgstr "चल रहा काम"
+msgstr "प्रगति में कार्य"
 
 msgid "Work in Progress (default)"
-msgstr "प्रक्रिया में कार्य (डिफ़ॉल्ट)"
+msgstr "प्रगति में कार्य (डिफ़ॉल्ट)"
 
 msgid "Work in Progress (WIP)"
-msgstr "प्रक्रिया में कार्य (WIP)"
+msgstr "प्रगति में कार्य (WIP)"
 
 msgid "Work instruction"
 msgstr "कार्य निर्देश"
@@ -17466,7 +17466,7 @@ msgid "Work Phone"
 msgstr "कार्य फोन"
 
 msgid "Work shift tracking is active."
-msgstr "कार्य पारी ट्रैकिंग सक्रिय है।"
+msgstr "कार्य शिफ्ट ट्रैकिंग सक्रिय है।"
 
 msgid "Workflow"
 msgstr "वर्कफ़्लो"
@@ -17487,23 +17487,23 @@ msgid "Worst Performing Machines"
 msgstr "सबसे खराब प्रदर्शन करने वाली मशीनें"
 
 msgid "Write-Down Account"
-msgstr "मूल्य ह्रास खाता"
+msgstr "अवमूल्यन खाता"
 
 msgid "Write-off"
-msgstr "लिखित-बंद"
+msgstr "बट्टे खाते"
 
 msgid "Write-Off"
-msgstr "लिखित-बंद"
+msgstr "बट्टे खाते"
 
 msgid "Write-Off Account"
-msgstr "बट्टे खाता"
+msgstr "बट्टे खाते"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "{0} के लिए राइट-ऑफ"
+msgstr "{0} के लिए बट्टे खाते"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "निरीक्षण अस्वीकृतियों और एनसीआर निपटान के माध्यम से स्टॉक को स्क्रैप या वापस किए जाने की राइट-ऑफ"
+msgstr "निरीक्षण अस्वीकार और NCR निपटान के माध्यम से स्क्रैप या वापस किए गए स्टॉक के बट्टे खाते"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
 msgstr "किसी संपत्ति के मूल्य को उसके जीवन काल में कम करना — एक मासिक बैच जो आप बनाते हैं, ड्राफ्ट के रूप में समीक्षा करते हैं, फिर पोस्ट करते हैं।"
@@ -17521,7 +17521,7 @@ msgid "Yes, Accept"
 msgstr "हाँ, स्वीकार करें"
 
 msgid "Yes, also delete every nested storage unit."
-msgstr "हाँ, हर नेस्टेड स्टोरेज यूनिट को भी हटाएं।"
+msgstr "हाँ, हर नेस्टेड भंडारण इकाई को भी हटाएँ।"
 
 msgid "Yes, Reject"
 msgstr "हाँ, अस्वीकार करें"
@@ -17542,7 +17542,7 @@ msgid "You can only see this key once. Store it safely."
 msgstr "आप इस कुंजी को केवल एक बार देख सकते हैं। इसे सुरक्षित रूप से संग्रहीत करें।"
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "आपने <0/> पर साइन इन किया। आप नीचे अपने साइन आउट समय को संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
+msgstr "आपने <0/> पर साइन इन किया। आप नीचे अपने कार्य समाप्ति का समय संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity
@@ -17551,19 +17551,19 @@ msgid ""
 "                        {0} than the\n"
 "                        ordered quantity of {1}. What would you like\n"
 "                        to do with the extra parts?"
-msgstr "आपने {leftoverQuantity} अधिक {0} पूरा किया है जो {1} की ऑर्डर की गई मात्रा से अधिक है। आप अतिरिक्त भागों के साथ क्या करना चाहते हैं?"
+msgstr "आप {leftoverQuantity} अधिक \n                        {0} को {1} की ऑर्डर की गई \n                        मात्रा से पूरा कर चुके हैं। आप अतिरिक्त पार्ट्स के साथ \n                        क्या करना चाहेंगे?"
 
 msgid "You do not have permission to edit workflows"
-msgstr "आपके पास वर्कफ़्लो संपादित करने की अनुमति नहीं है"
+msgstr "आपके पास वर्कफ़्लो को संपादित करने की अनुमति नहीं है"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "आपको इस सामग्री सूची को संपादित करने की अनुमति नहीं है।"
+msgstr "आपके पास इस बिल ऑफ़ मैटेरियल को संपादित करने की अनुमति नहीं है"
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "आपके पास इस प्रक्रिया बिल को संपादित करने की अनुमति नहीं है।"
+msgstr "आपके पास इस प्रक्रिया सूची को संपादित करने की अनुमति नहीं है"
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "आप इसे चलाएं; हम सुनिश्चित करते हैं कि यह सही तरीके से किया जाए। आपके सेटअप, डेटा और गो-लाइव पर विशेषज्ञ की नजर।"
+msgstr "आप इसे चलाते हैं; हम सुनिश्चित करते हैं कि यह सही तरीके से किया जाता है। आपकी तैयारी, डेटा और गो-लाइव पर विशेषज्ञ की नजर।"
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
@@ -17576,7 +17576,7 @@ msgid "You lead"
 msgstr "आप नेतृत्व करते हैं"
 
 msgid "You name a project owner with decision authority"
-msgstr "आप निर्णय लेने के अधिकार वाले प्रोजेक्ट मालिक का नाम देते हैं"
+msgstr "आप निर्णय लेने के अधिकार वाले परियोजना स्वामी का नाम देते हैं"
 
 msgid "You received this item"
 msgstr "आपने यह आइटम प्राप्त किया"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "आप Carbon पर लाइव हैं"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "आप अपने कार्यक्षेत्र से एक चरण दूर हैं।"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "आप Carbon को स्वयं सेट अप कर रहे हैं, अपनी गति से"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"
+msgstr "आप {hoursElapsed} घंटे से साइन इन हैं। क्या आप कार्य समाप्त करना भूल गए?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "यहां तक कि अगर आपका लॉगिन चोरी हो जाता है तो आपका खाता सुरक्षित रहता है"
@@ -17603,7 +17603,7 @@ msgid "Your books and how money flows."
 msgstr "आपकी किताबें और पैसा कैसे बहता है।"
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "आपके परिवर्तन इस परिवर्तन सूचना के साथ जारी किए गए एक नए मसौदा संस्करण में जाते हैं।"
+msgstr "आपके परिवर्तन इस परिवर्तन सूचना के साथ जारी किए गए एक नए ड्राफ्ट संस्करण में जाते हैं।"
 
 msgid "Your Console PIN"
 msgstr "आपका कंसोल PIN"
@@ -17636,7 +17636,7 @@ msgid "Your job here: check a real sample of each row, then mark it validated. F
 msgstr "आपका काम यहाँ है: प्रत्येक पंक्ति का एक वास्तविक नमूना जांचें, फिर इसे सत्यापित के रूप में चिह्नित करें। फाउंडेशन डेटा पहले लोड होता है, फिर मास्टर रिकॉर्ड, फिर कटओवर पर खुले लेनदेन।"
 
 msgid "Your legal name, addresses, branding, and document defaults"
-msgstr "आपका कानूनी नाम, पते, ब्रांडिंग, और दस्तावेज़ डिफ़ॉल्ट"
+msgstr "आपका कानूनी नाम, पते, ब्रांडिंग और दस्तावेज़ डिफ़ॉल्ट"
 
 msgid "Your main point of contact"
 msgstr "आपका मुख्य संपर्क बिंदु"
@@ -17687,7 +17687,7 @@ msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample si
 msgstr "Z1.4 निरीक्षण स्तर (I / II / III); उच्च स्तर का मतलब एक ही लॉट के लिए बड़े नमूने आकार।"
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4 गंभीरता (सामान्य / कठोर / कम); हाल की लॉट-स्वीकृति इतिहास के आधार पर नियम द्वारा स्विच करता है।"
+msgstr "Z1.4 गंभीरता (सामान्य / कठोर / शिथिल); हाल के लॉट-स्वीकार इतिहास के आधार पर नियम द्वारा स्विच करता है।"
 
 msgid "Zoom Box"
 msgstr "ज़ूम बॉक्स"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -170,7 +170,6 @@ msgstr "{count} ऑपरेशन में से {from}–{to}"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "और {hiddenCount}: {hiddenNames}"
-msgstr "{hiddenCount} और: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -305,7 +304,6 @@ msgstr "4 घंटे"
 
 msgid "5 user minimum"
 msgstr "न्यूनतम 5 उपयोगकर्ता"
-msgstr "5 उपयोगकर्ता न्यूनतम"
 
 msgid "5-8 weeks"
 msgstr "5-8 सप्ताह"
@@ -363,7 +361,6 @@ msgstr "एक ठेकेदार एक आपूर्तिकर्ता
 
 msgid "A custom solution to meet your needs"
 msgstr "आपकी आवश्यकताओं को पूरा करने के लिए एक कस्टम समाधान"
-msgstr "आपकी जरूरतों को पूरा करने के लिए एक कस्टम समाधान"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "एक ग्राहक एक व्यवसाय या व्यक्ति है जो आपके पार्ट्स या सेवाएं खरीदता है।"
@@ -477,7 +474,6 @@ msgstr "एक ऑर्डर पर निर्माण घटक जिस�
 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr "Carbon का एक प्रबंधित क्लाउड-होस्ट किया गया संस्करण"
-msgstr "Carbon का एक प्रबंधित क्लाउड-होस्टेड संस्करण"
 
 msgid "A managed version with all the advanced features"
 msgstr "सभी उन्नत सुविधाओं के साथ एक प्रबंधित संस्करण"
@@ -1339,7 +1335,6 @@ msgstr "सभी कार्य चयनित"
 
 msgid "All advanced features available"
 msgstr "सभी उन्नत विशेषताएं उपलब्ध हैं"
-msgstr "सभी उन्नत सुविधाएं उपलब्ध हैं"
 
 msgid "All Audit Logs"
 msgstr "सभी ऑडिट लॉग"
@@ -1612,7 +1607,6 @@ msgstr "आपके Carbon डेटा के लिए प्रोग्र�
 
 msgid "API, webhooks, and integrations"
 msgstr "API, वेबहुक, और एकीकरण"
-msgstr "API, webhooks, और integrations"
 
 msgid "Applied"
 msgstr "लागू"
@@ -2481,7 +2475,6 @@ msgstr "आधार मूल्य"
 
 msgid "Basic ERP, MES, and QMS functionality"
 msgstr "मूल ERP, MES और QMS कार्यक्षमता"
-msgstr "बुनियादी ERP, MES, और QMS कार्यक्षमता"
 
 msgid "Basic Information"
 msgstr "बुनियादी जानकारी"
@@ -2622,7 +2615,6 @@ msgstr "लाइब्रेरी ब्राउज़ करें"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "प्रकाशित संस्करण को केवल पढ़ने के लिए ब्राउज़ करें। आप अभी भी लेआउट को साफ करने के लिए चरणों को पुनर्व्यवस्थित कर सकते हैं।"
-msgstr "प्रकाशित संस्करण को केवल-पढ़ने के लिए देखें। आप अभी भी लेआउट को साफ करने के लिए चरणों को पुनः व्यवस्थित कर सकते हैं।"
 
 msgid "Bucket"
 msgstr "बकेट"
@@ -2830,7 +2822,6 @@ msgstr "RFQ नहीं भेज सकते"
 
 msgid "Cannot send through Stripe"
 msgstr "Stripe के माध्यम से भेजा नहीं जा सकता"
-msgstr "Stripe के माध्यम से नहीं भेज सकते"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "अपलोड नहीं कर सकते — आपूर्तिकर्ता इंटरैक्शन अभी तक बनाया नहीं गया"
@@ -3180,7 +3171,6 @@ msgstr "क्लाउड, या आपका स्व-होस्ट कि
 
 msgid "CMMC compliant"
 msgstr "CMMC अनुपालन"
-msgstr "CMMC अनुरूप"
 
 msgid "Code"
 msgstr "कोड"
@@ -3950,7 +3940,6 @@ msgstr "विक्रय आदेश को पूरा करने के 
 
 msgid "Create a new Stripe customer instead"
 msgstr "इसके बजाय एक नया Stripe ग्राहक बनाएँ"
-msgstr "इसके बजाय एक नया Stripe ग्राहक बनाएं"
 
 msgid "Create a new version"
 msgstr "एक नया संस्करण बनाएं"
@@ -4422,7 +4411,6 @@ msgstr "ग्राहक"
 
 msgid "Customizations, training, and integrations"
 msgstr "कस्टमाइज़ेशन, प्रशिक्षण और एकीकरण"
-msgstr "अनुकूलन, प्रशिक्षण, और integrations"
 
 msgid "Customize"
 msgstr "अनुकूलित करें"
@@ -6990,7 +6978,6 @@ msgstr "प्रारूप"
 
 msgid "Forward deployed engineer"
 msgstr "अग्रपंक्ति में तैनात इंजीनियर"
-msgstr "आगे तैनात इंजीनियर"
 
 msgid "Foundation"
 msgstr "आधार"
@@ -8144,7 +8131,6 @@ msgstr "समस्याएं"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "यह तब तक चलना बंद कर देगा जब तक आप फिर से एक संस्करण प्रकाशित नहीं करते। कुछ भी हटाया नहीं गया है।"
-msgstr "यह तब तक चलना बंद कर देगा जब तक आप फिर से एक संस्करण प्रकाशित न करें। कुछ भी हटाया नहीं गया है।"
 
 msgid "ITAR Certifications"
 msgstr "ITAR प्रमाणपत्र"
@@ -8516,7 +8502,6 @@ msgstr "कम मैनुअल काम, कम त्रुटियां"
 
 msgid "Let's Build"
 msgstr "चलिए निर्माण करें"
-msgstr "आइए निर्माण करें"
 
 msgid "Let's build something"
 msgstr "चलिए कुछ बनाते हैं"
@@ -8598,7 +8583,6 @@ msgstr "Linear समस्या को लिंक करें"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "इस Carbon ग्राहक को इनमें से किसी एक से जोड़ें, या एक अलग Stripe ग्राहक बनाएँ।"
-msgstr "इस Carbon ग्राहक को उनमें से किसी एक से जोड़ें, या एक अलग Stripe ग्राहक बनाएं।"
 
 msgid "Link to sales order line"
 msgstr "विक्रय आदेश पंक्ति से जोड़ें"
@@ -14343,7 +14327,6 @@ msgstr "Stripe चालान को ग्राहक को ईमेल क
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक नया ग्राहक बना देगी।"
-msgstr "Stripe के पास पहले से इस ईमेल वाला एक ग्राहक है"
 
 msgid "Stripe Due Date"
 msgstr "Stripe नियत तिथि"
@@ -15631,7 +15614,6 @@ msgstr "यह Discovery चरण को पूरा करता है।"
 
 msgid "This contact has no email address"
 msgstr "इस संपर्क के पास कोई ईमेल पता नहीं है"
-msgstr "इस संपर्क का कोई ईमेल पता नहीं है"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "यह प्रतिपक्ष के पास कुछ भी बकाया नहीं है — भुगतान खाते पर दर्ज किया जाएगा।"
@@ -15663,7 +15645,6 @@ msgstr "इस चालान के पास कोई उपयोगी न
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "यह चालान इस Carbon ग्राहक के लिए पहले से जुड़े Stripe ग्राहक को बिल किया जाएगा। इसके विवरण को बदलने के लिए, इसे Stripe डैशबोर्ड में संपादित करें।"
-msgstr "इस चालान की कोई उपयोगी देय तिथि नहीं है — Stripe के लिए एक चुनें।"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "इस चालान को Stripe ग्राहक को बिल दिया जाएगा जो पहले से इस Carbon ग्राहक से जुड़ा हुआ है। इसके विवरण को बदलने के लिए, Stripe डैशबोर्ड में संपादित करें।"
@@ -16401,7 +16382,6 @@ msgstr "अप्रकाशित करें"
 
 msgid "Unpublish {name}?"
 msgstr "अप्रकाशित करें {name}?"
-msgstr "प्रकाशन रद्द करें"
 
 msgid "Unpublish {name}?"
 msgstr "{name} को प्रकाशन रद्द करें?"
@@ -16766,7 +16746,6 @@ msgstr "संस्करण"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "संस्करण {0} अभी प्रकाशित है और प्रतिस्थापित किया जाएगा।"
-msgstr "संस्करण {0} अब प्रकाशित है और प्रतिस्थापित किया जाएगा।"
 
 msgid "Version:"
 msgstr "संस्करण:"
@@ -17652,7 +17631,6 @@ msgstr "आप Carbon पर लाइव हैं"
 
 msgid "You're one step away from your workspace."
 msgstr "आप अपने कार्यक्षेत्र से एक चरण दूर हैं।"
-msgstr "आप अपने कार्यक्षेत्र से एक कदम दूर हैं।"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "आप Carbon को स्वयं सेट अप कर रहे हैं, अपनी गति से"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -3581,7 +3581,7 @@ msgid "Control how operators pick material and track time on the shop floor."
 msgstr "नियंत्रित करें कि ऑपरेटर शॉप फ्लोर पर सामग्री कैसे चुनते हैं और समय कैसे ट्रैक करते हैं।"
 
 msgid "Control whether item IDs (parts, materials, consumables, tools, and services) may contain lowercase characters."
-msgstr "नियंत्रित करें कि क्या आइटम आईडी (भाग, सामग्री, उपभोग्य सामग्री, उपकरण, और सेवाएं) लोअरकेस वर्ण हो सकते हैं।"
+msgstr "नियंत्रित करें कि क्या आइटम ID (पार्ट्स, सामग्री, उपभोग्य सामग्री, टूल और सेवा) में लोअरकेस वर्ण हो सकते हैं।"
 
 msgid "Controller, Accountant"
 msgstr "नियंत्रक, लेखाकार"
@@ -8930,7 +8930,7 @@ msgid "Map Lines Now"
 msgstr "अभी लाइनें मैप करें"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "अपने खाता चार्ट को प्रदाता के साथ मैप करें। पोस्टिंग-डिफ़ॉल्ट और व्यय खाते आवश्यक के रूप में चिह्नित हैं; पोस्ट किए गए जर्नल मैप किए गए प्रदाता खाता कोड का उपयोग करके पुश किए जाते हैं।"
+msgstr "अपने खातों का चार्ट को प्रदाता के साथ मैप करें। पोस्टिंग-डिफ़ॉल्ट और व्यय खाते आवश्यक के रूप में चिह्नित हैं; पोस्ट किए गए जर्नल मैप किए गए प्रदाता खाता कोड का उपयोग करके पुश किए जाते हैं।"
 
 msgid "Map your current process, systems, and data"
 msgstr "अपनी वर्तमान प्रक्रिया, सिस्टम और डेटा को मैप करें"
@@ -9785,7 +9785,7 @@ msgid "No Access"
 msgstr "कोई एक्सेस नहीं"
 
 msgid "No accounts match your search"
-msgstr "कोई खाते आपकी खोज से मेल नहीं खाते"
+msgstr "कोई खाता आपकी खोज से मेल नहीं खाता"
 
 msgid "No action needed"
 msgstr "कोई कार्रवाई की आवश्यकता नहीं है"
@@ -14342,17 +14342,17 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe चालान को ग्राहक को ईमेल करता है, इसलिए एक पता आवश्यक है। यह Carbon में संपर्क के लिए भी सहेजा जाएगा।"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी तक कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक बनाएगी।"
+msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक नया ग्राहक बना देगी।"
 msgstr "Stripe के पास पहले से इस ईमेल वाला एक ग्राहक है"
 
 msgid "Stripe Due Date"
-msgstr "Stripe देय तिथि"
+msgstr "Stripe नियत तिथि"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe ग्राहक को चालान ईमेल करता है, इसलिए एक पता आवश्यक है। यह Carbon में संपर्क के लिए भी सहेजा जाएगा।"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी कोई ग्राहक नहीं है। पोस्ट करने से आपके जुड़े खाते पर एक बनाया जाएगा।"
+msgstr "Stripe के पास इस Carbon ग्राहक के लिए अभी कोई ग्राहक नहीं है। पोस्टिंग आपके जुड़े खाते पर एक नया ग्राहक बना देगी।"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "कानबान तालिका में दिखाने के लिए कानबान आउटपुट की शैली"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} स्क्रैप किया गया"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} पास किए गए यूनिट(यूनिट्स) पूरी की जाएंगी।"
+msgstr "{completions} उत्तीर्ण इकाई(यों) को पूर्ण किया जाएगा।"
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} नमूना विफलता(एं) दर्ज की गई है और पूर्ण नहीं की जाएगी — उन्हें क्रियाएं मेनू से हल करें।"
@@ -94,7 +94,7 @@ msgid "Add & Issue"
 msgstr "जोड़ें और जारी करें"
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "प्रिंटिंग सेटिंग्स में एक प्रिंटर जोड़ें ताकि लेबल सीधे प्रिंट कर सकें।"
+msgstr "प्रिंटिंग सेटिंग्स में एक प्रिंटर जोड़ें ताकि सीधे लेबल प्रिंट कर सकें।"
 
 msgid "Add Inventory"
 msgstr "इन्वेंटरी जोड़ें"
@@ -112,7 +112,7 @@ msgid "All clear"
 msgstr "सब कुछ स्पष्ट"
 
 msgid "All rework"
-msgstr "सभी रीवर्क"
+msgstr "सभी पुनः कार्य"
 
 msgid "All scrap"
 msgstr "सभी स्क्रैप"
@@ -124,13 +124,13 @@ msgid "Allocate units"
 msgstr "इकाइयों को आवंटित करें"
 
 msgid "Are you sure you want to delete this step?"
-msgstr "क्या आप सुनिश्चित हैं कि आप इस चरण को हटाना चाहते हैं?"
+msgstr "क्या आप वाकई इस चरण को हटाना चाहते हैं?"
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
-msgstr "क्या आप सुनिश्चित हैं कि आप इस टाइमकार्ड को हटाना चाहते हैं? यह पूर्ववत नहीं किया जा सकता।"
+msgstr "क्या आप वाकई इस टाइमकार्ड को हटाना चाहते हैं? यह अपरिवर्तनीय है।"
 
 msgid "Are you sure you want to end all production events? This will end all active operations without completing or finishing them."
-msgstr "क्या आप सुनिश्चित हैं कि आप सभी उत्पादन घटनाओं को समाप्त करना चाहते हैं? यह सभी सक्रिय संचालन को पूरा किए बिना या समाप्त किए बिना समाप्त कर देगा।"
+msgstr "क्या आप सभी उत्पादन इवेंट को समाप्त करना चाहते हैं? यह सभी चल रहे ऑपरेशन को पूर्ण किए बिना समाप्त कर देगा।"
 
 msgid "Are you sure you want to finish this operation? This will end all active production events for this operation."
 msgstr "क्या आप सुनिश्चित हैं कि आप इस ऑपरेशन को समाप्त करना चाहते हैं? यह इस ऑपरेशन के लिए सभी सक्रिय उत्पादन इवेंट को समाप्त कर देगा।"
@@ -213,13 +213,13 @@ msgid "Clear Filters"
 msgstr "फ़िल्टर साफ़ करें"
 
 msgid "Clear Search"
-msgstr "खोज साफ़ करें"
+msgstr "खोज साफ करें"
 
 msgid "Clock In"
-msgstr "घड़ी में प्रवेश करें"
+msgstr "कार्य प्रारंभ"
 
 msgid "Clock Out"
-msgstr "घड़ी बंद करें"
+msgstr "कार्य समाप्त"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/> से घड़ी चालू है"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "सभी को पूर्ण करें"
 
 msgid "Complete passed"
-msgstr "पूर्ण पास"
+msgstr "उत्तीर्ण को पूर्ण करें"
 
 msgid "Completed"
 msgstr "पूर्ण"
@@ -296,7 +296,7 @@ msgid "Create Quality Issue"
 msgstr "गुणवत्ता समस्या बनाएं"
 
 msgid "Create Rework"
-msgstr "रीवर्क बनाएं"
+msgstr "पुनः कार्य बनाएँ"
 
 msgid "Current work"
 msgstr "वर्तमान कार्य"
@@ -317,7 +317,7 @@ msgid "Default"
 msgstr "डिफ़ॉल्ट"
 
 msgid "Default Storage Unit"
-msgstr "डिफ़ॉल्ट स्टोरेज यूनिट"
+msgstr "डिफ़ॉल्ट भंडारण इकाई"
 
 msgid "Delete"
 msgstr "हटाएं"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "विवरण"
 
 msgid "Dispatch not found"
-msgstr "डिस्पैच नहीं मिला"
+msgstr "रखरखाव कार्य नहीं मिला"
 
 msgid "Display"
 msgstr "प्रदर्शन"
@@ -363,7 +363,7 @@ msgid "Down for planned maintenance"
 msgstr "नियोजित रखरखाव के लिए बंद"
 
 msgid "Download"
-msgstr "डाउनलोड"
+msgstr "डाउनलोड करें"
 
 msgid "Download Labels"
 msgstr "लेबल डाउनलोड करें"
@@ -388,7 +388,7 @@ msgid "Due {0}"
 msgstr "Due {0} के लिए"
 
 msgid "Due Date"
-msgstr "देय तारीख"
+msgstr "नियत तिथि"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
@@ -398,7 +398,7 @@ msgid "Due today?"
 msgstr "आज देय?"
 
 msgid "Duplicate batch number"
-msgstr "डुप्लिकेट बैच नंबर"
+msgstr "डुप्लिकेट बैच संख्या"
 
 msgid "Duplicate serial number"
 msgstr "डुप्लिकेट सीरियल नंबर"
@@ -416,10 +416,10 @@ msgid "Email Address"
 msgstr "ईमेल पता"
 
 msgid "Empty work centers"
-msgstr "खाली कार्य केंद्र"
+msgstr "खाली वर्क सेंटर"
 
 msgid "End Operations"
-msgstr "संचालन समाप्त करें"
+msgstr "ऑपरेशन समाप्त करें"
 
 #. placeholder {0}: selectedPerson.name
 msgid "Enter PIN for {0}"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "अनुमानित"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "हर इकाई का एक निर्णय है: {passes} पास और {fails} विफल। लॉट बंद हो जाता है और प्रत्येक इकाई अपने परिणाम के लिए रूट की जाती है।"
+msgstr "प्रत्येक इकाई का निर्णय है: {passes} उत्तीर्ण और {fails} असफल। लॉट बंद हो जाता है जब प्रत्येक इकाई को अपने परिणाम के अनुसार भेजा जाता है।"
 
 msgid "Expand features table"
 msgstr "फीचर्स टेबल को विस्तृत करें"
@@ -466,10 +466,10 @@ msgid "Failed to complete inventory adjustment"
 msgstr "इन्वेंटरी समायोजन पूरा करने में विफल"
 
 msgid "Failed to end operations"
-msgstr "संचालन समाप्त करने में विफल"
+msgstr "ऑपरेशन समाप्त करने में विफल"
 
 msgid "Failed to fetch active operations"
-msgstr "सक्रिय संचालन प्राप्त करने में विफल"
+msgstr "चल रहे ऑपरेशन प्राप्त करने में विफल"
 
 msgid "Failed to fetch storageUnits"
 msgstr "storageUnits को प्राप्त करने में विफल"
@@ -503,7 +503,7 @@ msgid "Files related to the job and the opportunity line."
 msgstr "नौकरी और अवसर लाइन से संबंधित फाइलें।"
 
 msgid "Filter"
-msgstr "फ़िल्टर"
+msgstr "फ़िल्टर करें"
 
 msgid "Filter by location"
 msgstr "स्थान के अनुसार फ़िल्टर करें"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "वैसे भी समाप्त करें"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "अपना खाता सेट अप करना पूर्ण करें"
 
 msgid "Finish with material unpicked?"
 msgstr "सामग्री बिना चुने समाप्त करें?"
 
 msgid "Forgot to Clock Out?"
-msgstr "घड़ी से बाहर निकलना भूल गए?"
+msgstr "कार्य समाप्त करना भूल गए?"
 
 msgid "Go back to operation"
 msgstr "ऑपरेशन पर वापस जाएं"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "ऑनबोर्डिंग पर जाएं"
 
 msgid "How many were actually picked?"
 msgstr "वास्तव में कितने चुने गए?"
@@ -619,10 +619,10 @@ msgid "Job Traveler"
 msgstr "जॉब ट्रैवलर"
 
 msgid "Jobs"
-msgstr "नौकरियां"
+msgstr "जॉब"
 
 msgid "Keep picking"
-msgstr "चुनना जारी रखें"
+msgstr "पिकिंग जारी रखें"
 
 msgid "Kit"
 msgstr "किट"
@@ -668,11 +668,11 @@ msgid "Log completed for {0}"
 msgstr "{0} के लिए पूर्ण लॉग करें"
 
 msgid "Log Rework"
-msgstr "रीवर्क लॉग करें"
+msgstr "पुनः कार्य लॉग करें"
 
 #. placeholder {0}: operation.itemReadableId
 msgid "Log rework for {0}"
-msgstr "{0} के लिए रीवर्क लॉग करें"
+msgstr "{0} के लिए पुनः कार्य लॉग करें"
 
 msgid "Log Scrap"
 msgstr "स्क्रैप लॉग करें"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "इन्वेंटरी में आइटम मैन्युअली जोड़ें"
 
 msgid "Manually remove items from inventory"
-msgstr "इन्वेंटरी से आइटम को मैन्युअली हटाएं"
+msgstr "इन्वेंटरी से मैनुअल रूप से आइटम निकालें"
 
 msgid "Mark Short"
 msgstr "कम चिह्नित करें"
@@ -773,22 +773,22 @@ msgid "No"
 msgstr "नहीं"
 
 msgid "No active job at this work center"
-msgstr "इस कार्य केंद्र पर कोई सक्रिय कार्य नहीं"
+msgstr "इस वर्क सेंटर पर कोई चल रहा जॉब नहीं है"
 
 msgid "No active maintenance dispatches"
-msgstr "कोई सक्रिय रखरखाव प्रेषण नहीं"
+msgstr "कोई चल रहा रखरखाव कार्य नहीं है"
 
 msgid "No active operations"
-msgstr "कोई सक्रिय संचालन नहीं"
+msgstr "कोई चल रहा ऑपरेशन नहीं है"
 
 msgid "No active work centers at this location."
-msgstr "इस स्थान पर कोई सक्रिय कार्य केंद्र नहीं।"
+msgstr "इस स्थान पर कोई कार्यशील वर्क सेंटर नहीं हैं।"
 
 msgid "No assigned operations"
 msgstr "कोई नियुक्त ऑपरेशन नहीं"
 
 msgid "No available filters"
-msgstr "कोई उपलब्ध फ़िल्टर नहीं"
+msgstr "कोई उपलब्ध फ़िल्टर नहीं है"
 
 msgid "No available serial numbers found"
 msgstr "कोई उपलब्ध सीरियल नंबर नहीं मिला"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "कोई उपलब्ध ट्रैक किए गए इकाइयां नहीं मिलीं"
 
 msgid "No dispatches assigned to you"
-msgstr "आपको कोई डिस्पैच असाइन नहीं किया गया है"
+msgstr "आपको कोई असाइन किया गया रखरखाव कार्य नहीं है"
 
 msgid "No files"
 msgstr "कोई फ़ाइलें नहीं"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "कोई सामग्री नहीं"
 
 msgid "No open jobs"
-msgstr "कोई खुली नौकरी नहीं"
+msgstr "कोई खुली जॉब नहीं"
 
 msgid "No open units to allocate"
 msgstr "आवंटित करने के लिए कोई खुली इकाई नहीं"
@@ -839,7 +839,7 @@ msgid "No printer configured"
 msgstr "कोई प्रिंटर कॉन्फ़िगर नहीं किया गया"
 
 msgid "No recent operations"
-msgstr "कोई हाल के संचालन नहीं"
+msgstr "कोई हाल की ऑपरेशन नहीं"
 
 msgid "No remaining entities to inspect."
 msgstr "निरीक्षण करने के लिए कोई शेष इकाई नहीं है।"
@@ -878,13 +878,13 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "इस आइटम के लिए कोई गोदाम स्टॉक रिकॉर्ड पर नहीं है। आप इसे अभी भी चुन सकते हैं — ऑन-हैंड नकारात्मक हो जाएगा जब तक गिनती समेकित नहीं हो जाती।"
 
 msgid "No Work Center"
-msgstr "कोई कार्य केंद्र नहीं"
+msgstr "कोई वर्क सेंटर नहीं"
 
 msgid "No work centers are blocked"
-msgstr "कोई कार्य केंद्र अवरुद्ध नहीं हैं"
+msgstr "कोई वर्क सेंटर अवरुद्ध नहीं है"
 
 msgid "No work centers exist"
-msgstr "कोई कार्य केंद्र मौजूद नहीं है"
+msgstr "कोई वर्क सेंटर मौजूद नहीं है"
 
 msgid "None"
 msgstr "कोई नहीं"
@@ -896,7 +896,7 @@ msgid "Nothing running"
 msgstr "कुछ नहीं चल रहा"
 
 msgid "Nothing scheduled at this work center"
-msgstr "इस कार्य केंद्र पर कुछ भी शेड्यूल नहीं है"
+msgstr "इस वर्क सेंटर पर कुछ भी शेड्यूल नहीं है"
 
 msgid "Nothing to scrap"
 msgstr "स्क्रैप करने के लिए कुछ नहीं"
@@ -921,19 +921,19 @@ msgid "Open"
 msgstr "खुला"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "कार्य केंद्र पर लगी स्क्रीन पर एक डिस्प्ले खोलें और इसे चलता रहने दें। प्रत्येक बोर्ड अपने आप ताज़ा हो जाता है।"
+msgstr "वर्क सेंटर पर लगी स्क्रीन पर एक डिस्प्ले खोलें और इसे चलाते रहें। प्रत्येक बोर्ड स्वयं रीफ्रेश होता है।"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "एमआरबी डिस्पोजिशन के लिए एनसीआर खोलें"
+msgstr "MRB निपटान के लिए एक NCR खोलें"
 
 msgid "Open Jobs"
-msgstr "खुली नौकरियां"
+msgstr "खुली जॉब्स"
 
 msgid "Operations"
-msgstr "संचालन"
+msgstr "ऑपरेशन"
 
 msgid "Operations ended"
-msgstr "संचालन समाप्त"
+msgstr "ऑपरेशन समाप्त"
 
 msgid "Operator"
 msgstr "ऑपरेटर"
@@ -966,7 +966,7 @@ msgid "Partial Disposition"
 msgstr "आंशिक निपटान"
 
 msgid "Passed Inspection"
-msgstr "निरीक्षण पास किया"
+msgstr "निरीक्षण उत्तीर्ण"
 
 msgid "Passkey unlock failed"
 msgstr "पासकी अनलॉक विफल"
@@ -1026,7 +1026,7 @@ msgid "Priority"
 msgstr "प्राथमिकता"
 
 msgid "Procedure"
-msgstr "प्रक्रिया"
+msgstr "कार्यविधि"
 
 msgid "Process"
 msgstr "प्रक्रिया"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "कतार खाली"
 
 msgid "Reason for rework"
-msgstr "रीवर्क का कारण"
+msgstr "पुनः कार्य का कारण"
 
 msgid "Recent"
 msgstr "हाल ही में"
@@ -1081,37 +1081,37 @@ msgid "Reject Lot"
 msgstr "लॉट अस्वीकार करें"
 
 msgid "Remove"
-msgstr "हटाएं"
+msgstr "निकालें"
 
 msgid "Remove filter"
-msgstr "फ़िल्टर हटाएं"
+msgstr "फ़िल्टर निकालें"
 
 msgid "Remove Inventory"
-msgstr "इन्वेंटरी हटाएं"
+msgstr "इन्वेंटरी निकालें"
 
 msgid "Remove part"
-msgstr "भाग हटाएं"
+msgstr "पार्ट निकालें"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "सबअ्यासेम्बली को फिर से खोलें और एक प्रतिस्थापन इकाई बनाएं"
+msgstr "सब-असेंबली को फिर से खोलें और एक रिप्लेसमेंट इकाई बनाएँ"
 
 msgid "Result"
 msgstr "परिणाम"
 
 msgid "Rework"
-msgstr "रीवर्क"
+msgstr "पुनः कार्य"
 
 msgid "Rework created successfully"
-msgstr "रीवर्क सफलतापूर्वक बनाया गया"
+msgstr "पुनः कार्य सफलतापूर्वक बनाया गया"
 
 msgid "Rework quantity"
-msgstr "रीवर्क मात्रा"
+msgstr "पुनः कार्य की मात्रा"
 
 msgid "Running"
 msgstr "चल रहा है"
 
 msgid "Sales Order"
-msgstr "बिक्रय आदेश"
+msgstr "विक्रय आदेश"
 
 msgid "Save"
 msgstr "सहेजें"
@@ -1120,7 +1120,7 @@ msgid "Scan"
 msgstr "स्कैन करें"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "पहले नमूना कॉलम जोड़ने के लिए ट्रैक की गई इकाई को स्कैन करें।"
+msgstr "पहली नमूना कॉलम जोड़ने के लिए एक ट्रैक की गई इकाई को स्कैन करें।"
 
 msgid "Scan or enter serial number"
 msgstr "स्कैन करें या सीरियल नंबर दर्ज करें"
@@ -1132,10 +1132,10 @@ msgid "Scan or enter tracking number"
 msgstr "स्कैन करें या ट्रैकिंग नंबर दर्ज करें"
 
 msgid "Scan or search serial number..."
-msgstr "सीरियल नंबर स्कैन या खोजें..."
+msgstr "सीरियल नंबर स्कैन करें या खोजें..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "इस लॉट से ट्रैक की गई इकाई को स्कैन या चुनें इसे नमूना कॉलम के रूप में जोड़ने के लिए, फिर ग्रिड में इसके परिणाम को रिकॉर्ड करें।"
+msgstr "इस लॉट से एक ट्रैक की गई इकाई को स्कैन या चुनें, इसे नमूना कॉलम के रूप में जोड़ें, और फिर ग्रिड में इसका परिणाम रिकॉर्ड करें।"
 
 msgid "Schedule"
 msgstr "शेड्यूल"
@@ -1183,7 +1183,7 @@ msgid "Select a completion quantity"
 msgstr "पूर्ण मात्रा का चयन करें"
 
 msgid "Select a rework quantity"
-msgstr "रीवर्क मात्रा चुनें"
+msgstr "पुनः कार्य की मात्रा चुनें"
 
 msgid "Select a scrap quantity and reason"
 msgstr "स्क्रैप मात्रा और कारण चुनें"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "सत्र लॉक किया गया"
 
 msgid "Set Clock Out"
-msgstr "क्लॉक आउट सेट करें"
+msgstr "कार्य समाप्ति सेट करें"
 
 msgid "Set clock-out time"
 msgstr "घड़ी बंद करने का समय सेट करें"
@@ -1316,7 +1316,7 @@ msgstr "स्टेशन: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "सांख्यिकीय स्वीकृति विफल हुई, इसलिए {0} का पूरा लॉट गैर-अनुरूप माना जाता है (ISO 9001:2015 §8.7) — {passes} नमूना पास और {fails} विफलता(एं)। नीचे दी गई इकाइयों को स्क्रैप या रीवर्क के लिए रूट करें, या केवल निर्णय रिकॉर्ड करें।"
+msgstr "सांख्यिकीय स्वीकृति विफल हुई, इसलिए {0} का पूरा लॉट गैर-अनुरूप माना जाता है (ISO 9001:2015 §8.7) — {passes} नमूनाकृत उत्तीर्ण और {fails} विफलता(एं)। नीचे दी गई इकाइयों को स्क्रैप या पुनः कार्य के लिए रूट करें, या केवल फैसला रिकॉर्ड करें।"
 
 msgid "Status"
 msgstr "स्थिति"
@@ -1355,13 +1355,13 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "इस ऑपरेशन के लिए पूर्ण मात्रा आवश्यक मात्रा {targetQuantity} से कम है।"
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "लॉट को पास के रूप में चिह्नित किया जाएगा और {remaining} शेष इकाई(यों) को इस ऑपरेशन पर पूरा किया जाएगा।"
+msgstr "लॉट को उत्तीर्ण के रूप में चिह्नित किया जाएगा और {remaining} शेष इकाई(यों) को इस ऑपरेशन पर पूर्ण किया जाएगा।"
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "लॉट को अभी भी डिस्पोज़ किया जाएगा, लेकिन कम से कम एक Issue Type कॉन्फ़िगर होने तक NCR नहीं बनाया जा सकता।"
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "इस सामग्री के लिए कोई उपलब्ध या खपत ट्रैक की गई वस्तुएं नहीं हैं।"
+msgstr "इस सामग्री के लिए कोई उपलब्ध या उपयोग की गई ट्रैक की गई पार्ट नहीं है।"
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "बिल ऑफ मेटेरियल पर सीरियल या बैच ट्रैक किए गए मेटेरियल हैं जो पूरी तरह से जारी नहीं किए गए हैं। जारी किए बिना पूरा करने से गलत ट्रेसेबिलिटी रिकॉर्ड हो सकते हैं।"
@@ -1373,13 +1373,13 @@ msgid "This lot is expired and can't be picked."
 msgstr "यह लॉट समाप्त हो गया है और इसे चुना नहीं जा सकता।"
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "यह हिस्सा आदेश के अनुसार बनाया गया था। इसे स्क्रैप करने से इसका रूटिंग फिर से खुल सकता है प्रतिस्थापन बनाने के लिए।"
+msgstr "यह पार्ट ऑर्डर के अनुसार बनाया गया था। इसे स्क्रैप करने से इसकी रूटिंग को फिर से खोला जा सकता है ताकि एक रिप्लेसमेंट बनाया जा सके।"
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
 msgstr "यह हिस्सा स्टॉक से स्क्रैप किया जाएगा। इसकी आवश्यकता खुली रहती है ताकि आप एक प्रतिस्थापन जारी कर सकें।"
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
-msgstr "यह इकाई स्थायी रूप से स्क्रैप की जाएगी और एक प्रतिस्थापन सीरीयल नंबर बनाया जाएगा।"
+msgstr "इस इकाई को स्थायी रूप से स्क्रैप किया जाएगा और एक रिप्लेसमेंट सीरियल नंबर बनाया जाएगा।"
 
 msgid "Thumbnail"
 msgstr "थंबनेल"
@@ -1415,10 +1415,10 @@ msgid "Tracking"
 msgstr "ट्रैकिंग"
 
 msgid "Two-factor authentication"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण"
+msgstr "दो-कारक प्रमाणीकरण"
 
 msgid "Two-factor authentication required"
-msgstr "दो-फ़ैक्टर प्रमाणीकरण आवश्यक है"
+msgstr "दो-कारक प्रमाणीकरण आवश्यक है"
 
 msgid "Type a message..."
 msgstr "एक संदेश लिखें..."
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "सत्यापित करें"
 
 msgid "View maintenance dispatch"
-msgstr "रखरखाव डिस्पैच देखें"
+msgstr "रखरखाव कार्य देखें"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "हमने आपके खाते में साइन इन करने के लिए आपको एक जादुई लिंक भेजा है।"
@@ -1498,22 +1498,22 @@ msgid "WIP"
 msgstr "WIP"
 
 msgid "Work Center"
-msgstr "कार्य केंद्र"
+msgstr "वर्क सेंटर"
 
 msgid "Work Center Displays"
-msgstr "कार्य केंद्र डिस्प्ले"
+msgstr "वर्क सेंटर डिस्प्ले"
 
 msgid "Yes"
 msgstr "हां"
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "आपने <0/> पर घड़ी शुरू की है। आप नीचे अपने निकास समय को संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
+msgstr "आपने <0/> पर कार्य शुरू किया। आप नीचे अपने कार्य समाप्ति समय को संपादित कर सकते हैं या स्वीकार कर सकते हैं कि आप अभी भी काम कर रहे हैं।"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "आप {hoursElapsed} घंटे के लिए क्लॉक इन हैं। क्या आप क्लॉक आउट करना भूल गए?"
+msgstr "आप {hoursElapsed} घंटों से कार्य पर हैं। क्या आप कार्य समाप्त करना भूल गए?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "आपका खाता अभी तक किसी कंपनी का हिस्सा नहीं है। जारी रखने के लिए Carbon ERP में ऑनबोर्डिंग पूर्ण करें।"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "आपके संगठन को एक ऑथेंटिकेटर ऐप की आवश्यकता है। इसे Carbon में सेट अप करें, फिर यहाँ वापस आएं।"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -520,7 +520,6 @@ msgstr "वैसे भी समाप्त करें"
 
 msgid "Finish setting up your account"
 msgstr "अपना खाता सेट अप करना पूर्ण करें"
-msgstr "अपना खाता सेट करना समाप्त करें"
 
 msgid "Finish with material unpicked?"
 msgstr "सामग्री बिना चुने समाप्त करें?"
@@ -1515,7 +1514,6 @@ msgstr "आप {hoursElapsed} घंटों से कार्य पर ह�
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "आपका खाता अभी तक किसी कंपनी का हिस्सा नहीं है। जारी रखने के लिए Carbon ERP में ऑनबोर्डिंग पूर्ण करें।"
-msgstr "आपका खाता अभी तक किसी कंपनी का हिस्सा नहीं है। जारी रखने के लिए Carbon ERP में ऑनबोर्डिंग पूरी करें।"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "आपके संगठन को एक ऑथेंटिकेटर ऐप की आवश्यकता है। इसे Carbon में सेट अप करें, फिर यहाँ वापस आएं।"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -3584,7 +3584,7 @@ msgid "Control how operators pick material and track time on the shop floor."
 msgstr "Controlla come gli operatori prelevano il materiale e tracciano il tempo in officina."
 
 msgid "Control whether item IDs (parts, materials, consumables, tools, and services) may contain lowercase characters."
-msgstr "Controlla se gli ID degli articoli (parti, materiali, consumabili, strumenti e servizi) possono contenere caratteri minuscoli."
+msgstr "Controlla se gli ID articolo (componenti, materiali, materiali di consumo, utensili e servizi) possono contenere caratteri minuscoli."
 
 msgid "Controller, Accountant"
 msgstr "Controllore, Contabile"
@@ -8933,7 +8933,7 @@ msgid "Map Lines Now"
 msgstr "Mappa Righe Ora"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Associa il tuo piano dei conti con quello del fornitore. I conti di registrazione predefinita e i conti spese sono contrassegnati come Obbligatori; i diari contabili registrati vengono inviati utilizzando il codice account del fornitore mappato."
+msgstr "Mappa il tuo piano dei conti a quello del provider. I conti predefiniti di registrazione e i conti di spesa sono contrassegnati come richiesti; le prime note registrate vengono inviate utilizzando il codice conto provider mappato."
 
 msgid "Map your current process, systems, and data"
 msgstr "Mappa il tuo processo attuale, i sistemi e i dati"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 msgid " A supplier is a business or person who sells you parts or services."
-msgstr "Un fornitore è un'azienda o una persona che ti vende parti o servizi."
+msgstr "Un fornitore è un'azienda o una persona che ti vende componenti o servizi."
 
 #. placeholder {0}: formatDateTime(lastReconciliation.runAt)
 msgid "— last checked {0}"
@@ -30,10 +30,10 @@ msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
 msgstr "\"{0}\" non è disponibile sulla superficie selezionata. Scegli un altro campo."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "\"{storageUnitName}\" ha {childCount} unità di archiviazione nidificate dirette. L'eliminazione comporterà anche l'eliminazione di queste e di tutto ciò che si trova al di sotto. Questa azione non può essere annullata."
+msgstr "\"{storageUnitName}\" ha {childCount} unità di stoccaggio direttamente annidate. L'eliminazione comporterà anche l'eliminazione di esse e di tutto ciò che vi si trova. Questa azione non può essere annullata."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "\"{storageUnitName}\" ha 1 unità di archiviazione nidificata diretta. L'eliminazione comporterà anche l'eliminazione di tale unità e di tutto ciò che si trova al di sotto di essa. Questa azione non può essere annullata."
+msgstr "\"{storageUnitName}\" ha 1 unità di stoccaggio direttamente annidata. L'eliminazione comporterà anche l'eliminazione di tale unità e di tutto ciò che vi si trova. Questa azione non può essere annullata."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -43,7 +43,7 @@ msgstr "\"{taskName}\" si spunta automaticamente una volta che i suoi {0} elemen
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "\"{taskName}\" è completato — tutti i {0} elementi della Setup Map sono configurati."
+msgstr "\"{taskName}\" è completato — tutti i {0} articoli della sua Mappa di attrezzaggio sono configurati."
 
 msgid "(excluded for this customer)"
 msgstr "(escluso per questo cliente)"
@@ -79,11 +79,11 @@ msgstr "{0} eliminato con successo"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} bozze di registrazioni contabili"
+msgstr "{0} righe di registrazione in bozza"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} processi creati"
+msgstr "{0} ordini di produzione creati"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} valori mancanti"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} parti saltate — hanno già processi aperti"
+msgstr "{alreadyPlannedItemCount} componenti saltati — hanno già ordini di produzione aperti"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% dei debiti"
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} di {count} operazioni"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} altri: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,16 +186,16 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} mesi con totali non corrispondenti"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} giornali mancanti nel provider"
+msgstr "{missingCount} prime note mancanti nel provider"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} giornali mancanti e {mismatchCount} mesi non corrispondenti"
+msgstr "{missingCount} prime note mancanti e {mismatchCount} mesi non corrispondenti"
 
 msgid "{name} deleted"
 msgstr "{name} eliminato"
 
 msgid "{noDemandItemCount} parts skipped — nothing to make"
-msgstr "{noDemandItemCount} parti saltate — niente da produrre"
+msgstr "{noDemandItemCount} componenti saltati — nulla da produrre"
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
@@ -220,7 +220,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} processi aggiornati"
+msgstr "{updatedJobCount} ordini di produzione aggiornati"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} caricato — campi compilati dal documento."
@@ -246,7 +246,7 @@ msgid "↩ {0} redirected from superseded {1}"
 msgstr "↩ {0} reindirizzato da {1} obsoleto"
 
 msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
-msgstr "<0>Aggiungi una parte fornitore</0> per questo articolo per impostare un fornitore preferito."
+msgstr "<0>Aggiungi un componente fornitore</0> per questo articolo per impostare un fornitore preferenziale."
 
 msgid "0 operations"
 msgstr "0 operazioni"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 giorno"
 
 msgid "1 draft journal entry"
-msgstr "1 bozza di registrazione contabile"
+msgstr "1 riga di registrazione in bozza"
 
 msgid "1 job created"
 msgstr "1 processo creato"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimo 5 utenti"
 
 msgid "5-8 weeks"
 msgstr "5-8 settimane"
 
 msgid "52-week demand"
-msgstr "Domanda a 52 settimane"
+msgstr "Fabbisogno di 52 settimane"
 
 msgid "5MB file limit"
 msgstr "Limite di file 5MB"
@@ -336,7 +336,7 @@ msgid "A clearing account holding the value of goods received but not yet billed
 msgstr "Un conto di compensazione che tiene il valore della merce ricevuta ma non ancora fatturata; la fattura del fornitore la compensa."
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
-msgstr "Un'azienda che progetta e costruisce i propri prodotti finiti da capo a piedi (qui, lo shop che costruisce robot umanoidi) piuttosto che fabbricare parti secondo le specifiche di un'altra azienda."
+msgstr "Un'azienda che progetta e costruisce i propri prodotti finiti da capo a piedi (qui, l'officina che costruisce robot umanoidi) piuttosto che realizzare componenti secondo le specifiche di un'altra azienda."
 
 msgid "A company that sits at or above selected companies in the group hierarchy and receives their intercompany cancelling entries for consolidated reporting; it is never a party to the trade itself."
 msgstr "Un'azienda che si trova a o al di sopra delle società selezionate nella gerarchia del gruppo e riceve le loro voci di annullamento interaziendale per la rendicontazione consolidata; non è mai una parte della transazione stessa."
@@ -345,7 +345,7 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "Un campo aggiuntivo definito dall'azienda allegato a una tabella principale (cliente, parte, ordine); viene visualizzato nel modulo del record, salvato insieme ai campi integrati ed è interrogabile tramite l'API."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Un asse tag definito dall'azienda allegato alle righe del giornale in modo che gli stessi conti possano essere suddivisi per ubicazione, reparto o qualsiasi asse personalizzato senza moltiplicare il piano dei conti."
+msgstr "Un asse di tag definito dall'azienda allegato alle righe di registrazione in modo che gli stessi conti possano essere suddivisi per ubicazione, reparto o qualsiasi asse personalizzato senza moltiplicare il piano dei conti."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "Uno Sconto o Ricarico nell'ambito aziendale, per percentuale o importo fisso, che regola il prezzo di una riga verso l'alto o verso il basso quando la riga corrisponde alle condizioni di quantità, data, articolo e cliente della regola."
@@ -354,16 +354,16 @@ msgid "A completed job's output, received into inventory at the job's actual acc
 msgstr "L'output di un lavoro completato, ricevuto in inventario al costo WIP accumulato effettivo del lavoro."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un consumabile è un articolo fisico utilizzato per realizzare una parte che può essere utilizzata in più lavori"
+msgstr "Un materiale di consumo è un articolo fisico utilizzato per realizzare un componente che può essere utilizzato su più ordini di produzione"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Un appaltatore è un contatto fornitore con particolari competenze e ore disponibili"
+msgstr "Un collaboratore esterno è un contatto fornitore con competenze particolari e ore disponibili"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Una soluzione personalizzata per soddisfare le tue esigenze"
 
 msgid "A customer is a business or person who buys your parts or services."
-msgstr "Un cliente è un'azienda o una persona che acquista i tuoi prodotti o servizi."
+msgstr "Un cliente è un'azienda o una persona che compra i tuoi componenti o servizi."
 
 msgid "A customer is created"
 msgstr "Un cliente è creato"
@@ -375,7 +375,7 @@ msgid "A customer's account manager changes"
 msgstr "Il gestore account del cliente cambia"
 
 msgid "A customer's assignee changes"
-msgstr "L'assegnazione del cliente cambia"
+msgstr "L'assegnatario di un cliente cambia"
 
 msgid "A customer's currency changes"
 msgstr "La valuta del cliente cambia"
@@ -384,7 +384,7 @@ msgid "A customer's name changes"
 msgstr "Il nome del cliente cambia"
 
 msgid "A customer's sales contact changes"
-msgstr "Il contatto commerciale del cliente cambia"
+msgstr "Il contatto di vendita di un cliente cambia"
 
 msgid "A customer's status changes"
 msgstr "Lo stato del cliente cambia"
@@ -426,16 +426,16 @@ msgid "A job is deleted"
 msgstr "Un lavoro è eliminato"
 
 msgid "A job is put on hold"
-msgstr "Un lavoro è messo in attesa"
+msgstr "Un ordine di produzione è sospeso"
 
 msgid "A job is released"
 msgstr "Un lavoro è rilasciato"
 
 msgid "A job operation is completed"
-msgstr "Un'operazione di lavoro è completata"
+msgstr "Un'operazione dell'ordine è completata"
 
 msgid "A job's assignee changes"
-msgstr "L'assegnazione del lavoro cambia"
+msgstr "L'assegnatario di un ordine di produzione cambia"
 
 msgid "A job's deadline type changes"
 msgstr "Il tipo di scadenza del lavoro cambia"
@@ -467,28 +467,28 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Un elenco è collegato a {0}, quindi questo passaggio viene eseguito una volta per ogni elemento in esso — fino a {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Un componente Fabrica su Ordine che ottiene il proprio lavoro e instradamento all'interno della compilazione del padre."
+msgstr "Un componente Produzione su commessa che ottiene il suo ordine di produzione e ciclo di lavorazione all'interno della costruzione del padre."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Un componente Fabrica su Ordine le cui parti vengono emesse insieme nel lavoro padre — nessuna compilazione separata."
+msgstr "Un componente Produzione su commessa i cui componenti vengono scaricati insieme nell'ordine di produzione padre — nessuna costruzione separata."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Una versione gestita ospitata nel cloud di Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Una versione gestita con tutte le funzionalità avanzate"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Un materiale è un articolo fisico utilizzato per realizzare una parte che può essere utilizzata in più lavori"
+msgstr "Un materiale è un articolo fisico utilizzato per realizzare un componente che può essere utilizzato su più ordini di produzione"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "Uno strumento di misurazione (calibro, micrometro, calibro a spilli, CMM) tracciato come record e sottoposto a un programma di calibrazione ricorrente."
+msgstr "Uno strumento di misura (calibro, micrometro, calibro di spessore, CMM) tracciato come un record e sottoposto a un programma di taratura ricorrente."
 
 msgid "A name is required to save a view"
 msgstr "Un nome è obbligatorio per salvare una vista"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Un prezzo negoziato fissato per un articolo specifico, per cliente, tipo di cliente o tutti i clienti, che sostituisce completamente il prezzo di base, facoltativamente con interruzioni di quantità."
+msgstr "Un prezzo negoziato fissato per un articolo specifico — per cliente, tipo di cliente o tutti i clienti — che sostituisce completamente il prezzo base, facoltativamente con scaglioni di quantità."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
 msgstr "Un nuovo ordine di acquisto verrà creato per ogni fornitore. In alternativa, puoi scegliere un ordine di acquisto in bozza esistente per il fornitore per aggiungere le operazioni esterne."
@@ -500,19 +500,19 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Una nuova dimensione verrà creata utilizzando una copia della dimensione attuale"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Verrà creato un nuovo cliente Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "Un documento non in contanti che regola una fattura rispetto a un conto motivo: un credito abbassa ciò che è dovuto, un debito lo aumenta."
+msgstr "Un documento non in contanti che cancella una fattura rispetto a un conto di motivo: un avere abbassa ciò che è dovuto, un dare lo aumenta."
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
-msgstr "Una non conformità condivisa con un fornitore tramite un collegamento /share/scar senza accesso, in modo che possano rispondere al problema e aggiornare i relativi compiti dall'esterno di Carbon."
+msgstr "Una non conformità condivisa con un fornitore tramite un collegamento /share/scar senza login, in modo che possano rispondere al problema e aggiornare le relative attività dall'esterno di Carbon."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Un supplemento non imponibile (p. es. spese recuperabili come tasse di permesso) aggiunto alla riga ed escluso dalla base imponibile."
+msgstr "Un supplemento non tassabile (ad es. spese recuperabili come tasse di permesso) aggiunto alla riga; escluso dalla base imponibile."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Un'attività di non conformità che corregge una causa principale confermata — a differenza di un'azione preventiva o di contenimento immediato."
+msgstr "Un'attività di non conformità che risolve una causa radice confermata — al contrario di un'azione preventiva o di contenimento immediato."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
 msgstr "Un'attività di non conformità che impedisce il ripetersi del problema altrove — distinta dalla correzione corrective e dal contenimento."
@@ -527,10 +527,10 @@ msgid "A point in one of Carbon's own flows that a workflow can watch — a job 
 msgstr "Un punto nei flussi di Carbon che un flusso di lavoro può osservare — un lavoro rilasciato, un'offerta accettata, una spedizione pubblicata — in contrasto con una modifica di campo grezzo; passa al flusso di lavoro i record coinvolti per id."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Una voce contabile registrata: un'intestazione più righe di debito e credito bilanciate contro i conti GL."
+msgstr "Una registrazione contabile: un'intestazione più righe bilanciate di Dare e Avere contro i conti contabili."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Una transazione di cassa registrata: una ricevuta da un cliente o un pagamento a un fornitore, applicata alle fatture tramite regolamenti, spostandosi da Bozza → Registrato → Annullato."
+msgstr "Una transazione di cassa registrata — un Incasso da un cliente o un Esborso a un fornitore — applicata alle fatture attraverso i pagamenti, passando da Bozza → Registrata → Stornata."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Una descrizione pre-scritta inserita in ogni problema che utilizza questo flusso di lavoro; i segnaposti come {itemId} e {location} vengono sostituiti al momento della creazione."
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "Un ordine di acquisto è eliminato"
 
 msgid "A purchase order's assignee changes"
-msgstr "L'assegnazione dell'ordine di acquisto cambia"
+msgstr "L'assegnatario di un ordine di acquisto cambia"
 
 msgid "A purchase order's order date changes"
 msgstr "La data dell'ordine di acquisto cambia"
@@ -575,13 +575,13 @@ msgid "A purchase order's type changes"
 msgstr "Il tipo di ordine di acquisto cambia"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Un problema di qualità — una deviazione registrata o un difetto con un flusso di lavoro configurabile di attività di indagine e azione."
+msgstr "Un problema di qualità — una deroga o un difetto registrati con un flusso di lavoro configurabile di indagine e attività di intervento."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Una quantità di unità identiche condivide un'entità tracciata e il numero di lotto — un'entità, molte unità."
 
 msgid "A quote is a set of prices for specific parts and quantities."
-msgstr "Un preventivo è un insieme di prezzi per parti e quantità specifiche."
+msgstr "Un'offerta è un insieme di prezzi per componenti e quantità specifiche."
 
 msgid "A quote is accepted"
 msgstr "Un'offerta è accettata"
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "Un preventivo è inviato"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Una riga di preventivo contiene prezzi e tempi di consegna per una parte particolare"
+msgstr "Una riga offerta contiene prezzi e lead time per un componente particolare"
 
 msgid "A quote's assignee changes"
-msgstr "Il responsabile del preventivo cambia"
+msgstr "L'assegnatario di un'offerta cambia"
 
 msgid "A quote's completed date changes"
 msgstr "La data di completamento del preventivo cambia"
@@ -632,7 +632,7 @@ msgid "A receipt is posted"
 msgstr "Una ricevuta è registrata"
 
 msgid "A receipt's assignee changes"
-msgstr "Il responsabile della ricevuta cambia"
+msgstr "L'assegnatario di un'entrata merci cambia"
 
 msgid "A receipt's invoiced changes"
 msgstr "Lo stato fatturato della ricevuta cambia"
@@ -656,10 +656,10 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Un insieme riutilizzabile e versionato di istruzioni di lavoro allegate a un processo, che fornisce a un'operazione i suoi passaggi ordinati da registrare e controllare più i parametri con cui viene eseguita."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Un passaggio di routing su un job rilasciato, la copia propria del job di un'operazione, che porta uno stato che il reparto guida da Todo a Done."
+msgstr "Un passo di ciclo di lavorazione su un ordine di produzione rilasciato, la copia propria dell'ordine di un'operazione, con uno stato che il reparto spinge da Da fare a Fatto."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Una fattura di vendita (fatturi a un cliente) o una fattura d'acquisto (un fornitore ti fattura), regolata applicando pagamenti e note di credito o debito."
+msgstr "Una fattura di vendita (emetti una fattura a un cliente) o una fattura di acquisto (un fornitore ti emette una fattura), regolate applicando pagamenti e note di credito o di addebito."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
 msgstr "Una fattura di vendita è un documento che specifica i prodotti o i servizi venduti a un cliente e il costo corrispondente."
@@ -671,7 +671,7 @@ msgid "A sales invoice line contains invoice details for a particular item"
 msgstr "Una riga di fattura di vendita contiene i dettagli della fattura per un articolo particolare"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Un ordine di vendita contiene informazioni sull'accordo tra l'azienda e un cliente specifico per parti e servizi."
+msgstr "Un ordine di vendita contiene informazioni sull'accordo tra l'azienda e un cliente specifico per componenti e servizi."
 
 msgid "A sales order is created"
 msgstr "Un ordine di vendita è creato"
@@ -683,7 +683,7 @@ msgid "A sales order line contains order details for a particular item"
 msgstr "Una riga dell'ordine di vendita contiene i dettagli dell'ordine per un articolo particolare"
 
 msgid "A sales order's assignee changes"
-msgstr "Il responsabile dell'ordine di vendita cambia"
+msgstr "L'assegnatario di un ordine di vendita cambia"
 
 msgid "A sales order's completed date changes"
 msgstr "La data di completamento dell'ordine di vendita cambia"
@@ -707,7 +707,7 @@ msgid "A sales order's status changes"
 msgstr "Lo stato dell'ordine di vendita cambia"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Una richiesta di preventivo (RFQ) è un'inchiesta del cliente per i prezzi su un insieme di parti e quantità. Potrebbe risultare in un preventivo."
+msgstr "Una richiesta di offerta (RdO) di vendita è una richiesta del cliente per i prezzi su un insieme di componenti e quantità. Potrebbe risultare in un'offerta."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "Un RFQ di vendita (un cliente ti chiede di quotare) o un RFQ di acquisto (chiedi ai fornitori); entrambi alimentano il thread di opportunità."
@@ -716,16 +716,16 @@ msgid "A scoped secret sent on the carbon-key request header that authenticates 
 msgstr "Un segreto con ambito inviato nell'intestazione della richiesta carbon-key che autentica le chiamate programmatiche a Carbon, portando le proprie autorizzazioni e limite di velocità invece della sessione utente."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "Un calendario separato per la dichiarazione dei redditi quando le regole fiscali richiedono un metodo diverso dall'ammortamento contabile."
+msgstr "Un prospetto separato per la dichiarazione fiscale quando le norme fiscali richiedono un metodo diverso dall'ammortamento civile."
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "Un servizio è un'attività fatturabile che viene acquistata o eseguita — non viene mai spedita, ricevuta o stoccata"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Un insieme di aziende sotto un unico proprietario che condividono una configurazione a livello di gruppo — il piano dei conti, le valute e le dimensioni — in modo che la stessa configurazione contabile si applichi a ogni azienda del gruppo."
+msgstr "Un insieme di aziende di un proprietario che condividono una configurazione a livello di gruppo — il piano dei conti, le valute e le dimensioni — in modo che la stessa configurazione contabile si estenda a tutte le aziende del gruppo."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Un insieme di istruzioni per prelevare i materiali in sospeso di un lavoro dal magazzino e allestirli in linea; un prelievo sposta lo stock al punto di utilizzo piuttosto che consumarlo."
+msgstr "Un insieme di istruzioni per prelevare i materiali in sospeso di un ordine di produzione dal deposito e posizionarli al bordo linea; un prelievo sposta la giacenza al punto di utilizzo piuttosto che consumarla."
 
 msgid "A shipment is created"
 msgstr "Una spedizione è creata"
@@ -737,10 +737,10 @@ msgid "A shipment is posted"
 msgstr "Una spedizione è registrata"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "Una linea di spedizione inviata direttamente dal fornitore al cliente, ignorando il tuo magazzino — impostata per riga, non nell'intestazione."
+msgstr "Una riga spedizione inviata direttamente dal fornitore al cliente, ignorando il vostro deposito — impostata per riga, non sull'intestazione."
 
 msgid "A shipment's assignee changes"
-msgstr "Il responsabile della spedizione cambia"
+msgstr "L'assegnatario di una spedizione cambia"
 
 msgid "A shipment's customer changes"
 msgstr "Il cliente della spedizione cambia"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "Il nome di un fornitore cambia"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "La risposta con prezzo di un fornitore a un RFQ di acquisto — una per fornitore ; Bozza → Attivo quando presentano, o Rifiutato."
+msgstr "La risposta con prezzo di un fornitore a un RdO di acquisto — uno per fornitore; da Bozza → Attivo quando inviano, o Rifiutato."
 
 msgid "A supplier's status changes"
 msgstr "Lo stato di un fornitore cambia"
@@ -794,25 +794,25 @@ msgid "A supplier's type changes"
 msgstr "Il tipo di fornitore cambia"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "Un supplemento imponibile (manipolazione, configurazione, carburante) aggiunto alla riga e incluso nella base imponibile."
+msgstr "Un sovrapprezzo imponibile (movimentazione, allestimento, carburante) aggiunto alla riga; entra nella base imponibile."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Un record temporizzato di lavoro di Setup, Manodopera o Macchina registrato rispetto a un'operazione di lavoro, la cui durata si accumula nel costo effettivo dell'operazione."
+msgstr "Una registrazione temporale di Attrezzaggio, Manodopera, o lavoro di Macchina registrata contro un'operazione dell'ordine, la cui durata si accumula nel costo effettivo dell'operazione."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Uno strumento è un articolo fisico utilizzato per realizzare una parte che può essere utilizzata in più lavori"
+msgstr "Un utensile è un articolo fisico usato per fare un componente che può essere usato su più ordini di produzione"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
 msgstr "Un utente registra la data di scadenza su ogni lotto o numero seriale quando i beni vengono ricevuti. Utilizzare quando i fornitori spediscono lotti con date di scadenza diverse."
 
 msgid "abilities"
-msgstr "capacità"
+msgstr "Competenze"
 
 msgid "Abilities"
 msgstr "Competenze"
 
 msgid "ability"
-msgstr "capacità"
+msgstr "Competenza"
 
 msgid "About"
 msgstr "Informazioni"
@@ -855,7 +855,7 @@ msgid "Account & Details"
 msgstr "Conto e dettagli"
 
 msgid "Account balances with debits and credits"
-msgstr "Saldi dei conti con debiti e crediti"
+msgstr "Saldi dei conti con dare e avere"
 
 msgid "Account for advance payments made before goods or services are received"
 msgstr "Contabilizzate i pagamenti anticipati effettuati prima della ricezione di beni o servizi."
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "Contabilità"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "La contabilità è attualmente in beta. Richiedi l'accesso per abilitare report, voci di diario, periodi contabili, cespiti e altro."
+msgstr "La contabilità è attualmente in beta. Richiedi accesso per abilitare reportistica, registrazioni contabili, periodi contabili, cespiti e altro ancora."
 
 msgid "Accounting is disabled"
 msgstr "La contabilità è disabilitata"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "Periodi Contabili"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Contabilità: GL, AR, AP e chiusura di fine mese"
+msgstr "Contabilità: contabilità generale, crediti verso clienti, debiti verso fornitori e chiusura di fine mese"
 
 msgid "Accounts"
 msgstr "Account"
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "Crediti verso clienti per importi dovuti dai clienti."
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Conti referenziati da impostazioni di default di posting o cronologia giornale che non hanno ancora una mappatura provider."
+msgstr "Conti referenziati da impostazioni predefinite di registrazione o cronologia prima nota che non hanno ancora una mappatura del provider."
 
 msgid "Accumulated Depreciation"
 msgstr "Fondo di ammortamento"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Conto fondo di ammortamento"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Fondo di ammortamento sulla cessione"
+msgstr "Fondo ammortamento su dismissione"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Fondo di ammortamento sulla cessione (predefinito)"
+msgstr "Fondo ammortamento su dismissione (predefinito)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Periodo di Accumulo (Settimane)"
@@ -1011,13 +1011,13 @@ msgid "Active"
 msgstr "Attivo"
 
 msgid "Active Jobs"
-msgstr "Lavori Attivi"
+msgstr "Ordini di produzione in corso"
 
 msgid "Active Statuses"
 msgstr "Stati Attivi"
 
 msgid "Active Supplier Quotes"
-msgstr "Preventivi Fornitori Attivi"
+msgstr "Offerte del fornitore attive"
 
 msgid "Activity"
 msgstr "Attività"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "Aggiungi un commento..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Aggiungi una riga di prezzo personalizzata per sovrascrivere quantità, prezzo, spedizione, lead time e tasse"
+msgstr "Aggiungi una riga di prezzo personalizzata per forzare quantità, prezzo, spedizione, lead time e imposta"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "Aggiungi una sezione materiali che elenca ogni articolo della distinta base con la sua quantità."
@@ -1083,7 +1083,7 @@ msgid "Add Affected Item"
 msgstr "Aggiungi elemento interessato"
 
 msgid "Add any notes about your decision..."
-msgstr "Aggiungi eventuali note sulla tua decisione..."
+msgstr "Aggiungi note sulla tua decisione..."
 
 msgid "Add Approval Requirement"
 msgstr "Aggiungi Requisito di Approvazione"
@@ -1092,10 +1092,10 @@ msgid "Add Authenticator App"
 msgstr "Aggiungi app autenticatore"
 
 msgid "Add Calibration Record"
-msgstr "Aggiungi Record di Calibrazione"
+msgstr "Aggiungi un registro di taratura"
 
 msgid "Add Child Storage Unit"
-msgstr "Aggiungi Unità di Archiviazione Secondaria"
+msgstr "Aggiungi un'unità di stoccaggio secondaria"
 
 msgid "Add clause"
 msgstr "Aggiungi clausola"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "Aggiungi condizione"
 
 msgid "Add Contractor"
-msgstr "Aggiungi Appaltatore"
+msgstr "Aggiungi un collaboratore esterno"
 
 msgid "Add cost center"
 msgstr "Aggiungi centro di costo"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Aggiungi Nota"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Aggiungi note e documentazione per questo ordine di manutenzione"
+msgstr "Aggiungi note e documentazione per questo intervento di manutenzione"
 
 msgid "Add Operation"
 msgstr "Aggiungi Operazione"
@@ -1167,7 +1167,7 @@ msgid "Add Partner"
 msgstr "Aggiungi Partner"
 
 msgid "Add parts"
-msgstr "Aggiungi parti"
+msgstr "Aggiungi componenti"
 
 msgid "Add Passkey"
 msgstr "Aggiungi passkey"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Tutte le {0} celle si bilanciano"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Tutte le {total} fasi sono completate. Ottimo lavoro — il tuo team è operativo."
+msgstr "Tutte le {total} fasi sono completate. Buon lavoro — il vostro team è operativo."
 
 msgid "All accounts"
 msgstr "Tutti i conti"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Tutte le azioni selezionate"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Tutte le funzioni avanzate disponibili"
 
 msgid "All Audit Logs"
 msgstr "Tutti i registri di audit"
@@ -1352,7 +1352,7 @@ msgid "All Documents"
 msgstr "Tutti i documenti"
 
 msgid "All item types"
-msgstr "Tutti i tipi di articoli"
+msgstr "Tutti i tipi di articolo"
 
 msgid "All Items"
 msgstr "Tutti gli articoli"
@@ -1364,7 +1364,7 @@ msgid "All members of selected groups and selected individuals will be able to a
 msgstr "Tutti i membri dei gruppi selezionati e gli individui selezionati potranno approvare le richieste"
 
 msgid "All posting accounts are mapped"
-msgstr "Tutti i conti di posting sono mappati"
+msgstr "Tutti i conti di registrazione sono mappati"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Tutte le righe importate — {inserted} inserite, {updated} aggiornate."
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "Tipo di Importo"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Un bucket contabile che raggruppa le spese per dipartimento o funzione in modo che la GL possa riportare le spese per gruppo, non solo per conto."
+msgstr "Un bucket di contabilità che raggruppa le spese per reparto o funzione in modo che la Contabilità generale possa riportare le spese per gruppo, non solo per conto."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Un record contabile per un elemento capitalizzato che ammortizzi anziché spendere; Bozza → Attivo → Completamente ammortizzato → Ceduto."
+msgstr "Un record di contabilità per un articolo capitalizzato che ammortizzi anziché spendere; Bozza → Attivo → Completamente ammortizzato → Dismesso."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Un avviso che qualcosa ha bisogno dell'attenzione di una persona, distribuito da un evento carbon/notify alla posta in arrivo in-app più email e Slack facoltativi, silenziabili per argomento per utente."
@@ -1434,13 +1434,13 @@ msgid "An approval requirement on a non-conformance whose reviewers (seeded Engi
 msgstr "Un requisito di approvazione su una non conformità i cui revisori (seeded Engineering and Quality) devono firmare prima che il problema possa chiudersi."
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "Il costo di acquisizione di un asset meno l'ammortamento cumulato — quello che vale ancora sui libri e l'importo a cui viene ceduto."
+msgstr "Il costo di acquisizione di un'attività meno il fondo ammortamento — quanto vale ancora nei libri e la cifra a cui è dismesso."
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "Un'automazione che costruisci su una tela: un trigger, poi passaggi che controllano le condizioni, cercano i record e agiscono — notificando qualcuno, creando o aggiornando un record, o chiamando un URL esterno."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "Una modifica ingegneristica: gli elementi interessati i cui metodi vengono rivisti in una bozza e rilasciati insieme, sostituendo le versioni che sostituiscono."
+msgstr "Una modifica tecnica: gli articoli interessati i cui metodi sono revisionati in una bozza e rilasciati insieme, sostituendo le versioni che sostituiscono."
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "Una richiesta https che Carbon invia a un tuo sistema quando un flusso di lavoro raggiunge quel passaggio, portando i header e il corpo che hai configurato."
@@ -1449,7 +1449,7 @@ msgid "An integration or a custom change — the small slice that's actually cus
 msgstr "Un'integrazione o una modifica personalizzata — la piccola parte che è effettivamente personalizzata."
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "Un invito è in sospeso. Diventano attivi una volta che lo accettano."
+msgstr "Un invito è in attesa. Diventano attivi una volta che l'accettano."
 
 msgid "An issue is created"
 msgstr "Un problema è creato"
@@ -1500,25 +1500,25 @@ msgid "An item's assignee changes"
 msgstr "L'assegnatario di un elemento cambia"
 
 msgid "An item's default method type changes"
-msgstr "Il tipo di metodo predefinito di un elemento cambia"
+msgstr "Il tipo di fornitura predefinito di un articolo cambia"
 
 msgid "An item's name changes"
 msgstr "Il nome di un elemento cambia"
 
 msgid "An item's replenishment system changes"
-msgstr "Il sistema di rifornimento di un elemento cambia"
+msgstr "Il sistema di approvvigionamento di un articolo cambia"
 
 msgid "An item's revision status changes"
 msgstr "Lo stato della revisione di un elemento cambia"
 
 msgid "An item's tracking type changes"
-msgstr "Il tipo di tracciamento di un elemento cambia"
+msgstr "Il tipo di tracciabilità di un articolo cambia"
 
 msgid "An item's unit of measure changes"
 msgstr "L'unità di misura di un elemento cambia"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Un'operazione effettuata da un fornitore esterno anziché da un centro di lavoro interno, coperta da un ordine di acquisto di subappalto."
+msgstr "Un'operazione eseguita da un fornitore esterno anziché da un centro di lavoro interno, coperta da un ordine di acquisto per lavori in conto terzi."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "La posizione di un'operazione nella coda del suo centro di lavoro, l'ordine in cui il reparto raccoglie il lavoro, impostato riordinando le schede sulla bacheca Work Centers senza modificare alcuna data."
@@ -1576,19 +1576,19 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "Qualsiasi cosa non esplicitamente elencata nell'ambito di cui sopra"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Debiti verso fornitori"
 
 msgid "AP Aging"
-msgstr "Anzianità dei Debiti"
+msgstr "Invecchiamento Debiti verso fornitori"
 
 msgid "AP Clerk"
-msgstr "Addetto Contabilità Fornitori"
+msgstr "Impiegato Debiti verso fornitori"
 
 msgid "AP Outstanding"
-msgstr "AP in sospeso"
+msgstr "Debiti verso fornitori in sospeso"
 
 msgid "AP Overdue"
-msgstr "AP Scaduto"
+msgstr "Debiti verso fornitori in ritardo"
 
 msgid "API Docs"
 msgstr "Documentazione API"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chiavi API per l'accesso programmatico ai tuoi dati Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhook e integrazioni"
 
 msgid "Applied"
 msgstr "Applicato"
@@ -1634,7 +1634,7 @@ msgid "Applies to all work centers"
 msgstr "Si applica a tutti i centri di lavoro"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
-msgstr "Si applica alle funzionalità senza una propria regola e al lotto quando questo piano determina un'ispezione."
+msgstr "Si applica alle funzioni senza regola propria e al lotto quando questo piano attiva un controllo."
 
 msgid "Apply"
 msgstr "Applica"
@@ -1658,7 +1658,7 @@ msgid "Apply Rules On Top"
 msgstr "Applica regole in alto"
 
 msgid "Apply suggestions"
-msgstr "Applica suggerimenti"
+msgstr "Applica proposte"
 
 msgid "Apply To"
 msgstr "Applica a"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Crediti verso clienti"
 
 msgid "AR / AP representation"
-msgstr "Rappresentazione AR / AP"
+msgstr "Rappresentazione Crediti verso clienti / Debiti verso fornitori"
 
 msgid "AR Aging"
-msgstr "Anzianità dei Crediti"
+msgstr "Invecchiamento Crediti verso clienti"
 
 msgid "AR Clerk"
-msgstr "Addetto Contabilità Clienti"
+msgstr "Impiegato Crediti verso clienti"
 
 msgid "AR Outstanding"
-msgstr "Crediti in sospeso"
+msgstr "Crediti verso clienti in sospeso"
 
 msgid "AR Overdue"
-msgstr "AR Scaduto"
+msgstr "Crediti verso clienti in ritardo"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Crediti verso clienti/Debiti verso fornitori"
 
 msgid "Archive"
 msgstr "Archivio"
@@ -1750,7 +1750,7 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "Sei sicuro di voler attivare il processo: {name}? Apparirà di nuovo nei menu a discesa."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Sei sicuro di voler attivare questo calibro?."
+msgstr "Sei sicuro di voler attivare questo strumento di misura?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
@@ -1758,7 +1758,7 @@ msgstr "Sei sicuro di voler cancellare {0}? Sarà chiuso e in sola lettura fino 
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
-msgstr "Sei sicuro di voler annullare {0}? Questo annullerà anche tutte le quotazioni dei fornitori correlate."
+msgstr "Sei sicuro di voler annullare {0}? Questo annullerà anche tutte le offerte del fornitore correlate."
 
 msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "Sei sicuro di voler annullare {orderLabel}? Questo chiuderà l'ordine."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Sei sicuro di voler completare questo trasferimento di magazzino?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Sei sicuro di voler confermare questo ordine di vendita? La conferma dell'ordine influenzerà le quantità dell'ordine utilizzate per calcolare l'offerta e la domanda."
+msgstr "Sei sicuro di voler confermare questo ordine di vendita? La conferma dell'ordine influenzerà le quantità in ordine utilizzate per calcolare copertura e fabbisogno."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "Sei sicuro di voler convertire la RFQ in un preventivo?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Sei sicuro di voler creare job per questo ordine di vendita? Questo creerà job per tutte le righe che non hanno già job."
+msgstr "Sei sicuro di voler creare ordini di produzione per questo ordine di vendita? Questo creerà ordini di produzione per tutte le righe che non ne hanno già."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Sei sicuro di voler disattivare questi utenti?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Sei sicuro di voler disattivare questo calibro?."
+msgstr "Sei sicuro di voler disattivare questo strumento di misura?."
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Sei sicuro di voler disattivare questo utente?"
@@ -1859,7 +1859,7 @@ msgstr "Sei sicuro di voler eliminare la chiave API: {0}? Questa azione non può
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare la classe di beni: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare la classe di cespiti: {0}? Questa azione non può essere annullata."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
@@ -1870,7 +1870,7 @@ msgid "Are you sure you want to delete the change notice category: {0}? This can
 msgstr "Sei sicuro di voler eliminare la categoria dell'avviso di modifica: {0}? Questa operazione non può essere annullata."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare l'appaltatore: {name}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare il collaboratore esterno: {name}? Questa azione non può essere annullata."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1888,7 +1888,7 @@ msgid "Are you sure you want to delete the customer type: {0}? This cannot be un
 msgstr "Sei sicuro di voler eliminare il tipo di cliente: {0}? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare il dipartimento: {name}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare il reparto: {name}? Questa azione non può essere annullata."
 
 #. placeholder {0}: employeeType.name
 msgid "Are you sure you want to delete the employee type: {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "Sei sicuro di voler eliminare la modalità di guasto: {name}? Questa azi
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare il tipo di calibro: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare il tipo di strumento: {0}? Questa azione non può essere annullata."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1949,7 +1949,7 @@ msgstr "Sei sicuro di voler eliminare il grado di materiale: {0}? Questa azione 
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare la sostanza materiale: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare il materiale base: {0}? Questa azione non può essere annullata."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "Sei sicuro di voler eliminare il tipo di materiale: {0}? Questa azione n
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare il motivo senza preventivo: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare il motivo di nessuna offerta: {0}? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare il partner: {name}? Questa azione non può essere annullata."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare il termine di pagamento: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare le condizioni di pagamento: {0}? Questa azione non può essere annullata."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1991,7 +1991,7 @@ msgstr "Sei sicuro di voler eliminare la riga dell'ordine di vendita per {0} {1}
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare il motivo di scarto: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare la causale di scarto: {0}? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare la sequenza del numero di serie per {itemLabel}? Questa azione non può essere annullata."
@@ -2009,7 +2009,7 @@ msgstr "Sei sicuro di voler eliminare il tipo di archiviazione: {0}? Questa azio
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare l'unità di archiviazione: {0}? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare l'unità di stoccaggio: {0}? Questa azione non può essere annullata."
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
@@ -2034,13 +2034,13 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "Sei sicuro di voler eliminare questo avviso di modifica?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Sei sicuro di voler eliminare questo calibro?"
+msgstr "Sei sicuro di voler eliminare questo strumento di misura?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "Sei sicuro che desideri eliminare questo piano di ispezione?"
+msgstr "Sei sicuro di voler eliminare questo piano di controllo?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare questo piano di ispezione? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare questo piano di controllo? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Sei sicuro di voler eliminare questo flusso di lavoro dei problemi?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare questa scheda kanban? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Sei sicuro di voler eliminare questo ordine di manutenzione? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare questo intervento di manutenzione? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "Sei sicuro di voler eliminare questa passkey? Non potrai più usarla per accedere."
@@ -2073,7 +2073,7 @@ msgid "Are you sure you want to delete this risk? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare questo rischio? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete this suggestion? This action cannot be undone."
-msgstr "Sei sicuro di voler eliminare questo suggerimento? Questa azione non può essere annullata."
+msgstr "Sei sicuro di voler eliminare questa proposta? Questa azione non può essere annullata."
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare questo foglio presenze? Questa azione non può essere annullata."
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "Sei sicuro di voler eliminare permanentemente {0}?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "Sei sicuro di voler eliminare permanentemente il processo fornitore?"
+msgstr "Sei sicuro di voler eliminare permanentemente il processo del fornitore?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "Sei sicuro di voler registrare questa ricevuta?"
@@ -2112,7 +2112,7 @@ msgid "Are you sure you want to reject this quote?"
 msgstr "Sei sicuro di voler rifiutare questa offerta?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "Sei sicuro di voler rilasciare questo lavoro? Diventerà disponibile per il reparto di produzione e guiderà gli acquisti e la produzione."
+msgstr "Sei sicuro di voler rilasciare questo ordine di produzione? Sarà disponibile per l'officina e avvierà gli acquisti e la produzione."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Sei sicuro di voler inviare un invito a questo utente?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Sei sicuro di voler annullare questa fattura di acquisto? Questa azione invertirà tutte le transazioni finanziarie e non può essere annullata."
+msgstr "Sei sicuro di voler stornare questa fattura di acquisto? Questa azione annullerà tutte le transazioni finanziarie e non può essere annullata."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Sei sicuro di voler annullare questa ricevuta? Questa azione invertirà tutte le transazioni di inventario e non può essere annullata."
+msgstr "Sei sicuro di voler stornare questa entrata merci? Questa azione annullerà tutte le transazioni di magazzino e non può essere annullata."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Sei sicuro di voler annullare questa fattura di vendita? Questa azione invertirà tutte le transazioni finanziarie e non può essere annullata."
+msgstr "Sei sicuro di voler stornare questa fattura di vendita? Questa azione annullerà tutte le transazioni finanziarie e non può essere annullata."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Sei sicuro di voler annullare questa spedizione? Questa azione invertirà tutte le transazioni di inventario e non può essere annullata."
+msgstr "Sei sicuro di voler stornare questa spedizione? Questa azione annullerà tutte le transazioni di magazzino e non può essere annullata."
 
 msgid "Are you sure?"
 msgstr "Sei sicuro?"
@@ -2206,25 +2206,25 @@ msgid "Asset Acquisition Cost (default)"
 msgstr "Costo di acquisizione dell'asset (predefinito)"
 
 msgid "asset class"
-msgstr "classe di attivo"
+msgstr "classe di cespiti"
 
 msgid "Asset class"
-msgstr "Classe di attivo"
+msgstr "Classe di cespiti"
 
 msgid "Asset Class"
-msgstr "Classe di attivo"
+msgstr "Classe di cespiti"
 
 msgid "asset classes"
-msgstr "classi di attivi"
+msgstr "classi di cespiti"
 
 msgid "Asset Classes"
 msgstr "Classi di Cespiti"
 
 msgid "Asset Cost on Disposal"
-msgstr "Costo dell'asset alla cessione"
+msgstr "Costo dei cespiti in dismissione"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Costo dell'asset alla cessione (predefinito)"
+msgstr "Costo dei cespiti in dismissione (predefinito)"
 
 msgid "Asset ID"
 msgstr "ID Bene"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Assegnazioni"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Assegna questa unità di stoccaggio a un centro di lavoro (lineside)"
+msgstr "Assegna questa unità di stoccaggio a un centro di lavoro (bordo linea)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Assegna questa unità a un centro di lavoro per il materiale lineside, in modo che gli operatori la vedano nella vista della produzione; ereditato dall'unità madre quando impostato lì."
+msgstr "Assegna questa unità a un centro di lavoro per il materiale a bordo linea, in modo che gli operatori lo vedano nella visualizzazione della produzione; ereditato dall'unità padre se impostato lì."
 
 msgid "At each gate"
 msgstr "Ad ogni gate"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Attributo"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Standard di campionamento per attributi utilizzato per calcolare le dimensioni dei lotti campionati e i numeri di accettazione/rifiuto nelle ispezioni in entrata."
+msgstr "Piano di campionamento per attributi utilizzato per calcolare le dimensioni dei campioni dei lotti e i numeri di accettazione/rifiuto nei controlli in accettazione."
 
 msgid "Attributes"
 msgstr "Attributi"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Registro di Audit"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registrazione di audit"
 
 msgid "Audit Logging"
 msgstr "Registrazione di audit"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Codice QR generato automaticamente"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Formati di numerazione automatica per ordini, lavori, parti e altro"
+msgstr "Formati di numerazione automatica per ordini, ordini di produzione, componenti e altro"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Suggerisci automaticamente acquisti da domanda e punti di riordino"
+msgstr "Suggerimenti automatici di acquisti in base al fabbisogno e ai punti di riordino"
 
 msgid "Automate"
 msgstr "Automatizza"
@@ -2371,13 +2371,13 @@ msgid "Automatic Cost Updates"
 msgstr "Aggiornamenti automatici dei costi"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Aggiornamenti Automatici dei Tempi di Consegna"
+msgstr "Aggiornamenti automatici dei lead time"
 
 msgid "Automatic Updates"
 msgstr "Aggiornamenti Automatici"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Aggiornamenti e backup automatici"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automatico e proporzionato dei materiali non tracciati di un lavoro quando viene segnalata l'uscita — i materiali tracciati vengono emessi manualmente."
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "Torna alla tracciabilità"
 
 msgid "Backflush"
-msgstr "Scarico automatico"
+msgstr "Backflush"
 
 msgid "Backups"
 msgstr "Backup"
@@ -2426,7 +2426,7 @@ msgid "Balance"
 msgstr "Saldo"
 
 msgid "Balance Sheet"
-msgstr "Bilancio"
+msgstr "Stato patrimoniale"
 
 msgid "Balanced"
 msgstr "Equilibrato"
@@ -2435,10 +2435,10 @@ msgid "Balloon"
 msgstr "Palloncino"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "Disegni con palloncini con caratteristiche di ispezione."
+msgstr "Disegni con annotazioni per il controllo."
 
 msgid "Bank - Cash"
-msgstr "Banca - Contanti"
+msgstr "Banca - Cassa"
 
 msgid "Bank - Foreign Currency"
 msgstr "Banca - Valuta estera"
@@ -2447,7 +2447,7 @@ msgid "Bank - Local Currency"
 msgstr "Banca - Valuta locale"
 
 msgid "Bank — Cash (default)"
-msgstr "Banca — Contanti (predefinito)"
+msgstr "Banca — Cassa (predefinito)"
 
 msgid "Bank — Foreign Currency (default)"
 msgstr "Banca — Valuta estera (predefinita)"
@@ -2468,7 +2468,7 @@ msgid "Bank and financial service charge expenses"
 msgstr "Spese per commissioni di servizi bancari e finanziari."
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Le barre mostrano il flusso settimanale di ogni settimana: &lt;0&gt;l'offerta&lt;/0&gt; spinge l'inventario verso l'alto, &lt;1&gt;la domanda&lt;/1&gt; lo tira verso il basso. La &lt;2&gt;linea&lt;/2&gt; è l'inventario disponibile proiettato — quando scende al di sotto &lt;3&gt;dello stock di sicurezza&lt;/3&gt; sei a rischio, e al di sotto di zero è un &lt;4&gt;esaurimento&lt;/4&gt;."
+msgstr "I grafici mostrano il flusso di ogni settimana: <0>copertura</0> spinge il magazzino verso l'alto, <1>fabbisogno</1> lo tira verso il basso. La <2>riga</2> è il tuo magazzino disponibile previsto — quando scende al di sotto della <3>scorta di sicurezza</3> sei a rischio, e al di sotto di zero è una <4>rottura di stock</4>."
 
 msgid "Base Currency"
 msgstr "Valuta di Base"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Prezzo Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funzionalità ERP, MES e QMS di base"
 
 msgid "Basic Information"
 msgstr "Informazioni di base"
@@ -2517,7 +2517,7 @@ msgid "Being phased out — successor: <0>{0}</0>"
 msgstr "In fase di eliminazione — successore: <0>{0}</0>"
 
 msgid "Below safety stock"
-msgstr "Sotto stock di sicurezza"
+msgstr "Sotto la scorta di sicurezza"
 
 msgid "Beta"
 msgstr "Beta"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "Distinta Base"
 
 msgid "Bill of Process"
-msgstr "Distinta Base"
+msgstr "Lista delle operazioni"
 
 msgid "Bill To"
 msgstr "Fattura a"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Blocca con un errore"
 
 msgid "Block, allow override"
-msgstr "Blocca, consenti override"
+msgstr "Blocca, consenti forzatura"
 
 msgid "Blocked"
 msgstr "Bloccato"
@@ -2581,7 +2581,7 @@ msgid "BOM synced successfully"
 msgstr "BOM sincronizzato con successo"
 
 msgid "BOMs"
-msgstr "Distinte base"
+msgstr "BOM"
 
 msgid "Bonus Depreciation %"
 msgstr "Ammortamento bonus %"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Breadcrumb"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Importa i tuoi componenti, distinte base, ciclo di lavorazione e costi — con gli strumenti di importazione di Carbon, CSV o assistenza LLM."
+msgstr "Importa i tuoi componenti, BOM, lista delle operazioni e calcolo dei costi — con gli strumenti di importazione di Carbon, CSV o aiuto LLM."
 
 msgid "Browse library"
 msgstr "Sfoglia libreria"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Visualizza la versione pubblicata in sola lettura. Puoi comunque riorganizzare i passi per ordinare il layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Crea integrazioni e personalizzazioni"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Crea preventivi estraendo dati di parti live, costi e Bill of Process"
+msgstr "Crea offerte prelevando dati attuali di componente, costo e Lista delle operazioni"
 
 msgid "Build role-based training materials"
 msgstr "Crea materiali di formazione basati sui ruoli"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Importazione in blocco"
 
 msgid "Bulk Jobs"
-msgstr "Lavori in Blocco"
+msgstr "Ordini di produzione in blocco"
 
 msgid "Business moment"
 msgstr "Momento aziendale"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "Acquista"
 
 msgid "Buy and Make"
-msgstr "Acquista e Produci"
+msgstr "Acquisto e produzione"
 
 msgid "Buyer"
-msgstr "Acquirente"
+msgstr "Buyer"
 
 msgid "Buyer, Planner"
-msgstr "Acquirente, Pianificatore"
+msgstr "Buyer, Pianificatore"
 
 msgid "by {byUser}"
 msgstr "da {byUser}"
@@ -2710,31 +2710,31 @@ msgid "Calculation Method"
 msgstr "Metodo di Calcolo"
 
 msgid "Calibration"
-msgstr "Calibrazione"
+msgstr "Taratura"
 
 msgid "Calibration Attempts"
-msgstr "Tentativi di calibrazione"
+msgstr "Tentativi di taratura"
 
 msgid "Calibration Expiration Notifications"
-msgstr "Notifiche di Scadenza della Calibrazione"
+msgstr "Notifiche di scadenza della taratura"
 
 msgid "Calibration Interval (Months)"
-msgstr "Intervallo di Calibrazione (Mesi)"
+msgstr "Intervallo di taratura (Mesi)"
 
 msgid "Calibration Record"
-msgstr "Registro di calibrazione"
+msgstr "Registro di taratura"
 
 msgid "Calibration Records"
-msgstr "Registri di Calibrazione"
+msgstr "Registri di taratura"
 
 msgid "Calibration Status"
-msgstr "Stato di Calibrazione"
+msgstr "Stato della taratura"
 
 msgid "Calibration Supplier"
-msgstr "Fornitore di Calibrazione"
+msgstr "Fornitore di taratura"
 
 msgid "Calibrations"
-msgstr "Calibrazioni"
+msgstr "Tarature"
 
 msgid "Call an outside URL"
 msgstr "Chiama un URL esterno"
@@ -2746,7 +2746,7 @@ msgid "Can't delete this period"
 msgstr "Impossibile eliminare questo periodo"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "Non è possibile disabilitare l'unico break attivo. Aggiungi un altro break o attiva/disattiva l'opzione Active dell'override."
+msgstr "Impossibile disabilitare l'unica pausa Attiva. Aggiungi un'altra pausa oppure commuta l'Attivo della forzatura."
 
 msgid "Can't download this file"
 msgstr "Impossibile scaricare questo file"
@@ -2809,7 +2809,7 @@ msgid "Cannot convert RFQ to quote"
 msgstr "Impossibile convertire RFQ in preventivo"
 
 msgid "Cannot move to parts bucket without item ID"
-msgstr "Impossibile spostare nel bucket parti senza ID elemento"
+msgstr "Impossibile spostare al bucket Componenti senza ID articolo"
 
 msgid "Cannot place order - no supplier associated with this item"
 msgstr "Impossibile effettuare l'ordine - nessun fornitore associato a questo articolo"
@@ -2821,13 +2821,13 @@ msgid "Cannot send RFQ"
 msgstr "Impossibile inviare RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Impossibile inviare tramite Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Impossibile caricare — interazione fornitore non ancora creata"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "Impossibile caricare nel bucket delle parti senza ID elemento"
+msgstr "Impossibile caricare al bucket Componenti senza ID articolo"
 
 msgid "Caption"
 msgstr "Didascalia"
@@ -2876,7 +2876,7 @@ msgstr "Valore Carbon"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon utilizzerà l'IA per indovinare un conto provider per ognuno dei tuoi {0} conti non mappati. I suggerimenti sono un punto di partenza — puoi rivederli prima che qualsiasi cosa venga salvata."
+msgstr "Carbon userà l'IA per indovinare un conto fornitore per ognuno dei tuoi {0} conti non mappati. Le proposte sono un punto di partenza — puoi esaminarle prima che qualsiasi cosa sia salvata."
 
 msgid "Carbon-only"
 msgstr "Solo Carbon"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Solo Carbon · il cliente vede questo testo, bloccato."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Il nome di Carbon per una lista di materiali e lista dei processi (instradamento): i componenti più le operazioni che producono una parte."
+msgstr "Nome di Carbon per distinta base e ciclo di lavorazione: i componenti più le operazioni che producono un componente."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "L'esecuzione della pianificazione di Carbon consente di compensare l'offerta rispetto alla domanda e di espandere i metodi, rivelando carenze — ma non crea ordini."
+msgstr "L'esecuzione di pianificazione di Carbon compensa la copertura rispetto al fabbisogno ed esplode i metodi, mostrando i deficit — ma non crea ordini da sola."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Ordine di produzione di Carbon — un lavoro costruisce una quantità di un articolo dal suo metodo e routing copiati."
+msgstr "Ordine di produzione di Carbon — un ordine di produzione costruisce una quantità di un articolo dal suo metodo e ciclo di lavorazione copiato."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "L'app del reparto di Carbon dove gli operatori eseguono operazioni, segnalano quantità, emettono materiale e registrano il tempo rispetto ai lavori rilasciati in tempo reale."
+msgstr "L'app officina di Carbon dove gli operatori eseguono operazioni, segnalano quantità, scaricano materiale e registrano il tempo rispetto a ordini di produzione rilasciati in tempo reale."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Il singolo record di Carbon per qualsiasi cosa con un numero di parte — Parte, Materiale, Strumento, Servizio, Consumabile o Fixture — a cui si riferiscono lavori, metodi, ordini e inventario."
+msgstr "Il singolo record di Carbon per qualsiasi cosa con un numero di componente — Componente, Materiale, Utensile, Servizio, Materiale di consumo o Attrezzatura di fissaggio — che ordini di produzione, metodi, ordini e magazzino puntano."
 
 msgid "Cards"
 msgstr "Schede"
@@ -2912,7 +2912,7 @@ msgid "Carrier Account"
 msgstr "Conto Vettore"
 
 msgid "Cash & Banking"
-msgstr "Contanti e Banca"
+msgstr "Cassa e banche"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Categorie che classificano come viene immagazzinato il magazzino"
@@ -2963,7 +2963,7 @@ msgid "Change Document"
 msgstr "Modifica Documento"
 
 msgid "Change Inspection Plan"
-msgstr "Modifica Piano di Ispezione"
+msgstr "Modifica Piano di controllo"
 
 msgid "Change notice"
 msgstr "Avviso di modifica"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Controlla il registro degli articoli per eventuali articoli con una quantità disponibile negativa alla fine del periodo — di solito una ricevuta mancante o una registrazione fuori ordine che distorce il valore dell'inventario e il costo dei beni venduti. Contrassegnalo come completato una volta rivisto, o salta con una motivazione."
+msgstr "Verifica il registro articoli per eventuali articoli con quantità disponibile negativa al termine del periodo — solitamente un'entrata merci mancante o una registrazione fuori ordine che distorce il valore del magazzino e il costo del venduto. Segna come fatto una volta revisionato, o salta con un motivo."
 
 msgid "Check your email"
 msgstr "Controlla la tua email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Verifica di Stripe per questo cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Scegli un altro file"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Scegli cosa appare sul foglio di viaggio del lavoro stampato."
+msgstr "Scegli cosa appare sul cartellino di produzione stampato."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Scegli la tua lingua preferita per l'interfaccia."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Classe (ereditata)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Classifica un'operazione di routing: le operazioni di Processo, Assemblaggio e Ispezione vengono eseguite nel tuo shop floor nel MES — Assemblaggio ottiene la vista di assemblaggio guidata e Ispezione un controllo qualità — mentre un'operazione di Lavorazione Esterna è subappaltata a un fornitore e crea un ordine di acquisto; il processo riporta lo stesso tipo e lo imposta di default sulle nuove operazioni."
+msgstr "Classifica un'operazione di ciclo di lavorazione: le operazioni Processo, Assemblaggio e Controllo vengono eseguite sulla tua officina nel MES — Assemblaggio ottiene la vista assemblaggio guidato e Controllo un controllo qualità — mentre un'operazione Conto lavoro è subappaltata a un fornitore e crea un ordine di acquisto; il processo porta lo stesso tipo e lo predefinisce sulle nuove operazioni."
 
 msgid "Clean and approve the migrated data"
 msgstr "Pulisci e approva i dati migrati"
@@ -3095,13 +3095,13 @@ msgid "Clear selection"
 msgstr "Cancella selezione"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Cancella questa fattura con i crediti registrati della parte nonché in contanti. I crediti si applicano direttamente — nessuna registrazione necessaria."
+msgstr "Cancella questa fattura con i crediti registrati della parte così come il denaro. I crediti si applicano direttamente — nessuna registrazione necessaria."
 
 msgid "Clear value"
 msgstr "Cancella valore"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Conto di compensazione tra ricevimento merce e fattura fornitore; si compensa quando entrambi sono stati registrati."
+msgstr "Conto di compensazione tra entrata merci e fattura fornitore; si bilancia quando entrambi hanno registrato."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Conto di compensazione per ricevimento merce / abbinamento ricevimento fattura"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "Fare clic per caricare un disegno PDF"
 
 msgid "Clock In"
-msgstr "Accedi"
+msgstr "Timbra inizio"
 
 msgid "Clock Out"
-msgstr "Orario di uscita"
+msgstr "Timbra fine"
 
 msgid "Clocked in since <0/>"
 msgstr "In servizio da <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Cloud, o il tuo ambiente self-hosted."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Conforme a CMMC"
 
 msgid "Code"
 msgstr "Codice"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "Assegna un utente campione per ogni area"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Conferma di una ricevuta, spedizione o fattura: le quantità si muovono, i movimenti del giornale colpiscono il mastro, e lo stato diventa Registrato."
+msgstr "Registrazione di un'entrata merci, spedizione o fattura: le quantità si muovono, i movimenti della prima nota colpiscono il libro mastro, e lo stato diventa Registrato."
 
 msgid "Community support"
-msgstr ""
+msgstr "Supporto della comunità"
 
 msgid "Companies"
 msgstr "Aziende"
@@ -3266,7 +3266,7 @@ msgid "Compare Quotes"
 msgstr "Confronta Preventivi"
 
 msgid "Compare Supplier Quotes"
-msgstr "Confronta Preventivi Fornitori"
+msgstr "Confronta Offerte del fornitore"
 
 msgid "Complete"
 msgstr "Completa"
@@ -3357,25 +3357,25 @@ msgid "Configure Item"
 msgstr "Configura Articolo"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Configura le notifiche per quando i calibri escono dalla calibrazione."
+msgstr "Configura notifiche per quando gli strumenti di misura escono dalla taratura."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Configura le notifiche per quando i lavori sono completati."
+msgstr "Configura notifiche per quando gli ordini di produzione sono completati."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Configura le notifiche per quando gli ordini di manutenzione vengono creati dal reparto produzione. Le notifiche vengono instradate in base al tipo di modalità di guasto."
+msgstr "Configura le notifiche per quando gli interventi di manutenzione vengono creati dall'officina. Le notifiche vengono indirizzate in base al tipo di modalità di guasto."
 
 msgid "Configure notifications for when new suggestions are submitted."
-msgstr "Configura le notifiche per quando vengono inviate nuove suggerimenti."
+msgstr "Configura le notifiche per quando vengono inviate nuove proposte."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Configura siti, centri di lavoro, Bill of Process, BOM, costi, ruoli"
+msgstr "Configura siti, centri di lavoro, lista delle operazioni, BOM, calcolo dei costi, ruoli"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Configura gli account predefiniti utilizzati per vari tipi di transazioni nel tuo sistema"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "Configura i mesi di inizio per i tuoi anni fiscali e fiscali"
+msgstr "Configura i mesi di inizio per gli anni fiscali e tributari"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "Configura quando i costi degli articoli acquistati devono essere aggiornati dalle transazioni dei fornitori."
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Stock in entrata confermato — ordini di acquisto e di produzione (barre sopra zero)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Stock in uscita confermato — ordini di vendita e materiali di lavoro (barre sotto zero)."
+msgstr "Giacenza in uscita confermata - ordini di vendita e materiali dell'ordine (barre sotto zero)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Conferma che ogni registrazione contabile registrata nel periodo abbia debiti e crediti uguali. Se una registrazione è squilibrata, il bilancio di prova non sarà bilanciato, quindi deve essere corretta prima che il periodo possa chiudersi."
+msgstr "Conferma che ogni riga di registrazione registrata nel periodo ha uguali dare e avere. Se una riga non è in equilibrio, la bilancia di verifica non si quadrerà, quindi deve essere corretta prima che il periodo possa essere chiuso."
 
 msgid "Conflict reason"
 msgstr "Motivo del conflitto"
@@ -3493,22 +3493,22 @@ msgid "Console Operator"
 msgstr "Operatore Console"
 
 msgid "consumable"
-msgstr "consumabile"
+msgstr "materiale di consumo"
 
 msgid "Consumable"
-msgstr "Consumabile"
+msgstr "Materiale di consumo"
 
 msgid "Consumable Details"
-msgstr "Dettagli Consumabile"
+msgstr "Dettagli del materiale di consumo"
 
 msgid "Consumable ID"
-msgstr "ID Consumabile"
+msgstr "ID del materiale di consumo"
 
 msgid "consumables"
-msgstr "consumabili"
+msgstr "materiali di consumo"
 
 msgid "Consumables"
-msgstr "Consumibili"
+msgstr "Materiali di consumo"
 
 msgid "Consumed"
 msgstr "Consumato"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contatto (facoltativo)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Contattaci"
 
 msgid "contacts"
 msgstr "contatti"
@@ -3559,10 +3559,10 @@ msgid "Contra-revenue GL account for discounts given on customer invoices."
 msgstr "Conto GL di controrivenuta per sconti accordati su fatture clienti."
 
 msgid "Contractor"
-msgstr "Appaltatore"
+msgstr "Collaboratore esterno"
 
 msgid "Contractors"
-msgstr "Appaltatori"
+msgstr "Collaboratori esterni"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "Controllare le modifiche di progettazione con revisioni / ECO"
@@ -3574,10 +3574,10 @@ msgid "Controller, Accountant"
 msgstr "Controllore, Contabile"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "Controlla come la pianificazione gestisce un articolo discontinuo: Consuma Prima esaurisce le scorte disponibili prima di passare al successore, Preferisci Nuovo reindirizza immediatamente la nuova domanda al successore, Solo Stock mantiene solo una riserva di servizio minima e Nessuno Stock rimuove completamente l'articolo dalla pianificazione."
+msgstr "Controlla come la pianificazione gestisce un articolo ritirato dal commercio: Consumare prima esaurisce le giacenze prima di passare al successore, Preferisci il nuovo reindirizza la nuova domanda al successore immediatamente, Solo giacenza mantiene solo una riserva di servizio minima e Nessuna giacenza elimina completamente l'articolo dalla pianificazione."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Controlla se la distinta base e il foglio di lavoro di una revisione rilasciata (Produzione) possono essere modificati al di fuori di un ordine di modifica."
+msgstr "Controlla se il BOM e la lista delle operazioni di una revisione Rilasciata (Produzione) possono essere modificati al di fuori di un ordine di modifica."
 
 msgid "Convention"
 msgstr "Convenzione"
@@ -3604,10 +3604,10 @@ msgid "Convert Line to Job"
 msgstr "Converti Riga in Commessa"
 
 msgid "Convert Lines to Jobs"
-msgstr "Converti Righe in Lavori"
+msgstr "Converti righe in ordini di produzione"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Converti i suggerimenti MRP in ordini di acquisto e commesse."
+msgstr "Converti le proposte MRP in ordini di acquisto e ordini di produzione."
 
 msgid "Convert to Quote"
 msgstr "Converti in Preventivo"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "Copia"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Copia tutti gli articoli e i prezzi a un altro cliente o tipo."
+msgstr "Copia tutti gli articoli e la determinazione dei prezzi a un altro cliente o tipo."
 
 msgid "Copy API Key"
 msgstr "Copia Chiave API"
@@ -3634,13 +3634,13 @@ msgid "Copy company unique identifier"
 msgstr "Copia identificatore univoco azienda"
 
 msgid "Copy consumable number"
-msgstr "Copia numero consumabile"
+msgstr "Copia il numero del materiale di consumo"
 
 msgid "Copy dispatch ID"
-msgstr "Copia ID dispatch"
+msgstr "Copia l'ID dell'intervento di manutenzione"
 
 msgid "Copy dispatch number"
-msgstr "Copia numero di spedizione"
+msgstr "Copia il numero dell'intervento di manutenzione"
 
 msgid "Copy document name"
 msgstr "Copia nome documento"
@@ -3667,10 +3667,10 @@ msgid "Copy link to change notice"
 msgstr "Copia il collegamento all'avviso di modifica"
 
 msgid "Copy link to consumable"
-msgstr "Copia il collegamento al consumabile"
+msgstr "Copia il collegamento al materiale di consumo"
 
 msgid "Copy link to dispatch"
-msgstr "Copia il collegamento alla richiesta di intervento"
+msgstr "Copia il collegamento all'intervento di manutenzione"
 
 msgid "Copy link to document"
 msgstr "Copia il collegamento al documento"
@@ -3718,10 +3718,10 @@ msgid "Copy PIN"
 msgstr "Copia PIN"
 
 msgid "Copy pricing to a single customer"
-msgstr "Copia i prezzi a un singolo cliente"
+msgstr "Copia la determinazione dei prezzi a un singolo cliente"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Copia i prezzi a tutti i clienti di un tipo"
+msgstr "Copia la determinazione dei prezzi a tutti i clienti di un tipo"
 
 msgid "Copy Procedure"
 msgstr "Copia Procedura"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "Copia identificatore univoco del servizio"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Copia il prezzo di questo articolo in un altro ambito."
+msgstr "Copia la determinazione dei prezzi di questo articolo a un altro ambito."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "Copia questo link per condividere l'offerta con un cliente"
@@ -3817,31 +3817,31 @@ msgid "Cost Centers"
 msgstr "Centri di Costo"
 
 msgid "Cost History"
-msgstr "Storico dei Costi"
+msgstr "Cronologia dei costi"
 
 msgid "Cost of Goods Sold"
-msgstr "Costo dei Beni Venduti"
+msgstr "Costo del venduto"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Costo dei beni venduti (COGS)"
+msgstr "Costo del venduto (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Costo dei Beni Venduti (predefinito)"
+msgstr "Costo del venduto (predefinito)"
 
 msgid "Cost of Sales"
-msgstr "Costo del venduto"
+msgstr "Costo della vendita"
 
 msgid "Costing"
 msgstr "Calcolo dei costi"
 
 msgid "Costing & Posting"
-msgstr "Determinazione costi e registrazione"
+msgstr "Calcolo dei costi e registrazione"
 
 msgid "Costing method"
-msgstr "Metodo di determinazione dei costi"
+msgstr "Metodo di calcolo dei costi"
 
 msgid "Costing Method"
-msgstr "Metodo di Determinazione dei Costi"
+msgstr "Metodo di calcolo dei costi"
 
 msgid "Could not analyze cropped region"
 msgstr "Impossibile analizzare la regione ritagliata"
@@ -3885,7 +3885,7 @@ msgid "Count"
 msgstr "Conteggio"
 
 msgid "Count History"
-msgstr "Storico dei Conteggi"
+msgstr "Cronologia dei conteggi"
 
 msgid "Count ID"
 msgstr "ID Conteggio"
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Crea una nuova scheda kanban per il rifornimento basato su scansione."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Crea un nuovo ordine di manutenzione per tracciare le riparazioni delle apparecchiature e le attività di manutenzione"
+msgstr "Crea un nuovo intervento di manutenzione per tracciare le riparazioni dell'impianto e le attività di manutenzione"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Crea un nuovo ordine di produzione per evadere l'ordine di vendita"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Crea un nuovo cliente Stripe invece"
 
 msgid "Create a new version"
 msgstr "Crea una nuova versione"
@@ -3975,7 +3975,7 @@ msgid "Create Issue"
 msgstr "Crea Problema"
 
 msgid "Create Jobs"
-msgstr "Crea Lavori"
+msgstr "Crea ordini di produzione"
 
 msgid "Create Kanban"
 msgstr "Crea Kanban"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "Account creato"
 
 msgid "Created asset class"
-msgstr "Classe di Bene Creata"
+msgstr "Classe di cespiti creata"
 
 msgid "Created at"
 msgstr "Creato il"
@@ -4044,7 +4044,7 @@ msgid "Created change notice type"
 msgstr "Tipo di avviso di modifica creato"
 
 msgid "Created consumable"
-msgstr "Consumabile creato"
+msgstr "Materiale di consumo creato"
 
 msgid "Created cost center"
 msgstr "Centro di costo creato"
@@ -4063,13 +4063,13 @@ msgid "Created customer: {0}"
 msgstr "Cliente creato: {0}"
 
 msgid "Created department"
-msgstr "Dipartimento creato"
+msgstr "Reparto creato"
 
 msgid "Created failure mode"
 msgstr "Modalità di guasto creata"
 
 msgid "Created gauge type"
-msgstr "Tipo di calibro creato"
+msgstr "Tipo di strumento creato"
 
 msgid "Created item group"
 msgstr "Gruppo articoli creato"
@@ -4096,13 +4096,13 @@ msgid "Created material grade"
 msgstr "Grado di materiale creato"
 
 msgid "Created material substance"
-msgstr "Sostanza materiale creata"
+msgstr "Materiale base creato"
 
 msgid "Created material type"
 msgstr "Tipo di materiale creato"
 
 msgid "Created no quote reason"
-msgstr "Motivo senza preventivo creato"
+msgstr "Causale di nessuna offerta creata"
 
 msgid "Created non conformance type"
 msgstr "Tipo di non conformità creato"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Parte creata"
 
 msgid "Created payment term"
-msgstr "Termine di pagamento creato"
+msgstr "Condizioni di pagamento create"
 
 msgid "Created process"
 msgstr "Processo creato"
@@ -4120,7 +4120,7 @@ msgid "Created required action"
 msgstr "Azione richiesta creata"
 
 msgid "Created scrap reason"
-msgstr "Motivo di scarto creato"
+msgstr "Causale di scarto creata"
 
 msgid "Created service"
 msgstr "Servizio creato"
@@ -4129,7 +4129,7 @@ msgid "Created shipping method"
 msgstr "Metodo di spedizione creato"
 
 msgid "Created stock transfer line"
-msgstr "Linea di trasferimento stock creata"
+msgstr "Riga di trasferimento creata"
 
 msgid "Created storage type"
 msgstr "Tipo di archiviazione creato"
@@ -4151,7 +4151,7 @@ msgid "Created work center"
 msgstr "Centro di lavoro creato"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "Crea i 12 periodi mensili per un anno fiscale. I periodi che già esistono vengono mantenuti."
+msgstr "Crea i 12 periodi mensili per un esercizio fiscale. I periodi già esistenti vengono mantenuti."
 
 msgid "Creating part..."
 msgstr "Creazione parte in corso..."
@@ -4164,16 +4164,16 @@ msgid "Credit ({0})"
 msgstr "Credito ({0})"
 
 msgid "Credit / debit memo"
-msgstr "Nota di credito / debito"
+msgstr "Nota di credito / nota di debito"
 
 msgid "Credit / Debit Memos"
-msgstr "Memo di Credito / Debito"
+msgstr "Note di credito / Note di debito"
 
 msgid "Credit Account"
 msgstr "Conto Credito"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Conto credito quando il tempo di lavoro/macchina viene assorbito in WIP"
+msgstr "Conto da accreditare quando manodopera e tempo macchina vengono assorbiti nel WIP"
 
 msgid "Credit account when overhead is absorbed into WIP"
 msgstr "Conto di credito quando i costi generali vengono assorbiti nel WIP"
@@ -4188,7 +4188,7 @@ msgid "Credits"
 msgstr "Crediti"
 
 msgid "Credits & Debits"
-msgstr "Crediti e Debiti"
+msgstr "Avere e Dare"
 
 msgid "Credits applied"
 msgstr "Crediti applicati"
@@ -4209,7 +4209,7 @@ msgid "Cumulative %"
 msgstr "% Cumulativo"
 
 msgid "Currencies & tax"
-msgstr "Valute e tasse"
+msgstr "Valute e imposte"
 
 msgid "Currency"
 msgstr "Valuta"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "Codice valuta"
 
 msgid "Currency Translation"
-msgstr "Traduzione della Valuta"
+msgstr "Conversione valuta"
 
 msgid "Currency Translation (default)"
-msgstr "Traduzione della Valuta (predefinita)"
+msgstr "Conversione valuta (predefinita)"
 
 msgid "current"
 msgstr "attuale"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "Parte Cliente"
 
 msgid "Customer Part ID"
-msgstr "ID Parte Cliente"
+msgstr "Codice articolo cliente"
 
 msgid "Customer Part Number"
 msgstr "Numero Parte Cliente"
@@ -4335,7 +4335,7 @@ msgid "Customer Part Revision"
 msgstr "Revisione Parte Cliente"
 
 msgid "Customer Parts"
-msgstr "Parti Cliente"
+msgstr "Componenti cliente"
 
 msgid "Customer Payment Discounts"
 msgstr "Sconti di Pagamento del Cliente"
@@ -4356,7 +4356,7 @@ msgid "Customer Portals"
 msgstr "Portali Clienti"
 
 msgid "Customer pricing"
-msgstr "Prezzi cliente"
+msgstr "Determinazione dei prezzi cliente"
 
 msgid "Customer reference"
 msgstr "Riferimento cliente"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Tipi di Cliente"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Cancellazione Cliente (Crediti Inesigibili)"
+msgstr "Stralcio cliente (Crediti inesigibili)"
 
 msgid "customers"
 msgstr "clienti"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clienti"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizzazioni, formazione e integrazioni"
 
 msgid "Customize"
 msgstr "Personalizza"
@@ -4425,7 +4425,7 @@ msgid "Cutover checklist"
 msgstr "Elenco di controllo della migrazione"
 
 msgid "Cutover step"
-msgstr "Fase di cutover"
+msgstr "Passo di cutover"
 
 msgid "Cutover support"
 msgstr "Supporto di cutover"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Giorni di Scadenza"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Giorni dall'ordine di una parte alla sua disponibilità; la pianificazione compensa la domanda all'indietro di questo importo."
+msgstr "Giorni dall'ordine di una componente alla disponibilità; il fabbisogno viene spostato all'indietro di questo numero di giorni."
 
 msgid "Days Off"
 msgstr "Giorni liberi"
@@ -4571,20 +4571,20 @@ msgid "Deadline Type"
 msgstr "Tipo di Scadenza"
 
 msgid "Debit"
-msgstr "Debito"
+msgstr "Dare"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
-msgstr "Debito ({0})"
+msgstr "Dare ({0})"
 
 msgid "Debit Account"
-msgstr "Conto Debito"
+msgstr "Conto addebito"
 
 msgid "Debit Memo"
-msgstr "Nota di Debito"
+msgstr "Nota di debito"
 
 msgid "Debits"
-msgstr "Debiti"
+msgstr "Dare"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Decidi cosa vede un operatore se tenta di emettere un lotto o un numero seriale già scaduto."
@@ -4593,19 +4593,19 @@ msgid "Decide what happens when an operator presses Finish on the shop floor wit
 msgstr "Decidi cosa accade quando un operatore preme Fine in officina con materiale ancora non prelevato."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "Decide quando il materiale prelevato per un centro di lavoro ma non consumato torna al magazzino."
+msgstr "Decidere quando il materiale prelevato a un centro di lavoro ma non consumato ritorna al deposito."
 
 msgid "Decimal Places"
 msgstr "Posizioni Decimali"
 
 msgid "Declining balance"
-msgstr "Ammortamento decrescente"
+msgstr "Quote decrescenti"
 
 msgid "Default"
 msgstr "Predefinito"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Conto predefinito per la contabilizzazione dei ricavi di vendita dalle fatture"
+msgstr "Conto predefinito per la registrazione dei ricavi dalle fatture"
 
 msgid "Default Accounts"
 msgstr "Conti Predefiniti"
@@ -4620,13 +4620,13 @@ msgid "Default accounts for long-term assets and depreciation"
 msgstr "Conti predefiniti per i beni a lungo termine e l'ammortamento"
 
 msgid "Default accounts for sales and income"
-msgstr "Conti predefiniti per le vendite e i ricavi"
+msgstr "Conti predefiniti per vendite e proventi"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "Conti predefiniti per le transazioni relative alle imposte"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Conti predefiniti per il costo dei beni venduti e gli acquisti indiretti"
+msgstr "Conti predefiniti per il costo del venduto e gli acquisti indiretti"
 
 msgid "Default Approver"
 msgstr "Approvatore Predefinito"
@@ -4653,13 +4653,13 @@ msgid "Default GL account debited when a fixed-asset disposal results in a loss.
 msgstr "Conto di contabilità generale predefinito addebitato quando la dismissione di un cespite genera una perdita."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
-msgstr "Conto GL predefinito utilizzato per le transazioni in contanti quando non è selezionato uno specifico conto bancario."
+msgstr "Conto contabile predefinito utilizzato per le transazioni di cassa quando non è selezionato nessun conto bancario."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Conto GL di spesa predefinito per la manutenzione di attrezzature e strutture."
+msgstr "Conto spesa predefinito per la manutenzione di impianti e strutture."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Conto GL di spesa predefinito per le esecuzioni di ammortamento periodico."
+msgstr "Conto spesa predefinito per i cicli di ammortamento periodici."
 
 msgid "Default Method"
 msgstr "Metodo Predefinito"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Metodo predefinito che viene precompilato su nuovi beni in questa classe (ancora modificabile per singolo bene)."
 
 msgid "Default method type"
-msgstr "Tipo di metodo predefinito"
+msgstr "Tipo di fornitura predefinito"
 
 msgid "Default Method Type"
-msgstr "Tipo di Metodo Predefinito"
+msgstr "Tipo di fornitura predefinito"
 
 msgid "Default Permissions"
 msgstr "Autorizzazioni Predefinite"
@@ -4692,10 +4692,10 @@ msgid "Default Source"
 msgstr "Fonte Predefinita"
 
 msgid "Default Storage Unit"
-msgstr "Unità di Archiviazione Predefinita"
+msgstr "Unità di stoccaggio predefinita"
 
 msgid "Default tax depreciation method for new assets in this class."
-msgstr "Metodo di ammortamento fiscale predefinito per i nuovi beni di questa classe."
+msgstr "Metodo di ammortamento fiscale predefinito per i nuovi cespiti di questa classe."
 
 msgid "Default tax-book life for new assets in this class."
 msgstr "Vita fiscale predefinita per i nuovi beni di questa classe."
@@ -4716,16 +4716,16 @@ msgid "Deferred Tax Expense (default)"
 msgstr "Imposte Differite - Spese (predefinito)"
 
 msgid "Deferred Tax Liability"
-msgstr "Passività Fiscale Differita"
+msgstr "Imposte differite passive"
 
 msgid "Deferred Tax Liability (default)"
-msgstr "Passività Fiscale Differita (predefinita)"
+msgstr "Imposte differite passive (predefinito)"
 
 msgid "Define a manufacturing operation first."
 msgstr "Definisci prima un'operazione di produzione."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Definire distinte base multi-livello e Bill of Process (metodi di produzione)"
+msgstr "Definire BOM multilivello e Lista delle operazioni (metodi di produzione)"
 
 msgid "Delete"
 msgstr "Elimina"
@@ -4756,7 +4756,7 @@ msgid "Delete Asset"
 msgstr "Elimina Bene"
 
 msgid "Delete Asset Class"
-msgstr "Elimina Classe di Beni"
+msgstr "Elimina Classe di cespiti"
 
 msgid "Delete Assignment"
 msgstr "Elimina Incarico"
@@ -4774,13 +4774,13 @@ msgid "Delete Change Notice"
 msgstr "Elimina avviso di modifica"
 
 msgid "Delete Consumable"
-msgstr "Elimina Consumabile"
+msgstr "Elimina Materiale di consumo"
 
 msgid "Delete Contact"
 msgstr "Elimina Contatto"
 
 msgid "Delete Contractor"
-msgstr "Elimina Appaltatore"
+msgstr "Elimina Collaboratore esterno"
 
 msgid "Delete Count"
 msgstr "Elimina Conteggio"
@@ -4798,13 +4798,13 @@ msgid "Delete Customer Type"
 msgstr "Elimina Tipo di Cliente"
 
 msgid "Delete Department"
-msgstr "Elimina Dipartimento"
+msgstr "Elimina Reparto"
 
 msgid "Delete Dimension"
 msgstr "Elimina Dimensione"
 
 msgid "Delete Dispatch"
-msgstr "Elimina Dispatch"
+msgstr "Elimina Intervento di manutenzione"
 
 msgid "Delete Document"
 msgstr "Elimina Documento"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Elimina Festività"
 
 msgid "Delete Inspection Plan"
-msgstr "Elimina Piano di Ispezione"
+msgstr "Elimina Piano di controllo"
 
 msgid "Delete Issue"
 msgstr "Elimina Problema"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Elimina gruppo articoli"
 
 msgid "Delete Journal Entry"
-msgstr "Elimina Registrazione"
+msgstr "Elimina Riga di registrazione"
 
 msgid "Delete line"
 msgstr "Elimina riga"
@@ -4882,7 +4882,7 @@ msgid "Delete Payment"
 msgstr "Elimina Pagamento"
 
 msgid "Delete Payment Term"
-msgstr "Elimina Termine di Pagamento"
+msgstr "Elimina Condizioni di pagamento"
 
 msgid "Delete Period"
 msgstr "Elimina Periodo"
@@ -4894,7 +4894,7 @@ msgid "Delete Portal"
 msgstr "Elimina Portale"
 
 msgid "Delete Price Break"
-msgstr "Elimina Fascia di Prezzo"
+msgstr "Elimina Scaglione di prezzo"
 
 msgid "Delete Pricing Rule"
 msgstr "Elimina Regola di Prezzo"
@@ -4981,13 +4981,13 @@ msgid "Delete Storage Type"
 msgstr "Elimina Tipo di Archiviazione"
 
 msgid "Delete Storage Unit"
-msgstr "Elimina Unità di Archiviazione"
+msgstr "Elimina Unità di stoccaggio"
 
 msgid "Delete Substance"
 msgstr "Elimina Sostanza"
 
 msgid "Delete Suggestion"
-msgstr "Elimina Suggerimento"
+msgstr "Elimina Proposta"
 
 msgid "Delete supplier"
 msgstr "Elimina fornitore"
@@ -4996,14 +4996,14 @@ msgid "Delete Supplier"
 msgstr "Elimina Fornitore"
 
 msgid "Delete Supplier Quote"
-msgstr "Elimina Offerta Fornitore"
+msgstr "Elimina Offerta del fornitore"
 
 msgid "Delete Supplier Type"
 msgstr "Elimina Tipo Fornitore"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Eliminare il break di prezzo per la quantità {0}? Questa azione non può essere annullata."
+msgstr "Eliminare lo scaglione di prezzo per la quantità {0}? Questa azione non può essere annullata."
 
 msgid "Delete Timecard"
 msgstr "Elimina Foglio Presenze"
@@ -5033,7 +5033,7 @@ msgid "Delete View"
 msgstr "Elimina Vista"
 
 msgid "Delete Warehouse Transfer"
-msgstr "Elimina Trasferimento Magazzino"
+msgstr "Elimina Trasferimento deposito"
 
 msgid "Delete Webhook"
 msgstr "Elimina Webhook"
@@ -5048,25 +5048,25 @@ msgid "Delivery Location"
 msgstr "Luogo di consegna"
 
 msgid "Demand"
-msgstr "Domanda"
+msgstr "Fabbisogno"
 
 msgid "Demand forecast"
-msgstr "Previsione della Domanda"
+msgstr "Previsione di fabbisogno"
 
 msgid "Demand Forecast"
-msgstr "Previsione della Domanda"
+msgstr "Previsione di fabbisogno"
 
 msgid "Demand Forecast — Driven by"
-msgstr "Previsione della domanda — Guidata da"
+msgstr "Previsione di fabbisogno — Determinato da"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Previsione della domanda = domanda esplosa da BOM da ordini di vendita aperti, lavori attivi e proiezioni di produzione."
+msgstr "Previsione di fabbisogno = fabbisogno esploso da BOM da ordini di vendita aperti, ordini di produzione in corso e proiezioni di produzione."
 
 msgid "Demand projection"
-msgstr "Proiezione della domanda"
+msgstr "Proiezione di fabbisogno"
 
 msgid "Demand Projections"
-msgstr "Proiezioni della Domanda"
+msgstr "Proiezioni di fabbisogno"
 
 msgid "Demand-Based"
 msgstr "Basato sulla domanda"
@@ -5084,16 +5084,16 @@ msgid "Demo data was applied to this company. Keep it, or revert to put back exa
 msgstr "I dati demo sono stati applicati a questa azienda. Mantienili o ripristina per ripristinare esattamente quello che c'era prima."
 
 msgid "department"
-msgstr "dipartimento"
+msgstr "reparto"
 
 msgid "Department"
-msgstr "Dipartimento"
+msgstr "Reparto"
 
 msgid "Department Name"
-msgstr "Nome Dipartimento"
+msgstr "Nome reparto"
 
 msgid "departments"
-msgstr "dipartimenti"
+msgstr "reparti"
 
 msgid "Departments"
 msgstr "Reparti"
@@ -5117,16 +5117,16 @@ msgid "Depreciation Method (default)"
 msgstr "Metodo di Ammortamento (predefinito)"
 
 msgid "Depreciation reversal when a fixed asset is disposed"
-msgstr "Storno dell'ammortamento quando un'immobilizzazione viene dismessa"
+msgstr "Storno di ammortamento quando un cespite viene dismesso"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "I cicli di ammortamento che terminano in questo periodo e che sono ancora in Bozza devono essere registrati affinché il periodo rifletta la corretta spesa di ammortamento e l'ammortamento accumulato. Salta con un motivo se l'ammortamento non si applica in questo periodo."
+msgstr "Le esecuzioni di ammortamento che terminano in questo periodo e sono ancora in Bozza devono essere registrate affinché il periodo rifletta la corretta spesa di ammortamento e il fondo ammortamento. Salta con una motivazione se l'ammortamento non si applica in questo periodo."
 
 msgid "Depreciation Start Date"
 msgstr "Data di Inizio Ammortamento"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Deriva la vita utile di questo articolo dalla vita utile più breve dei suoi componenti, ignorando il campo Giorni sopra."
+msgstr "Derivare la durata di conservazione di questo articolo dalla durata di conservazione più breve dei suoi componenti, ignorando il campo Giorni sopra."
 
 msgid "Description"
 msgstr "Descrizione"
@@ -5180,7 +5180,7 @@ msgid "Dimension slots"
 msgstr "Slot dimensionali"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Valori di dimensione nei journal contabilizzati che non hanno ancora un mapping provider."
+msgstr "Valori di dimensione su prime note registrate che non dispongono ancora di una mappatura del provider."
 
 msgid "dimensions"
 msgstr "dimensioni"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Ignora"
 
 msgid "Dispatch"
-msgstr "Spedizione"
+msgstr "Intervento di manutenzione"
 
 msgid "Dispatch ID"
-msgstr "ID Dispatch"
+msgstr "ID intervento di manutenzione"
 
 msgid "Dispatch priority"
-msgstr "Priorità di spedizione"
+msgstr "Priorità intervento di manutenzione"
 
 msgid "Dispatches"
-msgstr "Spedizioni"
+msgstr "Interventi di manutenzione"
 
 msgid "Display Settings"
 msgstr "Impostazioni di visualizzazione"
 
 msgid "Disposal"
-msgstr "Cessione"
+msgstr "Dismissione"
 
 msgid "Disposal Date"
-msgstr "Data di Cessione"
+msgstr "Data dismissione"
 
 msgid "Dispose"
 msgstr "Cedere"
@@ -5283,7 +5283,7 @@ msgid "Dispositions"
 msgstr "Disposizioni"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
-msgstr "Vuoi sovrascrivere i permessi attuali dell'utente con i permessi predefiniti per questo tipo di dipendente?"
+msgstr "Desideri sovrascrivere le autorizzazioni attuali dell'utente con le autorizzazioni predefinite per questo tipo di dipendente?"
 
 msgid "Doc-Backed"
 msgstr "Supportato da Documento"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Documenti"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documenti invia fatture, bollette e pagamenti come documenti nativi del provider; i loro giornali vengono registrati come coperti dal documento. Estrae anche i pagamenti registrati nel provider nel Carbon, chiudendo la fattura o la bolletta corrispondente e registrando un giornale GL di Carbon. Off li registra come deliberatamente esclusi."
+msgstr "I Documenti spingono Fatture, Fatture di acquisto e Pagamenti come documenti nativi del provider; le relative Prime note sono registrate come coperte dal documento. Inoltre estraggono i Pagamenti registrati nel provider in Carbon, chiudendo la corrispondente Fattura o Fattura di acquisto e registrando una Prima nota di Contabilità generale di Carbon. Off li registra come deliberatamente esclusi."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "I documenti che apri verranno visualizzati qui per un accesso rapido."
@@ -5328,7 +5328,7 @@ msgid "Done"
 msgstr "Fatto"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Completato quando le operazioni quotidiane funzionano senza il nostro supporto in loco"
+msgstr "Fatto quando le operazioni quotidiane funzionano senza di noi in sala."
 
 msgid "Download"
 msgstr "Scarica"
@@ -5344,7 +5344,7 @@ msgid "Download Labels"
 msgstr "Scarica Etichette"
 
 msgid "Download Link"
-msgstr "Collegamento di download"
+msgstr "Link di download"
 
 msgid "Download PDF"
 msgstr "Scarica PDF"
@@ -5359,7 +5359,7 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "La bozza è modificabile; Attivo è in uso e richiede una nuova versione per essere modificato; Archiviato è ritirato."
 
 msgid "Draft Journal Entries"
-msgstr "Bozze di Registrazioni Contabili"
+msgstr "Righe di registrazione in bozza"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "Trascina e rilascia i file, oppure fai clic per sfogliare"
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "Rilascia il tuo file qui, oppure fai clic per sfogliare."
 
 msgid "Drop-ship"
-msgstr "Spedizione Diretta"
+msgstr "Consegna diretta"
 
 msgid "Due"
 msgstr "Scadenza"
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Data di scadenza dell'ultimo lavoro"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Data di scadenza del primo lavoro nel lotto in blocco; i lavori successivi sono spaziati uniformemente tra questa data e la data di scadenza dell'ultimo lavoro."
+msgstr "Data di scadenza del primo Ordine di produzione nel lotto di creazione in massa; gli Ordini di produzione successivi sono spaziati uniformemente tra questa data e la Data di scadenza dell'ultimo Ordine di produzione."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Data di scadenza del lavoro finale nel lotto; combinata con la data di scadenza del primo lavoro per distanziare uniformemente i lavori."
+msgstr "Data di scadenza dell'ultimo Ordine di produzione nel lotto di creazione in massa; combinata con la Data di scadenza del primo Ordine di produzione per spaziare uniformemente gli Ordini di produzione."
 
 msgid "Due Days"
 msgstr "Giorni di Scadenza"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "ad es. 48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "ad es. Acme Manufacturing"
+msgstr "es. Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "ad es. Detroit"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "ad es. Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Il materiale inutilizzato di ogni operazione torna non appena l'operazione è completata."
+msgstr "Ogni Materiale non utilizzato dell'Operazione ritorna non appena l'Operazione è completata."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "Ogni unità fisica ottiene la propria entità tracciata e numero univoco — un'entità, un'unità."
@@ -5558,7 +5558,7 @@ msgid "Edit Asset"
 msgstr "Modifica Bene"
 
 msgid "Edit Asset Class"
-msgstr "Modifica Classe di Bene"
+msgstr "Modifica Classe di cespiti"
 
 msgid "Edit Assignment"
 msgstr "Modifica Assegnazione"
@@ -5588,7 +5588,7 @@ msgid "Edit Contact"
 msgstr "Modifica Contatto"
 
 msgid "Edit Contractor"
-msgstr "Modifica Appaltatore"
+msgstr "Modifica Collaboratore esterno"
 
 msgid "Edit Cost Center"
 msgstr "Modifica Centro di Costo"
@@ -5612,13 +5612,13 @@ msgid "Edit Customer Type"
 msgstr "Modifica Tipo di Cliente"
 
 msgid "Edit Department"
-msgstr "Modifica Dipartimento"
+msgstr "Modifica Reparto"
 
 msgid "Edit Dimension"
 msgstr "Modifica Dimensione"
 
 msgid "Edit Dispatch"
-msgstr "Modifica Dispatch"
+msgstr "Modifica Intervento di manutenzione"
 
 msgid "Edit Employee"
 msgstr "Modifica Dipendente"
@@ -5636,13 +5636,13 @@ msgid "Edit Failure Mode"
 msgstr "Modifica Modalità di Guasto"
 
 msgid "Edit Fixed Asset"
-msgstr "Modifica Immobilizzazione"
+msgstr "Modifica Cespite"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Modifica Record di Taratura Calibro"
+msgstr "Modifica Registro di taratura"
 
 msgid "Edit Gauge Type"
-msgstr "Modifica Tipo di Calibro"
+msgstr "Modifica Tipo di strumento"
 
 msgid "Edit Group"
 msgstr "Modifica Gruppo"
@@ -5651,13 +5651,13 @@ msgid "Edit Holiday"
 msgstr "Modifica Festività"
 
 msgid "Edit Inspection Plan"
-msgstr "Modifica Piano di Ispezione"
+msgstr "Modifica Piano di controllo"
 
 msgid "Edit Item Group"
 msgstr "Modifica Gruppo Articoli"
 
 msgid "Edit Journal Entry"
-msgstr "Modifica Registrazione"
+msgstr "Modifica Riga di registrazione"
 
 msgid "Edit Kanban"
 msgstr "Modifica Kanban"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Modifica Ubicazione"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Modifica Manutenzione Dispatch"
+msgstr "Modifica Intervento di manutenzione"
 
 msgid "Edit Material"
 msgstr "Modifica Materiale"
@@ -5687,7 +5687,7 @@ msgid "Edit Material Shape"
 msgstr "Modifica Forma Materiale"
 
 msgid "Edit Material Substance"
-msgstr "Modifica Sostanza Materiale"
+msgstr "Modifica Materiale base"
 
 msgid "Edit Material Type"
 msgstr "Modifica Tipo di Materiale"
@@ -5714,7 +5714,7 @@ msgid "Edit Payment Term"
 msgstr "Modifica Condizioni di Pagamento"
 
 msgid "Edit permissions"
-msgstr "Permessi di modifica"
+msgstr "Modifica Autorizzazioni"
 
 msgid "Edit Permissions"
 msgstr "Modifica Autorizzazioni"
@@ -5726,10 +5726,10 @@ msgid "Edit Portal"
 msgstr "Modifica Portale"
 
 msgid "Edit Price Override"
-msgstr "Modifica Sconto Prezzo"
+msgstr "Modifica Forzatura di prezzo"
 
 msgid "Edit Pricing"
-msgstr "Modifica Prezzi"
+msgstr "Modifica Determinazione dei prezzi"
 
 msgid "Edit Pricing Rule"
 msgstr "Modifica Regola di Prezzo"
@@ -5807,7 +5807,7 @@ msgid "Edit Storage Type"
 msgstr "Modifica Tipo di Archiviazione"
 
 msgid "Edit Storage Unit"
-msgstr "Modifica Unità di Archiviazione"
+msgstr "Modifica Unità di stoccaggio"
 
 msgid "Edit Substance"
 msgstr "Modifica Sostanza"
@@ -5819,7 +5819,7 @@ msgid "Edit Supplier Part"
 msgstr "Modifica Fornitore Parte"
 
 msgid "Edit supplier process"
-msgstr "Modifica processo fornitore"
+msgstr "Modifica processo del fornitore"
 
 msgid "Edit Supplier Type"
 msgstr "Modifica Tipo Fornitore"
@@ -5927,13 +5927,13 @@ msgid "Enable digital quotes for your company. This will allow you to send digit
 msgstr "Abilita le quotazioni digitali per la tua azienda. Questo ti permetterà di inviare quotazioni digitali ai tuoi clienti e consentire loro di accettarle online."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Abilita la contabilità per competenza completa con registrazioni contabili, report finanziari e registrazione della contabilità generale."
+msgstr "Abilita la contabilità per competenza completa con righe di registrazione, rapporti finanziari e registrazioni della Contabilità generale."
 
 msgid "Enable in Settings"
 msgstr "Abilita nelle Impostazioni"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "Abilita le notifiche quando un RFQ è contrassegnato come pronto per la quotazione."
+msgstr "Abilita Notifiche quando una RdO è contrassegnata come Pronto per offerta."
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
 msgstr "Abilita la modalità workstation condivisa per i terminali MES. Gli operatori si identificano tramite PIN prima di eseguire il lavoro."
@@ -5951,7 +5951,7 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "Abilita per registrare automaticamente le transazioni nella contabilità generale."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "Abilita per configurare metodi di ammortamento specifici per le imposte sulle classi di asset (ad es., MACRS, accelerato)."
+msgstr "Abilita la configurazione di Metodi di ammortamento specifici per le tasse sulle Classi di cespiti (es. MACRS, accelerato)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
 msgstr "Abilita per generare ID e descrizioni per le materie prime."
@@ -6003,7 +6003,7 @@ msgid "Engineering"
 msgstr "Ingegneria"
 
 msgid "Engineering changes and CAD"
-msgstr "Modifiche ingegneristiche e CAD"
+msgstr "Modifiche tecniche e CAD"
 
 msgid "Engineering Changes and CAD"
 msgstr "Modifiche Tecniche e CAD"
@@ -6022,7 +6022,7 @@ msgid "Enter a quantity between 1 and {0}."
 msgstr "Inserisci una quantità tra 1 e {0}."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Inserisci e approva fatture fornitori rispetto a un ordine di acquisto (verifica a tre vie)"
+msgstr "Inserire e Approvare Fatture di acquisto in base a un Ordine di acquisto (Riscontro a tre vie)"
 
 msgid "Enter number…"
 msgstr "Inserisci numero…"
@@ -6067,7 +6067,7 @@ msgid "Entity certification: Expired"
 msgstr "Certificazione dell'entità: Scaduta"
 
 msgid "Entity certification: Pending"
-msgstr "Certificazione dell'entità: In sospeso"
+msgstr "Certificazione dell'Entità: In attesa"
 
 msgid "Entity Type"
 msgstr "Tipo di Entità"
@@ -6088,10 +6088,10 @@ msgid "Equity"
 msgstr "Patrimonio Netto"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "Conto di patrimonio per profitti o perdite accumulati"
+msgstr "Conto di Patrimonio netto per utili o perdite accumulati"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Conto di patrimonio per rettifiche di conversione valutaria (CTA)"
+msgstr "Conto di Patrimonio netto per rettifiche di Conversione valuta (CTA)"
 
 msgid "Error"
 msgstr "Errore"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Errore nel recupero dei dati del fornitore"
 
 msgid "Error loading assigned dispatches"
-msgstr "Errore nel caricamento dei dispatches assegnati"
+msgstr "Errore nel caricamento degli Interventi di manutenzione Assegnati"
 
 msgid "Error loading assigned documents"
 msgstr "Errore nel caricamento dei documenti assegnati"
@@ -6139,7 +6139,7 @@ msgid "Error removing model from job"
 msgstr "Errore nella rimozione del modello dal lavoro"
 
 msgid "Error removing model from quote line"
-msgstr "Errore nella rimozione del modello dalla riga di preventivo"
+msgstr "Errore nella rimozione del modello dalla Riga offerta"
 
 msgid "Error removing model from RFQ line"
 msgstr "Errore nella rimozione del modello dalla riga RFQ"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Ogni corrispondenza"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Ogni attività richiesta deve essere Completata o Saltata prima che il periodo possa essere chiuso."
+msgstr "Ogni Attività richiesta deve essere Fatta o Saltata prima che il periodo possa essere Chiuso."
 
 msgid "Every row was imported successfully."
 msgstr "Ogni riga è stata importata correttamente."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapping esistenti. Scegli un'opzione provider diversa per rimappare."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente Stripe esistente"
 
 msgid "Expand"
 msgstr "Espandi"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "Espandi sottostruttura"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Domanda futura prevista per una parte da produrre inserita settimana per settimana prima che esista alcun ordine di vendita; la pianificazione la compensa rispetto all'offerta e esplode il metodo per ordinare i componenti in anticipo."
+msgstr "Fabbisogno futuro previsto per un Articolo di Produzione inserito settimana per settimana prima di qualsiasi Ordine di vendita; la Pianificazione lo bilancia rispetto alla Copertura ed esplode il Metodo per ordinare i Componenti in anticipo."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "Domanda futura prevista per un articolo, suddivisa per periodo, compilata dall'esecuzione della pianificazione insieme alla domanda effettiva."
+msgstr "Fabbisogno futuro previsto per un Articolo, raggruppato per periodo, popolato dall'esecuzione della Pianificazione insieme al Fabbisogno effettivo."
 
 msgid "Expected Receipt"
 msgstr "Ricevimento Previsto"
@@ -6293,7 +6293,7 @@ msgid "Expected Receipt Date"
 msgstr "Data di Ricezione Prevista"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Conto spese per i saldi dei clienti cancellati come non riscuotibili al momento del regolamento dei crediti"
+msgstr "Conto di Spesa per i saldi dei Clienti cancellati come inesigibili alla regolazione dei Crediti verso clienti"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "Conto spese per rettifiche di imposte differite su ammortamenti"
@@ -6308,13 +6308,13 @@ msgid "Expense account for non-inventory purchases (services, supplies)"
 msgstr "Conto spese per acquisti non di magazzino (servizi, forniture)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Conto spese GL addebitato quando l'inventario viene spedito/emesso rispetto a una vendita."
+msgstr "Conto spese per il costo degli articoli venduti"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Lato spese dei movimenti di imposte differite (abbinato a passivo d'imposta differita)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Impossibile creare la classe di cespiti: {0}"
+msgstr "Lato spesa dei movimenti di imposte differite (abbinato a passività per imposte differite)."
 
 msgid "Expenses"
 msgstr "Spese"
@@ -6404,7 +6404,7 @@ msgid "External notes"
 msgstr "Note esterne"
 
 msgid "External Notes"
-msgstr "Note Esterne"
+msgstr "Note esterne"
 
 msgid "External Ref."
 msgstr "Rif. Esterno"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Informazioni aggiuntive inviate con la richiesta, come una chiave di autorizzazione; i valori dell'intestazione sono nascosti nella cronologia di esecuzione, anche se i nomi rimangono leggibili."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Tag aggiuntivi per suddividere i tuoi report GL"
+msgstr "Tag aggiuntivi per suddividere la rendicontazione della contabilità generale"
 
 msgid "Fail"
-msgstr "Non superato"
+msgstr "Non conforme"
 
 msgid "Failed"
 msgstr "Non riuscito"
@@ -6432,11 +6432,11 @@ msgstr "Caratteristiche fallite"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (prima scadenza, prima uscita)"
+msgstr "Impossibile creare la classe di cespiti: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
-msgstr "Impossibile creare consumabile: {0}"
+msgstr "Impossibile creare il materiale di consumo: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create cost center: {0}"
@@ -6460,7 +6460,7 @@ msgstr "Impossibile creare il cliente: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create department: {0}"
-msgstr "Impossibile creare il dipartimento: {0}"
+msgstr "Impossibile creare il reparto: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create failure mode: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Impossibile creare la modalità di guasto: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Impossibile creare il tipo di calibro: {0}"
+msgstr "Impossibile creare il tipo di strumento: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6500,7 +6500,7 @@ msgstr "Impossibile creare il grado di materiale: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Impossibile creare la sostanza materiale: {0}"
+msgstr "Impossibile creare il materiale base: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6512,7 +6512,7 @@ msgstr "Impossibile creare il materiale: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Impossibile creare motivo senza preventivo: {0}"
+msgstr "Impossibile creare il motivo di nessuna offerta: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "Impossibile creare parte: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Impossibile creare il termine di pagamento: {0}"
+msgstr "Impossibile creare le condizioni di pagamento: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6574,7 +6574,7 @@ msgid "Failed to fetch risks"
 msgstr "Impossibile recuperare i rischi"
 
 msgid "Failed to fetch suggestions"
-msgstr "Impossibile recuperare i suggerimenti"
+msgstr "Impossibile recuperare le proposte"
 
 msgid "Failed to get options"
 msgstr "Impossibile ottenere le opzioni"
@@ -6583,10 +6583,10 @@ msgid "Failed to initialize Carbon client"
 msgstr "Impossibile inizializzare il client Carbon"
 
 msgid "Failed to insert quote line"
-msgstr "Impossibile inserire la riga di preventivo"
+msgstr "Impossibile inserire la riga offerta"
 
 msgid "Failed to insert supplier quote line"
-msgstr "Impossibile inserire la riga di preventivo fornitore"
+msgstr "Impossibile inserire la riga offerta del fornitore"
 
 msgid "Failed to load configuration parameters"
 msgstr "Impossibile caricare i parametri di configurazione"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Impossibile caricare i dati"
 
 msgid "Failed to load inbound inspections"
-msgstr "Impossibile caricare le ispezioni in entrata"
+msgstr "Impossibile caricare i controlli in accettazione"
 
 msgid "Failed to load item data"
 msgstr "Impossibile caricare i dati dell'elemento"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "Impossibile caricare i dettagli dell'articolo"
 
 msgid "Failed to load job operations"
-msgstr "Impossibile caricare le operazioni di lavoro"
+msgstr "Impossibile caricare le operazioni dell'ordine"
 
 msgid "Failed to load jobs"
-msgstr "Impossibile caricare i lavori"
+msgstr "Impossibile caricare gli ordini di produzione"
 
 msgid "Failed to load purchase order lines"
 msgstr "Impossibile caricare le righe dell'ordine di acquisto"
@@ -6625,13 +6625,13 @@ msgid "Failed to load receipts"
 msgstr "Impossibile caricare le ricevute"
 
 msgid "Failed to load sales order lines"
-msgstr "Impossibile caricare le righe dell'ordine di vendita"
+msgstr "Impossibile caricare le righe ordine di vendita"
 
 msgid "Failed to load sales orders"
 msgstr "Impossibile caricare gli ordini di vendita"
 
 msgid "Failed to load shipment lines"
-msgstr "Impossibile caricare le righe di spedizione"
+msgstr "Impossibile caricare le righe spedizione"
 
 msgid "Failed to load shipments"
 msgstr "Impossibile caricare le spedizioni"
@@ -6647,7 +6647,7 @@ msgid "Failed to move account: {0}"
 msgstr "Impossibile spostare il conto: {0}"
 
 msgid "Failed to regenerate thumbnail"
-msgstr "Impossibile rigenerare l'anteprima"
+msgstr "Impossibile rigenerare la miniatura"
 
 msgid "Failed to register passkey"
 msgstr "Impossibile registrare la passkey"
@@ -6662,7 +6662,7 @@ msgid "Failed to remove purchase order"
 msgstr "Impossibile rimuovere l'ordine di acquisto"
 
 msgid "Failed to remove thumbnail"
-msgstr "Impossibile rimuovere l'anteprima"
+msgstr "Impossibile rimuovere la miniatura"
 
 msgid "Failed to resize image"
 msgstr "Impossibile ridimensionare l'immagine"
@@ -6683,7 +6683,7 @@ msgid "Failed to save measurement"
 msgstr "Impossibile salvare la misurazione"
 
 msgid "Failed to save parts"
-msgstr "Errore nel salvataggio delle parti"
+msgstr "Impossibile salvare i componenti"
 
 msgid "Failed to save result"
 msgstr "Impossibile salvare il risultato"
@@ -6713,10 +6713,10 @@ msgid "Failed to update opportunity with purchase order"
 msgstr "Impossibile aggiornare l'opportunità con l'ordine di acquisto"
 
 msgid "Failed to update quote line"
-msgstr "Impossibile aggiornare la riga di preventivo"
+msgstr "Impossibile aggiornare la riga offerta"
 
 msgid "Failed to update supplier quote line"
-msgstr "Impossibile aggiornare la riga del preventivo fornitore"
+msgstr "Impossibile aggiornare la riga offerta del fornitore"
 
 msgid "Failed to update thumbnail path"
 msgstr "Impossibile aggiornare il percorso della miniatura"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Commissioni"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Finitura"
+msgstr "FEFO (primo scaduto-primo uscito)"
 
 msgid "Fetch"
 msgstr "Recupera"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "Terminare con materiale non prelevato?"
 
 msgid "Finished goods"
-msgstr "Finiture"
+msgstr "Prodotti finiti"
 
 msgid "Finished Goods"
 msgstr "Prodotti Finiti"
@@ -6904,19 +6904,19 @@ msgid "First-year additional deduction taken before the regular MACRS schedule b
 msgstr "Immobilizzazione"
 
 msgid "Fiscal year"
-msgstr "Anno fiscale"
+msgstr "Esercizio fiscale"
 
 msgid "Fiscal Year"
-msgstr "Anno Fiscale"
+msgstr "Esercizio fiscale"
 
 msgid "Fiscal Year Settings"
-msgstr "Impostazioni Anno Fiscale"
+msgstr "Impostazioni esercizio fiscale"
 
 msgid "Fiscal Year to Date"
-msgstr "Anno fiscale a oggi"
+msgstr "Da inizio esercizio fiscale"
 
 msgid "Fiscal Years"
-msgstr "Anni Fiscali"
+msgstr "Esercizi fiscali"
 
 msgid "Fit view"
 msgstr "Adatta alla vista"
@@ -6928,16 +6928,16 @@ msgid "Fixed"
 msgstr "Fisso"
 
 msgid "Fixed asset"
-msgstr "Varianza di ammortamento dei costi fissi quando la dimensione del lotto differisce dallo standard"
+msgstr "Cespite"
 
 msgid "Fixed Asset"
 msgstr "Cespite Fisso"
 
 msgid "Fixed Assets"
-msgstr "Immobilizzazioni"
+msgstr "Cespiti"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Utili e Perdite"
+msgstr "Scostamento di ammortamento del costo fisso quando la dimensione del lotto differisce dallo standard"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "Fissato una volta che i periodi contabili sono stati registrati o chiusi. Elimina tutti i periodi aperti per modificarlo."
@@ -6949,10 +6949,10 @@ msgid "Fixed Shelf Life"
 msgstr "Durata di Conservazione Fissa"
 
 msgid "Fixture"
-msgstr "Accessorio"
+msgstr "Attrezzatura di fissaggio"
 
 msgid "Fixture ID"
-msgstr "ID Accessorio"
+msgstr "ID attrezzatura di fissaggio"
 
 msgid "Flags"
 msgstr "Flag"
@@ -6962,16 +6962,16 @@ msgstr "per qualsiasi cosa. Porteranno la persona giusta."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Metodo di previsione: <0>{0}</0>. Questa riga non è stata derivata da lavori attivi, quindi nessuna fonte padre è disponibile."
+msgstr "Metodo di previsione: <0>{0}</0>. Questa riga non è stata derivata da ordini di produzione attivi, quindi nessuna fonte padre è disponibile."
 
 msgid "Forgot to Clock Out?"
-msgstr "Hai dimenticato di timbrare l'uscita?"
+msgstr "Hai dimenticato di timbrare la fine?"
 
 msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Ingegnere dispiegato in prima linea"
 
 msgid "Foundation"
 msgstr "Fondamenti"
@@ -7021,13 +7021,13 @@ msgid "From Storage Unit"
 msgstr "Da Unità di Stoccaggio"
 
 msgid "Fulfillment Location"
-msgstr "Ubicazione di Adempimento"
+msgstr "Ubicazione di spedizione"
 
 msgid "Full name"
 msgstr "Nome completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configurazione completa e migrazioni"
 
 msgid "Fully Depreciated"
 msgstr "Completamente Ammortizzato"
@@ -7051,43 +7051,43 @@ msgid "Gains recognized on disposal of fixed assets"
 msgstr "Guadagni riconosciuti sulla dismissione dei cespiti"
 
 msgid "gauge"
-msgstr "Calibri"
+msgstr "strumento di misura"
 
 msgid "Gauge"
-msgstr "Calibro"
+msgstr "Strumento di misura"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Notifiche di Calibrazione Manometri"
+msgstr "Notifiche di taratura degli strumenti di misura"
 
 msgid "Gauge ID"
-msgstr "ID Calibro"
+msgstr "ID dello strumento di misura"
 
 msgid "Gauge not found"
-msgstr "Calibro non trovato"
+msgstr "Strumento di misura non trovato"
 
 msgid "Gauge Type"
-msgstr "Tipo di Calibro"
+msgstr "Tipo di strumento"
 
 msgid "Gauge Types"
-msgstr "Tipi di Calibro"
+msgstr "Tipi di strumento"
 
 msgid "gauges"
-msgstr "Genealogia"
+msgstr "strumenti di misura"
 
 msgid "Gauges"
-msgstr "Calibri"
+msgstr "Strumenti di misura"
 
 msgid "Genealogy"
-msgstr "Libro Mastro"
+msgstr "Genealogia"
 
 msgid "General"
 msgstr "Generale"
 
 msgid "General ledger"
-msgstr "Conto GL che cattura le differenze di costo sulle operazioni di lavorazione esterna."
+msgstr "Contabilità generale"
 
 msgid "General Ledger"
-msgstr "Libro Mastro"
+msgstr "Contabilità generale"
 
 msgid "General Ledger and month-end close"
 msgstr "Contabilità generale e chiusura di fine mese"
@@ -7102,10 +7102,10 @@ msgid "Generate and send customer invoices"
 msgstr "Genera e invia fatture ai clienti"
 
 msgid "Generate fiscal year"
-msgstr "Genera anno fiscale"
+msgstr "Genera esercizio fiscale"
 
 msgid "Generate Fiscal Year"
-msgstr "Genera Anno Fiscale"
+msgstr "Genera esercizio fiscale"
 
 msgid "Generate material IDs and descriptions based on the properties of the material."
 msgstr "Genera ID materiali e descrizioni in base alle proprietà del materiale."
@@ -7123,13 +7123,13 @@ msgid "Generated IDs are enabled"
 msgstr "Gli ID generati sono abilitati"
 
 msgid "Generating suggestions…"
-msgstr "Generazione suggerimenti…"
+msgstr "Generazione delle proposte…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "Attiva Carbon: un unico sistema che gestisce preventivi, acquisti, shop floor, inventario e finanza, sostituendo gli strumenti attuali."
+msgstr "Passa a Carbon: un unico sistema per quotazioni, acquisti, officina, magazzino e finanza, sostituendo gli strumenti attuali."
 
 msgid "Get Method"
-msgstr "Ottieni Metodo"
+msgstr "Recupera metodo"
 
 msgid "Get started"
 msgstr "Inizia"
@@ -7144,10 +7144,10 @@ msgid "Getting set up"
 msgstr "Configurazione in corso"
 
 msgid "Give it an owner and a date"
-msgstr "Assegnagli un proprietario e una data"
+msgstr "Assegnagli un responsabile e una data"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Contabilità generale"
 
 msgid "GL Account"
 msgstr "Conto Contabile"
@@ -7156,13 +7156,13 @@ msgid "GL account capturing cost differences on outside-processing operations."
 msgstr "Conto GL che cattura le differenze di costo sulle operazioni di lavorazione esterna."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Conto GL che cattura le differenze tra i costi indiretti di produzione applicati e effettivi."
+msgstr "Conto contabile di contabilità generale che registra le differenze tra i costi generali di produzione applicati e quelli effettivi."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Conto GL che cattura le differenze tra il materiale previsto dalla BOM e il materiale effettivamente consumato."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Conto GL che cattura le differenze tra il tempo di lavoro/macchina previsto dal routing e quello effettivo."
+msgstr "Conto contabile di contabilità generale che registra le differenze tra la manodopera e il tempo macchina previsti dal ciclo e quelli effettivi."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Conto GL che cattura le differenze di costo fisso quando la dimensione del lotto effettiva differisce da quella prevista."
@@ -7174,13 +7174,13 @@ msgid "GL account credited when a supplier invoice is posted (AP balance)."
 msgstr "Conto GL accreditato quando una fattura fornitore viene registrata (saldo dei debiti verso fornitori)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Conto GL accreditato quando il costo del lavoro o della macchina viene assorbito in un ordine di produzione."
+msgstr "Conto contabile di contabilità generale accreditato quando il costo di manodopera o macchina viene assorbito in un ordine di produzione."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "Conto di contabilità generale accreditato quando i costi generali di produzione vengono assorbiti in un ordine di produzione."
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "Conto GL addebitato per cancellare l'ammortamento cumulato quando un cespite viene dismesso."
+msgstr "Conto contabile di contabilità generale addebitato per azzerare il fondo ammortamento quando un cespite viene dismesso."
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
 msgstr "Conto GL addebitato quando una fattura cliente viene registrata; cancellato quando il cliente paga."
@@ -7192,25 +7192,25 @@ msgid "GL account for bank service charges and similar fees."
 msgstr "Conto GL per le commissioni per servizi bancari e le spese simili."
 
 msgid "GL account for interest income or expense."
-msgstr "Conto GL per i ricavi o le spese per interessi."
+msgstr "Conto contabile di contabilità generale per gli interessi attivi o passivi."
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "Conto GL per l'imposta sugli acquisti pagata ai fornitori (o recuperabile)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "Conto GL per le imposte dovute secondo le regole di inversione del soggetto passivo dove l'acquirente effettua l'autovalutazione."
+msgstr "Conto contabile di contabilità generale per le imposte rilevate in regime di reverse charge dove il buyer si auto-valuta."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "Conto GL per le differenze temporali fiscali (ad es. ammortamento fiscale accelerato vs. ammortamento contabile)."
+msgstr "Conto contabile di contabilità generale per le differenze temporali di imposta (ad es. ammortamento fiscale accelerato rispetto all'ammortamento contabile)."
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Conto GL interessato quando i conteggi fisici differiscono dall'inventario di sistema."
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "Conto GL nella società di origine da addebitare per questa transazione intersocietaria."
+msgstr "Conto contabile di contabilità generale dell'azienda di origine da addebitare per questa transazione interaziendale."
 
 msgid "GL account in the target company to credit for this intercompany transaction."
-msgstr "Conto GL nella società target da accreditare per questa transazione intersocietaria."
+msgstr "Conto contabile di contabilità generale dell'azienda di destinazione da accreditare per questa transazione interaziendale."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
 msgstr "Conto GL che assorbe le differenze di arrotondamento in sub-centesimi alla registrazione."
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "Conto GL che riporta il costo di acquisizione originale di un cespite — addebitato all'acquisizione e accreditato per l'intero costo lordo quando viene dismesso o venduto."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Conto GL che tiene il valore dei lavori in produzione fino a quando non vengono registrati come prodotti finiti."
+msgstr "Conto contabile di contabilità generale che mantiene il valore degli ordini di produzione fino a quando non vengono registrati nei prodotti finiti."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "Conto di contabilità generale che contiene il valore dei beni fabbricati (articoli Make); addebitato al completamento del lavoro, accreditato sulla spedizione."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "Conto GL dove vengono registrati gli sconti di pagamento anticipato ottenuti dai fornitori."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Conto GL contra-attività accreditato quando l'ammortamento viene registrato in ogni periodo e addebitato per intero quando il cespite viene venduto o rottamato."
+msgstr "Conto contabile di contabilità generale a saldo negativo dell'attivo accreditato quando l'ammortamento viene registrato ogni periodo e completamente addebitato quando il cespite viene venduto o rottamato."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Conto GL contra-attività che accumula l'ammortamento registrato rispetto ai beni fissi."
+msgstr "Conto contabile di contabilità generale a saldo negativo dell'attivo che accumula l'ammortamento registrato rispetto ai cespiti."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Conto GL di patrimonio netto (riserva CTA) che detiene le differenze di cambio non realizzate dalla ritraduzione dei saldi in valuta estera al termine del periodo; separato da guadagno/perdita di cambio realizzato in P&L."
+msgstr "Conto patrimoniale di contabilità generale (riserva CTA) che mantiene le differenze valutarie non realizzate dalla retraduzione dei saldi in valuta estera a fine periodo; separato dalle plusvalenze/minusvalenze valutarie realizzate a conto economico."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Conto GL di patrimonio netto dove l'utile netto viene chiuso a fine anno fiscale."
+msgstr "Conto patrimoniale di contabilità generale dove il reddito netto chiude a fine esercizio fiscale."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Conto GL di spesa addebitato ogni periodo quando l'ammortamento viene registrato."
+msgstr "Conto spese di contabilità generale addebitato ogni periodo quando l'ammortamento viene registrato."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Conto GL di spesa addebitato quando il valore contabile di un cespite viene ridotto per svalutazione, ossia quando il suo valore recuperabile scende al di sotto del valore netto contabile."
+msgstr "Conto spese di contabilità generale addebitato quando il valore di bilancio di un cespite è ridotto per riduzione di valore, ovvero quando il suo importo recuperabile scende al di sotto del valore contabile netto."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Conto GL di spesa per acquisti non di magazzino (forniture, servizi)."
+msgstr "Conto spese di contabilità generale per gli acquisti non a magazzino (forniture, servizi)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Conto GL di passività accreditato per l'IVA riscossa dai clienti."
+msgstr "Conto di passività di contabilità generale accreditato per le imposte di vendita riscosse dai clienti."
 
 msgid "GL tie-out"
-msgstr "Riconciliazione GL"
+msgstr "Riconciliazione della contabilità generale"
 
 msgid "GL Tie-Out"
-msgstr "Riconciliazione GL"
+msgstr "Riconciliazione della Contabilità Generale"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Vai in produzione al primo tentativo — con il nostro team al tuo fianco"
@@ -7358,7 +7358,7 @@ msgid "Guided implementation"
 msgstr "Implementazione guidata"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Gestire le registrazioni contabili ricorrenti e di storno"
+msgstr "Gestire le prime note ricorrenti e di storno"
 
 msgid "Hands-on"
 msgstr "Pratico"
@@ -7400,16 +7400,16 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "Dati storici più vecchi di quelli sulla Mappa di Migrazione Dati"
 
 msgid "Historical Rate (equity)"
-msgstr "Tasso Storico (Patrimonio)"
+msgstr "Cambio storico (patrimonio netto)"
 
 msgid "Historical Rate (Equity)"
-msgstr "Tasso Storico (Patrimonio)"
+msgstr "Cambio storico (Patrimonio netto)"
 
 msgid "History"
 msgstr "Cronologia"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Mantieni il giornale come avvertimento da correggere."
+msgstr "Metti in sospeso la prima nota come avviso da correggere."
 
 msgid "Holiday"
 msgstr "Festività"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Ore/Pezzo"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Come un articolo è complessivamente reintegrato (Acquista, Fabrica o Acquista e Fabrica), impostato per articolo, a differenza del tipo di metodo per riga."
+msgstr "Come viene rifornito complessivamente un articolo (Acquisto, Produzione, o Acquisto e produzione), impostato per articolo, diversamente dal tipo di fornitura per riga."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Come un articolo è reintegrato: Riordino Manuale, Riordino Basato sulla Domanda, Quantità di Riordino Fissa o Quantità Massima."
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "Quanti ne sono stati effettivamente prelevati?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Con che frequenza questo manometro deve essere ricalibrato; combinato con la data dell'ultimo ricalibrato per ricalcolare automaticamente la prossima data di ricalibrazione."
+msgstr "Ogni quanto questo strumento di misura deve essere ritarato; combinato con data ultima taratura per ricalcolare automaticamente la prossima data di taratura."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Con che frequenza questa manutenzione si ripete — Giornaliero, Settimanale, Mensile, Al Conteggio del Ciclo; Giornaliero rivela il selettore del giorno della settimana, gli altri usano una matematica di intervallo più semplice."
+msgstr "Ogni quanto questa manutenzione ricorre — Giornaliero, Settimanale, Mensile, Su conteggio ciclico; Giornaliero mostra il selettore del giorno della settimana, gli altri usano semplice aritmetica di intervalli."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Quanto è rigida la data di scadenza — Scadenza Rigida blocca la programmazione, Scadenza Morbida consente alla pianificazione di estendersi con un avviso, Nessuna Scadenza la ignora completamente."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "Come viene approvvigionato il materiale (produrre, acquistare o prelevare dall'inventario) e l'unità di stoccaggio da cui viene prelevato."
+msgstr "Come viene rifornito il materiale (prodotto, acquistato, o prelevato da magazzino) e l'unità di stoccaggio da cui viene prelevato."
 
 msgid "How the resolved price was calculated."
 msgstr "Come è stato calcolato il prezzo risolto."
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "Come leggere questo grafico"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Quanto è urgente questo spedizione — Basso / Medio / Alto / Critico; combinato con Priorità e Impatto OEE per decidere lo slot di programma."
+msgstr "Quanto è urgente questo intervento di manutenzione — Basso / Medio / Alto / Critico; combinato con Priorità e Impatto OEE per decidere lo slot di programma."
 
 msgid "How we know we're done"
 msgstr "Come sappiamo che abbiamo finito"
@@ -7547,7 +7547,7 @@ msgid "How your quotes, orders, and invoices look when they go out"
 msgstr "Come appaiono i tuoi preventivi, ordini e fatture quando vengono inviati"
 
 msgid "How your team is organized into departments"
-msgstr "Come il tuo team è organizzato nei dipartimenti"
+msgstr "Come la tua squadra è organizzata nei reparti"
 
 msgid "Humidity"
 msgstr "Umidità"
@@ -7577,7 +7577,7 @@ msgid "ID"
 msgstr "ID"
 
 msgid "Ideas, suggestions or problems?"
-msgstr "Idee, suggerimenti o problemi?"
+msgstr "Idee, proposte o problemi?"
 
 msgid "Idempotency key"
 msgstr "Chiave di idempotenza"
@@ -7595,25 +7595,25 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "Se non può aspettare la prossima call, i responsabili da entrambi i lati decidono."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "Se blocca o una data è a rischio, riceve un proprietario e viene tracciato."
+msgstr "Se blocca o una data è a rischio, riceve un responsabile ed è tracciato."
 
 msgid "If items already exist"
 msgstr "Se gli articoli esistono già"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "Se ordinato, nessun esaurimento delle scorte previsto nelle prossime 48 settimane"
+msgstr "Se ordinato, nessuna rottura di stock prevista nelle prossime 48 settimane"
 
 msgid "If something is off track"
 msgstr "Se qualcosa non è in linea"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "Se desideri modificare i numeri di parte, fai clic su Annulla e assegna manualmente le parti per ogni elemento di riga prima della conversione."
+msgstr "Se desideri modificare i numeri dei componenti, fai clic su Annulla e assegna manualmente i componenti per ogni riga prima della conversione."
 
 msgid "II (normal default)"
 msgstr "II (normale predefinito)"
 
 msgid "III (tightened)"
-msgstr "III (stretto)"
+msgstr "III (rinforzato)"
 
 msgid "Impact"
 msgstr "Impatto"
@@ -7701,13 +7701,13 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Le azioni inattive non appariranno negli elenchi di selezione"
 
 msgid "Inbound inspection"
-msgstr "Ispezione in entrata"
+msgstr "Controllo in accettazione"
 
 msgid "Inbox"
 msgstr "Posta in arrivo"
 
 msgid "Include extra parts in shipment"
-msgstr "Includi parti extra nella spedizione"
+msgstr "Includi componenti aggiuntivi nella spedizione"
 
 msgid "Include Inactive"
 msgstr "Includi Inattivi"
@@ -7716,10 +7716,10 @@ msgid "Included"
 msgstr "Incluso"
 
 msgid "Includes tax and shipping costs"
-msgstr "Include tasse e costi di spedizione"
+msgstr "Include imposta e spese di spedizione"
 
 msgid "Income / Balance (inherited)"
-msgstr "Reddito / Bilancio (ereditato)"
+msgstr "Proventi / Saldo (ereditato)"
 
 msgid "Income Statement"
 msgstr "Conto Economico"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "Imposta sul reddito"
 
 msgid "Income/Balance"
-msgstr "Reddito/Saldo"
+msgstr "Proventi/Saldo"
 
 msgid "incoming"
 msgstr "in arrivo"
@@ -7776,7 +7776,7 @@ msgid "Inherited from the group: where this account appears on financial stateme
 msgstr "Ereditato dal gruppo: dove questo account appare nei rendiconti finanziari."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Ereditato dal gruppo: se questo account si chiude agli utili non distribuiti (reddito) o si porta avanti (bilancio)."
+msgstr "Ereditato dal gruppo: se questo conto si chiude agli utili non distribuiti (proventi) o si riporta a nuovo (saldo)."
 
 msgid "Inherited from the parent group."
 msgstr "Ereditato dal gruppo padre."
@@ -7803,37 +7803,37 @@ msgid "Inspect Item"
 msgstr "Ispeziona Articolo"
 
 msgid "Inspection"
-msgstr "Ispezione"
+msgstr "Controllo"
 
 msgid "Inspection document"
-msgstr "Documento di ispezione"
+msgstr "Documento di controllo"
 
 msgid "Inspection Level"
-msgstr "Livello di Ispezione"
+msgstr "Livello di controllo"
 
 msgid "Inspection Plan"
-msgstr "Piano di Ispezione"
+msgstr "Piano di controllo"
 
 msgid "Inspection Plan Assignments"
-msgstr "Assegnazioni Piano di Ispezione"
+msgstr "Assegnazioni del piano di controllo"
 
 msgid "Inspection Plans"
-msgstr "Piani di Ispezione"
+msgstr "Piani di controllo"
 
 msgid "Inspection Status"
-msgstr "Stato di Ispezione"
+msgstr "Stato del controllo"
 
 msgid "Inspections"
-msgstr "Ispezioni"
+msgstr "Controlli"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Ispezioni, non conformità e CAPA"
+msgstr "Controlli, non conformità e CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Ispezioni, Non conformità, CAPA"
+msgstr "Controlli, Non conformità, CAPA"
 
 msgid "Inspections: Require Different Inspector"
-msgstr "Ispezioni: Richiedi un Ispettore Diverso"
+msgstr "Controlli: Richiedi ispettore diverso"
 
 msgid "Install"
 msgstr "Installa"
@@ -7881,7 +7881,7 @@ msgid "Interest (default)"
 msgstr "Interesse (predefinito)"
 
 msgid "Interest income or expense from banking activities"
-msgstr "Reddito o spese di interesse da attività bancarie"
+msgstr "Proventi o spese di interessi da attività bancarie"
 
 msgid "Internal"
 msgstr "Interno"
@@ -7893,7 +7893,7 @@ msgid "Internal notes"
 msgstr "Note interne"
 
 msgid "Internal Notes"
-msgstr "Note Interne"
+msgstr "Note interne"
 
 msgid "inv"
 msgstr "inv"
@@ -7917,10 +7917,10 @@ msgid "Inventory actions"
 msgstr "Azioni inventario"
 
 msgid "Inventory Adjustment"
-msgstr "Rettifica Inventario"
+msgstr "Rettifica di magazzino"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Rettifica dell'Inventario (predefinito)"
+msgstr "Rettifica di magazzino (predefinita)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Inventario e acquisti, con pianificazione automatizzata"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Problemi"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Si interromperà fino a quando non pubblichi di nuovo una versione. Nulla viene eliminato."
 
 msgid "ITAR Certifications"
 msgstr "Certificazioni ITAR"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Master Articoli e Metodi di Produzione"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Anagrafica articoli, BOM e Ciclo di lavorazione"
+msgstr "Anagrafe articoli, BOM e Lista delle operazioni"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "L'articolo deve corrispondere a un tipo selezionato E a un gruppo selezionato"
@@ -8190,7 +8190,7 @@ msgid "Item Type (optional)"
 msgstr "Tipo di articolo (facoltativo)"
 
 msgid "Item types"
-msgstr "Tipi di articolo"
+msgstr "Tipi articolo"
 
 msgid "items"
 msgstr "articoli"
@@ -8205,10 +8205,10 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Gli articoli all'interno di questa finestra ricevono un badge giallo."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Articoli: anagrafica articoli, BOM, ciclo di lavorazione, modifiche ingegneristiche, CAD"
+msgstr "Articoli: anagrafe articoli, BOM, Lista delle operazioni, modifiche tecniche, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "La progettazione potrebbe cambiare prima che la notifica di modifica venga rilasciata."
+msgstr "Il suo design potrebbe cambiare prima che l'Avviso di modifica sia emesso."
 
 msgid "Job"
 msgstr "Lavoro"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "Ubicazione Lavoro"
 
 msgid "Job make method"
-msgstr "Metodo di creazione del lavoro"
+msgstr "Metodo di produzione dell'ordine"
 
 msgid "Job Materials"
-msgstr "Materiali Lavoro"
+msgstr "Materiali dell'ordine"
 
 msgid "Job operation"
-msgstr "Operazione di lavoro"
+msgstr "Operazione dell'ordine"
 
 msgid "Job Operation"
-msgstr "Operazione di Lavoro"
+msgstr "Operazione dell'ordine"
 
 msgid "Job Operations"
-msgstr "Operazioni di Lavoro"
+msgstr "Operazioni dell'ordine"
 
 msgid "Job Priority"
 msgstr "Priorità del lavoro"
@@ -8244,38 +8244,38 @@ msgid "Job readable"
 msgstr "Lavoro leggibile"
 
 msgid "Job Traveler"
-msgstr "Foglio di Viaggio del Lavoro"
+msgstr "Cartellino di produzione"
 
 msgid "Jobs"
-msgstr "Lavori"
+msgstr "Ordini di produzione"
 
 msgid "Jobs Assigned to Me"
-msgstr "Lavori assegnati a me"
+msgstr "Ordini di produzione assegnati a me"
 
 msgid "Jobs Required"
-msgstr "Lavori Richiesti"
+msgstr "Ordini di produzione richiesti"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Lavori che hanno questo articolo nella loro distinta base"
+msgstr "Ordini di produzione che hanno questo articolo nella loro distinta base"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Unisciti a {0}"
 
 msgid "Journal"
-msgstr "Giornale"
+msgstr "Prima nota"
 
 msgid "Journal Entries"
-msgstr "Registrazioni Contabili"
+msgstr "Righe di registrazione"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "Le registrazioni contabili datate in questo periodo che sono ancora in Bozza devono essere registrate o rivalutate in un periodo aperto successivo. Le bozze di registrazioni non fanno parte della contabilità generale, quindi i loro debiti e crediti mancherebbero dalla chiusura."
+msgstr "Le righe di registrazione datate in questo periodo ancora in Bozza devono essere registrate o ridatate in un periodo aperto successivo. Le righe in Bozza non fanno parte della contabilità, quindi i loro Dare e Avere mancherebbero dalla chiusura."
 
 msgid "Journal Entry"
-msgstr "Registrazione Contabile"
+msgstr "Riga di registrazione"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "I giornali datati in questa data o prima sono trattati come bloccati. Uniti con la data di blocco segnalata dal provider quando entrambi esistono."
+msgstr "Le prime note datate su o prima di questa data sono trattate come bloccate. Unite alla data di blocco segnalata dal provider quando entrambe esistono."
 
 msgid "Just one"
 msgstr "Solo uno"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Mantieni Attuale"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Mantieni i prezzi esistenti, aggiungi solo i nuovi articoli"
+msgstr "Mantieni la determinazione dei prezzi esistente, aggiungi solo nuovi articoli"
 
 msgid "Keep only items where…"
 msgstr "Mantieni solo gli elementi dove…"
@@ -8342,19 +8342,19 @@ msgid "Labels"
 msgstr "Etichette"
 
 msgid "Labor"
-msgstr "Lavoro"
+msgstr "Manodopera"
 
 msgid "Labor & Machine Absorption"
-msgstr "Assorbimento del Lavoro e della Macchina"
+msgstr "Assorbimento manodopera e macchina"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "Assorbimento del Lavoro e della Macchina (predefinito)"
+msgstr "Assorbimento manodopera e macchina (predefinito)"
 
 msgid "Labor & Machine Variance"
-msgstr "Varianza del Lavoro e della Macchina"
+msgstr "Scostamento manodopera e macchina"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Varianza del Lavoro e della Macchina (predefinita)"
+msgstr "Scostamento manodopera e macchina (predefinito)"
 
 msgid "Labor rate"
 msgstr "Tariffa manodopera"
@@ -8369,13 +8369,13 @@ msgid "Labor time"
 msgstr "Tempo manodopera"
 
 msgid "Labor Time"
-msgstr "Tempo di Lavoro"
+msgstr "Tempo manodopera"
 
 msgid "Labor unit"
 msgstr "Unità manodopera"
 
 msgid "Labor Unit"
-msgstr "Unità di Lavoro"
+msgstr "Unità di manodopera"
 
 msgid "Language"
 msgstr "Lingua"
@@ -8390,10 +8390,10 @@ msgid "Last Attempt"
 msgstr "Ultimo tentativo"
 
 msgid "Last Calibration"
-msgstr "Ultima Calibrazione"
+msgstr "Ultima taratura"
 
 msgid "Last Calibration Date"
-msgstr "Data dell'ultima calibrazione"
+msgstr "Data dell'ultima taratura"
 
 msgid "Last day"
 msgstr "Ultimo giorno"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Latitudine"
 
 msgid "Lead time"
-msgstr "Tempo di Consegna"
+msgstr "Lead time"
 
 msgid "Lead Time"
-msgstr "Tempo di consegna"
+msgstr "Lead time"
 
 msgid "Lead time (days)"
-msgstr "Tempo di consegna (giorni)"
+msgstr "Lead time (giorni)"
 
 msgid "Lead Time (Days)"
-msgstr "Tempo di consegna (Giorni)"
+msgstr "Lead time (giorni)"
 
 msgid "Lead Time:"
-msgstr "Tempo di consegna:"
+msgstr "Lead time:"
 
 msgid "Learn"
 msgstr "Impara"
@@ -8474,7 +8474,7 @@ msgid "Left item"
 msgstr "Elemento sinistro"
 
 msgid "Leftover Parts Detected"
-msgstr "Parti Rimanenti Rilevate"
+msgstr "Componenti rimanenti rilevati"
 
 msgid "Leftover staged material returns when the whole job completes."
 msgstr "Il materiale in staging rimanente torna quando l'intero lavoro è completato."
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Meno lavoro manuale, meno errori"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Costruiamo"
 
 msgid "Let's build something"
 msgstr "Costruiamo qualcosa"
@@ -8504,7 +8504,7 @@ msgid "Liability account for deferred taxes from accelerated depreciation"
 msgstr "Conto passività per imposte differite da ammortamento accelerato"
 
 msgid "Liability account for sales tax collected from customers"
-msgstr "Conto passività per l'IVA riscossa dai clienti"
+msgstr "Conto passività per imposta di vendita riscossa dai clienti"
 
 msgid "Liability account for tax paid on purchases"
 msgstr "Conto passività per l'imposta pagata su acquisti"
@@ -8549,16 +8549,16 @@ msgid "Lines need internal part numbers"
 msgstr "Le righe necessitano di numeri di parte interni"
 
 msgid "Lines need prices or lead times"
-msgstr "Le righe necessitano di prezzi o tempi di consegna"
+msgstr "Le righe hanno bisogno di prezzi o lead time"
 
 msgid "Lineside"
-msgstr "In linea"
+msgstr "Bordo linea"
 
 msgid "Link"
 msgstr "Collegamento"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "Collegamento (facoltativo) — ad es. /x/settings/…"
+msgstr "Collegamento (facoltativo) — es. /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Collega Problema Jira"
@@ -8567,7 +8567,7 @@ msgid "Link Linear Issue"
 msgstr "Collega problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Collega questo cliente Carbon a uno di loro, oppure crea un cliente Stripe separato."
 
 msgid "Link to sales order line"
 msgstr "Collega alla riga dell'ordine di vendita"
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Caricato per ultimo, proprio al momento del cutover, quindi i saldi sono attuali."
 
 msgid "Loading associated jobs..."
-msgstr "Caricamento dei lavori associati..."
+msgstr "Caricamento degli ordini di produzione associati..."
 
 msgid "Loading current quantity…"
 msgstr "Caricamento della quantità attuale…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Bloccato"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "Il blocco rende il periodo di sola lettura per i documenti operativi (ricevute, spedizioni, fatture) mentre consente ancora aggiustamenti contabili come ammortamento e dismissioni. Un periodo deve essere bloccato prima di poter essere chiuso."
+msgstr "Il blocco rende il periodo di sola lettura per i documenti operativi (entrate merci, spedizioni, fatture) consentendo ancora rettifiche contabili come ammortamenti e dismissioni. Un periodo deve essere bloccato prima di poter essere chiuso."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Registra non conformità e avvia una CAPA"
@@ -8713,22 +8713,22 @@ msgid "Lot"
 msgstr "Lotto"
 
 msgid "Lot size"
-msgstr "Dimensione lotto"
+msgstr "Dimensione del lotto"
 
 msgid "Lot Size"
-msgstr "Dimensione Lotto"
+msgstr "Dimensione del lotto"
 
 msgid "Lot Size Variance"
-msgstr "Varianza della Dimensione del Lotto"
+msgstr "Scostamento della dimensione del lotto"
 
 msgid "Lot Size Variance (default)"
-msgstr "Varianza della Dimensione del Lotto (predefinita)"
+msgstr "Scostamento della dimensione del lotto (predefinito)"
 
 msgid "Lot Size:"
-msgstr "Dimensione lotto:"
+msgstr "Dimensione del lotto:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Ispezione basata su lotto della merce ricevuta secondo un piano di campionamento; le unità vengono registrate In sospeso al ricevimento e vengono rilasciate a Disponibile solo dopo che il lotto è stato disposto come accettato."
+msgstr "Controllo basato su lotto delle merci ricevute rispetto a un piano di campionamento; le unità rimangono sospese al ricevimento e si rendono disponibili solo una volta che il lotto è stato disposizionato come accettato."
 
 msgid "Low"
 msgstr "Basso"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "Manutenzione"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Notifiche di Invio Manutenzione"
+msgstr "Notifiche interventi di manutenzione"
 
 msgid "Maintenance Dispatches"
-msgstr "Ordini di Manutenzione"
+msgstr "Interventi di manutenzione"
 
 msgid "Maintenance Expense"
 msgstr "Spese di Manutenzione"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Prendi la decisione go / no-go"
 
 msgid "Make to Order"
-msgstr "Produzione su ordinazione"
+msgstr "Produzione su commessa"
 
 msgid "Make tracked entities available again"
 msgstr "Rendi le entità tracciate disponibili di nuovo"
@@ -8884,10 +8884,10 @@ msgid "Map accounts"
 msgstr "Mappa conti"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Mappa i conti Carbon al piano dei conti del provider. I giornali posting vengono inviati utilizzando il codice conto provider mappato."
+msgstr "Mappa i conti di Carbon nel piano dei conti del fornitore. I giornali registrati si inoltrano usando il codice account del fornitore mappato."
 
 msgid "Map Extracted Invoice Lines"
-msgstr "Mappa Righe Fattura Estratte"
+msgstr "Mappa le righe fattura estratte"
 
 msgid "Map Extracted Lines"
 msgstr "Mappa Righe Estratte"
@@ -8933,16 +8933,16 @@ msgid "Mark Dark Mode"
 msgstr "Marchio Modalità Scura"
 
 msgid "Mark done"
-msgstr "Segna come completato"
+msgstr "Segna come fatto"
 
 msgid "Mark Done"
-msgstr "Segna Come Completato"
+msgstr "Segna come fatto"
 
 msgid "Mark Light Mode"
 msgstr "Marchio Modalità Chiara"
 
 msgid "Mark not done"
-msgstr "Segna come non completato"
+msgstr "Segna come non fatto"
 
 msgid "Mark scope as agreed"
 msgstr "Contrassegna ambito come concordato"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "Proprietà dei Materiali"
 
 msgid "Material Review Board (MRB)"
-msgstr "Commissione di revisione dei materiali (MRB)"
+msgstr "Material Review Board (MRB)"
 
 msgid "Material Shape"
 msgstr "Forma Materiale"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Forme Materiali"
 
 msgid "Material Substance"
-msgstr "Sostanza Materiale"
+msgstr "Materiale base"
 
 msgid "Material Substances"
-msgstr "Sostanze Materiali"
+msgstr "Materiali base"
 
 msgid "material type"
 msgstr "Tipo di Materiale"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "Tipi di Materiale"
 
 msgid "Material Usage Variance"
-msgstr "Varianza di Utilizzo dei Materiali"
+msgstr "Scostamento di utilizzo materiale"
 
 msgid "Material Usage Variance (default)"
-msgstr "Varianza di Utilizzo dei Materiali (predefinita)"
+msgstr "Scostamento di utilizzo materiale (predefinito)"
 
 msgid "materials"
 msgstr "Materiali"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "Tempo Medio di Riparazione"
 
 msgid "Measurement Standard"
-msgstr "Standard di Misurazione"
+msgstr "Campione di riferimento"
 
 msgid "Media Size"
 msgstr "Dimensione supporto"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Operazioni Metodo"
 
 msgid "Method type"
-msgstr "Tipo di Metodo"
+msgstr "Tipo di fornitura"
 
 msgid "Method Type"
-msgstr "Tipo di Metodo"
+msgstr "Tipo di fornitura"
 
 msgid "Methods"
 msgstr "Metodi"
@@ -9191,7 +9191,7 @@ msgid "Minimum Cost"
 msgstr "Costo Minimo"
 
 msgid "Minimum Order Quantity"
-msgstr "Quantità Minima Ordine"
+msgstr "Quantità minima d'ordine"
 
 msgid "Minimum Order:"
 msgstr "Ordine Minimo:"
@@ -9221,7 +9221,7 @@ msgid "Missing Operations"
 msgstr "Operazioni Mancanti"
 
 msgid "Missing Shipping Costs"
-msgstr "Costi di spedizione mancanti"
+msgstr "Spese di spedizione mancanti"
 
 msgid "Missing Suppliers"
 msgstr "Fornitori Mancanti"
@@ -9275,7 +9275,7 @@ msgid "Monthly"
 msgstr "Mensile"
 
 msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
-msgstr "Mesi in cui questo asset si deprezza a fini fiscali (quando non si utilizza MACRS)."
+msgstr "Mesi in cui questo cespite si ammortizza a fini fiscali (quando non si utilizza MACRS)."
 
 msgid "More"
 msgstr "Altro"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Sposta elemento"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Sposta parte della quantità in una nuova riga di disposizione in modo che MRB possa decidere ogni porzione separatamente (ad es. scartare alcuni, rielaborare alcuni)."
+msgstr "Sposta parte della quantità in una nuova riga di disposizione in modo che il MRB possa decidere ciascuna porzione separatamente (ad es. scartare alcuni, rilavorare altri)."
 
 msgid "Move to"
 msgstr "Sposta in"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "Nome"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "Designare un proprietario di progetto interno con autorità decisionale"
+msgstr "Nomina un responsabile interno del progetto con autorità decisionale"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "I nomi vengono compilati ovunque questi ruoli siano referenziati in tutto l'hub."
@@ -9391,13 +9391,13 @@ msgid "Net book value"
 msgstr "Valore Netto Contabile"
 
 msgid "Net Book Value"
-msgstr "Valore di Bilancio Netto"
+msgstr "Valore contabile netto"
 
 msgid "Net Change"
 msgstr "Variazione netta"
 
 msgid "Net Income"
-msgstr "Utile netto"
+msgstr "Proventi netti"
 
 msgid "Never"
 msgstr "Mai"
@@ -9418,7 +9418,7 @@ msgid "New Approval Rule"
 msgstr "Nuova Regola di Approvazione"
 
 msgid "New Asset Class"
-msgstr "Nuova Classe di Bene"
+msgstr "Nuova classe di cespiti"
 
 msgid "New Assignment"
 msgstr "Nuovo Incarico"
@@ -9439,16 +9439,16 @@ msgid "New Change Notice Type"
 msgstr "Nuovo tipo di avviso di modifica"
 
 msgid "New Consumable"
-msgstr "Nuovo Consumabile"
+msgstr "Nuovo materiale di consumo"
 
 msgid "New Contractor"
-msgstr "Nuovo Appaltatore"
+msgstr "Nuovo collaboratore esterno"
 
 msgid "New Cost Center"
 msgstr "Nuovo Centro di Costo"
 
 msgid "New Credit / Debit Memo"
-msgstr "Nuovo Memo di Credito / Debito"
+msgstr "Nuova nota di credito / debito"
 
 msgid "New Custom Field"
 msgstr "Nuovo Campo Personalizzato"
@@ -9460,7 +9460,7 @@ msgid "New Customer Part"
 msgstr "Nuova Parte Cliente"
 
 msgid "New Department"
-msgstr "Nuovo Dipartimento"
+msgstr "Nuovo reparto"
 
 msgid "New Dimension"
 msgstr "Nuova Dimensione"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Nuovo Cespite"
 
 msgid "New Gauge"
-msgstr "Nuovo Indicatore"
+msgstr "Nuovo strumento di misura"
 
 msgid "New Gauge Calibration Record"
-msgstr "Nuovo Registro di Taratura del Calibro"
+msgstr "Nuovo Registro di taratura dello strumento di misura"
 
 msgid "New Gauge Type"
-msgstr "Nuovo Tipo di Calibro"
+msgstr "Nuovo Tipo di strumento"
 
 msgid "New Group"
 msgstr "Nuovo Gruppo"
@@ -9499,7 +9499,7 @@ msgid "New IC Transaction"
 msgstr "Nuova Transazione IC"
 
 msgid "New Inspection Plan"
-msgstr "Nuovo Piano di Ispezione"
+msgstr "Nuovo Piano di controllo"
 
 msgid "New Inventory Count"
 msgstr "Nuovo Conteggio Inventario"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "Nuova Posizione"
 
 msgid "New Maintenance Dispatch"
-msgstr "Nuovo Ordine di Manutenzione"
+msgstr "Nuovo Intervento di manutenzione"
 
 msgid "New Material"
 msgstr "Nuovo Materiale"
@@ -9544,7 +9544,7 @@ msgid "New Material Shape"
 msgstr "Nuova Forma Materiale"
 
 msgid "New Material Substance"
-msgstr "Nuova Sostanza Materiale"
+msgstr "Nuovo Materiale base"
 
 msgid "New Material Type"
 msgstr "Nuovo Tipo di Materiale"
@@ -9553,10 +9553,10 @@ msgid "New Non Conformance Type"
 msgstr "Nuovo Tipo di Non Conformità"
 
 msgid "New Owner"
-msgstr "Nuovo Proprietario"
+msgstr "Nuovo Responsabile"
 
 msgid "New Part"
-msgstr "Nuova Parte"
+msgstr "Nuovo componente"
 
 msgid "New Password"
 msgstr "Nuova Password"
@@ -9565,10 +9565,10 @@ msgid "New Payment"
 msgstr "Nuovo Pagamento"
 
 msgid "New Payment Term"
-msgstr "Nuovo Termine di Pagamento"
+msgstr "Nuova Condizione di pagamento"
 
 msgid "New Picking List"
-msgstr "Nuovo Elenco di Prelievo"
+msgstr "Nuova Lista di prelievo"
 
 msgid "New PIN"
 msgstr "Nuovo PIN"
@@ -9577,7 +9577,7 @@ msgid "New PO"
 msgstr "Nuovo PO"
 
 msgid "New Price Override"
-msgstr "Nuovo Sconto Prezzo"
+msgstr "Nuova Forzatura di prezzo"
 
 msgid "New Pricing Rule"
 msgstr "Nuova Regola di Prezzo"
@@ -9598,7 +9598,7 @@ msgid "New Quote"
 msgstr "Nuovo Preventivo"
 
 msgid "New Quote Line"
-msgstr "Nuova Riga Preventivo"
+msgstr "Nuova Riga offerta"
 
 msgid "New Receipt"
 msgstr "Nuova Ricevuta"
@@ -9670,7 +9670,7 @@ msgid "New Tool"
 msgstr "Nuovo Strumento"
 
 msgid "New Training"
-msgstr "Nuovo Addestramento"
+msgstr "Nuova Formazione"
 
 msgid "New Transfer"
 msgstr "Nuovo Trasferimento"
@@ -9685,7 +9685,7 @@ msgid "New Version"
 msgstr "Nuova Versione"
 
 msgid "New Warehouse Transfer"
-msgstr "Nuovo Trasferimento Magazzino"
+msgstr "Nuovo Trasferimento tra depositi"
 
 msgid "New Webhook"
 msgstr "Nuovo Webhook"
@@ -9703,10 +9703,10 @@ msgid "Next"
 msgstr "Avanti"
 
 msgid "Next Calibration"
-msgstr "Prossima Calibrazione"
+msgstr "Prossima Taratura"
 
 msgid "Next Calibration Date"
-msgstr "Data della prossima calibrazione"
+msgstr "Data della prossima taratura"
 
 msgid "Next Date"
 msgstr "Data successiva"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Nessuna azione selezionata"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Nessun lavoro attivo trovato per questo ordine di vendita. L'ordine verrà annullato direttamente."
+msgstr "Nessun ordine di produzione in corso trovato per questo ordine di vendita. L'ordine verrà annullato direttamente."
 
 msgid "No active plan"
 msgstr "Nessun piano attivo"
@@ -9785,7 +9785,7 @@ msgstr "Nessuna applicazione. Il pagamento sarà a conto."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Nessun log archiviato ancora. I log più vecchi di {0} giorni verranno archiviati automaticamente e disponibili per il download qui."
+msgstr "Nessun log archiviato ancora. I log più vecchi di {0} giorni verranno automaticamente archiviati e disponibili per il download qui."
 
 msgid "No attachments."
 msgstr "Nessun allegato."
@@ -9797,13 +9797,13 @@ msgid "No available tracked entities found"
 msgstr "Nessuna entità tracciata disponibile trovata"
 
 msgid "No BOM input has a shelf-life policy"
-msgstr "Nessun input della distinta base ha una politica di shelf-life"
+msgstr "Nessun articolo di ingresso BOM ha una politica di shelf-life"
 
 msgid "No CAD model to preview."
 msgstr "Nessun modello CAD da visualizzare."
 
 msgid "No calibration records found"
-msgstr "Nessun record di calibrazione trovato"
+msgstr "Nessun registro di taratura trovato"
 
 msgid "No changes recorded"
 msgstr "Nessuna modifica registrata"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Nessun commento ancora. Sii il primo ad aggiungere un commento."
 
 msgid "No completed jobs within range"
-msgstr "Nessun lavoro completato nell'intervallo"
+msgstr "Nessun ordine di produzione completato entro l'intervallo"
 
 msgid "No condition may match"
 msgstr "Nessuna condizione può corrispondere"
@@ -9848,7 +9848,7 @@ msgid "No dimension values mapped yet"
 msgstr "Nessun valore di dimensione mappato ancora"
 
 msgid "No draft make method for this item yet."
-msgstr "Nessun metodo di creazione della bozza per questo elemento ancora."
+msgstr "Ancora nessun metodo di produzione in bozza per questo articolo."
 
 msgid "No draft versions available"
 msgstr "Nessuna versione bozza disponibile"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Nessun file caricato"
 
 msgid "No Gauge Selected"
-msgstr "Nessun Calibro Selezionato"
+msgstr "Nessuno strumento di misura selezionato"
 
 msgid "No grouped notifications"
 msgstr "Nessuna notifica raggruppata"
@@ -9908,7 +9908,7 @@ msgid "No image"
 msgstr "Nessuna immagine"
 
 msgid "No inspection plans"
-msgstr "Nessun piano di ispezione"
+msgstr "Nessun piano di controllo"
 
 msgid "No issue types configured"
 msgstr "Nessun tipo di problema configurato"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Nessun articolo ha attività di inventario qui ancora."
 
 msgid "No jobs were created"
-msgstr "Nessun processo è stato creato"
+msgstr "Non sono stati creati ordini di produzione"
 
 msgid "No journal lines in scope for this period"
-msgstr "Nessuna riga di diario nell'ambito per questo periodo"
+msgstr "Nessuna riga di prima nota per questo periodo"
 
 msgid "No lines to map"
 msgstr "Nessuna riga da mappare"
@@ -10001,7 +10001,7 @@ msgid "No part ID"
 msgstr "Nessun ID parte"
 
 msgid "No parts"
-msgstr "Nessuna parte"
+msgstr "Nessun componente"
 
 msgid "No passkeys registered yet."
 msgstr "Nessuna passkey registrata finora."
@@ -10016,7 +10016,7 @@ msgid "No planning data"
 msgstr "Nessun dato di pianificazione"
 
 msgid "No posted journals in this period for this account"
-msgstr "Nessun giornale registrato in questo periodo per questo conto"
+msgstr "Nessuna prima nota registrata in questo periodo per questo conto"
 
 msgid "No pricing for selected quantity"
 msgstr "Nessun prezzo per la quantità selezionata"
@@ -10043,7 +10043,7 @@ msgid "No Quote"
 msgstr "Nessuna offerta"
 
 msgid "No Quote Reason"
-msgstr "Nessun motivo di preventivo"
+msgstr "Nessun motivo dell'offerta"
 
 msgid "No Quote Reasons"
 msgstr "Nessun motivo di mancata offerta"
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "Nessuno stock in questa posizione"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "Nessuna esaurimento previsto nelle prossime 48 settimane"
+msgstr "Nessuna rottura di stock prevista nei prossimi 48 settimane"
 
 msgid "No storage unit"
 msgstr "Nessuna unità di stoccaggio"
@@ -10133,7 +10133,7 @@ msgid "No variables available"
 msgstr "Nessuna variabile disponibile"
 
 msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
-msgstr "Nessun stock di magazzino è registrato per questo articolo. Puoi comunque prelevarlo — la giacenza disponibile diventerà negativa fino al riconciliamento del conteggio."
+msgstr "Nessuna giacenza di magazzino è registrata per questo articolo. Puoi comunque prelevarlo — la giacenza disponibile diventerà negativa fino al riconciliamento del conteggio."
 
 msgid "No work center utilization data within range"
 msgstr "Nessun dato di utilizzo del centro di lavoro nell'intervallo"
@@ -10160,16 +10160,16 @@ msgid "Non-conformance (issue)"
 msgstr "Non conformità (problema)"
 
 msgid "Non-Inventory"
-msgstr "Non-Inventario"
+msgstr "Non a magazzino"
 
 msgid "Non-Inventory Tracking"
-msgstr "Tracciamento Non-Inventario"
+msgstr "Tracciamento non a magazzino"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Conto spese non operative addebitato quando un cespite di questa classe viene venduto o demolito al di sotto del suo valore contabile netto."
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "Conto ricavi non operativi accreditato quando un cespite di questa classe viene venduto a un prezzo superiore al suo valore contabile netto."
+msgstr "Conto di proventi non operativi accreditato quando un'attività di questa classe viene venduta per un valore superiore al suo valore contabile netto."
 
 msgid "Non-Taxable Add-On Cost"
 msgstr "Costo Add-On Non Tassabile"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normale"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Non una tabella ma un saldo del libro mastro: il costo si accumula quando i materiali di lavoro vengono emessi e si cancella quando il lavoro viene ricevuto a magazzino."
+msgstr "Non è una tabella ma un saldo della contabilità generale: il costo si accumula man mano che i materiali dell'ordine di produzione vengono emessi e si azzera quando l'ordine viene ricevuto in magazzino."
 
 msgid "Not certified"
 msgstr "Non certificato"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Non ci sono abbastanza lavori per coprire la quantità"
+msgstr "Non ci sono abbastanza ordini di produzione per coprire la quantità"
 
 msgid "Not reached"
 msgstr "Non raggiunto"
@@ -10214,7 +10214,7 @@ msgid "Not started"
 msgstr "Non iniziato"
 
 msgid "Not started training for"
-msgstr "Non ha iniziato l'addestramento per"
+msgstr "Nessuna formazione iniziata per"
 
 msgid "Not yet"
 msgstr "Non ancora"
@@ -10290,7 +10290,7 @@ msgid "OEE Impact"
 msgstr "Impatto OEE"
 
 msgid "OEM (original equipment manufacturer)"
-msgstr "OEM (Original Equipment Manufacturer)"
+msgstr "OEM (Produttore di Attrezzature Originali)"
 
 msgid "of"
 msgstr "di"
@@ -10329,13 +10329,13 @@ msgid "On Hold"
 msgstr "In Sospeso"
 
 msgid "On Jobs"
-msgstr "Su Lavori"
+msgstr "Su Ordini di produzione"
 
 msgid "On order"
 msgstr "In ordine"
 
 msgid "On Production Demand"
-msgstr "In Domanda di Produzione"
+msgstr "Su Fabbisogno di Produzione"
 
 msgid "On Purchase Order"
 msgstr "In Ordine di Acquisto"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "L'inventario disponibile rimane"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "Valore disponibile per ubicazione o articolo, con riconciliazione contabile"
+msgstr "Valore a magazzino per ubicazione o articolo, con riconciliazione a contabilità generale"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "Valore disponibile dei beni fabbricati (articoli Make)"
@@ -10374,7 +10374,7 @@ msgid "On-time delivery"
 msgstr "Consegna puntuale"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "Un'esecuzione di un workflow, registrata passo dopo passo con i valori utilizzati e prodotti da ciascun passaggio, agendo sempre con i permessi del proprietario del workflow."
+msgstr "Un'esecuzione di un flusso di lavoro, registrata passo per passo con i valori che ogni passo ha utilizzato e prodotto, agendo sempre con i permessi del proprietario del flusso di lavoro."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
 msgstr "Un'unità seriale o un lotto che Carbon segue individualmente, portando il suo stato e gli attributi propri come una data di scadenza."
@@ -10383,10 +10383,10 @@ msgid "One set of numbers"
 msgstr "Un unico set di numeri"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Un passaggio nel routing di un lavoro, che denomina un processo e un centro di lavoro e porta i suoi propri tempi e tariffe di configurazione, lavoro e macchina."
+msgstr "Un passo nel ciclo di lavorazione di un ordine di produzione, che designa un processo e un centro di lavoro e dispone di propri tempi e tariffe di attrezzaggio, manodopera e tempo macchina."
 
 msgid "One system from quote to cash"
-msgstr "Un sistema dalla quotazione al pagamento"
+msgstr "Un sistema unico da offerta a incasso"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
 msgstr "Solo le procedure in bozza sono modificabili. Crea una nuova versione per modificare una procedura attiva o archiviata."
@@ -10431,10 +10431,10 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Apri un NCR per la disposizione MRB"
 
 msgid "Open AP"
-msgstr "AP aperto"
+msgstr "Debiti verso fornitori aperti"
 
 msgid "Open AR"
-msgstr "AR aperto"
+msgstr "Crediti verso clienti aperti"
 
 msgid "Open Audit Log"
 msgstr "Apri Registro di Audit"
@@ -10446,7 +10446,7 @@ msgid "Open Date"
 msgstr "Data di apertura"
 
 msgid "Open Dispatches"
-msgstr "Spedizioni Aperte"
+msgstr "Interventi di manutenzione aperti"
 
 msgid "Open in Carbon"
 msgstr "Apri in Carbon"
@@ -10464,10 +10464,10 @@ msgid "Open Issues"
 msgstr "Problemi Aperti"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Domanda di lavoro aperta più trasferimenti in sospeso da questo contenitore"
+msgstr "Fabbisogno aperto di ordini di produzione più trasferimenti in sospeso da questo contenitore"
 
 msgid "Open jobs"
-msgstr "Lavori aperti"
+msgstr "Ordini di produzione aperti"
 
 msgid "Open menu"
 msgstr "Apri menu"
@@ -10533,13 +10533,13 @@ msgid "Operating Expenses"
 msgstr "Spese Operative"
 
 msgid "Operating Income"
-msgstr "Utile operativo"
+msgstr "Proventi operativi"
 
 msgid "Operation"
 msgstr "Operazione"
 
 msgid "Operation lead time"
-msgstr "Tempo di consegna dell'operazione"
+msgstr "Lead time dell'operazione"
 
 msgid "Operation minimum cost"
 msgstr "Costo minimo dell'operazione"
@@ -10569,7 +10569,7 @@ msgid "Operations"
 msgstr "Operazioni"
 
 msgid "Operations / steps"
-msgstr "Operazioni / fasi"
+msgstr "Operazioni / Passi"
 
 msgid "Operations Type"
 msgstr "Tipo Operazioni"
@@ -10593,7 +10593,7 @@ msgid "Operators can use shared workstations with PIN authentication."
 msgstr "Gli operatori possono utilizzare workstation condivise con autenticazione PIN."
 
 msgid "Operators start on the Scan tab"
-msgstr "Gli operatori iniziano dalla scheda Scan"
+msgstr "Gli operatori iniziano dalla scheda Scansiona"
 
 msgid "Operators start the timer themselves when they begin an operation."
 msgstr "Gli operatori avviano il timer da soli quando iniziano un'operazione."
@@ -10602,7 +10602,7 @@ msgid "Opportunity"
 msgstr "Opportunità"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr "Ottimizzato per anteprime veloci — i download forniscono sempre il file originale caricato"
+msgstr "Ottimizzato per anteprime veloci — i download servono sempre il file caricato originale"
 
 msgid "Optional"
 msgstr "Facoltativo"
@@ -10648,7 +10648,7 @@ msgid "Order Multiple"
 msgstr "Multiplo d'Ordine"
 
 msgid "Order Parts"
-msgstr "Ordina Parti"
+msgstr "Ordina Componenti"
 
 msgid "Order Qty"
 msgstr "Quantità Ordine"
@@ -10687,13 +10687,13 @@ msgid "Other Expense"
 msgstr "Altre spese"
 
 msgid "Other Income"
-msgstr "Altre entrate"
+msgstr "Altri proventi"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "Account di Altro Reddito per guadagni in valuta estera quando un pagamento regola una fattura in valuta estera a un tasso più favorevole"
+msgstr "Conto altri proventi per guadagni FX quando un pagamento salda una fattura in valuta estera a un tasso più favorevole"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Account Altre Entrate per saldi fornitori liquidati senza pagamento completo al momento del regolamento dei Debiti verso Fornitori"
+msgstr "Conto altri proventi per saldi fornitori azzerati senza pagamento completo nella regolazione dei debiti verso fornitori"
 
 msgid "Other Type"
 msgstr "Altro Tipo"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Output"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "L'output non supera mai i suoi materiali grezzi. Ritorna alla durata fissa quando nessun input ha una data di scadenza."
+msgstr "L'output non supera mai le sue materie prime. Ricade alla durata fissa quando nessun input ha una data di scadenza."
 
 msgid "Outside operation"
 msgstr "Varianza Indiretta"
@@ -10723,7 +10723,7 @@ msgid "Overall result"
 msgstr "Risultato complessivo"
 
 msgid "Overdue"
-msgstr "Scaduto"
+msgstr "In ritardo"
 
 msgid "Overhead Absorption"
 msgstr "Assorbimento dei Costi Generali"
@@ -10732,34 +10732,34 @@ msgid "Overhead Absorption (default)"
 msgstr "Assorbimento dei Costi Generali (predefinito)"
 
 msgid "Overhead rate"
-msgstr "Tasso di overhead"
+msgstr "Tariffa dei costi generali"
 
 msgid "Overhead Rate"
-msgstr "Tasso di Overhead"
+msgstr "Tariffa dei Costi Generali"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "Tasso di Overhead (Orario)"
+msgstr "Tariffa dei Costi Generali (Oraria)"
 
 msgid "Overhead Variance"
-msgstr "Varianza Indiretta (predefinita)"
+msgstr "Scostamento dei Costi Generali"
 
 msgid "Overhead Variance (default)"
-msgstr "Proprietario (centro di costo)"
+msgstr "Scostamento dei Costi Generali (predefinito)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "L'override richiede l'autorizzazione inventory:update e una motivazione."
+msgstr "La forzatura richiede l'autorizzazione inventory:update e un motivo."
 
 msgid "Override Price"
-msgstr "Prezzo di Override"
+msgstr "Forzatura Prezzo"
 
 msgid "Override price for a single customer"
-msgstr "Sovrascrivi il prezzo per un singolo cliente"
+msgstr "Forzatura prezzo per un singolo cliente"
 
 msgid "Override price for all customers of a type"
-msgstr "Sovrascrivi il prezzo per tutti i clienti di un tipo"
+msgstr "Forzatura prezzo per tutti i clienti di un tipo"
 
 msgid "Override the expiration on {label}."
-msgstr "Sostituisci la scadenza su {label}."
+msgstr "Forza la scadenza su {label}."
 
 msgid "Overtime"
 msgstr "Straordinario"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "Sovrascrivi il metodo di produzione target con il metodo di quotazione"
 
 msgid "Owner"
-msgstr "Proprietario"
+msgstr "Responsabile"
 
 msgid "Owner (cost center)"
-msgstr "Centro di costo principale"
+msgstr "Responsabile (Centro di costo)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,13 +10814,13 @@ msgid "Params"
 msgstr "Parametri"
 
 msgid "Parent cost center"
-msgstr "pezzo"
+msgstr "Centro di costo padre"
 
 msgid "Parent Cost Center"
 msgstr "Centro di Costo Principale"
 
 msgid "Parent Department"
-msgstr "Dipartimento Principale"
+msgstr "Reparto padre"
 
 msgid "Parent Group"
 msgstr "Gruppo Padre"
@@ -10832,7 +10832,7 @@ msgid "Parent items. (If you click into one of the parent parts below, you'll se
 msgstr "Articoli padre. (Se fai clic su uno degli articoli padre di seguito, vedrai questo articolo incluso come componente nella distinta base.)"
 
 msgid "Parent Storage Unit"
-msgstr "Unità di Archiviazione Principale"
+msgstr "Unità di stoccaggio padre"
 
 msgid "Pareto by Type"
 msgstr "Pareto per Tipo"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Parcheggia come errore"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Parcheggia il journal con un avvertimento fino a quando il valore non è mappato"
+msgstr "Metti in sospeso la prima nota con un avviso fino al mappamento del valore"
 
 msgid "part"
 msgstr "pezzi"
@@ -10874,16 +10874,16 @@ msgid "Partners"
 msgstr "Partner"
 
 msgid "parts"
-msgstr "Debiti verso Fornitori"
+msgstr "componenti"
 
 msgid "Parts"
-msgstr "Parti"
+msgstr "Componenti"
 
 msgid "Parts & items"
-msgstr "Parti e articoli"
+msgstr "Componenti e articoli"
 
 msgid "Parts, materials, and how you classify them."
-msgstr "Parti, materiali e come li classifichi."
+msgstr "Componenti, materiali e come li classifichi."
 
 msgid "Party Type"
 msgstr "Tipo di Parte"
@@ -10916,10 +10916,10 @@ msgid "Payables"
 msgstr "Debiti verso Fornitori (predefinito)"
 
 msgid "Payables (AP)"
-msgstr "Debiti (AP)"
+msgstr "Debiti (Debiti verso fornitori)"
 
 msgid "Payables (default)"
-msgstr "termine di pagamento"
+msgstr "Debiti (predefinito)"
 
 msgid "Payables aging"
 msgstr "Invecchiamento dei debiti"
@@ -10937,22 +10937,22 @@ msgid "Payment ID"
 msgstr "ID Pagamento"
 
 msgid "payment term"
-msgstr "termini di pagamento"
+msgstr "condizioni di pagamento"
 
 msgid "Payment term"
-msgstr "Termine di pagamento"
+msgstr "Condizioni di pagamento"
 
 msgid "Payment Term"
 msgstr "Condizione di Pagamento"
 
 msgid "payment terms"
-msgstr "persone"
+msgstr "condizioni di pagamento"
 
 msgid "Payment Terms"
 msgstr "Condizioni di Pagamento"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "Termini di pagamento come Net 30 o pagamento alla ricezione"
+msgstr "Condizioni di pagamento come Netto 30 o pagamento al ricevimento"
 
 msgid "Payments"
 msgstr "Pagamenti"
@@ -10979,10 +10979,10 @@ msgid "PDF Watermark"
 msgstr "Filigrana PDF"
 
 msgid "Pending"
-msgstr "In sospeso"
+msgstr "In attesa"
 
 msgid "people"
-msgstr "Spesa di ammortamento periodico per immobilizzazioni"
+msgstr "personale"
 
 msgid "People"
 msgstr "Persone"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Per unità"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Sostituzione per riga della posizione di adempimento dell'intestazione dell'ordine; utilizzata per spedizioni frazionate e drop-ship."
+msgstr "Forzatura per riga dell'ubicazione di spedizione dell'ordine; utilizzata per spedizioni suddivise e consegne dirette."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Sostituzione per riga della posizione di consegna dell'intestazione del PO; utilizzata per consegne divise a più magazzini o spedizioni dirette."
+msgstr "Forzatura per riga dell'ubicazione di consegna dell'ordine d'acquisto; utilizzata per consegne suddivise a più depositi o consegne dirette."
 
 msgid "Percentage"
 msgstr "Percentuale"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "Politica di blocco del periodo"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Il prelievo offre entità tracciate in ordine di scadenza più prossima per primo, quindi lo stock in scadenza più vicina esce per primo per impostazione predefinita."
+msgstr "Spesa di ammortamento periodico per i cespiti"
 
 msgid "Permanently Delete"
 msgstr "Elimina definitivamente"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Durate delle fasi"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Eliminazione graduale di un articolo a favore di una parte successore, in modo che la pianificazione reindirizza la domanda dell'articolo precedente — moltiplicata per un fattore di conversione — a quella nuova."
+msgstr "Ritiro di un articolo a favore del suo successore, in modo che la pianificazione reindirizza il fabbisogno dell'articolo precedente — moltiplicato per un fattore di conversione — al successore."
 
 msgid "Phone"
 msgstr "Telefono"
@@ -11105,7 +11105,7 @@ msgid "Picking Lines"
 msgstr "Righe di prelievo"
 
 msgid "Picking list"
-msgstr "Elenco di prelievo"
+msgstr "Lista di prelievo"
 
 msgid "Picking List"
 msgstr "Lista di prelievo"
@@ -11114,13 +11114,13 @@ msgid "Picking List ID"
 msgstr "ID Lista di Prelievo"
 
 msgid "Picking List Notes"
-msgstr "Note Elenco Prelievo"
+msgstr "Note della lista di prelievo"
 
 msgid "Picking Lists"
-msgstr "Elenchi di prelievo"
+msgstr "Liste di prelievo"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Pianificato"
+msgstr "Il prelievo offre le entità tracciate con scadenza più prossima per prima, quindi la giacenza prossima alla scadenza esce per prima per impostazione predefinita."
 
 msgid "Pieces/Hour"
 msgstr "Pezzi/Ora"
@@ -11164,7 +11164,7 @@ msgid "Planned Order"
 msgstr "Ordine Pianificato"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "Ordine pianificato = suggerimento MRP per coprire la domanda prevista in base alla politica di riordino dell'articolo (o aggiunto manualmente)."
+msgstr "Ordine pianificato = proposta MRP per coprire il fabbisogno previsto in base alla politica di riordino dell'articolo (o aggiunto manualmente)."
 
 msgid "Planned purchase order"
 msgstr "Ordine d'acquisto pianificato"
@@ -11188,7 +11188,7 @@ msgid "Planning's upper bound on a single suggested replenishment; quantities ab
 msgstr "Limite superiore della pianificazione su un singolo rifornimento suggerito; le quantità al di sopra di questo sono divise in più ordini."
 
 msgid "Plants, warehouses"
-msgstr "Stabilimenti, magazzini"
+msgstr "Stabilimenti, depositi"
 
 msgid "Please contact your administrator to enable audit logging."
 msgstr "Contatta il tuo amministratore per abilitare la registrazione di audit."
@@ -11251,7 +11251,7 @@ msgid "Post Invoice"
 msgstr "Registra Fattura"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "Registra movimenti di diario con codici di conto e descrizione appropriati"
+msgstr "Registra inserimenti della prima nota con codici di conto e descrizione appropriati"
 
 msgid "Post Receipt"
 msgstr "Registra Ricevuta"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Pubblicato da"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "I giornali registrati con questi tipi di origine si sincronizzano sempre. Il riepilogo giornaliero raggruppa i giornali di un giorno in una voce del provider per conto."
+msgstr "Le prime note registrate con questi tipi di origine si sincronizzano sempre. Il riepilogo giornaliero raggruppa le prime note di un giorno in una voce provider per conto."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Registrato una volta, corretto {corrections} volte."
@@ -11290,10 +11290,10 @@ msgid "Posted once, no corrections."
 msgstr "Registrato una volta, nessuna correzione."
 
 msgid "Posting"
-msgstr "Anticipi"
+msgstr "Registrazione"
 
 msgid "Posting date"
-msgstr "Data di pubblicazione"
+msgstr "Data di registrazione"
 
 msgid "Posting Date"
 msgstr "Data di registrazione"
@@ -11305,16 +11305,16 @@ msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pre-compilato per un nuovo articolo quando la scadenza è Durata Fissa."
 
 msgid "Preferred Supplier"
-msgstr "Fornitore Preferito"
+msgstr "Fornitore preferenziale"
 
 msgid "Prefix"
 msgstr "Prefisso"
 
 msgid "Prepayments"
-msgstr "Anticipi (predefinito)"
+msgstr "Acconti"
 
 msgid "Prepayments (default)"
-msgstr "Azione preventiva"
+msgstr "Acconti (predefinito)"
 
 msgid "Present Week"
 msgstr "Settimana corrente"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "Prec"
 
 msgid "Preventive action"
-msgstr "Conto principale per la valutazione dell'inventario disponibile"
+msgstr "Azione preventiva"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "Programmi di manutenzione preventiva per le vostre apparecchiature"
+msgstr "Programmi di manutenzione preventiva per il tuo impianto"
 
 msgid "Preview"
 msgstr "Anteprima"
@@ -11357,7 +11357,7 @@ msgid "Price break actions"
 msgstr "Azioni di scaglione di prezzo"
 
 msgid "Price Break History"
-msgstr "Storico Scaglioni di Prezzo"
+msgstr "Cronologia scaglioni di prezzo"
 
 msgid "Price Breaks"
 msgstr "Scaglioni di Prezzo"
@@ -11372,13 +11372,13 @@ msgid "Price Lists"
 msgstr "Listini Prezzi"
 
 msgid "Price override"
-msgstr "Override del prezzo"
+msgstr "Forzatura del prezzo"
 
 msgid "Prices"
 msgstr "Prezzi"
 
 msgid "Pricing"
-msgstr "Prezzi"
+msgstr "Determinazione dei prezzi"
 
 msgid "Pricing rule"
 msgstr "Regola di determinazione del prezzo"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "Regole di Prezzo"
 
 msgid "Pricing Trace"
-msgstr "Traccia Prezzi"
+msgstr "Traccia della determinazione dei prezzi"
 
 msgid "Primary cash account for bank transactions"
-msgstr "procedura"
+msgstr "Conto cassa primario per le transazioni bancarie"
 
 msgid "Print"
 msgstr "Stampa"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "Stampa {0} Etichette"
 
 msgid "Print Jobs"
-msgstr "Lavori di stampa"
+msgstr "Stampa ordini di produzione"
 
 msgid "Print Label"
 msgstr "Stampa Etichetta"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Procedura"
 
 msgid "procedures"
-msgstr "processo"
+msgstr "procedure"
 
 msgid "Procedures"
 msgstr "Procedure"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Quantità di Produzione"
 
 msgid "Production variance"
-msgstr "Domanda proiettata esplosa da distinte base e previsioni."
+msgstr "Scostamento di produzione"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Produzione: app shop-floor e pianificazione"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "Progetto"
 
 msgid "Project owner"
-msgstr "Proprietario del progetto"
+msgstr "Responsabile del progetto"
 
 msgid "Project Plan"
 msgstr "Piano di Progetto"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Inizio progetto"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Inventario Proiettato"
+msgstr "Fabbisogno previsto esploso da BOM e previsioni."
 
 msgid "Projected inventory"
 msgstr "Disponibile Proiettato"
@@ -11543,14 +11543,14 @@ msgstr "Stock previsto"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Proiettato a scendere sotto lo stock di sicurezza la settimana del {0}"
+msgstr "Rottura di stock prevista nella settimana del {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
-msgstr "Proiettato a rimanere al di sopra dello stock di sicurezza"
+msgstr "Previsto il calo sotto la scorta di sicurezza nella settimana del {0}"
 
 msgid "Projected to stay above safety stock"
-msgstr "Ordine di Acquisto"
+msgstr "Previsto di restare sopra la scorta di sicurezza"
 
 msgid "Projection"
 msgstr "Proiezione"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Pubblicato da Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versione Pubblicata"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Le versioni pubblicate non possono essere modificate. Sfoglia in sola lettura o crea una nuova versione per apportare modifiche."
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "Estrai dalla contabilità"
 
 msgid "Pull from Inventory"
-msgstr "Preleva da Inventario"
+msgstr "Preleva da magazzino"
 
 msgid "Pull, map, and load your data"
 msgstr "Estrai, mappa e carica i tuoi dati"
@@ -11653,7 +11653,7 @@ msgid "Purchase Invoices"
 msgstr "Fatture di Acquisto"
 
 msgid "Purchase order"
-msgstr "Varianza di Prezzo di Acquisto"
+msgstr "Ordine di acquisto"
 
 msgid "Purchase Order"
 msgstr "Ordine di Acquisto"
@@ -11692,13 +11692,13 @@ msgid "Purchase planning"
 msgstr "Pianificazione degli acquisti"
 
 msgid "Purchase price variance"
-msgstr "Varianza di Prezzo di Acquisto"
+msgstr "Scostamento di prezzo di acquisto"
 
 msgid "Purchase Price Variance"
-msgstr "Varianza di Prezzo di Acquisto (predefinita)"
+msgstr "Scostamento di Prezzo di Acquisto"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Imposta di Acquisto Pagabile"
+msgstr "Scostamento di Prezzo di Acquisto (default)"
 
 msgid "Purchase Qty"
 msgstr "Quantità Acquisto"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "Imposta di Acquisto Pagabile (predefinita)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "acquisti"
+msgstr "Imposta di Acquisto Pagabile (default)"
 
 msgid "Purchase to Order"
-msgstr "Acquisto su ordinazione"
+msgstr "Acquisto su commessa"
 
 msgid "Purchase Unit of Measure"
 msgstr "Unità di Misura di Acquisto"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Invia le modifiche dei record ai sistemi esterni nel momento in cui si verificano."
 
 msgid "Push the journal without the dimension"
-msgstr "Contabilizza il journal senza la dimensione"
+msgstr "Registra la prima nota senza la dimensione"
 
 msgid "Push to accounting"
 msgstr "Invia alla contabilità"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Qtà. Scartata"
 
 msgid "quality"
-msgstr "Quotazione a Pagamento"
+msgstr "qualità"
 
 msgid "Quality"
 msgstr "Qualità"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "Tipo di Qualità"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "Qualità: ispezioni, non conformità, CAPA"
+msgstr "Qualità: controlli, non conformità, CAPA"
 
 msgid "Quantities"
 msgstr "Quantità"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Quantità in arrivo: su ordini d'acquisto aperti più su ordini di produzione (fabbricazione)."
 
 msgid "Quantity Breaks"
-msgstr "Fasce di Quantità"
+msgstr "Scaglioni di Quantità"
 
 msgid "Quantity complete"
 msgstr "Quantità completa"
@@ -11840,13 +11840,13 @@ msgid "Quantity must be greater than 0"
 msgstr "La quantità deve essere maggiore di 0"
 
 msgid "Quantity on hand"
-msgstr "Quantità a magazzino"
+msgstr "Quantità in giacenza"
 
 msgid "Quantity on Hand"
-msgstr "Quantità in magazzino"
+msgstr "Quantità in giacenza"
 
 msgid "Quantity on Jobs"
-msgstr "Quantità nei Lavori"
+msgstr "Quantità su Ordini di Produzione"
 
 msgid "Quantity on Purchase Order"
 msgstr "Quantità in Ordine di Acquisto"
@@ -11858,10 +11858,10 @@ msgid "Quantity Per Job"
 msgstr "Quantità Per Lavoro"
 
 msgid "Quantity per Parent"
-msgstr "Quantità per Genitore"
+msgstr "Quantità per padre"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Quantità fisicamente presente sull'unità di stoccaggio (scaffale) assegnata al materiale. Diventa rossa quando è inferiore a ciò che tale unità deve fornire."
+msgstr "Quantità fisicamente presente nell'unità di stoccaggio assegnata del materiale (scaffale). Diventa rossa quando è inferiore a ciò che l'unità ha bisogno di fornire."
 
 msgid "Quantity Range"
 msgstr "Intervallo di Quantità"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Tipo di Quantità"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Livelli di prezzo basati sulla quantità per questo override; il prezzo unitario applicato è la riga con la quantità minima più grande che soddisfa la riga dell'ordine."
+msgstr "Scaglioni di prezzo basati sulla quantità per questa forzatura; il prezzo unitario applicato è la riga con la quantità minima più grande che la riga dell'ordine soddisfa."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11916,10 +11916,10 @@ msgid "Quote line"
 msgstr "Riga offerta"
 
 msgid "Quote Line"
-msgstr "Riga di Preventivo"
+msgstr "Riga offerta"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "Righe di preventivo la cui distinta base include questo articolo"
+msgstr "Righe offerta la cui distinta base include questo articolo"
 
 msgid "Quote Location"
 msgstr "Ubicazione Preventivo"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Numero Preventivo"
 
 msgid "Quote to cash"
-msgstr "Crediti verso Clienti"
+msgstr "Dalla offerta al pagamento"
 
 msgid "Quote Type"
 msgstr "Tipo di Preventivo"
@@ -12006,7 +12006,7 @@ msgid "Ready"
 msgstr "Pronto"
 
 msgid "Ready for Quote"
-msgstr "Pronto per Preventivo"
+msgstr "Pronto per offerta"
 
 msgid "ready to keep or revert"
 msgstr "pronto per mantenere o ripristinare"
@@ -12075,16 +12075,16 @@ msgid "Receipts"
 msgstr "Ricevute"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Le ricevute, le spedizioni, le fatture di vendita, le fatture di acquisto, i pagamenti e le note di credito/debito che sono ancora in Bozza o in Sospeso devono essere registrate o annullate — sia i documenti datati in questo periodo che i documenti non datati che riceveranno una data quando registrati. Finché non vengono registrati, i loro importi non sono nella contabilità generale, quindi il periodo sarebbe sottodimensionato."
+msgstr "Le entrate merci, le spedizioni, le fatture di vendita, le fatture di acquisto, i pagamenti e le note di credito/debito che sono ancora in Bozza o In attesa devono essere registrate o stornate — sia i documenti datati in questo periodo che i documenti senza data che riceverebbero una data al momento della registrazione. Fino a quando non vengono registrati, i loro importi non sono nella contabilità generale, quindi il periodo risulterebbe sottostimato."
 
 msgid "Receivables"
 msgstr "Crediti verso Clienti (predefinito)"
 
 msgid "Receivables (AR)"
-msgstr "Crediti (AR)"
+msgstr "Crediti verso clienti (AR)"
 
 msgid "Receivables (default)"
-msgstr "Riconciliazione di un ordine di acquisto con quanto ricevuto e fatturato — implicito in Carbon, tramite le quantità di riga e il saldo GR/IR."
+msgstr "Crediti (default)"
 
 msgid "Receivables aging"
 msgstr "Invecchiamento crediti"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "Quantità Ricevuta"
 
 msgid "Receiving Location"
-msgstr "Ubicazione di ricezione"
+msgstr "Ubicazione di ricevimento"
 
 msgid "Recent"
 msgstr "Recenti"
@@ -12145,7 +12145,7 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "La riconciliazione ha riscontrato discrepanze con il provider"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Periodo di Recupero"
+msgstr "Riconciliazione di un ordine di acquisto rispetto a ciò che è stato ricevuto e fatturato — implicito in Carbon, tramite le quantità di riga e il saldo GR/IR."
 
 msgid "Record"
 msgstr "Registra"
@@ -12154,25 +12154,25 @@ msgid "Record a credit or debit memo against a customer or supplier. Application
 msgstr "Registra una nota di credito o di debito contro un cliente o fornitore. Le applicazioni a fatture specifiche vengono aggiunte dopo la creazione della nota."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Registra il denaro ricevuto da un cliente (Ricevuta) o pagato a un fornitore (Versamento). Le applicazioni a fatture specifiche vengono aggiunte dopo la creazione del pagamento."
+msgstr "Registra denaro ricevuto da un cliente o pagato a un fornitore. Le applicazioni a fatture specifiche vengono aggiunte dopo la creazione del pagamento."
 
 msgid "Record deleted"
 msgstr "Record eliminato"
 
 msgid "Record inspections tied to a part and a job"
-msgstr "Registra ispezioni collegate a una parte e a un lavoro"
+msgstr "Registra i controlli legati a un componente e a un ordine di produzione"
 
 msgid "Record type"
 msgstr "Tipo di record"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Registrato in una taratura che l'indicatore ha bisogno di riparazione prima che le sue letture possano essere affidabili."
+msgstr "Registrato su una taratura che lo strumento di misura necessita di riparazione prima che i suoi valori possano essere considerati affidabili."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Registrato che il follow-up è necessario dopo questa calibrazione; mostra questo indicatore nella coda delle azioni aperte."
+msgstr "Registrato che il follow-up è necessario dopo questa taratura; visualizza questo strumento di misura nella coda delle azioni aperte."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Registrato che l'indicatore è stato regolato durante questa calibrazione; influisce sul ricalcolo dell'intervallo di calibrazione."
+msgstr "Registrato che lo strumento di misura è stato regolato durante questa taratura; influisce su come l'intervallo di taratura si ricalcola."
 
 msgid "Records"
 msgstr "Registri"
@@ -12199,7 +12199,7 @@ msgid "Regenerate thumbnail from the 3D model"
 msgstr "Rigenerare la miniatura dal modello 3D"
 
 msgid "Regenerating thumbnail…"
-msgstr "Rigenerazione dell'anteprima…"
+msgstr "Rigenerazione miniatura in corso…"
 
 msgid "Register"
 msgstr "Registrare Attivo Esistente"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Registrato"
 
 msgid "Registered"
-msgstr "Punto di Riordino"
+msgstr "Registrato"
 
 msgid "Registration failed"
 msgstr "Registrazione non riuscita"
@@ -12335,7 +12335,7 @@ msgid "Remove sort by column"
 msgstr "Rimuovi ordinamento per colonna"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Rimuovi questo tipo di archiviazione da tutte le unità di archiviazione che lo referenziano ed eliminalo. Questa azione non può essere annullata."
+msgstr "Rimuovi questo tipo di stoccaggio da tutte le unità di stoccaggio che lo referenziano ed eliminalo. Questa azione non può essere annullata."
 
 msgid "Remove tool"
 msgstr "Rimuovi strumento"
@@ -12396,7 +12396,7 @@ msgid "Reordering Policy"
 msgstr "Politica di Riordino"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Riordina solo la sequenza di spedizione e il centro di lavoro — non ripianifica. Cambia le date nella bacheca delle date."
+msgstr "Riordina solo la sequenza di intervento e il centro di lavoro — non riprogramma. Modifica le date sulla bacheca Dates."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Si ripete una volta per ogni elemento in {inputLabel}"
@@ -12420,10 +12420,10 @@ msgid "Replenishment"
 msgstr "Rifornimento"
 
 msgid "Replenishment system"
-msgstr "Sistema di reintegro"
+msgstr "Sistema di approvvigionamento"
 
 msgid "Replenishment System"
-msgstr "Sistema di Rifornimento"
+msgstr "Sistema di approvvigionamento"
 
 msgid "Report"
 msgstr "Rapporto"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "Azioni Richieste (in ordine)"
 
 msgid "Required Date"
-msgstr "Data Richiesta"
+msgstr "Data fabbisogno"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Richiesto in un ambiente controllato — i registri di audit non possono essere disattivati."
@@ -12507,7 +12507,7 @@ msgid "Requires Action"
 msgstr "Richiede Azione"
 
 msgid "Requires Adjustment"
-msgstr "Richiede Regolazione"
+msgstr "Richiede rettifica"
 
 msgid "Requires Repair"
 msgstr "Richiede Riparazione"
@@ -12516,7 +12516,7 @@ msgid "Reserve floor"
 msgstr "Limite di riserva"
 
 msgid "Reserved"
-msgstr "Riservato"
+msgstr "Impegnato"
 
 msgid "Reset"
 msgstr "Ripristina"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Ripristina dal Cestino"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Ripristina questa entità al magazzino disponibile nel bin e al costo da cui è stata scartata."
+msgstr "Ripristina questa entità alle giacenze disponibili nel contenitore e al costo da cui è stata scartata."
 
 msgid "Restore tracked entities to available"
 msgstr "Ripristina le entità tracciate come disponibili"
@@ -12622,16 +12622,16 @@ msgid "Revenue and expenses over a period"
 msgstr "Ricavi e spese in un periodo"
 
 msgid "Reverse all inventory adjustments"
-msgstr "Annulla tutti gli adeguamenti dell'inventario"
+msgstr "Inverti tutte le rettifiche di magazzino"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "Storna tutti i movimenti di giornale e di contabilità analitica"
+msgstr "Inverti tutte le voci della prima nota e del conto di costo"
 
 msgid "Reverse any item ledger entries from this invoice"
 msgstr "Storna qualsiasi voce di ledger articoli da questa fattura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Inversione contabile"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposta di vendita con inversione contabile"
@@ -12640,7 +12640,7 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "Imposta di vendita con inversione contabile (predefinito)"
 
 msgid "Reverse the related journal entries"
-msgstr "Storna le relative registrazioni contabili"
+msgstr "Inverti le voci della prima nota correlate"
 
 msgid "Reversed"
 msgstr "Stornato"
@@ -12655,16 +12655,16 @@ msgid "Review"
 msgstr "Revisione"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "Rivedi i cambiamenti di ogni elemento, poi conferma — il rilascio non può essere annullato."
+msgstr "Rivedi le modifiche di ogni articolo, quindi conferma — il rilascio non può essere annullato."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Rivedi il bilancio e il conto economico del periodo e conferma che i dati sembrino corretti. Questo è un completamento manuale — contrassegnalo come eseguito una volta revisionati."
+msgstr "Rivedi lo stato patrimoniale e il conto economico del periodo e conferma che i dati siano corretti. Si tratta di un'autorizzazione manuale — segna come fatto dopo averli revisionati."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "Esamina gli abbinamenti suggeriti prima di applicare. Questi sono il miglior tentativo — conferma che ciascuno sia corretto."
+msgstr "Rivedi gli abbinamenti suggeriti prima di applicare. Si tratta di ipotesi — conferma che ciascuno sia corretto."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Rivedi gli avvisi di seguito, quindi pubblica il conteggio per applicare gli aggiustamenti."
+msgstr "Rivedi gli avvisi di seguito, quindi registra il conteggio per applicare le rettifiche."
 
 msgid "Revision"
 msgstr "Revisione"
@@ -12695,7 +12695,7 @@ msgid "RFQ"
 msgstr "RFQ"
 
 msgid "RFQ (request for quote)"
-msgstr "RFQ (richiesta di preventivo)"
+msgstr "RdO (richiesta di offerta)"
 
 msgid "RFQ Date"
 msgstr "Data RFQ"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "RFQ"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Trasporta le dimensioni Carbon insieme nei journal contabilizzati. Ogni slot mappa una dimensione Carbon a un target di analisi provider; il mapping dei valori sottostante associa i singoli valori di dimensione alle opzioni provider."
+msgstr "Converti le dimensioni Carbon nelle prime note inviate. Ogni slot mappa una dimensione Carbon a un obiettivo di analisi del provider; il mapping dei valori di seguito associa i valori delle singole dimensioni alle opzioni del provider."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "Conto di arrotondamento (predefinito)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Instrada tutti i fatture AP a un indirizzo (ad es. sede centrale) invece di singoli acquirenti."
+msgstr "Instrada tutte le fatture di acquisto a un indirizzo (ad es. sede centrale) invece che ai singoli acquirenti."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Instrada tutti i fatture AR a un indirizzo (ad es. sede centrale) invece di singole sedi."
+msgstr "Instrada tutte le fatture di vendita a un indirizzo (ad es. sede centrale) invece che alle singole ubicazioni."
 
 msgid "Routing"
-msgstr "Ciclo di lavoro"
+msgstr "Ciclo di lavorazione"
 
 msgid "rows"
 msgstr "righe"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Esegui la checklist di accettazione fino al superamento"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Gestisci il reparto su tablet: registra il lavoro, segnala i progressi, visualizza le istruzioni"
+msgstr "Gestisci il reparto su tablet: registra la manodopera, comunica i progressi, visualizza le istruzioni"
 
 msgid "Run this workflow now?"
 msgstr "Eseguire questo workflow ora?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "In esecuzione"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "Inventario aggiornato dopo la domanda e l'offerta di ogni settimana — la linea."
+msgstr "Giacenza corrente dopo la copertura e il fabbisogno di ogni settimana — la riga."
 
 msgid "Running Total"
 msgstr "Totale Progressivo"
@@ -12867,17 +12867,17 @@ msgid "S-4 (finest special)"
 msgstr "S-4 (speciale più fine)"
 
 msgid "Safety stock"
-msgstr "Stock di sicurezza"
+msgstr "Scorta di sicurezza"
 
 msgid "Safety Stock"
-msgstr "Stock di Sicurezza"
+msgstr "Scorta di sicurezza"
 
 #. placeholder {0}: numberFormatter.format(safetyStockValue)
 msgid "Safety stock ({0})"
-msgstr "Stock di sicurezza ({0})"
+msgstr "Scorta di sicurezza ({0})"
 
 msgid "Safety Stock:"
-msgstr "Stock di Sicurezza:"
+msgstr "Scorta di sicurezza:"
 
 msgid "Sale Price"
 msgstr "Prezzo di Vendita"
@@ -12898,7 +12898,7 @@ msgid "Sales & Revenue"
 msgstr "Vendite e ricavi"
 
 msgid "Sales contact"
-msgstr "Contatto commerciale"
+msgstr "Contatto vendite"
 
 msgid "Sales Contact"
 msgstr "Contatto Vendite"
@@ -13066,7 +13066,7 @@ msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator 
 msgstr "Scansiona questo codice QR con la tua app autenticatore (ad es. Google Authenticator o 1Password), quindi inserisci il codice a 6 cifre che mostra."
 
 msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
-msgstr "Scannerizza questo con la tua app autenticatore, quindi inserisci il codice a 6 cifre che mostra."
+msgstr "Scansiona questo con la tua app di autenticazione, quindi inserisci il codice a 6 cifre che mostra."
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -13078,7 +13078,7 @@ msgid "Schedule"
 msgstr "Pianificazione"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Pianifica i lavori in base alla capacità del centro di lavoro"
+msgstr "Programma gli ordini di produzione rispetto alla capacità dei centri di lavoro"
 
 msgid "Schedule Name"
 msgstr "Nome Pianificazione"
@@ -13132,16 +13132,16 @@ msgid "Scrap Quantity Per Job"
 msgstr "Quantità di Scarto Per Lavoro"
 
 msgid "scrap reason"
-msgstr "Motivo dello scarto"
+msgstr "causale di scarto"
 
 msgid "Scrap Reason"
-msgstr "Motivo dello Scarto"
+msgstr "Causale di scarto"
 
 msgid "scrap reasons"
-msgstr "Motivi dello scarto"
+msgstr "causali di scarto"
 
 msgid "Scrap Reasons"
-msgstr "Motivi di Scarto"
+msgstr "Causali di scarto"
 
 msgid "Scrapped"
 msgstr "Scartato"
@@ -13198,7 +13198,7 @@ msgid "Search operators..."
 msgstr "Cerca operatori..."
 
 msgid "Search parts..."
-msgstr "Cerca parti…"
+msgstr "Cerca componenti..."
 
 msgid "Search processes..."
 msgstr "Cerca processi..."
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "Seleziona un documento"
 
 msgid "Select a new owner"
-msgstr "Seleziona un nuovo proprietario"
+msgstr "Seleziona un nuovo responsabile"
 
 msgid "Select a new parent group for this account."
 msgstr "Seleziona un nuovo gruppo principale per questo account."
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "Seleziona un preventivo"
 
 msgid "Select a quote line"
-msgstr "Seleziona una riga di preventivo"
+msgstr "Seleziona una riga offerta"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "Seleziona un motivo per cui l'offerta non è stata creata."
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Seleziona campo"
 
 msgid "Select Gauge"
-msgstr "Seleziona Calibro"
+msgstr "Seleziona strumento di misura"
 
 msgid "Select groups or individuals"
 msgstr "Seleziona gruppi o individui"
@@ -13418,10 +13418,10 @@ msgid "Select surfaces"
 msgstr "Seleziona superfici"
 
 msgid "Select the groups that should complete this training"
-msgstr "Seleziona i gruppi che devono completare questo training"
+msgstr "Seleziona i gruppi che dovrebbero completare questa formazione"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Seleziona le fatture che questo pagamento regola. Lo sconto e la cancellazione sono nella valuta della fattura."
+msgstr "Seleziona le fatture che questo pagamento liquida. Lo sconto e lo stralcio sono nella valuta della fattura."
 
 msgid "Select value"
 msgstr "Seleziona valore"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Gestito autonomamente"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Self-hosted o gestito"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Onboarding autonomo"
 
 msgid "Self-paced"
 msgstr "Autonomo"
@@ -13527,7 +13527,7 @@ msgid "Serial/Batch #"
 msgstr "Seriale/Lotto #"
 
 msgid "Serialize & sell your parts"
-msgstr "Serializza e vendi i tuoi articoli"
+msgstr "Serializza e vendi i tuoi componenti"
 
 msgid "service"
 msgstr "servizio"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Imposta un obiettivo"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Configura Carbon in base a come funziona la tua azienda: siti, parti, distinte base, ciclo di lavorazione e i flussi che utilizzi."
+msgstr "Configura Carbon in base al modo in cui opera la tua azienda: ubicazioni, componenti, BOM, Lista delle operazioni e i flussi che utilizzi."
 
 msgid "Set Clock Out"
-msgstr "Imposta Uscita"
+msgstr "Imposta Timbra fine"
 
 msgid "Set clock-out time"
 msgstr "Imposta ora di uscita"
@@ -13572,7 +13572,7 @@ msgid "Set Console PIN"
 msgstr "Imposta PIN Console"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Imposta percentuali di markup predefinite per ogni categoria di costo su nuove righe di preventivo"
+msgstr "Imposta percentuali di ricarico predefinite per ogni categoria di costo nelle nuove righe offerta"
 
 msgid "Set demand projection values for each week"
 msgstr "Imposta i valori di proiezione della domanda per ogni settimana"
@@ -13581,7 +13581,7 @@ msgid "Set due date"
 msgstr "Imposta data di scadenza"
 
 msgid "Set Pricing"
-msgstr "Imposta Prezzi"
+msgstr "Imposta Determinazione dei prezzi"
 
 msgid "Set Quantity"
 msgstr "Imposta Quantità"
@@ -13609,7 +13609,7 @@ msgid "Set Version {0} as Active Version?"
 msgstr "Imposta la versione {0} come versione attiva?"
 
 msgid "Set your default location in profile settings to pick a storage unit."
-msgstr "Imposta la tua posizione predefinita nelle impostazioni del profilo per selezionare un'unità di archiviazione."
+msgstr "Imposta la tua ubicazione predefinita nelle impostazioni del profilo per scegliere un'unità di stoccaggio."
 
 msgid "Settings"
 msgstr "Impostazioni"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Mappa di configurazione"
 
 msgid "Setup time"
-msgstr "Tempo di setup"
+msgstr "tempo di attrezzaggio"
 
 msgid "Setup Time"
-msgstr "Tempo di Configurazione"
+msgstr "Tempo di attrezzaggio"
 
 msgid "Setup unit"
 msgstr "Unità di setup"
@@ -13687,7 +13687,7 @@ msgid "Shelf Life (Days)"
 msgstr "Durata di Conservazione (Giorni)"
 
 msgid "Shelf Life Start Process"
-msgstr "Processo di Inizio Shelf Life"
+msgstr "Processo di inizio della durata di conservazione"
 
 msgid "Shelf-Life"
 msgstr "Durata di Conservazione"
@@ -13735,7 +13735,7 @@ msgid "Shipment Line"
 msgstr "Riga di Spedizione"
 
 msgid "Shipment Lines"
-msgstr "Righe di spedizione"
+msgstr "Righe spedizione"
 
 msgid "Shipment Location"
 msgstr "Ubicazione della spedizione"
@@ -13753,7 +13753,7 @@ msgid "Shipping Contact"
 msgstr "Contatto di spedizione"
 
 msgid "Shipping Cost"
-msgstr "Costo di Spedizione"
+msgstr "Spese di spedizione"
 
 msgid "Shipping Customer"
 msgstr "Cliente di spedizione"
@@ -13777,7 +13777,7 @@ msgid "Shipping Methods"
 msgstr "Metodi di Spedizione"
 
 msgid "Shipping Notes"
-msgstr "Note di Spedizione"
+msgstr "Note di spedizione"
 
 msgid "Shipping Supplier"
 msgstr "Fornitore di spedizione"
@@ -13786,13 +13786,13 @@ msgid "Shipping:"
 msgstr "Spedizione:"
 
 msgid "Shop Floor"
-msgstr "Reparto Produzione"
+msgstr "Officina"
 
 msgid "Shop Floor and Scheduling"
-msgstr "Reparto Produzione e Pianificazione"
+msgstr "Officina e Pianificazione"
 
 msgid "Shop Floor leads, Planner"
-msgstr "Responsabili del reparto produttivo, Pianificatore"
+msgstr "Responsabili dell'Officina, Pianificatore"
 
 msgid "Shop-floor app and scheduling"
 msgstr "App del reparto e pianificazione"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Visualizzazione delle prime 500 righe"
 
 msgid "Showing the newest 200 journals"
-msgstr "Mostrando i 200 giornali più recenti"
+msgstr "Visualizzazione delle ultime 200 prime note"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Visualizzazione dei primi 1.000 gruppi per importo"
@@ -13868,10 +13868,10 @@ msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Mostrato come sfondo tenue dietro ogni pagina dei PDF generati"
 
 msgid "Shown to the user when this rule fails."
-msgstr "Mostrato all'utente quando questa regola non riesce."
+msgstr "Mostrato all'utente quando questa regola fallisce."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Accedi a Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Accedi con biometrica invece di un magic link. Le passkey sono protette da Face ID, Touch ID o dal PIN del tuo dispositivo."
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "Solutions Engineer"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "Alcune righe estratte dal PDF non potevano essere mappate automaticamente ai tuoi articoli di inventario. Rivedi e mappa ogni riga di seguito."
+msgstr "Alcune righe estratte dal PDF non potevano essere mappate automaticamente ai tuoi articoli. Rivedi e mappa ogni riga di seguito."
 
 msgid "Something went wrong. Please try again."
 msgstr "Qualcosa è andato storto. Riprova."
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "Dividi riga spedizione"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configura l'hosting"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "Fattore standard"
 
 msgid "Standard Lead Time"
-msgstr "Tempo di consegna standard"
+msgstr "Lead time ordinario"
 
 msgid "Start"
 msgstr "Avvia"
@@ -14130,7 +14130,7 @@ msgid "Start Now"
 msgstr "Inizia Ora"
 
 msgid "Start of Fiscal Year"
-msgstr "Inizio dell'anno fiscale"
+msgstr "Inizio dell'esercizio fiscale"
 
 msgid "Start of Tax Year"
 msgstr "Inizio dell'anno fiscale"
@@ -14202,7 +14202,7 @@ msgid "Steps are inherited from the assembly instruction."
 msgstr "I passaggi vengono ereditati dalle istruzioni di montaggio."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "I passaggi sono ereditati dal piano di ispezione."
+msgstr "I passi sono ereditati dal piano di controllo."
 
 msgid "Stock movement corrected"
 msgstr "Movimento di magazzino corretto"
@@ -14211,10 +14211,10 @@ msgid "Stock Transfer ID"
 msgstr "ID Trasferimento Magazzino"
 
 msgid "Stock Transfer Lines"
-msgstr "Righe di Trasferimento Magazzino"
+msgstr "Righe di trasferimento"
 
 msgid "Stock Transfer Notes"
-msgstr "Note di Trasferimento Giacenze"
+msgstr "Note di trasferimento"
 
 msgid "Stock Transfer Wizard"
 msgstr "Procedura guidata trasferimento stock"
@@ -14230,7 +14230,7 @@ msgid "Stocked for spares only."
 msgstr "Immagazzinato solo per ricambi."
 
 msgid "Stockout"
-msgstr "Esaurimento scorte"
+msgstr "Rottura di stock"
 
 msgid "Stop raising purchase orders after this date"
 msgstr "Smetti di creare ordini di acquisto dopo questa data"
@@ -14257,10 +14257,10 @@ msgid "Storage Types"
 msgstr "Tipi di Archiviazione"
 
 msgid "storage unit"
-msgstr "unità di archiviazione"
+msgstr "unità di stoccaggio"
 
 msgid "Storage unit"
-msgstr "Unità di archiviazione"
+msgstr "Unità di stoccaggio"
 
 msgid "Storage Unit"
 msgstr "Unità di Stoccaggio"
@@ -14269,7 +14269,7 @@ msgid "Storage Unit (optional)"
 msgstr "Unità di Stoccaggio (facoltativo)"
 
 msgid "storage units"
-msgstr "unità di archiviazione"
+msgstr "unità di stoccaggio"
 
 msgid "Storage Units"
 msgstr "Unità di Stoccaggio"
@@ -14284,22 +14284,22 @@ msgid "Store a fixed number of days on this item. Expiry start date is set on ea
 msgstr "Memorizza un numero fisso di giorni su questo articolo. La data di inizio della scadenza viene impostata su ogni lotto o seriale quando viene ricevuto."
 
 msgid "Straight line"
-msgstr "Lineare"
+msgstr "quote costanti"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe ha già un cliente con questo indirizzo email"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Data di scadenza Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe invia l'email della fattura al cliente, quindi è richiesto un indirizzo. Questo sarà anche salvato al contatto in Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe non ha ancora un cliente per questo cliente Carbon. La registrazione ne creerà uno nel tuo account connesso."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Stile dell'output kanban da mostrare nella tabella Kanban"
@@ -14314,10 +14314,10 @@ msgid "Subassembly"
 msgstr "Sottoassembly"
 
 msgid "Subcontracting Variance"
-msgstr "Varianza di Terziarizzazione"
+msgstr "Scostamento di subfornitura"
 
 msgid "Subcontracting Variance (default)"
-msgstr "Varianza di Terziarizzazione (predefinita)"
+msgstr "Scostamento di subappalto (impostazione predefinita)"
 
 msgid "Subject"
 msgstr "Oggetto"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "Invia per approvazione"
 
 msgid "Submit Inspection"
-msgstr "Invia Ispezione"
+msgstr "Invia controllo"
 
 msgid "Submitted By"
 msgstr "Inviato da"
@@ -14395,13 +14395,13 @@ msgid "Suggested orders you haven't placed yet."
 msgstr "Ordini suggeriti che non hai ancora effettuato."
 
 msgid "Suggestion"
-msgstr "Suggerimento"
+msgstr "Proposta"
 
 msgid "Suggestion Notifications"
-msgstr "Notifiche di suggerimento"
+msgstr "Notifiche proposte"
 
 msgid "Suggestions"
-msgstr "Suggerimenti"
+msgstr "Proposte"
 
 msgid "Sunday"
 msgstr "Domenica"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Parte Fornitore"
 
 msgid "Supplier Part ID"
-msgstr "ID Parte Fornitore"
+msgstr "Codice articolo fornitore"
 
 msgid "Supplier Part Number"
 msgstr "Numero Parte Fornitore"
@@ -14476,7 +14476,7 @@ msgid "Supplier Part Numbers"
 msgstr "Numeri di Parte Fornitore"
 
 msgid "Supplier Parts"
-msgstr "Parti Fornitore"
+msgstr "Componenti fornitore"
 
 msgid "Supplier Payment Discounts"
 msgstr "Sconti per il Pagamento dei Fornitori"
@@ -14485,34 +14485,34 @@ msgid "Supplier Payment Discounts (default)"
 msgstr "Sconti per il Pagamento dei Fornitori (predefinito)"
 
 msgid "Supplier Prepayments"
-msgstr "Pagamenti Anticipati a Fornitori"
+msgstr "Acconti fornitori"
 
 msgid "supplier process"
-msgstr "Processo Fornitore"
+msgstr "processo del fornitore"
 
 msgid "supplier processes"
-msgstr "Processi Fornitore"
+msgstr "processi del fornitore"
 
 msgid "Supplier Processes"
-msgstr "Processi Fornitore"
+msgstr "Processi del fornitore"
 
 msgid "Supplier Quality"
 msgstr "Qualità dei Fornitori"
 
 msgid "Supplier quote"
-msgstr "Quotazione Fornitore"
+msgstr "offerta del fornitore"
 
 msgid "Supplier Quote"
-msgstr "Preventivo Fornitore"
+msgstr "Offerta del fornitore"
 
 msgid "Supplier Quote ID"
-msgstr "ID Offerta Fornitore"
+msgstr "ID offerta fornitore"
 
 msgid "Supplier Quote Notifications"
-msgstr "Notifiche di quotazione fornitore"
+msgstr "Notifiche offerta fornitore"
 
 msgid "Supplier Quotes"
-msgstr "Preventivi Fornitori"
+msgstr "Offerte del fornitore"
 
 msgid "Supplier Ref."
 msgstr "Rif. Fornitore"
@@ -14557,10 +14557,10 @@ msgid "Suppliers"
 msgstr "Fornitori"
 
 msgid "Supply"
-msgstr "Fornitura"
+msgstr "Copertura"
 
 msgid "Supply & Demand"
-msgstr "Offerta e Domanda"
+msgstr "Copertura e fabbisogno"
 
 msgid "Support"
 msgstr "Supporto"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "Azienda di Destinazione"
 
 msgid "Target customers by type."
-msgstr "Articolo di destinazione"
+msgstr "Indirizzare clienti per tipo."
 
 msgid "Target disposition row"
 msgstr "Riga di disposizione di destinazione"
@@ -14696,43 +14696,43 @@ msgid "Tax"
 msgstr "Imposta"
 
 msgid "Tax & Additional Costs"
-msgstr "Tasse e costi aggiuntivi"
+msgstr "Imposta e costi aggiuntivi"
 
 msgid "Tax & Shipping"
-msgstr "Tasse e spedizione"
+msgstr "Imposta e spedizione"
 
 msgid "Tax Amount"
 msgstr "Importo Imposta"
 
 msgid "Tax codes, rates"
-msgstr "Codici fiscali, aliquote"
+msgstr "Codici imposta, aliquote"
 
 msgid "Tax Depreciation"
-msgstr "Ammortamento Fiscale"
+msgstr "Ammortamento fiscale"
 
 msgid "Tax Depreciation Method"
-msgstr "Metodo di Ammortamento Fiscale"
+msgstr "Metodo di ammortamento fiscale"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "esente da imposta"
 
 msgid "Tax Exempt"
 msgstr "Esente da Imposte"
 
 msgid "Tax ID"
-msgstr "Codice Fiscale"
+msgstr "Codice fiscale"
 
 msgid "Tax Information"
-msgstr "Informazioni Fiscali"
+msgstr "Informazioni fiscali"
 
 msgid "Tax liability for reverse-charge transactions"
-msgstr "Responsabilità Fiscale per Operazioni in Reverse Charge"
+msgstr "Passività fiscale per transazioni con reverse charge"
 
 msgid "Tax Method"
-msgstr "Metodo Fiscale"
+msgstr "Metodo fiscale"
 
 msgid "Tax Method (default)"
-msgstr "Metodo Fiscale (predefinito)"
+msgstr "Metodo fiscale (impostazione predefinita)"
 
 msgid "Tax percent"
 msgstr "Percentuale imposta"
@@ -14741,28 +14741,28 @@ msgid "Tax Percent"
 msgstr "Percentuale Imposta"
 
 msgid "Tax Residual Value %"
-msgstr "Valore Residuo Fiscale %"
+msgstr "Valore residuo fiscale %"
 
 msgid "Tax Useful Life (default)"
-msgstr "Vita Utile Fiscale (predefinita)"
+msgstr "Vita utile fiscale (impostazione predefinita)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Vita Utile Fiscale (mesi)"
+msgstr "Vita utile fiscale (mesi)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Vita Utile Fiscale (Mesi)"
+msgstr "Vita utile fiscale (Mesi)"
 
 msgid "Tax:"
 msgstr "Imposta:"
 
 msgid "Taxes"
-msgstr "Tasse"
+msgstr "Imposte"
 
 msgid "Team trained"
 msgstr "Team addestrato"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Supporto tecnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -14805,12 +14805,12 @@ msgstr "Quel nome è già utilizzato da un altro passaggio."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "La fase \"{0}\" si completa automaticamente una volta che tutte le sue attività nel piano di progetto sono completate."
+msgstr "La fase \"{0}\" si contrassegna come fatta una volta che tutte le sue attività nel piano di progetto sono fatte."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "La fase \"{0}\" è completata — il suo checkpoint \"{1}\" è stato superato."
+msgstr "La fase \"{0}\" è fatta — il suo checkpoint \"{1}\" è stato superato."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
@@ -14823,7 +14823,7 @@ msgid "The accounts Carbon posts to automatically"
 msgstr "I conti su cui Carbon registra automaticamente"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "L'azione che copia un metodo salvato (i suoi materiali, operazioni e istruzioni di lavoro) su una riga di lavoro o preventivo."
+msgstr "L'azione che copia un metodo salvato (i suoi materiali, operazioni e istruzioni di lavoro) su un ordine di produzione o su una riga offerta."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "I valori consentiti per un attributo di tipo elenco; gli utenti scelgono tra questi anziché digitare liberamente."
@@ -14832,7 +14832,7 @@ msgid "The allowed values users can pick when tagging postings with this dimensi
 msgstr "I valori consentiti che gli utenti possono scegliere quando taggano le registrazioni con questa dimensione."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "L'importo dei giorni dopo il metodo di calcolo in cui lo sconto in contanti è disponibile"
+msgstr "Il numero di giorni dopo il metodo di calcolo durante i quali lo sconto cassa è disponibile"
 
 msgid "The amount of days after the calculation method that the payment is due"
 msgstr "L'importo dei giorni dopo il metodo di calcolo in cui il pagamento è dovuto"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "L'autorizzazione è stata rifiutata in Onshape. Riprova a connetterti."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Il libro di tutte le righe di giornale registrate, sommate per conto – scritto solo quando la contabilità è abilitata per l'azienda."
+msgstr "Il libro di tutte le righe della prima nota registrate, sommate per conto — scritto solo quando l'azienda ha la contabilità abilitata."
 
 msgid "The buckets you track costs against"
 msgstr "I bucket in cui traccia i costi"
@@ -14877,7 +14877,7 @@ msgid "The carriers and methods you ship orders with"
 msgstr "I vettori e i metodi con cui spedisci gli ordini"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "Lo sconto in contanti che il cliente può ottenere se paga entro il periodo di sconto."
+msgstr "Lo sconto di cassa che il cliente può ottenere se paga entro la finestra di sconto."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
 msgstr "La ragione del catalogo che spiega questo scarto; si accumula nei rapporti di scarto indicizzati per ragione piuttosto che per quantità."
@@ -14895,7 +14895,7 @@ msgid "The categories your fixed assets fall into"
 msgstr "Le categorie in cui rientrano i tuoi cespiti fissi"
 
 msgid "The category a fixed asset belongs to, carrying the GL accounts every asset of that kind posts to."
-msgstr "La categoria a cui appartiene un immobilizzazione, portando i conti di contabilità generale a cui viene registrato ogni bene di quel tipo."
+msgstr "La categoria a cui appartiene un cespite, che contiene i conti contabili verso cui ogni cespite di quel tipo viene registrato."
 
 msgid "The category of risk (operational, strategic, financial, compliance, etc.); drives which reports the risk rolls into."
 msgstr "La categoria di rischio (operativa, strategica, finanziaria, di conformità, ecc.); determina in quali rapporti il rischio si accumula."
@@ -14913,7 +14913,7 @@ msgid "The code printed on the kanban card that operators scan to mark the job c
 msgstr "Il codice stampato sulla scheda kanban che gli operatori scansionano per contrassegnare il lavoro come completo; generato automaticamente se lasciato vuoto."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "La disponibilità settimanale prevista dell'appaltatore; la pianificazione la usa come limite superiore quando assegna questo appaltatore a operazioni durante la settimana."
+msgstr "La disponibilità settimanale prevista del collaboratore esterno; la programmazione utilizza questo come limite superiore quando assegna questo collaboratore esterno alle operazioni durante la settimana."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "La data di scadenza corretta per questo lotto/numero di serie; l'inventario in mano esistente viene rivalutato rispetto alla politica di shelf-life dopo la modifica."
@@ -14952,16 +14952,16 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "La data in cui inizia l'ammortamento per questo bene; solitamente la data di entrata in servizio."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "La data dopo la quale i prezzi di questo preventivo non sono più onorati; la conversione in un ordine dopo questa data può richiedere una nuova quotazione."
+msgstr "La data oltre la quale il prezzo di questa offerta non è più valido; la conversione in ordine dopo questa data potrebbe richiedere una nuova offerta."
 
 msgid "The date the customer expects to receive the goods"
 msgstr "La data in cui il cliente si aspetta di ricevere la merce"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "La data in cui le merci lasciano effettivamente il magazzino; registrata sulla registrazione della spedizione e utilizzata per il punteggio di spedizione puntuale."
+msgstr "La data in cui le merci effettivamente lasciano il deposito; registrata nella registrazione della spedizione e utilizzata per il punteggio di puntualità della consegna."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "La data in cui l'articolo è richiesto in loco per coprire la domanda prevista del periodo."
+msgstr "La data in cui l'articolo è richiesto in loco per coprire il fabbisogno proiettato del periodo."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
 msgstr "La data in cui questo bene viene ritirato dal servizio; l'ammortamento si arresta in questa data e il valore netto contabile residuo viene contabilizzato nel conto di dismissione."
@@ -14985,13 +14985,13 @@ msgid "The default run quantity when this part is made; planning rounds replenis
 msgstr "La quantità di esecuzione predefinita quando questa parte viene realizzata; i cicli di pianificazione integrano il rifornimento fino a multipli di questo."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "L'aliquota fiscale predefinita applicata alle righe di offerta e ordine di vendita di questo cliente, prima dei override per riga; il calcolo fiscale specifico della giurisdizione viene eseguito in cima."
+msgstr "L'aliquota fiscale predefinita applicata alle righe di offerta e ordine di vendita di questo cliente, prima delle forzature per riga; il calcolo fiscale specifico della giurisdizione viene applicato sopra."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
-msgstr "Il dipartimento sotto il quale questo si accumula per il reporting e le gerarchie di conteggio; lasciare vuoto per un dipartimento di livello superiore."
+msgstr "Il reparto sotto il quale questo si aggrega per la reportistica e le gerarchie organizzative; lasciare vuoto per un reparto di primo livello."
 
 msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
-msgstr "Il metodo di qualità 8D, modellato con i compiti del flusso di lavoro di non conformità piuttosto che hard-coded."
+msgstr "Il metodo della qualità a otto discipline, modellato con le attività del flusso di lavoro della non conformità piuttosto che hard-coded."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
 msgstr "Il dipendente responsabile di questo centro di costo — quando le approvazioni degli ordini di acquisto sono attivate, è l'approvatore della spesa registrata contro di esso."
@@ -15003,10 +15003,10 @@ msgid "The endpoint that receives a POST request with the updated data when the 
 msgstr "L'endpoint che riceve una richiesta POST con i dati aggiornati quando la tabella viene aggiornata"
 
 msgid "The engineering drawing this inspection plan is tied to; inspections recorded against this part reference back to this drawing."
-msgstr "Il disegno tecnico a cui è associato questo piano di ispezione; le ispezioni registrate rispetto a questa parte fanno riferimento a questo disegno."
+msgstr "Il disegno tecnico a cui questo piano di controllo è legato; i controlli registrati rispetto a questo componente fanno riferimento a questo disegno."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "La percentuale attesa della produzione di questo articolo persa durante la produzione; la pianificazione moltiplica la domanda per 1 / (1 − scarto) per compensare."
+msgstr "La percentuale prevista di produzione di questo articolo persa durante la produzione; la pianificazione moltiplica il fabbisogno per 1 / (1 − scarto) per compensare."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Il conto spese a cui questa riga di spesa indiretta viene contabilizzata; obbligatorio perché le righe indirette non hanno una voce di inventario da cui derivare il conto."
@@ -15033,19 +15033,19 @@ msgid "The following assemblies have no operations. Please assign an operation t
 msgstr "I seguenti assiemi non hanno operazioni. Assegnare un'operazione a ciascuno prima del rilascio."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "I seguenti articoli di riga non hanno prezzi o tempi di consegna:"
+msgstr "Le seguenti righe non hanno prezzi o lead time:"
 
 msgid "The following tasks are not done yet:"
-msgstr "I seguenti task non sono ancora completati:"
+msgstr "Le seguenti attività non sono ancora state completate:"
 
 msgid "The forms and shapes your raw materials come in"
-msgstr "Le forme e le forme dei tuoi materiali grezzi"
+msgstr "Le forme e dimensioni in cui vengono fornite le tue materie prime"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "La frazione di ogni lotto da ispezionare; il conteggio effettivo viene calcolato dalle dimensioni del lotto al momento dell'ispezione."
+msgstr "La frazione di ogni lotto da controllare; il conteggio effettivo viene calcolato dalla dimensione del lotto al momento del controllo."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "La differenza tra il prezzo di un ordine di acquisto e la fattura del fornitore, contabilizzata in un conto di varianza al momento della registrazione della fattura."
+msgstr "La differenza tra il prezzo dell'ordine di acquisto e la fattura del fornitore, registrata in un conto di scostamento quando la fattura viene registrata."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "Il conto GL in cui vengono contabilizzati i costi di questo vettore (spese di trasporto, trasporto dentro/fuori)."
@@ -15066,7 +15066,7 @@ msgid "The hourly cost of running the machinery on this work center; combined wi
 msgstr "Il costo orario di funzionamento dei macchinari in questo centro di lavoro; combinato con le ore di macchina registrate per addebitare il costo della macchina nel WIP di un lavoro."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "L'onere di costo indiretto orario applicato a questo centro di lavoro; la differenza tra manodopera + macchina e il tasso di quotazione completo è ciò che assorbe il sovraccarico."
+msgstr "L'onere dei costi indiretti orari applicato a questo centro di lavoro; la differenza tra manodopera + macchina e il tasso di quotazione completo è ciò che i costi generali assorbono."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "L'indirizzo https a cui il passaggio webhook di un flusso di lavoro invia post — http semplice, reindirizzamenti e host che si risolvono in indirizzi privati o link-local vengono rifiutati e la chiamata si arrende dopo dieci secondi."
@@ -15087,7 +15087,7 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "La valutazione dell'impatto se il rischio si realizza (1 = trascurabile a 5 = catastrofico); accoppiato con Probabilità per calcolare il punteggio di rischio."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "Il documento di ricezione inbound che accoglie merci in magazzino (da un ordine di acquisto, trasferimento o output di lavoro) e crea entità tracciate."
+msgstr "Il documento di registrazione in entrata che mette i beni in magazzino (da un ordine di acquisto, trasferimento o output dell'ordine di produzione) e crea qualsiasi entità tracciata."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
 msgstr "La regola Incoterms (FOB, DAP, EXW, CIF, ...) che governa chi paga il trasporto, chi assume il rischio e dove avviene il trasferimento del titolo nelle spedizioni da questo fornitore."
@@ -15096,7 +15096,7 @@ msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight
 msgstr "La regola Incoterms (FOB, DAP, EXW, CIF, ...) che governa chi paga il trasporto, chi assume il rischio e dove avviene il trasferimento del titolo nelle spedizioni verso questo cliente."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Il costo di magazzino riconosciuto quando viene registrata una spedizione, valutato dal metodo di determinazione del costo dell'articolo."
+msgstr "Il costo dell'inventario riconosciuto quando una spedizione viene registrata, valutato in base al metodo di calcolo dei costi dell'articolo."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "La classe di periodo di recupero IRS per questo bene secondo MACRS (3, 5, 7, 10, 15, 20, 27,5, 39 anni)."
@@ -15108,7 +15108,7 @@ msgid "The job's position in its location's schedule queue — a fractional numb
 msgstr "La posizione del lavoro nella coda di pianificazione della sua ubicazione — un numero frazionario che Carbon calcola dalla data di scadenza e dal tipo di scadenza, non una valutazione Basso/Alto."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "Il tipo di rettifica che questa regola applica - sconto, maggiorazione o override fisso; combinato con Tipo di Importo per calcolare il delta effettivo su ogni riga."
+msgstr "Il tipo di rettifica che questa regola applica — sconto, sovrapprezzo o forzatura fissa; combinato con il tipo di importo per calcolare il delta effettivo su ogni riga."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
 msgstr "Il tipo di valore che questo attributo accetta (testo, numero, data, booleano, elenco); bloccato dopo che l'attributo ha valori registrati."
@@ -15132,25 +15132,25 @@ msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.
 msgstr "Lo stato del ciclo di vita di questo cliente - Attivo, Prospect, Inattivo, ecc.; solo i clienti Attivi compaiono nei selezionatori di ordini di vendita."
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "Lo stato del ciclo di vita di questo fornitore - Attivo, Inattivo, Approvazione in Sospeso, ecc.; solo i fornitori Attivi compaiono nei selezionatori PO/preventivi."
+msgstr "Lo stato del ciclo di vita di questo fornitore — Attivo, Inattivo, In attesa di approvazione, ecc.; solo i fornitori attivi compaiono nei selettori di ordine di acquisto / offerta."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "Il fuso orario locale in cui questa posizione segnala l'ora; i programmi, i fogli presenze e le ore di turno in questa posizione vengono interpretati in questo fuso indipendentemente dalla locale del browser dell'utente."
+msgstr "Il fuso orario locale in cui questa ubicazione riporta l'ora; i programmi, la rilevazione tempi e gli orari di turno in questa ubicazione vengono interpretati in questo fuso orario indipendentemente dalla locale del browser dell'utente."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "La posizione predefinita di questo dipendente; determina l'interpretazione del fuso orario sulle loro schede orarie e i selezionatori di turno predefiniti nel loro record di lavoro."
+msgstr "L'ubicazione predefinita di questo dipendente; determina l'interpretazione del fuso orario nella rilevazione tempi e i selettori di turno predefiniti nel suo record dell'ordine di produzione."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "La posizione da cui questo ordine sarà eseguito; le posizioni per riga la sostituiscono quando impostate."
+msgstr "L'ubicazione da cui questo ordine verrà evaso; le ubicazioni per riga sovrascrivono questa quando impostato."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "La posizione da cui questo preventivo sarà eseguito se si converte in un ordine; utilizzato dalla pianificazione per proiettare l'offerta al magazzino giusto."
+msgstr "L'ubicazione da cui questa offerta verrà evasa se si converte in ordine; utilizzata dalla pianificazione per proiettare la copertura al deposito giusto."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
 msgstr "La posizione da cui questa richiesta sarebbe eseguita se si converte in un preventivo e poi in un ordine."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "Il registro dei rischi e delle opportunità sollevati rispetto a qualsiasi entità, ciascuno valutato da severità e probabilità indipendenti da 1 a 5 e risolti."
+msgstr "Il registro dei rischi e delle opportunità segnalati rispetto a qualsiasi entità, ciascuno valutato da gravità e probabilità indipendenti da 1 a 5 e gestito fino alla risoluzione."
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "I loghi mostrati sui tuoi documenti stampati e inviati per email"
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "Il piano di campionamento per caratteristica del lotto sarà ri-risolto dal documento selezionato."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "L'importo minimo che questo fornitore addebiterà per questo processo, indipendentemente dalla quantità; i lavori al di sotto del volume di pareggio costano comunque almeno questo importo."
+msgstr "L'importo minimo che questo fornitore addebiterà per questo processo, indipendentemente dalla quantità; gli ordini di produzione al di sotto del volume di pareggio costano ancora almeno questo importo."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Le macchine, celle e stazioni attraverso cui passa il tuo lavoro"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "Il mese in cui inizia il vostro anno fiscale; i periodi sono numerati a partire da questo mese."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "Il mese in cui inizia il vostro anno fiscale; può differire dall'anno fiscale in alcune giurisdizioni."
+msgstr "Il mese in cui inizia il tuo anno fiscale; può differire dall'esercizio fiscale in alcune giurisdizioni."
 
 msgid "The monthly periods you post into and close"
 msgstr "I periodi mensili in cui registri e chiudi"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "La modalità di guasto più probabile che il richiedente sospetta; il tecnico conferma o sostituisce questo alla chiusura, e la differenza tra sospetto e effettivo alimenta i report di affidabilità."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "Il prezzo unitario negoziato su questa riga; l'icona di traccia in linea mostra quale regola di prezzo o override l'ha prodotta."
+msgstr "Il prezzo negoziato per unità su questa riga; l'icona di traccia in linea mostra quale regola di prezzo o forzatura l'ha prodotto."
 
 msgid "The new version number of the document"
 msgstr "Il nuovo numero di versione del documento"
@@ -15207,16 +15207,16 @@ msgid "The new version number of the procedure"
 msgstr "Il nuovo numero di versione della procedura"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Il numero di giorni tra la collocazione di una PO con il fornitore preferito e l'arrivo delle merci al molo; la pianificazione compensa la domanda all'indietro di questo importo."
+msgstr "Il numero di giorni tra il piazzamento di un ordine di acquisto con il fornitore preferenziale e l'arrivo dei beni al dock; la pianificazione anticipa il fabbisogno di questo importo."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Il numero di giorni per costruire un lotto di questo articolo, misurato dal rilascio del lavoro al completamento; la pianificazione compensa la domanda all'indietro di questo importo."
+msgstr "Il numero di giorni per costruire un lotto di produzione di questo articolo, misurato dal rilascio dell'ordine di produzione al completamento; la pianificazione anticipa il fabbisogno di questo importo."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
 msgstr "Il numero di unità aggiuntive da costruire per compensare lo scarto previsto; la pianificazione la somma con la quantità ordinata al momento della prenotazione dei materiali."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "Il numero di ore a settimana che l'appaltatore è disponibile a lavorare."
+msgstr "Il numero di ore a settimana disponibili per il collaboratore esterno per lavorare."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "Il numero di mesi durante i quali questo asset sarà ammortizzato."
@@ -15231,16 +15231,16 @@ msgid "The ordered list of tasks issues using this workflow must complete; the o
 msgstr "L'elenco ordinato delle attività che i problemi che utilizzano questo flusso di lavoro devono completare; l'ordine qui è l'ordine in cui appaiono sul problema."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "La sequenza ordinata delle operazioni che un lavoro esegue, copiata dal distinta base dei processi del metodo."
+msgstr "La sequenza ordinata di operazioni che un ordine di produzione esegue, copiata dalla lista delle operazioni del metodo."
 
 msgid "The original model file is no longer available"
 msgstr "Il file del modello originale non è più disponibile"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "Il documento di contabilizzazione in uscita che estrae i beni da magazzino a un cliente, contabilizzando COGS mentre procede."
+msgstr "Il documento di registrazione in uscita che preleva beni dal magazzino verso un cliente, registrando il COGS mentre procede."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "I fornitori esterni che eseguono questo processo; ogni volta ottiene una riga di voci di prezzo e tempo di consegna sul modulo di processo del fornitore."
+msgstr "I fornitori esterni che eseguono questo processo; ognuno ottiene una riga di input di prezzo e lead time nel modulo del processo del fornitore."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "La catena padre-figlio delle entità monitorate - di cosa è stata costruita un'unità e cosa è diventata."
@@ -15261,37 +15261,37 @@ msgid "The per-company counter behind a document type's readable number, assembl
 msgstr "Il contatore per azienda dietro il numero leggibile di un tipo di documento, che assembla il prefisso, il valore successivo riempito di zeri e il suffisso, e avanza quando ogni documento viene creato."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "L'esito per articolo registrato sul materiale interessato da una non-conformità — In sospeso, Reso al fornitore, Rielaborazione, Scarto o Usa così com'è — deciso per ogni lotto o seriale interessato individualmente."
+msgstr "L'esito per articolo registrato sul materiale interessato di una non conformità — In attesa, Reso al fornitore, Rilavorazione, Scarto o Usa così com'è — deciso per ogni lotto o seriale interessato in modo indipendente."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "La percentuale dello sconto in contanti. Usa 0 per nessuno sconto."
+msgstr "La percentuale dello sconto di cassa. Utilizza 0 per nessuno sconto."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Il set di autorizzazioni che i nuovi dipendenti di questo tipo ricevono automaticamente; la modifica qui cambia il modello solo per i futuri assunti - i dipendenti esistenti mantengono quello che hanno a meno che non vengono esplicitamente aggiornati in massa."
 
 msgid "The plants, warehouses, and sites where your work and stock live"
-msgstr "Gli impianti, i magazzini e i siti dove il tuo lavoro e le tue scorte si trovano"
+msgstr "Gli impianti, i depositi e i siti dove vivono il tuo lavoro e le tue giacenze"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "Il bundle predefinito di attività e requisiti di approvazione applicati a questo problema; sostituisce il flusso di lavoro predefinito del tipo di problema quando impostato."
+msgstr "Il pacchetto predefinito di attività e requisiti di approvazione applicato a questo problema; sostituisce il flusso di lavoro predefinito del tipo di problema quando impostato."
 
 msgid "The principle:"
 msgstr "Il principio:"
 
 msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
-msgstr "La valutazione della probabilità che il rischio si verifichi (1 = raro a 5 = quasi certo); associato alla Severità per calcolare il punteggio di rischio."
+msgstr "La valutazione della probabilità che il rischio si verifichi (1 = raro a 5 = quasi certo); accoppiata con Gravità per calcolare il punteggio di rischio."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
 msgstr "La procedura che i tecnici seguono quando viene eseguita questa manutenzione; sostituirla dopo che i programmi sono già stati generati influisce solo sulle istanze future."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "I processi che questo centro di lavoro può eseguire; appare nei selezionatori di processo durante la programmazione delle operazioni e limita quali lavori possono instradare attraverso questo centro di lavoro."
+msgstr "I processi che questo centro di lavoro può eseguire; appare nelle selezioni di processo durante la pianificazione delle operazioni e limita quali ordini di produzione possono instradare attraverso questo centro di lavoro."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "Il provider non offre target di dimensione. Abilita prima la funzione nel provider (ad es. categorie di tracciamento, tracciamento di classe o campi)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "I punti di interruzione della quantità a cui è quotata questa riga; ogni colonna porta il suo prezzo unitario per la negoziazione acquirente-fornitore e la conversione ai documenti a valle."
+msgstr "I punti di rottura della quantità ai quali è prezzo questa riga; ogni colonna ha il proprio prezzo per unità per la negoziazione acquirente–fornitore e per la conversione ai documenti a valle."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "La quantità dell'articolo da riordinare sul rifornimento basato su scansione."
@@ -15309,7 +15309,7 @@ msgid "The raw stock and material master you buy and consume"
 msgstr "Le materie prime e il master materiale che acquisti e consumi"
 
 msgid "The reasons you record when parts get scrapped"
-msgstr "I motivi che registri quando le parti vengono scartate"
+msgstr "I motivi che registri quando i componenti vengono scartati"
 
 msgid "The reasons you record when you decline an RFQ"
 msgstr "I motivi che registri quando rifiuti una richiesta di offerta"
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "Il record a cui una notifica del flusso di lavoro punta, denominato come un ID più il suo tipo; lasciarlo vuoto e la notifica si collega all'esecuzione del flusso di lavoro stesso."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "Il record che applica un pagamento o una nota a una fattura, contenente gli importi applicati, di sconto e di cancellazione."
+msgstr "Il record che applica un pagamento o una nota a una fattura, portando gli importi applicati, di sconto e di stralcio."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "La genealogia registrata delle entità monitorate - quali input sono stati consumati per produrre quali output, dalla ricezione alla spedizione."
@@ -15329,18 +15329,18 @@ msgstr "I dati di riferimento su cui tutto il resto si basa. Caricati per primi.
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will be expected again and counted as incoming supply."
-msgstr "I rimanenti {0} {1} saranno previsti di nuovo e conteggiati come fornitura in arrivo."
+msgstr "I restanti {0} {1} saranno attesi di nuovo e conteggiati come copertura in entrata."
 
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "I rimanenti {0} {1} non saranno più previsti. La fornitura ordinata e l'MRP smetteranno di contarla. La quantità ordinata e i prezzi rimangono invariati."
+msgstr "I restanti {0} {1} non saranno più attesi. La copertura da ordinare e MRP smetteranno di contarli. La quantità ordinata e il prezzo rimangono invariati."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "Il corpo della richiesta inviato testualmente con un tipo di contenuto JSON dopo che le variabili del flusso di lavoro al suo interno vengono sostituite, sui metodi che ne portano uno."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "Il WIP residuo che un lavoro ha lasciato alla chiusura, spazzato via in un conto di varianza di produzione - l'unica varianza che Carbon registra per un lavoro."
+msgstr "Il WIP residuo che un ordine di produzione ha lasciato alla chiusura, trasferito a un conto di Scostamento di produzione — l'unico scostamento che Carbon registra per un ordine di produzione."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "Nella risposta di Onshape mancavano i parametri richiesti. Riprova a connetterti."
@@ -15352,10 +15352,10 @@ msgid "The revision number of the part"
 msgstr "Il numero di revisione della parte"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "La riga dell'ordine di vendita per la quale questo lavoro è stato creato per soddisfare, collegando il lavoro alla domanda del cliente dietro di esso."
+msgstr "La riga dell'ordine di vendita per la quale questo ordine di produzione è stato creato per rifornire, collegando l'ordine di produzione alla domanda del cliente dietro di esso."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "Il calendario utilizzato per distribuire il costo di questo asset sulla sua vita utile (linea retta, saldo decrescente, unità di produzione)."
+msgstr "Il programma utilizzato per distribuire il costo di questo asset nel corso della sua vita utile (lineare, quote decrescenti, unità di produzione)."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Gli scaffali e i contenitori dove il magazzino si trova fisicamente"
@@ -15370,7 +15370,7 @@ msgid "The size of the part"
 msgstr "La dimensione della parte"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Le competenze e le abilità che traccia per il suo team"
+msgstr "Le competenze e abilità che tracci per il tuo personale"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "La quantità più piccola che questo fornitore accetterà su una riga di PO per questa parte; la pianificazione arrotonda a essa."
@@ -15394,13 +15394,13 @@ msgid "The standard dimensions your materials are stocked in"
 msgstr "Le dimensioni standard in cui i tuoi materiali sono immagazzinati"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "Il fattore standard (ore, minuti, pezzi) le operazioni su questo centro di lavoro sono misurate per impostazione predefinita; gli override per operazione vincono quando impostati."
+msgstr "Il fattore normale (ore, minuti, pezzi) con il quale le operazioni su questo centro di lavoro sono misurate per impostazione predefinita; le forzature per operazione prevalgono se impostate."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
 msgstr "Il fattore standard utilizzato per misurare questo processo - ore, minuti, pezzi, piedi quadrati - quando le sue operazioni vengono stimate e quotate."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "Lo stato di questa riga di quotazione - Bozza, Nessun Preventivo, Completato; Nessun Preventivo rivela il campo Motivo ed esclude la riga dal totale del preventivo."
+msgstr "Lo stato di questa riga offerta — Bozza, Nessuna offerta, Completa; Nessuna offerta rivela il campo Motivo e esclude la riga dal totale dell'offerta."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Il bucket del rendiconto che tutti gli account sotto questo gruppo utilizzeranno."
@@ -15409,7 +15409,7 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "Le impostazioni del passaggio — questa esecuzione precede la registrazione dei valori che ha utilizzato."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Le dimensioni di stock in cui questo materiale viene acquistato e mantenuto; ogni dimensione diventa una variante selezionabile separata su lavori e PO."
+msgstr "Le dimensioni di giacenza in cui questo materiale viene acquistato e mantenuto; ogni dimensione diventa una variante selezionabile separata negli ordini di produzione e negli ordini di acquisto."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
 msgstr "Il contenitore di stoccaggio da cui questa riga preleva; se vuoto, il prelievo utilizza l'unità di stoccaggio predefinita dell'articolo."
@@ -15439,7 +15439,7 @@ msgid "The suppliers and vendors you buy from"
 msgstr "I fornitori e i venditori da cui acquisti"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "I fornitori che ricevono questa RFQ; ognuno ottiene la propria riga sulla RFQ a cui rispondono con il proprio prezzo."
+msgstr "I fornitori che ricevono questa RdO; ognuno riceve la propria riga nella RdO a cui rispondono con il proprio prezzo."
 
 msgid "The surface finishes available on your materials"
 msgstr "Le finiture superficiali disponibili sui tuoi materiali"
@@ -15457,28 +15457,28 @@ msgid "The timer starts manually"
 msgstr "Il timer si avvia manualmente"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Gli attrezzi e i dispositivi su cui le tue operazioni si basano"
+msgstr "Gli strumenti e le attrezzature di fissaggio su cui le tue operazioni si affidano"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Il totale da fabbricare su tutti i lavori creati in questo lotto in massa; combinato con Quantità per Lavoro per decidere quanti lavori creare."
+msgstr "Il totale da produrre in tutti gli ordini di produzione creati in questo lotto di produzione; combinato con Quantità per ordine di produzione per decidere quanti ordini di produzione creare."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "Il riferimento tracciabile (ad esempio, standard NIST, numero di serie della misura master) rispetto al quale i valori di calibrazione sono stati confrontati."
+msgstr "Il riferimento tracciabile (ad es. standard NIST, numero seriale dello strumento di misura campione) su cui i valori di taratura sono stati confrontati."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "Il foglio di viaggio elenca ogni articolo della distinta base con la sua quantità."
+msgstr "Il cartellino di produzione elenca ogni articolo nella distinta base con la sua quantità."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "Il tipo controlla le autorizzazioni predefinite che riceve il nuovo dipendente; selezionarlo qui precompila la matrice di autorizzazione dal modello del tipo."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Il numero tipico di giorni tra l'invio del lavoro a questo fornitore per questo processo e la ricezione; la pianificazione compensa la domanda di questo importo quando si seleziona un fornitore."
+msgstr "Il numero tipico di giorni tra l'invio del lavoro a questo fornitore per questo processo e il ricevimento indietro; la pianificazione compensa la domanda di questo importo quando seleziona un fornitore."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "L'identificatore univoco su questa unità fisica; una riga per numero di serie, la quantità è sempre 1."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "L'unità in cui è espressa una durata di routing, ad esempio Ore/Pezzo o Ore Totali, che indica a Carbon se il tempo varia in base alla quantità o è fisso per ciclo."
+msgstr "L'unità in cui è espresso un tempo di ciclo di lavorazione, come Ore/Pezzo o Ore totali, indicando a Carbon se il tempo è scalato con la quantità o è fisso per esecuzione."
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "Il prezzo unitario dell'articolo al momento dell'acquisto"
@@ -15493,7 +15493,7 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "Le unità di misura in cui acquisti, immagazzini e vendi"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "Il sistema di ammortamento fiscale statunitense con le tabelle di classe di proprietà IRS, eseguito come un programma fiscale separato insieme al programma di libri."
+msgstr "Il sistema di ammortamento fiscale US con tabelle di classificazione della proprietà IRS, eseguito come programma fiscale separato insieme al programma contabile."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "Gli utenti in questo gruppo; i permessi e le notifiche con ambito di gruppo si applicano a ogni membro e gli utenti possono appartenere a più gruppi (le autorizzazioni effettive sono l'unione)."
@@ -15511,16 +15511,16 @@ msgid "The version stamp for this procedure; new versions create a copy that sup
 msgstr "Il timestamp della versione per questa procedura; le nuove versioni creano una copia che sostituisce la precedente senza eliminarla."
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "Il magazzino da cui verranno spediti i beni di questo ordine; la posizione di spedizione del cliente è dove arriveranno."
+msgstr "Il deposito da cui i beni su questo ordine spediranno; l'ubicazione di spedizione del cliente è dove arriveranno."
 
 msgid "The warehouse goods on this quote will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "Il magazzino da cui verranno spediti i beni di questo preventivo; la posizione di spedizione del cliente è dove arriveranno."
+msgstr "Il deposito da cui i beni su questa offerta spediranno; l'ubicazione di spedizione del cliente è dove arriveranno."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "I modi in cui l'attrezzatura si guasta, per la manutenzione e il monitoraggio della qualità"
+msgstr "I modi in cui l'impianto si guasta, per il tracciamento della manutenzione e della qualità"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Il contenitore proprio del centro di lavoro dove il materiale prelevato viene preparato per il prelievo produttivo, in contrasto con lo scaffale di origine del magazzino."
+msgstr "Il contenitore proprio del centro di lavoro dove il materiale prelevato viene preparato per il consumo da parte della produzione, in contrasto con lo scaffale di origine nel deposito."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Gli orari di lavoro e i calendari che guidano la pianificazione"
@@ -15535,7 +15535,7 @@ msgid "Then by"
 msgstr "Quindi per"
 
 msgid "There are no active supplier quotes to compare for this RFQ."
-msgstr "Non ci sono preventivi fornitori attivi da confrontare per questa RFQ."
+msgstr "Non ci sono offerte attive del fornitore da confrontare per questa RdO."
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
 msgstr "Ci sono operazioni esterne associate a questo lavoro che non hanno fornitori. Assegna un fornitore a ogni operazione esterna prima di rilasciarlo."
@@ -15547,7 +15547,7 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "Questi campi personalizzati saranno disponibili solo per le entità con gli stessi tag"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Questi documenti non sono stati registrati nella contabilità generale, quindi i loro importi mancano da questo periodo. Registra o annulla ciascuno — un documento non datato riceve la data del giorno della registrazione quando viene registrato."
+msgstr "Questi documenti non sono stati registrati nella contabilità generale, quindi i loro importi mancano da questo periodo. Registra o storna ognuno — un documento non datato riceve la data del giorno di registrazione quando viene registrato."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "Questi indirizzi email verranno automaticamente messi in CC su tutte le email inviate ai fornitori (preventivi, ordini di acquisto, ecc.)."
@@ -15559,10 +15559,10 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Questi articoli hanno ancora materiale da prelevare. Il completamento ora contrassegna l'elenco come Parziale."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Questi lavori hanno operazioni assegnate a questo centro di lavoro:"
+msgstr "Questi ordini di produzione hanno operazioni assegnate a questo centro di lavoro:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Queste registrazioni contabili sono ancora in Bozza, quindi i loro debiti e crediti non sono nella contabilità generale per questo periodo. Registra ciascuna o rivalutala in un periodo aperto successivo."
+msgstr "Queste voci di prima nota sono ancora Bozza, quindi i loro dare e avere non sono nel registro per questo periodo. Registra ognuno, o ri-datalo in un periodo aperto successivo."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "A questa istanza di Carbon mancano le credenziali OAuth di Onshape. Chiedi a un amministratore di configurarle."
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "Questo completa il passaggio Discovery."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Questo contatto non ha un indirizzo email"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Questa controparte non ha nulla in sospeso — il pagamento verrà registrato come credito in conto."
@@ -15586,10 +15586,10 @@ msgid "This download link is invalid or has been tampered with."
 msgstr "Questo link di download non è valido o è stato manomesso."
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "Questo file non è più disponibile oppure non hai il permesso di scaricarlo."
+msgstr "Questo file non è più disponibile, oppure non hai l'autorizzazione per scaricarlo."
 
 msgid "This Fiscal Year"
-msgstr "Questo Anno Fiscale"
+msgstr "Questo esercizio fiscale"
 
 msgid "This information will be used on document headers"
 msgstr "Queste informazioni verranno utilizzate nelle intestazioni dei documenti"
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Queste informazioni saranno visibili a tutti gli utenti, quindi fai attenzione a ciò che condividi."
 
 msgid "this inspection plan"
-msgstr "questo piano di ispezione"
+msgstr "questo piano di controllo"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "Questo invito per unirti a {0} è scaduto. Puoi richiedere un nuovo invito da inviare alla tua email."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Questa fattura non ha una data di scadenza utilizzabile — scegline una per Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Questa fattura sarà addebitata al cliente Stripe già collegato a questo cliente Carbon. Per modificare i suoi dettagli, modificalo nel dashboard Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Questo è un ambiente controllato, quindi è necessaria un'app autenticatore."
@@ -15629,7 +15629,7 @@ msgid "This is taking longer than expected. It may still finish — if it doesn'
 msgstr "Sta richiedendo più tempo del previsto. Potrebbe comunque finire - se non finisce, riprova il ripristino per ripristinare i tuoi dati."
 
 msgid "This is the month your fiscal year starts."
-msgstr "Questo è il mese in cui inizia il tuo anno fiscale."
+msgstr "Questo è il mese in cui inizia il tuo esercizio fiscale."
 
 msgid "This is the month your tax year starts."
 msgstr "Questo è il mese in cui inizia il tuo anno fiscale."
@@ -15638,13 +15638,13 @@ msgid "this item"
 msgstr "questo articolo"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Questo articolo viene costruito tramite un configuratore e risolve i suoi componenti per ordine; i lavori creati per esso ereditano il BOM risolto del configuratore."
+msgstr "Questo articolo è costruito tramite un configuratore e risolve i suoi componenti per ordine; gli ordini di produzione creati per esso ereditano la distinta base risolta dal configuratore."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "La distinta base di questo articolo non ha input con shelf-life abilitato, quindi nessuna scadenza verrà calcolata dalla distinta base."
+msgstr "La distinta base di questo articolo non ha componenti con scadenza abilitata, quindi nessuna scadenza verrà calcolata dalla BOM."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "Questo lavoro sarà ricevuto in inventario. Non sarà più disponibile sul piano di produzione."
+msgstr "Questo ordine di produzione verrà ricevuto in magazzino. Non sarà più disponibile in officina."
 
 msgid "This job will no longer be available on the shop floor."
 msgstr "Questo lavoro non sarà più disponibile in officina."
@@ -15680,13 +15680,13 @@ msgid "This part is obsolete (No Stock)."
 msgstr "Questo pezzo è obsoleto (Nessun Stock)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "Questa parte è superata e impostata su Solo Stock — viene reintegrata al suo livello di riserva di ricambi, indipendentemente dalla domanda."
+msgstr "Questo componente è superato e impostato su Solo giacenza — viene rifornito fino al suo livello minimo di ricambi, indipendentemente dal fabbisogno."
 
 msgid "This path only decides what runs next"
 msgstr "Questo percorso decide solo cosa viene eseguito dopo"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "Questo periodo non ha movimenti di diario registrati e può essere eliminato permanentemente. Questo non può essere annullato."
+msgstr "Questo periodo non ha voci di prima nota registrate e può essere eliminato permanentemente. Questa azione non può essere annullata."
 
 msgid "this purchase order"
 msgstr "questo ordine di acquisto"
@@ -15707,17 +15707,17 @@ msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS}
 msgstr "Questa esecuzione ha più passaggi di quelli che mostriamo qui. Solo i primi {MAX_RUN_STEPS} sono elencati."
 
 msgid "This runs the workflow for real. It will create records, send notifications and call any webhooks exactly as a live run would. This cannot be undone."
-msgstr "Questo esegue il flusso di lavoro per davvero. Creerà record, invierà notifiche e chiamerà qualsiasi webhook esattamente come farebbe un'esecuzione in tempo reale. Questo non può essere annullato."
+msgstr "Questo esegue il flusso di lavoro per davvero. Creerà record, invierà notifiche e chiamerà qualsiasi Webhook esattamente come farebbe un'esecuzione in tempo reale. Questa azione non può essere annullata."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Questo ordine di vendita ha processi associati. Scegli cosa fare con loro."
+msgstr "Questo ordine di vendita ha ordini di produzione associati. Scegli cosa fare con loro."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Questo ordine di vendita ha righe che richiedono la creazione di lavori"
+msgstr "Questo ordine di vendita ha righe che richiedono la creazione di ordini di produzione"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "Questo tipo di archiviazione è attualmente utilizzato da {usageCount} unità di archiviazione{0}."
+msgstr "Questo tipo di stoccaggio è attualmente utilizzato da {usageCount} unità di stoccaggio{0}."
 
 msgid "this supplier"
 msgstr "questo fornitore"
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "Questa versione non può essere aperta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Questa versione è pubblicata"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Questa versione è pubblicata. Crea una nuova versione per modificarla."
 
 msgid "This version's definition could not be read."
 msgstr "La definizione di questa versione non potrebbe essere letta."
@@ -15786,7 +15786,7 @@ msgid "This will write off the remaining book value of the asset."
 msgstr "Questo cancellerà il valore netto contabile rimanente dell'asset."
 
 msgid "Three-way match"
-msgstr "Riconciliazione a tre vie"
+msgstr "Riscontro a tre vie"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15796,7 +15796,7 @@ msgid "Thumbnail"
 msgstr "Miniatura"
 
 msgid "Thumbnail is still generating"
-msgstr "L'anteprima è ancora in generazione"
+msgstr "La miniatura è ancora in fase di generazione"
 
 msgid "Thumbnail path"
 msgstr "Percorso miniatura"
@@ -15805,7 +15805,7 @@ msgid "Thumbnail removed"
 msgstr "Miniatura rimossa"
 
 msgid "Thumbnail updated"
-msgstr "Anteprima aggiornata"
+msgstr "Miniatura aggiornata"
 
 msgid "Thumbnail uploaded"
 msgstr "Miniatura caricata"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Riconciliazione non disponibile"
 
 msgid "Tightened"
-msgstr "Stretto"
+msgstr "Rinforzato"
 
 msgid "Time of day"
 msgstr "Ora del giorno"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "Foglio presenze"
 
 msgid "Timecards"
-msgstr "Fogli presenze"
+msgstr "Rilevazione tempi"
 
 msgid "Timecards are disabled"
-msgstr "I fogli di presenze sono disabilitati"
+msgstr "Rilevazione tempi disabilitata"
 
 msgid "Timecards are enabled"
-msgstr "I fogli di presenze sono abilitati"
+msgstr "Rilevazione tempi abilitata"
 
 msgid "Timezone"
 msgstr "Fuso orario"
@@ -15871,7 +15871,7 @@ msgid "To Ship and Receive"
 msgstr "Da spedire e ricevere"
 
 msgid "To Storage Unit"
-msgstr "A Storage Unit"
+msgstr "A Unità di stoccaggio"
 
 msgid "To supplier"
 msgstr "Al fornitore"
@@ -15976,10 +15976,10 @@ msgid "Total Quantity"
 msgstr "Quantità Totale"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Quantità totale disponibile dell'articolo su tutte le unità di stoccaggio in questa posizione. Diventa rossa quando la giacenza più gli arrivi non riescono a coprire la domanda totale."
+msgstr "Quantità totale in giacenza per l'articolo in tutte le unità di stoccaggio in questa ubicazione. Diventa rossa quando la giacenza più gli ordini in arrivo non riescono a coprire il fabbisogno totale."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Quantità totale richiesta su tutti i lavori attivi e gli ordini di vendita in questa posizione, non solo questo lavoro."
+msgstr "Quantità totale richiesta in tutti gli ordini di produzione e gli ordini di vendita attivi in questa ubicazione — non solo questo ordine di produzione."
 
 msgid "Total scrap quantity"
 msgstr "Quantità totale di scarto"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "Valore Totale"
 
 msgid "Total Variance"
-msgstr "Varianza Totale"
+msgstr "Scostamento totale"
 
 msgid "Total:"
 msgstr "Totale:"
@@ -16024,7 +16024,7 @@ msgid "Track tax depreciation separately"
 msgstr "Traccia l'ammortamento fiscale separatamente"
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "Traccia l'ammortamento fiscale separatamente dall'ammortamento contabile e registra automaticamente le voci di passività fiscale differita."
+msgstr "Traccia l'ammortamento fiscale separatamente dall'ammortamento contabile e registra automaticamente le voci di imposte differite passive."
 
 msgid "Track transactions by segment (cost center, project, service line)"
 msgstr "Traccia le transazioni per segmento (centro di costo, progetto, linea di servizio)"
@@ -16063,10 +16063,10 @@ msgid "Tracking Number"
 msgstr "Numero di tracciamento"
 
 msgid "Tracking type"
-msgstr "Tipo di tracciamento"
+msgstr "Tipo di tracciabilità"
 
 msgid "Tracking Type"
-msgstr "Tipo di tracciamento"
+msgstr "Tipo di tracciabilità"
 
 msgid "Tracking URL"
 msgstr "URL di tracciamento"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "Corsi di formazione"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "Le transazioni creeranno registrazioni contabili e aggiorneranno la contabilità generale."
+msgstr "Le transazioni creeranno voci di prima nota e aggiorneranno la contabilità generale."
 
 msgid "Transfer"
 msgstr "Trasferimento"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "ID Trasferimento"
 
 msgid "Transfer Lines"
-msgstr "Linee di Trasferimento"
+msgstr "Righe di trasferimento"
 
 msgid "Transfer Ownership"
 msgstr "Trasferisci Proprietà"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "Cestino"
 
 msgid "Trial Balance"
-msgstr "Bilancia di Verifica"
+msgstr "Bilancio di verifica"
 
 msgid "Trigger"
 msgstr "Trigger"
@@ -16180,7 +16180,7 @@ msgid "Type an email and press Enter to add an external recipient"
 msgstr "Digita un'email e premi Invio per aggiungere un destinatario esterno"
 
 msgid "Type of Permission Update"
-msgstr "Tipo di Aggiornamento Permessi"
+msgstr "Tipo di aggiornamento autorizzazione"
 
 msgid "Type to search across your workspace"
 msgstr "Digita per cercare nel tuo workspace"
@@ -16219,7 +16219,7 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Le righe non conteggiate rimangono invariate al post — non vengono azzerate."
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "Nel Reorder Basato sulla Domanda, la pianificazione somma la domanda all'interno di questa finestra mobile quando calcola una quantità di rifornimento."
+msgstr "Nel riordino basato sul fabbisogno, la pianificazione somma il fabbisogno entro questa finestra mobile durante il calcolo di una quantità di rifornimento."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
 msgstr "Con la politica Quantità Fissa di Riordino, gli ordini di pianificazione sono della quantità esatta ogni volta che il punto di riordino si attiva."
@@ -16291,10 +16291,10 @@ msgid "unknown location"
 msgstr "posizione sconosciuta"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Supporto funzionale illimitato"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Record illimitati"
 
 msgid "Unlink"
 msgstr "Scollega"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Documenti Non Registrati"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Annulla pubblicazione"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Annullare la pubblicazione di {name}?"
 
 msgid "Unreceived POs"
 msgstr "PO non ricevuti"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "Riga senza titolo"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "Materiale prelevato inutilizzato riportato dal centro di lavoro al magazzino."
+msgstr "Materiale prelevato non utilizzato reso dal centro di lavoro al deposito."
 
 msgid "UoM"
 msgstr "UdM"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Aggiorna problema Linear"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Aggiorna i tempi di consegna delle parti dalle ricevute di acquisto registrate."
+msgstr "Aggiorna i lead time dei componenti dalle entrate merci registrate."
 
 msgid "Update Password"
 msgstr "Aggiorna Password"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "Caricamento in corso…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "Facendo clic su Converti, le parti verranno create con i seguenti numeri di parte interni:"
+msgstr "Facendo clic su Converti, i componenti verranno creati con i seguenti numeri di parte interni:"
 
 msgid "URL"
 msgstr "URL"
@@ -16528,7 +16528,7 @@ msgid "Usage/Day (90d)"
 msgstr "Utilizzo/Giorno (90g)"
 
 msgid "Use ... to get the next consumable ID"
-msgstr "Usa ... per ottenere l'ID consumabile successivo"
+msgstr "Usa ... per ottenere il prossimo ID di materiale di consumo"
 
 msgid "Use ... to get the next material ID"
 msgstr "Usa ... per ottenere il prossimo ID materiale"
@@ -16651,34 +16651,34 @@ msgid "Variables"
 msgstr "Variabili"
 
 msgid "Variance"
-msgstr "Varianza"
+msgstr "Scostamento"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Varianza tra il consumo reale e standard dei componenti della distinta base"
+msgstr "Scostamento tra il consumo effettivo e il consumo standard del componente della BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Varianza tra ore e tariffe di instradamento reali e standard"
+msgstr "Scostamento tra ore e tariffe di ciclo di lavorazione effettive e standard"
 
 msgid "Variance between actual purchase price and standard cost"
-msgstr "Varianza tra il prezzo di acquisto effettivo e il costo standard"
+msgstr "Scostamento tra il prezzo di acquisto effettivo e il costo standard"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Varianza tra i costi generali di produzione effettivi e applicati"
+msgstr "Scostamento tra i costi generali di produzione imputati e effettivi"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "Varianza dovuta agli adeguamenti di conteggio dell'inventario fisico"
+msgstr "Scostamento dovuto alle rettifiche dell'inventario fisico"
 
 msgid "Variance in outside processing costs"
-msgstr "Varianza nei costi di lavorazione esterna"
+msgstr "Scostamento nei costi di conto lavoro"
 
 msgid "Variance only"
 msgstr "Solo scostamento"
 
 msgid "VAT Number"
-msgstr "Numero IVA"
+msgstr "Partita IVA"
 
 msgid "Vendor Write-Off Income"
-msgstr "Reddito da Cancellazione Fornitore"
+msgstr "Proventi da Stralcio"
 
 msgid "Verification Error"
 msgstr "Errore di verifica"
@@ -16703,7 +16703,7 @@ msgstr "Versione"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "La versione {0} è ora pubblicata e sarà sostituita."
 
 msgid "Version:"
 msgstr "Versione:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Visualizza"
 
 msgid "View Active Jobs"
-msgstr "Visualizza Lavori Attivi"
+msgstr "Visualizza ordini di produzione attivi"
 
 msgid "View Active Quotes"
 msgstr "Visualizza Preventivi Attivi"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Visualizza Asset"
 
 msgid "View Assigned Jobs"
-msgstr "Visualizza lavori assegnati"
+msgstr "Visualizza ordini di produzione assegnati"
 
 msgid "View Attachment"
 msgstr "Visualizza Allegato"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Visualizza Anagrafica Articolo"
 
 msgid "View Journal Entry"
-msgstr "Visualizza Registrazione Contabile"
+msgstr "Visualizza riga di registrazione"
 
 msgid "View Lists"
 msgstr "Visualizza Elenchi"
 
 msgid "View maintenance dispatch"
-msgstr "Visualizza manutenzione dispatch"
+msgstr "Visualizza intervento di manutenzione"
 
 msgid "View Memo"
 msgstr "Visualizza Memo"
@@ -16832,7 +16832,7 @@ msgid "View Period"
 msgstr "Visualizza Periodo"
 
 msgid "View permissions"
-msgstr "Permessi di visualizzazione"
+msgstr "Visualizza autorizzazioni"
 
 msgid "View Permissions"
 msgstr "Autorizzazioni di visualizzazione"
@@ -16874,7 +16874,7 @@ msgid "View Stock Transfer"
 msgstr "Visualizza Trasferimento Magazzino"
 
 msgid "View Suggestion"
-msgstr "Visualizza Suggerimento"
+msgstr "Visualizza proposta"
 
 msgid "View Suppliers"
 msgstr "Visualizza Fornitori"
@@ -16901,25 +16901,25 @@ msgid "Visible on a user's public profile"
 msgstr "Visibile sul profilo pubblico di un utente"
 
 msgid "Void"
-msgstr "Annulla"
+msgstr "Storna"
 
 msgid "Void Invoice"
-msgstr "Annulla Fattura"
+msgstr "Storna fattura"
 
 msgid "Void Purchase Invoice"
-msgstr "Annulla Fattura di Acquisto"
+msgstr "Storna fattura di acquisto"
 
 msgid "Void Receipt"
-msgstr "Annulla Ricevuta"
+msgstr "Storna entrata merci"
 
 msgid "Void Sales Invoice"
-msgstr "Annulla Fattura di Vendita"
+msgstr "Storna fattura di vendita"
 
 msgid "Void Shipment"
-msgstr "Annulla Spedizione"
+msgstr "Storna spedizione"
 
 msgid "Voided"
-msgstr "Annullato"
+msgstr "Stornato"
 
 msgid "Voiding this purchase invoice will:"
 msgstr "L'annullamento di questa fattura di acquisto comporterà:"
@@ -16931,7 +16931,7 @@ msgid "Voiding this shipment will:"
 msgstr "Annullare questa spedizione comporterà:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Esamina ogni area con il tuo responsabile e disattiva tutto ciò che esula dall'ambito. I codici seguono il formato Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Esamina ogni area con il tuo champion e attiva/disattiva tutto ciò che è fuori ambito. I codici seguono il formato Modulo.Area.Numero (ACC.GL.01 = Contabilità, Contabilità generale, voce 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Esamina il tuo processo attuale, i sistemi e i dati"
@@ -16940,13 +16940,13 @@ msgid "Want our team alongside you? Expert eyes on your setup, data, and go-live
 msgstr "Vuoi il nostro team al tuo fianco? Occhi esperti sulla tua configurazione, dati e lancio."
 
 msgid "Warehouse Transfer"
-msgstr "Trasferimento Magazzino"
+msgstr "Trasferimento di deposito"
 
 msgid "Warehouse Transfers"
-msgstr "Trasferimenti tra Magazzini"
+msgstr "Trasferimenti di deposito"
 
 msgid "Warehouse, Ops"
-msgstr "Magazzino, Ops"
+msgstr "Deposito, Operazioni"
 
 msgid "Warn"
 msgstr "Avviso"
@@ -16973,7 +16973,7 @@ msgid "Watch full video"
 msgstr "Guarda il video completo"
 
 msgid "We auto-matched each column. Review the values below before continuing."
-msgstr "Abbiamo abbinato automaticamente ogni colonna. Rivedi i valori di seguito prima di continuare."
+msgstr "Abbiamo abbinato automaticamente ogni colonna. Esamina i valori qui sotto prima di continuare."
 
 msgid "We triage and fix issues fast while your team settles in"
 msgstr "Triamo e risolviamo i problemi rapidamente mentre il tuo team si ambientalizza"
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "Settimanale"
 
 msgid "Weekly demand"
-msgstr "Domanda settimanale"
+msgstr "Fabbisogno settimanale"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Cosa ha fatto aumentare o diminuire l'inventario, per qualsiasi dimensione"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Cosa accade quando un giornale è datato in un periodo bloccato."
+msgstr "Cosa succede quando una registrazione è datata in un periodo bloccato."
 
 msgid "What is {translatedTerm}?"
 msgstr "Cos'è {translatedTerm}?"
@@ -17101,16 +17101,16 @@ msgid "What it is"
 msgstr "Che cos'è"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "Che tipo di modifica è questa: Versione aggiorna il modo in cui il pezzo viene realizzato, Revisione rivede i suoi dettagli e documenti, Pezzo sostitutivo scambia un nuovo numero di pezzo che sostituisce quello vecchio e Nuovo pezzo introduce un pezzo completamente nuovo senza predecessore."
+msgstr "Che tipo di modifica è questa: Versione aggiorna come il componente è prodotto, Revisione rivede i suoi dettagli e documenti, Componente di sostituzione introduce un nuovo numero di componente che sostituisce il vecchio, e Nuovo componente introduce un componente completamente nuovo senza predecessore."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Quale tipo di output registra questa voce — Produzione (unità buone), Scrap (non recuperabile) o Rilavorazione (rimandato per correzione); rivela Scrap Reason quando Scrap."
+msgstr "Che tipo di output questa registrazione registra — Produzione (unità idonee), Scarto (irrecuperabile), o Rilavorazione (rimandato per correzione); rivela causale di scarto quando Scarto."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Quale tipo di PO è questo — beni standard, servizi, lavorazione esterna o accordo blanket; determina il layout di linea e le regole di contabilizzazione GL."
+msgstr "Che tipo di ordine d'acquisto è questo — merci ordinarie, servizi, conto lavoro, o accordo quadro; determina il layout delle righe e le regole di registrazione della contabilità generale."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
-msgstr "Quale tipo di preventivo è questo — preventivo fornitore standard, preventivo con prezzo accordo blanket o preventivo di produzione contrattuale; determina il layout di linea PO quando convertito."
+msgstr "Che tipo di offerta del fornitore è questa — offerta fornitore standard, offerta a prezzo fisso per accordo quadro, o offerta di produzione in conto lavorazione; determina il layout delle righe dell'ordine d'acquisto quando convertita."
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
 msgstr "Da quale fonte questa dimensione attinge i suoi valori consentiti (elenco personalizzato o un'entità esistente come cliente, ubicazione, dipendente)."
@@ -17128,10 +17128,10 @@ msgid "What this shipment is fulfilling — a sales order, an outbound transfer,
 msgstr "Ciò che questa spedizione sta soddisfacendo — un ordine di vendita, un trasferimento in uscita, un reso RMA o una spedizione manuale."
 
 msgid "What this task means"
-msgstr "Cosa significa questo compito"
+msgstr "Cosa significa questa attività"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Ciò che questa voce di tempo conta come — Manodopera (tempo operatore), Macchina (tempo di esecuzione) o Setup (tempo di cambio); ognuno si riassume a un tasso diverso."
+msgstr "Cosa conta questa registrazione di tempo — Manodopera (tempo operatore), Macchina (tempo di lavorazione), o Attrezzaggio (tempo di cambio); ognuna si accumula sotto un tariffario diverso."
 
 msgid "What to set up"
 msgstr "Cosa configurare"
@@ -17167,7 +17167,7 @@ msgid "When expired stock is used"
 msgstr "Quando viene utilizzato stock scaduto"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "Quando MRP utilizza il successore per la nuova domanda"
+msgstr "Quando MRP utilizza il successore per nuovo fabbisogno"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "Se abilitato, gli attributi in questa categoria vengono visualizzati nel profilo pubblico di una persona; in caso contrario, sono visibili solo agli amministratori."
@@ -17176,16 +17176,16 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Se abilitato, i dipendenti possono modificare il valore di questo attributo nel proprio profilo; in caso contrario, solo gli amministratori possono farlo."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Se abilitato, le regole di prezzo (sconti in volume, promozioni) vengono comunque applicate in cima a questo override; se disabilitato, questo override è il prezzo finale."
+msgstr "Quando attivo, le regole di prezzo (sconti di volume, promozioni) continuano ad applicarsi oltre questa forzatura; quando disattivo, questa forzatura è il prezzo finale."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Se abilitato, la scansione del codice a barre dell'operazione di questo processo segnala tutta la quantità aperta rimanente come completata in un'azione; disabilitare quando gli operatori segnalano regolarmente parziali."
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
-msgstr "Se abilitato, le fatture di questa parte saltano il calcolo delle tasse; la parte è responsabile di mantenere il certificato di esenzione aggiornato."
+msgstr "Quando attivo, le fatture di questo soggetto saltano il calcolo imposte; il soggetto è responsabile di mantenere il certificato di esenzione aggiornato."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Se abilitato, questo override di prezzo si applica agli ordini corrispondenti; se disabilitato, l'override viene conservato senza eliminazione per preservare la cronologia di audit."
+msgstr "Quando attivo, questa forzatura di prezzo si applica agli ordini corrispondenti; disattivare senza eliminare preserva la cronologia per l'audit."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando attivato, questa regola si attiva per ogni target del suo tipo. Le righe di assegnazione vengono ignorate ma conservate."
@@ -17194,10 +17194,10 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "Quando si prevede che i fornitori rispondano; i fornitori vedono questa data sul portale RFQ e Carbon smette di accettare risposte tardive dopo di essa (configurabile)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "Quando l'acquirente ha chiesto i beni; il fornitore può promettere qualcosa di diverso sulla Data Promessa e contabilizzare qualcosa di diverso di nuovo sulla Data di Consegna."
+msgstr "Quando il buyer ha richiesto la merce; il fornitore può promettere qualcosa di diverso sulla data promessa e consegnare qualcosa di diverso di nuovo sulla data di consegna."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "Quando l'acquirente ha bisogno dei beni di questa linea alla banchina; la pianificazione utilizza questa data per la disponibilità delle scorte e la programmazione del trattamento esterno."
+msgstr "Quando l'acquirente ha bisogno della merce di questa riga al ricevimento; la pianificazione utilizza questa data per la disponibilità delle giacenze e la pianificazione del conto lavoro."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
 msgstr "Quando il cliente ha richiesto la consegna; l'ordine si impegna alla Data Promessa, che può essere diversa."
@@ -17221,7 +17221,7 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Quando la carta kanban viene scansionata, il lavoro viene automaticamente spostato dalla bozza e rilasciato al piano."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Quando la località ricevente si aspetta l'arrivo delle scorte; determina la disponibilità MRP alla destinazione."
+msgstr "Quando l'ubicazione di ricevimento si aspetta l'arrivo della giacenza; determina la disponibilità MRP presso la destinazione."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Quando il fornitore si è impegnato a consegnare; la pianificazione utilizza questa data per la proiezione dell'arrivo del magazzino in entrata."
@@ -17230,19 +17230,19 @@ msgid "When the supplier's pricing stops being honored; converting this quote to
 msgstr "Quando la determinazione dei prezzi del fornitore non è più onorata; la conversione di questa quotazione a un ordine di acquisto dopo questa data potrebbe richiedere una nuova quotazione."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Quando questo indicatore diventa scaduto per la taratura; una volta scaduto legge Fuori da taratura."
+msgstr "Quando questo strumento di misura è scaduto per la taratura; una volta scaduto, indica Non tarato."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Quando questo calibro è stato calibrato correttamente per l'ultima volta; la data di successiva taratura viene ricalcolata da questo valore più l'intervallo."
+msgstr "Quando questo strumento di misura è stato tarato con successo per l'ultima volta; la data della prossima taratura viene ricalcolata da questo valore più l'intervallo."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "Quando sembra giusto, contrassegnalo come concordato. Questo completa il passaggio Discovery nel tuo centro di comando."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Quando questa linea specifica è promessa di spedizione; sostituzione per linea della Data Promessa dell'intestazione dell'ordine per spedizioni divise."
+msgstr "Quando questa riga specifica è promessa per la spedizione; forzatura per riga della Data promessa dell'intestazione dell'ordine per spedizioni suddivise."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Quando questo lotto/numero di serie specifico scade; determina la selezione FEFO e la politica di vita di magazzino al consumo."
+msgstr "Quando questo lotto/seriale scade; determina il prelievo FEFO e la politica di shelf-life al consumo."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Quando vi siete impegnati a consegnare; la pianificazione tratta questo come la data di scadenza della domanda per l'adempimento."
@@ -17254,19 +17254,19 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "Dove viene consegnata una notifica del flusso di lavoro — in-app viene sempre inviato, mentre email richiede un piano Business o Partner e Slack necessita del tuo spazio di lavoro Slack connesso."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Dove un'operazione viene eseguita; porta tassi di manodopera e di quotazione, con spese generali la differenza tra di esse."
+msgstr "Dove viene eseguita un'operazione; porta le tariffe di manodopera e di preventivo, con costi generali la differenza tra di loro."
 
 msgid "Where and how you make things."
 msgstr "Dove e come realizzi le cose."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Dove i beni su questo PO vengono spediti per impostazione predefinita dal fornitore; le locazioni di consegna per linea sul PO sostituiscono questo per scenari drop-ship e consegna divisa."
+msgstr "Dove i beni in questo PO vengono spediti per impostazione predefinita; le ubicazioni di consegna per riga nel PO sostituiscono questa per scenari di consegna diretta e consegna suddivisa."
 
 msgid "Where it lives today"
 msgstr "Dove si trova oggi"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Dove il nuovo stock di questo articolo si posa per impostazione predefinita al ricevimento; le selezioni di archiviazione per linea su una ricevuta lo sostituiscono."
+msgstr "Dove la nuova giacenza di questo articolo atterra per impostazione predefinita all'entrata merci; le selezioni di stoccaggio per riga all'entrata merci la sostituiscono."
 
 msgid "Where stock lives and how it ships."
 msgstr "Dove il magazzino risiede e come viene spedito."
@@ -17275,16 +17275,16 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "Dove gli elementi interessati sono utilizzati in tutto il sistema. Informativo — niente qui blocca il rilascio."
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "Da dove proviene questa voce (immissione manuale, contabilizzazione da vendite/acquisti, modello ricorrente, ecc.)."
+msgstr "Da dove proviene questa voce (immissione manuale, registrazione dalle vendite/acquisti, modello ricorrente, ecc.)."
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
 msgstr "Da dove è stato sollevato questo problema — QA interno, reclamo cliente, audit fornitore, ecc. ; utilizzato per la segnalazione, non blocca il flusso di lavoro."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "Dove i beni di questa linea atterrano in inventario al ricevimento; se vuoto, i ricevimenti utilizzano l'unità di magazzino predefinita dell'articolo."
+msgstr "Dove i beni di questa riga finiscono nelle giacenze all'entrata merci; se vuoto, le entrate merci utilizzano l'Unità di stoccaggio predefinita dell'articolo."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "Da dove è stata originata questa richiesta di manutenzione — segnalata dall'operatore, programmata, trigger di monitoraggio dello stato, ispezione post-lavoro; determina la ripartizione dell'origine nei rapporti di manutenzione."
+msgstr "Da dove proviene questa richiesta di manutenzione — segnalata dall'operatore, programmata, trigger di monitoraggio condizioni, ispezione post-lavoro; determina la scomposizione della fonte nei rapporti di manutenzione."
 
 msgid "Where you are today"
 msgstr "Dove sei oggi"
@@ -17296,28 +17296,28 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Se l'importo viene interpretato come percentuale del prezzo di riga o come importo fisso in valuta."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Se Carbon tiene traccia di ogni unità (Serial), ogni lotto (Batch), la quantità (Inventory) o nessun tracciamento (Non-Inventory)."
+msgstr "Se Carbon segue ogni unità (Seriale), ogni lotto (Lotto di produzione), la quantità (Magazzino), o nessuna tracciabilità (Non a magazzino)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Se il conteggio del tempo inizia quando il processo scelto comincia o quando si completa."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Se questo lotto/seriale supera l'ispezione (Pass) o non la supera (Fail); un Fail impedisce che la merce venga ricevuta nell'inventario disponibile."
+msgstr "Se questo lotto/seriale è conforme al controllo (Conforme) o non conforme (Non conforme); una non conformità blocca la giacenza dal ricevimento nelle giacenze disponibili."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Se questo processo viene eseguito su centri di lavoro interni (Processo, Assemblaggio o Ispezione) o presso fornitori esterni (Lavorazione Esterna); rivela diversi campi a valle, modifica il modo in cui i percorsi di pianificazione funzionano per questo processo, e imposta il tipo di operazione di default sulle nuove operazioni."
+msgstr "Se questo processo viene eseguito su centri di lavoro interni (Processo, Assemblaggio o Controllo) o presso fornitori esterni (Conto lavoro); rivela campi a valle diversi, cambia il modo in cui i percorsi di pianificazione funzionano per questo processo e predispone il tipo di operazione sulle nuove operazioni."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "Se questo lavoro blocca la produzione (Inattivo), la degrada (Impatto), si trova in una finestra di tempo di inattività pianificata (Pianificato) o non ha impatto sulla produzione (Nessun Impatto); informa la pianificazione e la comunicazione dei tempi di inattività orientata al cliente."
+msgstr "Se questo lavoro blocca la produzione (Fermo), la degrada (Impatto), è in una finestra di fermo programmato (Pianificato) o non ha impatto sulla produzione (Nessun impatto); informa la pianificazione e la comunicazione del fermo rivolto ai clienti."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "Se le autorizzazioni selezionate vengono Aggiunte sopra ciò che ogni utente ha già, o Aggiornate sostituendo il set di autorizzazioni di ogni utente con la selezione di seguito."
 
 msgid "Which document drives each inspection flow for this item."
-msgstr "Quale documento gestisce ogni flusso di ispezione per questo articolo."
+msgstr "Quale documento guida ogni flusso di controllo per questo articolo."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Che tipo di richiesta inviare: GET legge qualcosa, POST crea, PUT e PATCH aggiornano, DELETE rimuove. Un nuovo passaggio inizia con GET e solo POST, PUT e PATCH portano un corpo."
+msgstr "Quale tipo di richiesta inviare: GET legge qualcosa, POST crea, PUT e PATCH aggiornano, DELETE rimuove. Un nuovo passo inizia con GET e solo POST, PUT e PATCH portano un corpo."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "Quale evento di produzione avvia l'orologio della vita di magazzino — ad esempio, riempimento, sigillatura o QC finale."
@@ -17329,7 +17329,7 @@ msgid "Who can do what"
 msgstr "Chi può fare cosa"
 
 msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
-msgstr "Chi fa cosa, nei sei step. Il tuo lato è evidenziato in alto. Gestiscilo bene e il progetto procede."
+msgstr "Chi fa cosa, in tutti i sei passi. Il tuo lato è evidenziato in alto. Possiedi bene e il progetto si muove."
 
 msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
 msgstr "Chi riceve la formazione su cosa, in quale formato. La tua parte: proteggi il tempo della sessione pratica nei calendari dei tuoi champion in anticipo. È quello che scivola di più quando le aziende sono occupate."
@@ -17338,34 +17338,34 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Chi deve approvare preventivi, ordini e acquisti — e quando"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Chi dovrebbe ricevere notifiche per i dispatches relativi alla manutenzione?"
+msgstr "Chi dovrebbe ricevere notifiche per interventi di manutenzione?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Chi dovrebbe ricevere notifiche per i dispatches relativi alle operazioni?"
+msgstr "Chi dovrebbe ricevere notifiche per interventi correlati alle operazioni?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "Chi dovrebbe ricevere notifiche per altri invii?"
+msgstr "Chi dovrebbe ricevere notifiche per altri interventi?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Chi dovrebbe ricevere notifiche per i dispatches relativi alla qualità?"
+msgstr "Chi dovrebbe ricevere notifiche per interventi correlati alla qualità?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
 msgstr "Chi dovrebbe ricevere notifiche quando un preventivo digitale viene accettato o scaduto?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Chi dovrebbe ricevere notifiche quando un calibro esce dalla calibrazione?"
+msgstr "Chi dovrebbe ricevere notifiche quando uno strumento di misura va fuori taratura?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
-msgstr "Chi dovrebbe ricevere notifiche quando viene inviato un nuovo suggerimento?"
+msgstr "Chi dovrebbe ricevere notifiche quando una nuova proposta viene presentata?"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "Chi dovrebbe ricevere notifiche quando un RFQ è contrassegnato come pronto per la quotazione?"
+msgstr "Chi dovrebbe ricevere notifiche quando un RdO è contrassegnato come pronto per offerta?"
 
 msgid "Who should receive notifications when a sales job is completed?"
 msgstr "Chi dovrebbe ricevere notifiche quando un lavoro di vendita è completato?"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
-msgstr "Chi dovrebbe ricevere notifiche quando un'offerta di un fornitore viene inviata?"
+msgstr "Chi dovrebbe ricevere notifiche quando un'offerta del fornitore viene presentata?"
 
 msgid "Who should receive notifications when an inventory job is completed?"
 msgstr "Chi dovrebbe ricevere notifiche quando un lavoro di inventario è completato?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "Perché è bloccato?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Perché il magazzino sta cambiando — Positivo (trovato), Negativo (perso/scrap) o Impostare (sostituire la quantità con un valore misurato)."
+msgstr "Perché la giacenza sta cambiando — Positivo (trovato), Negativo (perso/scarto), o Impostato (sostituisci il conteggio con un valore misurato)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Perché questa linea viene rifiutata; visualizzato sul preventivo stampabile e registrato per i rapporti di vincita/perdita."
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "WIP"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Senza una lista di prelievo, gli operatori prelevano il materiale dalla scheda Scan."
+msgstr "Senza una lista di prelievo, gli operatori prelevano il materiale dalla scheda Scansione."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17490,23 +17490,23 @@ msgid "Write-Down Account"
 msgstr "Conto di Svalutazione"
 
 msgid "Write-off"
-msgstr "Cancellazione"
+msgstr "Stralcio"
 
 msgid "Write-Off"
-msgstr "Cancellazione"
+msgstr "Stralcio"
 
 msgid "Write-Off Account"
-msgstr "Conto di Cancellazione"
+msgstr "Conto stralcio"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Cancellazione per {0}"
+msgstr "Stralcio per {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Eliminazione dei scorte scartate o restituite tramite rifiuti di ispezione e disposizioni NCR"
+msgstr "Stralcio della giacenza scartata o restituita tramite rifiuti di controllo e disposizioni NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "Ridurre il valore di un bene nel corso della sua vita utile — un batch mensile che crei, rivedi come bozza, quindi contabilizzi."
+msgstr "Ammortamento del valore di un bene nel corso della sua vita — un lotto mensile che crei, rivedi come bozza, poi registri."
 
 msgid "Year"
 msgstr "Anno"
@@ -17521,7 +17521,7 @@ msgid "Yes, Accept"
 msgstr "Sì, Accetta"
 
 msgid "Yes, also delete every nested storage unit."
-msgstr "Sì, elimina anche ogni unità di archiviazione nidificata."
+msgstr "Sì, elimina anche ogni unità di stoccaggio nidificata."
 
 msgid "Yes, Reject"
 msgstr "Sì, Rifiuta"
@@ -17551,16 +17551,16 @@ msgid ""
 "                        {0} than the\n"
 "                        ordered quantity of {1}. What would you like\n"
 "                        to do with the extra parts?"
-msgstr "Hai completato {leftoverQuantity} {0} in più rispetto alla quantità ordinata di {1}. Cosa vorresti fare con le parti extra?"
+msgstr "Hai completato {leftoverQuantity} più \n                        {0} della\n                        quantità ordinata di {1}. Cosa vorresti\n                        fare con i pezzi extra?"
 
 msgid "You do not have permission to edit workflows"
-msgstr "Non hai il permesso di modificare i flussi di lavoro"
+msgstr "Non hai l'autorizzazione per modificare i flussi di lavoro"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "Non hai il permesso di modificare questa distinta base."
+msgstr "Non hai l'autorizzazione per modificare questa distinta base."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Non hai i permessi per modificare questo ciclo di lavorazione."
+msgstr "Non hai l'autorizzazione per modificare questa lista delle operazioni."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
 msgstr "Tu lo guidi; noi ci assicuriamo che sia fatto bene. Occhi esperti sulla tua configurazione, dati e lancio."
@@ -17576,7 +17576,7 @@ msgid "You lead"
 msgstr "Tu guidi"
 
 msgid "You name a project owner with decision authority"
-msgstr "Nomini un proprietario del progetto con autorità decisionale"
+msgstr "Nomina un responsabile del progetto con autorità decisionale"
 
 msgid "You received this item"
 msgstr "Hai ricevuto questo articolo"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Sei live su Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Sei a un passo dal tuo spazio di lavoro."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Stai configurando Carbon da solo, al tuo ritmo"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Sei stato registrato per {hoursElapsed} ore. Hai dimenticato di registrare l'uscita?"
+msgstr "Sei timbrato da {hoursElapsed} ore. Hai dimenticato di timbrare fine?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Il tuo account rimane al sicuro anche se il tuo accesso viene rubato"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "te stesso"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Livello di ispezione Z1.4 (I / II / III); livelli superiori significano dimensioni di campione più grandi per lo stesso lotto."
+msgstr "Livello di controllo Z1.4 (I / II / III); i livelli più alti significano dimensioni del campione più grandi per lo stesso lotto."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Gravità Z1.4 (Normale / Irrigidita / Ridotta); passa per regola in base alla cronologia di accettazione recente del lotto."
+msgstr "Gravità Z1.4 (Normale / Rinforzato / Ridotto); cambia per regola in base alla cronologia recente di accettazione del lotto."
 
 msgid "Zoom Box"
 msgstr "Zoom Box"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -361,7 +361,6 @@ msgstr "Un collaboratore esterno è un contatto fornitore con competenze partico
 
 msgid "A custom solution to meet your needs"
 msgstr "Una soluzione personalizzata per soddisfare le tue esigenze"
-msgstr "Una soluzione personalizzata per le tue esigenze"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Un cliente è un'azienda o una persona che compra i tuoi componenti o servizi."
@@ -478,7 +477,6 @@ msgstr "Una versione gestita ospitata nel cloud di Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Una versione gestita con tutte le funzionalità avanzate"
-msgstr "Una versione gestita di Carbon ospitata nel cloud"
 
 msgid "A managed version with all the advanced features"
 msgstr "Una versione gestita con tutte le funzioni avanzate"
@@ -2626,7 +2624,6 @@ msgstr "Sfoglia libreria"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Visualizza la versione pubblicata in sola lettura. Puoi comunque riorganizzare i passi per ordinare il layout."
-msgstr "Sfoglia la versione pubblicata in sola lettura. Puoi comunque riorganizzare i passaggi per organizzare il layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -3042,7 +3039,6 @@ msgstr "Controlla la tua email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verifica di Stripe per questo cliente…"
-msgstr "Controllo di Stripe per questo cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3953,7 +3949,6 @@ msgstr "Crea un nuovo ordine di produzione per evadere l'ordine di vendita"
 
 msgid "Create a new Stripe customer instead"
 msgstr "Crea un nuovo cliente Stripe invece"
-msgstr "Crea invece un nuovo cliente Stripe"
 
 msgid "Create a new version"
 msgstr "Crea una nuova versione"
@@ -6992,7 +6987,6 @@ msgstr "Formato"
 
 msgid "Forward deployed engineer"
 msgstr "Ingegnere dispiegato in prima linea"
-msgstr "Ingegnere distribuito in avanti"
 
 msgid "Foundation"
 msgstr "Fondamenti"
@@ -7049,7 +7043,6 @@ msgstr "Nome completo"
 
 msgid "Full setup and migrations"
 msgstr "Configurazione completa e migrazioni"
-msgstr "Configurazione e migrazioni complete"
 
 msgid "Fully Depreciated"
 msgstr "Completamente Ammortizzato"
@@ -8147,7 +8140,6 @@ msgstr "Problemi"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Si interromperà fino a quando non pubblichi di nuovo una versione. Nulla viene eliminato."
-msgstr "Smetterà di funzionare finché non pubblichi di nuovo una versione. Niente viene eliminato."
 
 msgid "ITAR Certifications"
 msgstr "Certificazioni ITAR"
@@ -8519,7 +8511,6 @@ msgstr "Meno lavoro manuale, meno errori"
 
 msgid "Let's Build"
 msgstr "Costruiamo"
-msgstr "Iniziamo a costruire"
 
 msgid "Let's build something"
 msgstr "Costruiamo qualcosa"
@@ -8601,7 +8592,6 @@ msgstr "Collega problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Collega questo cliente Carbon a uno di loro, oppure crea un cliente Stripe separato."
-msgstr "Collega questo cliente Carbon a uno di loro, o crea un cliente Stripe separato."
 
 msgid "Link to sales order line"
 msgstr "Collega alla riga dell'ordine di vendita"
@@ -11652,7 +11642,6 @@ msgstr "Pubblicato da Carbon"
 
 msgid "Published Version"
 msgstr "Versione Pubblicata"
-msgstr "Versione pubblicata"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Le versioni pubblicate non possono essere modificate. Sfoglia in sola lettura o crea una nuova versione per apportare modifiche."
@@ -12676,7 +12665,6 @@ msgstr "Storna qualsiasi voce di ledger articoli da questa fattura"
 
 msgid "Reverse charge"
 msgstr "Inversione contabile"
-msgstr "Inversione d'imponibilità"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposta di vendita con inversione contabile"
@@ -13498,7 +13486,6 @@ msgstr "Self-hosted o gestito"
 
 msgid "Self-onboarding"
 msgstr "Onboarding autonomo"
-msgstr "Auto-ospitato o gestito"
 
 msgid "Self-onboarding"
 msgstr "Auto-onboarding"
@@ -14343,7 +14330,6 @@ msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
 msgstr "Stripe ha già un cliente con questo indirizzo email"
-msgstr "Stripe ha già un cliente con questa email"
 
 msgid "Stripe Due Date"
 msgstr "Data di scadenza Stripe"
@@ -14353,7 +14339,6 @@ msgstr "Stripe invia l'email della fattura al cliente, quindi è richiesto un in
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe non ha ancora un cliente per questo cliente Carbon. La registrazione ne creerà uno nel tuo account connesso."
-msgstr "Stripe invia la fattura al cliente per email, quindi è richiesto un indirizzo. Questo verrà salvato anche nel contatto in Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe non ha ancora un cliente per questo cliente Carbon. La registrazione ne creerà uno sul tuo account collegato."
@@ -14772,7 +14757,6 @@ msgstr "Metodo di ammortamento fiscale"
 
 msgid "Tax exempt"
 msgstr "esente da imposta"
-msgstr "Esente da imposta"
 
 msgid "Tax Exempt"
 msgstr "Esente da Imposte"
@@ -15667,7 +15651,6 @@ msgstr "Questa fattura non ha una data di scadenza utilizzabile — scegline una
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Questa fattura sarà addebitata al cliente Stripe già collegato a questo cliente Carbon. Per modificare i suoi dettagli, modificalo nel dashboard Stripe."
-msgstr "Questa fattura verrà addebitata al cliente Stripe già collegato a questo cliente Carbon. Per modificarne i dettagli, modificala nel dashboard di Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Questo è un ambiente controllato, quindi è necessaria un'app autenticatore."
@@ -15808,7 +15791,6 @@ msgstr "Questa versione è pubblicata"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Questa versione è pubblicata. Crea una nuova versione per modificarla."
-msgstr "Questa versione è pubblicata. Crea una nuova versione per modificare."
 
 msgid "This version's definition could not be read."
 msgstr "La definizione di questa versione non potrebbe essere letta."
@@ -16403,7 +16385,6 @@ msgstr "Annulla pubblicazione"
 
 msgid "Unpublish {name}?"
 msgstr "Annullare la pubblicazione di {name}?"
-msgstr "Annulla pubblicazione di {name}?"
 
 msgid "Unreceived POs"
 msgstr "PO non ricevuti"
@@ -16765,7 +16746,6 @@ msgstr "Versione"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "La versione {0} è ora pubblicata e sarà sostituita."
-msgstr "La versione {0} è pubblicata ora e verrà sostituita."
 
 msgid "Version:"
 msgstr "Versione:"

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Scartati"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} unità passate saranno completate."
+msgstr "{completions} unità superate verranno completate."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} errore(i) campionato(i) registrato(i) e NON sarà(sarranno) completato(i) — risolvere(li) dal menu azioni."
@@ -124,7 +124,7 @@ msgid "Allocate units"
 msgstr "Assegna unità"
 
 msgid "Are you sure you want to delete this step?"
-msgstr "Sei sicuro di voler eliminare questa fase?"
+msgstr "Sei sicuro di voler eliminare questo passo?"
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "Sei sicuro di voler eliminare questo cartellino? Questa azione non può essere annullata."
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Cancella Ricerca"
 
 msgid "Clock In"
-msgstr "Timbratura Ingresso"
+msgstr "Timbra inizio"
 
 msgid "Clock Out"
-msgstr "Timbratura Uscita"
+msgstr "Timbra fine"
 
 msgid "Clocked in since <0/>"
 msgstr "Connesso da <0/>"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "Completa tutto"
 
 msgid "Complete passed"
-msgstr "Completa passati"
+msgstr "Completa i superati"
 
 msgid "Completed"
 msgstr "Completato"
@@ -296,7 +296,7 @@ msgid "Create Quality Issue"
 msgstr "Crea Problema di Qualità"
 
 msgid "Create Rework"
-msgstr "Crea Rielaborazione"
+msgstr "Crea rilavorazione"
 
 msgid "Current work"
 msgstr "Lavoro attuale"
@@ -317,13 +317,13 @@ msgid "Default"
 msgstr "Predefinito"
 
 msgid "Default Storage Unit"
-msgstr "Unità di Archiviazione Predefinita"
+msgstr "Unità di stoccaggio predefinita"
 
 msgid "Delete"
 msgstr "Elimina"
 
 msgid "Delete Step"
-msgstr "Elimina Fase"
+msgstr "Elimina passo"
 
 msgid "Delete Timecard (<0/>)"
 msgstr "Elimina Scheda Orario (<0/>)"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Dettagli"
 
 msgid "Dispatch not found"
-msgstr "Intervento non trovato"
+msgstr "Intervento di manutenzione non trovato"
 
 msgid "Display"
 msgstr "Visualizzazione"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "Stimato"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "Ogni unità ha un verdetto: {passes} approvate e {fails} non approvate. Il lotto si chiude con ogni unità instradata al suo risultato."
+msgstr "Ogni unità ha un verdetto: {passes} superate e {fails} fallite. Il lotto si chiude con ogni unità indirizzata al suo esito."
 
 msgid "Expand features table"
 msgstr "Espandi tabella funzionalità"
@@ -463,7 +463,7 @@ msgid "Failed features"
 msgstr "Funzionalità non riuscite"
 
 msgid "Failed to complete inventory adjustment"
-msgstr "Impossibile completare la rettifica dell'inventario"
+msgstr "Impossibile completare la rettifica di magazzino"
 
 msgid "Failed to end operations"
 msgstr "Impossibile terminare le operazioni"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Termina comunque"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Completa la configurazione del tuo account"
 
 msgid "Finish with material unpicked?"
 msgstr "Terminare con il materiale non prelevato?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Hai dimenticato di timbrare l'uscita?"
+msgstr "Hai dimenticato il timbra fine?"
 
 msgid "Go back to operation"
 msgstr "Torna all'operazione"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Vai all'onboarding"
 
 msgid "How many were actually picked?"
 msgstr "Quanti sono stati effettivamente prelevati?"
@@ -577,10 +577,10 @@ msgid "Insufficient quantity"
 msgstr "Quantità insufficiente"
 
 msgid "Inventory adjustment completed"
-msgstr "Rettifica inventario completata"
+msgstr "Rettifica di magazzino completata"
 
 msgid "Inventory Adjustments"
-msgstr "Rettifiche Inventario"
+msgstr "Rettifiche di magazzino"
 
 msgid "is"
 msgstr "è"
@@ -616,10 +616,10 @@ msgid "Job Details"
 msgstr "Dettagli Commessa"
 
 msgid "Job Traveler"
-msgstr "Foglio di Lavorazione"
+msgstr "Cartellino di produzione"
 
 msgid "Jobs"
-msgstr "Lavori"
+msgstr "Ordini di produzione"
 
 msgid "Keep picking"
 msgstr "Continua il prelievo"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Manutenzione Completata"
 
 msgid "Maintenance overdue"
-msgstr "Manutenzione scaduta"
+msgstr "Manutenzione in ritardo"
 
 msgid "Make a replacement"
 msgstr "Crea una sostituzione"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Nessuna entità tracciata disponibile trovata"
 
 msgid "No dispatches assigned to you"
-msgstr "Nessun intervento assegnato a te"
+msgstr "Nessun intervento di manutenzione assegnato"
 
 msgid "No files"
 msgstr "Nessun file"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Nessun materiale"
 
 msgid "No open jobs"
-msgstr "Nessun lavoro aperto"
+msgstr "Nessun ordine di produzione aperto"
 
 msgid "No open units to allocate"
 msgstr "Nessuna unità aperta da allocare"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "Nessuna opzione trovata."
 
 msgid "No picking lists assigned"
-msgstr "Nessun elenco di prelievo assegnato"
+msgstr "Nessuna lista di prelievo assegnata"
 
 msgid "No printer configured"
 msgstr "Nessuna stampante configurata"
@@ -875,7 +875,7 @@ msgid "No time entries for this week"
 msgstr "Nessuna registrazione oraria per questa settimana"
 
 msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
-msgstr "Nessun stock di magazzino è registrato per questo articolo. Puoi comunque prelevarlo — la giacenza disponibile diventerà negativa fino al riconciliamento del conteggio."
+msgstr "Non è registrata giacenza di deposito per questo articolo. Puoi comunque effettuare il prelievo — la giacenza disponibile diventerà negativa fino al riconciliamento dell'inventario."
 
 msgid "No Work Center"
 msgstr "Nessun centro di lavoro"
@@ -927,7 +927,7 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Apri un NCR per la disposizione MRB"
 
 msgid "Open Jobs"
-msgstr "Lavori Aperti"
+msgstr "Ordini di produzione aperti"
 
 msgid "Operations"
 msgstr "Operazioni"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "Risultato complessivo"
 
 msgid "Overdue PMs?"
-msgstr "PM scaduti?"
+msgstr "Manutenzioni preventive in ritardo?"
 
 msgid "Parameters"
 msgstr "Parametri"
@@ -966,13 +966,13 @@ msgid "Partial Disposition"
 msgstr "Disposizione Parziale"
 
 msgid "Passed Inspection"
-msgstr "Ispezione Superata"
+msgstr "Controllo superato"
 
 msgid "Passkey unlock failed"
 msgstr "Sblocco con passkey non riuscito"
 
 msgid "Pause"
-msgstr "Pausa"
+msgstr "Sospendi"
 
 msgid "Pick"
 msgstr "Preleva"
@@ -1002,7 +1002,7 @@ msgid "Planned"
 msgstr "Pianificato"
 
 msgid "Please record all steps for this operation before closing."
-msgstr "Registrare tutte le fasi di questa operazione prima di chiuderla."
+msgstr "Registra tutti i passi per questa operazione prima di chiudere."
 
 msgid "Please select an item"
 msgstr "Selezionare un articolo"
@@ -1099,10 +1099,10 @@ msgid "Result"
 msgstr "Risultato"
 
 msgid "Rework"
-msgstr "Rielaborazione"
+msgstr "Rilavorazione"
 
 msgid "Rework created successfully"
-msgstr "Rework creato con successo"
+msgstr "Rilavorazione creata con successo"
 
 msgid "Rework quantity"
 msgstr "Quantità di rilavorazione"
@@ -1153,7 +1153,7 @@ msgid "Scrap quantity"
 msgstr "Quantità di scarto"
 
 msgid "Scrap Reason"
-msgstr "Motivo Scarto"
+msgstr "Causale di scarto"
 
 msgid "Scrapped"
 msgstr "Scartato"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Sessione bloccata"
 
 msgid "Set Clock Out"
-msgstr "Imposta Uscita"
+msgstr "Registra timbra fine"
 
 msgid "Set clock-out time"
 msgstr "Imposta orario di uscita"
@@ -1328,10 +1328,10 @@ msgid "Stay on this page"
 msgstr "Rimani su questa pagina"
 
 msgid "Steps"
-msgstr "Fasi"
+msgstr "Passi"
 
 msgid "Steps are missing"
-msgstr "Fasi mancanti"
+msgstr "Passi mancanti"
 
 msgid "Storage Unit"
 msgstr "Unità di Stoccaggio"
@@ -1340,7 +1340,7 @@ msgid "Submit anonymously"
 msgstr "Invia in forma anonima"
 
 msgid "Suggestion"
-msgstr "Suggerimento"
+msgstr "Proposta"
 
 msgid "Support Required"
 msgstr "Supporto Richiesto"
@@ -1361,7 +1361,7 @@ msgid "The lot will still be dispositioned, but an NCR cannot be created until a
 msgstr "Il lotto sarà comunque disposizionato, ma non è possibile creare un NCR finché non è configurato almeno un tipo di problema."
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "Non ci sono parti tracciate disponibili o consumate per questo materiale."
+msgstr "Non ci sono componenti tracciati disponibili o consumati per questo materiale."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Ci sono materiali tracciati per numero di serie o lotto nella distinta base che non sono stati completamente prelevati. Completare senza prelevare potrebbe causare registrazioni di tracciabilità errate."
@@ -1373,10 +1373,10 @@ msgid "This lot is expired and can't be picked."
 msgstr "Questo lotto è scaduto e non può essere prelevato."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Questa parte è stata realizzata su ordinazione. Lo scarto può riaprire il percorso di produzione per creare una sostituzione."
+msgstr "Questo componente è stato realizzato su ordinazione. Il suo scarto può riaprire il ciclo di lavorazione per produrre un componente di sostituzione."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "Questa parte sarà scartata dallo stock. Il suo fabbisogno rimane aperto per poter emettere una sostituzione."
+msgstr "Questo componente sarà scartato dal magazzino. Il suo requisito rimane aperto per permetterti di ritirare una sostituzione."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "Questa unità sarà permanentemente scartata e verrà creato un nuovo numero seriale."
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "Annulla prelievo {0}"
 
 msgid "Unplanned downtime"
-msgstr "Tempo di inattività non pianificato"
+msgstr "Fermo macchina non pianificato"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Ti sei connesso a <0/>. Puoi modificare l'orario di disconnessione di seguito o confermare che stai ancora lavorando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Sei timbrato in ingresso da {hoursElapsed} ore. Hai dimenticato di timbrare l'uscita?"
+msgstr "Sei timbrato da {hoursElapsed} ore. Hai dimenticato di timbra fine?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Il tuo account non è ancora parte di un'azienda. Completa l'onboarding in Carbon ERP per continuare."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "La tua organizzazione richiede un'app di autenticazione. Configurala in Carbon, quindi torna qui."

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -1514,7 +1514,6 @@ msgstr "Sei timbrato da {hoursElapsed} ore. Hai dimenticato di timbra fine?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Il tuo account non è ancora parte di un'azienda. Completa l'onboarding in Carbon ERP per continuare."
-msgstr "Il tuo account non fa ancora parte di un'azienda. Completa l'onboarding in Carbon ERP per continuare."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "La tua organizzazione richiede un'app di autenticazione. Configurala in Carbon, quindi torna qui."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -170,7 +170,6 @@ msgstr "{from}–{to} / {count} 件の工程"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "{hiddenCount} 件さらに表示: {hiddenNames}"
-msgstr "{hiddenCount}その他: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -305,7 +304,6 @@ msgstr "4時間"
 
 msgid "5 user minimum"
 msgstr "最低 5 ユーザー"
-msgstr "ユーザー最小5名"
 
 msgid "5-8 weeks"
 msgstr "5～8週間"
@@ -479,7 +477,6 @@ msgstr "Carbonのマネージド クラウド ホスト版"
 
 msgid "A managed version with all the advanced features"
 msgstr "すべての高度な機能を備えたマネージド版"
-msgstr "管理されたクラウドホスト版Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "すべての高度な機能を備えた管理版"
@@ -507,7 +504,6 @@ msgstr "新しいサイズが現在のサイズのコピーを使用して作成
 
 msgid "A new Stripe customer will be created"
 msgstr "新しい Stripe 顧客が作成されます"
-msgstr "新しいStripeカスタマーが作成されます"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "請求書を理由勘定に対して決済する非現金文書。貸方は支払額を減らし、借方は増やします。"
@@ -1617,7 +1613,6 @@ msgstr "Carbonデータへのプログラマティックアクセス用のAPIキ
 
 msgid "API, webhooks, and integrations"
 msgstr "API、Webhook、および連携"
-msgstr "API、ウェブフック、および統合"
 
 msgid "Applied"
 msgstr "適用"
@@ -2626,7 +2621,6 @@ msgstr "ライブラリを参照"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "公開済バージョンを読み取り専用で閲覧できます。レイアウトを整理するためにステップを並び替えることもできます。"
-msgstr "公開されたバージョンを読み取り専用で参照できます。レイアウトをきれいにするためにステップを再配置することもできます。"
 
 msgid "Bucket"
 msgstr "バケット"
@@ -2834,7 +2828,6 @@ msgstr "RFQを送信できません"
 
 msgid "Cannot send through Stripe"
 msgstr "Stripeを通じて送信できません"
-msgstr "Stripeを経由して送信できません"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "アップロードできません — 仕入先インタラクションがまだ作成されていません"
@@ -3043,7 +3036,6 @@ msgstr "メールを確認してください"
 
 msgid "Checking Stripe for this customer…"
 msgstr "この得意先の Stripe を確認中…"
-msgstr "このカスタマーのStripeを確認中…"
 
 msgid "Checkpoint ·"
 msgstr "チェックポイント ·"
@@ -3954,7 +3946,6 @@ msgstr "受注を満たすために新しい生産製造指図を作成"
 
 msgid "Create a new Stripe customer instead"
 msgstr "代わりに新しいStripe得意先を作成"
-msgstr "代わりに新しいStripeカスタマーを作成する"
 
 msgid "Create a new version"
 msgstr "新しいバージョンを作成"
@@ -4426,7 +4417,6 @@ msgstr "得意先"
 
 msgid "Customizations, training, and integrations"
 msgstr "カスタマイズ、教育訓練、連携"
-msgstr "カスタマイズ、トレーニング、および統合"
 
 msgid "Customize"
 msgstr "カスタマイズ"
@@ -6273,7 +6263,6 @@ msgstr "既存のマッピング。異なるプロバイダーオプションを
 
 msgid "Existing Stripe customer"
 msgstr "既存のStripe顧客"
-msgstr "既存のStripeカスタマー"
 
 msgid "Expand"
 msgstr "展開"
@@ -6995,7 +6984,6 @@ msgstr "フォーマット"
 
 msgid "Forward deployed engineer"
 msgstr "現地配置エンジニア"
-msgstr "フィールドデプロイエンジニア"
 
 msgid "Foundation"
 msgstr "基礎"
@@ -7052,7 +7040,6 @@ msgstr "氏名"
 
 msgid "Full setup and migrations"
 msgstr "完全なセットアップとマイグレーション"
-msgstr "完全なセットアップと移行"
 
 msgid "Fully Depreciated"
 msgstr "完全償却済み"
@@ -8150,7 +8137,6 @@ msgstr "問題"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "バージョンを再度公開するまで実行は停止します。削除されるものはありません。"
-msgstr "バージョンを再度公開するまで実行が停止します。何も削除されません。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR認定"
@@ -8603,7 +8589,6 @@ msgstr "Linear イシューをリンク"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "このCarbonの得意先をいずれかにリンクするか、別のStripe顧客を作成してください。"
-msgstr "このCarbonカスタマーをそのいずれかにリンクするか、別のStripeカスタマーを作成してください。"
 
 msgid "Link to sales order line"
 msgstr "受注明細へのリンク"
@@ -11654,7 +11639,6 @@ msgstr "Carbonによって公開済"
 
 msgid "Published Version"
 msgstr "公開済バージョン"
-msgstr "公開されたバージョン"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "公開済みバージョンは編集できません。読み取り専用で参照するか、新しいバージョンをブランチして変更してください。"
@@ -12678,7 +12662,6 @@ msgstr "この請求書の品目台帳の仕訳をすべて反対仕訳する"
 
 msgid "Reverse charge"
 msgstr "逆請求"
-msgstr "リバースチャージ"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "リバースチャージ売上税"
@@ -13497,7 +13480,6 @@ msgstr "自己管理"
 
 msgid "Self-hosted or managed"
 msgstr "セルフホストまたはマネージド"
-msgstr "セルフホスト型または管理型"
 
 msgid "Self-onboarding"
 msgstr "セルフオンボーディング"
@@ -14351,7 +14333,6 @@ msgstr "Stripeは得意先に請求書をメール送信するため、住所が
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "StripeにはこのCarbon得意先に対応する顧客がまだありません。転記すると、接続済みアカウント上に作成されます。"
-msgstr "Stripeにはこのメールアドレスを持つカスタマーが既に存在します"
 
 msgid "Stripe Due Date"
 msgstr "Stripe支払期日"
@@ -14776,7 +14757,6 @@ msgstr "税務減価償却方法"
 
 msgid "Tax exempt"
 msgstr "非課税"
-msgstr "税金免除"
 
 msgid "Tax Exempt"
 msgstr "非課税"
@@ -15640,7 +15620,6 @@ msgstr "これはDiscoveryステップを完了します。"
 
 msgid "This contact has no email address"
 msgstr "この担当者はメールアドレスを持っていません"
-msgstr "この連絡先にはメールアドレスがありません"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "この取引先には未払い金がありません。支払いは掛け金として記録されます。"
@@ -15672,7 +15651,6 @@ msgstr "この請求書には使用可能な期日がありません。Stripeの
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "この請求書は、すでにこのCarbon得意先にリンクされているStripe顧客に請求されます。詳細を変更するには、Stripeダッシュボードで編集してください。"
-msgstr "この請求書には使用可能な支払期日がありません — Stripeのために1つ選択してください。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "この請求書は、すでにこのCarbon得意先にリンクされているStripe顧客に請求されます。詳細を変更するには、Stripeダッシュボードで編集してください。"
@@ -15816,7 +15794,6 @@ msgstr "このバージョンは公開済です"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "このバージョンは公開済です。編集するには新しいバージョンを作成してください。"
-msgstr "このバージョンは公開されています"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "このバージョンは公開済です。編集するには新しいバージョンを作成してください。"
@@ -16414,7 +16391,6 @@ msgstr "非公開にする"
 
 msgid "Unpublish {name}?"
 msgstr "{name}を非公開にしますか？"
-msgstr "公開を取り消す"
 
 msgid "Unpublish {name}?"
 msgstr "{name}の公開を取り消しますか?"
@@ -16779,7 +16755,6 @@ msgstr "バージョン"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "バージョン {0} は現在公開済であり、置き換えられます。"
-msgstr "バージョン{0}は現在公開されており、置き換えられます。"
 
 msgid "Version:"
 msgstr "バージョン:"
@@ -17665,7 +17640,6 @@ msgstr "Carbonで本番稼働中です"
 
 msgid "You're one step away from your workspace."
 msgstr "ワークスペースの1ステップ手前です。"
-msgstr "ワークスペースまであと1ステップです。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "あなた自身のペースでCarbonをセットアップしています"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 msgid " A supplier is a business or person who sells you parts or services."
-msgstr "サプライヤーは、あなたに部品またはサービスを販売する企業または個人です。"
+msgstr " 仕入先は、部品または外注サービスを販売するビジネスまたは個人です。"
 
 #. placeholder {0}: formatDateTime(lastReconciliation.runAt)
 msgid "— last checked {0}"
@@ -27,13 +27,13 @@ msgstr ", {years}年"
 
 #. placeholder {0}: fieldDef?.label ?? condition.field
 msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
-msgstr "「{0}」は選択されたサーフェス上で利用できません。別のフィールドを選択してください。"
+msgstr "「{0}」は選択されたサーフェスで利用不可です。別のフィールドを選択してください。"
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "「{storageUnitName}」には{childCount}個の直下の階層化されたストレージユニットがあります。これを削除すると、それらとその下にあるすべてのものも削除されます。この操作は取り消せません。"
+msgstr "\"{storageUnitName}\" には {childCount} 個の直接ネストされた保管ユニットがあります。それを削除すると、それらとその下にあるすべてのものも削除されます。この操作は元に戻せません。"
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "「${storageUnitName}」には1つの直接ネストされたストレージユニットがあります。これを削除すると、そのユニットとその下にあるすべてのものも削除されます。これは元に戻すことはできません。"
+msgstr "\"{storageUnitName}\" には 1 個の直接ネストされた保管ユニットがあります。それを削除すると、そのユニットとその下にあるすべてのものも削除されます。この操作は元に戻せません。"
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -46,7 +46,7 @@ msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured.
 msgstr "「{taskName}」は完了しました — セットアップマップのすべての {0} 項目が設定されています。"
 
 msgid "(excluded for this customer)"
-msgstr "(このお客様では除外されています)"
+msgstr "（このお客様向けに除外されています）"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -66,7 +66,7 @@ msgstr "{0}個のデルタを持つセル"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
-msgstr "{0}件の残高のある顧客"
+msgstr "残高がある{0}社"
 
 #. placeholder {0}: rule.escalationDays
 msgid "{0} days"
@@ -83,7 +83,7 @@ msgstr "{0}件の下書き仕訳"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0}件のジョブが作成されました"
+msgstr "{0} 件の製造指図が作成されました"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -92,7 +92,7 @@ msgstr "{0}件のラインをマップします"
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
-msgstr "{0} 件 / {1} 件の仕訳勘定がマップされています"
+msgstr "{0} 件/{1} 件の転記勘定がマップされました"
 
 #. placeholder {0}: rows.length
 msgid "{0} of {maxSlots} provider slots used"
@@ -104,7 +104,7 @@ msgstr "{0}件の注文"
 
 #. placeholder {0}: issues.length
 msgid "{0} problems — not published"
-msgstr "{0}個の問題 — 未発行"
+msgstr "{0}個の問題 — 公開済ではありません"
 
 #. placeholder {0}: selectedProcesses.length
 msgid "{0} Processes"
@@ -129,7 +129,7 @@ msgstr "{0}個のマッピングされていないアカウントが{1}個のプ
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} unposted documents"
-msgstr "{0}件の未転記書類"
+msgstr "{0}件の未転記文書"
 
 #. placeholder {0}: file.name
 msgid "{0} uploaded successfully"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0}個の値が見つかりません"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount}件のパーツをスキップしました — 既にオープンジョブがあります"
+msgstr "{alreadyPlannedItemCount}個の部品はスキップ済 — 既に進行中の製造指図があります"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}%の買掛金"
@@ -154,7 +154,7 @@ msgid "{arOverduePct}% of receivables"
 msgstr "{arOverduePct}%の売掛金"
 
 msgid "{chainLabel}. Consider pointing this part directly at the final successor."
-msgstr "{chainLabel}。このパーツを最終的な後継品に直接指定することを検討してください。"
+msgstr "{chainLabel}。この部品を最終的な後継品目に直接ポイントすることを検討してください。"
 
 msgid "{count, plural, one {# course} other {# courses}}"
 msgstr "{count, plural, one {# コース} other {# コース}}"
@@ -166,15 +166,15 @@ msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}～{to}件 (合計{count}件の操作)"
+msgstr "{from}–{to} / {count} 件の工程"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} 件さらに表示: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
-msgstr "{inserted}件挿入、{updated}件更新、{0}件修正が必要、{1}件スキップ。"
+msgstr "{inserted}件を追加、{updated}件を更新、{0}件を修正が必要、{1}件をスキップ。"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -186,20 +186,20 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount}ヶ月の合計が一致していません"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "プロバイダーで{missingCount}件のジャーナルが見つかりません"
+msgstr "プロバイダーに {missingCount} 件の仕訳が不足しています"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount}件のジャーナルが見つからず、{mismatchCount}ヶ月の合計が一致していません"
+msgstr "{missingCount} 件の不足している仕訳と {mismatchCount} ヶ月のミスマッチ"
 
 msgid "{name} deleted"
 msgstr "{name}が削除されました"
 
 msgid "{noDemandItemCount} parts skipped — nothing to make"
-msgstr "{noDemandItemCount}件のパーツをスキップしました — 製造する必要がありません"
+msgstr "{noDemandItemCount}個の部品はスキップ済 — 製造する必要がありません"
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel}はリビジョン{0}として編集のために再度開かれます。既にサプライヤーに送信したドキュメントは、確定して注文を再度送信するまで変更されません。"
+msgstr "{orderLabel} はリビジョン {0} として編集のため再度オープンされます。仕入先に送信済みの文書は、ファイナライズして発注書を再送信するまで変更されません。"
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# フェーズ残り} other {# フェーズ残り}}"
@@ -208,7 +208,7 @@ msgid "{scopeCount} permissions"
 msgstr "{scopeCount} 個の権限"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "{total}個のフェーズでお客様の企業をCarbonで稼働させます。各フェーズはチェックポイントで終了します。"
+msgstr "{total}つのフェーズでご利用開始までご案内します。各フェーズはチェックポイントで終了します。"
 
 msgid "{total} phases to go live"
 msgstr "{total}個のフェーズをライブにする"
@@ -220,10 +220,10 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount}件のジョブが更新されました"
+msgstr "{updatedJobCount} 件の製造指図が更新されました"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
-msgstr "{uploadedFileName} をアップロードしました — ドキュメントからフィールドに入力されました。"
+msgstr "{uploadedFileName} がアップロードされました — フィールドは文書から入力されました。"
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
 msgstr "{variances, plural, one {# 行が予想数量と異なります} other {# 行が予想数量と異なります}}"
@@ -249,7 +249,7 @@ msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
 msgstr "<0>この商品の仕入先部品を追加</0>して、優先仕入先を設定してください。"
 
 msgid "0 operations"
-msgstr "0件の操作"
+msgstr "0 件の工程"
 
 msgid "0-4 weeks"
 msgstr "0～4週間"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1日"
 
 msgid "1 draft journal entry"
-msgstr "1件の下書き仕訳"
+msgstr "1 件の下書き仕訳行"
 
 msgid "1 job created"
 msgstr "1件のジョブが作成されました"
@@ -267,16 +267,16 @@ msgid "1 job updated"
 msgstr "1件のジョブが更新されました"
 
 msgid "1 part skipped — it already has an open job"
-msgstr "1件のパーツをスキップしました — 既にオープンジョブがあります"
+msgstr "1個の部品はスキップ済 — 既に進行中の製造指図があります"
 
 msgid "1 part skipped — nothing to make"
-msgstr "1件のパーツをスキップしました — 製造する必要がありません"
+msgstr "1個の部品はスキップ済 — 製造する必要がありません"
 
 msgid "1 problem — not published"
-msgstr "1個の問題 — 未発行"
+msgstr "1個の問題 — 公開済ではありません"
 
 msgid "1 unposted document"
-msgstr "1件の未転記書類"
+msgstr "1 件の未転記文書"
 
 msgid "12 monthly periods"
 msgstr "12ヶ月間の期間"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4時間"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "最低 5 ユーザー"
 
 msgid "5-8 weeks"
 msgstr "5～8週間"
 
 msgid "52-week demand"
-msgstr "52週間の需要"
+msgstr "52 週間の所要量"
 
 msgid "5MB file limit"
 msgstr "5MBファイル制限"
@@ -330,73 +330,73 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Carbon実行のデータ移行 — あなたが自分のデータをロードします"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "変更通知は、レビューと実装を通じて制御されたエンジニアリングまたは製造上の変更を追跡します。"
+msgstr "変更通知は、エンジニアリングまたは製造変更をレビューと実施を通じて追跡します。"
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "受け取ったが請求されていない商品の価値を保有するクリアリング勘定。仕入先請求書がそれを結済します。"
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
-msgstr "他社の仕様に従うのではなく、独自の完成品をエンドツーエンドで設計・製造する企業（ここでは、ヒューマノイドロボットを製造するショップ）。"
+msgstr "自社で最初から最後まで完成製品を設計・製造する会社です（ここでは、ヒューマノイドロボットを製造するショップ）。別の会社の仕様に従って部品を製造するのではなく。"
 
 msgid "A company that sits at or above selected companies in the group hierarchy and receives their intercompany cancelling entries for consolidated reporting; it is never a party to the trade itself."
-msgstr "グループ階層内の選択された企業と同じレベルまたは上位に位置し、統合報告のための企業間相殺エントリを受け取る企業。取引の当事者にはなりません。"
+msgstr "グループ階層内で選択された会社の上に位置し、連結報告のための企業間打ち消し仕訳を受け取る会社です。その会社自身は取引当事者になることはありません。"
 
 msgid "A company-defined extra field attached to a core table (customer, part, order); it shows on the record's form, saves alongside the built-in fields, and is queryable through the API."
-msgstr "コア テーブル (顧客、部品、注文) に添付されたユーザー定義の追加フィールド。レコードのフォームに表示され、組み込みフィールドと並んで保存され、API を通じてクエリ可能です。"
+msgstr "会社が定義した追加フィールド。コアテーブル（得意先、部品、発注書）に関連付けられます。レコードのフォームに表示され、組み込みフィールドと一緒に保存され、APIを通じて問い合わせることができます。"
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
 msgstr "仕訳行に添付されたユーザー定義のタグ軸。勘定科目表を増やさずに、同じ勘定科目を場所、部門、またはカスタム軸でスライスできます。"
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
-msgstr "会社スコープの割引または値上げ (パーセンテージまたは固定額)。行が、ルールの数量、日付、品目、および顧客条件に一致するときに、行の価格を上下に調整します。"
+msgstr "会社スコープの値引またはマークアップ。パーセンテージまたは固定金額で、明細が、ルールの数量、日付、品目、得意先条件と一致するとき、明細の価格を調整します。"
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "完了したジョブの出力は、ジョブの実際の累積WIPコストでインベントリに受け取られます。"
+msgstr "完了した製造指図の出力で、その製造指図の実績累積仕掛品原価で在庫に受け入れられます。"
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "消耗品は、複数のジョブで使用できるパーツを作成するために使用される物理的なアイテムです"
+msgstr "消耗品は、部品を製造するために使用される物理的な品目で、複数の製造指図で使用できます。"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "契約者は、特定の能力と利用可能な時間を持つサプライヤー連絡先です"
+msgstr "外部作業者は、特定のスキルと利用可能な時間を持つ仕入先の担当者です。"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "お客様のニーズに合わせたカスタムソリューション"
 
 msgid "A customer is a business or person who buys your parts or services."
-msgstr "顧客とは、あなたの部品またはサービスを購入する企業または個人です。"
+msgstr "得意先は、あなたの部品またはサービスを購入する企業または個人です。"
 
 msgid "A customer is created"
-msgstr "顧客が作成されました"
+msgstr "得意先が作成されました"
 
 msgid "A customer is deleted"
-msgstr "顧客が削除されました"
+msgstr "得意先が削除されました"
 
 msgid "A customer's account manager changes"
-msgstr "顧客のアカウントマネージャーが変更されました"
+msgstr "得意先のアカウント マネージャーが変わりました"
 
 msgid "A customer's assignee changes"
-msgstr "顧客の担当者が変更されました"
+msgstr "得意先の担当者が変わりました"
 
 msgid "A customer's currency changes"
-msgstr "顧客の通貨が変更されました"
+msgstr "得意先の通貨が変わりました"
 
 msgid "A customer's name changes"
-msgstr "顧客の名前が変更されました"
+msgstr "得意先名が変わりました"
 
 msgid "A customer's sales contact changes"
-msgstr "顧客の営業担当者が変更されました"
+msgstr "得意先の販売担当者が変更される"
 
 msgid "A customer's status changes"
-msgstr "顧客のステータスが変更されました"
+msgstr "得意先のステータスが変わりました"
 
 msgid "A customer's type changes"
-msgstr "顧客のタイプが変更されました"
+msgstr "得意先のタイプが変わりました"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "ゲージが追跡可能な標準に対してチェックされたことを証明する日付付きレコード。措置要求、調整要求、または修理要求フラグがオンになっていない限り合格し、ゲージの次回実施予定日をリセットします。"
+msgstr "測定器が標準器に対してチェックされたことを示す日付付きレコード。「対応が必要」「調整が必要」「修理が必要」フラグがチェックされていない限り合格し、測定器の次回期限をリセットします。"
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "仕訳が該当する日付ウィンドウ。クローズステータスは開始 → ロック → クローズに移行し、クローズされた期間は新規仕訳から凍結されます。"
+msgstr "転記が入る日付付きウィンドウ。そのクローズ ステータスはオープン→ロック中→クローズ済に移行し、クローズ済ピリオドは新しい転記に対して凍結されます。"
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "毎期残り帳簿価額の一定の割合を請求する減価償却方法—早期はより重く、後期はより軽い。"
@@ -405,7 +405,7 @@ msgid "A depreciation method that charges an equal amount each period across the
 msgstr "資産の耐用年数全体にわたって、毎期同じ金額を請求する減価償却方法。"
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
-msgstr "顧客の配送への固い約束；履行ステータスは完了に達する前に出荷と請求書間で分割します。"
+msgstr "得意先への確定的な配送約束。出荷と請求書で履行状態が分割され、完了に到達します。"
 
 msgid "A firm order to a supplier; status moves through receive and invoice before Completed as goods and bills arrive."
 msgstr "仕入先への確定注文；商品と請求書が到着するにつれて、ステータスは完了前に受け取りと請求を通じて移動します。"
@@ -414,7 +414,7 @@ msgid "A formal acceptance / sign-off phase"
 msgstr "正式な承認/サインオフフェーズ"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "マスターの役割を持つゲージ。日常的なチェックに使用されるものではなく、他のゲージがキャリブレーションされる基準標準です。"
+msgstr "ロールが標準器である測定器。定期チェックに使用されるものではなく、他の測定器が校正される参照基準です。"
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "問題レコードは品質問題とその解決プロセスを追跡します。"
@@ -432,7 +432,7 @@ msgid "A job is released"
 msgstr "ジョブがリリースされました"
 
 msgid "A job operation is completed"
-msgstr "ジョブ操作が完了しました"
+msgstr "指図工程が完了しました"
 
 msgid "A job's assignee changes"
 msgstr "ジョブの担当者が変更されました"
@@ -441,7 +441,7 @@ msgid "A job's deadline type changes"
 msgstr "ジョブの期限タイプが変更されました"
 
 msgid "A job's due date changes"
-msgstr "ジョブの期限が変更されました"
+msgstr "製造指図の期日が変わりました"
 
 msgid "A job's priority changes"
 msgstr "ジョブの優先度が変更されました"
@@ -467,31 +467,31 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "リストが{0}に接続されているため、このステップはその中の各項目ごとに1回実行されます。最大{MAX_LIST_ITEMS}個です。"
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "親のビルド内で独自のジョブとルーティングを取得する受注製造コンポーネント。"
+msgstr "親の製造時に自身のジョブと工順を取得する受注生産部品。"
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "その部品が親ジョブに一緒に発行される受注製造コンポーネント—別のビルドはありません。"
+msgstr "部品が親ジョブに一緒に出庫される受注生産部品。別途製造なし。"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbonのマネージド クラウド ホスト版"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "すべての高度な機能を備えたマネージド版"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "材料は、複数のジョブで使用できるパーツを作成するために使用される物理的なアイテムです"
+msgstr "材料は部品を製造するために使用される物理的品目で、複数の製造指図にわたって使用できます"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "測定器 (ノギス、マイクロメータ、ピンゲージ、CMM) として追跡され、定期的なキャリブレーション スケジュールに従うレコード。"
+msgstr "キャリパー、マイクロメーター、ピンゲージ、CMM などの測定器で、レコードとして追跡され、定期的な校正スケジュールに従います。"
 
 msgid "A name is required to save a view"
 msgstr "ビューを保存するには名前が必要です"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "特定の品目に固定された交渉価格 (顧客、顧客タイプ、またはすべての顧客ごと)。基本価格を完全に置き換え、オプションで数量割引を適用します。"
+msgstr "特定の品目に対する交渉済み価格で、顧客ごと、顧客タイプごと、またはすべての顧客に対して設定でき、基本価格に置き換わります。必要に応じて数量スケールを設定できます。"
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "新しい発注書が各サプライヤーに対して作成されます。または、既存のドラフト発注書を選択して、外部オペレーションを追加することもできます。"
+msgstr "仕入先ごとに新しい発注書が作成されます。または、既存の下書き発注書を選択して、外注工程を追加することもできます。"
 
 msgid "A new revision will be created using a copy of the current revision"
 msgstr "現在のリビジョンのコピーを使用して、新しいリビジョンが作成されます"
@@ -500,19 +500,19 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "新しいサイズが現在のサイズのコピーを使用して作成されます"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "新しい Stripe 顧客が作成されます"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "請求書を理由勘定に対して決済する非現金ドキュメント。クレジットは債務額を低下させ、デビットは債務額を増加させます。"
+msgstr "請求書を理由勘定に対して決済する非現金文書。貸方は支払額を減らし、借方は増やします。"
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
-msgstr "ログインなしの /share/scar リンク経由でサプライヤーと共有される不適合。サプライヤーは Carbon 外から問題に対応し、タスクを更新できます。"
+msgstr "ログイン不要の/share/scarリンク経由で仕入先と共有された不適合。仕入先はCarbonの外から問題に対応してタスクを更新できます。"
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "非課税追加料金（返還可能経費など許可手数料）を行に追加し、課税ベースから除外します。"
+msgstr "明細に追加された非課税手数料（例：許可手数料などの回収可能な費用）。税ベースから除外。"
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "確認された根本原因を修正する不適合タスク—予防的または直接封じ込め処置とは異なります。"
+msgstr "確定した根本原因に対処する不適合タスク。予防措置または即時の封じ込め対策とは異なります。"
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
 msgstr "問題が他の場所で再発するのを防ぐ不適合タスク—是正措置と封じ込めとは異なります。"
@@ -521,70 +521,70 @@ msgid "A part contains the information about a specific item that can be purchas
 msgstr "パーツには、購入または製造できる特定の品目に関する情報が含まれています。"
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "物理的なプル信号 (在庫と一緒に保管される印刷されたカードまたは QR コード)。スキャンされてビンを補充する瞬間に、購買注文またはジョブを起動します。"
+msgstr "物理的なプルシグナル。在庫に付属する印刷されたカードまたはQRコード。スキャンされた時点で発注書またはジョブを作成してビンを補充します。"
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "ワークフローが監視できるCarbonの独自フロー内のポイント（ジョブのリリース、引用符の受け入れ、出荷の投稿など）。生の変更ではなく、ワークフローにIDで関連レコードを渡します。"
+msgstr "Carbon のワークフロー内のポイント（製造指図がリリース済、見積が承諾済、出荷が転記済など）で、ワークフローが監視できます。生のフィールド変更とは異なり、関連するレコードを ID で提供します。"
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "投稿されたエントリ：GLアカウントに対してバランスの取れたヘッダープラスデビットおよびクレジットラインのペアリング。"
+msgstr "転記済会計エントリ。ヘッダーと勘定科目に対する均衡した借方・貸方明細から構成。"
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "転記された現金取引 (顧客からの受取金または仕入先への支出)。決済を通じて請求書に適用され、下書き → 転記 → 無効に移行します。"
+msgstr "転記済みのキャッシュトランザクション — 得意先からの入金または仕入先への出金 — 決済を通じて請求書に適用され、下書き → 転記済 → 取消済に移行します。"
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "このワークフローを使用するすべての問題に挿入される事前作成された説明。{itemId}と{location}などのプレースホルダーは作成時に置き換えられます。"
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "価格付きの販売見積もり。ドラフト→送信→注文済み、または失われた、期限切れ、またはキャンセルで終わります。"
+msgstr "価格付き販売見積。下書き→送信→発注済、または失注・期限切れ・キャンセル済で終了。"
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
-msgstr "購入請求書は、顧客が購入した製品またはサービスと対応するコストを指定するドキュメントです。"
+msgstr "仕入先請求書は、顧客が購入した製品またはサービスと対応する原価を指定する文書です。"
 
 msgid "A purchase invoice is posted"
-msgstr "購買請求書が投稿されました"
+msgstr "仕入先請求書が転記されました"
 
 msgid "A purchase order is created"
-msgstr "購買注文が作成されました"
+msgstr "発注書が作成されました"
 
 msgid "A purchase order is deleted"
-msgstr "購買注文が削除されました"
+msgstr "発注書が削除されました"
 
 msgid "A purchase order's assignee changes"
-msgstr "購買注文の担当者が変更されました"
+msgstr "発注書の担当者が変わりました"
 
 msgid "A purchase order's order date changes"
-msgstr "購買注文の注文日が変更されました"
+msgstr "発注書の発注日が変わりました"
 
 msgid "A purchase order's status changes"
-msgstr "購買注文のステータスが変更されました"
+msgstr "発注書のステータスが変更される"
 
 msgid "A purchase order's supplier changes"
-msgstr "購買注文のサプライヤーが変更されました"
+msgstr "発注書の仕入先が変更される"
 
 msgid "A purchase order's supplier location changes"
-msgstr "購買注文のサプライヤーの場所が変更されました"
+msgstr "発注書の仕入先の拠点が変更される"
 
 msgid "A purchase order's supplier reference changes"
-msgstr "購買注文のサプライヤー参照が変更されました"
+msgstr "発注書の仕入先参照が変更される"
 
 msgid "A purchase order's tags changes"
-msgstr "購買注文のタグが変更されました"
+msgstr "発注書のタグが変更される"
 
 msgid "A purchase order's type changes"
-msgstr "購買注文のタイプが変更されました"
+msgstr "発注書の種類が変更される"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "品質問題—記録された逸脱または欠陥であり、調査および実施タスクの構成可能なワークフローがあります。"
+msgstr "品質上の問題―記録された特別採用または不具合で、調査およびアクションタスクの設定可能なワークフローを備えています。"
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
-msgstr "同一ユニットの数量は、追跡エンティティとバッチ番号を共有します—1つのエンティティ、多くのユニット。"
+msgstr "同一の単位の数量は1つの追跡対象とバッチ番号を共有します―1つのエンティティ、多くの単位。"
 
 msgid "A quote is a set of prices for specific parts and quantities."
 msgstr "見積もりは、特定の部品と数量の価格セットです。"
 
 msgid "A quote is accepted"
-msgstr "引用符が受け入れられました"
+msgstr "見積が承諾済になる"
 
 msgid "A quote is created"
 msgstr "引用符が作成されました"
@@ -596,7 +596,7 @@ msgid "A quote is sent"
 msgstr "見積が送信される"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "見積行には、特定の部品の価格とリードタイムが含まれています"
+msgstr "見積明細には特定の部品の価格設定とリードタイムが含まれている"
 
 msgid "A quote's assignee changes"
 msgstr "見積の担当者が変更される"
@@ -605,10 +605,10 @@ msgid "A quote's completed date changes"
 msgstr "見積の完了日が変更される"
 
 msgid "A quote's customer changes"
-msgstr "見積の顧客が変更される"
+msgstr "見積の得意先が変更される"
 
 msgid "A quote's due date changes"
-msgstr "見積の期限日が変更される"
+msgstr "見積の期日が変更される"
 
 msgid "A quote's estimator changes"
 msgstr "見積の見積作成者が変更される"
@@ -635,7 +635,7 @@ msgid "A receipt's assignee changes"
 msgstr "領収書の担当者が変更される"
 
 msgid "A receipt's invoiced changes"
-msgstr "領収書の請求状況が変更される"
+msgstr "入荷の請求済が変更される"
 
 msgid "A receipt's location changes"
 msgstr "領収書の場所が変更される"
@@ -644,7 +644,7 @@ msgid "A receipt's posting date changes"
 msgstr "領収書の転記日が変更される"
 
 msgid "A receipt's source document changes"
-msgstr "領収書のソース文書が変更される"
+msgstr "入荷の参照伝票が変更される"
 
 msgid "A receipt's status changes"
 msgstr "領収書のステータスが変更される"
@@ -653,16 +653,16 @@ msgid "A receipt's supplier changes"
 msgstr "領収書の仕入先が変更される"
 
 msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
-msgstr "プロセスに添付された再利用可能でバージョン管理された作業指示のセット。操作に記録・確認するための順序付きステップと実行パラメータを提供します。"
+msgstr "工法に添付された再利用可能でバージョン管理された作業手順書のセット。工程に記録および確認する順序付きステップとそれが実行されるときのパラメーターを提供します。"
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "リリースされたジョブ上のルーティングステップで、ジョブ独自のオペレーションのコピーであり、フロアがTodoからDoneまで駆動するステータスを持ちます。"
+msgstr "リリース済の製造指図上の工順ステップ。製造指図自身の工程のコピーで、床面で駆動される「完了する」までのステータスを持つ。"
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "売上請求書 (顧客に請求) または仕入請求書 (仕入先から請求)。支払いと貸方貸方または借方貸方メモを適用して決済します。"
+msgstr "売上請求書（得意先に請求）または仕入先請求書（仕入先から請求されたもの）で、支払と貸方／借方メモを適用して決済されます。"
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
-msgstr "売上請求書は、顧客に販売された製品またはサービスと対応する費用を指定するドキュメントです。"
+msgstr "売上請求書は、得意先に販売した製品またはサービスと対応する原価を指定する文書です。"
 
 msgid "A sales invoice is posted"
 msgstr "売上請求書が転記される"
@@ -671,61 +671,61 @@ msgid "A sales invoice line contains invoice details for a particular item"
 msgstr "売上請求書行には、特定の品目の請求書詳細が含まれています"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "営業注文には、会社と特定の顧客との部品およびサービスに関する契約情報が含まれています。"
+msgstr "受注には、会社と特定の得意先との間の部品およびサービスの契約に関する情報が含まれています。"
 
 msgid "A sales order is created"
-msgstr "販売注文が作成される"
+msgstr "受注が作成される"
 
 msgid "A sales order is deleted"
-msgstr "販売注文が削除される"
+msgstr "受注が削除される"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "販売注文行には、特定の品目の注文詳細が含まれています"
+msgstr "受注明細には特定の品目の注文詳細が含まれています"
 
 msgid "A sales order's assignee changes"
-msgstr "販売注文の担当者が変更される"
+msgstr "受注の担当者が変更される"
 
 msgid "A sales order's completed date changes"
-msgstr "販売注文の完了日が変更される"
+msgstr "受注の完了日が変更される"
 
 msgid "A sales order's customer changes"
-msgstr "販売注文の顧客が変更される"
+msgstr "受注の得意先が変更される"
 
 msgid "A sales order's customer reference changes"
-msgstr "販売注文の顧客参照が変更される"
+msgstr "受注の得意先参照が変更される"
 
 msgid "A sales order's location changes"
-msgstr "販売注文の場所が変更される"
+msgstr "受注の拠点が変更される"
 
 msgid "A sales order's order date changes"
-msgstr "販売注文の注文日が変更される"
+msgstr "受注の注文日が変更される"
 
 msgid "A sales order's salesperson changes"
-msgstr "販売注文の営業担当者が変更される"
+msgstr "受注の営業担当者が変更される"
 
 msgid "A sales order's status changes"
-msgstr "販売注文のステータスが変更される"
+msgstr "受注のステータスが変更される"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "営業見積依頼（RFQ）は、一連の部品と数量の価格設定に関する顧客からの問い合わせです。見積書につながる可能性があります。"
+msgstr "売上見積依頼（RFQ）は、複数の部品と数量に関する価格設定についての得意先からの問い合わせです。見積が発行される可能性があります。"
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
-msgstr "販売RFQ（顧客が見積りを依頼）または購買RFQ（仕入先に依頼）。両方が機会スレッドを供給します。"
+msgstr "売上見積依頼（得意先が見積をお願いする）または購買見積依頼（仕入先に見積をお願いする）で、どちらも商談に情報を提供します。"
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
 msgstr "carbon-key リクエスト ヘッダーで送信されるスコープ付きシークレット。Carbon へのプログラマティック呼び出しを認証し、ユーザー セッションではなく独自の権限とレート制限を保有します。"
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "税務規則が帳簿折旧と異なる方法を要求する場合の税務報告用の別個のスケジュール。"
+msgstr "税務報告のための別のスケジュール。税務ルールが帳簿減価償却とは異なる方法を要求する場合。"
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "サービスは、購入または実行される請求可能なアクティビティです。配送、受取、または在庫されることはありません"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "同一の所有者の下にある会社の集合で、グループ単位の構成（勘定科目表、通貨、ディメンション）を共有し、同じ会計設定がグループ内のすべての会社に適用されます。"
+msgstr "1つのオーナーの下で、グループ規模の構成（勘定科目表、通貨、ディメンション）を共有する複数の会社のセット。同じ会計設定がグループ内のすべての会社に適用されます。"
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "ジョブの未処理材料をウェアハウスから引き出し、ラインサイドにステージングする一連の指示。ピッキングは在庫を消費するのではなく、使用場所に移動します。"
+msgstr "製造指図の未処理の材料を倉庫から引き出し、ラインサイドで配置するための一連の指示。ピッキングは在庫を消費するのではなく、使用の地点に移動させます。"
 
 msgid "A shipment is created"
 msgstr "出荷が作成される"
@@ -737,13 +737,13 @@ msgid "A shipment is posted"
 msgstr "出荷が転記される"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "仕入先からお客様に直接送られる出荷ラインで、倉庫をバイパスします。行ごとに設定され、ヘッダーではありません。"
+msgstr "仕入先から得意先に直接送付され、倉庫をバイパスする出荷明細―ヘッダーではなく、明細ごとに設定されます。"
 
 msgid "A shipment's assignee changes"
 msgstr "出荷の担当者が変更される"
 
 msgid "A shipment's customer changes"
-msgstr "出荷の顧客が変更される"
+msgstr "出荷の得意先が変更される"
 
 msgid "A shipment's location changes"
 msgstr "出荷の場所が変更される"
@@ -752,13 +752,13 @@ msgid "A shipment's posting date changes"
 msgstr "出荷の転記日が変更される"
 
 msgid "A shipment's shipping method changes"
-msgstr "出荷の配送方法が変更される"
+msgstr "出荷の出荷方法が変更される"
 
 msgid "A shipment's status changes"
 msgstr "出荷のステータスが変更される"
 
 msgid "A shipment's tracking number changes"
-msgstr "配送の追跡番号が変更される"
+msgstr "出荷の追跡番号が変更される"
 
 msgid "A step needs a name."
 msgstr "ステップには名前が必要です。"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "仕入先の名前が変更される"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "購買RFQに対するサプライヤーの価格応答—サプライヤーごとに1つ。ドラフト→提出時のアクティブ、またはDeclined。"
+msgstr "購買見積依頼に対する仕入先の価格設定された応答―仕入先ごとに1つ。下書き→提出時に有効または却下。"
 
 msgid "A supplier's status changes"
 msgstr "仕入先のステータスが変更される"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "課税対象の追加料金（取扱、セットアップ、燃料）を行に追加し、課税ベースに含めます。"
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "ジョブ操作に対して記録されたセットアップ、労務、または機械作業の時間記録。その期間は操作の実際のコストに集計されます。"
+msgstr "ジョブ指図工程に対して記録された段取り、労務、または機械作業の時間記録であり、その期間は工程の実際原価に集計されます。"
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "ツールは、複数のジョブで使用できるパーツを作成するために使用される物理的なアイテムです"
+msgstr "工具は部品を製造するために使用され、複数の製造指図で使用できる物理的アイテムです"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "ユーザーが商品を受け取る際に、各バッチまたはシリアルの有効期限を記録します。サプライヤーが異なる有効期限のロットを出荷する場合に使用します。"
+msgstr "ユーザーは商品受取時に各バッチまたはシリアルの使用期限を記録します。仕入先が異なる使用期限のロットを出荷する場合に使用します。"
 
 msgid "abilities"
-msgstr "能力"
+msgstr "スキル"
 
 msgid "Abilities"
-msgstr "能力"
+msgstr "スキル"
 
 msgid "ability"
-msgstr "能力"
+msgstr "スキル"
 
 msgid "About"
 msgstr "について"
@@ -827,13 +827,13 @@ msgid "Academy"
 msgstr "アカデミー"
 
 msgid "Accept Lot"
-msgstr "ロットを受け入れる"
+msgstr "ロット承諾"
 
 msgid "Accept lot?"
-msgstr "ロットを受け入れますか？"
+msgstr "ロットを承諾しますか?"
 
 msgid "Accept Quote"
-msgstr "見積もりを承認"
+msgstr "見積承諾"
 
 msgid "Acceptable Quality Level — the highest defect rate that's still considered passable under the Z1.4 / ISO 2859-1 tables."
 msgstr "許容品質水準（AQL）—Z1.4 / ISO 2859-1テーブルに基づいて、まだ受け入れ可能と見なされる最高不良率。"
@@ -842,11 +842,11 @@ msgid "Acceptance"
 msgstr "受け入れ"
 
 msgid "Acceptance passed"
-msgstr "受け入れ完了"
+msgstr "承諾合格"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
-msgstr "{0} に承認"
+msgstr "承諾済 {0}"
 
 msgid "Account"
 msgstr "アカウント"
@@ -858,7 +858,7 @@ msgid "Account balances with debits and credits"
 msgstr "借方貸方を含む勘定残高"
 
 msgid "Account for advance payments made before goods or services are received"
-msgstr "商品またはサービスの受領前に行われた前払いをアカウントします。"
+msgstr "商品またはサービスが受領される前に行われた前払いを記録します。"
 
 msgid "Account for production orders not yet completed"
 msgstr "まだ完了していない生産注文のアカウント。"
@@ -867,10 +867,10 @@ msgid "Account for small rounding differences in transactions"
 msgstr "トランザクションの小さな丸め差を説明します。"
 
 msgid "Account for the cost of fixed assets when disposed"
-msgstr "資産廃棄時の固定資産費用の計上。"
+msgstr "固定資産を除却する際の原価を会計処理する"
 
 msgid "Account for the purchase cost of fixed assets"
-msgstr "固定資産の取得費用の計上。"
+msgstr "固定資産の購入原価を会計処理する"
 
 msgid "Account manager"
 msgstr "アカウント マネージャー"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "会計期間"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "会計: GL、AR、AP、および月末決算"
+msgstr "会計: 総勘定元帳、売掛金、買掛金、および月末クローズ"
 
 msgid "Accounts"
 msgstr "アカウント"
@@ -936,28 +936,28 @@ msgid "Accounts Receivable"
 msgstr "売掛金"
 
 msgid "Accounts receivable for amounts owed by customers"
-msgstr "顧客に支払う金額の売掛金。"
+msgstr "得意先から支払われるべき金額の売掛金"
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "転記デフォルトまたはジャーナル履歴で参照されているが、プロバイダーマッピングがまだない勘定科目。"
+msgstr "転記デフォルトまたは仕訳履歴によって参照されているが、プロバイダーマッピングがないアカウント。"
 
 msgid "Accumulated Depreciation"
-msgstr "累計減価償却費"
+msgstr "減価償却累計額"
 
 msgid "Accumulated Depreciation (default)"
-msgstr "累計減価償却費（デフォルト）"
+msgstr "減価償却累計額 (デフォルト)"
 
 msgid "Accumulated Depreciation (opening)"
-msgstr "累計減価償却費（期首）"
+msgstr "減価償却累計額 (開始)"
 
 msgid "Accumulated Depreciation Account"
-msgstr "累計減価償却費勘定"
+msgstr "減価償却累計額勘定"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "処分時の累計減価償却費"
+msgstr "除却時の減価償却累計額"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "処分時の累計減価償却費（デフォルト）"
+msgstr "除却時の減価償却累計額 (デフォルト)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "蓄積期間（週）"
@@ -981,7 +981,7 @@ msgid "Action"
 msgstr "アクション"
 
 msgid "Action Status"
-msgstr "アクション状態"
+msgstr "アクションステータス"
 
 msgid "Action Type"
 msgstr "アクションタイプ"
@@ -1002,7 +1002,7 @@ msgid "Activate Process"
 msgstr "プロセスを有効化"
 
 msgid "Activate Work Center"
-msgstr "ワークセンターを有効化"
+msgstr "作業区を有効にする"
 
 msgid "Activation fee · we advise"
 msgstr "アクティベーション料金 · アドバイス提供"
@@ -1011,13 +1011,13 @@ msgid "Active"
 msgstr "有効"
 
 msgid "Active Jobs"
-msgstr "アクティブなジョブ"
+msgstr "有効な製造指図"
 
 msgid "Active Statuses"
 msgstr "アクティブなステータス"
 
 msgid "Active Supplier Quotes"
-msgstr "アクティブなサプライヤー見積"
+msgstr "有効な仕入先見積"
 
 msgid "Activity"
 msgstr "アクティビティ"
@@ -1026,7 +1026,7 @@ msgid "Actual"
 msgstr "実際"
 
 msgid "Actual Cost"
-msgstr "実際のコスト"
+msgstr "実際原価"
 
 msgid "Actual End"
 msgstr "実際の終了"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "コメントを追加..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "数量、価格、送料、リードタイム、税金を上書きするカスタム価格行を追加します"
+msgstr "数量、価格、配送、リードタイム、および税を上書きするカスタム価格設定行を追加します"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "部品表の各項目とその数量をリストアップした材料セクションを追加します。"
@@ -1062,7 +1062,7 @@ msgid "Add a printer in the printing settings to print labels directly."
 msgstr "プリンター設定にプリンターを追加して、ラベルを直接印刷します。"
 
 msgid "Add a requirement"
-msgstr "要件を追加"
+msgstr "要求事項を追加"
 
 msgid "Add a row"
 msgstr "行を追加"
@@ -1086,16 +1086,16 @@ msgid "Add any notes about your decision..."
 msgstr "あなたの決定についてのメモを追加してください..."
 
 msgid "Add Approval Requirement"
-msgstr "承認要件を追加"
+msgstr "承認要求事項を追加"
 
 msgid "Add Authenticator App"
 msgstr "認証器アプリを追加"
 
 msgid "Add Calibration Record"
-msgstr "キャリブレーション記録を追加"
+msgstr "校正記録を追加"
 
 msgid "Add Child Storage Unit"
-msgstr "子ストレージユニットを追加"
+msgstr "子保管ユニットを追加"
 
 msgid "Add clause"
 msgstr "句を追加"
@@ -1107,10 +1107,10 @@ msgid "Add condition"
 msgstr "条件を追加"
 
 msgid "Add Contractor"
-msgstr "契約業者を追加"
+msgstr "外部作業者を追加"
 
 msgid "Add cost center"
-msgstr "コスト センターを追加"
+msgstr "原価センターを追加"
 
 msgid "Add Entry"
 msgstr "エントリを追加"
@@ -1143,10 +1143,10 @@ msgid "Add New"
 msgstr "新規追加"
 
 msgid "Add Note"
-msgstr "ノートを追加"
+msgstr "メモを追加"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "このメンテナンスディスパッチのメモとドキュメントを追加"
+msgstr "この保全指示のメモとドキュメントを追加"
 
 msgid "Add Operation"
 msgstr "操作を追加"
@@ -1191,7 +1191,7 @@ msgid "Add Receipt"
 msgstr "領収書を追加"
 
 msgid "Add Requirement"
-msgstr "要件を追加"
+msgstr "要求事項を追加"
 
 msgid "Add Risk"
 msgstr "リスクを追加"
@@ -1206,7 +1206,7 @@ msgid "Add Selector"
 msgstr "セレクターを追加"
 
 msgid "Add Shipment"
-msgstr "配送を追加"
+msgstr "出荷を追加"
 
 msgid "Add Shipping"
 msgstr "配送を追加"
@@ -1215,19 +1215,19 @@ msgid "Add slot"
 msgstr "スロットを追加"
 
 msgid "Add Spare Part"
-msgstr "スペアパーツを追加"
+msgstr "予備品を追加"
 
 msgid "Add Step"
 msgstr "ステップを追加"
 
 msgid "Add steps to preview the operator view."
-msgstr "オペレータビューをプレビューするステップを追加してください。"
+msgstr "作業者ビューをプレビューするためにステップを追加"
 
 msgid "Add Stock Transfer"
 msgstr "在庫移動を追加"
 
 msgid "Add Supplier"
-msgstr "サプライヤーを追加"
+msgstr "仕入先を追加"
 
 msgid "Add the next capability on the same system instead of buying another tool."
 msgstr "同じシステム上に次の機能を追加して、別のツールを購入する代わりにします。"
@@ -1249,13 +1249,13 @@ msgid "Add-On"
 msgstr "アドオン"
 
 msgid "Add-On Cost"
-msgstr "アドオンコスト"
+msgstr "追加原価"
 
 msgid "Added"
 msgstr "追加済み"
 
 msgid "Added for this customer"
-msgstr "このカスタマー向けに追加"
+msgstr "この得意先に追加済み"
 
 msgid "Adding demo records"
 msgstr "デモレコードを追加中"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "すべてのアクションが選択されました"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "すべての高度な機能が利用可能"
 
 msgid "All Audit Logs"
 msgstr "すべての監査ログ"
@@ -1346,13 +1346,13 @@ msgid "All Companies"
 msgstr "すべての会社"
 
 msgid "All Customers"
-msgstr "すべての顧客"
+msgstr "すべての得意先"
 
 msgid "All Documents"
 msgstr "すべてのドキュメント"
 
 msgid "All item types"
-msgstr "すべてのアイテムタイプ"
+msgstr "すべての品目タイプ"
 
 msgid "All Items"
 msgstr "すべてのアイテム"
@@ -1373,7 +1373,7 @@ msgid "All slotted dimension values are mapped"
 msgstr "すべてのスロット化されたディメンション値がマップされています"
 
 msgid "All Suppliers"
-msgstr "すべてのサプライヤー"
+msgstr "すべての仕入先"
 
 msgid "All Time"
 msgstr "すべての期間"
@@ -1388,7 +1388,7 @@ msgid "All users"
 msgstr "すべてのユーザー"
 
 msgid "All Work Centers"
-msgstr "すべての作業センター"
+msgstr "すべての作業区"
 
 msgid "Allows acknowledge & continue"
 msgstr "確認して続行できます"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "金額"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "この行の資産/経費を増加させるか、負債/資本/収益を減少させる金額。"
+msgstr "この明細で資産/費用を増加させるか、負債/純資産/売上高を減少させる金額"
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "この行の負債/資本/収益を増加させるか、資産/経費を減少させる金額。"
+msgstr "この明細で負債/純資産/売上高を増加させるか、資産/費用を減少させる金額"
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,34 +1422,34 @@ msgid "Amount Type"
 msgstr "金額タイプ"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "部門や機能別に費用をグループ化する会計バケットで、GLがアカウントだけでなくグループ別に支出を報告できるようにします。"
+msgstr "部門または機能ごとに費用をグループ化する会計カテゴリで、総勘定元帳がアカウントだけでなくグループごとの支出を報告できます。"
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "費用ではなく減価償却する資本化されたアイテムの会計レコード。ドラフト→アクティブ→完全に減価償却→処分。"
+msgstr "資本化資産の会計記録（費用化ではなく減価償却対象）。下書き → 有効 → 償却済 → 除却済。"
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "何かが人の注意が必要であることを示すアラート。carbon/notify イベントからアプリ内インボックスおよびオプションのメールと Slack にファンアウトされ、ユーザーごと、トピックごとにミュート可能です。"
 
 msgid "An approval requirement on a non-conformance whose reviewers (seeded Engineering and Quality) must sign off before the issue can close."
-msgstr "不適合に対する承認要件。レビュアー (エンジニアリングおよび品質部門) は、問題がクローズされる前にサインオフする必要があります。"
+msgstr "不適合に対する承認要件。レビュアー（シード済みのエンジニアリング部門と品質部門）の承認が必要で、問題がクローズされる前に承認される必要があります。"
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "資産の取得原価から累計減価償却費を差し引いたもの—帳簿上の現在の価値と処分される金額。"
+msgstr "資産の取得原価から減価償却累計額を差し引いた額。帳簿上の現在価値であり、除却時の計上額です"
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "キャンバス上に構築するオートメーション：1つのトリガーと、その後の条件チェック、レコード検索、アクションを実行するステップ — 誰かに通知、レコード作成または更新、または外部URLの呼び出し。"
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "エンジニアリング変更：ドラフト上で方法が改訂され、一緒にリリースされる影響を受けるアイテム。それらが置き換える版に取って代わります。"
+msgstr "設計変更。影響を受ける品目の製法が下書きで改訂され、一緒にリリースされ、置き換える版に置き換わります。"
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "ワークフローがそのステップに到達したときに、Carbonがあなたのシステムに送信するHTTPSリクエスト。設定したヘッダーと本文が含まれます。"
 
 msgid "An integration or a custom change — the small slice that's actually custom."
-msgstr "統合またはカスタム変更 — 実際にカスタムである小さなスライス。"
+msgstr "連携またはカスタム変更 — 実際にカスタムされている小さなスライス。"
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "招待は保留中です。受け入れるとアクティブになります。"
+msgstr "招待待機中。承諾後に有効になります。"
 
 msgid "An issue is created"
 msgstr "問題が作成される"
@@ -1464,7 +1464,7 @@ msgid "An issue's close date changes"
 msgstr "問題のクローズ日が変更される"
 
 msgid "An issue's due date changes"
-msgstr "問題の期限が変更される"
+msgstr "案件の期日が変更される"
 
 msgid "An issue's location changes"
 msgstr "問題の位置が変更される"
@@ -1497,16 +1497,16 @@ msgid "An item's active changes"
 msgstr "アイテムのアクティブが変更される"
 
 msgid "An item's assignee changes"
-msgstr "アイテムの割り当て者が変更されます"
+msgstr "品目の担当者が変更される"
 
 msgid "An item's default method type changes"
-msgstr "アイテムのデフォルトメソッドタイプが変更されます"
+msgstr "品目のデフォルト供給方式が変更される"
 
 msgid "An item's name changes"
 msgstr "アイテムの名前が変更されます"
 
 msgid "An item's replenishment system changes"
-msgstr "アイテムの補充システムが変更されます"
+msgstr "品目の調達方式が変更される"
 
 msgid "An item's revision status changes"
 msgstr "アイテムのリビジョンステータスが変更されます"
@@ -1518,10 +1518,10 @@ msgid "An item's unit of measure changes"
 msgstr "アイテムの計量単位が変更されます"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "社内の作業センターではなく、外部の仕入先によって行われた操作。下請購買注文でカバーされます。"
+msgstr "社内作業区ではなく外部仕入先が実行する工程で、外注発注書でカバーされます。"
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "作業センターのキューの中での操作の位置。フロアが仕事を取り上げる順序。作業センター ボード上のカードを並べ替えることで設定され、日付は変更されません。"
+msgstr "作業区内でのこの工程の位置（作業班が着手する順序）。作業区ボード上でカードを並び替えることで設定できます（日付は変更しません）"
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Onshape への接続中に予期しないエラーが発生しました。もう一度接続してください。"
@@ -1561,34 +1561,34 @@ msgid "Annotation updated"
 msgstr "注釈が更新されました"
 
 msgid "Another cost center this one rolls up into, letting you nest a sub-department under its parent for hierarchical cost reporting."
-msgstr "これが集計される別のコストセンター。階層的なコストレポート用に、親の下に部分コストセンターをネストできます。"
+msgstr "このコストセンターがロールアップされる別の原価センター。親の下に部門をネストさせて、階層的なコスト報告を実現します"
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "これがネストされている別のストレージユニット（例えば、ラック内のビン）。同じ場所にある必要があります。"
+msgstr "この保管ユニットがネストされる別の保管ユニット（例：ラック内のビン）。同じ拠点にある必要があります"
 
 msgid "Any item group"
 msgstr "任意のアイテムグループ"
 
 msgid "Any item type"
-msgstr "任意のアイテムタイプ"
+msgstr "任意の品目タイプ"
 
 msgid "Anything not explicitly listed in scope above"
 msgstr "上記の範囲に明示的にリストされていないもの"
 
 msgid "AP"
-msgstr "AP"
+msgstr "買掛金"
 
 msgid "AP Aging"
-msgstr "支払い老化分析"
+msgstr "買掛金エージング"
 
 msgid "AP Clerk"
-msgstr "AP クラーク"
+msgstr "買掛金担当者"
 
 msgid "AP Outstanding"
-msgstr "AP未払金"
+msgstr "未払買掛金"
 
 msgid "AP Overdue"
-msgstr "AP 期限超過"
+msgstr "期限超過買掛金"
 
 msgid "API Docs"
 msgstr "API ドキュメント"
@@ -1597,7 +1597,7 @@ msgid "API Documentation"
 msgstr "APIドキュメント"
 
 msgid "API key"
-msgstr "API キー"
+msgstr "APIキー"
 
 msgid "API Key"
 msgstr "APIキー"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbonデータへのプログラマティックアクセス用のAPIキー。"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API、Webhook、および連携"
 
 msgid "Applied"
 msgstr "適用"
@@ -1631,7 +1631,7 @@ msgid "Applies to all"
 msgstr "すべてに適用"
 
 msgid "Applies to all work centers"
-msgstr "すべてのワークセンターに適用"
+msgstr "すべての作業区に適用"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
 msgstr "独自のルールがない機能に適用され、このプランが検査を実施する場合、ロットに適用されます。"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "売掛金"
 
 msgid "AR / AP representation"
-msgstr "AR / AP の表現"
+msgstr "売掛金/買掛金の表示"
 
 msgid "AR Aging"
-msgstr "売上老化分析"
+msgstr "売掛金エージング"
 
 msgid "AR Clerk"
-msgstr "AR事務員"
+msgstr "売掛金係員"
 
 msgid "AR Outstanding"
 msgstr "売掛金未払い"
 
 msgid "AR Overdue"
-msgstr "売掛金滞納"
+msgstr "売掛金期限超過"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "売掛金/買掛金"
 
 msgid "Archive"
 msgstr "アーカイブ"
@@ -1739,32 +1739,32 @@ msgid "Archived"
 msgstr "アーカイブ済み"
 
 msgid "Archived Logs"
-msgstr "アーカイブされたログ"
+msgstr "アーカイブ済ログ"
 
 #. placeholder {0}: getQuoteDisplayId(quote)
 #. placeholder {1}: formatter.format(total)
 msgid "Are you sure you want to accept quote {0} for {1}?"
-msgstr "本当に見積書 {0} を {1} で受け入れてもよろしいですか？"
+msgstr "{0} の見積を {1} で承諾してもよろしいですか?"
 
 msgid "Are you sure you want to activate the process: {name}? It will appear in dropdowns again."
 msgstr "プロセス「{name}」を有効化してもよろしいですか？ドロップダウンに再度表示されるようになります。"
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "このゲージを有効化してもよろしいですか？"
+msgstr "この測定器を有効にしてもよろしいですか?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "{0}をキャンセルしてもよろしいですか？閉じられて、再度開くまで読み取り専用になります。"
+msgstr "{0} をキャンセルしてもよろしいですか?クローズ済になり、再オープンするまで読み取り専用になります。"
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
-msgstr "{0}をキャンセルしてもよろしいですか？これにより、関連するすべてのサプライヤー見積もりもキャンセルされます。"
+msgstr "{0} をキャンセルしてもよろしいですか?関連するすべての仕入先見積もキャンセルされます。"
 
 msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "{orderLabel}をキャンセルしてもよろしいですか？これにより注文が閉じられます。"
 
 msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
-msgstr "このジョブをキャンセルしてもよろしいですか？ショップフロアで利用できなくなります。"
+msgstr "この製造指図をキャンセルしてもよろしいですか？製造現場で利用できなくなります。"
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
 msgstr "本当に{propertyName}プロパティを変更してもよろしいですか？生成された材料IDを使用しているため、このパーツのパーツIDと関連するすべてのリビジョンが変更されます。"
@@ -1773,17 +1773,17 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "このストック転送を完了してもよろしいですか？"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "この販売注文を確認してもよろしいですか？注文を確認すると、供給と需要の計算に使用される注文数量に影響します。"
+msgstr "この受注を確認してもよろしいですか?受注を確認すると、供給と所要量の計算に使用される発注数量に影響します。"
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "RFQを見積もりに変換してもよろしいですか？"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "このセールスオーダーのジョブを作成してもよろしいですか？これにより、まだジョブを持っていないすべての行のジョブが作成されます。"
+msgstr "この受注の製造指図を作成してもよろしいですか?まだ製造指図がないすべての明細の製造指図が作成されます。"
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
-msgstr "{0}を非アクティブ化してもよろしいですか？"
+msgstr "{0} を無効化してもよろしいですか?"
 
 #. placeholder {0}: selectedCategory?.name
 msgid "Are you sure you want to deactivate the {0} attribute category?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "これらのユーザーを無効化してもよろしいですか？"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "このゲージを非アクティブ化してもよろしいですか?"
+msgstr "この測定器を無効化してもよろしいですか?."
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "このユーザーを無効化してもよろしいですか？"
@@ -1855,7 +1855,7 @@ msgstr "本当にアカウント {0}{1} を削除してもよろしいですか�
 
 #. placeholder {0}: apiKey.name
 msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
-msgstr "API キー: {0} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "APIキー: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
@@ -1870,22 +1870,22 @@ msgid "Are you sure you want to delete the change notice category: {0}? This can
 msgstr "変更通知カテゴリ「{0}」を削除してもよろしいですか？この操作は取り消せません。"
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "本当に契約者 {name} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "外部作業者: {name} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
-msgstr "本当に{0}の顧客部品を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "{0} の得意先部品を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete the customer portal for: {customerName}? This cannot be undone."
 msgstr "顧客ポータル {customerName} を削除してもよろしいですか？この操作は取り消せません。"
 
 #. placeholder {0}: customerStatus.name
 msgid "Are you sure you want to delete the customer status: {0}? This cannot be undone."
-msgstr "顧客ステータス「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "得意先ステータス: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: customerType.name
 msgid "Are you sure you want to delete the customer type: {0}? This cannot be undone."
-msgstr "顧客タイプ「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "得意先タイプ: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
 msgstr "本当に部門「{name}」を削除してもよろしいですか？この操作は取り消せません。"
@@ -1899,7 +1899,7 @@ msgstr "失敗モード「{name}」を削除してもよろしいですか？こ
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "ゲージタイプ「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "測定器タイプ: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1929,15 +1929,15 @@ msgid "Are you sure you want to delete the location: {name}? This cannot be undo
 msgstr "本当に位置情報を削除してもよろしいですか: {name}? これは元に戻すことができません。"
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "メンテナンススケジュール「{name}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "保全スケジュール: {name} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "本当に材料寸法「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "材料ディメンション: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "本当に材料仕上げを削除してもよろしいですか: {0}? この操作は取り消せません。"
+msgstr "表面処理: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
@@ -1949,7 +1949,7 @@ msgstr "本当に材料グレード: {0} を削除してもよろしいですか
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "本当に材料物質「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "素材: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "本当に材料タイプ: {0} を削除してもよろしいですか？
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "本当に見積もり不可の理由「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "見積辞退理由: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "パートナー「{name}」を削除してもよろしいですか？この操作は取り消せません。"
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "支払い条件「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "支払条件: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1977,31 +1977,31 @@ msgstr "このプリンター「{0}」を削除してもよろしいですか？
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "購入請求書行の{0} {1}を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "仕入先請求書明細 {0} {1} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "本当に販売請求書行の{0} {1}を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "売上請求書明細 {0} {1} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "本当に販売注文行 {0} {1} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "受注明細 {0} {1} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "スクラップ理由「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "不良理由: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "{itemLabel} 用のシリアル番号シーケンスを削除してもよろしいですか？この操作は取り消すことができません。"
+msgstr "{itemLabel} のシリアル番号採番を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "シフト「{name}」を{locationName}から削除してもよろしいですか？この操作は取り消せません。"
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "配送方法「{0}」を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "出荷方法: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
@@ -2009,11 +2009,11 @@ msgstr "ストレージタイプ: {0} を削除してもよろしいですか？
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "本当に保存ユニット: {0} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "保管ユニット: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
-msgstr "サプライヤータイプ: {0} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "仕入先タイプ: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 #. placeholder {0}: unitOfMeasure.name
 msgid "Are you sure you want to delete the unit of measure: {0}? This cannot be undone."
@@ -2025,7 +2025,7 @@ msgstr "本当に「{0}」ビューを削除してもよろしいですか？"
 
 #. placeholder {0}: webhook.name
 msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
-msgstr "本当にウェブフック: {0} を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "Webhook: {0} を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete this approval rule? This cannot be undone."
 msgstr "このアプリケーション承認ルールを削除してもよろしいですか？この操作は取り消せません。"
@@ -2034,13 +2034,13 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "この変更通知を削除してもよろしいですか？"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "このゲージを削除してもよろしいですか？"
+msgstr "この測定器を削除してもよろしいですか?"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "この検査計画を削除しますか？"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "このインスペクションプランを削除してもよろしいですか?この操作は取り消せません。"
+msgstr "この検査計画を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "このイシューワークフローを削除してもよろしいですか？"
@@ -2049,16 +2049,16 @@ msgid "Are you sure you want to delete this issue?"
 msgstr "このイシューを削除してもよろしいですか？"
 
 msgid "Are you sure you want to delete this kanban card? This cannot be undone."
-msgstr "このカンバンカードを削除してもよろしいですか？この操作は取り消せません。"
+msgstr "このかんばんカードを削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "このメンテナンスディスパッチを削除してもよろしいですか？この操作は取り消せません。"
+msgstr "この保全指示を削除してもよろしいですか?これは元に戻せません。"
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "このパスキーを削除してもよろしいですか？サインインに使用できなくなります。"
 
 msgid "Are you sure you want to delete this quality document?"
-msgstr "このクオリティドキュメントを削除してもよろしいですか？"
+msgstr "この品質文書を削除してもよろしいですか?"
 
 msgid "Are you sure you want to delete this record?"
 msgstr "このレコードを削除してもよろしいですか？"
@@ -2085,7 +2085,7 @@ msgid "Are you sure you want to finalize the quote?"
 msgstr "見積書を確定してもよろしいですか？"
 
 msgid "Are you sure you want to finalize the supplier quote?"
-msgstr "サプライヤー見積もりを確定してもよろしいですか？"
+msgstr "仕入先見積を確定してもよろしいですか?"
 
 msgid "Are you sure you want to leave this page?"
 msgstr "このページを離れてもよろしいですか？"
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "{0}を完全に削除してもよろしいですか？"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "サプライヤープロセスを完全に削除してもよろしいですか？"
+msgstr "仕入先工法を完全に削除してもよろしいですか？"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "このレシートを転記してもよろしいですか？"
@@ -2109,20 +2109,20 @@ msgid "Are you sure you want to post this shipment?"
 msgstr "この出荷を転記してもよろしいですか？"
 
 msgid "Are you sure you want to reject this quote?"
-msgstr "このクォートを拒否してもよろしいですか？"
+msgstr "この見積を却下してもよろしいですか？"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "このジョブをリリースしてもよろしいですか？ショップフロアで利用可能になり、購買と生産を推進します。"
+msgstr "この製造指図をリリースしてもよろしいですか？これは製造現場で利用可能になり、購買と生産を推進します。"
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "本当に{0}をこのアイテムのサプライヤーから削除してもよろしいですか?この操作は取り消せません。"
+msgstr "{0}をこの品目の仕入先として除去してもよろしいですか？これは取り消せません。"
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "このアイテムのサプライヤーとして{supplierName}を削除してもよろしいですか？この操作は取り消せません。"
+msgstr "{supplierName}をこの品目の仕入先として除去してもよろしいですか？これは取り消せません。"
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "このアイテムを価格リストから削除してもよろしいですか？この操作は取り消せません。"
+msgstr "この品目を価格リストから除去してもよろしいですか？これは取り消せません。"
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "このユーザーの招待を取り消してもよろしいですか？"
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "このユーザーに招待を送信してもよろしいですか?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "この購買請求書を無効にしてもよろしいですか？このアクションはすべての財務取引を取り消し、元に戻すことはできません。"
+msgstr "この仕入先請求書を取消してもよろしいですか？この操作はすべての財務取引を取消し、取り消せません。"
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "このレシートを無効にしてもよろしいですか？このアクションはすべての在庫トランザクションを取り消し、元に戻すことはできません。"
+msgstr "この入荷を取消してもよろしいですか？この操作はすべての在庫取引を取消し、取り消せません。"
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "この売上請求書を無効にしてもよろしいですか？このアクションはすべての財務取引を取り消し、元に戻すことはできません。"
+msgstr "この売上請求書を取消してもよろしいですか？この操作はすべての財務取引を取消し、取り消せません。"
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "本当にこの出荷をキャンセルしてもよろしいですか？このアクションはすべての在庫トランザクションを取り消し、元に戻すことはできません。"
+msgstr "この出荷を取消してもよろしいですか？この操作はすべての在庫取引を取消し、取り消せません。"
 
 msgid "Are you sure?"
 msgstr "本当ですか？"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "以下の日付時点:"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "会社のオーナーとして、別の従業員に所有権を譲渡できます。これにより、彼らは請求と管理設定に完全にアクセスできるようになります。"
+msgstr "会社責任者として、別の従業員に所有権を譲渡できます。これにより、請求とシステム管理の設定への完全なアクセス権が与えられます。"
 
 msgid "Ascending"
 msgstr "昇順"
@@ -2197,7 +2197,7 @@ msgid "Asset Account"
 msgstr "資産勘定"
 
 msgid "Asset account for advance payments made to suppliers before goods or services are received"
-msgstr "商品またはサービスが受け取られる前に仕入先に行われた前払いを記録するための資産アカウント"
+msgstr "仕入先に対する前払い金の資産勘定（商品またはサービスが受け取られる前に行われた支払い）"
 
 msgid "Asset Acquisition Cost"
 msgstr "資産取得原価"
@@ -2221,10 +2221,10 @@ msgid "Asset Classes"
 msgstr "資産クラス"
 
 msgid "Asset Cost on Disposal"
-msgstr "処分時の資産原価"
+msgstr "資産除却時の原価"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "処分時の資産原価（デフォルト）"
+msgstr "資産除却時の原価（デフォルト）"
 
 msgid "Asset ID"
 msgstr "資産 ID"
@@ -2233,10 +2233,10 @@ msgid "Assets"
 msgstr "資産"
 
 msgid "Assets, liabilities and equity as of a date"
-msgstr "特定日時点での資産、負債および資本"
+msgstr "特定の日付時点での資産、負債および純資産"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
-msgstr "プリンターをロケーションに割り当てます。配送、受け取り、ワークセンターは、オーバーライドされない限りロケーションのデフォルトを継承します。"
+msgstr "プリンターを拠点に割り当てます。出荷、入荷受付、および作業区は、上書きされない限り拠点のデフォルトを継承します。"
 
 msgid "Assign To"
 msgstr "割り当て先"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "割り当て"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "このストレージユニットをワークセンター（ラインサイド）に割り当てます"
+msgstr "この保管ユニットを作業区（ラインサイド）に割り当てます。"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "このユニットを作業センターに割り当ててラインサイドの材料を使用し、オペレーターが生産ビューで見ることができるようにします。親ユニットでセットされている場合は継承されます。"
+msgstr "この保管ユニットをラインサイド材料用の作業区に割り当てます。作業者は生産ビューでそれを参照できます。親ユニットで設定されている場合、そこから継承されます。"
 
 msgid "At each gate"
 msgstr "各ゲートで"
@@ -2293,19 +2293,19 @@ msgid "Attribute"
 msgstr "属性"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "ロット標本サイズおよび受入検査の合格/不合格番号を計算するために使用される属性サンプリング標準。"
+msgstr "ロットのサンプルサイズと受入検査の承諾/却下数を計算するために使用される属性抜取検査基準。"
 
 msgid "Attributes"
 msgstr "属性"
 
 msgid "Attributes are inherited from the procedure."
-msgstr "属性は手順から継承されます。"
+msgstr "属性は手順書から継承されます。"
 
 msgid "Audit Log"
 msgstr "監査ログ"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "監査ログ"
 
 msgid "Audit Logging"
 msgstr "監査ログ"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "自動生成されたQRコード"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "注文、ジョブ、部品などの自動採番形式"
+msgstr "受注、製造指図、部品などの自動採番フォーマット"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "需要に基づいて購買を自動提案し、再注文ポイントを設定"
+msgstr "所要量および発注点から購買を自動提案"
 
 msgid "Automate"
 msgstr "自動化"
@@ -2368,7 +2368,7 @@ msgid "Automate your business processes with event-driven workflows that trigger
 msgstr "Carbonで発生するときにアクションをトリガーするイベント駆動型ワークフローでビジネスプロセスを自動化します。"
 
 msgid "Automatic Cost Updates"
-msgstr "自動コスト更新"
+msgstr "原価の自動更新"
 
 msgid "Automatic Lead Time Updates"
 msgstr "自動リードタイム更新"
@@ -2377,16 +2377,16 @@ msgid "Automatic Updates"
 msgstr "自動更新"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "自動更新とバックアップ"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "出力が報告されるとジョブの追跡されていない材料の自動的な比例消費。追跡された材料は手動で発行されます。"
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "カンバンがスキャンされたときに自動的にジョブをリリースします"
+msgstr "かんばんがスキャンされたときに自動的に製造指図をリリース"
 
 msgid "Automatically start the job when the kanban is scanned"
-msgstr "カンバンがスキャンされたときに自動的にジョブを開始します"
+msgstr "かんばんがスキャンされたときに自動的に製造指図を開始"
 
 msgid "available"
 msgstr "利用可能"
@@ -2441,7 +2441,7 @@ msgid "Bank - Cash"
 msgstr "銀行-現金"
 
 msgid "Bank - Foreign Currency"
-msgstr "銀行-外国為替"
+msgstr "銀行 - 外国通貨"
 
 msgid "Bank - Local Currency"
 msgstr "銀行-地元通貨"
@@ -2450,7 +2450,7 @@ msgid "Bank — Cash (default)"
 msgstr "銀行—現金（デフォルト）"
 
 msgid "Bank — Foreign Currency (default)"
-msgstr "銀行—外国為替（デフォルト）"
+msgstr "銀行 — 外国通貨（デフォルト）"
 
 msgid "Bank — Local Currency (default)"
 msgstr "銀行—地元通貨（デフォルト）"
@@ -2459,16 +2459,16 @@ msgid "Bank / Cash Account"
 msgstr "銀行 / 現金口座"
 
 msgid "Bank account denominated in a foreign currency"
-msgstr "外国為替で示された銀行口座。"
+msgstr "外国通貨で表示される銀行口座"
 
 msgid "Bank account denominated in the local currency"
 msgstr "地元通貨で示された銀行口座。"
 
 msgid "Bank and financial service charge expenses"
-msgstr "銀行および金融サービス手数料の費用。"
+msgstr "銀行およびサービス料費用"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "バーは毎週の流れを示します：&lt;0&gt;供給&lt;/0&gt;が在庫を上げます、&lt;1&gt;需要&lt;/1&gt;がそれを下げます。&lt;2&gt;線&lt;/2&gt;は投影された利用可能在庫です—&lt;3&gt;安全在庫&lt;/3&gt;を下回ると危険、ゼロ以下は&lt;4&gt;欠品&lt;/4&gt;です。"
+msgstr "棒グラフは毎週の流れを表示します：<0>供給</0>は在庫を増加させ、<1>所要量</1>は減少させます。<2>線</2>は予測在庫です。<3>安全在庫</3>を下回る場合はリスク状態であり、ゼロを下回る場合は<4>欠品</4>です。"
 
 msgid "Base Currency"
 msgstr "基本通貨"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "基本価格"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "基本的なERP、MES、およびQMS機能"
 
 msgid "Basic Information"
 msgstr "基本情報"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "バッチ / シリアル"
 
 msgid "Batch items require a sales order"
-msgstr "バッチ品目は販売注文が必要です"
+msgstr "バッチ品目は受注が必要です"
 
 msgid "Batch number"
 msgstr "バッチ番号"
@@ -2514,7 +2514,7 @@ msgstr "開始"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Being phased out — successor: <0>{0}</0>"
-msgstr "段階的に廃止予定 — 後継品: <0>{0}</0>"
+msgstr "段階的に廃止されます — 後継品目：<0>{0}</0>"
 
 msgid "Below safety stock"
 msgstr "安全在庫以下"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "ベータ"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "スクラップの最大原因（理由別、品目別、または作業中心別）"
+msgstr "理由、品目、または作業区別の最大スクラップ原因"
 
 msgid "Bill of Material"
 msgstr "材料表"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "部品表"
 
 msgid "Bill of Process"
-msgstr "プロセスの部品表"
+msgstr "工程表"
 
 msgid "Bill To"
 msgstr "請求先"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "エラーでブロック"
 
 msgid "Block, allow override"
-msgstr "ブロック、オーバーライドを許可"
+msgstr "ブロック、上書き許可"
 
 msgid "Blocked"
 msgstr "ブロック中"
@@ -2587,13 +2587,13 @@ msgid "Bonus Depreciation %"
 msgstr "ボーナス減価償却 %"
 
 msgid "Book a call to discuss guided implementation"
-msgstr "ガイド付き実装について相談する通話を予約する"
+msgstr "実施についてのガイド付きディスカッションの通話を予約"
 
 msgid "Book a call with Carbon"
 msgstr "Carbonとの通話を予約する"
 
 msgid "Book Depreciation"
-msgstr "簿価償却"
+msgstr "減価償却の計上"
 
 msgid "Books lock date (manual)"
 msgstr "帳簿ロック日 (手動)"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "パンくずリスト"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "パーツ、BOM、Bill of Process、原価計算をインポートしてください。Carbonのインポートツール、CSV、またはLLMヘルプを使用できます。"
+msgstr "部品、BOM、工程表、原価計算をインポート — Carbonのツール、CSV、LLM支援で。"
 
 msgid "Browse library"
 msgstr "ライブラリを参照"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "公開済バージョンを読み取り専用で閲覧できます。レイアウトを整理するためにステップを並び替えることもできます。"
 
 msgid "Bucket"
 msgstr "バケット"
@@ -2626,22 +2626,22 @@ msgid "Bugs and changes"
 msgstr "バグと変更"
 
 msgid "Build any net-new integrations or customizations"
-msgstr "新しい統合またはカスタマイズを構築する"
+msgstr "新規の連携またはカスタマイズを構築"
 
 msgid "Build any net-new work"
 msgstr "新しい作業を構築する"
 
 msgid "Build integrations and customizations"
-msgstr "統合とカスタマイズを構築"
+msgstr "連携とカスタマイズを構築"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "ライブパーツ、コスト、およびプロセス部品表データを取得して見積もりを作成"
+msgstr "部品、原価、工程表データをリアルタイムで取得する見積を構築"
 
 msgid "Build role-based training materials"
-msgstr "ロールベースのトレーニング資料を作成"
+msgstr "ロールベースの教育訓練教材を構築"
 
 msgid "Build tailored, role-based training materials"
-msgstr "カスタマイズされたロールベースのトレーニング資料を作成"
+msgstr "カスタマイズされたロールベースの教育訓練教材を構築"
 
 msgid "Built and costed as its own method"
 msgstr "独自の方法として構築および原価計算"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "一括インポート"
 
 msgid "Bulk Jobs"
-msgstr "一括ジョブ"
+msgstr "一括製造指図"
 
 msgid "Business moment"
 msgstr "ビジネスモーメント"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "購入"
 
 msgid "Buy and Make"
-msgstr "購入と製造"
+msgstr "購入・内製"
 
 msgid "Buyer"
-msgstr "購入者"
+msgstr "購買担当者"
 
 msgid "Buyer, Planner"
-msgstr "購買者、プランナー"
+msgstr "購買担当者、プランナー"
 
 msgid "by {byUser}"
 msgstr "{byUser}による"
@@ -2680,7 +2680,7 @@ msgid "By dimension"
 msgstr "ディメンション別"
 
 msgid "By Document Date"
-msgstr "ドキュメント日付別"
+msgstr "文書日付で"
 
 msgid "By Due Date"
 msgstr "支払期日別"
@@ -2704,49 +2704,49 @@ msgid "Calculate from BOM"
 msgstr "BOMから計算"
 
 msgid "Calculated finished-good expiry"
-msgstr "計算済み完成品の有効期限"
+msgstr "完成品の計算使用期限"
 
 msgid "Calculation Method"
 msgstr "計算方法"
 
 msgid "Calibration"
-msgstr "キャリブレーション"
+msgstr "校正"
 
 msgid "Calibration Attempts"
-msgstr "キャリブレーション試行"
+msgstr "校正試行"
 
 msgid "Calibration Expiration Notifications"
-msgstr "キャリブレーション有効期限通知"
+msgstr "校正期限切れ通知"
 
 msgid "Calibration Interval (Months)"
-msgstr "キャリブレーション間隔（月）"
+msgstr "校正周期（月）"
 
 msgid "Calibration Record"
-msgstr "キャリブレーションレコード"
+msgstr "校正記録"
 
 msgid "Calibration Records"
-msgstr "キャリブレーション記録"
+msgstr "校正記録"
 
 msgid "Calibration Status"
-msgstr "キャリブレーション状態"
+msgstr "校正ステータス"
 
 msgid "Calibration Supplier"
-msgstr "キャリブレーション供給業者"
+msgstr "校正仕入先"
 
 msgid "Calibrations"
-msgstr "キャリブレーション"
+msgstr "校正"
 
 msgid "Call an outside URL"
 msgstr "外部URLを呼び出す"
 
 msgid "Called a method in Carbon — the components plus operations that produce a part."
-msgstr "Carbonで呼ばれるメソッド—部品を生成するコンポーネントと操作。"
+msgstr "Carbonで「製法」と呼ばれるもの — 部品を製造するための部品と工程。"
 
 msgid "Can't delete this period"
 msgstr "この期間は削除できません"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "唯一のアクティブなブレークを無効にすることはできません。別のブレークを追加するか、オーバーライドのアクティブを切り替えてください。"
+msgstr "唯一の有効な休止を無効にすることはできません。別の休止を追加するか、上書きの有効を切り替えてください。"
 
 msgid "Can't download this file"
 msgstr "このファイルをダウンロードできません"
@@ -2770,7 +2770,7 @@ msgid "Cancel Purchase Order"
 msgstr "発注書をキャンセル"
 
 msgid "Cancel Sales Order"
-msgstr "販売注文をキャンセル"
+msgstr "受注キャンセル"
 
 msgid "Cancel SO"
 msgstr "SO をキャンセル"
@@ -2809,10 +2809,10 @@ msgid "Cannot convert RFQ to quote"
 msgstr "RFQを見積に変換できません"
 
 msgid "Cannot move to parts bucket without item ID"
-msgstr "アイテムIDなしでパーツバケットに移動することはできません"
+msgstr "品目IDなしで部品バケットに移動することはできません"
 
 msgid "Cannot place order - no supplier associated with this item"
-msgstr "注文を配置できません - このアイテムに関連付けられたサプライヤーがありません"
+msgstr "発注できません - この品目に関連付けられた仕入先がありません"
 
 msgid "Cannot post — shipment contains expired tracked entities."
 msgstr "投稿できません — 出荷に期限切れの追跡対象エンティティが含まれています。"
@@ -2821,13 +2821,13 @@ msgid "Cannot send RFQ"
 msgstr "RFQを送信できません"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripeを通じて送信できません"
 
 msgid "Cannot upload — supplier interaction not yet created"
-msgstr "アップロードできません — サプライヤーインタラクションがまだ作成されていません"
+msgstr "アップロードできません — 仕入先インタラクションがまだ作成されていません"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "アイテムIDなしでパーツバケットにアップロードできません"
+msgstr "品目IDなしで部品バケットにアップロードすることはできません"
 
 msgid "Caption"
 msgstr "キャプション"
@@ -2842,10 +2842,10 @@ msgid "Carbon account"
 msgstr "Carbon勘定科目"
 
 msgid "Carbon client is not available"
-msgstr "Carbonクライアントは利用できません"
+msgstr "Carbon client は利用不可です"
 
 msgid "Carbon client not available"
-msgstr "Carbonクライアントが利用できません"
+msgstr "Carbon client 利用不可"
 
 msgid "Carbon client not found"
 msgstr "Carbonクライアントが見つかりません"
@@ -2854,7 +2854,7 @@ msgid "Carbon column"
 msgstr "Carbonカラム"
 
 msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
-msgstr "Carbonがあなたの会社の運営方法に合わせて設定され、データが読み込まれ、チームがそれを自信を持って使用できるようになっています。その状態になれば、本番環境への移行準備が整っています。"
+msgstr "Carbon がご会社の運営方法に合わせて設定され、データが読み込まれ、チームが自信を持って使用できる状態になったとき、本番運用開始の準備ができています。"
 
 msgid "Carbon leads"
 msgstr "Carbonがリード"
@@ -2876,40 +2876,40 @@ msgstr "カーボン値"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbonはあなたの{0}個のマッピングされていないアカウントのそれぞれに対してAIを使用してプロバイダーアカウントを推測します。提案は出発点です—何かが保存される前にそれらを確認することができます。"
+msgstr "Carbonはあなたの{0}個のマップされていないアカウントのそれぞれについて、プロバイダーアカウントをAIで推測します。提案は出発点です — 保存する前にそれらをレビューできます。"
 
 msgid "Carbon-only"
 msgstr "Carbon専用"
 
 msgid "Carbon-only · fill in real targets for this customer. They see the values, locked."
-msgstr "Carbon専用 · このお客様の実際のターゲットを入力してください。お客様は値を表示のみで確認できます。"
+msgstr "Carbon のみ · このお客様の実際の目標を入力してください。値が表示されますが、ロックされています。"
 
 msgid "Carbon-only · the customer sees this text, locked."
-msgstr "Carbon専用 · 顧客はこのテキストを表示のみで見ることができます。"
+msgstr "Carbon のみ · 顧客に表示されるロック中のテキスト。"
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "材料表と処理リスト（ルーティング）のCarbonの名前：部品を製造するコンポーネントと操作。"
+msgstr "部品表と工程表（工順）に対するCarbonの名前：部品を製造するための部品と工程。"
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Carbonの計画実行は、供給を需要に対してネットし、メソッドを展開し、不足を表示します—ただし、注文自体は作成しません。"
+msgstr "Carbonの計画実行は供給を所要量に対してネット化し、製法を展開して不足分を表面化します — ただし、発注は作成しません。"
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Carbonの生産指示 — 1つのジョブは、コピーされたメソッドとルーティングから1つのアイテムの数量を製造します。"
+msgstr "Carbon の製造指図 — 1 つの製造指図が、独自にコピーされた製法と工順から 1 品目の数量を製造します。"
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "オペレーターが操作を実行し、数量をレポートし、材料を払い出し、リリースされたジョブに対してリアルタイムで時間をログするCarbon のショップフロア アプリ。"
+msgstr "Carbonの生産現場アプリ：作業者が工程を実行し、数量を報告し、材料を出庫し、リリース済の製造指図に対してリアルタイムで時間を記録します。"
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "部品番号を持つすべてのもの(部品、材料、工具、サービス、消耗品、または治具)のCarbonの単一レコードであり、ジョブ、方法、注文、および在庫がすべて指しています。"
+msgstr "Carbonの単一レコード。部品番号を持つあらゆるもの（部品、材料、工具、外注サービス、消耗品、治具）に対応し、製造指図、製法、受注、在庫管理すべてが参照します。"
 
 msgid "Cards"
 msgstr "カード"
 
 msgid "Carrier"
-msgstr "配送業者"
+msgstr "運送業者"
 
 msgid "Carrier Account"
-msgstr "キャリアアカウント"
+msgstr "運送業者アカウント"
 
 msgid "Cash & Banking"
 msgstr "現金と銀行"
@@ -2948,7 +2948,7 @@ msgid "Chain"
 msgstr "チェーン"
 
 msgid "Champion users are available for training and data validation"
-msgstr "チャンピオンユーザーがトレーニングとデータ検証に利用可能です"
+msgstr "チャンピオンユーザーは教育訓練とデータ検証に利用可能です"
 
 msgid "Champion(s)"
 msgstr "チャンピオン"
@@ -2960,7 +2960,7 @@ msgid "Change"
 msgstr "変更"
 
 msgid "Change Document"
-msgstr "ドキュメント変更"
+msgstr "変更文書"
 
 msgid "Change Inspection Plan"
 msgstr "検査計画を変更"
@@ -2984,13 +2984,13 @@ msgid "Change notices could not be loaded, so new versions and revisions are blo
 msgstr "変更通知を読み込めませんでした。新しいバージョンとリビジョンはブロックされています。再度読み込んでください。"
 
 msgid "Change order"
-msgstr "変更注文"
+msgstr "変更指示"
 
 msgid "Change status"
 msgstr "ステータスを変更"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "アイテムタイプを変更します（例：部品、材料、工具など）"
+msgstr "品目タイプを変更します（例：部品、材料、工具など）"
 
 msgid "Change type"
 msgstr "種類を変更"
@@ -3011,7 +3011,7 @@ msgid "Changing this will update the part ID"
 msgstr "これを変更するとパーツIDが更新されます"
 
 msgid "Changing type resets this item's draft edits."
-msgstr "種類を変更すると、このアイテムのドラフト編集がリセットされます。"
+msgstr "タイプを変更すると、この品目の下書き編集がリセットされます。"
 
 msgid "Chart of accounts"
 msgstr "勘定科目表"
@@ -3029,7 +3029,7 @@ msgid "Check your email"
 msgstr "メールを確認してください"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "この得意先の Stripe を確認中…"
 
 msgid "Checkpoint ·"
 msgstr "チェックポイント ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "別のファイルを選択"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "印刷されたジョブトラベラーに表示される内容を選択します。"
+msgstr "印刷された製造指図現品票に表示される内容を選択します。"
 
 msgid "Choose your preferred language for the interface."
 msgstr "インターフェースの言語を選択してください。"
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "クラス（継承）"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "ルーティング操作を分類します：Process、Assembly、およびInspection操作はMESの自分のショップフロアで実行されます—Assemblyはガイド付きアセンブリビューを取得し、Inspectionは品質チェック—一方、Outside Processing操作はサプライヤーに下請けに出され、購買注文を作成します。プロセスは同じタイプを持ち、新しい操作のデフォルトになります。"
+msgstr "工順工程を分類します：工法、組立、検査工程は独自の製造現場でMESで実行されます。組立は案内付き組立ビューを取得し、検査は品質チェックを実行します。一方、外注加工工程は仕入先に外注され、発注書を作成します。プロセスは同じタイプを持ち、新しい工程でそれをデフォルト設定します。"
 
 msgid "Clean and approve the migrated data"
 msgstr "移行されたデータをクリーンアップして承認する"
@@ -3080,10 +3080,10 @@ msgid "Clear"
 msgstr "クリア"
 
 msgid "Clear due date"
-msgstr "期限をクリア"
+msgstr "期日をクリア"
 
 msgid "Clear Filters"
-msgstr "フィルターをクリア"
+msgstr "絞り込みをクリア"
 
 msgid "Clear search"
 msgstr "検索をクリア"
@@ -3095,7 +3095,7 @@ msgid "Clear selection"
 msgstr "選択をクリア"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "このインボイスをパーティの転記済みクレジットおよび現金でクリアします。クレジットは直接適用されます — 転記は不要です。"
+msgstr "転記済みクレジットと現金を使用して請求書をクリアします。クレジットは直接適用されます。転記は不要です。"
 
 msgid "Clear value"
 msgstr "値をクリア"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "PDFドローイングをアップロードするにはクリック"
 
 msgid "Clock In"
-msgstr "時刻入力"
+msgstr "作業開始"
 
 msgid "Clock Out"
-msgstr "時間外"
+msgstr "作業終了"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/>からクロックイン中"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "クラウド、またはセルフホストされた環境。"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC準拠"
 
 msgid "Code"
 msgstr "コード"
@@ -3182,13 +3182,13 @@ msgid "Collapse all"
 msgstr "すべて折りたたむ"
 
 msgid "Collapse Costs"
-msgstr "コストを折りたたむ"
+msgstr "原価を折りたたみ"
 
 msgid "Collapse features table"
 msgstr "機能テーブルを折りたたむ"
 
 msgid "Collapse Labor"
-msgstr "労働を折りたたむ"
+msgstr "労務を折りたたみ"
 
 msgid "Collapse Machine"
 msgstr "機械を折りたたむ"
@@ -3212,7 +3212,7 @@ msgid "Columns"
 msgstr "列"
 
 msgid "Combine filters"
-msgstr "フィルターを組み合わせる"
+msgstr "絞り込みを組み合わせ"
 
 msgid "Coming soon"
 msgstr "近日公開予定"
@@ -3233,7 +3233,7 @@ msgid "Committing a receipt, shipment, or invoice: quantities move, journal entr
 msgstr "領収書、出荷、または請求書のコミット: 数量が移動し、仕訳帳エントリが元帳に記載され、ステータスが投稿されます。"
 
 msgid "Community support"
-msgstr ""
+msgstr "コミュニティサポート"
 
 msgid "Companies"
 msgstr "企業"
@@ -3266,7 +3266,7 @@ msgid "Compare Quotes"
 msgstr "見積もりを比較"
 
 msgid "Compare Supplier Quotes"
-msgstr "サプライヤー見積もりを比較"
+msgstr "仕入先見積を比較"
 
 msgid "Complete"
 msgstr "完了"
@@ -3324,7 +3324,7 @@ msgid "Configuration Parameters"
 msgstr "設定パラメータ"
 
 msgid "Configuration, data migration, and any integrations"
-msgstr "設定、データ移行、および統合"
+msgstr "構成、データ移行、および任意の連携"
 
 msgid "Configurator"
 msgstr "コンフィギュレーター"
@@ -3339,16 +3339,16 @@ msgid "Configure Carbon"
 msgstr "Carbonを設定"
 
 msgid "Configure default accounts for cash and bank transactions"
-msgstr "現金およびバンク取引のデフォルトアカウントを構成する"
+msgstr "現金と銀行取引のデフォルトアカウントを構成"
 
 msgid "Configure default accounts for inventory management"
 msgstr "在庫管理のデフォルトアカウントを構成する"
 
 msgid "Configure default accounts for vendor and supplier transactions"
-msgstr "ベンダーとサプライヤー取引のデフォルトアカウントを構成する"
+msgstr "ベンダーおよび仕入先取引のデフォルトアカウントを構成"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "デフォルトのエクイティと留保利益勘定を構成する"
+msgstr "純資産および利益剰余金のデフォルトアカウントを構成"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "品質ダッシュボードのデフォルトを設定します。"
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "アイテムを構成"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "ゲージが校正範囲外になったときの通知を設定します。"
+msgstr "測定器の校正が外れたときの通知を構成"
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "ジョブが完了したときの通知を設定します。"
+msgstr "製造指図が完了したときの通知を構成"
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "保全ディスパッチが作業現場から作成されるときの通知を設定します。通知は故障モードタイプに基づいてルーティングされます。"
+msgstr "製造現場から保全指示が作成されたときの通知を構成します。通知は故障モードタイプに基づいてルーティングされます。"
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "新しい提案が送信されたときの通知を設定します。"
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "サイト、ワークセンター、プロセス部品表、BOM、原価計算、ロールを構成する"
+msgstr "サイト、作業区、工程表、BOM、原価計算、ロールを構成"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "様々なトランザクションタイプに使用されるデフォルトアカウントをシステム全体で設定します"
@@ -3378,10 +3378,10 @@ msgid "Configure the start months for your fiscal and tax years"
 msgstr "会計年度と税務年度の開始月を設定します"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
-msgstr "購入した品目のコストをサプライヤー取引から更新するタイミングを設定します。"
+msgstr "仕入先取引から購買品目の原価を更新する時期を構成"
 
 msgid "Configure who should receive notifications when a supplier submits a quote."
-msgstr "サプライヤーが見積もりを送信したときに通知を受け取るべき人を設定します。"
+msgstr "仕入先が見積を提出したときに通知を受け取る人を構成"
 
 msgid "Configure-to-order"
 msgstr "構成から注文まで"
@@ -3424,7 +3424,7 @@ msgid "Confirm disconnect"
 msgstr "切断を確認"
 
 msgid "Confirm how your company runs and lock the scope."
-msgstr "貴社の運営方法を確認し、スコープをロックします。"
+msgstr "会社の運営方法を確認し、範囲をロックします。"
 
 msgid "Confirm ID Change"
 msgstr "IDの変更を確認"
@@ -3445,13 +3445,13 @@ msgid "Confirm Skip"
 msgstr "スキップを確認"
 
 msgid "Confirmed incoming stock — purchase & production orders (bars above zero)."
-msgstr "確認された入荷在庫 — 購買および生産注文（ゼロ以上のバー）。"
+msgstr "確定済み入庫在庫—購買と生産受注（ゼロより上のバー）。"
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "確認された出荷在庫 — 販売注文とジョブ材料（ゼロ未満のバー）。"
+msgstr "確定済み出庫在庫—売上受注と指図材料（ゼロより下のバー）。"
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "当期中に転記されたすべての仕訳が借方と貸方で一致していることを確認します。仕訳が不均衡な場合、試算表が合致しないため、当期を終了する前に修正する必要があります。"
+msgstr "期間内のすべての転記済仕訳行が等しい借方と貸方を持つことを確認します。いずれかの行が不平衡な場合、試算表が一致しないため、期間をクローズするまえに修正する必要があります。"
 
 msgid "Conflict reason"
 msgstr "紛争の理由"
@@ -3466,13 +3466,13 @@ msgid "Connect Linear issue"
 msgstr "Linear イシューを接続"
 
 msgid "Connect Slack under Settings → Integrations first."
-msgstr "最初に設定 → 統合でSlackを接続してください。"
+msgstr "まず設定→連携の下でSlackに接続します。"
 
 msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "条件に一致しないときに実行するノードにOtherwiseハンドルを接続します。"
 
 msgid "Connect the outside tools your company already runs on"
-msgstr "貴社が既に使用している外部ツールを接続する"
+msgstr "会社がすでに実行している外部ツールに接続"
 
 msgid "Connected to"
 msgstr "接続先"
@@ -3517,22 +3517,22 @@ msgid "Consuming material from inventory into a job, which writes a Consumption 
 msgstr "在庫からジョブへの材料の消費。これにより、アイテム帳簿に消費エントリが書き込まれます。"
 
 msgid "contact"
-msgstr "連絡先"
+msgstr "担当者"
 
 msgid "Contact"
-msgstr "連絡先"
+msgstr "担当者"
 
 msgid "Contact (optional)"
-msgstr "連絡先（オプション）"
+msgstr "担当者（任意）"
 
 msgid "Contact us"
-msgstr ""
+msgstr "お問い合わせください"
 
 msgid "contacts"
-msgstr "連絡先"
+msgstr "担当者"
 
 msgid "Contacts"
-msgstr "連絡先"
+msgstr "担当者"
 
 msgid "Contained"
 msgstr "含有"
@@ -3541,7 +3541,7 @@ msgid "Containment"
 msgstr "封じ込め"
 
 msgid "Containment action"
-msgstr "是正処置"
+msgstr "封じ込め対策"
 
 msgid "Content"
 msgstr "コンテンツ"
@@ -3553,31 +3553,31 @@ msgid "Contra-asset account for total depreciation of fixed assets"
 msgstr "固定資産の総減価償却費の逆資産勘定"
 
 msgid "Contra-revenue account for discounts given on sales"
-msgstr "売上割引に対する逆収益勘定"
+msgstr "販売における値引に対する反売上勘定科目"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
-msgstr "顧客請求書の割引に対する逆収益GL勘定。"
+msgstr "得意先請求書における値引に対する反売上勘定科目"
 
 msgid "Contractor"
-msgstr "請負業者"
+msgstr "外部作業者"
 
 msgid "Contractors"
-msgstr "請負業者"
+msgstr "外部作業者"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "設計変更をリビジョン/ECOで管理"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "オペレーターが材料をピックして、現場で時間を追跡する方法を制御します。"
+msgstr "作業者が製造現場で材料をピッキングし時間を追跡する方法を制御します。"
 
 msgid "Controller, Accountant"
 msgstr "コントローラー、会計士"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "計画が廃止品目をどのように処理するかを制御します。「Consume First」は在庫を使い切ってから後継品に切り替え、「Prefer New」は新規需要をすぐに後継品にリダイレクト、「Stock Only」は最小限のサービス在庫のみを保持、「No Stock」は品目を計画から完全に削除します。"
+msgstr "計画が廃止品目をどのように処理するかを制御します：先に消費は在庫がなくなるまで消費してから後継品目に切り替え、新を優先は新しい所要量を即座に後継品目にリダイレクト、在庫のみは最小サービス在庫のみを保持、在庫なしは品目を計画から完全に除外します。"
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "リリース(本番)リビジョンのBOM(部品表)およびBOP(工程表)を変更指示の外で編集できるかどうかを制御します。"
+msgstr "リリース済み生産リビジョンの部品表と工程表が変更指示の外で編集できるかどうかを制御します。"
 
 msgid "Convention"
 msgstr "慣例"
@@ -3598,16 +3598,16 @@ msgid "Convert"
 msgstr "変換"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "見積もりを再入力なしで販売注文に変換する"
+msgstr "見積を受注に変換（再入力なし）"
 
 msgid "Convert Line to Job"
 msgstr "ラインをジョブに変換"
 
 msgid "Convert Lines to Jobs"
-msgstr "ラインをジョブに変換"
+msgstr "明細を製造指図に変換"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "MRP提案を発注書とジョブに変換します。"
+msgstr "MRP提案を発注書と製造指図に変換します。"
 
 msgid "Convert to Quote"
 msgstr "見積に変換"
@@ -3616,7 +3616,7 @@ msgid "Converting…"
 msgstr "変換中…"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "サプライヤーの購入単位をPO、領収書、または請求書行のインベントリ単位に変換します — 12個の箱で購入、個別にストック。"
+msgstr "仕入先の購入単位をPO、入荷、または請求書上で在庫単位に変換します — 12個のカートン単位で仕入れ、個単位で在庫する。"
 
 msgid "Copied link to clipboard"
 msgstr "クリップボードにリンクをコピーしました"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "コピー"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "すべてのアイテムと価格設定を別の顧客またはタイプにコピーします。"
+msgstr "すべての品目と価格設定を別の得意先またはタイプにコピーします。"
 
 msgid "Copy API Key"
 msgstr "APIキーをコピー"
@@ -3637,16 +3637,16 @@ msgid "Copy consumable number"
 msgstr "消耗品番号をコピー"
 
 msgid "Copy dispatch ID"
-msgstr "ディスパッチIDをコピー"
+msgstr "保全指示IDをコピー"
 
 msgid "Copy dispatch number"
-msgstr "ディスパッチ番号をコピー"
+msgstr "保全指示番号をコピー"
 
 msgid "Copy document name"
-msgstr "ドキュメント名をコピー"
+msgstr "文書名をコピー"
 
 msgid "Copy document unique identifier"
-msgstr "ドキュメントの一意の識別子をコピー"
+msgstr "文書の識別子をコピー"
 
 msgid "Copy ID"
 msgstr "IDをコピー"
@@ -3670,10 +3670,10 @@ msgid "Copy link to consumable"
 msgstr "消耗品へのリンクをコピー"
 
 msgid "Copy link to dispatch"
-msgstr "ディスパッチへのリンクをコピー"
+msgstr "保全指示へのリンクをコピー"
 
 msgid "Copy link to document"
-msgstr "ドキュメントへのリンクをコピー"
+msgstr "文書へのリンクをコピー"
 
 msgid "Copy link to issue"
 msgstr "問題へのリンクをコピー"
@@ -3688,7 +3688,7 @@ msgid "Copy link to part"
 msgstr "パーツへのリンクをコピー"
 
 msgid "Copy link to procedure"
-msgstr "プロシージャへのリンクをコピー"
+msgstr "手順書へのリンクをコピー"
 
 msgid "Copy link to service"
 msgstr "サービスへのリンクをコピー"
@@ -3697,7 +3697,7 @@ msgid "Copy link to tool"
 msgstr "ツールへのリンクをコピー"
 
 msgid "Copy link to training"
-msgstr "トレーニングへのリンクをコピー"
+msgstr "教育訓練へのリンクをコピー"
 
 msgid "Copy material number"
 msgstr "材料番号をコピー"
@@ -3718,19 +3718,19 @@ msgid "Copy PIN"
 msgstr "PINをコピー"
 
 msgid "Copy pricing to a single customer"
-msgstr "単一の顧客に価格設定をコピーする"
+msgstr "単一の得意先に価格設定をコピー"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "タイプのすべての顧客に価格設定をコピーします"
+msgstr "あるタイプのすべての得意先に価格設定をコピー"
 
 msgid "Copy Procedure"
-msgstr "手順をコピー"
+msgstr "手順書をコピー"
 
 msgid "Copy procedure name"
-msgstr "プロシージャ名をコピー"
+msgstr "手順書名をコピー"
 
 msgid "Copy procedure unique identifier"
-msgstr "プロシージャの一意の識別子をコピー"
+msgstr "手順書の識別子をコピー"
 
 msgid "Copy Quality Document"
 msgstr "品質文書をコピー"
@@ -3751,10 +3751,10 @@ msgid "Copy this item's pricing to another scope."
 msgstr "このアイテムの価格設定を別のスコープにコピーします。"
 
 msgid "Copy this link to share the quote with a customer"
-msgstr "このリンクをコピーして、顧客と見積書を共有してください"
+msgstr "この見積を得意先と共有するためのリンクをコピー"
 
 msgid "Copy this link to share the quote with a supplier"
-msgstr "このリンクをコピーして、サプライヤーと見積もりを共有してください"
+msgstr "この見積を仕入先と共有するためのリンクをコピー"
 
 msgid "Copy tool number"
 msgstr "ツール番号をコピー"
@@ -3763,10 +3763,10 @@ msgid "Copy tool unique identifier"
 msgstr "ツール固有識別子をコピー"
 
 msgid "Copy training name"
-msgstr "トレーニング名をコピー"
+msgstr "教育訓練名をコピー"
 
 msgid "Copy training unique identifier"
-msgstr "トレーニングの一意の識別子をコピー"
+msgstr "教育訓練の識別子をコピー"
 
 msgid "Correct"
 msgstr "訂正"
@@ -3799,25 +3799,25 @@ msgid "Corrective action"
 msgstr "是正処置"
 
 msgid "cost center"
-msgstr "コストセンター"
+msgstr "原価センター"
 
 msgid "Cost center"
-msgstr "コストセンター"
+msgstr "原価センター"
 
 msgid "Cost Center"
-msgstr "コストセンター"
+msgstr "原価センター"
 
 msgid "Cost Center Name"
-msgstr "コスト センター名"
+msgstr "原価センター名"
 
 msgid "cost centers"
-msgstr "コストセンター"
+msgstr "原価センター"
 
 msgid "Cost Centers"
-msgstr "コストセンター"
+msgstr "原価センター"
 
 msgid "Cost History"
-msgstr "コスト履歴"
+msgstr "原価履歴"
 
 msgid "Cost of Goods Sold"
 msgstr "売上原価"
@@ -3829,7 +3829,7 @@ msgid "Cost of Goods Sold (default)"
 msgstr "売上原価（デフォルト）"
 
 msgid "Cost of Sales"
-msgstr "売上原価"
+msgstr "販売原価"
 
 msgid "Costing"
 msgstr "原価計算"
@@ -3858,7 +3858,7 @@ msgstr "分析用の領域画像を準備できませんでした"
 
 #. placeholder {0}: extraction?.error ?? ""
 msgid "Could not read the document: {0}"
-msgstr "ドキュメントを読み込めませんでした: {0}"
+msgstr "文書が読み込めません: {0}"
 
 msgid "Could not save"
 msgstr "保存できませんでした"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "ドキュメントを読み込めませんでした"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "関連ドキュメントを読み込めませんでした。重複を避けるため、新規作成前に更新してください。"
+msgstr "関連ドキュメントを読み込めませんでした。新しいものを作成する前に更新して、重複を回避してください。"
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "プロバイダーのディメンションターゲットを読み込めませんでした。接続を確認して再度読み込んでください。"
@@ -3930,25 +3930,25 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "スキャンベースの補充用に新しいかんばんカードを作成します。"
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "新しい保守ディスパッチを作成して、機器の修理と保守活動を追跡します"
+msgstr "設備の修理と保全活動を追跡するための新しい保全指示を作成します"
 
 msgid "Create a new production job to fulfill the sales order"
-msgstr "販売注文を履行するための新しい生産ジョブを作成します"
+msgstr "受注を満たすために新しい生産製造指図を作成"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "代わりに新しいStripe得意先を作成"
 
 msgid "Create a new version"
 msgstr "新しいバージョンを作成"
 
 msgid "Create a purchase order"
-msgstr "購買注文を作成"
+msgstr "発注書を作成"
 
 msgid "Create a quote with a new quote ID"
 msgstr "新しい見積ID で見積を作成"
 
 msgid "Create a sales order"
-msgstr "販売注文を作成"
+msgstr "受注を作成"
 
 msgid "Create Account"
 msgstr "アカウントを作成"
@@ -3963,7 +3963,7 @@ msgid "Create an issue"
 msgstr "問題を作成"
 
 msgid "Create and approve purchase orders"
-msgstr "購買注文を作成して承認する"
+msgstr "発注書を作成して承認"
 
 msgid "Create audit trail entries"
 msgstr "監査証跡エントリを作成"
@@ -3975,10 +3975,10 @@ msgid "Create Issue"
 msgstr "問題を作成"
 
 msgid "Create Jobs"
-msgstr "ジョブを作成"
+msgstr "製造指図を作成"
 
 msgid "Create Kanban"
-msgstr "カンバンを作成"
+msgstr "かんばんを作成"
 
 msgid "Create new rule"
 msgstr "新しいルールを作成"
@@ -4014,7 +4014,7 @@ msgid "Create Version"
 msgstr "バージョンを作成"
 
 msgid "Create Work Center"
-msgstr "ワークセンターを作成"
+msgstr "作業区を作成"
 
 msgid "Created"
 msgstr "作成日時"
@@ -4047,20 +4047,20 @@ msgid "Created consumable"
 msgstr "消耗品を作成しました"
 
 msgid "Created cost center"
-msgstr "コスト センターを作成しました"
+msgstr "原価センターを作成しました"
 
 msgid "Created customer portal"
 msgstr "顧客ポータルを作成しました"
 
 msgid "Created customer status"
-msgstr "顧客ステータスを作成しました"
+msgstr "得意先ステータスを作成しました"
 
 msgid "Created customer type"
-msgstr "顧客タイプを作成しました"
+msgstr "得意先タイプを作成しました"
 
 #. placeholder {0}: createdCustomer?.name ?? t`Customer`
 msgid "Created customer: {0}"
-msgstr "顧客を作成しました: {0}"
+msgstr "得意先を作成しました: {0}"
 
 msgid "Created department"
 msgstr "部門を作成しました"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "障害モードを作成しました"
 
 msgid "Created gauge type"
-msgstr "ゲージタイプを作成しました"
+msgstr "測定器タイプを作成しました"
 
 msgid "Created item group"
 msgstr "アイテムグループを作成しました"
@@ -4078,7 +4078,7 @@ msgid "Created location"
 msgstr "ロケーションを作成しました"
 
 msgid "Created maintenance schedule"
-msgstr "メンテナンススケジュールを作成しました"
+msgstr "保全スケジュールを作成しました"
 
 msgid "Created material"
 msgstr "材料を作成しました"
@@ -4087,7 +4087,7 @@ msgid "Created material dimension"
 msgstr "マテリアルディメンションを作成しました"
 
 msgid "Created material finish"
-msgstr "マテリアルフィニッシュを作成しました"
+msgstr "表面処理を作成しました"
 
 msgid "Created material form"
 msgstr "マテリアルフォームを作成しました"
@@ -4096,13 +4096,13 @@ msgid "Created material grade"
 msgstr "材料グレードを作成しました"
 
 msgid "Created material substance"
-msgstr "材料物質を作成しました"
+msgstr "素材を作成しました"
 
 msgid "Created material type"
 msgstr "マテリアルタイプを作成しました"
 
 msgid "Created no quote reason"
-msgstr "見積なし理由を作成しました"
+msgstr "見積辞退理由を作成しました"
 
 msgid "Created non conformance type"
 msgstr "不適合タイプを作成しました"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "パーツを作成しました"
 
 msgid "Created payment term"
-msgstr "支払い条件を作成しました"
+msgstr "支払条件を作成しました"
 
 msgid "Created process"
 msgstr "プロセスを作成しました"
@@ -4120,16 +4120,16 @@ msgid "Created required action"
 msgstr "必須アクションを作成しました"
 
 msgid "Created scrap reason"
-msgstr "スクラップ理由を作成しました"
+msgstr "不良理由を作成しました"
 
 msgid "Created service"
 msgstr "サービスを作成しました"
 
 msgid "Created shipping method"
-msgstr "配送方法を作成しました"
+msgstr "出荷方法を作成しました"
 
 msgid "Created stock transfer line"
-msgstr "在庫移動行を作成しました"
+msgstr "在庫転送明細を作成しました"
 
 msgid "Created storage type"
 msgstr "ストレージタイプを作成しました"
@@ -4145,10 +4145,10 @@ msgid "Created unit of measure"
 msgstr "単位が作成されました"
 
 msgid "Created webhook"
-msgstr "ウェブフックを作成しました"
+msgstr "Webhookを作成しました"
 
 msgid "Created work center"
-msgstr "ワークセンターを作成しました"
+msgstr "作業区を作成しました"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
 msgstr "会計年度の12ヶ月間の期間を作成します。既に存在する期間は保持されます。"
@@ -4173,22 +4173,22 @@ msgid "Credit Account"
 msgstr "クレジット勘定"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "労力/機械時間がWIPに吸収される場合のクレジット勘定"
+msgstr "労務/機械時間が仕掛品に吸収されたときに貸方勘定を計上"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "製造間接費がWIPに吸収される場合のクレジットアカウント"
+msgstr "間接費が仕掛品に吸収されたときに貸方勘定を計上"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "製造原価がWIPに吸収される場合に使用されるクレジットアカウント"
+msgstr "製造原価が仕掛品に吸収されたときに使用される貸方勘定"
 
 msgid "Credit Memo"
-msgstr "貸方メモ"
+msgstr "クレジットメモ"
 
 msgid "Credits"
 msgstr "クレジット"
 
 msgid "Credits & Debits"
-msgstr "クレジット＆デビット"
+msgstr "貸方と借方"
 
 msgid "Credits applied"
 msgstr "適用されたクレジット"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "現在"
 
 msgid "Current Net Book Value:"
-msgstr "現在の純簿価額:"
+msgstr "現在の未償却残高:"
 
 msgid "Current Password"
 msgstr "現在のパスワード"
@@ -4239,7 +4239,7 @@ msgid "Current quantity"
 msgstr "現在の数量"
 
 msgid "Currently training for"
-msgstr "現在トレーニング中"
+msgstr "現在の教育訓練"
 
 msgid "Custom"
 msgstr "カスタム"
@@ -4251,16 +4251,16 @@ msgid "Custom {label}"
 msgstr "カスタム {label}"
 
 msgid "Custom attributes you track against your people"
-msgstr "あなたの従業員に対して追跡するカスタム属性"
+msgstr "貴社の人員に対して追跡するカスタム属性"
 
 msgid "Custom development beyond what's listed"
 msgstr "リストに記載されていないカスタム開発"
 
 msgid "Custom development, integrations, or self-hosting"
-msgstr "カスタム開発、統合、またはセルフホスティング"
+msgstr "カスタム開発、連携、またはセルフホスティング"
 
 msgid "Custom field"
-msgstr "カスタム フィールド"
+msgstr "カスタムフィールド"
 
 msgid "Custom Field"
 msgstr "カスタムフィールド"
@@ -4269,7 +4269,7 @@ msgid "Custom Fields"
 msgstr "カスタムフィールド"
 
 msgid "Custom fields are not available for items yet."
-msgstr "カスタムフィールドはまだアイテムで利用できません。"
+msgstr "品目のカスタムフィールドはまだ利用可能ではありません。"
 
 msgid "Custom SOW · we manage"
 msgstr "カスタムSOW · 当社が管理"
@@ -4278,76 +4278,76 @@ msgid "Custom…"
 msgstr "カスタム…"
 
 msgid "customer"
-msgstr "顧客"
+msgstr "得意先"
 
 msgid "Customer"
-msgstr "顧客"
+msgstr "得意先"
 
 msgid "Customer Accounts"
-msgstr "顧客アカウント"
+msgstr "得意先アカウント"
 
 msgid "Customer contact"
-msgstr "顧客連絡先"
+msgstr "得意先担当者"
 
 msgid "Customer Contact"
-msgstr "顧客連絡先"
+msgstr "得意先担当者"
 
 msgid "Customer contacts"
-msgstr "顧客連絡先"
+msgstr "得意先担当者"
 
 msgid "Customer Details"
-msgstr "顧客詳細"
+msgstr "得意先詳細"
 
 msgid "Customer engineering contact"
-msgstr "顧客エンジニアリング連絡先"
+msgstr "得意先エンジニアリング担当者"
 
 msgid "Customer follows it alone"
-msgstr "顧客が単独で実行します"
+msgstr "得意先が単独でそれに従う"
 
 msgid "Customer ID"
-msgstr "顧客ID"
+msgstr "得意先ID"
 
 msgid "Customer ID cannot be changed after creation"
-msgstr "顧客IDは作成後に変更することはできません"
+msgstr "得意先IDは作成後に変更することはできません"
 
 msgid "Customer Invoice Number"
-msgstr "顧客請求書番号"
+msgstr "得意先請求書番号"
 
 msgid "Customer location"
-msgstr "顧客の場所"
+msgstr "得意先拠点"
 
 msgid "Customer Location"
-msgstr "顧客ロケーション"
+msgstr "得意先拠点"
 
 msgid "Customer Overview"
-msgstr "顧客概要"
+msgstr "得意先概要"
 
 msgid "Customer Part"
-msgstr "顧客部品"
+msgstr "得意先品番"
 
 msgid "Customer Part ID"
-msgstr "顧客部品ID"
+msgstr "得意先品番"
 
 msgid "Customer Part Number"
-msgstr "顧客部品番号"
+msgstr "得意先品番"
 
 msgid "Customer Part Revision"
-msgstr "顧客部品リビジョン"
+msgstr "得意先品番リビジョン"
 
 msgid "Customer Parts"
-msgstr "顧客部品"
+msgstr "得意先部品"
 
 msgid "Customer Payment Discounts"
-msgstr "顧客支払割引"
+msgstr "得意先支払値引"
 
 msgid "Customer Payment Discounts (default)"
-msgstr "顧客支払割引（デフォルト）"
+msgstr "得意先支払値引（デフォルト）"
 
 msgid "Customer PO"
-msgstr "顧客PO"
+msgstr "得意先PO"
 
 msgid "Customer PO Number"
-msgstr "顧客PO番号"
+msgstr "得意先PO番号"
 
 msgid "Customer Portal"
 msgstr "顧客ポータル"
@@ -4356,58 +4356,58 @@ msgid "Customer Portals"
 msgstr "顧客ポータル"
 
 msgid "Customer pricing"
-msgstr "顧客価格"
+msgstr "得意先価格設定"
 
 msgid "Customer reference"
-msgstr "顧客参照"
+msgstr "得意先参照"
 
 msgid "Customer Reference"
-msgstr "顧客参照"
+msgstr "得意先参照"
 
 msgid "Customer Revision"
-msgstr "顧客リビジョン"
+msgstr "得意先リビジョン"
 
 msgid "Customer RFQ"
-msgstr "顧客RFQ"
+msgstr "得意先見積依頼"
 
 msgid "Customer Scope"
-msgstr "顧客スコープ"
+msgstr "得意先スコープ"
 
 msgid "customer status"
-msgstr "顧客ステータス"
+msgstr "得意先ステータス"
 
 msgid "Customer Status"
-msgstr "顧客ステータス"
+msgstr "得意先ステータス"
 
 msgid "customer statuses"
-msgstr "顧客ステータス"
+msgstr "得意先ステータス"
 
 msgid "Customer Statuses"
-msgstr "顧客ステータス"
+msgstr "得意先ステータス"
 
 msgid "customer type"
-msgstr "顧客タイプ"
+msgstr "得意先種別"
 
 msgid "Customer Type"
-msgstr "顧客タイプ"
+msgstr "得意先種別"
 
 msgid "customer types"
-msgstr "顧客タイプ"
+msgstr "得意先種別"
 
 msgid "Customer Types"
-msgstr "顧客タイプ"
+msgstr "得意先種別"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "顧客償却（貸倒金）"
+msgstr "得意先償却（不良債権）"
 
 msgid "customers"
-msgstr "顧客"
+msgstr "得意先"
 
 msgid "Customers"
-msgstr "顧客"
+msgstr "得意先"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "カスタマイズ、教育訓練、連携"
 
 msgid "Customize"
 msgstr "カスタマイズ"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "カットオーバーサポート"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "サイクルカウントを実施し、監査証跡で調整"
+msgstr "循環棚卸と監査証跡を使用した調整"
 
 msgid "Daily"
 msgstr "毎日"
@@ -4440,10 +4440,10 @@ msgid "Daily check-ins while your team finds its feet on the live system"
 msgstr "ライブシステムでチームが軌道に乗るまでの毎日のチェックイン"
 
 msgid "Daily summary"
-msgstr "日次集約"
+msgstr "毎日のサマリー"
 
 msgid "Daily Usage"
-msgstr "日次使用量"
+msgstr "毎日の使用量"
 
 msgid "Dark"
 msgstr "ダーク"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "支払期日"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "部品の注文から利用可能になるまでの日数; 計画はこの量だけ需要を後方にオフセットします。"
+msgstr "部品を注文してから利用可能になるまでの日数。計画オフセットは所要量をこの分だけ後ろにシフトさせます。"
 
 msgid "Days Off"
 msgstr "休日"
@@ -4556,13 +4556,13 @@ msgid "Deactivate Process"
 msgstr "プロセスを無効化"
 
 msgid "Deactivate Supplier"
-msgstr "サプライヤーを無効化"
+msgstr "仕入先を無効化"
 
 msgid "Deactivate Users"
 msgstr "ユーザーを無効化"
 
 msgid "Deactivate Work Center"
-msgstr "ワークセンターを無効化"
+msgstr "作業区を無効化"
 
 msgid "Deadline type"
 msgstr "期限のタイプ"
@@ -4571,29 +4571,29 @@ msgid "Deadline Type"
 msgstr "期限タイプ"
 
 msgid "Debit"
-msgstr "デビット"
+msgstr "借方"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
-msgstr "デビット ({0})"
+msgstr "借方 ({0})"
 
 msgid "Debit Account"
-msgstr "デビット勘定"
+msgstr "借方勘定"
 
 msgid "Debit Memo"
 msgstr "借方メモ"
 
 msgid "Debits"
-msgstr "デビット"
+msgstr "借方"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "オペレーターが既に期限切れのバッチまたはシリアルを発行しようとした場合に表示される内容を決定します。"
+msgstr "作業者が既に期限切れのバッチまたはシリアルを出庫しようとした場合に何が表示されるかを決定します。"
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "オペレーターが店舗の床で材料がまだピックされていない状態で「完了」を押すとどうなるかを決定します。"
+msgstr "作業者が製造現場で完了を押したときに、ピック待ちの材料がある場合に何が起こるかを決定します。"
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "作業センターに仕分けされたが消費されなかった材料が倉庫に戻る時期を決定します。"
+msgstr "作業区にピッキングされたが消費済みでない材料がいつ倉庫に戻されるかを決定"
 
 msgid "Decimal Places"
 msgstr "小数位数"
@@ -4605,22 +4605,22 @@ msgid "Default"
 msgstr "デフォルト"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "請求書からの売上収益を記録するためのデフォルト口座"
+msgstr "請求書からの販売売上高を転記するデフォルト勘定"
 
 msgid "Default Accounts"
 msgstr "デフォルトアカウント"
 
 msgid "Default accounts for business expenses"
-msgstr "事業費のデフォルト口座"
+msgstr "ビジネス費用のデフォルト勘定"
 
 msgid "Default accounts for customer transactions and receivables"
-msgstr "顧客取引と売掛金のデフォルト口座"
+msgstr "得意先取引と売掛金のデフォルト勘定科目"
 
 msgid "Default accounts for long-term assets and depreciation"
 msgstr "長期資産と減価償却のデフォルト口座"
 
 msgid "Default accounts for sales and income"
-msgstr "売上と収益のデフォルト口座"
+msgstr "販売と収益のデフォルト勘定"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "税関連取引のデフォルト口座"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "デフォルトCC受信者"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "固定資産の処分により利益が発生した場合に貸方に計上される既定の一般勘定科目。"
+msgstr "固定資産の除却により利益が生じた場合にクレジットされるデフォルト勘定科目"
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "固定資産の処分により損失が発生した場合に借方に計上される既定の一般勘定科目。"
+msgstr "固定資産の除却により損失が生じた場合にデビットされるデフォルト勘定科目"
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
 msgstr "特定の銀行口座が選択されていない場合、現金取引に使用されるデフォルトGLアカウント。"
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "機器および施設のメンテナンス用のデフォルトGL支出勘定。"
+msgstr "設備と施設保全のデフォルトGL費用勘定科目"
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "定期的な減価償却実行のためのデフォルトGL支出勘定。"
+msgstr "定期的な減価償却実行のデフォルトGL費用勘定科目"
 
 msgid "Default Method"
 msgstr "デフォルト方法"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "このクラスの新しい資産に事前入力されるデフォルト方法（資産ごとに編集可能）。"
 
 msgid "Default method type"
-msgstr "デフォルトメソッドタイプ"
+msgstr "デフォルト供給方式"
 
 msgid "Default Method Type"
-msgstr "デフォルトメソッドタイプ"
+msgstr "デフォルト供給方式"
 
 msgid "Default Permissions"
 msgstr "デフォルト権限"
@@ -4680,10 +4680,10 @@ msgid "Default Priority"
 msgstr "デフォルト優先度"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "売上請求書が転記されるときにクレジットされるデフォルト収益GLアカウント。"
+msgstr "売上請求書が転記されたときに貸方計上されるデフォルト売上GL勘定科目"
 
 msgid "Default Sampling"
-msgstr "デフォルトサンプリング"
+msgstr "デフォルト抜取検査"
 
 msgid "Default shelf-life duration (days)"
 msgstr "デフォルト保管期間（日数）"
@@ -4692,7 +4692,7 @@ msgid "Default Source"
 msgstr "デフォルトソース"
 
 msgid "Default Storage Unit"
-msgstr "デフォルトストレージユニット"
+msgstr "デフォルト保管ユニット"
 
 msgid "Default tax depreciation method for new assets in this class."
 msgstr "このクラスの新しい資産に対するデフォルト税務減価償却方法。"
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "最初に製造作業を定義します。"
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "複数レベルのBOMおよびプロセス表(製造方法)を定義する"
+msgstr "多階層BOMおよび工程表（製造方法）を定義"
 
 msgid "Delete"
 msgstr "削除"
@@ -4777,10 +4777,10 @@ msgid "Delete Consumable"
 msgstr "消耗品を削除"
 
 msgid "Delete Contact"
-msgstr "連絡先を削除"
+msgstr "担当者を削除"
 
 msgid "Delete Contractor"
-msgstr "契約者を削除"
+msgstr "外部作業者を削除"
 
 msgid "Delete Count"
 msgstr "カウントを削除"
@@ -4789,25 +4789,25 @@ msgid "Delete Custom Field"
 msgstr "カスタムフィールドを削除"
 
 msgid "Delete Customer"
-msgstr "顧客を削除"
+msgstr "得意先を削除"
 
 msgid "Delete Customer Status"
-msgstr "顧客ステータスを削除"
+msgstr "得意先ステータスを削除"
 
 msgid "Delete Customer Type"
-msgstr "顧客タイプを削除"
+msgstr "得意先タイプを削除"
 
 msgid "Delete Department"
 msgstr "部門を削除"
 
 msgid "Delete Dimension"
-msgstr "分析軸を削除"
+msgstr "ディメンションを削除"
 
 msgid "Delete Dispatch"
-msgstr "ディスパッチを削除"
+msgstr "保全指示を削除"
 
 msgid "Delete Document"
-msgstr "ドキュメントを削除"
+msgstr "文書を削除"
 
 msgid "Delete Employee Type"
 msgstr "従業員タイプを削除"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "アイテムグループを削除"
 
 msgid "Delete Journal Entry"
-msgstr "仕訳帳エントリを削除"
+msgstr "仕訳行を削除"
 
 msgid "Delete line"
 msgstr "行を削除"
@@ -4849,10 +4849,10 @@ msgid "Delete Material"
 msgstr "材料を削除"
 
 msgid "Delete Material Dimension"
-msgstr "材料寸法を削除"
+msgstr "材料ディメンションを削除"
 
 msgid "Delete Material Finish"
-msgstr "マテリアルフィニッシュを削除"
+msgstr "表面処理を削除"
 
 msgid "Delete Material Grade"
 msgstr "材料グレードを削除"
@@ -4882,7 +4882,7 @@ msgid "Delete Payment"
 msgstr "支払いを削除"
 
 msgid "Delete Payment Term"
-msgstr "支払い条件を削除"
+msgstr "支払条件を削除"
 
 msgid "Delete Period"
 msgstr "期間を削除"
@@ -4894,25 +4894,25 @@ msgid "Delete Portal"
 msgstr "ポータルを削除"
 
 msgid "Delete Price Break"
-msgstr "価格ブレークを削除"
+msgstr "価格スケールを削除"
 
 msgid "Delete Pricing Rule"
 msgstr "価格設定ルールを削除"
 
 msgid "Delete Procedure"
-msgstr "手順を削除"
+msgstr "手順書を削除"
 
 msgid "Delete Process"
 msgstr "プロセスを削除"
 
 msgid "Delete Purchase Invoice"
-msgstr "購入請求書を削除"
+msgstr "仕入先請求書を削除"
 
 msgid "Delete Purchase Order"
-msgstr "購買注文を削除"
+msgstr "発注書を削除"
 
 msgid "Delete Purchase Orders"
-msgstr "購買注文を削除"
+msgstr "発注書を削除"
 
 msgid "Delete Question"
 msgstr "質問を削除"
@@ -4930,7 +4930,7 @@ msgid "Delete receipt line"
 msgstr "領収書行を削除"
 
 msgid "Delete requirement"
-msgstr "要件を削除"
+msgstr "要求事項を削除"
 
 msgid "Delete RFQ"
 msgstr "RFQを削除"
@@ -4948,7 +4948,7 @@ msgid "Delete Sales Invoice"
 msgstr "売上請求書を削除"
 
 msgid "Delete Sales Order"
-msgstr "販売注文を削除"
+msgstr "受注を削除"
 
 msgid "Delete Schedule"
 msgstr "スケジュールを削除"
@@ -4960,13 +4960,13 @@ msgid "Delete Shift"
 msgstr "シフトを削除"
 
 msgid "Delete Shipment"
-msgstr "配送を削除"
+msgstr "出荷を削除"
 
 msgid "Delete shipment line"
-msgstr "配送ラインを削除"
+msgstr "出荷明細を削除"
 
 msgid "Delete Shipping Method"
-msgstr "配送方法を削除"
+msgstr "出荷方法を削除"
 
 msgid "Delete step"
 msgstr "ステップを削除"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "ストレージタイプを削除"
 
 msgid "Delete Storage Unit"
-msgstr "ストレージユニットを削除"
+msgstr "保管ユニットを削除"
 
 msgid "Delete Substance"
 msgstr "物質を削除"
@@ -4990,20 +4990,20 @@ msgid "Delete Suggestion"
 msgstr "提案を削除"
 
 msgid "Delete supplier"
-msgstr "サプライヤーを削除"
+msgstr "仕入先を削除"
 
 msgid "Delete Supplier"
-msgstr "サプライヤーを削除"
+msgstr "仕入先を削除"
 
 msgid "Delete Supplier Quote"
-msgstr "サプライヤー見積を削除"
+msgstr "仕入先見積を削除"
 
 msgid "Delete Supplier Type"
-msgstr "サプライヤータイプを削除"
+msgstr "仕入先タイプを削除"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "数量{0}の価格ブレークを削除しますか？この操作は元に戻せません。"
+msgstr "数量{0}の価格スケールを削除しますか？この操作は取り消せません。"
 
 msgid "Delete Timecard"
 msgstr "タイムカードを削除"
@@ -5012,13 +5012,13 @@ msgid "Delete Tool"
 msgstr "ツールを削除"
 
 msgid "Delete Training"
-msgstr "トレーニングを削除"
+msgstr "教育訓練を削除"
 
 msgid "Delete Transfer"
 msgstr "転送を削除"
 
 msgid "Delete Transfer Line"
-msgstr "転送ラインを削除"
+msgstr "転送明細を削除"
 
 msgid "Delete Type"
 msgstr "タイプを削除"
@@ -5042,31 +5042,31 @@ msgid "Delete Workflow"
 msgstr "ワークフローを削除"
 
 msgid "Delivery Date"
-msgstr "配送日"
+msgstr "納期"
 
 msgid "Delivery Location"
 msgstr "配送先"
 
 msgid "Demand"
-msgstr "需要"
+msgstr "所要量"
 
 msgid "Demand forecast"
-msgstr "需要予測"
+msgstr "所要量予測"
 
 msgid "Demand Forecast"
-msgstr "需要予測"
+msgstr "所要量予測"
 
 msgid "Demand Forecast — Driven by"
-msgstr "需要予測 — 駆動元"
+msgstr "所要量予測 — 駆動元"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "需要予測 = BOM展開需要（オープン販売注文、アクティブなジョブ、および生産予測から）"
+msgstr "所要量予測 = 処理中の受注、進行中の製造指図、および生産計画から展開されたBOM所要量。"
 
 msgid "Demand projection"
-msgstr "需要予測"
+msgstr "所要量計画"
 
 msgid "Demand Projections"
-msgstr "需要予測"
+msgstr "所要量計画"
 
 msgid "Demand-Based"
 msgstr "需要ベース"
@@ -5081,7 +5081,7 @@ msgid "Demo data applied"
 msgstr "デモデータが適用されました"
 
 msgid "Demo data was applied to this company. Keep it, or revert to put back exactly what was here before."
-msgstr "このコンパニーにデモデータが適用されました。保持するか、以前の状態に戻してください。"
+msgstr "デモデータがこの会社に適用されました。保持するか、適用前の状態に戻してください。"
 
 msgid "department"
 msgstr "部門"
@@ -5108,7 +5108,7 @@ msgid "Depreciation Expense (default)"
 msgstr "減価償却費（デフォルト）"
 
 msgid "Depreciation Expense Account"
-msgstr "減価償却費勘定"
+msgstr "減価償却費勘定科目"
 
 msgid "Depreciation Method"
 msgstr "減価償却方法"
@@ -5120,13 +5120,13 @@ msgid "Depreciation reversal when a fixed asset is disposed"
 msgstr "固定資産を処分する場合の減価償却の逆転"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "当期中に終了する減価償却実行がまだ下書きの場合は、当期が正しい減価償却費と累積減価償却を反映するために転記する必要があります。当期に減価償却が適用されない場合は、理由を付けてスキップしてください。"
+msgstr "この期間で終了し、まだ下書き状態にある減価償却実行は転記する必要があります。これにより、期間が正しい減価償却費と減価償却累計額を反映します。この期間に減価償却が適用されない場合は、理由を付けてスキップしてください。"
 
 msgid "Depreciation Start Date"
 msgstr "減価償却開始日"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "このアイテムの有効期間を、その成分の最短有効期間から導き出します。上記のDaysフィールドは無視します。"
+msgstr "この品目の保存期間を、その構成要素の最短保存期間から導出し、上記の日数フィールドを無視します。"
 
 msgid "Description"
 msgstr "説明"
@@ -5156,10 +5156,10 @@ msgid "Digital Quote"
 msgstr "デジタル見積"
 
 msgid "Digital quote accepted by"
-msgstr "デジタル見積もりが受け入れられました"
+msgstr "デジタル見積の承諾者"
 
 msgid "Digital quote accepted by email"
-msgstr "デジタル見積もりがメールで受け入れられました"
+msgstr "メールによるデジタル見積の承諾"
 
 msgid "Digital quote rejected by"
 msgstr "デジタル見積もりが却下されました"
@@ -5174,19 +5174,19 @@ msgid "dimension"
 msgstr "ディメンション"
 
 msgid "Dimension"
-msgstr "寸法"
+msgstr "ディメンション"
 
 msgid "Dimension slots"
 msgstr "ディメンションスロット"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "まだプロバイダーマッピングがない投稿済みジャーナルのディメンション値。"
+msgstr "プロバイダマッピングがまだない転記済の仕訳上のディメンション値。"
 
 msgid "dimensions"
 msgstr "ディメンション"
 
 msgid "Dimensions"
-msgstr "寸法"
+msgstr "ディメンション"
 
 msgid "Direct"
 msgstr "直接"
@@ -5216,29 +5216,29 @@ msgid "Discontinuation Date"
 msgstr "廃止日"
 
 msgid "Discount"
-msgstr "割引"
+msgstr "値引"
 
 msgid "Discount Days"
 msgstr "割引日数"
 
 msgid "Discount Days after {selectedCalculationMethod}"
-msgstr "{selectedCalculationMethod}後の割引日数"
+msgstr "{selectedCalculationMethod}後の値引日数"
 
 #. placeholder {0}: r.invoiceId
 msgid "Discount for {0}"
-msgstr "{0}の割引"
+msgstr "{0}の値引"
 
 msgid "Discount Percent"
-msgstr "割引率"
+msgstr "値引率"
 
 msgid "Discount Percentage"
-msgstr "割引率"
+msgstr "値引パーセント"
 
 msgid "Discounts earned for early payment to suppliers"
-msgstr "サプライヤーへの早期支払いで獲得した割引"
+msgstr "仕入先への早期支払に対して得られた割引"
 
 msgid "Discounts given to customers for early payment"
-msgstr "早期支払いのため顧客に与えられた割引"
+msgstr "早期支払に対して得意先に与えられた値引"
 
 msgid "Discovery"
 msgstr "発見"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "閉じる"
 
 msgid "Dispatch"
-msgstr "ディスパッチ"
+msgstr "保全指示"
 
 msgid "Dispatch ID"
-msgstr "ディスパッチID"
+msgstr "保全指示ID"
 
 msgid "Dispatch priority"
-msgstr "ディスパッチ優先度"
+msgstr "保全指示の優先度"
 
 msgid "Dispatches"
-msgstr "配送"
+msgstr "保全指示"
 
 msgid "Display Settings"
 msgstr "表示設定"
 
 msgid "Disposal"
-msgstr "処分"
+msgstr "除却"
 
 msgid "Disposal Date"
-msgstr "処分日"
+msgstr "除却日"
 
 msgid "Dispose"
 msgstr "処分する"
@@ -5280,10 +5280,10 @@ msgid "Disposition"
 msgstr "処置"
 
 msgid "Dispositions"
-msgstr "処分"
+msgstr "処置"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
-msgstr "このEmployee Typeのデフォルト権限でユーザーの現在の権限を上書きしますか?"
+msgstr "このユーザーの現在の権限をこの従業員タイプのデフォルト権限で上書きしますか？"
 
 msgid "Doc-Backed"
 msgstr "文書バック"
@@ -5295,25 +5295,25 @@ msgid "Docs & videos"
 msgstr "ドキュメント＆動画"
 
 msgid "Document"
-msgstr "ドキュメント"
+msgstr "文書"
 
 msgid "Document Control"
-msgstr "ドキュメント管理"
+msgstr "文書管理"
 
 msgid "Document Templates"
-msgstr "ドキュメントテンプレート"
+msgstr "文書テンプレート"
 
 msgid "Document Type"
-msgstr "ドキュメントタイプ"
+msgstr "文書タイプ"
 
 msgid "Document:"
-msgstr "ドキュメント:"
+msgstr "文書："
 
 msgid "Documents"
 msgstr "ドキュメント"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "ドキュメントは、請求書、帳票、支払いをネイティブプロバイダードキュメントとしてプッシュします。それらの仕訳はドキュメントでカバーされているものとして記録されます。また、プロバイダーで記録された支払いをCarbonに引き戻し、一致する請求書または帳票を閉じて、CarbonのGL仕訳を投稿します。Offはそれらを意図的に除外されたものとして記録します。"
+msgstr "ドキュメントはネイティブプロバイダ文書として請求書および支払をプッシュします。それらの仕訳は文書でカバーされたものとして記録されます。また、プロバイダで記録された支払をCarbonに取り込み、対応する請求書をクローズし、Carbon総勘定元帳仕訳を転記します。オフはそれらを意図的に除外したものとして記録します。"
 
 msgid "Documents you open will show up here for quick access."
 msgstr "開いたドキュメントはここに表示され、すぐにアクセスできます。"
@@ -5395,19 +5395,19 @@ msgid "Drawing replaced. Balloon placements were removed; feature rows are uncha
 msgstr "図面が置き換わりました。バルーン配置は削除されました。機能行は変更されていません。"
 
 msgid "Drop Shipment"
-msgstr "ドロップシップメント"
+msgstr "直送"
 
 msgid "Drop Shipment Statuses"
-msgstr "ドロップシップメントステータス"
+msgstr "直送ステータス"
 
 msgid "Drop whole pages or sections a customer doesn't need."
-msgstr "顧客が不要なページまたはセクション全体を削除します。"
+msgstr "得意先が必要としない全ページまたはセクションを削除します。"
 
 msgid "Drop your file here, or click to browse."
 msgstr "ファイルをここにドラッグするか、クリックして参照してください。"
 
 msgid "Drop-ship"
-msgstr "ドロップシップ"
+msgstr "直送"
 
 msgid "Due"
 msgstr "期限"
@@ -5429,13 +5429,13 @@ msgid "Due Date of First Job"
 msgstr "最初のジョブの期日"
 
 msgid "Due Date of Last Job"
-msgstr "最後のジョブの期限"
+msgstr "最後の製造指図の期日"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "バルク一括処理の最初のジョブの期日; 後のジョブはこの日付と最後のジョブの期日の間に均等に間隔を置いています。"
+msgstr "バルクバッチの最初の製造指図の期日。後続の製造指図は、この日付と最後の製造指図の期日の間に均等に配置されます。"
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "バルク一括処理の最後のジョブの期日; 最初のジョブの期日と組み合わせてジョブを均等に間隔を置きます。"
+msgstr "バルクバッチの最終製造指図の期日。最初の製造指図の期日と組み合わせて、製造指図を均等に配置します。"
 
 msgid "Due Days"
 msgstr "期日"
@@ -5522,7 +5522,7 @@ msgid "Each operation's unused material returns as soon as the operation is done
 msgstr "各操作の未使用材料は操作が完了するとすぐに戻されます。"
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
-msgstr "各物理ユニットは独自の追跡エンティティと一意の番号を取得します — 1つのエンティティ、1つのユニット。"
+msgstr "各物理的な個が独自の追跡対象と一意番号を取得します。1 追跡対象 = 1 個。"
 
 msgid "Each, lb, ft…"
 msgstr "各、ポンド、フィート…"
@@ -5534,7 +5534,7 @@ msgid "Easier to extend"
 msgstr "拡張が簡単"
 
 msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
-msgstr "経済オペレーターの登録と識別番号; EU/UKの税関境界線を超える商品に必要です。"
+msgstr "経済事業者登録識別番号; EU/UK の税関国境を越える商品に必要です。"
 
 msgid "Edit"
 msgstr "編集"
@@ -5585,13 +5585,13 @@ msgid "Edit column visibility"
 msgstr "列の表示/非表示を編集"
 
 msgid "Edit Contact"
-msgstr "連絡先を編集"
+msgstr "担当者を編集"
 
 msgid "Edit Contractor"
-msgstr "契約者を編集"
+msgstr "外部作業者を編集"
 
 msgid "Edit Cost Center"
-msgstr "コスト センターを編集"
+msgstr "原価センターを編集"
 
 msgid "Edit Count"
 msgstr "カウントを編集"
@@ -5603,13 +5603,13 @@ msgid "Edit Custom Field"
 msgstr "カスタムフィールドを編集"
 
 msgid "Edit Customer Part"
-msgstr "顧客部品を編集"
+msgstr "得意先部品を編集"
 
 msgid "Edit Customer Status"
-msgstr "顧客ステータスを編集"
+msgstr "得意先ステータスを編集"
 
 msgid "Edit Customer Type"
-msgstr "顧客タイプを編集"
+msgstr "得意先タイプを編集"
 
 msgid "Edit Department"
 msgstr "部門を編集"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "ディメンションを編集"
 
 msgid "Edit Dispatch"
-msgstr "ディスパッチを編集"
+msgstr "保全指示を編集"
 
 msgid "Edit Employee"
 msgstr "従業員を編集"
@@ -5630,7 +5630,7 @@ msgid "Edit expiration date"
 msgstr "有効期限を編集"
 
 msgid "Edit Expiry"
-msgstr "有効期限を編集"
+msgstr "使用期限を編集"
 
 msgid "Edit Failure Mode"
 msgstr "故障モードを編集"
@@ -5639,10 +5639,10 @@ msgid "Edit Fixed Asset"
 msgstr "固定資産を編集"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "ゲージキャリブレーション記録を編集"
+msgstr "測定器校正記録を編集"
 
 msgid "Edit Gauge Type"
-msgstr "ゲージタイプを編集"
+msgstr "測定器タイプを編集"
 
 msgid "Edit Group"
 msgstr "グループを編集"
@@ -5657,10 +5657,10 @@ msgid "Edit Item Group"
 msgstr "アイテムグループを編集"
 
 msgid "Edit Journal Entry"
-msgstr "仕訳帳エントリを編集"
+msgstr "仕訳行を編集"
 
 msgid "Edit Kanban"
-msgstr "カンバンを編集"
+msgstr "かんばんを編集"
 
 msgid "Edit Line"
 msgstr "行を編集"
@@ -5669,16 +5669,16 @@ msgid "Edit Location"
 msgstr "ロケーションを編集"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "メンテナンスディスパッチを編集"
+msgstr "保全指示を編集"
 
 msgid "Edit Material"
 msgstr "材料を編集"
 
 msgid "Edit Material Dimension"
-msgstr "材料寸法を編集"
+msgstr "材料ディメンションを編集"
 
 msgid "Edit Material Finish"
-msgstr "材料仕上げを編集"
+msgstr "表面処理を編集"
 
 msgid "Edit Material Grade"
 msgstr "材料グレードを編集"
@@ -5687,7 +5687,7 @@ msgid "Edit Material Shape"
 msgstr "材料形状を編集"
 
 msgid "Edit Material Substance"
-msgstr "材料物質を編集"
+msgstr "素材を編集"
 
 msgid "Edit Material Type"
 msgstr "材料タイプを編集"
@@ -5711,7 +5711,7 @@ msgid "Edit Payment"
 msgstr "支払いを編集"
 
 msgid "Edit Payment Term"
-msgstr "支払い条件を編集"
+msgstr "支払条件を編集"
 
 msgid "Edit permissions"
 msgstr "編集権限"
@@ -5726,10 +5726,10 @@ msgid "Edit Portal"
 msgstr "ポータルを編集"
 
 msgid "Edit Price Override"
-msgstr "価格オーバーライドを編集"
+msgstr "価格上書きを編集"
 
 msgid "Edit Pricing"
-msgstr "価格を編集"
+msgstr "価格設定を編集"
 
 msgid "Edit Pricing Rule"
 msgstr "価格設定ルールを編集"
@@ -5747,7 +5747,7 @@ msgid "Edit Production Quantity"
 msgstr "生産数量を編集"
 
 msgid "Edit purchase order line type"
-msgstr "購買注文行タイプを編集"
+msgstr "発注書明細タイプを編集"
 
 msgid "Edit Question"
 msgstr "質問を編集"
@@ -5771,10 +5771,10 @@ msgid "Edit Schedule"
 msgstr "スケジュールを編集"
 
 msgid "Edit Scheduled Maintenance"
-msgstr "スケジュール済みメンテナンスを編集"
+msgstr "定期保全を編集"
 
 msgid "Edit Sequence"
-msgstr "シーケンスを編集"
+msgstr "採番を編集"
 
 msgid "Edit Serial Number"
 msgstr "シリアル番号を編集"
@@ -5786,13 +5786,13 @@ msgid "Edit Shift"
 msgstr "シフトを編集"
 
 msgid "Edit Shipment"
-msgstr "配送を編集"
+msgstr "出荷を編集"
 
 msgid "Edit Shipping"
 msgstr "配送を編集"
 
 msgid "Edit Shipping Method"
-msgstr "配送方法を編集"
+msgstr "出荷方法を編集"
 
 msgid "Edit Size"
 msgstr "サイズを編集"
@@ -5807,25 +5807,25 @@ msgid "Edit Storage Type"
 msgstr "ストレージタイプを編集"
 
 msgid "Edit Storage Unit"
-msgstr "ストレージユニットを編集"
+msgstr "保管ユニットを編集"
 
 msgid "Edit Substance"
 msgstr "物質を編集"
 
 msgid "Edit Supplier"
-msgstr "サプライヤーを編集"
+msgstr "仕入先を編集"
 
 msgid "Edit Supplier Part"
-msgstr "サプライヤー部品を編集"
+msgstr "仕入先部品を編集"
 
 msgid "Edit supplier process"
-msgstr "サプライヤープロセスを編集"
+msgstr "仕入先工法を編集"
 
 msgid "Edit Supplier Type"
-msgstr "サプライヤータイプを編集"
+msgstr "仕入先タイプを編集"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "ルールを編集して「すべてに適用」フラグを削除する"
+msgstr "ルールを編集して、\"すべてに適用\" フラグを削除します"
 
 msgid "Edit Timecard"
 msgstr "タイムカードを編集"
@@ -5834,13 +5834,13 @@ msgid "Edit Tool"
 msgstr "ツールを編集"
 
 msgid "Edit Training"
-msgstr "トレーニングを編集"
+msgstr "教育訓練を編集"
 
 msgid "Edit Transfer"
 msgstr "転送を編集"
 
 msgid "Edit Transfer Line"
-msgstr "転送ラインを編集"
+msgstr "転送明細を編集"
 
 msgid "Edit Type"
 msgstr "タイプを編集"
@@ -5855,7 +5855,7 @@ msgid "Edit Webhook"
 msgstr "Webhookを編集"
 
 msgid "Edit Work Center"
-msgstr "ワークセンターを編集"
+msgstr "作業区を編集"
 
 msgid "Eliminated"
 msgstr "削除済み"
@@ -5918,13 +5918,13 @@ msgid "Empty list"
 msgstr "空のリスト"
 
 msgid "Empty work centers"
-msgstr "空の作業センター"
+msgstr "作業区がありません"
 
 msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "設定で監査ログを有効にして、データへの変更の追跡を開始します。"
 
 msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
-msgstr "貴社のデジタル見積もりを有効にします。これにより、顧客にデジタル見積もりを送信でき、顧客がオンラインで承認することができます。"
+msgstr "貴社においてデジタル見積を有効にします。これにより、デジタル見積を得意先に送信でき、得意先がオンラインで承諾することができます。"
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
 msgstr "完全な発生主義会計を有効にし、仕訳帳エントリ、財務報告書、および総勘定元帳への転記を行います。"
@@ -5933,10 +5933,10 @@ msgid "Enable in Settings"
 msgstr "設定で有効にする"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "RFQが見積もり準備完了としてマークされたときに通知を有効にします。"
+msgstr "見積依頼が見積準備完了の状態になったときに通知を有効にします。"
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
-msgstr "MESターミナル用の共有ワークステーションモードを有効にします。オペレーターは作業を実行する前にPINで自分自身を識別します。"
+msgstr "MES端末の共有ワークステーションモードを有効にします。作業者は作業前にPINで自分を識別します。"
 
 msgid "Enable this rule to automatically require approval for matching documents"
 msgstr "このルールを有効にして、一致するドキュメントの承認を自動的に要求します"
@@ -5963,7 +5963,7 @@ msgid "Enable to start tracking work shifts."
 msgstr "作業シフトの追跡を開始するには有効にしてください。"
 
 msgid "Enable to use metric units for material dimensions."
-msgstr "材料の寸法にメートル法を使用するには有効にしてください。"
+msgstr "材料寸法にメートル法単位を使用できるようにします。"
 
 msgid "Enabled"
 msgstr "有効"
@@ -6003,10 +6003,10 @@ msgid "Engineering"
 msgstr "エンジニアリング"
 
 msgid "Engineering changes and CAD"
-msgstr "エンジニアリング変更とCAD"
+msgstr "設計変更とCAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "エンジニアリング変更とCAD"
+msgstr "設計変更とCAD"
 
 msgid "Engineering Contact"
 msgstr "エンジニアリング担当者"
@@ -6022,7 +6022,7 @@ msgid "Enter a quantity between 1 and {0}."
 msgstr "1～{0}の数量を入力してください。"
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "ベンダー請求書をPOに対して入力および承認する（3者間照合）"
+msgstr "発注書に対する仕入先請求書を入力して承認します（三点照合）"
 
 msgid "Enter number…"
 msgstr "数字を入力..."
@@ -6061,13 +6061,13 @@ msgid "Entity"
 msgstr "エンティティ"
 
 msgid "Entity certification: Accepted"
-msgstr "事業体認定: 承認済み"
+msgstr "エンティティ認証：承諾済"
 
 msgid "Entity certification: Expired"
 msgstr "事業体認定: 期限切れ"
 
 msgid "Entity certification: Pending"
-msgstr "事業体認定: 保留中"
+msgstr "エンティティ認証：待機中"
 
 msgid "Entity Type"
 msgstr "エンティティタイプ"
@@ -6085,13 +6085,13 @@ msgid "EORI"
 msgstr "EORI"
 
 msgid "Equity"
-msgstr "資本"
+msgstr "純資産"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "蓄積利益または損失の資本勘定"
+msgstr "利益損失の累積のための純資産勘定科目"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "為替換算調整 (CTA) の資本勘定"
+msgstr "通貨換算調整（CTA）のための純資産勘定科目"
 
 msgid "Error"
 msgstr "エラー"
@@ -6103,13 +6103,13 @@ msgid "Error downloading file"
 msgstr "ファイルのダウンロードエラー"
 
 msgid "Error fetching customer data"
-msgstr "顧客データの取得エラー"
+msgstr "得意先データの取得エラー"
 
 msgid "Error fetching supplier data"
 msgstr "仕入先データの取得エラー"
 
 msgid "Error loading assigned dispatches"
-msgstr "割り当てられたディスパッチの読み込みエラー"
+msgstr "割り当てられた保全指示の読み込みエラー"
 
 msgid "Error loading assigned documents"
 msgstr "割り当てられたドキュメントの読み込みエラー"
@@ -6121,7 +6121,7 @@ msgid "Error loading job tree."
 msgstr "ジョブツリーの読み込みエラー。"
 
 msgid "Error loading make method"
-msgstr "メイク方法の読み込みエラー"
+msgstr "製造方法の読み込みエラー"
 
 msgid "Error moving file"
 msgstr "ファイルの移動エラー"
@@ -6139,16 +6139,16 @@ msgid "Error removing model from job"
 msgstr "ジョブからモデルを削除するエラー"
 
 msgid "Error removing model from quote line"
-msgstr "見積行からモデルを削除するエラー"
+msgstr "見積明細からモデルを除去するエラー"
 
 msgid "Error removing model from RFQ line"
 msgstr "RFQ行からモデルを削除するエラー"
 
 msgid "Error removing model from sales invoice line"
-msgstr "販売請求書行からモデルを削除するエラー"
+msgstr "売上請求書明細からモデルを除去するエラー"
 
 msgid "Error removing model from sales order line"
-msgstr "販売注文行からモデルを削除するエラー"
+msgstr "受注明細からモデルを除去するエラー"
 
 msgid "Escalate to the project leads"
 msgstr "プロジェクトリーダーにエスカレートする"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "すべてのマッチ"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "期間を閉じる前に、すべての必須タスクが完了またはスキップされている必要があります。"
+msgstr "すべての必須タスクは期間がクローズされる前に完了またはスキップ済である必要があります。"
 
 msgid "Every row was imported successfully."
 msgstr "すべての行が正常にインポートされました。"
@@ -6211,10 +6211,10 @@ msgid "Everything else"
 msgstr "その他すべて"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "その他すべてには、人、インポート、統合、およびAPI（ワークフローの1つではないもの）が含まれます。"
+msgstr "その他はすべて、人員、インポート、連携、およびAPI（ワークフロー以外のすべて）をカバーしています。"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MB を超えています — 送信するには添付ファイルを削除してください。"
+msgstr "{PO_EMAIL_ATTACHMENT_LIMIT_MB} MBを超えています。送信するために一部の添付ファイルを除去してください。"
 
 msgid "Exchange rate"
 msgstr "為替レート"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "既存のマッピング。異なるプロバイダーオプションを選択して再マップしてください。"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "既存のStripe顧客"
 
 msgid "Expand"
 msgstr "展開"
@@ -6263,13 +6263,13 @@ msgid "Expand all"
 msgstr "すべて展開"
 
 msgid "Expand Costs"
-msgstr "コストを展開"
+msgstr "原価を展開"
 
 msgid "Expand features table"
 msgstr "機能テーブルを展開"
 
 msgid "Expand Labor"
-msgstr "労働を展開"
+msgstr "労務を展開"
 
 msgid "Expand Machine"
 msgstr "機械を展開"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "サブツリーを展開"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "販売注文が存在する前に週単位で入力される部品製造の予想将来需要。計画はそれを供給に対してネットし、メソッドを爆発させてコンポーネントを事前に注文します。"
+msgstr "販売受注が存在する前に週単位で入力される内製品目の所要量見通し。計画はこれを供給に対して相殺し、先行して部品を発注するために製法を展開します。"
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "アイテムの予想される将来の需要、期間ごとに分類され、実際の需要とともに計画実行によって入力されます。"
+msgstr "品目の所要量見通し。期間別に集計され、計画実行時に実績所要量とともに入力されます。"
 
 msgid "Expected Receipt"
 msgstr "予想受取日"
@@ -6293,31 +6293,31 @@ msgid "Expected Receipt Date"
 msgstr "予想受取日"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "AR決済時に回収不可能として償却された顧客残高の費用勘定"
+msgstr "売掛金決済において回収不可能として償却された得意先残高の費用勘定"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "減価償却に関する繰延税金調整の費用勘定"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "機器と施設保守の費用勘定"
+msgstr "設備および施設保全の費用勘定"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
 msgstr "支払いが外貨建て請求書をより不利なレートで決済する場合のFX損失に対する費用勘定"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "在庫以外の購入 (サービス、供給品) の費用勘定"
+msgstr "非在庫購買（外注サービス、消耗品）の費用勘定"
 
 msgid "Expense account for the cost of items sold"
-msgstr "在庫が売上に対して出荷/発行されるときにデビットされた費用GLアカウント。"
+msgstr "販売品目の原価の費用勘定"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "繰延税金負債の動きの費用側（繰延税金負債と対になっている）。"
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "固定資産クラスの作成に失敗しました: {0}"
+msgstr "繰延税金変動の費用側（繰延税金負債とペア）。"
 
 msgid "Expenses"
-msgstr "経費"
+msgstr "費用"
 
 msgid "Expert guidance"
 msgstr "専門家によるガイダンス"
@@ -6362,16 +6362,16 @@ msgid "Expiring first"
 msgstr "最初に期限切れ"
 
 msgid "Expiry"
-msgstr "有効期限"
+msgstr "使用期限"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "選択したプロセスが完了したときに有効期限が開始されます。"
+msgstr "選択した工法が完了すると使用期限が開始します。"
 
 msgid "Expiry begins when the selected process starts."
-msgstr "有効期限は、選択されたプロセスが開始されたときに始まります。"
+msgstr "選択した工法が開始すると使用期限が開始します。"
 
 msgid "Expiry trace"
-msgstr "有効期限トレース"
+msgstr "使用期限トレース"
 
 msgid "Export"
 msgstr "エクスポート"
@@ -6386,31 +6386,31 @@ msgid "Extended Price"
 msgstr "拡張価格"
 
 msgid "External"
-msgstr "外部"
+msgstr "社外"
 
 msgid "External Delta"
-msgstr "外部デルタ"
+msgstr "社外差分"
 
 msgid "External document"
-msgstr "外部ドキュメント"
+msgstr "社外文書"
 
 msgid "External ID"
-msgstr "外部ID"
+msgstr "社外ID"
 
 msgid "External link"
-msgstr "外部リンク"
+msgstr "社外リンク"
 
 msgid "External notes"
-msgstr "外部メモ"
+msgstr "社外メモ"
 
 msgid "External Notes"
-msgstr "外部メモ"
+msgstr "社外メモ"
 
 msgid "External Ref."
-msgstr "外部参照"
+msgstr "社外参照"
 
 msgid "External Reference"
-msgstr "外部参照"
+msgstr "社外参照"
 
 msgid "Extra fields to capture data Carbon doesn't track by default"
 msgstr "Carbonがデフォルトで追跡しないデータをキャプチャするための追加フィールド"
@@ -6419,7 +6419,7 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "認可キーなど、リクエストと共に送信される追加情報。ヘッダー値は実行履歴では非表示ですが、名前は読み取り可能です。"
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "GL レポートをスライスするための追加タグ"
+msgstr "総勘定元帳報告をスライスするための追加タグ"
 
 msgid "Fail"
 msgstr "不合格"
@@ -6432,7 +6432,7 @@ msgstr "失敗した機能"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO（最先期限切れ先出法）"
+msgstr "資産クラスの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6440,7 +6440,7 @@ msgstr "消耗品の作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create cost center: {0}"
-msgstr "コスト センターの作成に失敗しました: {0}"
+msgstr "原価センターの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer portal: {0}"
@@ -6448,15 +6448,15 @@ msgstr "顧客ポータルの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer status: {0}"
-msgstr "顧客ステータスの作成に失敗しました: {0}"
+msgstr "得意先ステータスの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer type: {0}"
-msgstr "顧客タイプの作成に失敗しました: {0}"
+msgstr "得意先タイプの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer: {0}"
-msgstr "顧客の作成に失敗しました: {0}"
+msgstr "得意先の作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create department: {0}"
@@ -6468,7 +6468,7 @@ msgstr "失敗モードの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "ゲージタイプの作成に失敗しました: {0}"
+msgstr "測定器タイプの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6480,7 +6480,7 @@ msgstr "ロケーションの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "メンテナンススケジュールの作成に失敗しました: {0}"
+msgstr "保全スケジュールの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
@@ -6488,7 +6488,7 @@ msgstr "マテリアルディメンションの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "マテリアルフィニッシュの作成に失敗しました: {0}"
+msgstr "表面処理の作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
@@ -6500,7 +6500,7 @@ msgstr "材料グレードの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "材料物質の作成に失敗しました: {0}"
+msgstr "素材の作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6512,7 +6512,7 @@ msgstr "材料の作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "見積なし理由の作成に失敗しました: {0}"
+msgstr "見積辞退理由を作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "パーツの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "支払い条件の作成に失敗しました: {0}"
+msgstr "支払条件を作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6532,11 +6532,11 @@ msgstr "サービスの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create shipping method: {0}"
-msgstr "配送方法の作成に失敗しました: {0}"
+msgstr "出荷方法を作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "在庫移動行の作成に失敗しました: {0}"
+msgstr "転送明細を作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6544,7 +6544,7 @@ msgstr "ストレージタイプの作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create supplier: {0}"
-msgstr "サプライヤーの作成に失敗しました: {0}"
+msgstr "仕入先を作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create tool: {0}"
@@ -6552,11 +6552,11 @@ msgstr "ツール作成に失敗しました: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create webhook: {0}"
-msgstr "ウェブフックの作成に失敗しました: {0}"
+msgstr "Webhookを作成できませんでした: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
-msgstr "ワークセンターの作成に失敗しました: {0}"
+msgstr "作業区を作成できませんでした: {0}"
 
 msgid "Failed to delete file from old location"
 msgstr "古い場所からファイルを削除できませんでした"
@@ -6565,7 +6565,7 @@ msgid "Failed to download file for moving"
 msgstr "ファイルの移動用ダウンロードに失敗しました"
 
 msgid "Failed to fetch item costs"
-msgstr "アイテムコストの取得に失敗しました"
+msgstr "品目の原価を取得できませんでした"
 
 msgid "Failed to fetch place details"
 msgstr "場所の詳細の取得に失敗しました"
@@ -6583,22 +6583,22 @@ msgid "Failed to initialize Carbon client"
 msgstr "Carbonクライアントの初期化に失敗しました"
 
 msgid "Failed to insert quote line"
-msgstr "見積行の挿入に失敗しました"
+msgstr "見積明細を挿入できませんでした"
 
 msgid "Failed to insert supplier quote line"
-msgstr "サプライヤー見積行の挿入に失敗しました"
+msgstr "仕入先見積明細を挿入できませんでした"
 
 msgid "Failed to load configuration parameters"
 msgstr "設定パラメータの読み込みに失敗しました"
 
 msgid "Failed to load customer part details"
-msgstr "顧客部品の詳細の読み込みに失敗しました"
+msgstr "得意先の部品詳細を読み込めませんでした"
 
 msgid "Failed to load data"
 msgstr "データの読み込みに失敗しました"
 
 msgid "Failed to load inbound inspections"
-msgstr "受信検査の読み込みに失敗しました"
+msgstr "受入検査を読み込めませんでした"
 
 msgid "Failed to load item data"
 msgstr "アイテムデータの読み込みに失敗しました"
@@ -6607,16 +6607,16 @@ msgid "Failed to load item details"
 msgstr "アイテムの詳細の読み込みに失敗しました"
 
 msgid "Failed to load job operations"
-msgstr "ジョブ操作の読み込みに失敗しました"
+msgstr "指図工程を読み込めませんでした"
 
 msgid "Failed to load jobs"
-msgstr "ジョブの読み込みに失敗しました"
+msgstr "製造指図を読み込めませんでした"
 
 msgid "Failed to load purchase order lines"
-msgstr "購買注文行の読み込みに失敗しました"
+msgstr "発注書明細を読み込めませんでした"
 
 msgid "Failed to load purchase orders"
-msgstr "購買注文の読み込みに失敗しました"
+msgstr "発注書を読み込めませんでした"
 
 msgid "Failed to load receipt lines"
 msgstr "領収書行の読み込みに失敗しました"
@@ -6625,19 +6625,19 @@ msgid "Failed to load receipts"
 msgstr "領収書の読み込みに失敗しました"
 
 msgid "Failed to load sales order lines"
-msgstr "販売注文行の読み込みに失敗しました"
+msgstr "受注明細を読み込めませんでした"
 
 msgid "Failed to load sales orders"
-msgstr "販売注文の読み込みに失敗しました"
+msgstr "受注を読み込めませんでした"
 
 msgid "Failed to load shipment lines"
-msgstr "配送ラインの読み込みに失敗しました"
+msgstr "出荷明細を読み込めませんでした"
 
 msgid "Failed to load shipments"
 msgstr "出荷の読み込みに失敗しました"
 
 msgid "Failed to load supplier part details"
-msgstr "サプライヤー部品の詳細の読み込みに失敗しました"
+msgstr "仕入先の部品詳細を読み込めませんでした"
 
 msgid "Failed to load tracked entities"
 msgstr "追跡対象エンティティの読み込みに失敗しました"
@@ -6659,7 +6659,7 @@ msgid "Failed to remove model thumbnail"
 msgstr "モデルサムネイルの削除に失敗しました"
 
 msgid "Failed to remove purchase order"
-msgstr "購買注文の削除に失敗しました"
+msgstr "発注書の削除に失敗しました"
 
 msgid "Failed to remove thumbnail"
 msgstr "サムネイルの削除に失敗しました"
@@ -6707,13 +6707,13 @@ msgid "Failed to update count"
 msgstr "カウントの更新に失敗しました"
 
 msgid "Failed to update item cost"
-msgstr "アイテムコストの更新に失敗しました"
+msgstr "品目の原価を更新できませんでした"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "購買注文で営業機会を更新できませんでした"
+msgstr "商談を発注書で更新できませんでした"
 
 msgid "Failed to update quote line"
-msgstr "見積行の更新に失敗しました"
+msgstr "見積明細を更新できませんでした"
 
 msgid "Failed to update supplier quote line"
 msgstr "仕入先見積行の更新に失敗しました"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "手数料"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "フィニッシュ"
+msgstr "FEFO (先期限先出)"
 
 msgid "Fetch"
 msgstr "取得"
@@ -6835,22 +6835,22 @@ msgid "Files"
 msgstr "ファイル"
 
 msgid "Files attached here ride along on every purchase order email by default. Suppliers will receive them alongside the PO PDF."
-msgstr "ここに添付されたファイルは、デフォルトではすべての発注メールに自動的に含まれます。サプライヤーはPO PDFと一緒にそれらを受け取ります。"
+msgstr "ここに添付されたファイルは、デフォルトではすべての発注書メールに付属します。仕入先はPO PDFとともにこれらを受け取ります。"
 
 msgid "Files attached here ride along on every purchase order email sent to this supplier (in addition to company-wide defaults)."
-msgstr "ここに添付されたファイルは、このサプライヤーに送信されるすべての発注メールに含まれます（会社全体のデフォルトに加えて）。"
+msgstr "ここに添付されたファイルは、この仕入先に送信されるすべての発注書メールに付属します(会社全体のデフォルトに加えて)。"
 
 msgid "Fill this company with a realistic industry story so every screen has something in it. You can put back what was here before."
-msgstr "現実的なインダストリストーリーでこのコンパニーを埋めて、すべての画面に何か表示されるようにしてください。以前の状態に戻すことができます。"
+msgstr "この会社に現実的な業界ストーリーを入れて、すべての画面に何かが表示されるようにします。以前ここにあったものを戻すことができます。"
 
 msgid "Filter"
-msgstr "フィルター"
+msgstr "絞り込み"
 
 msgid "Finalize"
 msgstr "確定"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "開始 → ロック → クローズ ライフサイクルを通じて会計月をファイナライズします。クローズされた期間は凍結され、残高がスナップショットされ、明示的な再開でのみ取り消せます。"
+msgstr "会計月をオープン → ロック中 → クローズ済のライフサイクルを通じて確定します。クローズ済期間は固定され、残高はスナップショットされ、明示的な再オープンでのみ取り消し可能です。"
 
 msgid "Financial Statements"
 msgstr "財務諸表"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "ピッキングされていない材料のまま完了しますか？"
 
 msgid "Finished goods"
-msgstr "フィニッシュ"
+msgstr "完成品"
 
 msgid "Finished Goods"
 msgstr "完成品"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "固定"
 
 msgid "Fixed asset"
-msgstr "バッチサイズが標準と異なる場合の固定費用償却差異"
+msgstr "固定資産"
 
 msgid "Fixed Asset"
 msgstr "固定資産"
@@ -6937,7 +6937,7 @@ msgid "Fixed Assets"
 msgstr "固定資産"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "利益と損失"
+msgstr "バッチサイズが標準と異なる場合の固定原価配賦差異"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "会計期間に転記またはクローズされた後は固定されます。変更するにはすべてのオープン期間を削除してください。"
@@ -6946,13 +6946,13 @@ msgid "Fixed Reorder"
 msgstr "固定再注文"
 
 msgid "Fixed Shelf Life"
-msgstr "固定棚卸し期間"
+msgstr "固定保存期間"
 
 msgid "Fixture"
-msgstr "フィクスチャ"
+msgstr "治具"
 
 msgid "Fixture ID"
-msgstr "フィクスチャID"
+msgstr "治具ID"
 
 msgid "Flags"
 msgstr "フラグ"
@@ -6962,16 +6962,16 @@ msgstr "何でも構いません。彼らが適切な人を連れてきます。
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "予測方法: <0>{0}</0>。この行はアクティブなジョブから派生していないため、親ソースは利用できません。"
+msgstr "予測方法: <0>{0}</0>。この行は処理中の製造指図から導出されたものではないため、親ソースが利用できません。"
 
 msgid "Forgot to Clock Out?"
-msgstr "時刻記録を忘れましたか？"
+msgstr "作業終了を忘れましたか？"
 
 msgid "Format"
 msgstr "フォーマット"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "現地配置エンジニア"
 
 msgid "Foundation"
 msgstr "基礎"
@@ -6983,10 +6983,10 @@ msgid "Freeze the old system, no new transactions"
 msgstr "古いシステムをフリーズし、新しいトランザクションを禁止"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "このラインについてクライアントに請求される運送料、ラインの単価とは別。"
+msgstr "このラインの単価とは別に顧客に請求される送料。"
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
-msgstr "このサプライヤーがこのラインについて請求する運送料。ユニット価格に含める代わりに、運送料を個別に請求する場合。"
+msgstr "この仕入先がこの明細について請求した送料。単価に含めずに送料を明細化した場合。"
 
 msgid "Frequencies"
 msgstr "頻度"
@@ -7009,7 +7009,7 @@ msgid "From <0/>"
 msgstr "から <0/>"
 
 msgid "From customer"
-msgstr "顧客から"
+msgstr "得意先から"
 
 msgid "From Location"
 msgstr "出発地"
@@ -7018,16 +7018,16 @@ msgid "from on-account credit"
 msgstr "オンアカウントクレジットから"
 
 msgid "From Storage Unit"
-msgstr "保管場所から"
+msgstr "保管ユニットから"
 
 msgid "Fulfillment Location"
-msgstr "履行場所"
+msgstr "出荷拠点"
 
 msgid "Full name"
 msgstr "氏名"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "完全なセットアップとマイグレーション"
 
 msgid "Fully Depreciated"
 msgstr "完全償却済み"
@@ -7039,52 +7039,52 @@ msgid "FX G/L"
 msgstr "FX G/L"
 
 msgid "Gain on Disposal"
-msgstr "処分益"
+msgstr "除却益"
 
 msgid "Gain on Disposal (default)"
-msgstr "処分益（既定）"
+msgstr "除却益（デフォルト）"
 
 msgid "Gain on Disposal Account"
-msgstr "処分益勘定科目"
+msgstr "除却益勘定科目"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "固定資産の処分により認識された利益"
+msgstr "固定資産の除却により認識された利益"
 
 msgid "gauge"
-msgstr "ゲージ"
+msgstr "測定器"
 
 msgid "Gauge"
-msgstr "ゲージ"
+msgstr "測定器"
 
 msgid "Gauge Calibration Notifications"
-msgstr "ゲージキャリブレーション通知"
+msgstr "測定器の校正通知"
 
 msgid "Gauge ID"
-msgstr "ゲージID"
+msgstr "測定器 ID"
 
 msgid "Gauge not found"
-msgstr "ゲージが見つかりません"
+msgstr "測定器が見つかりません"
 
 msgid "Gauge Type"
-msgstr "ゲージタイプ"
+msgstr "測定器タイプ"
 
 msgid "Gauge Types"
-msgstr "ゲージタイプ"
+msgstr "測定器タイプ"
 
 msgid "gauges"
-msgstr "系統図"
+msgstr "測定器"
 
 msgid "Gauges"
-msgstr "ゲージ"
+msgstr "測定器"
 
 msgid "Genealogy"
-msgstr "総勘定元帳"
+msgstr "系譜"
 
 msgid "General"
 msgstr "一般"
 
 msgid "General ledger"
-msgstr "外部処理操作のコスト差異をキャプチャするGLアカウント。"
+msgstr "総勘定元帳"
 
 msgid "General Ledger"
 msgstr "総勘定元帳"
@@ -7096,10 +7096,10 @@ msgid "Generate"
 msgstr "生成"
 
 msgid "Generate a new 4-digit PIN. Share it with the operator so they can pin in at MES terminals."
-msgstr "新しい4桁のPINを生成します。オペレーターと共有して、MES端末にピンインできるようにしてください。"
+msgstr "新しい4桁のPINを生成します。作業者に共有して、MES端末にサインインできるようにします。"
 
 msgid "Generate and send customer invoices"
-msgstr "顧客請求書を生成して送信"
+msgstr "得意先請求書を生成して送信する"
 
 msgid "Generate fiscal year"
 msgstr "会計年度を生成"
@@ -7126,10 +7126,10 @@ msgid "Generating suggestions…"
 msgstr "提案を生成中…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "Carbonで本番稼働：見積、購買、生産現場、在庫、財務を実行する1つのシステムで、現在のツールを置き換えます。"
+msgstr "Carbonで稼働開始：見積、購買、製造現場、在庫、財務を実行する1つのシステムで、現在のツールに置き換わります。"
 
 msgid "Get Method"
-msgstr "メソッドを取得"
+msgstr "製法を取得"
 
 msgid "Get started"
 msgstr "始めましょう"
@@ -7144,16 +7144,16 @@ msgid "Getting set up"
 msgstr "セットアップ中"
 
 msgid "Give it an owner and a date"
-msgstr "所有者と期日を割り当てる"
+msgstr "責任者と日付を指定してください"
 
 msgid "GL"
-msgstr "GL"
+msgstr "総勘定元帳"
 
 msgid "GL Account"
 msgstr "GLアカウント"
 
 msgid "GL account capturing cost differences on outside-processing operations."
-msgstr "外注加工作業のコスト差異を捕捉するGLアカウント。"
+msgstr "外部処理工程の原価差異を記録する勘定科目"
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
 msgstr "適用された製造間接費と実際の製造間接費の差異をキャプチャするGLアカウント。"
@@ -7162,46 +7162,46 @@ msgid "GL account capturing differences between BOM-expected and actual material
 msgstr "BOM予想と実際に消費された材料の差異をキャプチャするGLアカウント。"
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "ルーティング予想と実際の労働/機械時間の差異をキャプチャするGLアカウント。"
+msgstr "ルーティング予想と実績の労務・機械時間の差異を記録する勘定科目"
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "実際のロットサイズが計画と異なる場合の固定費用差異をキャプチャするGLアカウント。"
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "資産の処分時に元の費用を削除するために貸方記入されるGLアカウント。"
+msgstr "資産が除却されるときに資産の原価を除去するために貸方記入される勘定科目"
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "仕入先請求書が転記されたときに貸方記入されるGLアカウント（AP残高）。"
+msgstr "仕入先請求書が転記されるときに貸方記入される勘定科目（買掛金残高）"
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "労働またはマシンコストが生産ジョブに吸収されるときに貸方記入されるGLアカウント。"
+msgstr "労務費または機械費が生産製造指図に吸収されるときにクレジットされる勘定科目。"
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "製造間接費が生産ジョブに吸収される場合にクレジットされるGLアカウント。"
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "資産の処分時に累積減価償却費をクリアするためにデビットされるGLアカウント。"
+msgstr "資産が除却されるときに減価償却累計額を消去するために借方記入される勘定科目"
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
-msgstr "顧客請求書が転記されるときにデビットされるGLアカウント。顧客が支払うときにクリアされます。"
+msgstr "得意先請求書が転記されるときに借方記入される勘定科目。顧客が支払うときにクリアされます。"
 
 msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
-msgstr "固定資産を取得する際にデビットされるGLアカウント（購入または資本化費用）。"
+msgstr "固定資産が取得されるとき（購入または資本化原価）に借方記入される勘定科目"
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "銀行手数料および類似の費用のためのGLアカウント。"
+msgstr "銀行のサービス料および同様の手数料用の勘定科目"
 
 msgid "GL account for interest income or expense."
-msgstr "利息収入または利息支出のGLアカウント。"
+msgstr "利息収入または利息費用の勘定科目。"
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "仕入先に支払った購入税のGLアカウント（または回収可能）。"
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "買い手が自己評価するリバースチャージルールの下で発生する税金のGLアカウント。"
+msgstr "買い手が自己評価する逆charge規則に基づいて発生した税の勘定科目。"
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "税務タイミングの差異のGLアカウント（加速償却対帳簿価額償却など）。"
+msgstr "税務上の減価償却と帳簿上の減価償却の時間差に関する勘定科目"
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "実地棚卸数量がシステム在庫と異なる場合に影響を受けるGLアカウント。"
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "資産の当初取得原価を計上する総勘定元帳（GL）勘定科目 — 取得時に借方記入され、処分または売却時に総額（グロス）で貸方記入される。"
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "生産中のジョブの価値を保有し、完成品にポストされるまでのGLアカウント。"
+msgstr "生産中の製造指図の価値を保持し、完成品に転記されるまでの勘定科目"
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "製造品（メイク品目）の価値を保有する総勘定元帳勘定。ジョブ完了時に借方記入され、出荷時に貸方記入されます。"
@@ -7231,43 +7231,43 @@ msgid "GL account that holds the value of purchased stock and components (Buy it
 msgstr "購入在庫および部品（買入品目）の価値を保有する総勘定元帳勘定。受取時に借方記入され、払出/出荷時に貸方記入されます。"
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
-msgstr "クライアントが請求書を発行する前に支払う場合に使用されるGLアカウント; 請求書が転記されるとクリアされます。"
+msgstr "得意先が請求書発行前に支払った場合に使用され、請求書が転記されるときにクリアされる勘定科目"
 
 msgid "GL account where early-payment discounts given to customers are recorded."
-msgstr "顧客に与えられた早期支払割引が記録されるGLアカウント。"
+msgstr "得意先に与えた早期支払割引が記録される勘定科目。"
 
 msgid "GL account where early-payment discounts taken from suppliers are recorded."
-msgstr "サプライヤーから得られた早期支払割引が記録されるGLアカウント。"
+msgstr "仕入先から取得した早期支払割引が記録される勘定科目。"
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "各期に減価償却が計上されるたびに貸方記入され、資産の売却または除却時に全額借方記入される、減価償却累計額に相当するGLの資産控除（コントラアセット）勘定科目。"
+msgstr "毎期減価償却が転記されるときにクレジットされ、固定資産が売却または除却されるときに全額がデビットされる対資産勘定科目。"
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "固定資産に対して記録された減価償却を累積するGL反対資産勘定。"
+msgstr "固定資産に対して計上された減価償却を累積する対資産勘定科目。"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "GL株主資本勘定（CTA準備金）は、期末時点で外貨残高を再変換することから生じる未実現FX差異を保有しています。 P&Lの実現FX利得/損失とは別。"
+msgstr "期末に外貨建残高を再換算することから生じる未実現FX差異を保有するGL純資産勘定（CTA引当金）。P&Lの実現FX利益/損失とは別。"
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "会計年度末にネット収入が閉じられるGL株主資本勘定。"
+msgstr "年度末に純利益がクローズされるGL純資産勘定。"
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "減価償却が転記される各期間に借方記入されるGL支出勘定。"
+msgstr "毎期減価償却が転記されるときにデビットされるGL費用勘定。"
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "資産の帳簿価額が減損により減少した場合、すなわち回収可能価額が正味簿価（NBV）を下回った場合に借方記入されるGL費用勘定科目。"
+msgstr "固定資産の簿価が減損によって削減されるとき、つまり回収可能額が未償却残高を下回るときにデビットされるGL費用勘定。"
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "非インベントリ購入（用品、サービス）のためのGL支出勘定。"
+msgstr "非在庫品購入（物資、外注サービス）のGL費用勘定。"
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "顧客から徴収された売上税についてクレジットされるGL負債勘定。"
+msgstr "得意先から徴収した売上税がクレジットされるGL負債勘定。"
 
 msgid "GL tie-out"
-msgstr "GL照合"
+msgstr "GL試算表"
 
 msgid "GL Tie-Out"
-msgstr "GL照合"
+msgstr "GL試算表"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "初回から正しく本番運用を開始 — 当社チームがサポートします"
@@ -7277,7 +7277,7 @@ msgid "Go to {0}"
 msgstr "{0}に移動"
 
 msgid "Go to implementation hub"
-msgstr "実装ハブに移動"
+msgstr "実施ハブに移動"
 
 msgid "Go-Live"
 msgstr "ゴーライブ"
@@ -7313,7 +7313,7 @@ msgid "Google Places API key not configured"
 msgstr "Google Places APIキーが設定されていません"
 
 msgid "GR/IR (goods received, not invoiced)"
-msgstr "GR/IR（商品受領、未請求）"
+msgstr "GR/IR（入荷済、請求未到着）"
 
 msgid "GR/IR Clearing"
 msgstr "GR/IRクリアリング"
@@ -7355,7 +7355,7 @@ msgid "Guided"
 msgstr "ガイド付き"
 
 msgid "Guided implementation"
-msgstr "ガイド付き実装"
+msgstr "ガイド付き実施"
 
 msgid "Handle recurring and reversing journal entries"
 msgstr "繰り返しおよび逆仕訳の処理"
@@ -7400,16 +7400,16 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "データ移行マップにあるもの以前の履歴データ"
 
 msgid "Historical Rate (equity)"
-msgstr "歴史レート（エクイティ）"
+msgstr "取得時レート(純資産)"
 
 msgid "Historical Rate (Equity)"
-msgstr "歴史レート（エクイティ）"
+msgstr "取得時レート(純資産)"
 
 msgid "History"
 msgstr "履歴"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "修正する警告としてジャーナルを保持する"
+msgstr "修正が必要な警告として仕訳を保留"
 
 msgid "Holiday"
 msgstr "祝日"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "時間/個"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "アイテムがどのように全体的に補充されるか（購入、製造、または購入および製造）、アイテムごとに設定、行ごとの方法タイプとは異なります。"
+msgstr "品目全体がどのように補充されるか(購入、内製、または購入・内製)。品目ごとに設定され、行ごとの供給方式とは異なります"
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "アイテムがどのように補充されるか：手動再注文、需要ベースの再注文、固定再注文数量、または最大数量。"
@@ -7451,7 +7451,7 @@ msgid "How an item is sourced when added to a method or BOM line."
 msgstr "メソッドまたはBOMラインに追加されるときにアイテムがどのように調達されるか。"
 
 msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
-msgstr "アイテムの単価コストがどのように評価されるか：標準、平均、FIFO、またはLIFO。アイテムごとに設定。"
+msgstr "品目の単価をどのように評価するか: 標準、平均、先入先出、または後入先出。品目ごとに設定します。"
 
 msgid "How items roll up for posting and reporting"
 msgstr "アイテムが転記とレポートにどのようにロールアップされるか"
@@ -7460,7 +7460,7 @@ msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank
 msgstr "各フェーズの実行期間（週単位）。プランのタイムラインを決定します。空白のままにするとデフォルトを使用します。"
 
 msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
-msgstr "このスケジュールの1回の実行に通常要する時間; スケジューリングはスケジュールされた各インスタンスで、ワークセンターをこの数分間ブロックします。"
+msgstr "このスケジュールの1回の実行に通常かかる時間(分数)。スケジュール対象ごとに作業区をこの時間ブロックします"
 
 msgid "How many"
 msgstr "数量"
@@ -7469,13 +7469,13 @@ msgid "How many days a serial or batch of this item stays usable after its start
 msgstr "このアイテムの一連またはバッチがその開始イベント後、どのくらい使用可能なままか; 保有期限ポリシーは、この日付を過ぎた後の処理を決定します。"
 
 msgid "How many days after the calculation date the early-payment discount is still available."
-msgstr "計算日から何日後に早期支払割引が利用可能なままか。"
+msgstr "計算日の何日後まで早期支払割引が利用可能か。"
 
 msgid "How many days after the calculation date the full amount is due."
 msgstr "計算日から何日後に全額が期日となるか。"
 
 msgid "How many days from invoice date this customer is given to pay; drives the default due date on customer invoices."
-msgstr "この顧客が請求日から支払うために得られる日数; 顧客請求書のデフォルト期日を決定します。"
+msgstr "得意先が支払うまでの請求書日付からの日数。得意先請求書のデフォルト期日を設定します"
 
 msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
 msgstr "この仕入先が請求日から支払いを期待する日数; 請求書のデフォルト期日を決定します。"
@@ -7484,7 +7484,7 @@ msgid "How many fractional digits to keep when rounding amounts in this currency
 msgstr "この通貨で金額を丸める場合に保持する小数位の数。"
 
 msgid "How many of the successor replace one old part"
-msgstr "後継品が旧部品1個をいくつ置き換えるか"
+msgstr "1つの旧部品を何個の後継品目で置き換えるか"
 
 msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
 msgstr "ジョブの親アイテムの1つを構築するために必要なこの材料の量; ジョブ数量を乗じて消費をサイズ化します。"
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "このゲージを再度キャリブレーションする必要がある頻度; 最後のキャリブレーション日と組み合わせて、次のキャリブレーション日を自動的に再計算します。"
+msgstr "この測定器をどのくらい頻繁に再校正する必要があるか。最終校正日と組み合わせて次の校正日を自動的に再計算します"
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "このメンテナンスが繰り返される頻度—毎日、毎週、毎月、サイクルカウント時; 毎日は曜日セレクタを表示し、他の方は単純な間隔の数学を使用します。"
+msgstr "この保全がどのくらい頻繁に繰り返されるか — 毎日、毎週、毎月、循環棚卸時。毎日の場合は曜日セレクタが表示され、その他は単純な間隔計算を使用します"
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "期日がどれほど厳格であるか——ハード期限はスケジューリングをブロック、ソフト期限は計画を警告で押し出すことを許可、期限なしは完全に無視します。"
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "材料の調達方法（製造、購入、または在庫からの引き当て）と、引き当て元の保管単位。"
+msgstr "材料がどのように調達されるか(内製、購入、または在庫から引当)と、それが引き当てられる保管ユニット"
 
 msgid "How the resolved price was calculated."
 msgstr "解決された価格がどのように計算されたかを示します。"
@@ -7514,7 +7514,7 @@ msgid "How the sample size is decided — Inspect All, Inspect First N, Percenta
 msgstr "サンプルサイズがどのように決定されるか—すべてを検査、最初のNを検査、ロットのパーセンテージまたはAQL（Z1.4 / ISO 2859-1）。各モードは下記の独自のパラメータフィールドを表示します。"
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "このゲージの使用方法。標準 (定期的なチェック) またはマスター (他のゲージをキャリブレーション)。"
+msgstr "この測定器の使用方法 — なみ検査(通常のチェック)または標準器(他の測定器を校正)"
 
 msgid "How this price was calculated"
 msgstr "この価格がどのように計算されたか"
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "このチャートを読む方法"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "このディスパッチがどの程度急いでいるか—低/中/高/クリティカル; スケジュールスロットを決定するための優先度とOEE影響と組み合わされています。"
+msgstr "この保全指示がどのくらい緊急か — 低/中/高/重大。優先度とOEE影響と組み合わせてスケジュールスロットを決定します"
 
 msgid "How we know we're done"
 msgstr "完了の判断基準"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "ハイパーケア：最初の数週間の集中的なサポート"
 
 msgid "I (reduced)"
-msgstr "I（削減）"
+msgstr "I(ゆるい検査)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "この個人は22 CFR 120.62で定義されている米国人である合理的な根拠があります"
@@ -7595,13 +7595,13 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "次の通話を待つことができない場合、両側のリーダーが決定します。"
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "ブロッキングしている場合、または日付がリスクにある場合、所有者が割り当てられ、追跡されます。"
+msgstr "ブロック状態か期日がリスクの場合は、責任者が割り当てられ追跡されます"
 
 msgid "If items already exist"
 msgstr "アイテムが既に存在する場合"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "注文した場合、今後48週間の在庫切れは予測されていません"
+msgstr "発注済の場合、今後48週間での欠品は見込まれていません"
 
 msgid "If something is off track"
 msgstr "何か問題が生じた場合"
@@ -7613,7 +7613,7 @@ msgid "II (normal default)"
 msgstr "II（通常デフォルト）"
 
 msgid "III (tightened)"
-msgstr "III（厳しい）"
+msgstr "III(きつい検査)"
 
 msgid "Impact"
 msgstr "影響"
@@ -7622,13 +7622,13 @@ msgid "Imperial"
 msgstr "インペリアル"
 
 msgid "Implementation"
-msgstr "実装"
+msgstr "実施"
 
 msgid "Implementation Hub"
-msgstr "実装ハブ"
+msgstr "実施ハブ"
 
 msgid "Implementation Lead"
-msgstr "実装リード"
+msgstr "実施リード"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV をインポート"
@@ -7644,19 +7644,19 @@ msgid "in {0}"
 msgstr "{0}以内に"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "Onshape でこの OAuth アプリケーションの権限を編集し、「Application can write to your documents」を含めてから、もう一度接続してください。"
+msgstr "Onshapeで、このOAuthアプリケーションの権限を編集して「Application can write to your documents」を含めた後、もう一度接続してください。"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
-msgstr "このRFQを見積に変換するには、すべての行に内部部品番号が必要です。"
+msgstr "この見積依頼を見積に変換するには、すべての明細が社内部品番号を持つ必要があります。"
 
 msgid "In order to convert this RFQ to a quote, it must be associated with a customer."
-msgstr "このRFQを見積に変換するには、顧客に関連付ける必要があります。"
+msgstr "この見積依頼を見積に変換するには、得意先に関連付けられている必要があります。"
 
 msgid "In order to convert this RFQ to a quote, it must have a customer."
-msgstr "このRFQを見積に変換するには、顧客が必要です。"
+msgstr "この見積依頼を見積に変換するには、得意先を持つ必要があります。"
 
 msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
-msgstr "このRFQをサプライヤーに送信するには、まずRFQにサプライヤーを追加する必要があります。"
+msgstr "この見積依頼を仕入先に送信するには、まず見積依頼に仕入先を追加する必要があります。"
 
 msgid "In Process Only"
 msgstr "処理中のみ"
@@ -7695,10 +7695,10 @@ msgid "In-app notifications are always delivered. Choose which topics also reach
 msgstr "アプリ内通知は常に配信されます。どのトピックがメールでも届くかを選択してください。"
 
 msgid "Inactive"
-msgstr "非アクティブ"
+msgstr "無効"
 
 msgid "Inactive actions will not appear in selection lists"
-msgstr "非アクティブなアクションは選択リストに表示されません"
+msgstr "無効なアクションは選択リストに表示されません。"
 
 msgid "Inbound inspection"
 msgstr "受入検査"
@@ -7710,7 +7710,7 @@ msgid "Include extra parts in shipment"
 msgstr "出荷に追加部品を含める"
 
 msgid "Include Inactive"
-msgstr "非アクティブを含める"
+msgstr "無効を含める"
 
 msgid "Included"
 msgstr "含まれています"
@@ -7719,7 +7719,7 @@ msgid "Includes tax and shipping costs"
 msgstr "税金と送料を含みます"
 
 msgid "Income / Balance (inherited)"
-msgstr "収入/残高（継承）"
+msgstr "収益 / 残高 (継承)"
 
 msgid "Income Statement"
 msgstr "損益計算書"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "所得税"
 
 msgid "Income/Balance"
-msgstr "収入/残高"
+msgstr "収益/残高"
 
 msgid "incoming"
 msgstr "入庫"
@@ -7737,7 +7737,7 @@ msgid "Incoming"
 msgstr "入荷予定"
 
 msgid "Incoterm"
-msgstr "インコターム"
+msgstr "インコタームズ"
 
 msgid "Incoterm Location"
 msgstr "インコタームズの場所"
@@ -7758,7 +7758,7 @@ msgid "Inherit"
 msgstr "継承"
 
 msgid "Inherit document default"
-msgstr "ドキュメントのデフォルトを継承"
+msgstr "文書のデフォルトを継承"
 
 msgid "Inherit From Materials"
 msgstr "材料から継承"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "親から継承"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "グループから継承：トップレベルの分類（資産、負債、エクイティ、収益、支出）。"
+msgstr "グループから継承：トップレベルの分類 (資産、負債、純資産、売上高、費用)。"
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "グループから継承：このアカウントが財務諸表に表示される場所。"
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "グループから継承：このアカウントが留保利益（収入）に閉じるか、繰り越す（バランス）か。"
+msgstr "グループから継承：このアカウントが利益剰余金 (収益) にクローズするか、繰り越す (残高) かどうか。"
 
 msgid "Inherited from the parent group."
 msgstr "親グループから継承。"
@@ -7806,10 +7806,10 @@ msgid "Inspection"
 msgstr "検査"
 
 msgid "Inspection document"
-msgstr "検査ドキュメント"
+msgstr "検査文書"
 
 msgid "Inspection Level"
-msgstr "検査レベル"
+msgstr "検査水準"
 
 msgid "Inspection Plan"
 msgstr "検査計画"
@@ -7827,7 +7827,7 @@ msgid "Inspections"
 msgstr "検査"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "検査、不適合、および是正予防措置"
+msgstr "検査、不適合、およびCAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
 msgstr "検査、不適合、CAPA"
@@ -7845,19 +7845,19 @@ msgid "Instructions"
 msgstr "手順"
 
 msgid "Instructions are inherited from the procedure."
-msgstr "手順から継承された指示。"
+msgstr "手順は手順書から継承されています。"
 
 msgid "Integration"
-msgstr "統合"
+msgstr "連携"
 
 msgid "Integration not found"
-msgstr "統合が見つかりません"
+msgstr "連携が見つかりません"
 
 msgid "Integrations"
-msgstr "統合"
+msgstr "連携"
 
 msgid "Integrations not named here"
-msgstr "ここで名前が挙げられていない統合"
+msgstr "ここに名前が付けられていない連携"
 
 msgid "Intercompany"
 msgstr "企業間"
@@ -7875,25 +7875,25 @@ msgid "Intercompany transactions involving this company that are still Unmatched
 msgstr "この会社が関係する会社間取引がまだ未照合の場合は、照合して消去する必要があります。連結結果がエンティティ間の活動を二重に計算しないようにするため。"
 
 msgid "Interest"
-msgstr "金利"
+msgstr "利息"
 
 msgid "Interest (default)"
-msgstr "金利（デフォルト）"
+msgstr "利息 (デフォルト)"
 
 msgid "Interest income or expense from banking activities"
-msgstr "銀行業務からの利息収入または支出"
+msgstr "銀行業務からの利息収益または利息費用"
 
 msgid "Internal"
-msgstr "内部"
+msgstr "社内"
 
 msgid "Internal Delta"
-msgstr "内部デルタ"
+msgstr "社内差異"
 
 msgid "Internal notes"
-msgstr "内部メモ"
+msgstr "社内メモ"
 
 msgid "Internal Notes"
-msgstr "内部メモ"
+msgstr "社内メモ"
 
 msgid "inv"
 msgstr "在庫"
@@ -7971,25 +7971,25 @@ msgid "Invoice"
 msgstr "請求書"
 
 msgid "Invoice Contact"
-msgstr "請求先担当者"
+msgstr "請求書担当者"
 
 msgid "Invoice customer"
-msgstr "請求顧客"
+msgstr "請求書得意先"
 
 msgid "Invoice Customer"
-msgstr "請求顧客"
+msgstr "請求書得意先"
 
 msgid "Invoice customer contact"
-msgstr "請求顧客連絡先"
+msgstr "請求書得意先担当者"
 
 msgid "Invoice Customer Contact"
-msgstr "請求書顧客連絡先"
+msgstr "請求書得意先担当者"
 
 msgid "Invoice customer location"
-msgstr "請求顧客場所"
+msgstr "請求書得意先拠点"
 
 msgid "Invoice Customer Location"
-msgstr "請求顧客の場所"
+msgstr "請求書得意先拠点"
 
 msgid "Invoice ID"
 msgstr "請求書ID"
@@ -8004,19 +8004,19 @@ msgid "Invoice settlement"
 msgstr "請求書決済"
 
 msgid "Invoice supplier"
-msgstr "請求仕入先"
+msgstr "請求書仕入先"
 
 msgid "Invoice Supplier"
-msgstr "請求書サプライヤー"
+msgstr "請求書仕入先"
 
 msgid "Invoice supplier contact"
-msgstr "請求仕入先連絡先"
+msgstr "請求書仕入先担当者"
 
 msgid "Invoice Supplier Contact"
 msgstr "請求書仕入先担当者"
 
 msgid "Invoice supplier location"
-msgstr "請求仕入先場所"
+msgstr "請求書仕入先拠点"
 
 msgid "Invoice Supplier Location"
 msgstr "請求書仕入先の場所"
@@ -8037,7 +8037,7 @@ msgid "Invoices"
 msgstr "請求書"
 
 msgid "Invoices this memo has been applied to. Click a row to open the document."
-msgstr "このメモが適用された請求書です。行をクリックしてドキュメントを開きます。"
+msgstr "このメモが適用された請求書。行をクリックして文書を開きます。"
 
 msgid "Invoicing"
 msgstr "請求"
@@ -8049,13 +8049,13 @@ msgid "is any of"
 msgstr "のいずれかである"
 
 msgid "Is console operator"
-msgstr "コンソール演算子です"
+msgstr "コンソールオペレーターである"
 
 msgid "Is customer org group"
-msgstr "顧客組織グループです"
+msgstr "得意先組織グループである"
 
 msgid "Is customer type group"
-msgstr "顧客タイプグループです"
+msgstr "得意先タイプグループである"
 
 msgid "Is employee type group"
 msgstr "従業員タイプグループです"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "問題"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "バージョンを再度公開するまで実行は停止します。削除されるものはありません。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR認定"
@@ -8139,7 +8139,7 @@ msgid "Item / Location"
 msgstr "品目 / 場所"
 
 msgid "Item filters"
-msgstr "アイテムフィルター"
+msgstr "品目の絞り込み"
 
 msgid "item group"
 msgstr "アイテムグループ"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "品目マスターと製造方法"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "アイテムマスター、BOM、およびプロセス表"
+msgstr "品目マスター、BOMおよび工程表"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "アイテムは選択されたタイプと選択されたグループの両方に一致する必要があります"
@@ -8184,13 +8184,13 @@ msgid "Item Scope"
 msgstr "アイテムスコープ"
 
 msgid "Item Type"
-msgstr "アイテムタイプ"
+msgstr "品目タイプ"
 
 msgid "Item Type (optional)"
-msgstr "アイテムタイプ（オプション）"
+msgstr "品目タイプ（オプション）"
 
 msgid "Item types"
-msgstr "アイテムタイプ"
+msgstr "品目タイプ"
 
 msgid "items"
 msgstr "アイテム"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "このウィンドウ内のアイテムは黄色いバッジが表示されます。"
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "アイテム: アイテムマスター、BOM、プロセス仕様書、エンジニアリング変更、CAD"
+msgstr "品目：品目マスター、BOM、工程表、設計変更、CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "変更通知のリリース前に、そのデザインが変わる可能性があります。"
@@ -8226,16 +8226,16 @@ msgid "Job make method"
 msgstr "ジョブ製造方法"
 
 msgid "Job Materials"
-msgstr "ジョブ材料"
+msgstr "指図材料"
 
 msgid "Job operation"
-msgstr "ジョブ操作"
+msgstr "指図工程"
 
 msgid "Job Operation"
-msgstr "作業操作"
+msgstr "指図工程"
 
 msgid "Job Operations"
-msgstr "ジョブ操作"
+msgstr "指図工程"
 
 msgid "Job Priority"
 msgstr "ジョブ優先度"
@@ -8244,26 +8244,26 @@ msgid "Job readable"
 msgstr "ジョブ読取可能"
 
 msgid "Job Traveler"
-msgstr "ジョブトラベラー"
+msgstr "現品票"
 
 msgid "Jobs"
-msgstr "ジョブ"
+msgstr "製造指図"
 
 msgid "Jobs Assigned to Me"
-msgstr "私に割り当てられたジョブ"
+msgstr "私に割り当てられた製造指図"
 
 msgid "Jobs Required"
-msgstr "ジョブが必要です"
+msgstr "必要な製造指図"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "このアイテムが部品表に含まれるジョブ"
+msgstr "この品目が部品表に含まれる製造指図"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "{0}に参加"
 
 msgid "Journal"
-msgstr "ジャーナル"
+msgstr "仕訳"
 
 msgid "Journal Entries"
 msgstr "仕訳帳"
@@ -8272,25 +8272,25 @@ msgid "Journal entries dated in this period that are still Draft must be posted,
 msgstr "当期に日付が付けられた仕訳がまだ下書きの場合は、転記するか、後の開いている期間に再度日付を付け直す必要があります。下書き仕訳は元帳の一部ではないため、それらの借方と貸方は決算から除外されます。"
 
 msgid "Journal Entry"
-msgstr "仕訳"
+msgstr "仕訳行"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "この日付以前の日付のジャーナルはロック済みとして扱われます。両方存在する場合はプロバイダーが報告するロック日と統合されます。"
+msgstr "この日付以前の仕訳はロック中として扱われます。両方が存在する場合、プロバイダーが報告したロック日付とマージされます。"
 
 msgid "Just one"
 msgstr "1つだけ"
 
 msgid "Kanban"
-msgstr "カンバン"
+msgstr "かんばん"
 
 msgid "Kanban for {kanbanName}"
-msgstr "Kanban for {kanbanName}"
+msgstr "{kanbanName}のかんばん"
 
 msgid "Kanban Output"
-msgstr "カンバン出力"
+msgstr "かんばん出力"
 
 msgid "Kanbans"
-msgstr "カンバン"
+msgstr "かんばん"
 
 msgid "Keep"
 msgstr "保持"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "現在の設定を保持"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "既存の価格を保持し、新しい項目のみを追加"
+msgstr "既存の価格設定を保持し、新しい品目のみを追加"
 
 msgid "Keep only items where…"
 msgstr "以下の条件を満たすアイテムのみを保持…"
@@ -8329,53 +8329,53 @@ msgid "Label"
 msgstr "ラベル"
 
 msgid "Label to complete the current operation for this kanban"
-msgstr "このカンバンの現在の操作を完了するためのラベル"
+msgstr "このかんばんの現在の工程を完了するためのラベル"
 
 #. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
 msgid "Label to create a {0} for this kanban"
-msgstr "このカンバンの{0}を作成するためのラベル"
+msgstr "このかんばんの{0}を作成するためのラベル"
 
 msgid "Label to start the next operation for this kanban"
-msgstr "このカンバンの次の操作を開始するためのラベル"
+msgstr "このかんばんの次の工程を開始するためのラベル"
 
 msgid "Labels"
 msgstr "ラベル"
 
 msgid "Labor"
-msgstr "労働"
+msgstr "労務"
 
 msgid "Labor & Machine Absorption"
-msgstr "労力と機械の吸収"
+msgstr "労務・機械吸収"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "労力と機械の吸収（デフォルト）"
+msgstr "労務・機械吸収（デフォルト）"
 
 msgid "Labor & Machine Variance"
-msgstr "労力と機械の分散"
+msgstr "労務・機械差異"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "労力と機械の分散（デフォルト）"
+msgstr "労務・機械差異（デフォルト）"
 
 msgid "Labor rate"
-msgstr "労働費率"
+msgstr "労務単価"
 
 msgid "Labor Rate"
 msgstr "労務費率"
 
 msgid "Labor Rate (Hourly)"
-msgstr "労働率（時間単位）"
+msgstr "労務単価（時間当たり）"
 
 msgid "Labor time"
-msgstr "労働時間"
+msgstr "労務時間"
 
 msgid "Labor Time"
-msgstr "労働時間"
+msgstr "労務時間"
 
 msgid "Labor unit"
-msgstr "労働単位"
+msgstr "労務単位"
 
 msgid "Labor Unit"
-msgstr "労働単位"
+msgstr "労務単位"
 
 msgid "Language"
 msgstr "言語"
@@ -8390,16 +8390,16 @@ msgid "Last Attempt"
 msgstr "最後の試行"
 
 msgid "Last Calibration"
-msgstr "最後のキャリブレーション"
+msgstr "最終校正"
 
 msgid "Last Calibration Date"
-msgstr "最後のキャリブレーション日"
+msgstr "最終校正日"
 
 msgid "Last day"
 msgstr "最終日"
 
 msgid "Last Fiscal Year"
-msgstr "前年度"
+msgstr "前会計年度"
 
 msgid "Last Login"
 msgstr "最後のログイン"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "手作業を減らし、エラーを削減"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "ビルドしましょう"
 
 msgid "Let's build something"
 msgstr "何か作ってみましょう"
@@ -8504,7 +8504,7 @@ msgid "Liability account for deferred taxes from accelerated depreciation"
 msgstr "加速度的な減価償却による繰延税金の負債勘定"
 
 msgid "Liability account for sales tax collected from customers"
-msgstr "顧客から徴収された売上税の負債勘定"
+msgstr "得意先から徴収した売上税の負債勘定"
 
 msgid "Liability account for tax paid on purchases"
 msgstr "購入に支払う税金の負債勘定"
@@ -8525,7 +8525,7 @@ msgid "Light Mode"
 msgstr "ライトモード"
 
 msgid "Likelihood"
-msgstr "可能性"
+msgstr "発生可能性"
 
 msgid "Line description (optional)"
 msgstr "行の説明 (オプション)"
@@ -8546,7 +8546,7 @@ msgid "Lines"
 msgstr "行"
 
 msgid "Lines need internal part numbers"
-msgstr "ラインには内部部品番号が必要です"
+msgstr "明細には社内部品番号が必要です"
 
 msgid "Lines need prices or lead times"
 msgstr "ラインには価格またはリードタイムが必要です"
@@ -8558,7 +8558,7 @@ msgid "Link"
 msgstr "リンク"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "リンク（オプション）— 例：/x/settings/…"
+msgstr "リンク（オプション） — 例: /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Jira イシューをリンク"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Linear イシューをリンク"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "このCarbonの得意先をいずれかにリンクするか、別のStripe顧客を作成してください。"
 
 msgid "Link to sales order line"
-msgstr "販売注文行へのリンク"
+msgstr "受注明細へのリンク"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "最後に読み込まれ、カットオーバー時に残高が最新の状態になります。"
 
 msgid "Loading associated jobs..."
-msgstr "関連するジョブを読み込み中..."
+msgstr "関連する製造指図を読み込み中..."
 
 msgid "Loading current quantity…"
 msgstr "現在の数量を読み込み中…"
@@ -8658,13 +8658,13 @@ msgid "Lock Period"
 msgstr "期間をロック"
 
 msgid "Locked"
-msgstr "ロック済み"
+msgstr "ロック中"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "ロックにより、当期は運用書類（受領書、出荷、請求書）に対して読み取り専用になりますが、減価償却や処分などの会計調整は引き続き可能です。期間は終了する前にロックする必要があります。"
+msgstr "ロックすると、期間は業務文書（入荷、出荷、請求書）に対しては読み取り専用になりますが、減価償却や除却などの会計調整は引き続き許可されます。期間をクローズする前にロックする必要があります。"
 
 msgid "Log nonconformances and drive a CAPA"
-msgstr "不適合を記録し、是正予防処置を実施する"
+msgstr "不適合を記録し、CAPAを推進する"
 
 msgid "Login or create a new account"
 msgstr "ログインするか新しいアカウントを作成してください"
@@ -8695,19 +8695,19 @@ msgid "Looks empty here"
 msgstr "ここは空のようです"
 
 msgid "Loss on Disposal"
-msgstr "処分損"
+msgstr "除却損"
 
 msgid "Loss on Disposal (default)"
-msgstr "処分損（既定）"
+msgstr "除却損（デフォルト）"
 
 msgid "Loss on Disposal Account"
-msgstr "処分損勘定科目"
+msgstr "除却損勘定"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "固定資産の処分により認識された損失"
+msgstr "固定資産の除却時に認識される損失"
 
 msgid "Lost"
-msgstr "失った"
+msgstr "失注"
 
 msgid "Lot"
 msgstr "ロット"
@@ -8719,16 +8719,16 @@ msgid "Lot Size"
 msgstr "ロットサイズ"
 
 msgid "Lot Size Variance"
-msgstr "ロットサイズの分散"
+msgstr "ロットサイズ差異"
 
 msgid "Lot Size Variance (default)"
-msgstr "ロットサイズの分散（デフォルト）"
+msgstr "ロットサイズ差異（デフォルト）"
 
 msgid "Lot Size:"
 msgstr "ロットサイズ:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "サンプリング計画に対する受け取った商品のロットベースの検査。ユニットは受取時に保留 (On Hold) として転記され、ロットが受け入れられたと判定されたときにのみ利用可能 (Available) にリリースされます。"
+msgstr "入荷商品をロット単位で抜取検査方式に従って検査します。受取時に単位が保留中に設定され、ロットが承諾済として処分されたら利用可能にリリースされます。"
 
 msgid "Low"
 msgstr "低"
@@ -8776,25 +8776,25 @@ msgid "Maintain a single part and item master"
 msgstr "単一の部品とアイテムマスターを維持する"
 
 msgid "Maintenance"
-msgstr "メンテナンス"
+msgstr "保全"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "メンテナンスディスパッチ通知"
+msgstr "保全指示通知"
 
 msgid "Maintenance Dispatches"
-msgstr "メンテナンスディスパッチ"
+msgstr "保全指示"
 
 msgid "Maintenance Expense"
-msgstr "保守経費"
+msgstr "保全費用"
 
 msgid "Maintenance Expense (default)"
-msgstr "保守経費 (デフォルト)"
+msgstr "保全費用（デフォルト）"
 
 msgid "Maintenance Schedules"
-msgstr "メンテナンススケジュール"
+msgstr "保全スケジュール"
 
 msgid "Maintenance Type"
-msgstr "メンテナンスタイプ"
+msgstr "保全タイプ"
 
 msgid "Make"
 msgstr "製造"
@@ -8806,10 +8806,10 @@ msgid "Make Default"
 msgstr "デフォルトに設定"
 
 msgid "Make Inactive"
-msgstr "非アクティブにする"
+msgstr "無効にする"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "製造品は直接請求できません。方法をピックに変更して続行してください。"
+msgstr "内製品目は直接請求できません。続行するにはメソッドをピックに変更してください。"
 
 msgid "Make Method Version"
 msgstr "製造方法バージョン"
@@ -8842,16 +8842,16 @@ msgid "Make tracked entities available again"
 msgstr "追跡対象エンティティを再度利用可能にする"
 
 msgid "Makes this document active again."
-msgstr "このドキュメントを再度アクティブにします。"
+msgstr "このドキュメントを再度有効にします。"
 
 msgid "Makes this document active and visible."
-msgstr "このドキュメントをアクティブにして表示します。"
+msgstr "このドキュメントを有効にして表示します。"
 
 msgid "Manage"
 msgstr "管理"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "棚卸資産全体で賞味期限がどのように追跡、計算、および実施されるかを管理します。"
+msgstr "保存期間が在庫全体で追跡、計算、および適用される方法を管理します。"
 
 msgid "Manage Ownership"
 msgstr "所有権を管理"
@@ -8884,10 +8884,10 @@ msgid "Map accounts"
 msgstr "勘定をマップ"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Carbon勘定科目をプロバイダーの勘定科目体系にマップします。転記されたジャーナルはマップされたプロバイダー勘定科目コードを使用して転記されます。"
+msgstr "Carbonの勘定科目をプロバイダーの勘定科目表にマップします。転記済の仕訳は、マップされたプロバイダー勘定科目コードを使用してプッシュされます。"
 
 msgid "Map Extracted Invoice Lines"
-msgstr "抽出された請求書行をマップする"
+msgstr "抽出された請求書明細をマップ"
 
 msgid "Map Extracted Lines"
 msgstr "抽出行をマップ"
@@ -8906,7 +8906,7 @@ msgstr "マップされた値"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "\"{0}\"をパスしたとしてマークしますか？"
+msgstr "「{0}」を合格にしますか？"
 
 msgid "Mark all as configured"
 msgstr "すべてを設定済みとしてマーク"
@@ -8924,7 +8924,7 @@ msgid "Mark as Unpaid"
 msgstr "未払いとしてマーク"
 
 msgid "Mark checkpoint passed"
-msgstr "チェックポイント完了をマーク"
+msgstr "チェックポイント合格をマークする"
 
 msgid "Mark Complete"
 msgstr "完了にマーク"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "削除対象にマーク"
 
 msgid "Master gauge"
-msgstr "マスター ゲージ"
+msgstr "標準器"
 
 msgid "Master records"
 msgstr "マスターレコード"
@@ -8999,19 +8999,19 @@ msgid "Material"
 msgstr "材料"
 
 msgid "Material Dimension"
-msgstr "材料寸法"
+msgstr "材料ディメンション"
 
 msgid "Material Dimensions"
-msgstr "材料寸法"
+msgstr "材料ディメンション"
 
 msgid "Material dimensions use metric units."
-msgstr "材料の寸法はメートル法の単位を使用しています。"
+msgstr "材料ディメンションはメートル法単位を使用します。"
 
 msgid "Material Finish"
-msgstr "マテリアルフィニッシュ"
+msgstr "表面処理"
 
 msgid "Material Finishes"
-msgstr "材料仕上げ"
+msgstr "表面処理"
 
 msgid "Material Form"
 msgstr "マテリアルフォーム"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "材料特性"
 
 msgid "Material Review Board (MRB)"
-msgstr "材料検討委員会 (MRB)"
+msgstr "材料審査会(MRB)"
 
 msgid "Material Shape"
 msgstr "材料形状"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "材料形状"
 
 msgid "Material Substance"
-msgstr "材料物質"
+msgstr "素材"
 
 msgid "Material Substances"
-msgstr "材料物質"
+msgstr "素材"
 
 msgid "material type"
 msgstr "材料タイプ"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "平均修復時間"
 
 msgid "Measurement Standard"
-msgstr "測定標準"
+msgstr "計量標準"
 
 msgid "Media Size"
 msgstr "メディアサイズ"
@@ -9152,13 +9152,13 @@ msgid "Method Materials"
 msgstr "方法材料"
 
 msgid "Method Operations"
-msgstr "メソッド操作"
+msgstr "製法工程"
 
 msgid "Method type"
-msgstr "メソッドタイプ"
+msgstr "供給方式"
 
 msgid "Method Type"
-msgstr "メソッドタイプ"
+msgstr "供給方式"
 
 msgid "Methods"
 msgstr "方法"
@@ -9188,10 +9188,10 @@ msgid "Minimum Amount"
 msgstr "最小金額"
 
 msgid "Minimum Cost"
-msgstr "最小コスト"
+msgstr "最小原価"
 
 msgid "Minimum Order Quantity"
-msgstr "最小注文数量"
+msgstr "最小発注数量"
 
 msgid "Minimum Order:"
 msgstr "最小注文数:"
@@ -9218,13 +9218,13 @@ msgid "Missing Information"
 msgstr "不足している情報"
 
 msgid "Missing Operations"
-msgstr "操作がありません"
+msgstr "工程が不足しています"
 
 msgid "Missing Shipping Costs"
-msgstr "配送コストが不足しています"
+msgstr "送料が不足しています"
 
 msgid "Missing Suppliers"
-msgstr "サプライヤーが見つかりません"
+msgstr "仕入先が不足しています"
 
 msgid "Mobile Phone"
 msgstr "携帯電話"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "アイテムを移動"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "数量の一部を新しい処分行に移動して、MRBが各部分を個別に判断できるようにします（例：一部をスクラップ、一部を再加工）。"
+msgstr "数量の一部を新しい処置行に移動して、MRBが各部分を個別に決定できるようにします(例えば一部をスクラップ、一部を手直し)。"
 
 msgid "Move to"
 msgstr "移動先"
@@ -9352,13 +9352,13 @@ msgid "Name"
 msgstr "名前"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "内部プロジェクトオーナーを指定し、決定権を付与する"
+msgstr "意思決定権を持つ社内プロジェクト責任者を指定する"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "名前はハブ全体でそれらのロールが参照されている場所に入力されます。"
 
 msgid "Native CAD integration (for example Onshape)"
-msgstr "ネイティブCAD統合（例：Onshape）"
+msgstr "ネイティブCAD連携(例えばOnshape)"
 
 msgid "Navigate"
 msgstr "ナビゲート"
@@ -9388,16 +9388,16 @@ msgid "Negative Adjustment"
 msgstr "負の調整"
 
 msgid "Net book value"
-msgstr "純簿価額"
+msgstr "未償却残高"
 
 msgid "Net Book Value"
-msgstr "純簿価額"
+msgstr "未償却残高"
 
 msgid "Net Change"
 msgstr "純変化"
 
 msgid "Net Income"
-msgstr "純利益"
+msgstr "純収益"
 
 msgid "Never"
 msgstr "なし"
@@ -9442,10 +9442,10 @@ msgid "New Consumable"
 msgstr "新しい消耗品"
 
 msgid "New Contractor"
-msgstr "新しい契約者"
+msgstr "新規外部作業者"
 
 msgid "New Cost Center"
-msgstr "新しいコストセンター"
+msgstr "新規原価センター"
 
 msgid "New Credit / Debit Memo"
 msgstr "新しい貸方/借方メモ"
@@ -9454,10 +9454,10 @@ msgid "New Custom Field"
 msgstr "新しいカスタムフィールド"
 
 msgid "New Customer"
-msgstr "新規顧客"
+msgstr "新規得意先"
 
 msgid "New Customer Part"
-msgstr "新しい顧客部品"
+msgstr "新規得意先部品"
 
 msgid "New Department"
 msgstr "新しい部門"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "新しい固定資産"
 
 msgid "New Gauge"
-msgstr "新しいゲージ"
+msgstr "新規測定器"
 
 msgid "New Gauge Calibration Record"
-msgstr "新しいゲージキャリブレーションレコード"
+msgstr "新規測定器校正記録"
 
 msgid "New Gauge Type"
-msgstr "新しいゲージタイプ"
+msgstr "新規測定器タイプ"
 
 msgid "New Group"
 msgstr "新しいグループ"
@@ -9514,7 +9514,7 @@ msgid "New Item Group"
 msgstr "新しいアイテムグループ"
 
 msgid "New Kanban"
-msgstr "新しいカンバン"
+msgstr "新規かんばん"
 
 msgid "New Line"
 msgstr "新しい行"
@@ -9526,16 +9526,16 @@ msgid "New Location"
 msgstr "新しい場所"
 
 msgid "New Maintenance Dispatch"
-msgstr "新しい保守ディスパッチ"
+msgstr "新規保全指示"
 
 msgid "New Material"
 msgstr "新しい材料"
 
 msgid "New Material Dimension"
-msgstr "新しい材料寸法"
+msgstr "新規材料ディメンション"
 
 msgid "New Material Finish"
-msgstr "新しい材料仕上げ"
+msgstr "新規表面処理"
 
 msgid "New Material Grade"
 msgstr "新しい材料グレード"
@@ -9544,7 +9544,7 @@ msgid "New Material Shape"
 msgstr "新しい材料形状"
 
 msgid "New Material Substance"
-msgstr "新しい材料物質"
+msgstr "新規素材"
 
 msgid "New Material Type"
 msgstr "新しい材料タイプ"
@@ -9553,10 +9553,10 @@ msgid "New Non Conformance Type"
 msgstr "新しい不適合タイプ"
 
 msgid "New Owner"
-msgstr "新しいオーナー"
+msgstr "新規責任者"
 
 msgid "New Part"
-msgstr "新しい部品"
+msgstr "新規部品"
 
 msgid "New Password"
 msgstr "新しいパスワード"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "新しい支払い"
 
 msgid "New Payment Term"
-msgstr "新しい支払い条件"
+msgstr "新規支払条件"
 
 msgid "New Picking List"
 msgstr "新しいピッキングリスト"
@@ -9577,13 +9577,13 @@ msgid "New PO"
 msgstr "新規PO"
 
 msgid "New Price Override"
-msgstr "新しい価格オーバーライド"
+msgstr "新規価格上書き"
 
 msgid "New Pricing Rule"
 msgstr "新しい価格設定ルール"
 
 msgid "New Procedure"
-msgstr "新しい手順"
+msgstr "新規手順書"
 
 msgid "New Process"
 msgstr "新しいプロセス"
@@ -9592,13 +9592,13 @@ msgid "New Production Projection"
 msgstr "新しい生産予測"
 
 msgid "New Quality Document"
-msgstr "新しい品質ドキュメント"
+msgstr "新規品質文書"
 
 msgid "New Quote"
 msgstr "新規見積"
 
 msgid "New Quote Line"
-msgstr "新しい見積行"
+msgstr "新規見積明細"
 
 msgid "New Receipt"
 msgstr "新しい領収書"
@@ -9622,16 +9622,16 @@ msgid "New Sales Invoice"
 msgstr "新しい売上請求書"
 
 msgid "New Sales Invoice Line"
-msgstr "新しい販売請求書行"
+msgstr "新規売上請求書明細"
 
 msgid "New Sales Order"
-msgstr "新しい販売注文"
+msgstr "新規受注"
 
 msgid "New Sales Order Line"
-msgstr "新しい販売注文行"
+msgstr "新規受注明細"
 
 msgid "New Scheduled Maintenance"
-msgstr "新しいスケジュール済みメンテナンス"
+msgstr "新規定期保全"
 
 msgid "New Serial Number"
 msgstr "新しいシリアル番号"
@@ -9646,7 +9646,7 @@ msgid "New Shipment"
 msgstr "新しい出荷"
 
 msgid "New Shipping Method"
-msgstr "新しい配送方法"
+msgstr "新規出荷方法"
 
 msgid "New Size"
 msgstr "新しいサイズ"
@@ -9658,10 +9658,10 @@ msgid "New Storage Unit"
 msgstr "新しい保管ユニット"
 
 msgid "New Supplier"
-msgstr "新しいサプライヤー"
+msgstr "新規仕入先"
 
 msgid "New Supplier Part"
-msgstr "新しいサプライヤー部品"
+msgstr "新規仕入先部品"
 
 msgid "New Timecard"
 msgstr "新しいタイムカード"
@@ -9670,13 +9670,13 @@ msgid "New Tool"
 msgstr "新しいツール"
 
 msgid "New Training"
-msgstr "新しいトレーニング"
+msgstr "新規教育訓練"
 
 msgid "New Transfer"
 msgstr "新しい転送"
 
 msgid "New Transfer Line"
-msgstr "新しい転送ライン"
+msgstr "新規転送明細"
 
 msgid "New Unit of Measure"
 msgstr "新しい測定単位"
@@ -9691,7 +9691,7 @@ msgid "New Webhook"
 msgstr "新しいWebhook"
 
 msgid "New Work Center"
-msgstr "新しい作業センター"
+msgstr "新規作業区"
 
 msgid "New Workflow"
 msgstr "新規ワークフロー"
@@ -9715,13 +9715,13 @@ msgid "Next Due"
 msgstr "次回期限"
 
 msgid "Next Due Date"
-msgstr "次の期限日"
+msgstr "次の期日"
 
 msgid "Next page"
 msgstr "次のページ"
 
 msgid "Next Sequence"
-msgstr "次のシーケンス"
+msgstr "次の採番"
 
 msgid "Next step"
 msgstr "次のステップ"
@@ -9738,14 +9738,14 @@ msgstr "{0}が見つかりません"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "{0}同期操作はありません"
+msgstr "{0}の同期操作がありません"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
 msgstr "まだ{0}がありません"
 
 msgid "No abilities added"
-msgstr "能力が追加されていません"
+msgstr "スキルが追加されていません"
 
 msgid "No Access"
 msgstr "アクセスなし"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "アクションが選択されていません"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "このセールスオーダーのアクティブなジョブが見つかりません。注文は直接キャンセルされます。"
+msgstr "この受注について処理中の製造指図が見つかりません。受注は直接キャンセルされます。"
 
 msgid "No active plan"
 msgstr "アクティブなプランなし"
@@ -9785,13 +9785,13 @@ msgstr "申請がありません。支払いはオンアカウントになりま
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "まだアーカイブされたログはありません。{0}日以上前のログは自動的にアーカイブされ、ここからダウンロードできます。"
+msgstr "まだアーカイブされたログがありません。{0}日以上前のログは自動的にアーカイブされ、ここからダウンロード可能になります。"
 
 msgid "No attachments."
 msgstr "添付ファイルがありません。"
 
 msgid "No available filters"
-msgstr "利用可能なフィルターがありません"
+msgstr "利用可能な絞り込みはありません"
 
 msgid "No available tracked entities found"
 msgstr "利用可能な追跡対象エンティティが見つかりません"
@@ -9803,7 +9803,7 @@ msgid "No CAD model to preview."
 msgstr "プレビューするCADモデルがありません。"
 
 msgid "No calibration records found"
-msgstr "キャリブレーション記録が見つかりません"
+msgstr "校正記録が見つかりません"
 
 msgid "No changes recorded"
 msgstr "変更が記録されていません"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "まだコメントがありません。最初のコメントを追加してください。"
 
 msgid "No completed jobs within range"
-msgstr "範囲内に完了したジョブがありません"
+msgstr "範囲内に完了した製造指図がありません"
 
 msgid "No condition may match"
 msgstr "条件が一致しない"
@@ -9827,7 +9827,7 @@ msgid "No conversion is required"
 msgstr "変換は不要です"
 
 msgid "No cost history found"
-msgstr "コスト履歴が見つかりません"
+msgstr "原価の履歴が見つかりません"
 
 msgid "No Data"
 msgstr "データなし"
@@ -9848,13 +9848,13 @@ msgid "No dimension values mapped yet"
 msgstr "まだディメンション値がマップされていません"
 
 msgid "No draft make method for this item yet."
-msgstr "このアイテムのドラフト製造方法はまだありません。"
+msgstr "この品目の下書き製造方法はまだありません。"
 
 msgid "No draft versions available"
-msgstr "ドラフト版は利用できません"
+msgstr "利用可能な下書きバージョンはありません"
 
 msgid "No due date"
-msgstr "期限なし"
+msgstr "期日なし"
 
 msgid "No editable properties for this item."
 msgstr "このアイテムの編集可能なプロパティはありません。"
@@ -9869,16 +9869,16 @@ msgid "No events found."
 msgstr "イベントが見つかりません。"
 
 msgid "No extra cutover steps yet. Add anything specific to this customer."
-msgstr "まだ追加のカットオーバーステップがありません。このお客様に固有のものを追加してください。"
+msgstr "追加のカットオーバーステップはまだありません。この得意先に固有のものを追加してください。"
 
 msgid "No extra data sets yet. Add anything specific to this customer."
-msgstr "まだ追加のデータセットがありません。このお客様に固有のものを追加してください。"
+msgstr "追加のデータセットはまだありません。この得意先に固有のものを追加してください。"
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "まだ追加の要件がありません。このお客様に固有のものを追加してください。"
+msgstr "追加の要求事項はまだありません。この得意先に固有のものを追加してください。"
 
 msgid "No extra setup items yet. Add anything specific to this customer."
-msgstr "このカスタマーに固有のセットアップ項目はまだありません。追加してください。"
+msgstr "追加のセットアップ項目はまだありません。この得意先に固有のものを追加してください。"
 
 msgid "No failure path — the run stops here and is marked failed"
 msgstr "失敗パスなし — 実行がここで停止し失敗とマークされます"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "ファイルがアップロードされていません"
 
 msgid "No Gauge Selected"
-msgstr "ゲージが選択されていません"
+msgstr "測定器が選択されていません"
 
 msgid "No grouped notifications"
 msgstr "グループ化された通知がありません"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "ここにはまだアイテムの在庫活動がありません。"
 
 msgid "No jobs were created"
-msgstr "ジョブが作成されていません"
+msgstr "製造指図は作成されませんでした"
 
 msgid "No journal lines in scope for this period"
-msgstr "この期間のスコープ内にジャーナルラインがありません"
+msgstr "この期間の対象仕訳明細がありません"
 
 msgid "No lines to map"
 msgstr "マップするラインがありません"
@@ -9956,25 +9956,25 @@ msgid "No new notifications"
 msgstr "新しい通知はありません"
 
 msgid "No notes"
-msgstr "ノートなし"
+msgstr "メモなし"
 
 msgid "No open invoices"
 msgstr "未処理の請求書がありません"
 
 msgid "No open orders for this item are available to link."
-msgstr "このアイテムにリンク可能なオープンオーダーはありません。"
+msgstr "この品目にリンク可能なオープンな注文はありません"
 
 msgid "No open sales order lines"
-msgstr "オープンな販売注文行がありません"
+msgstr "オープン受注明細がありません"
 
 msgid "No operations found."
-msgstr "操作が見つかりません。"
+msgstr "工程が見つかりません。"
 
 msgid "No operations require picking at this location"
-msgstr "この場所でのピッキングが必要な操作はありません"
+msgstr "この拠点でピッキングが必要な工程はありません"
 
 msgid "No operators."
-msgstr "オペレーターがありません。"
+msgstr "作業者がいません。"
 
 msgid "No option found."
 msgstr "オプションが見つかりません。"
@@ -9989,7 +9989,7 @@ msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "他の従業員が見つかりません。所有権の譲渡を有効にするために従業員を追加してください。"
 
 msgid "No outstanding trainings"
-msgstr "未処理のトレーニングはありません"
+msgstr "未実施の教育訓練がありません"
 
 msgid "No overtime scheduled"
 msgstr "残業予定なし"
@@ -10004,10 +10004,10 @@ msgid "No parts"
 msgstr "部品がありません"
 
 msgid "No passkeys registered yet."
-msgstr "まだパスキーは登録されていません。"
+msgstr "登録済のパスキーがまだありません。"
 
 msgid "No payables"
-msgstr "支払い義務なし"
+msgstr "買掛金がありません"
 
 msgid "No payments yet."
 msgstr "まだ支払いはありません。"
@@ -10016,13 +10016,13 @@ msgid "No planning data"
 msgstr "計画データなし"
 
 msgid "No posted journals in this period for this account"
-msgstr "この期間にこのアカウントの転記済みジャーナルはありません"
+msgstr "この期間、このアカウントに転記済の仕訳がありません"
 
 msgid "No pricing for selected quantity"
 msgstr "選択した数量の価格設定がありません"
 
 msgid "No pricing options found"
-msgstr "価格オプションが見つかりません"
+msgstr "価格設定オプションが見つかりません"
 
 msgid "No printer configured"
 msgstr "プリンターが設定されていません"
@@ -10040,13 +10040,13 @@ msgid "No purchases in this period"
 msgstr "この期間に購入がありません"
 
 msgid "No Quote"
-msgstr "見積なし"
+msgstr "見積辞退"
 
 msgid "No Quote Reason"
-msgstr "見積なし理由"
+msgstr "見積辞退理由"
 
 msgid "No Quote Reasons"
-msgstr "見積なし理由"
+msgstr "見積辞退理由"
 
 msgid "No receivables"
 msgstr "売掛金がありません"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "検索に一致するレポートはありません。"
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "この会社の代表者はまだ Carbon GovCloud Rider を承認していません。誰かが Carbon にアクセスする前に、この会社の管理者が承認する必要があります — Carbon のスタッフが代わりに承認することはできません。"
+msgstr "この会社の代表者はまだCarbonのGovCloud Riderを承諾していません。誰もCarbonにアクセスできるようになる前に、この会社の管理者が承諾する必要があります。Carbonスタッフはあなたに代わって承諾することはできません。"
 
 msgid "No results"
 msgstr "結果がありません"
@@ -10091,16 +10091,16 @@ msgid "No stock at this location"
 msgstr "この場所には在庫がありません"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "今後48週間の在庫切れは予測されていません"
+msgstr "今後48週間に欠品は予測されていません"
 
 msgid "No storage unit"
-msgstr "ストレージユニットがありません"
+msgstr "保管ユニットがありません"
 
 msgid "No suppliers yet"
-msgstr "まだサプライヤーがありません"
+msgstr "仕入先がまだありません"
 
 msgid "No sync operations yet"
-msgstr "同期操作がまだありません"
+msgstr "まだ同期操作がありません"
 
 msgid "No time entries for this week"
 msgstr "今週のタイムエントリがありません"
@@ -10136,10 +10136,10 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "このアイテムの倉庫在庫は記録されていません。それでも選択できます。実在庫がマイナスになり、数量が調整されるまで続きます。"
 
 msgid "No work center utilization data within range"
-msgstr "範囲内に作業センターの稼働率データがありません"
+msgstr "範囲内の作業区の稼働率データがありません"
 
 msgid "No work centers exist"
-msgstr "作業センターが存在しません"
+msgstr "作業区がありません"
 
 msgid "Nom"
 msgstr "公称値"
@@ -10166,13 +10166,13 @@ msgid "Non-Inventory Tracking"
 msgstr "非在庫追跡"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
-msgstr "このクラスの資産が帳簿価額を下回る価格で売却またはスクラップにされた場合に借方に計上される営業外費用勘定科目。"
+msgstr "このクラスの資産が未償却残高以下で売却または廃棄されたとき、営業外費用勘定が借記されます。"
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "このクラスの資産が帳簿価額を上回る価格で売却された場合に貸方に計上される営業外収益勘定科目。"
+msgstr "このクラスの資産が未償却残高を超える金額で売却されたとき、営業外収益勘定が貸記されます。"
 
 msgid "Non-Taxable Add-On Cost"
-msgstr "非課税アドオンコスト"
+msgstr "非課税上乗せ原価"
 
 msgid "Non-working days that scheduling and capacity respect"
 msgstr "スケジューリングと容量計画が考慮する非稼働日"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "通常"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "テーブルではなく、総勘定元帳残高：ジョブ材料が発行されるにつれてコストが蓄積され、ジョブが在庫に受け取られるとクリアになります。"
+msgstr "テーブルではなく総勘定元帳の残高です。指図材料が払い出されると原価が累積され、製造指図が在庫として受領されたときにクリアされます。"
 
 msgid "Not certified"
 msgstr "認定されていない"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "数量をカバーするのに十分なジョブがありません"
+msgstr "数量をカバーするのに十分な製造指図がありません"
 
 msgid "Not reached"
 msgstr "未到達"
@@ -10214,7 +10214,7 @@ msgid "Not started"
 msgstr "未開始"
 
 msgid "Not started training for"
-msgstr "まだトレーニングを開始していません"
+msgstr "まだ教育訓練を開始していない"
 
 msgid "Not yet"
 msgstr "まだ"
@@ -10275,22 +10275,22 @@ msgid "Number of lines"
 msgstr "行数"
 
 msgid "Number of open operations"
-msgstr "未実行オペレーションの数"
+msgstr "未完了の工程の数"
 
 msgid "Number of open tasks"
 msgstr "未実行タスクの数"
 
 msgid "Number of operations"
-msgstr "オペレーション数"
+msgstr "工程の数"
 
 msgid "Numbering sequence"
-msgstr "番号付けシーケンス"
+msgstr "採番"
 
 msgid "OEE Impact"
 msgstr "OEE影響"
 
 msgid "OEM (original equipment manufacturer)"
-msgstr "OEM (オリジナル機器メーカー)"
+msgstr "OEM（相手先商標製造業者）"
 
 msgid "of"
 msgstr "の"
@@ -10308,7 +10308,7 @@ msgid "Oldest first"
 msgstr "最も古いものから"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
-msgstr "カットオーバー当日は、以下のチェックリストを順番に実行してください。受け入れテストはスコープ内の要件から実施されます。サポートの詳細は下部にあります。"
+msgstr "カットオーバー日に、下のチェックリストを順番に作業してください。受け入れテストはあなたの対象要求事項から取得されます。サポートの詳細は下部にあります。"
 
 msgid "On day"
 msgstr "日付"
@@ -10329,19 +10329,19 @@ msgid "On Hold"
 msgstr "保留中"
 
 msgid "On Jobs"
-msgstr "ジョブ上"
+msgstr "製造指図に対して"
 
 msgid "On order"
 msgstr "発注済み"
 
 msgid "On Production Demand"
-msgstr "生産需要中"
+msgstr "生産所要量に対して"
 
 msgid "On Purchase Order"
-msgstr "購買注文中"
+msgstr "発注書に対して"
 
 msgid "On Sales Order"
-msgstr "販売注文中"
+msgstr "受注に対して"
 
 msgid "On Storage Unit"
 msgstr "保管ユニット上"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "現在庫が残っています"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "GL仕訳帳との照合付き場所または品目別手持ち在庫価値"
+msgstr "拠点または品目別の在庫額（総勘定元帳との照合付き）"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "製造品（メイク品目）の現在高価値"
@@ -10374,22 +10374,22 @@ msgid "On-time delivery"
 msgstr "オンタイム配送"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "ワークフローの1回の実行。各ステップが使用および生成した値とともにステップバイステップで記録され、ワークフローの所有者のアクセス権で動作します。"
+msgstr "ワークフローの1回の実行。各ステップが使用および生成した値を含めてステップバイステップで記録され、全体を通じてワークフロー責任者の権限で実行されます。"
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Carbonが個別に追跡する1つのシリアルユニットまたは1つのバッチであり、有効期限などの独自のステータスと属性を持ちます。"
+msgstr "Carbonが個別に追跡する1個のシリアルユニットまたは1つのバッチ。使用期限などのステータスと属性を独自に保有しています。"
 
 msgid "One set of numbers"
 msgstr "1つの数字セット"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "ジョブのルーティングの1つのステップであり、プロセスとワークセンターに名前を付け、独自のセットアップ、労働、機械の時間とレートを持ちます。"
+msgstr "製造指図の工順の1つのステップ。工法と作業区を指定し、段取り、労務、機械時間とそのレートを独自に保有しています。"
 
 msgid "One system from quote to cash"
 msgstr "見積から現金化まで一つのシステム"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "編集可能なのは下書き手順のみです。アクティブまたはアーカイブされた手順を変更するには、新しいバージョンを作成してください。"
+msgstr "下書きの手順書のみが編集可能です。有効またはアーカイブ済の手順書を変更するには、新しいバージョンを作成してください。"
 
 msgid "Only empty, open periods can be deleted."
 msgstr "空のオープン期間のみ削除できます。"
@@ -10428,10 +10428,10 @@ msgid "Open Actions"
 msgstr "オープンアクション"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "MRB処分のためにNCRを開く"
+msgstr "MRB処置のためにNCRを作成する"
 
 msgid "Open AP"
-msgstr "未払い債務"
+msgstr "オープン買掛金"
 
 msgid "Open AR"
 msgstr "未払い売掛金"
@@ -10446,7 +10446,7 @@ msgid "Open Date"
 msgstr "開始日"
 
 msgid "Open Dispatches"
-msgstr "オープンディスパッチ"
+msgstr "オープン保全指示"
 
 msgid "Open in Carbon"
 msgstr "Carbonで開く"
@@ -10464,19 +10464,19 @@ msgid "Open Issues"
 msgstr "未解決の問題"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "オープンジョブの需要とこのビンからの未決済移動"
+msgstr "このビンからの未処理転送を含むオープン製造指図所要量"
 
 msgid "Open jobs"
-msgstr "未処理ジョブ"
+msgstr "オープン製造指図"
 
 msgid "Open menu"
 msgstr "メニューを開く"
 
 msgid "Open payables by supplier and age"
-msgstr "仕入先および期間別未払い債務"
+msgstr "仕入先・日数別オープン買掛金"
 
 msgid "Open Purchase Invoices"
-msgstr "未払い購買請求書"
+msgstr "オープン仕入先請求書"
 
 msgid "Open purchase orders"
 msgstr "未処理の発注書"
@@ -10491,16 +10491,16 @@ msgid "Open Reactive"
 msgstr "オープン反応"
 
 msgid "Open receivables by customer and age"
-msgstr "顧客および期間別売上債権"
+msgstr "得意先別および期間別のオープン売掛金"
 
 msgid "Open RFQs"
 msgstr "オープンRFQ"
 
 msgid "Open sales orders"
-msgstr "未出荷の販売注文"
+msgstr "オープン受注"
 
 msgid "Open Sales Orders"
-msgstr "未処理の販売注文"
+msgstr "オープン受注"
 
 msgid "Open Scheduled"
 msgstr "スケジュール済みを開く"
@@ -10530,19 +10530,19 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "このアセットがCarbonに追加される前に既に予約されていた減価償却の期首残高（新規取得の場合は0を使用してください）。"
 
 msgid "Operating Expenses"
-msgstr "営業費"
+msgstr "営業費用"
 
 msgid "Operating Income"
-msgstr "営業利益"
+msgstr "営業収益"
 
 msgid "Operation"
 msgstr "操作"
 
 msgid "Operation lead time"
-msgstr "オペレーション所要時間"
+msgstr "工程リードタイム"
 
 msgid "Operation minimum cost"
-msgstr "オペレーション最小コスト"
+msgstr "工程最小原価"
 
 msgid "Operation order"
 msgstr "オペレーション順序"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "オペレーション数量"
 
 msgid "Operation supplier process"
-msgstr "オペレーションサプライヤープロセス"
+msgstr "工程仕入先工法"
 
 msgid "Operation type"
 msgstr "オペレーション種類"
@@ -10563,43 +10563,43 @@ msgid "Operation Type"
 msgstr "操作タイプ"
 
 msgid "Operation unit cost"
-msgstr "オペレーション単位コスト"
+msgstr "工程単位原価"
 
 msgid "Operations"
-msgstr "オペレーション"
+msgstr "工程"
 
 msgid "Operations / steps"
-msgstr "操作 / ステップ"
+msgstr "工程 / ステップ"
 
 msgid "Operations Type"
-msgstr "オペレーションタイプ"
+msgstr "工程タイプ"
 
 msgid "Operator"
-msgstr "オペレーター"
+msgstr "作業者"
 
 msgid "Operator gets a warning. Stock still goes through."
-msgstr "オペレーターに警告が表示されます。在庫はそのまま処理されます。"
+msgstr "作業者に警告が表示されます。在庫はそのまま処理されます。"
 
 msgid "Operator must pick a different batch/serial."
-msgstr "オペレーターは別のバッチ/シリアルを選択する必要があります。"
+msgstr "作業者は別のバッチ/シリアル番号を選択する必要があります。"
 
 msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
-msgstr "オペレーターは不足アイテムを確認でき、承認して完了できます。リストは「部分」フラグが付けられます。"
+msgstr "作業者は欠落している品目を確認して完了できます。リストは一部としてマークされます。"
 
 msgid "Operators"
-msgstr "オペレーター"
+msgstr "作業者"
 
 msgid "Operators can use shared workstations with PIN authentication."
-msgstr "オペレーターはPIN認証を使用して共有ワークステーションを使用できます。"
+msgstr "作業者は PIN 認証で共有ワークステーションを使用できます。"
 
 msgid "Operators start on the Scan tab"
-msgstr "オペレーターは「スキャン」タブで開始します"
+msgstr "作業者はスキャンタブで開始します。"
 
 msgid "Operators start the timer themselves when they begin an operation."
-msgstr "オペレーターは操作を開始するときに自分でタイマーを開始します。"
+msgstr "作業者は工程を開始するときにタイマーを自分で開始します。"
 
 msgid "Opportunity"
-msgstr "機会"
+msgstr "商談"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
 msgstr "高速プレビューに最適化されています — ダウンロードは常にアップロードされたオリジナルファイルを提供します"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "このルールのオプションコンテキスト"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "IAS 21に従って資本残高を変換する際に使用される任意の固定レート（期間レートの代わりに）。"
+msgstr "IAS 21 に従って純資産残高を換算する際に使用するオプションの固定レート（期間レートの代わり）。"
 
 msgid "Optional pages & sections"
 msgstr "オプションページとセクション"
@@ -10645,7 +10645,7 @@ msgid "Order Date"
 msgstr "注文日"
 
 msgid "Order Multiple"
-msgstr "注文倍数"
+msgstr "発注倍数"
 
 msgid "Order Parts"
 msgstr "部品を注文"
@@ -10657,7 +10657,7 @@ msgid "Order quantities must be whole multiples of this number (a multiple of 12
 msgstr "注文数量はこの数の整数倍である必要があります（12の倍数→12、24、36 …）。"
 
 msgid "Order rules are evaluated in — for discounts only the highest-priority match applies (no stacking); markups all apply and compound in priority order."
-msgstr "注文ルールは順に評価されます — 割引の場合は最も優先度の高い一致のみが適用されます（積み重ね不可）。マークアップはすべて適用され、優先度順に複合されます。"
+msgstr "発注ルールは優先度順に評価されます — 値引では最優先度のマッチのみが適用されます（積み重ねなし）。マークアップはすべて適用され、優先度順に複合します。"
 
 msgid "Order Total"
 msgstr "注文合計"
@@ -10684,16 +10684,16 @@ msgid "Original Count"
 msgstr "元のカウント"
 
 msgid "Other Expense"
-msgstr "その他費用"
+msgstr "営業外費用"
 
 msgid "Other Income"
-msgstr "その他収益"
+msgstr "営業外収益"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "支払いが外貨建て請求書をより有利なレートで決済する場合のFX利益に対するその他の収益勘定"
+msgstr "支払が外貨請求書をより有利なレートで決済する場合の為替差益のための営業外収益勘定"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "仕入先残高が全額支払いなしでAP決済時にクリアされた場合のその他の収益勘定"
+msgstr "買掛金決済で全額支払いなしに仕入先残高がクリアされる場合の営業外収益勘定"
 
 msgid "Other Type"
 msgstr "その他のタイプ"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "出力"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "出力は原材料より長く持ちません。入力に有効期限がない場合は、固定期間にフォールバックします。"
+msgstr "製品は原材料より長く保持されることはありません。入力に使用期限がない場合は、固定期間にフォールバックします。"
 
 msgid "Outside operation"
 msgstr "間接費差異"
@@ -10726,37 +10726,37 @@ msgid "Overdue"
 msgstr "期限超過"
 
 msgid "Overhead Absorption"
-msgstr "製造間接費吸収"
+msgstr "間接費配賦"
 
 msgid "Overhead Absorption (default)"
-msgstr "製造間接費吸収（デフォルト）"
+msgstr "間接費配賦（デフォルト）"
 
 msgid "Overhead rate"
 msgstr "間接費率"
 
 msgid "Overhead Rate"
-msgstr "オーバーヘッドレート"
+msgstr "間接費レート"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "オーバーヘッドレート（時間単位）"
+msgstr "間接費レート（時間あたり）"
 
 msgid "Overhead Variance"
 msgstr "間接費差異（デフォルト）"
 
 msgid "Overhead Variance (default)"
-msgstr "所有者（コストセンター）"
+msgstr "間接費差異（デフォルト）"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "オーバーライドには inventory:update 権限と理由が必要です。"
+msgstr "上書きにはinventory:update権限と理由が必要です。"
 
 msgid "Override Price"
 msgstr "上書き価格"
 
 msgid "Override price for a single customer"
-msgstr "単一の顧客の価格をオーバーライドする"
+msgstr "単一の得意先の価格を上書きする"
 
 msgid "Override price for all customers of a type"
-msgstr "すべての顧客タイプの価格をオーバーライドする"
+msgstr "得意先タイプのすべての得意先の価格を上書きする"
 
 msgid "Override the expiration on {label}."
 msgstr "有効期限を {label} で上書きします。"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "見積方法でターゲット製造方法を上書きします"
 
 msgid "Owner"
-msgstr "所有者"
+msgstr "責任者"
 
 msgid "Owner (cost center)"
-msgstr "親コストセンター"
+msgstr "責任者 (原価センター)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10808,16 +10808,16 @@ msgid "Parameters"
 msgstr "パラメータ"
 
 msgid "Parameters are inherited from the procedure."
-msgstr "パラメータは手順から継承されます。"
+msgstr "パラメータは手順書から継承されます。"
 
 msgid "Params"
 msgstr "パラメータ"
 
 msgid "Parent cost center"
-msgstr "部品"
+msgstr "親原価センター"
 
 msgid "Parent Cost Center"
-msgstr "親コストセンター"
+msgstr "親原価センター"
 
 msgid "Parent Department"
 msgstr "親部門"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "エラーとして保留"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "値がマップされるまで、ジャーナルに警告を付けて保留します"
+msgstr "値がマッピングされるまで警告付きで仕訳を保留する"
 
 msgid "part"
 msgstr "部品"
@@ -10862,10 +10862,10 @@ msgid "Part Number"
 msgstr "部品番号"
 
 msgid "Part Supersession"
-msgstr "パーツの廃止予定"
+msgstr "部品後継切替"
 
 msgid "Partial"
-msgstr "部分"
+msgstr "一部"
 
 msgid "Partner"
 msgstr "パートナー"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "パートナー"
 
 msgid "parts"
-msgstr "買掛金"
+msgstr "部品"
 
 msgid "Parts"
 msgstr "部品"
@@ -10892,7 +10892,7 @@ msgid "Pass"
 msgstr "合格"
 
 msgid "Passed"
-msgstr "完了"
+msgstr "合格"
 
 msgid "Passkey name"
 msgstr "パスキー名"
@@ -10919,10 +10919,10 @@ msgid "Payables (AP)"
 msgstr "買掛金 (AP)"
 
 msgid "Payables (default)"
-msgstr "支払条件"
+msgstr "買掛金 (デフォルト)"
 
 msgid "Payables aging"
-msgstr "支払い債務の経過"
+msgstr "買掛金経過日数"
 
 msgid "Payment"
 msgstr "支払い"
@@ -10946,25 +10946,25 @@ msgid "Payment Term"
 msgstr "支払条件"
 
 msgid "payment terms"
-msgstr "人"
+msgstr "支払条件"
 
 msgid "Payment Terms"
 msgstr "支払条件"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "Net 30などの支払い条件または領収書時の支払い"
+msgstr "Net 30のような支払条件または領収時に支払い"
 
 msgid "Payments"
 msgstr "支払い"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "このインボイスに適用された支払いとクレジット。行をクリックしてソースドキュメントを開きます。"
+msgstr "この請求書に充当された支払と調整額。行をクリックして参照伝票を開きます。"
 
 msgid "PDF"
 msgstr "PDF"
 
 msgid "PDF (Document)"
-msgstr "PDF（ドキュメント）"
+msgstr "PDF (文書)"
 
 msgid "PDF downloaded"
 msgstr "PDFをダウンロードしました"
@@ -10979,22 +10979,22 @@ msgid "PDF Watermark"
 msgstr "PDF透かし"
 
 msgid "Pending"
-msgstr "保留中"
+msgstr "待機中"
 
 msgid "people"
-msgstr "固定資産の定期的な減価償却費"
+msgstr "人員"
 
 msgid "People"
-msgstr "人"
+msgstr "人員"
 
 msgid "Per Unit"
 msgstr "単位あたり"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "注文ヘッダーの配送場所の行ごとのオーバーライド。分割出荷とドロップシップに使用されます。"
+msgstr "注文ヘッダーの出荷拠点を行ごとに上書き。分割出荷と直送に使用。"
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "POヘッダーの配送場所の行ごとのオーバーライド。複数の倉庫への分割配送またはドロップシップに使用されます。"
+msgstr "発注書ヘッダーの配送先拠点を行ごとに上書き。複数倉庫への分割配送または直送に使用。"
 
 msgid "Percentage"
 msgstr "パーセンテージ"
@@ -11015,13 +11015,13 @@ msgid "Period lock policy"
 msgstr "期間ロックポリシー"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "ピッキングは追跡対象エンティティを最も早い有効期限順に提供するため、デフォルトで最初に期限切れになる在庫が最初に出庫されます。"
+msgstr "固定資産の定期的な減価償却費"
 
 msgid "Permanently Delete"
 msgstr "完全に削除"
 
 msgid "Permission groups for granting access in bulk"
-msgstr "一括でアクセス権を付与するためのパーミッショングループ"
+msgstr "アクセスを一括付与するための権限グループ"
 
 msgid "Permissions"
 msgstr "権限"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "フェーズ期間"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "古いアイテムの需要を後継部品にリダイレクトするため、アイテムを段階的に廃止します。変換係数を乗じて新しいアイテムに転送されます。"
+msgstr "品目を後継品目に切り替える。計画は旧品目の所要量に換算係数を乗じて新品目にリダイレクトします。"
 
 msgid "Phone"
 msgstr "電話"
@@ -11060,7 +11060,7 @@ msgid "Pick a column to sort by"
 msgstr "ソート対象の列を選択"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "顧客または顧客タイプを選択して、その価格を表示します。"
+msgstr "得意先または得意先タイプを選択して価格設定を表示。"
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "日付を選択するか、空白のままにしてクリアしてください。"
@@ -11114,13 +11114,13 @@ msgid "Picking List ID"
 msgstr "ピッキングリストID"
 
 msgid "Picking List Notes"
-msgstr "ピッキングリストノート"
+msgstr "ピッキングリストのメモ"
 
 msgid "Picking Lists"
 msgstr "ピッキングリスト"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "計画済み"
+msgstr "ピッキングは追跡対象品目を使用期限が最も近い順に提供するため、期限切れが最も近い在庫がデフォルトで最初に出荷されます。"
 
 msgid "Pieces/Hour"
 msgstr "個/時間"
@@ -11164,7 +11164,7 @@ msgid "Planned Order"
 msgstr "計画注文"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "計画注文 = 品目の発注ポリシー（または手動で追加）に基づいて予測需要をカバーするためのMRP提案。"
+msgstr "計画済注文 = 品目の発注ポリシーに基づいて予測所要量をカバーするためのMRP提案(または手動追加)。"
 
 msgid "Planned purchase order"
 msgstr "計画済み発注書"
@@ -11182,7 +11182,7 @@ msgid "Planning rounds suggested replenishment up to a whole multiple of this nu
 msgstr "計画ラウンドは、この数の整数倍まで補充を提案しました。"
 
 msgid "Planning's lower bound on a suggested replenishment quantity; distinct from a supplier's MOQ, which lives on the supplier-part record."
-msgstr "提案された補充数量の計画の下限；サプライヤーの部品レコードに存在するサプライヤーのMOQとは異なります。"
+msgstr "計画の発注提案数量の下限。仕入先部品レコードにある仕入先のMOQとは別。"
 
 msgid "Planning's upper bound on a single suggested replenishment; quantities above this are split into multiple orders."
 msgstr "単一の提案された補充に対する計画の上限。これを超える数量は複数の注文に分割されます。"
@@ -11191,7 +11191,7 @@ msgid "Plants, warehouses"
 msgstr "工場、倉庫"
 
 msgid "Please contact your administrator to enable audit logging."
-msgstr "管理者に連絡して監査ログを有効にしてください。"
+msgstr "監査ログを有効化するには、管理者にお問い合わせください。"
 
 msgid "Please enter your email address"
 msgstr "メールアドレスを入力してください"
@@ -11230,7 +11230,7 @@ msgid "Policy"
 msgstr "ポリシー"
 
 msgid "Policy & Procedure"
-msgstr "ポリシーと手順"
+msgstr "ポリシーと手順書"
 
 msgid "Portal Link"
 msgstr "ポータルリンク"
@@ -11251,13 +11251,13 @@ msgid "Post Invoice"
 msgstr "請求書を転記"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "適切なアカウントと説明コードを使用してジャーナルエントリを転記する"
+msgstr "適切なアカウントと説明コードを使用して仕訳を転記する"
 
 msgid "Post Receipt"
 msgstr "領収書を転記"
 
 msgid "Post Shipment"
-msgstr "配送を転記"
+msgstr "出荷を転記する"
 
 msgid "Postal code"
 msgstr "郵便番号"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "投稿者"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "これらのソースタイプで転記された仕訳は常に同期されます。日次サマリーは、1日の仕訳をアカウントごとに1つのプロバイダーエントリにグループ化します。"
+msgstr "これらのソースタイプの転記済仕訳は常に同期されます。毎日サマリーは1日の仕訳を勘定科目ごとに1つのプロバイダーエントリにグループ化します。"
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "1回投稿され、{corrections}回訂正されました。"
@@ -11290,19 +11290,19 @@ msgid "Posted once, no corrections."
 msgstr "1回投稿され、訂正はありません。"
 
 msgid "Posting"
-msgstr "前払金"
+msgstr "転記"
 
 msgid "Posting date"
-msgstr "投稿日"
+msgstr "転記日付"
 
 msgid "Posting Date"
-msgstr "投稿日"
+msgstr "転記日付"
 
 msgid "Potential Data Loss"
 msgstr "潜在的データ損失"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "有効期限が固定期間の場合、新しい品目に対して事前入力されます。"
+msgstr "使用期限が固定期間の場合、新規品目に対して事前入力されます。"
 
 msgid "Preferred Supplier"
 msgstr "優先仕入先"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "前払金（デフォルト）"
 
 msgid "Prepayments (default)"
-msgstr "予防措置"
+msgstr "前払金 (デフォルト)"
 
 msgid "Present Week"
 msgstr "今週"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "前へ"
 
 msgid "Preventive action"
-msgstr "手持ち在庫評価の主要アカウント"
+msgstr "予防アクション"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "あなたの機器の予防保全スケジュール"
+msgstr "設備の予防保全スケジュール"
 
 msgid "Preview"
 msgstr "プレビュー"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "以前の{0}の値"
 
 msgid "Price break actions"
-msgstr "価格ブレークアクション"
+msgstr "価格スケールアクション"
 
 msgid "Price Break History"
-msgstr "価格ブレーク履歴"
+msgstr "価格スケール履歴"
 
 msgid "Price Breaks"
-msgstr "価格ブレーク"
+msgstr "価格スケール"
 
 msgid "Price List"
 msgstr "価格リスト"
@@ -11372,7 +11372,7 @@ msgid "Price Lists"
 msgstr "価格リスト"
 
 msgid "Price override"
-msgstr "価格オーバーライド"
+msgstr "価格上書き"
 
 msgid "Prices"
 msgstr "価格"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "価格設定ルール"
 
 msgid "Pricing Trace"
-msgstr "価格トレース"
+msgstr "価格設定トレース"
 
 msgid "Primary cash account for bank transactions"
-msgstr "手順"
+msgstr "銀行取引の主要な現金勘定"
 
 msgid "Print"
 msgstr "印刷"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "{0}個のラベルを印刷"
 
 msgid "Print Jobs"
-msgstr "印刷ジョブ"
+msgstr "製造指図の印刷"
 
 msgid "Print Label"
 msgstr "ラベルを印刷"
@@ -11437,16 +11437,16 @@ msgid "Private"
 msgstr "プライベート"
 
 msgid "procedure"
-msgstr "手順"
+msgstr "手順書"
 
 msgid "Procedure"
-msgstr "手順"
+msgstr "手順書"
 
 msgid "procedures"
-msgstr "プロセス"
+msgstr "手順書"
 
 msgid "Procedures"
-msgstr "手順"
+msgstr "手順書"
 
 msgid "process"
 msgstr "プロセス"
@@ -11488,7 +11488,7 @@ msgid "Production Event"
 msgstr "生産イベント"
 
 msgid "Production Events"
-msgstr "本番イベント"
+msgstr "生産イベント"
 
 msgid "Production planning"
 msgstr "生産計画"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "生産数量"
 
 msgid "Production variance"
-msgstr "BOMs および予測から展開された予測需要。"
+msgstr "生産差異"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "生産: ショップフロアアプリとスケジューリング"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "プロジェクト"
 
 msgid "Project owner"
-msgstr "プロジェクトオーナー"
+msgstr "プロジェクト責任者"
 
 msgid "Project Plan"
 msgstr "プロジェクト計画"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "プロジェクト開始"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "予測在庫"
+msgstr "BOMおよび予測から展開された所要量。"
 
 msgid "Projected inventory"
 msgstr "予測利用可能量"
@@ -11543,14 +11543,14 @@ msgstr "予測在庫"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "{0} の週の安全在庫を下回ると予測"
+msgstr "{0}の週の欠品予測"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "安全在庫を上回ったままと予測"
 
 msgid "Projected to stay above safety stock"
-msgstr "購買注文"
+msgstr "安全在庫を上回ると予測される"
 
 msgid "Projection"
 msgstr "予測"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "予測"
 
 msgid "Promised Date"
-msgstr "約束日"
+msgstr "回答納期"
 
 msgid "Properties"
 msgstr "プロパティ"
@@ -11577,7 +11577,7 @@ msgid "Protect the go-live date"
 msgstr "ゴーライブ日を保護する"
 
 msgid "Protect training time and attend"
-msgstr "トレーニング時間を確保して参加する"
+msgstr "教育訓練の時間を確保して参加する"
 
 msgid "Protects your company's data"
 msgstr "会社データを保護します"
@@ -11608,10 +11608,10 @@ msgid "Published"
 msgstr "公開済み"
 
 msgid "Published by Carbon"
-msgstr "Carbonによって公開"
+msgstr "Carbonによって公開済"
 
 msgid "Published Version"
-msgstr ""
+msgstr "公開済バージョン"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "公開済みバージョンは編集できません。読み取り専用で参照するか、新しいバージョンをブランチして変更してください。"
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "会計から引き出す"
 
 msgid "Pull from Inventory"
-msgstr "在庫から取得"
+msgstr "在庫から引当"
 
 msgid "Pull, map, and load your data"
 msgstr "データをプル、マップ、ロードする"
@@ -11638,55 +11638,55 @@ msgid "Purchase History"
 msgstr "購入履歴"
 
 msgid "Purchase invoice"
-msgstr "購入請求書"
+msgstr "仕入先請求書"
 
 msgid "Purchase Invoice"
-msgstr "購入請求書"
+msgstr "仕入先請求書"
 
 msgid "Purchase Invoice Amount"
-msgstr "購入請求書金額"
+msgstr "仕入先請求書金額"
 
 msgid "Purchase Invoice Line"
-msgstr "購入請求書行"
+msgstr "仕入先請求書明細"
 
 msgid "Purchase Invoices"
-msgstr "購入請求書"
+msgstr "仕入先請求書"
 
 msgid "Purchase order"
-msgstr "購買価格差異"
+msgstr "発注書"
 
 msgid "Purchase Order"
 msgstr "発注書"
 
 msgid "Purchase Order Amount"
-msgstr "購買注文金額"
+msgstr "発注書金額"
 
 msgid "Purchase Order approval rule"
-msgstr "購買注文承認ルール"
+msgstr "発注書承認ルール"
 
 msgid "Purchase Order ID"
-msgstr "購買注文ID"
+msgstr "発注書ID"
 
 msgid "Purchase Order Line"
-msgstr "購買注文行"
+msgstr "発注書明細"
 
 msgid "Purchase Order Location"
-msgstr "購入注文の場所"
+msgstr "発注書拠点"
 
 msgid "Purchase order removed successfully"
-msgstr "購買注文が正常に削除されました"
+msgstr "発注書は正常に削除されました"
 
 msgid "Purchase Order Type"
-msgstr "購買注文タイプ"
+msgstr "発注書種別"
 
 msgid "Purchase Orders"
-msgstr "購入注文"
+msgstr "発注書"
 
 msgid "Purchase Orders and Planning"
 msgstr "発注書と計画"
 
 msgid "Purchase orders required"
-msgstr "購入注文が必要です"
+msgstr "発注書が必要です"
 
 msgid "Purchase planning"
 msgstr "購買計画"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "購買価格差異（デフォルト）"
 
 msgid "Purchase Price Variance (default)"
-msgstr "仕入税金支払い"
+msgstr "仕入価格差異（デフォルト）"
 
 msgid "Purchase Qty"
 msgstr "購入数量"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "仕入税金支払い（デフォルト）"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "購買"
+msgstr "仕入税支払相当額（デフォルト）"
 
 msgid "Purchase to Order"
-msgstr "購入注文"
+msgstr "受注購買"
 
 msgid "Purchase Unit of Measure"
 msgstr "購入単位"
@@ -11755,10 +11755,10 @@ msgid "Push it re-dated to the first open day, keeping the original date in the 
 msgstr "元の日付を説明に保持しながら、最初の開いている日に再日付してプッシュする"
 
 msgid "Push record changes to external systems the moment they happen."
-msgstr "レコードの変更が発生した瞬間に外部システムにプッシュします。"
+msgstr "レコードの変更が発生した直後に社外システムにプッシュします。"
 
 msgid "Push the journal without the dimension"
-msgstr "ディメンションなしでジャーナルをプッシュ"
+msgstr "ディメンションなしで仕訳を転記する"
 
 msgid "Push to accounting"
 msgstr "会計にプッシュ"
@@ -11768,10 +11768,10 @@ msgstr "データを復元中"
 
 #. placeholder {0}: row.original.replenishmentSystem === "Make" ? "Job" : "Order"
 msgid "QR Code to create a {0} for this kanban"
-msgstr "このカンバンの{0}を作成するためのQRコード"
+msgstr "このかんばんの{0}を作成するためのQR Code"
 
 msgid "QR Code to start the next operation for this kanban"
-msgstr "このカンバンの次の操作を開始するためのQRコード"
+msgstr "このかんばんの次の工程を開始するためのQR Code"
 
 msgid "Qty"
 msgstr "数量"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "数量。スクラップ"
 
 msgid "quality"
-msgstr "見積から現金まで"
+msgstr "品質"
 
 msgid "Quality"
 msgstr "品質"
@@ -11804,7 +11804,7 @@ msgid "Quality Document approval rule"
 msgstr "品質文書承認ルール"
 
 msgid "Quality Documents"
-msgstr "品質文書"
+msgstr "品質ドキュメント"
 
 msgid "Quality Type"
 msgstr "品質タイプ"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "入荷予定数量 — 未処理の発注書および生産（製造）注文の分。"
 
 msgid "Quantity Breaks"
-msgstr "数量ブレーク"
+msgstr "数量スケール"
 
 msgid "Quantity complete"
 msgstr "完了数量"
@@ -11831,7 +11831,7 @@ msgid "Quantity Completed"
 msgstr "完了数量"
 
 msgid "Quantity in transit to the storage unit via open stock transfers."
-msgstr "未処理の在庫転送によって保管単位へ輸送中の数量。"
+msgstr "保管ユニットへ輸送中の数量（オープンな在庫転送経由）"
 
 msgid "Quantity is derived from completed serials/batches in MES and cannot be edited."
 msgstr "数量はMESで完了したシリアル/バッチから導出されており、編集することはできません。"
@@ -11840,28 +11840,28 @@ msgid "Quantity must be greater than 0"
 msgstr "数量は0より大きい必要があります"
 
 msgid "Quantity on hand"
-msgstr "手持ち数量"
+msgstr "現在庫数"
 
 msgid "Quantity on Hand"
-msgstr "手持在庫数量"
+msgstr "現在庫数"
 
 msgid "Quantity on Jobs"
-msgstr "ジョブの数量"
+msgstr "製造指図における数量"
 
 msgid "Quantity on Purchase Order"
-msgstr "購買注文数量"
+msgstr "発注書上の数量"
 
 msgid "Quantity on Sales Order"
-msgstr "販売注文の数量"
+msgstr "受注上の数量"
 
 msgid "Quantity Per Job"
 msgstr "ジョブあたりの数量"
 
 msgid "Quantity per Parent"
-msgstr "親あたりの数量"
+msgstr "員数"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "材料に割り当てられた保管単位（棚）に物理的にある数量。その単位が供給すべき量を下回ると赤くなります。"
+msgstr "材料に割り当てられた保管ユニット（棚）の物理的在庫数。その保管ユニットの供給必要数量以下の場合は赤く表示されます。"
 
 msgid "Quantity Range"
 msgstr "数量範囲"
@@ -11882,44 +11882,44 @@ msgid "Quantity Type"
 msgstr "数量タイプ"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "このオーバーライドの数量ベースの価格設定層。適用される単価は、注文行を満たす最大最小数量の行です。"
+msgstr "この上書きの数量ベース価格設定段階。適用される単価は、注文明細が満たす最大最小数量の行です。"
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
 msgstr "数量: {0}"
 
 msgid "Quarterly"
-msgstr "四半期"
+msgstr "四半期ごと"
 
 msgid "Question"
 msgstr "質問"
 
 msgid "Queued"
-msgstr "待機中"
+msgstr "キュー待ち"
 
 msgid "Quote"
 msgstr "見積"
 
 msgid "Quote Accepted By"
-msgstr "見積受け入れ者"
+msgstr "見積承諾者"
 
 msgid "Quote Accepted By Email"
-msgstr "見積受け入れ者メール"
+msgstr "見積承諾者メール"
 
 msgid "Quote expired"
-msgstr "見積書の有効期限が切れました"
+msgstr "見積期限切れ"
 
 msgid "Quote ID"
 msgstr "見積ID"
 
 msgid "Quote line"
-msgstr "見積行"
+msgstr "見積明細"
 
 msgid "Quote Line"
-msgstr "見積行"
+msgstr "見積明細"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "このアイテムが部品表に含まれる見積行"
+msgstr "この品目を含む部品表を持つ見積明細"
 
 msgid "Quote Location"
 msgstr "見積もりロケーション"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "見積番号"
 
 msgid "Quote to cash"
-msgstr "売掛金"
+msgstr "見積から現金へ"
 
 msgid "Quote Type"
 msgstr "見積タイプ"
@@ -11949,13 +11949,13 @@ msgid "Quotes"
 msgstr "見積"
 
 msgid "Quoting and sales orders"
-msgstr "見積と販売注文"
+msgstr "見積と受注"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "見積、注文、構成注文"
 
 msgid "Raise it at the weekly status call"
-msgstr "週次ステータスコールで提起する"
+msgstr "毎週のステータスミーティングで提起してください"
 
 msgid "raise it early and raise it plainly. A problem named in week 2 is a small fix; the same problem at go-live is a delay."
 msgstr "早期に報告し、明確に報告してください。2週目に特定された問題は小さな修正で済みますが、本番リリース時の同じ問題は遅延につながります。"
@@ -11994,22 +11994,22 @@ msgid "Readable"
 msgstr "読み取り可能"
 
 msgid "Readable ID"
-msgstr "判読可能なID"
+msgstr "表示ID"
 
 msgid "Readable id with revision"
-msgstr "リビジョン付き読み取り可能ID"
+msgstr "リビジョン付き表示ID"
 
 msgid "Reading the document..."
-msgstr "ドキュメントを読み込み中..."
+msgstr "文書を読み込み中です..."
 
 msgid "Ready"
 msgstr "準備完了"
 
 msgid "Ready for Quote"
-msgstr "見積もり準備完了"
+msgstr "見積準備完了"
 
 msgid "ready to keep or revert"
-msgstr "保持またはリバート可能"
+msgstr "保持または復元の準備完了"
 
 msgid "Real-time inventory and shop-floor visibility"
 msgstr "リアルタイム在庫と工場フロアの可視性"
@@ -12042,7 +12042,7 @@ msgid "Reasons"
 msgstr "理由"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "このロウから別の処分ロウに特定の追跡対象エンティティを再割り当てします。"
+msgstr "この行から特定の追跡対象を別の処置行に再割り当てします。"
 
 msgid "Recalculate"
 msgstr "再計算"
@@ -12066,16 +12066,16 @@ msgid "Receipt Lines"
 msgstr "領収書行"
 
 msgid "Receipt Promised Date"
-msgstr "受取予定日"
+msgstr "入荷回答納期"
 
 msgid "Receipt Requested Date"
-msgstr "受取要求日"
+msgstr "入荷希望納期"
 
 msgid "Receipts"
 msgstr "領収書"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "受領書、出荷、売上請求書、仕入請求書、支払、および貸方/借方メモがまだ下書きまたは保留中の場合は、転記するか無効にする必要があります。当期に日付が付けられた書類と、転記時に当期の日付を受け取る無日付書類の両方を含みます。これらが転記されるまで、それらの金額は総勘定元帳に含まれないため、当期は過小評価されます。"
+msgstr "入荷、出荷、売上請求書、仕入先請求書、支払、およびクレジット/デビットメモは、まだ下書きまたは待機中である場合は、転記または取消される必要があります。この期間に日付けられた文書と、転記時にこの期間に日付けを受け取る無期限文書の両方。転記されるまで、それらの金額は総勘定元帳に含まれていないため、期間が過少計上されます。"
 
 msgid "Receivables"
 msgstr "売掛金（デフォルト）"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "売掛金 (AR)"
 
 msgid "Receivables (default)"
-msgstr "購買注文を受け取った内容と請求内容で調整する — Carbon に暗黙的に含まれており、行数量と GR/IR 残高を通じて。"
+msgstr "売掛金（デフォルト）"
 
 msgid "Receivables aging"
 msgstr "売掛金の経過"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "受け取り数量"
 
 msgid "Receiving Location"
-msgstr "受取場所"
+msgstr "入荷拠点"
 
 msgid "Recent"
 msgstr "最近"
@@ -12145,16 +12145,16 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "調整でプロバイダとの不一致が見つかりました"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "回収期間"
+msgstr "購買発注書と受領および請求内容の照合。Carbonで暗黙的に実行されます。明細数量とGR/IR残高を使用します。"
 
 msgid "Record"
 msgstr "記録"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "顧客またはサプライヤーに対するクレジットまたはデビットメモを記録します。特定の請求書への適用は、メモが作成された後に追加されます。"
+msgstr "得意先または仕入先に対して貸方メモまたは借方メモを記録する。特定の請求書への適用はメモ作成後に追加される。"
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "顧客から受け取った現金（領収書）または仕入先に支払った現金（支払）を記録します。特定の請求書への適用は、支払が作成された後に追加されます。"
+msgstr "得意先から受け取った現金（受取）または仕入先に支払った現金（出金）を記録する。特定の請求書への適用は支払作成後に追加される。"
 
 msgid "Record deleted"
 msgstr "レコード削除済み"
@@ -12166,13 +12166,13 @@ msgid "Record type"
 msgstr "レコード種別"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "キャリブレーション時に、ゲージの読み値を信頼できるようになる前に修理が必要であることが記録されました。"
+msgstr "この校正で、測定器の読み取り値を信頼できる前に修理が必要であることを記録した。"
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "このキャリブレーション後にフォローアップが必要であることを記録しました。このゲージをオープンアクションキューに表示します。"
+msgstr "この校正後にフォローアップが必要であることを記録した。この測定器をオープンアクションキューに表示する。"
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "このキャリブレーション中にゲージが調整されたことが記録されました。キャリブレーション間隔の再計算に影響します。"
+msgstr "この校正中に測定器が調整されたことを記録した。校正周期の再計算方法に影響を与える。"
 
 msgid "Records"
 msgstr "記録"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "検証ページにリダイレクト中..."
 
 msgid "Reduced"
-msgstr "削減"
+msgstr "ゆるい検査"
 
 msgid "Reference"
 msgstr "参照"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "登録済み"
 
 msgid "Registered"
-msgstr "再注文点"
+msgstr "登録済"
 
 msgid "Registration failed"
 msgstr "登録に失敗しました"
@@ -12241,7 +12241,7 @@ msgid "Relative timeline · dates set in Setup & Controls"
 msgstr "相対タイムライン · 日付はセットアップとコントロールで設定されています"
 
 msgid "Relative timeline · dates to be confirmed"
-msgstr "相対的なタイムライン · 日付は確認待ちです"
+msgstr "相対的なタイムライン · 確認待ちの日付"
 
 msgid "Release"
 msgstr "リリース"
@@ -12268,7 +12268,7 @@ msgid "Released revision"
 msgstr "リリースされたリビジョン"
 
 msgid "Released revision is locked"
-msgstr "リリースされたリビジョンはロックされています"
+msgstr "発行済みリビジョンはロック中です"
 
 msgid "Remaining"
 msgstr "残高"
@@ -12280,68 +12280,68 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "このPINを覚えておいてください。MES端末でコンソールモードを終了するために必要になります。"
 
 msgid "Remove"
-msgstr "削除"
+msgstr "除去"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "{0}を削除"
+msgstr "{0}を除去"
 
 msgid "Remove {label}"
-msgstr "{label}を削除"
+msgstr "{label}を除去"
 
 msgid "Remove authenticator app"
-msgstr "認証器アプリを削除"
+msgstr "認証アプリを除去"
 
 msgid "Remove clause"
-msgstr "句を削除"
+msgstr "条項を除去"
 
 msgid "Remove condition"
-msgstr "条件を削除"
+msgstr "条件を除去"
 
 msgid "Remove filter"
-msgstr "フィルターを削除"
+msgstr "絞り込みを除去"
 
 msgid "Remove Filters"
-msgstr "フィルターを削除"
+msgstr "絞り込みを除去"
 
 msgid "Remove from Price List"
-msgstr "価格リストから削除"
+msgstr "価格リストから除去"
 
 msgid "Remove line"
-msgstr "行を削除"
+msgstr "明細を除去"
 
 msgid "Remove order"
-msgstr "注文を削除"
+msgstr "注文を除去"
 
 msgid "Remove pair"
-msgstr "ペアを削除"
+msgstr "ペアを除去"
 
 msgid "Remove part"
-msgstr "部品を削除"
+msgstr "部品を除去"
 
 msgid "Remove path"
-msgstr "パスを削除"
+msgstr "パスを除去"
 
 msgid "Remove row"
-msgstr "行を削除"
+msgstr "行を除去"
 
 msgid "Remove slide"
-msgstr "スライドを削除"
+msgstr "スライドを除去"
 
 msgid "Remove slot"
-msgstr "スロットを削除"
+msgstr "スロットを除去"
 
 msgid "Remove sort by column"
-msgstr "列でソートを削除"
+msgstr "列でのソートを除去"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "このストレージタイプをすべての参照ストレージユニットから削除し、削除します。これは元に戻すことはできません。"
+msgstr "この保管タイプをすべての参照する保管ユニットから除去して削除する。これは元に戻せません。"
 
 msgid "Remove tool"
-msgstr "ツールを削除"
+msgstr "工具を除去"
 
 msgid "Remove two-factor authentication"
-msgstr "二要素認証を削除"
+msgstr "二要素認証を除去"
 
 msgid "Removed"
 msgstr "削除済み"
@@ -12357,7 +12357,7 @@ msgid "Rendering label preview..."
 msgstr "ラベルプレビューをレンダリング中..."
 
 msgid "Reopen"
-msgstr "再度開く"
+msgstr "再オープン"
 
 msgid "Reorder"
 msgstr "並び替え"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "グループを並べ替え"
 
 msgid "Reorder point"
-msgstr "再注文点"
+msgstr "発注点"
 
 msgid "Reorder Point"
-msgstr "再注文ポイント"
+msgstr "発注点"
 
 msgid "Reorder Point:"
-msgstr "再注文ポイント:"
+msgstr "発注点:"
 
 msgid "Reorder Policy"
 msgstr "再注文ポリシー"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "リオーダー数量:"
 
 msgid "Reordering policy"
-msgstr "並び替えポリシー"
+msgstr "発注方針"
 
 msgid "Reordering Policy"
-msgstr "再注文ポリシー"
+msgstr "発注方針"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "出荷順序と作業センターのみを並べ替えます — 再スケジュールはしません。日付ボードで日付を変更してください。"
+msgstr "ディスパッチシーケンスと作業区のみを並べ替えます。スケジュール変更は行いません。「日付」ボードで日付を変更してください。"
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "{inputLabel}内の各アイテムに対して1回繰り返します"
@@ -12405,25 +12405,25 @@ msgid "Replace drawing?"
 msgstr "図面を置き換えますか？"
 
 msgid "Replace existing pricing with source values"
-msgstr "既存の価格を元の値に置き換える"
+msgstr "既存の価格設定をソース値で置き換える"
 
 msgid "Replace PDF"
 msgstr "PDFを置き換える"
 
 msgid "Replace this company's data with a demo dataset — snapshotted first, so you can revert."
-msgstr "このコンパニーのデータをデモデータセットで置き換えます。最初にスナップショットを取得するため、リバートできます。"
+msgstr "この会社のデータをデモデータセットで置き換えます — 最初にスナップショットが取得されるため、元に戻すことができます。"
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "PDFを置き換えると、このドキュメント上のすべてのバルーン配置が削除されます。機能行とその値は保持されます。新しい図面上に再度バルーンを配置できます。"
+msgstr "PDFを置き換えると、このドキュメント上のすべてのバルーン配置が削除されます。機能行とその値は残ります。新しい図面にバルーンを再度配置できます。"
 
 msgid "Replenishment"
 msgstr "補充"
 
 msgid "Replenishment system"
-msgstr "補充システム"
+msgstr "調達方式"
 
 msgid "Replenishment System"
-msgstr "補充システム"
+msgstr "調達方式"
 
 msgid "Report"
 msgstr "レポート"
@@ -12447,28 +12447,28 @@ msgid "Request access"
 msgstr "アクセスをリクエスト"
 
 msgid "Request Approval"
-msgstr "承認をリクエスト"
+msgstr "承認を依頼"
 
 msgid "Requested Date"
-msgstr "リクエスト日"
+msgstr "希望納期"
 
 msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "サインイン時に認証器アプリから6桁のコードが必要です。"
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
-msgstr "このコンパニーを開く前に認証アプリが必須になります。他のコンパニーには影響しません。<0>従業員アカウントページ</0>をご覧ください。"
+msgstr "このアプリケーション認証器を要求して、誰もがこの会社を開く前に認証を要求します。他の会社は影響を受けません。<0>従業員アカウントページ</0>にアクセスして、各個人のステータスを確認してください。"
 
 msgid "Require approval before suppliers can be set to Active"
-msgstr "サプライヤーをアクティブに設定する前に承認が必要です"
+msgstr "仕入先を有効に設定する前に承認が必要です"
 
 msgid "Require approval for purchase orders based on amount thresholds"
-msgstr "金額閾値に基づいて購買注文の承認を要求する"
+msgstr "金額の閾値に基づいて発注書の承認が必要です"
 
 msgid "Require approval for quality documents in your workflow"
-msgstr "ワークフロー内の品質文書の承認が必要です"
+msgstr "ワークフローの品質ドキュメントについて承認が必要です"
 
 msgid "Require two-factor authentication"
-msgstr "2要素認証が必須"
+msgstr "二要素認証が必要です"
 
 msgid "Required"
 msgstr "必須"
@@ -12486,22 +12486,22 @@ msgid "Required Actions (in order)"
 msgstr "必要なアクション（順番に）"
 
 msgid "Required Date"
-msgstr "必須日付"
+msgstr "所要日"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "管理された環境では必須です。監査ログはオフにできません。"
 
 msgid "Requirement"
-msgstr "要件"
+msgstr "要求事項"
 
 msgid "Requirements"
-msgstr "要件"
+msgstr "要求事項"
 
 msgid "Requirements & Process Map"
-msgstr "要件とプロセスマップ"
+msgstr "要求事項と工法マップ"
 
 msgid "Requirements and Process Map"
-msgstr "要件とプロセスマップ"
+msgstr "要求事項と工法マップ"
 
 msgid "Requires Action"
 msgstr "対応が必要"
@@ -12516,7 +12516,7 @@ msgid "Reserve floor"
 msgstr "予備床"
 
 msgid "Reserved"
-msgstr "予約済み"
+msgstr "引当済"
 
 msgid "Reset"
 msgstr "リセット"
@@ -12535,19 +12535,19 @@ msgstr "2要素認証をリセット"
 #. placeholder {0}: user.firstName
 #. placeholder {1}: user.lastName
 msgid "Reset two-factor authentication for {0} {1}"
-msgstr "{0} {1}の2要素認証をリセット"
+msgstr "{0} {1}の二要素認証をリセット"
 
 msgid "Reset view"
 msgstr "ビューをリセット"
 
 msgid "Residual value"
-msgstr "残存価値"
+msgstr "残存価額"
 
 msgid "Residual Value %"
-msgstr "残存価値 %"
+msgstr "残存価額 %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "NCRを完了する前にこれらを解決してください。すべての行は保留中以外の処分を持つ必要があり、リンクされたエンティティの数量は行の数量と一致する必要があります。"
+msgstr "NCRを完了する前にこれらを解決してください。すべての行に保留中ではない処置が必要で、リンクされたエンティティの数量は行の数量と一致する必要があります。"
 
 msgid "Resolved Price"
 msgstr "解決済み価格"
@@ -12589,7 +12589,7 @@ msgid "Retained Earnings (default)"
 msgstr "利益剰余金 (既定)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
-msgstr "除却または売却により資産を稼働から除外し、正味簿価に対する損益を計上したうえで、そのステータスを「処分済み」に設定すること。"
+msgstr "スクラップまたは販売により資産をサービスから除却し、利益または損失を未償却残高に対して計上し、ステータスを除却済に設定します。"
 
 msgid "Retry"
 msgstr "再試行"
@@ -12616,34 +12616,34 @@ msgid "Rev {revision}"
 msgstr "Rev {revision}"
 
 msgid "Revenue"
-msgstr "売上"
+msgstr "売上高"
 
 msgid "Revenue and expenses over a period"
-msgstr "期間にわたる収益と費用"
+msgstr "期間中の売上高と費用"
 
 msgid "Reverse all inventory adjustments"
 msgstr "すべての在庫調整を取り消す"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "すべての仕訳帳とコスト台帳エントリを取り消す"
+msgstr "すべての仕訳と原価台帳の仕訳を反対仕訳する"
 
 msgid "Reverse any item ledger entries from this invoice"
-msgstr "このインボイスからのアイテム台帳エントリをすべて取り消す"
+msgstr "この請求書の品目台帳の仕訳をすべて反対仕訳する"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "逆請求"
 
 msgid "Reverse Charge Sales Tax"
-msgstr "逆請求売上税"
+msgstr "リバースチャージ売上税"
 
 msgid "Reverse Charge Sales Tax (default)"
-msgstr "逆請求売上税 (既定)"
+msgstr "リバースチャージ売上税（デフォルト）"
 
 msgid "Reverse the related journal entries"
 msgstr "関連する仕訳エントリを取り消す"
 
 msgid "Reversed"
-msgstr "反転"
+msgstr "反対仕訳済"
 
 msgid "Revert"
 msgstr "リバート"
@@ -12652,19 +12652,19 @@ msgid "Reverting"
 msgstr "リバート中"
 
 msgid "Review"
-msgstr "確認"
+msgstr "レビュー"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "各アイテムの変更をレビューしてから確認してください。リリースは取り消せません。"
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "当期の貸借対照表と損益計算書を確認し、数字が正しいことを確認してください。これは手動による認可です。確認後、完了とマークしてください。"
+msgstr "期間の貸借対照表と損益計算書をレビューして、数字が正しいことを確認してください。これは手動の承認です。レビュー後、完了にマークしてください。"
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "適用する前に提案されたマッチを確認します。これらは最良の推測です—各マッチが正しいことを確認します。"
+msgstr "適用する前に提案されたマッチをレビューしてください。これらは最善の推測です。各項目が正しいことを確認してください。"
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "下の警告を確認してから、カウントを投稿して調整を適用してください。"
+msgstr "下の警告を確認してから、カウントを転記して調整を適用してください。"
 
 msgid "Revision"
 msgstr "リビジョン"
@@ -12689,22 +12689,22 @@ msgid "Revoke Invites"
 msgstr "招待を取り消す"
 
 msgid "Rework"
-msgstr "再作業"
+msgstr "手直し"
 
 msgid "RFQ"
 msgstr "RFQ"
 
 msgid "RFQ (request for quote)"
-msgstr "RFQ (見積もり依頼)"
+msgstr "見積依頼（見積依頼）"
 
 msgid "RFQ Date"
 msgstr "RFQ日付"
 
 msgid "RFQ has no customer"
-msgstr "RFQに顧客がありません"
+msgstr "見積依頼に得意先がありません"
 
 msgid "RFQ has no suppliers"
-msgstr "RFQにサプライヤーがありません"
+msgstr "見積依頼に仕入先がありません"
 
 msgid "RFQ ID"
 msgstr "RFQ ID"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "RFQ"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "プッシュされたジャーナルに沿ってCarbonディメンションを含める。各スロットは1つのCarbonディメンションを1つのプロバイダー分析ターゲットにマップします。以下の値マッピングは個々のディメンション値をプロバイダーオプションとペアリングします。"
+msgstr "プッシュされた仕訳と一緒にCarbonディメンションを乗せます。各スロットは、1つのCarbonディメンションを1つのプロバイダー分析ターゲットにマップします。下記の値マッピングは、個別のディメンション値をプロバイダーオプションと対応させます。"
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "丸めアカウント (既定)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "すべてのAP請求書を1つのアドレス（例：企業本社）にルーティングして、個別の購買担当者の代わりに使用します。"
+msgstr "すべての買掛金請求書を、個別の購買担当者の代わりに、1つの住所（例：本社）にルーティングします。"
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "すべてのAR請求書を1つのアドレス（例：企業本部）にルーティングして、個別の場所の代わりに使用します。"
+msgstr "すべての売掛金請求書を、個別の拠点の代わりに、1つの住所（例：本社）にルーティングします。"
 
 msgid "Routing"
-msgstr "ルーティング"
+msgstr "工順"
 
 msgid "rows"
 msgstr "行"
@@ -12780,7 +12780,7 @@ msgid "Rule"
 msgstr "ルール"
 
 msgid "Rule applies to every customer."
-msgstr "ルールはすべての顧客に適用されます。"
+msgstr "ルールはすべての得意先に適用されます。"
 
 msgid "Rule applies to every item."
 msgstr "ルールはすべてのアイテムに適用されます。"
@@ -12792,7 +12792,7 @@ msgid "Rules"
 msgstr "ルール"
 
 msgid "Rules that adjust prices automatically by quantity or customer"
-msgstr "数量または顧客に基づいて価格を自動的に調整するルール"
+msgstr "数量または得意先によって価格を自動調整するルール"
 
 msgid "Rules that decide where each item gets stored"
 msgstr "各アイテムがどこに保存されるかを決定するルール"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "受け入れチェックリストを実行してパスする"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "タブレットでフロアを運用：労働時間を記録、進捗を報告、指示を確認"
+msgstr "タブレットでショップフロアを実行：労務を記録、進捗を報告、指示を確認"
 
 msgid "Run this workflow now?"
 msgstr "このワークフローを今すぐ実行しますか？"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "実行中"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "毎週の需給の後に実行されるインベントリ — ラインです。"
+msgstr "毎週の供給と所要量の後に在庫管理を実行 — 明細"
 
 msgid "Running Total"
 msgstr "実行中の合計"
@@ -12883,37 +12883,37 @@ msgid "Sale Price"
 msgstr "販売価格"
 
 msgid "sales"
-msgstr "売上"
+msgstr "販売"
 
 msgid "Sales"
-msgstr "営業"
+msgstr "販売"
 
 msgid "Sales (default)"
-msgstr "売上 (既定)"
+msgstr "販売（デフォルト）"
 
 msgid "Sales & Quoting"
-msgstr "営業と見積"
+msgstr "販売・見積"
 
 msgid "Sales & Revenue"
-msgstr "売上と収益"
+msgstr "販売・売上高"
 
 msgid "Sales contact"
-msgstr "営業連絡先"
+msgstr "販売担当者"
 
 msgid "Sales Contact"
-msgstr "営業担当者"
+msgstr "販売担当者"
 
 msgid "Sales Discounts"
-msgstr "売上割引"
+msgstr "販売値引"
 
 msgid "Sales Discounts (default)"
-msgstr "売上割引 (既定)"
+msgstr "販売値引（デフォルト）"
 
 msgid "Sales Funnel"
-msgstr "営業ファネル"
+msgstr "販売ファネル"
 
 msgid "Sales invoice"
-msgstr "販売請求書"
+msgstr "売上請求書"
 
 msgid "Sales Invoice"
 msgstr "売上請求書"
@@ -12925,52 +12925,52 @@ msgid "Sales Invoices"
 msgstr "売上請求書"
 
 msgid "Sales Job Notifications"
-msgstr "営業ジョブ通知"
+msgstr "販売製造指図通知"
 
 msgid "Sales order"
-msgstr "販売注文"
+msgstr "受注"
 
 msgid "Sales Order"
-msgstr "販売注文"
+msgstr "受注"
 
 msgid "Sales Order ID"
-msgstr "販売注文ID"
+msgstr "受注ID"
 
 msgid "Sales order line"
-msgstr "販売注文行"
+msgstr "受注明細"
 
 msgid "Sales Order Line"
-msgstr "販売注文行"
+msgstr "受注明細"
 
 msgid "Sales Order Line (job)"
-msgstr "販売注文行（ジョブ）"
+msgstr "受注明細（製造指図）"
 
 msgid "Sales Order Location"
-msgstr "販売注文の場所"
+msgstr "受注拠点"
 
 msgid "Sales Order Number"
-msgstr "販売注文番号"
+msgstr "受注番号"
 
 msgid "Sales Orders"
-msgstr "販売注文"
+msgstr "受注"
 
 msgid "Sales Person"
 msgstr "営業担当者"
 
 msgid "Sales Revenue"
-msgstr "売上収益"
+msgstr "販売売上高"
 
 msgid "Sales Tax Payable"
-msgstr "売上税支払い勘定"
+msgstr "支払い売上税"
 
 msgid "Sales Tax Payable (default)"
-msgstr "売上税支払い勘定 (既定)"
+msgstr "支払い売上税（デフォルト）"
 
 msgid "Sales, Estimator"
-msgstr "営業、見積担当者"
+msgstr "販売、見積担当者"
 
 msgid "Sales, quoting, and configure-to-order"
-msgstr "営業、見積、およびコンフィグレーション・トゥ・オーダー"
+msgstr "販売、見積、設定注文"
 
 msgid "Salesperson"
 msgstr "営業担当者"
@@ -12985,13 +12985,13 @@ msgid "Sample Size"
 msgstr "サンプルサイズ"
 
 msgid "Sampling"
-msgstr "サンプリング"
+msgstr "抜取検査"
 
 msgid "Sampling — Feature {featureLabel}"
-msgstr "サンプリング — 機能 {featureLabel}"
+msgstr "抜取検査 — 機能{featureLabel}"
 
 msgid "Sampling Standard"
-msgstr "サンプリング標準"
+msgstr "抜取検査基準"
 
 msgid "Saturday"
 msgstr "土曜日"
@@ -13009,7 +13009,7 @@ msgid "Save applications"
 msgstr "アプリケーションを保存"
 
 msgid "Save contacts"
-msgstr "連絡先を保存"
+msgstr "担当者を保存"
 
 msgid "Save dimension settings"
 msgstr "ディメンション設定を保存"
@@ -13072,22 +13072,22 @@ msgid "SCAR"
 msgstr "SCAR"
 
 msgid "SCAR (supplier corrective action request)"
-msgstr "SCAR（サプライヤーの是正措置要求）"
+msgstr "SCAR（仕入先是正処置依頼）"
 
 msgid "Schedule"
 msgstr "スケジュール"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "ワークセンター容量に対してジョブをスケジュール"
+msgstr "ワークセンタ容量に対して製造指図をスケジュール"
 
 msgid "Schedule Name"
 msgstr "スケジュール名"
 
 msgid "Scheduled Maintenance"
-msgstr "定期メンテナンス"
+msgstr "計画保全"
 
 msgid "Scheduled Maintenances"
-msgstr "定期メンテナンス"
+msgstr "計画保全"
 
 msgid "Schedules"
 msgstr "スケジュール"
@@ -13111,19 +13111,19 @@ msgid "Scrap"
 msgstr "スクラップ"
 
 msgid "Scrap / Cost of Quality"
-msgstr "スクラップ / 品質コスト"
+msgstr "スクラップ/品質コスト"
 
 msgid "Scrap Percent"
 msgstr "スクラップ率"
 
 msgid "Scrap percentage"
-msgstr "廃棄率"
+msgstr "不良率"
 
 msgid "Scrap Qty"
 msgstr "スクラップ数量"
 
 msgid "Scrap quantity"
-msgstr "廃棄数量"
+msgstr "スクラップ数量"
 
 msgid "Scrap Quantity"
 msgstr "スクラップ数量"
@@ -13132,16 +13132,16 @@ msgid "Scrap Quantity Per Job"
 msgstr "ジョブあたりのスクラップ数量"
 
 msgid "scrap reason"
-msgstr "スクラップ理由"
+msgstr "不良理由"
 
 msgid "Scrap Reason"
-msgstr "スクラップ理由"
+msgstr "不良理由"
 
 msgid "scrap reasons"
-msgstr "スクラップ理由"
+msgstr "不良理由"
 
 msgid "Scrap Reasons"
-msgstr "スクラップ理由"
+msgstr "不良理由"
 
 msgid "Scrapped"
 msgstr "スクラップ済み"
@@ -13165,10 +13165,10 @@ msgid "Search by linear issue title..."
 msgstr "Linear イシュータイトルで検索..."
 
 msgid "Search customers and types..."
-msgstr "顧客とタイプを検索..."
+msgstr "得意先とタイプを検索..."
 
 msgid "Search customers or types..."
-msgstr "顧客またはタイプを検索..."
+msgstr "得意先またはタイプを検索..."
 
 msgid "Search employees..."
 msgstr "従業員を検索..."
@@ -13192,10 +13192,10 @@ msgid "Search list variables…"
 msgstr "リスト変数を検索…"
 
 msgid "Search operations…"
-msgstr "操作を検索…"
+msgstr "工程を検索…"
 
 msgid "Search operators..."
-msgstr "オペレーターを検索..."
+msgstr "作業者を検索..."
 
 msgid "Search parts..."
 msgstr "部品を検索..."
@@ -13210,7 +13210,7 @@ msgid "Search related items..."
 msgstr "関連アイテムを検索..."
 
 msgid "Search suppliers..."
-msgstr "サプライヤーを検索..."
+msgstr "仕入先を検索..."
 
 msgid "Search tools..."
 msgstr "ツールを検索..."
@@ -13240,7 +13240,7 @@ msgid "Security"
 msgstr "セキュリティ"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "顧客の価格設定と条件を決定するセグメント"
+msgstr "得意先の価格設定と条件を決定するセグメント"
 
 msgid "Select"
 msgstr "選択"
@@ -13255,10 +13255,10 @@ msgid "Select a destination"
 msgstr "宛先を選択"
 
 msgid "Select a document"
-msgstr "ドキュメントを選択"
+msgstr "文書を選択"
 
 msgid "Select a new owner"
-msgstr "新しい所有者を選択"
+msgstr "新しい責任者を選択"
 
 msgid "Select a new parent group for this account."
 msgstr "このアカウントの新しい親グループを選択してください。"
@@ -13271,7 +13271,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "プランを選択して開始します。最初の{0}日間は料金がかかりません。いつでも切り替えまたはキャンセルできます。"
 
 msgid "Select a process first to choose its supplier."
-msgstr "サプライヤーを選択するには、まずプロセスを選択してください。"
+msgstr "まず工法を選択して、その仕入先を選択してください。"
 
 msgid "Select a project"
 msgstr "プロジェクトを選択"
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "見積もりを選択"
 
 msgid "Select a quote line"
-msgstr "見積行を選択"
+msgstr "見積明細を選択"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "見積が作成されなかった理由を選択してください。"
@@ -13334,19 +13334,19 @@ msgid "Select at least one line to convert"
 msgstr "変換する行を少なくとも1つ選択してください"
 
 msgid "Select Contact"
-msgstr "連絡先を選択"
+msgstr "担当者を選択"
 
 msgid "Select Customer Status"
-msgstr "顧客ステータスを選択"
+msgstr "得意先ステータスを選択"
 
 msgid "Select Customer Type"
-msgstr "顧客タイプを選択"
+msgstr "得意先タイプを選択"
 
 msgid "Select customer types"
-msgstr "顧客タイプを選択"
+msgstr "得意先タイプを選択"
 
 msgid "Select customers"
-msgstr "顧客を選択"
+msgstr "得意先を選択"
 
 msgid "Select dimension"
 msgstr "ディメンションを選択"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "フィールドを選択"
 
 msgid "Select Gauge"
-msgstr "ゲージを選択"
+msgstr "測定器を選択"
 
 msgid "Select groups or individuals"
 msgstr "グループまたは個人を選択"
@@ -13376,7 +13376,7 @@ msgid "Select invoices in a single currency"
 msgstr "単一通貨の請求書を選択してください"
 
 msgid "Select Item Type"
-msgstr "アイテムタイプを選択"
+msgstr "品目タイプを選択"
 
 msgid "Select items"
 msgstr "アイテムを選択"
@@ -13418,10 +13418,10 @@ msgid "Select surfaces"
 msgstr "サーフェスを選択"
 
 msgid "Select the groups that should complete this training"
-msgstr "このトレーニングを完了する必要があるグループを選択してください"
+msgstr "この教育訓練を完了すべきグループを選択してください"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "この支払いで決済する請求書を選択してください。割引と償却は請求書通貨です。"
+msgstr "この支払いで決済する請求書を選択してください。値引と償却は請求書の通貨で表示されます。"
 
 msgid "Select value"
 msgstr "値を選択"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "自己管理"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "セルフホストまたはマネージド"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "セルフオンボーディング"
 
 msgid "Self-paced"
 msgstr "自習型"
@@ -13470,7 +13470,7 @@ msgid "Send Invites"
 msgstr "招待を送信"
 
 msgid "Send RFQ to Suppliers"
-msgstr "RFQをサプライヤーに送信"
+msgstr "仕入先に見積依頼を送信"
 
 msgid "Send to Carbon"
 msgstr "Carbon に送信"
@@ -13482,7 +13482,7 @@ msgid "Sending defective units back to an earlier operation to be corrected inst
 msgstr "不良ユニットをスクラップするのではなく、以前の操作に戻して修正する。"
 
 msgid "Sends this document for approval before it can go active."
-msgstr "このドキュメントを承認のために送信してから、アクティブにすることができます。"
+msgstr "この文書を有効にする前に承認用に送信します。"
 
 msgid "Sent complete date"
 msgstr "送信完了日"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "メール通知がオンになっている各受信者に送信されます。"
 
 msgid "Sequences"
-msgstr "シーケンス"
+msgstr "採番"
 
 msgid "Serial"
 msgstr "シリアル"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "シリアル / バッチ"
 
 msgid "Serial items require a sales order"
-msgstr "シリアル品は販売注文が必要です"
+msgstr "シリアル品目は受注が必要です"
 
 msgid "Serial Number"
 msgstr "シリアル番号"
@@ -13527,7 +13527,7 @@ msgid "Serial/Batch #"
 msgstr "シリアル/バッチ #"
 
 msgid "Serialize & sell your parts"
-msgstr "パーツをシリアル化して販売する"
+msgstr "部品をシリアル化して販売する"
 
 msgid "service"
 msgstr "サービス"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "ターゲットを設定"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Carbonを貴社の運営方法に合わせてセットアップします：サイト、部品、BOM、プロセス手順、および使用するフローです。"
+msgstr "Carbonを会社の運営方法に合わせてセットアップします：サイト、部品、BOM、工程表、および使用するワークフロー。"
 
 msgid "Set Clock Out"
-msgstr "クロックアウトを設定"
+msgstr "作業終了を設定"
 
 msgid "Set clock-out time"
 msgstr "退勤時刻を設定"
@@ -13572,13 +13572,13 @@ msgid "Set Console PIN"
 msgstr "コンソールPINを設定"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "各コスト カテゴリの新しい見積行のデフォルト マークアップ パーセンテージを設定します"
+msgstr "新しい見積明細の各原価カテゴリのデフォルトマークアップパーセンテージを設定"
 
 msgid "Set demand projection values for each week"
-msgstr "毎週の需要予測値を設定してください"
+msgstr "毎週の所要量予測値を設定"
 
 msgid "Set due date"
-msgstr "期限を設定"
+msgstr "期日を設定"
 
 msgid "Set Pricing"
 msgstr "価格設定"
@@ -13596,7 +13596,7 @@ msgid "Set up two-factor authentication"
 msgstr "二要素認証を設定"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "セットアップ、データ、トレーニング、本番稼働をカバーするステップバイステップの実装プランで会社をセットアップします。"
+msgstr "会社をステップバイステップの実施計画でセットアップします。セットアップ、データ、教育訓練、および本稼働をカバーしています。"
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "インポートツールとLLMの支援を使用して独自のデータをセットアップする"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "セットアップマップ"
 
 msgid "Setup time"
-msgstr "セットアップ時間"
+msgstr "段取り時間"
 
 msgid "Setup Time"
-msgstr "セットアップ時間"
+msgstr "段取り時間"
 
 msgid "Setup unit"
 msgstr "セットアップ単位"
@@ -13663,7 +13663,7 @@ msgid "Share"
 msgstr "共有"
 
 msgid "Share a branded portal link so customers can track their orders and documents."
-msgstr "ブランド化されたポータルリンクを共有して、顧客が注文と書類を追跡できるようにします。"
+msgstr "ブランド化されたポータルリンクを共有して、得意先が注文とドキュメントを追跡できるようにします。"
 
 msgid "Share Link"
 msgstr "リンクを共有"
@@ -13681,13 +13681,13 @@ msgid "Shared Sections"
 msgstr "共有セクション"
 
 msgid "Shelf life"
-msgstr "棚卸し期間"
+msgstr "保存期間"
 
 msgid "Shelf Life (Days)"
-msgstr "棚卸し期間（日数）"
+msgstr "保存期間（日数）"
 
 msgid "Shelf Life Start Process"
-msgstr "棚卸し開始プロセス"
+msgstr "保存期間開始プロセス"
 
 msgid "Shelf-Life"
 msgstr "棚卸し寿命"
@@ -13717,7 +13717,7 @@ msgid "Ship some, stock some"
 msgstr "一部を出荷し、一部を在庫に"
 
 msgid "Ship to Customer"
-msgstr "顧客に出荷"
+msgstr "得意先に出荷する"
 
 msgid "Ship-From Location"
 msgstr "発送元の場所"
@@ -13729,16 +13729,16 @@ msgid "Shipment Date"
 msgstr "出荷日"
 
 msgid "Shipment ID"
-msgstr "配送ID"
+msgstr "出荷ID"
 
 msgid "Shipment Line"
-msgstr "出荷ライン"
+msgstr "出荷明細"
 
 msgid "Shipment Lines"
-msgstr "出荷ラインs"
+msgstr "出荷明細"
 
 msgid "Shipment Location"
-msgstr "配送場所"
+msgstr "出荷拠点"
 
 msgid "Shipments"
 msgstr "出荷"
@@ -13750,49 +13750,49 @@ msgid "Shipping"
 msgstr "配送"
 
 msgid "Shipping Contact"
-msgstr "配送連絡先"
+msgstr "出荷担当者"
 
 msgid "Shipping Cost"
 msgstr "配送料金"
 
 msgid "Shipping Customer"
-msgstr "配送顧客"
+msgstr "出荷先得意先"
 
 msgid "Shipping Location"
 msgstr "配送場所"
 
 msgid "shipping method"
-msgstr "配送方法"
+msgstr "出荷方法"
 
 msgid "Shipping method"
-msgstr "配送方法"
+msgstr "出荷方法"
 
 msgid "Shipping Method"
-msgstr "配送方法"
+msgstr "出荷方法"
 
 msgid "shipping methods"
-msgstr "配送方法"
+msgstr "出荷方法"
 
 msgid "Shipping Methods"
-msgstr "配送方法"
+msgstr "出荷方法"
 
 msgid "Shipping Notes"
 msgstr "配送メモ"
 
 msgid "Shipping Supplier"
-msgstr "配送サプライヤー"
+msgstr "配送仕入先"
 
 msgid "Shipping:"
 msgstr "配送:"
 
 msgid "Shop Floor"
-msgstr "ショップフロア"
+msgstr "製造現場"
 
 msgid "Shop Floor and Scheduling"
-msgstr "ショップフロアとスケジューリング"
+msgstr "製造現場とスケジューリング"
 
 msgid "Shop Floor leads, Planner"
-msgstr "ショップフロアリード、プランナー"
+msgstr "製造現場リード、プランナー"
 
 msgid "Shop-floor app and scheduling"
 msgstr "ショップフロアアプリとスケジューリング"
@@ -13816,13 +13816,13 @@ msgid "Shortcuts"
 msgstr "ショートカット"
 
 msgid "Show a readable Customer ID column on the customer list, customer forms, and dropdowns. Customers are still identified internally either way."
-msgstr "顧客リスト、顧客フォーム、ドロップダウンに読みやすい顧客IDカラムを表示します。顧客は内部的にはどちらの方法でも識別されます。"
+msgstr "得意先リスト、得意先フォーム、ドロップダウンで読みやすい得意先IDカラムを表示します。得意先はどちらの方法でも内部的に識別されます。"
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
-msgstr "サプライヤーリスト、サプライヤーフォーム、ドロップダウンに読みやすいサプライヤーID列を表示します。サプライヤーは内部的にはどちらの方法でも識別されます。"
+msgstr "仕入先リスト、仕入先フォーム、ドロップダウンで読みやすい仕入先IDカラムを表示します。仕入先はどちらの方法でも内部的に識別されます。"
 
 msgid "Show Customer IDs"
-msgstr "顧客IDを表示"
+msgstr "得意先IDを表示"
 
 msgid "Show Durations"
 msgstr "期間を表示"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "最初の 500 行を表示中"
 
 msgid "Showing the newest 200 journals"
-msgstr "最新の200個のジャーナルを表示しています"
+msgstr "最新200件の仕訳を表示中"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "金額別上位 1,000 グループを表示中"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "このルールが失敗したときにユーザーに表示されます。"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbonにサインイン"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "マジックリンクの代わりに生体認証でサインインします。パスキーはFace ID、Touch ID、またはデバイスPINで保護されます。"
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "サイトと場所"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "サイト、ロケーション、ワークセンター、ユーザー、サプライヤー、および会社設定 — すべての基盤となります。既製テンプレートから開始します。"
+msgstr "サイト、拠点、作業区、ユーザー、仕入先、および会社設定 — すべての基盤。テンプレートから始めてください。"
 
 msgid "Size"
 msgstr "サイズ"
@@ -13940,13 +13940,13 @@ msgid "Skip raw-material dates set at receipt. Only inputs with their own shelf-
 msgstr "受け取り時に設定された原材料の日付をスキップします。独自の棚卸し有効期限ポリシーを持つ入力のみがカウントされます。"
 
 msgid "Skip scheduled maintenance on company holidays"
-msgstr "会社の祝日に予定されたメンテナンスをスキップする"
+msgstr "会社の休日の定期保全をスキップ"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "リリースされたが開始していない状態をスキップします。スキャン時にジョブがすぐに開始します。"
 
 msgid "Skipped"
-msgstr "スキップ"
+msgstr "スキップ済"
 
 msgid "Slack"
 msgstr "Slack"
@@ -13955,13 +13955,13 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "資産活動を場所、品目、または任意のディメンション別に表示"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "経費を場所、コスト センター、または任意のディメンション別に表示"
+msgstr "費用を場所、原価センター、またはディメンションでスライス"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "顧客、顧客タイプ、またはディメンション別に売上をスライス"
+msgstr "売上高を得意先、得意先タイプ、またはディメンションでスライス"
 
 msgid "Smoke-test the core daily flows end to end"
-msgstr "コア日次フローのスモークテストを端から端まで実施"
+msgstr "コアの毎日のワークフローをエンドツーエンドでスモークテストします"
 
 msgid "so you can assign it here."
 msgstr "ここで割り当てることができます。"
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "ソリューションズエンジニア"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "PDFから抽出された一部の行は、在庫アイテムに自動的にマップできませんでした。以下の各行を確認してマップしてください。"
+msgstr "PDFから抽出された一部の明細は在庫品目に自動的にマップできませんでした。以下の各明細を確認してマップしてください。"
 
 msgid "Something went wrong. Please try again."
 msgstr "何か問題が発生しました。もう一度お試しください。"
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "もうすぐ"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "最も早い有効期限が完成品を決定します。"
+msgstr "すべての材料で最も早い使用期限が完成品を決定します。"
 
 msgid "Sort"
 msgstr "ソート"
@@ -14003,16 +14003,16 @@ msgid "Source Company"
 msgstr "ソース会社"
 
 msgid "Source document"
-msgstr "ソースドキュメント"
+msgstr "参照伝票"
 
 msgid "Source Document"
-msgstr "ソース文書"
+msgstr "参照伝票"
 
 msgid "Source Document ID"
-msgstr "ソース文書ID"
+msgstr "参照伝票ID"
 
 msgid "Source document readable"
-msgstr "ソースドキュメント(読み取り可能)"
+msgstr "参照伝票判読可能"
 
 msgid "Source Item"
 msgstr "ソースアイテム"
@@ -14039,25 +14039,25 @@ msgid "Sourcing Type"
 msgstr "調達タイプ"
 
 msgid "Spare Part Consumption"
-msgstr "予備部品消費"
+msgstr "予備品消費"
 
 msgid "Spare Part Cost"
-msgstr "スペアパーツコスト"
+msgstr "予備品原価"
 
 msgid "Spec"
 msgstr "仕様"
 
 msgid "Specific Customer"
-msgstr "特定の顧客"
+msgstr "特定の得意先"
 
 msgid "Specific Customers"
-msgstr "特定の顧客"
+msgstr "特定の得意先"
 
 msgid "Specific Items"
 msgstr "特定の品目"
 
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
-msgstr "仕入先、品目、またはカテゴリー別の支出 — 最大のコスト ドライバー"
+msgstr "仕入先、品目、またはカテゴリ別の支出 — 最大の原価ドライバー"
 
 msgid "Split"
 msgstr "分割"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "領収書行を分割"
 
 msgid "Split shipment line"
-msgstr "出荷ラインを分割"
+msgstr "出荷明細を分割"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "ホスティングをセットアップ"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "在庫移動ID"
 
 msgid "Stock Transfer Lines"
-msgstr "在庫移動ライン"
+msgstr "在庫転送明細"
 
 msgid "Stock Transfer Notes"
 msgstr "在庫移動メモ"
@@ -14224,22 +14224,22 @@ msgstr "在庫移動"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Stocked for spares only — successor: <0>{0}</0>"
-msgstr "スペア用のみ在庫 — 後継品: <0>{0}</0>"
+msgstr "予備品在庫のみ—後継品目：<0>{0}</0>"
 
 msgid "Stocked for spares only."
 msgstr "スペア用のみ在庫あり。"
 
 msgid "Stockout"
-msgstr "在庫切れ"
+msgstr "欠品"
 
 msgid "Stop raising purchase orders after this date"
-msgstr "この日付以降、発注を停止します"
+msgstr "この日付以降の発注書の作成を停止"
 
 msgid "Stop Receiving"
 msgstr "受信を停止"
 
 msgid "Storage client not available"
-msgstr "ストレージクライアントが利用できません"
+msgstr "ストレージクライアントは利用できません"
 
 msgid "Storage Rules"
 msgstr "保管ルール"
@@ -14257,52 +14257,52 @@ msgid "Storage Types"
 msgstr "ストレージタイプ"
 
 msgid "storage unit"
-msgstr "ストレージユニット"
+msgstr "保管ユニット"
 
 msgid "Storage unit"
-msgstr "保管単位"
+msgstr "保管ユニット"
 
 msgid "Storage Unit"
-msgstr "保管単位"
+msgstr "保管ユニット"
 
 msgid "Storage Unit (optional)"
-msgstr "ストレージユニット（オプション）"
+msgstr "保管ユニット（オプション）"
 
 msgid "storage units"
-msgstr "ストレージユニット"
+msgstr "保管ユニット"
 
 msgid "Storage Units"
-msgstr "保管単位"
+msgstr "保管ユニット"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "このアイテムの固定日数を保存します。有効期限の開始日は、各バッチまたはシリアルが作成されたとき（またはトリガープロセスが実行されたとき、設定されている場合）に設定されます。"
+msgstr "このアイテムの使用期限を固定日数で管理します。各バッチまたはシリアルの使用期限開始日は、作成時（またはトリガープロセスが実行された場合）に設定されます。"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "このアイテムに固定日数を保存します。有効期限の開始日は、各バッチまたはシリアルが受け取られたまたは作成されたときに設定されます（またはトリガープロセスが実行される場合に設定されます）。"
+msgstr "このアイテムの使用期限を固定日数で管理します。各バッチまたはシリアルの使用期限開始日は、受け取られたとき、作成されたとき（またはトリガープロセスが実行された場合）に設定されます。"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "このアイテムの固定日数を保存します。有効期限の開始日は、各バッチまたはシリアルが受け取られたときに設定されます。"
+msgstr "このアイテムの使用期限を固定日数で管理します。各バッチまたはシリアルの使用期限開始日は、受け取られたときに設定されます。"
 
 msgid "Straight line"
 msgstr "定額法"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripeには既にこのメールアドレスの得意先があります"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe期日"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripeは請求書を得意先にメール送信するため、住所が必要です。これはCarbonの担当者にも保存されます。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "このCarbonの得意先に対してまだStripeの顧客がありません。転記すると接続されたアカウントに顧客が作成されます。"
 
 msgid "Style of kanban output to show in the Kanban table"
-msgstr "Kanbanテーブルに表示するカンバン出力のスタイル"
+msgstr "かんばんテーブルに表示するかんばん出力のスタイル"
 
 msgid "Sub-assembly expiries only"
 msgstr "サブアセンブリの有効期限のみ"
@@ -14326,13 +14326,13 @@ msgid "Subledger"
 msgstr "補助元帳"
 
 msgid "Submit anonymously"
-msgstr "匿名で送信"
+msgstr "匿名で提出"
 
 msgid "Submit for approval"
-msgstr "承認のために送信"
+msgstr "承認のため提出"
 
 msgid "Submit Inspection"
-msgstr "検査を送信"
+msgstr "検査を提出"
 
 msgid "Submitted By"
 msgstr "提出者"
@@ -14371,13 +14371,13 @@ msgid "Successfully created a new revision"
 msgstr "新しいリビジョンが正常に作成されました"
 
 msgid "Successor effectivity"
-msgstr "後継の有効性"
+msgstr "後継品目有効日"
 
 msgid "Successor Effectivity Date"
-msgstr "後継品有効日"
+msgstr "後継品目有効日"
 
 msgid "Successor Part"
-msgstr "後継部品"
+msgstr "後継品目"
 
 msgid "Suffix"
 msgstr "サフィックス"
@@ -14413,46 +14413,46 @@ msgid "Supersedes"
 msgstr "置き換える"
 
 msgid "Supersession"
-msgstr "後継"
+msgstr "後継切替"
 
 msgid "Supersession chain detected"
-msgstr "後継チェーンが検出されました"
+msgstr "後継切替チェーンが検出されました"
 
 msgid "Supersession Mode"
-msgstr "後継品モード"
+msgstr "後継切替モード"
 
 msgid "supplier"
 msgstr "仕入先"
 
 msgid "Supplier"
-msgstr "サプライヤー"
+msgstr "仕入先"
 
 msgid "Supplier Accounts"
-msgstr "サプライヤーアカウント"
+msgstr "仕入先アカウント"
 
 msgid "Supplier added and selected"
-msgstr "サプライヤーが追加され、選択されました"
+msgstr "仕入先が追加され選択されました"
 
 msgid "Supplier contact"
-msgstr "サプライヤーの連絡先"
+msgstr "仕入先担当者"
 
 msgid "Supplier Contact"
-msgstr "仕入先連絡先"
+msgstr "仕入先担当者"
 
 msgid "Supplier ID"
-msgstr "サプライヤーID"
+msgstr "仕入先ID"
 
 msgid "Supplier ID cannot be changed after creation"
-msgstr "サプライヤーIDは作成後に変更することはできません"
+msgstr "仕入先IDは作成後に変更できません"
 
 msgid "Supplier interaction"
-msgstr "サプライヤーとのやり取り"
+msgstr "仕入先対応"
 
 msgid "Supplier Invoice Number"
 msgstr "仕入先請求書番号"
 
 msgid "Supplier location"
-msgstr "サプライヤーの場所"
+msgstr "仕入先所在地"
 
 msgid "Supplier Location"
 msgstr "仕入先の場所"
@@ -14464,43 +14464,43 @@ msgid "Supplier Overview"
 msgstr "仕入先概要"
 
 msgid "Supplier Part"
-msgstr "サプライヤー部品"
+msgstr "仕入先品"
 
 msgid "Supplier Part ID"
-msgstr "仕入先部品ID"
+msgstr "仕入先品番"
 
 msgid "Supplier Part Number"
 msgstr "仕入先部品番号"
 
 msgid "Supplier Part Numbers"
-msgstr "サプライヤー部品番号"
+msgstr "仕入先品番"
 
 msgid "Supplier Parts"
-msgstr "サプライヤー部品"
+msgstr "仕入先部品"
 
 msgid "Supplier Payment Discounts"
-msgstr "仕入先の支払割引"
+msgstr "仕入先支払値引"
 
 msgid "Supplier Payment Discounts (default)"
-msgstr "仕入先の支払割引（デフォルト）"
+msgstr "仕入先支払値引（デフォルト）"
 
 msgid "Supplier Prepayments"
 msgstr "仕入先前払金"
 
 msgid "supplier process"
-msgstr "仕入先プロセス"
+msgstr "仕入先工法"
 
 msgid "supplier processes"
-msgstr "仕入先プロセス"
+msgstr "仕入先工法"
 
 msgid "Supplier Processes"
-msgstr "サプライヤープロセス"
+msgstr "仕入先工法"
 
 msgid "Supplier Quality"
-msgstr "サプライヤー品質"
+msgstr "仕入先品質"
 
 msgid "Supplier quote"
-msgstr "仕入先の見積もり"
+msgstr "仕入先見積"
 
 msgid "Supplier Quote"
 msgstr "仕入先見積"
@@ -14509,7 +14509,7 @@ msgid "Supplier Quote ID"
 msgstr "仕入先見積ID"
 
 msgid "Supplier Quote Notifications"
-msgstr "サプライヤー見積通知"
+msgstr "仕入先見積通知"
 
 msgid "Supplier Quotes"
 msgstr "仕入先見積"
@@ -14521,7 +14521,7 @@ msgid "Supplier Ref. Number"
 msgstr "仕入先参照番号"
 
 msgid "Supplier reference"
-msgstr "サプライヤー参照"
+msgstr "仕入先参照"
 
 msgid "Supplier Reference"
 msgstr "仕入先参照"
@@ -14539,28 +14539,28 @@ msgid "supplier types"
 msgstr "仕入先タイプ"
 
 msgid "Supplier Types"
-msgstr "サプライヤータイプ"
+msgstr "仕入先分類"
 
 msgid "Supplier Unit Price"
 msgstr "仕入先単価"
 
 msgid "Supplier updated"
-msgstr "サプライヤーが更新されました"
+msgstr "仕入先が更新されました"
 
 msgid "Supplier:"
-msgstr "サプライヤー:"
+msgstr "仕入先："
 
 msgid "suppliers"
 msgstr "仕入先"
 
 msgid "Suppliers"
-msgstr "サプライヤー"
+msgstr "仕入先"
 
 msgid "Supply"
 msgstr "供給"
 
 msgid "Supply & Demand"
-msgstr "供給と需要"
+msgstr "供給と所要量"
 
 msgid "Support"
 msgstr "サポート"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "切り替え"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "モジュールをオフにして、すべての場所から削除します：要件、データ、トレーニング、スコープ。"
+msgstr "モジュールをオフにして、すべての場所から削除します：要件、データ、教育訓練、スコープ。"
 
 msgid "Switch to pan mode"
 msgstr "パンモードに切り替え"
@@ -14627,16 +14627,16 @@ msgid "Tags"
 msgstr "タグ"
 
 msgid "Tailor this hub for the customer. Changes apply live for everyone viewing it. Never shown to the customer here."
-msgstr "このハブを顧客向けにカスタマイズします。変更はそれを表示している全員にリアルタイムで適用されます。顧客にはここに表示されません。"
+msgstr "このハブを得意先用にカスタマイズしてください。変更はそれを表示している全員にリアルタイムで適用されます。ここで得意先には表示されません。"
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "このアイテムを製造するために消費される材料全体で、最も短い残りの賞味期限を取得します。製品の有効期限がその成分に依存する場合に使用します。"
+msgstr "このアイテムを製造するために消費される材料全体で最短の保存期間を使用してください。製品の使用期限がその成分に依存する場合に使用してください。"
 
 msgid "taken"
 msgstr "実施"
 
 msgid "Talk to Sales"
-msgstr "営業に相談"
+msgstr "営業に相談してください"
 
 msgid "Target"
 msgstr "対象"
@@ -14648,10 +14648,10 @@ msgid "Target Company"
 msgstr "対象会社"
 
 msgid "Target customers by type."
-msgstr "対象アイテム"
+msgstr "得意先をタイプ別に絞り込む。"
 
 msgid "Target disposition row"
-msgstr "対象の処分行"
+msgstr "対象の処置行"
 
 msgid "Target go-live"
 msgstr "目標ゴーライブ"
@@ -14666,7 +14666,7 @@ msgid "Target number of open issues shown as a reference line on the Issue Trend
 msgstr "問題トレンドチャートの参照線として表示されるオープン問題の目標数。"
 
 msgid "Target one or more customers."
-msgstr "1つ以上の顧客をターゲットにします。"
+msgstr "1つ以上の得意先を対象にする。"
 
 msgid "Target one or more items."
 msgstr "ターゲットバージョン"
@@ -14696,7 +14696,7 @@ msgid "Tax"
 msgstr "税"
 
 msgid "Tax & Additional Costs"
-msgstr "税金と追加費用"
+msgstr "税 & 追加原価"
 
 msgid "Tax & Shipping"
 msgstr "税金と配送"
@@ -14708,16 +14708,16 @@ msgid "Tax codes, rates"
 msgstr "税コード、レート"
 
 msgid "Tax Depreciation"
-msgstr "税務償却"
+msgstr "税務減価償却"
 
 msgid "Tax Depreciation Method"
-msgstr "税務償却方法"
+msgstr "税務減価償却方法"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "非課税"
 
 msgid "Tax Exempt"
-msgstr "税務上免除"
+msgstr "非課税"
 
 msgid "Tax ID"
 msgstr "税務ID"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "チームが訓練を受けた"
 
 msgid "Technical support"
-msgstr ""
+msgstr "テクニカルサポート"
 
 msgid "Temperature"
 msgstr "温度"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "テンプレート"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "出荷時に資産の正味簿価を借方記入し、請求時に正味簿価を貸方記入する、販売サイクル全体を通じて残高がゼロになる一時的な処分清算勘定科目。"
+msgstr "一時的な処分・清算勘定科目で、資産の未償却残高は出荷時に借方記入され、請求時に貸方記入され、販売サイクル全体でゼロに相殺されます。"
 
 msgid "Terms and Privacy"
 msgstr "利用規約とプライバシー"
@@ -14810,7 +14810,7 @@ msgstr "「{0}」フェーズは、プロジェクトプランのすべてのタ
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "「{0}」フェーズが完了しました — 「{1}」チェックポイントに到達しました。"
+msgstr "「{0}」フェーズが完了しました — その「{1}」チェックポイントに合格しました。"
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
@@ -14823,7 +14823,7 @@ msgid "The accounts Carbon posts to automatically"
 msgstr "Carbonが自動的に転記するアカウント"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "保存されたメソッド（その材料、操作、および作業指示）をジョブまたは見積行にコピーするアクション。"
+msgstr "保存された製法（その材料、工程、および作業手順書）をジョブまたは見積明細にコピーするアクション。"
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "リスト型属性の許可された値。ユーザーは自由入力ではなくこれらの中から選択します。"
@@ -14832,7 +14832,7 @@ msgid "The allowed values users can pick when tagging postings with this dimensi
 msgstr "ユーザーがこのディメンションで転記にタグを付けるときに選択できる許可された値。"
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "計算方法の後、現金割引が利用可能になるまでの日数"
+msgstr "計算方法後の現金値引が利用可能な日数"
 
 msgid "The amount of days after the calculation method that the payment is due"
 msgstr "計算方法の後の支払い期日までの日数"
@@ -14847,37 +14847,37 @@ msgid "The book of all posted journal lines, summed by account — written only 
 msgstr "投稿されたすべての仕訳行のブック（勘定ごとに合計）。会社で会計が有効な場合にのみ記入されます。"
 
 msgid "The buckets you track costs against"
-msgstr "コストを追跡するバケット"
+msgstr "原価を追跡する集計単位"
 
 msgid "The capital assets you own and depreciate"
 msgstr "所有・減価償却する固定資産"
 
 msgid "The Carbon user currently responsible for working this record, set per record and independent of ownership fields like Account Manager or Sales Person."
-msgstr "このレコードで現在作業を担当しているCarbonユーザー。レコードごとに設定され、アカウントマネージャーや営業担当者などの所有権フィールドとは独立しています。"
+msgstr "このレコード作業に現在責任を持つCarbonユーザー。レコードごとに設定でき、Account ManagerやSales Personなどの所有フィールドとは独立しています。"
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
-msgstr "この顧客関係を担当するCarbonユーザー。この顧客に関するメールとリマインダーが彼らにルーティングされます。"
+msgstr "この得意先の関係について責任があるCarbon ユーザー。この得意先に関するメールとリマインダーがこのユーザーに送られます。"
 
 msgid "The Carbon user responsible for this supplier relationship; emails and reminders about this supplier route to them."
-msgstr "このサプライヤー関係を担当するCarbonユーザー。このサプライヤーに関するメールとリマインダーが彼らにルーティングされます。"
+msgstr "この仕入先の関係について責任があるCarbon ユーザー。この仕入先に関するメールとリマインダーがこのユーザーに送られます。"
 
 msgid "The Carbon user who owns this RFQ; supplier responses and reminders route to them."
-msgstr "このRFQを所有するCarbonユーザー。サプライヤーの応答とリマインダーが彼らにルーティングされます。"
+msgstr "このRFQを所有するCarbon ユーザー。仕入先からの回答とリマインダーがこのユーザーに送られます。"
 
 msgid "The carrier and service a shipment goes out on, supplying the tracking-URL template that turns a tracking number into a link and the account freight charges post to."
-msgstr "出荷が行われるキャリアとサービス。トラッキング番号をリンクに変換するトラッキングURLテンプレートと、アカウント運賃請求の転記先を提供します。"
+msgstr "出荷が発送される運送業者とサービス。追跡URLテンプレート（追跡番号をリンクに変換する）と、運賃料金が転記される勘定を提供します。"
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
-msgstr "このサプライヤーからの商品を配送する運送会社（サプライヤー自体と異なる場合）（例：サプライヤーが販売、FedExが配送）。"
+msgstr "この仕入先から商品を配送する運送業者。仕入先と異なる場合に使用します（例：仕入先が販売し、FedExが配送）。"
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "{trackingNumber}をプレースホルダーとした運送会社の追跡ページURL—Carbonは出荷のリンクを生成するときに実際の番号に置き換えます。"
+msgstr "運送業者の追跡ページURL（プレースホルダーとして{trackingNumber}を使用）。Carbonは出荷のリンク生成時に実際の番号に置き換えます。"
 
 msgid "The carriers and methods you ship orders with"
 msgstr "注文を発送する際に使用する運送業者と方法"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "割引期間内に支払った場合に顧客が受けられるキャッシュディスカウント。"
+msgstr "得意先がディスカウントウィンドウ内に支払う場合に受けられる現金値引。"
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
 msgstr "このスクラップを説明するカタログ上の理由。数量ではなく理由でキーを作成されたスクラップレポートに集約されます。"
@@ -14886,10 +14886,10 @@ msgid "The catalog you run on. Loads once foundation is in."
 msgstr "実行するカタログです。基礎データが読み込まれた後に読み込まれます。"
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "このユニットで許可されている在庫のカテゴリ。棚卸しルールを適用するために使用されます（例：冷蔵チェーン、危険物）。"
+msgstr "このユニット内で許可されている在庫のカテゴリ。棚入れルール（例：冷蔵チェーン、危険物）を実施するために使用されます。"
 
 msgid "The categories you group your suppliers into"
-msgstr "あなたがサプライヤーをグループ化するカテゴリ"
+msgstr "仕入先をグループ化するカテゴリ"
 
 msgid "The categories your fixed assets fall into"
 msgstr "固定資産が分類されるカテゴリー"
@@ -14901,19 +14901,19 @@ msgid "The category of risk (operational, strategic, financial, compliance, etc.
 msgstr "リスクのカテゴリー（運用、戦略、財務、コンプライアンスなど）。リスクがどのレポートに入るかを決定します。"
 
 msgid "The category of this issue (e.g. Customer Complaint, Audit Finding, Production Defect); drives which workflow template applies."
-msgstr "このイシューのカテゴリー（例：顧客苦情、監査調査、生産不具合）。どのワークフローテンプレートが適用されるかを決定します。"
+msgstr "この問題のカテゴリ（例：顧客苦情、監査指摘、生産不具合）。どのワークフローテンプレートが適用されるかを決定します。"
 
 msgid "The category this customer belongs to (OEM, distributor, end-user, internal); drives default pricing rules and GL accounts."
-msgstr "このカスタマーが属するカテゴリー（OEM、ディストリビューター、エンドユーザー、内部）。デフォルトの価格設定ルールとGLアカウントを決定します。"
+msgstr "この得意先が属するカテゴリ（OEM、ディストリビューター、エンドユーザー、社内）。デフォルトの価格設定ルール と勘定科目を決定します。"
 
 msgid "The category this supplier belongs to (raw-material, services, contract-manufacturer); drives default GL accounts and reporting groupings."
-msgstr "このサプライヤーが属するカテゴリー（原材料、サービス、契約製造業者）。デフォルトのGLアカウントとレポートグループ化を決定します。"
+msgstr "この仕入先が属するカテゴリ（原材料、サービス、請負製造業者）。デフォルトの勘定科目とレポートのグループ化を決定します。"
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "オペレーターがジョブを完了としてマークするためにスキャンするかんばんカードに印刷されているコード。空白のままにすると自動生成されます。"
+msgstr "かんばんカードに印刷されるコード。作業者がスキャンして製造指図を完了するとマークします。空白の場合は自動生成されます。"
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "請負業者の予想される週次の利用可能性。スケジューリングは、この請負業者を週中の操作に割り当てるときに、これを上限として使用します。"
+msgstr "外部作業者の期待される毎週の利用可能性。スケジューリングはこれを、週間を通じてこの外部作業者を工程に割り当てる際の上限として使用します。"
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "このロット/シリアル番号の修正された有効期限。変更後、既存のオンハンド在庫は棚寿命ポリシーに対して再評価されます。"
@@ -14922,25 +14922,25 @@ msgid "The currencies you trade in and their rates"
 msgstr "あなたが取引する通貨とそのレート"
 
 msgid "The customer record this portal account links to; only contacts already on that customer can be selected as the account holder below."
-msgstr "このポータルアカウントがリンクされているカスタマーレコード。そのカスタマー上にすでにある連絡先のみが、以下のアカウント所有者として選択できます。"
+msgstr "このポータル アカウントがリンクしている得意先レコード。その得意先にすでに存在する担当者のみが、以下のアカウント ホルダーとして選択できます。"
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "商品が配送される顧客（請求される顧客と異なる場合）（例：本社に請求、支店に配送）。"
+msgstr "配送先の得意先。請求先の得意先と異なる場合（例：本社に請求、支社に配送）。"
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
-msgstr "このポータルリンクがプロビジョニングされているカスタマー。このカスタマー上の連絡先のみがリンク経由でサインインできます。"
+msgstr "このポータル リンクがプロビジョニングされている得意先。この得意先の担当者のみがリンク経由でサインインできます。"
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "このドキュメントの顧客独自の参照 - 通常、そのシステム上のRFQまたはPO番号。印刷可能な出力に表示され、このドキュメントが変換されるドキュメントに転送されます。"
+msgstr "この文書に対する得意先独自の参照 — 通常は彼らのシステム上の見積依頼または発注書番号。印刷可能な出力に表示され、これが変換される任意の文書に引き継がれます。"
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
-msgstr "その部品IDの顧客の修正タグ（私たちのものと異なる場合）。相互参照レベルで固定、私たちの修正ではなく。"
+msgstr "得意先が所有する部品IDのリビジョン タグ。当社のものと異なる場合。クロスリファレンスレベルで固定され、当社のリビジョンではなく。"
 
 msgid "The customers who go live fastest own these well. The full ours/yours split is below."
-msgstr "最も早くライブになった顧客がこれらをよく所有しています。完全な私たち/あなたの分割は以下の通りです。"
+msgstr "最速で本番運用を開始した得意先は、これらの設定をよく理解しています。完全なカテゴリ分けは以下の通りです。"
 
 msgid "The customers you sell and ship to"
-msgstr "あなたが販売および配送する顧客"
+msgstr "販売し出荷する得意先"
 
 msgid "The dashed threshold you don't want inventory to fall below."
 msgstr "在庫が下回らないようにしたいダッシュ付きの閾値。"
@@ -14952,19 +14952,19 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "このアセットの減価償却が開始される日付。通常は償却開始日です。"
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "この見積もりの価格がもはや有効でない日付。この日付の後に注文に変換すると、見積もりのやり直しが必要になる場合があります。"
+msgstr "この見積の価格が有効でなくなった日付。この日付後に注文に変換する場合は、見積をやり直す必要がある場合があります。"
 
 msgid "The date the customer expects to receive the goods"
-msgstr "顧客が商品を受け取ることを期待する日付"
+msgstr "得意先が商品の受け取りを予定している日付"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
 msgstr "商品が実際に倉庫を離れた日付。出荷の転記に記録され、オンタイム配送スコアリングに使用されます。"
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "その期間の予想需要をカバーするために、アイテムがオンサイトで必要とされる日付。"
+msgstr "期間の予測所要量をカバーするために、品目がサイト上で必要な日付。"
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "このアセットがサービスから廃止される日付。この日に減価償却が停止し、残存簿価が処分勘定に記入されます。"
+msgstr "この資産がサービスから廃止される日付。この日付で減価償却が停止し、残りの未償却残高が除却勘定に計上されます。"
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "このエントリが総勘定元帳に記入される日付。会計期間を決定します。"
@@ -14973,19 +14973,19 @@ msgid "The date this intercompany transaction hits both companies' ledgers."
 msgstr "この会社間取引が両社の総勘定元帳に記入される日付。"
 
 msgid "The date you received this RFQ from the customer. Defaults to today."
-msgstr "このRFQを顧客から受け取った日付。デフォルトは今日の日付です。"
+msgstr "得意先からこのRFQを受け取った日付。デフォルトは今日です。"
 
 msgid "The deadline to send your quote to the customer."
-msgstr "顧客に見積もりを提出する期限。"
+msgstr "見積を得意先に送信する期限。"
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "デフォルトオーダーピッキングは、追跡エンティティを提供するために使用します：FEFO（最も早い有効期限）、FIFO（最も古い）またはLIFO（最も新しい）。"
+msgstr "ピッキングが追跡対象エンティティを提供するデフォルト。FEFO（最短有効期限ファースト）、先入先出（古いものファースト）、または後入先出（新しいものファースト）。"
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "このパーツが製造される場合のデフォルト実行数量。計画ラウンドはこれの倍数まで補充を行います。"
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "このカスタマーの見積もりと販売注文行に適用されるデフォルト税率（行ごとのオーバーライド前）。管轄区域固有の税金計算が実行されます。"
+msgstr "得意先の見積および販売注文明細に適用される既定の税率。明細ごとの上書き前。管轄区域固有の税計算が上に実行されます。"
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "レポートとヘッドカウント階層のために、このロールアップが行われるセクション。トップレベル部門の場合は空白のままにしてください。"
@@ -14994,10 +14994,10 @@ msgid "The eight-disciplines quality method, modeled with the nonconformance wor
 msgstr "8つの規律品質法。ハードコーディングではなく、不適合ワークフローのタスクでモデル化されています。"
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "このコストセンターの責任者である従業員。購買注文承認が有効な場合、このコストセンターに対して転記される支出の承認者です。"
+msgstr "この原価センターの責任者である従業員 — 発注書承認がオンの場合、彼らはそれに対して転記された支出の承認者です。"
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "顧客への見積もりから支払い回収までのエンドツーエンドの商流：RFQから見積、販売注文、出荷、請求書、支払い済みまで。"
+msgstr "得意先への見積から支払い回収までのエンドツーエンドの商業フロー：見積依頼から見積から受注、その後出荷、請求書、決済支払い。"
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "テーブルが更新されたときに、更新されたデータを含むPOSTリクエストを受け取るエンドポイント"
@@ -15006,10 +15006,10 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "この検査計画が関連付けられているエンジニアリング図面。このパーツに対して記録された検査はこの図面を参照します。"
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "生産中に失われるこのアイテムの出力の予想パーセンテージ。計画は補償するために需要に1 / (1 −スクラップ)を乗じます。"
+msgstr "生産中にこの品目の出力の失われると予想される割合。計画は所要量に1 / (1 − スクラップ)を乗算して補正します。"
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
-msgstr "この間接支出明細行が転記される経費勘定；間接明細行には勘定を導出するための項目台帳エントリがないため、必須です。"
+msgstr "この間接支出明細が転記される費用勘定。間接明細には品目台帳エントリがないため、勘定を導出できないため必須です。"
 
 msgid "the first 3 to 4 weeks"
 msgstr "最初の3～4週間"
@@ -15021,16 +15021,16 @@ msgid "The fixed-asset record this purchase capitalizes against; the line's rece
 msgstr "この購入が資本化される固定資産レコード。行の受領は、在庫エントリではなく資産エントリを作成します。"
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "この売却が処分する固定資産レコード。行の出荷は、COGSではなく資産の純簿価額処分エントリを投稿します。"
+msgstr "この販売が除却する固定資産レコード。明細の出荷は、売上原価ではなく資産の未償却残高除却エントリを転記します。"
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "資産が減価償却される下限値。純簿価がそこに達すると、資産は「完全減価償却」に変わります。"
+msgstr "資産が減価償却される下限。未償却残高がこれに達すると、資産は償却済に切り替わります。"
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "現場とオフィスが同じ在庫と原価数字を読む。"
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "以下のアセンブリには操作がありません。リリースする前に、それぞれに操作を割り当ててください。"
+msgstr "以下のアセンブリに工程がありません。リリース前に各アセンブリに工程を割り当ててください。"
 
 msgid "The following line items are missing prices or lead times:"
 msgstr "以下の行項目は価格またはリードタイムが不足しています:"
@@ -15045,10 +15045,10 @@ msgid "The fraction of each lot to inspect; the actual count is computed from lo
 msgstr "検査するロットの各フラクション；実際のカウントは検査時にロットサイズから計算されます。"
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "購買注文の価格とサプライヤーの請求書の差。請求書が転記されるときに分散勘定に転記されます。"
+msgstr "発注書の価格と仕入先の請求書間の差異。請求書が転記されるときに差異勘定に転記されます。"
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
-msgstr "この運送会社の料金が転記されるGLアカウント（運送経費、運送入出）。"
+msgstr "この運送業者の料金が転記される勘定科目（運送費、運送受取、運送支払）。"
 
 msgid "The goal"
 msgstr "目標"
@@ -15060,40 +15060,40 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "このアカウントがロールアップされるグループアカウント。種類、クラス、および明細書の配置を決定します。"
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "このワークセンターのオペレーター労働の時間当たり費用。ログされた労働時間と組み合わされて、ジョブのWIPに労働コストをチャージします。"
+msgstr "この作業区の作業者労務の時間原価。ログ記録された労務時間と組み合わせて、製造指図の仕掛品に労務原価を転記します。"
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "このワークセンターの機械の実行の時間当たり費用。ログされた機械時間と組み合わされて、ジョブのWIPに機械コストをチャージします。"
+msgstr "この作業区で機械を運用する時間当たりの原価。ログされた機械時間と組み合わせて、機械原価を製造指図のWIPに計上します。"
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "このワークセンターに適用される時間当たりの間接費負荷。労働+機械と完全な見積もり率の差は、オーバーヘッドが吸収するものです。"
+msgstr "この作業区に適用される時間当たりの間接費負担。労務 + 機械と完全な見積レートの差が間接費で吸収されます。"
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
-msgstr "ワークフロー の webhook ステップが送信する https アドレス。プレーン http、リダイレクト、プライベートまたはリンク ローカル アドレスに解決されるホストは拒否され、コールは 10 秒後にタイムアウトします。"
+msgstr "ワークフローのWebhookステップが転記するhttpsアドレス — プレーンなhttp、リダイレクト、およびプライベートまたはリンクローカルアドレスに解決されるホストは拒否され、呼び出しは10秒後に諦めます。"
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "シーケンスから生成され、レコードに保存された人間が読める形式のドキュメント番号（J000001またはECO-000001など）で、内部IDとは異なります。"
+msgstr "採番から生成され、レコードに保存される人間が読める文書番号（J000001またはECO-000001など）。内部IDとは異なります。"
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "顧客がこの部品をPOで使用する識別子。Carbon は注文インポート時に内部部品IDに解決します。"
+msgstr "得意先が発注書で使用するこの部品の識別子。Carbonは発注書のインポート時にそれを社内の部品IDに解決します。"
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
-msgstr "サプライヤーがこの部品を見積もりと請求書で使用する識別子。Carbon は内部部品IDに解決します。"
+msgstr "仕入先が見積と請求書で使用するこの部品の識別子。Carbonはそれを社内の部品IDに解決します。"
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
 msgstr "根本原因が判明する前に、影響を受けた在庫または作業を隔離する即座の不適合タスク。"
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
-msgstr "リスクが実現された場合の影響格付け（1 =無視できる、5 =壊滅的）。リスクスコアを計算するために可能性と組み合わせられます。"
+msgstr "リスクが現実化した場合の影響度レーティング（1＝無視できる～5＝壊滅的）。発生可能性と組み合わせてリスクスコアを計算します。"
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "PO、転送、またはジョブ出力から在庫に商品を取り込み、追跡対象エンティティを作成するインバウンド転記ドキュメント。"
+msgstr "発注書、転送、または製造指図出力から商品を在庫に入れ、追跡対象エンティティを作成する受け入れ転記文書です。"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "このサプライヤーからの出荷時に、誰が運送料を支払うか、誰がリスクを負うか、所有権の移転がどこで発生するかを管理するIncoterms規則（FOB、DAP、EXW、CIF、...）。"
+msgstr "この仕入先からの出荷に関するインコタームズルール（FOB、DAP、EXW、CIFなど）。運賃の支払い、リスク負担、所有権の移転時点を決定します。"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "このカスタマーへの出荷時に、誰が運送料を支払うか、誰がリスクを負うか、所有権の移転がどこで発生するかを管理するIncoterms規則（FOB、DAP、EXW、CIF、...）。"
+msgstr "この得意先への出荷時に誰が運送費を支払い、誰がリスクを負い、所有権の転送がどこで行われるかを管理するインコタームズルール（FOB、DAP、EXW、CIF、…）。"
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
 msgstr "出荷が転記されるときに認識されるインベントリコスト。品目の原価計算方法で評価されます。"
@@ -15105,43 +15105,43 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "この外部加工明細が対象とする作業。行の受領はこの作業に対して操作を閉じます。"
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "仕事の場所のスケジュール キューでの仕事の位置。Carbon が期日とデッドライン タイプから計算した小数値であり、Low/High の評価ではありません。"
+msgstr "このジョブのロケーション内のスケジュール順序での位置。Carbonが期日と期限タイプから計算した小数値で、低/高レーティングではありません。"
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "このルールが適用する調整の種類 - 割引、割増料金、または固定オーバーライド。各行の実際のデルタを計算するために金額タイプと組み合わせられます。"
+msgstr "このルールが適用する調整の種類—値引、割増、または固定上書き。Amount Typeと組み合わせて、各明細の実際の差分を計算します。"
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "このアトリビュートが受け入れるの値のタイプ（テキスト、数値、日付、ブール値、リスト）。属性に記録された値がある場合はロックされます。"
+msgstr "この属性が受け付ける値の種類（テキスト、数値、日付、ブール値、リスト）。属性に記録された値がある場合、ロック中になります。"
 
 msgid "The label and document printers your company prints to"
 msgstr "あなたの会社が印刷するラベルおよび文書プリンター"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "このPOを発注して、サプライヤーのリードタイムを考慮した上で、必要日までに到着するための最遅発注日です。"
+msgstr "仕入先のリードタイムを考慮して、この発注書が必要日までに到着するように発注書を出すべき最後の日付。"
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
-msgstr "請求される法的実体（商品を受け取るカスタマーと異なる場合）—親会社/子会社またはサードパーティの請求の手配の場合。"
+msgstr "商品を受け取る得意先と異なる請求先の法人エンティティ。親会社/子会社または第三者請求の場合に使用します。"
 
 msgid "The legal entity to bill, when different from the supplier who delivers the goods — for parent / subsidiary or factoring arrangements."
-msgstr "請求される法的実体（商品を提供するサプライヤーと異なる場合）—親会社/子会社またはファクタリング契約の場合。"
+msgstr "商品を配送する仕入先と異なる場合の支払先法人エンティティ。親会社/子会社またはファクタリング取引の場合を想定しています。"
 
 msgid "The lifecycle stages you track customers through"
-msgstr "顧客を追跡するライフサイクルステージ"
+msgstr "得意先を追跡するライフサイクルステージ。"
 
 msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.; only Active customers appear in sales-order selectors."
-msgstr "このカスタマーのライフサイクル状態 - アクティブ、見込み客、非アクティブなど。アクティブなカスタマーのみが販売注文セレクタに表示されます。"
+msgstr "このお客様のライフサイクル状態—有効、見込客、無効など。有効な得意先のみが受注セレクターに表示されます。"
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "このサプライヤーのライフサイクル状態 - アクティブ、非アクティブ、承認待機中など。アクティブなサプライヤーのみがPO/見積もりセレクタに表示されます。"
+msgstr "この仕入先のライフサイクル状態 — 有効、無効、承認待ち、など。有効な仕入先のみが発注書 / 見積セレクタに表示されます。"
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
 msgstr "この場所が時刻を報告する現地タイムゾーン。この場所でのスケジュール、タイムカード、シフト時間は、ユーザーのブラウザロケールに関係なく、このゾーンで解釈されます。"
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "このエンプロイがデフォルトする場所。彼らのタイムカードと仕事記録のデフォルトシフトセレクタの時間帯解釈を駆動します。"
+msgstr "この従業員のデフォルト拠点。タイムカードのタイムゾーン解釈と、ジョブレコードのデフォルトシフトセレクターを決定します。"
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "この注文が満たされるロケーション。行ごとのロケーションが設定されている場合はこれをオーバーライドします。"
+msgstr "このオーダーが履行される拠点。明細ごとの拠点がセットされた場合、これを上書きします。"
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
 msgstr "このクォートがオーダーに変換される場合の履行ロケーション。計画により、正しい倉庫での供給を投影するために使用されます。"
@@ -15150,7 +15150,7 @@ msgid "The location this RFQ would fulfill from if it converts to a quote and th
 msgstr "このRFQが見積もりに変換され、その後注文に変換される場合の履行ロケーション。"
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "任意のエンティティに対して提起されたリスクと機会のログで、それぞれが独立した1〜5の重大度と尤度で評価され、解決に向けて進められます。"
+msgstr "任意のエンティティに対して提起されたリスクと機会のログ。それぞれが独立した1～5の重大度と発生可能性で評価され、解決に推進されます。"
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "印刷およびメール送信されたドキュメントに表示されるロゴ"
@@ -15165,10 +15165,10 @@ msgid "The lot will still be rejected, but an NCR cannot be created until at lea
 msgstr "ロットは引き続き却下されますが、少なくとも1つの問題タイプが設定されるまでNCRを作成することはできません。"
 
 msgid "The lot's per-feature sampling plan will be re-resolved from the selected document."
-msgstr "ロットの機能ごとのサンプリング計画は、選択されたドキュメントから再度解決されます。"
+msgstr "ロットの機能別抜取検査方式は、選択した文書から再解決されます。"
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "このサプライヤーがこのプロセスに対して請求する最低額（数量に関係なく）。損益分岐点以下のジョブもこの金額以上の費用がかかります。"
+msgstr "数量に関わらず、この仕入先がこの工法に対して請求する最低金額。損益分岐点の下の製造指図でも最低でもこの金額がかかります。"
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "あなたの仕事が実行される機械、セル、およびステーション"
@@ -15177,7 +15177,7 @@ msgid "The master data to set up when first configuring Carbon, grouped by modul
 msgstr "Carbonを初めて設定する際にセットアップするマスターデータ。モジュール別にグループ化されています。設定が完了したら、各項目をマークしていきます。"
 
 msgid "The material is purchased from a supplier for that specific order, rather than made or pulled from stock."
-msgstr "その特定の注文のためにサプライヤーから購入された材料は、製造されたり、在庫から引き出されたりすることはありません。"
+msgstr "この材料は、製造または在庫から取得するのではなく、その特定のオーダーのために仕入先から購入されます。"
 
 msgid "The material types you organize your stock by"
 msgstr "あなたが在庫を整理する材料タイプ"
@@ -15195,28 +15195,28 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "リクエスターが疑う最も可能性の高い故障モード。技術者はクローズ時にこれを確認または置き換え、疑われたものと実際のものの違いが信頼性レポートに表示されます。"
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "この行で交渉された単価。インライントレースアイコンは、どの価格設定ルールまたはオーバーライドがそれを生成したかを示します。"
+msgstr "この明細の協議済み単価。この明細に表示されるトレースアイコンは、どの価格設定ルールまたは上書きが生成したかを示します。"
 
 msgid "The new version number of the document"
-msgstr "ドキュメントの新しいバージョン番号"
+msgstr "文書の新しいバージョン番号"
 
 msgid "The new version number of the method"
 msgstr "メソッドの新しいバージョン番号"
 
 msgid "The new version number of the procedure"
-msgstr "手順の新しいバージョン番号"
+msgstr "手順書の新しいバージョン番号"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "優先サプライヤーと注文を配置してから商品がドックに到着するまでの日数。計画はこの量だけ需要を後方にオフセットします。"
+msgstr "優先仕入先に発注書を出してから商品が到着するまでの日数。計画はこの量だけ所要量を前倒しします。"
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "このアイテムの1バッチを構築するのに必要な日数（ジョブ解放から完了まで）。計画はこの量だけ需要を後方にオフセットします。"
+msgstr "この品目の1バッチを製造するまでの日数。製造指図のリリースから完了まで測定。計画はこの量だけ所要量を前倒しします。"
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "予想される廃材を補うために構築する追加ユニット数。計画は、材料を予約するときにこれを注文数量と組み合わせます。"
+msgstr "期待されるスクラップを補償するために製造する追加個数。計画は材料を予約する際に、この値をオーダー数量に加算します。"
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "契約者が利用可能な週あたりの時間数。"
+msgstr "外部作業者が週に利用可能な作業時間数。"
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "このアセットが償却される月数。"
@@ -15225,22 +15225,22 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "数量ベースのポリシーに基づいて新しい補充注文をトリガーするオンハンド在庫レベル。"
 
 msgid "The operations and steps your parts move through"
-msgstr "部品が通過する操作とステップ"
+msgstr "部品が通過する工程とステップ。"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
 msgstr "このワークフローを使用するイシューが完了する必要があるタスクの順序付きリスト。ここの順序は、それらがイシューに表示される順序です。"
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "メソッドのプロセス一覧から コピーされた、ジョブが実行される操作の順序付きシーケンス。"
+msgstr "製造指図が実行する工程の順序立てられた並び。製法の工程表からコピーされます。"
 
 msgid "The original model file is no longer available"
 msgstr "元のモデルファイルは利用できなくなりました"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "在庫から顧客に商品を取り出す発信転記文書。転記時にCOGSを転記します。"
+msgstr "商品を得意先に出荷して在庫から除去し、その過程で売上原価を転記する出荷文書です。"
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "このプロセスを実行する外部サプライヤー。各者はサプライヤープロセスフォームで価格とリードタイムの入力の行を取得します。"
+msgstr "このプロセスを実行する外部仕入先。仕入先工法フォームで、各仕入先の価格設定とリードタイム行があります。"
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "追跡されたエンティティの親子チェーン—ユニットが何から構築され、それが何になったか。"
@@ -15249,22 +15249,22 @@ msgid "The part is manufactured as its own job when the parent that needs it is 
 msgstr "必要な親が構築される場合、部品は独自のジョブとして製造されます。"
 
 msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
-msgstr "親が構築される場合、既存の在庫から部品が取得されます—新しいジョブまたは購入注文はありません。"
+msgstr "部品はその親製品が製造されるときに既存在庫から取得されます。新しい製造指図または発注書は作成されません。"
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Carbonチーム側の実装を担当する人たちと、彼らへの連絡方法です。"
+msgstr "実装を実施する Carbon 側の人員および連絡方法"
 
 msgid "The people on your team and their access to Carbon"
-msgstr "チームのメンバーと Carbon へのアクセス権"
+msgstr "チームの人員と Carbon へのアクセス"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
-msgstr "ドキュメント タイプの可読番号を生成する会社単位のカウンター。プレフィックス、ゼロパディングされた次の値、およびサフィックスを組み合わせて構成され、ドキュメントが作成されるたびに進行します。"
+msgstr "文書タイプの判読可能番号の背後にある会社別のカウンター。プリフィックス、ゼロパディングされた次の値、サフィックスを組み立て、各文書が作成されるたびに進行します。"
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "不適合の影響を受けた材料に記録される項目ごとの結果 — 保留中、サプライヤーへの返品、再加工、スクラップ、またはそのまま使用 — 影響を受けた各ロットまたはシリアルに対して個別に決定されます。"
+msgstr "不適合の影響を受けた材料に記録される項目ごとの結果 — 待機中、仕入先への返品、手直し、スクラップ、またはそのまま使用 — 影響を受けた各ロットまたはシリアル番号について個別に決定されます。"
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "キャッシュディスカウントのパーセンテージ。割引なしの場合は0を使用してください。"
+msgstr "現金割引のパーセンテージ。割引なしの場合は 0 を使用します。"
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "このタイプの新しい従業員が自動的に受け取る権限セット。ここで編集すると、将来の雇用のみがテンプレートを変更します。既存の従業員は、明示的に大量更新されない限り、持っているものを保持します。"
@@ -15273,7 +15273,7 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "あなたの仕事と在庫が存在する工場、倉庫、およびサイト"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "この問題に適用されるタスクと承認要件の事前設定バンドル。設定すると、問題タイプのデフォルトワークフローをオーバーライドします。"
+msgstr "このイシューに適用される定義済みのタスクと承認要件のバンドル。設定されている場合、イシュータイプの既定ワークフローを上書きします。"
 
 msgid "The principle:"
 msgstr "原則:"
@@ -15282,16 +15282,16 @@ msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certa
 msgstr "リスクが発生する確率評価（1 =稀、5 =ほぼ確実）。重大度と組み合わされてリスクスコアを計算します。"
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "このメンテナンスが実行されるときにテクニシャンが従う手順。スケジュールが既に生成された後に置き換えると、将来のインスタンスにのみ影響します。"
+msgstr "この保全が実施されるときに技術者が従う手順書。スケジュールが既に生成された後にそれを置き換えると、将来のインスタンスにのみ影響します。"
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "このワークセンターが実行できるプロセス。オペレーションをスケジュールするときのプロセスピッカーに表示され、このワークセンターを通じてルーティングできるジョブを制限します。"
+msgstr "この作業区が実行できる工法。工程のスケジュール時にプロセスピッカーに表示され、この作業区を経由できる製造指図を制限します。"
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "プロバイダーはディメンションターゲットを提供していません。最初にプロバイダーで機能を有効にしてください(例:追跡カテゴリ、クラス追跡、またはフィールド)。"
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "この行が価格設定される数量ブレークポイント。各列は、買い手-サプライヤー交渉とダウンストリーム文書への変換のための独自の単価を行います。"
+msgstr "この明細が価格設定される数量ブレークポイント。各列は購買担当者と仕入先の交渉および下流文書への変換のための独自の単価を保有します。"
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "スキャンベースの補充時に再注文される品目の数量。"
@@ -15303,7 +15303,7 @@ msgid "The quote has been created"
 msgstr "見積書が作成されました"
 
 msgid "The quote will be copied with a revision suffix"
-msgstr "見積書は改訂サフィックス付きでコピーされます"
+msgstr "見積はリビジョンサフィックス付きでコピーされます。"
 
 msgid "The raw stock and material master you buy and consume"
 msgstr "購入して消費する原材料とマテリアルマスター"
@@ -15318,10 +15318,10 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "ワークフロー通知が指す レコード。ID とそのタイプで名前が付けられます。空のままにすると、通知はワークフロー実行そのものにリンクします。"
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "請求書に支払いまたはメモを適用するレコード、適用額、割引額、および償却額を含みます。"
+msgstr "支払またはメモを請求書に適用し、適用額、値引額、償却額を含むレコード。"
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
-msgstr "追跡されたエンティティの記録された系統 - どの入力がどの出力を生成するために消費され、受領から出荷まで。"
+msgstr "追跡対象エンティティの記録された系譜 — どのインプットがどのアウトプットを生成するために消費されたか、入荷から出荷まで。"
 
 msgid "The reference data everything else hangs off. Loads first."
 msgstr "参照データはすべての基盤となります。最初に読み込まれます。"
@@ -15334,13 +15334,13 @@ msgstr "残りの{0}{1}は再び期待され、入荷供給としてカウント
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "残りの{0}{1}は期待されなくなります。発注済み供給とMRPはそれをカウント対象から外します。注文数量と価格は変更されません。"
+msgstr "残り {0} {1} は予想されなくなります。発注済の供給と MRP はそれをカウントしなくなります。発注数量と価格設定は変更されません。"
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "ワークフロー変数が置き換えられた後、JSON コンテンツ タイプで逐語的に送信されるリクエスト本文。これを含むメソッドで送信されます。"
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "ジョブがクローズ時に残した残留WIP。生産差異勘定に削除されます—Carbonがジョブのために記録する唯一の差異。"
+msgstr "製造指図がクローズ時に残した残留仕掛品は、生産差異勘定に振り替えられます — これはCarbonが製造指図について計上する唯一の差異です。"
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "Onshape からの応答に必須パラメーターが含まれていませんでした。もう一度接続してください。"
@@ -15352,13 +15352,13 @@ msgid "The revision number of the part"
 msgstr "部品のリビジョン番号"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "この仕事が供給するために作成された販売注文ラインで、仕事を背後にある顧客の需要に結びつけます。"
+msgstr "この製造指図が供給するために作成された受注明細であり、製造指図を背後の得意先所要量に結びつけます。"
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "このアセットの費用を耐用年数にわたって分散するために使用される償却方法（定額法、減額法、生産単位）。"
+msgstr "この資産の原価を耐用年数にわたって配分するために使用されるスケジュール（定額法、定率法、生産単位法）。"
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "在物理上存放库存的货架和箱子"
+msgstr "在庫が物理的に置かれている棚とビン。"
 
 msgid "The shop supplies and consumables you keep on hand"
 msgstr "手元に保管する店舗用品と消耗品"
@@ -15370,37 +15370,37 @@ msgid "The size of the part"
 msgstr "部品のサイズ"
 
 msgid "The skills and abilities you track for your people"
-msgstr "あなたの人々のために追跡するスキルと能力"
+msgstr "人員が保有するスキル。"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "このサプライヤーがこの部品のPO行で受け入れる最小数量。計画はそれまでに丸めます。"
+msgstr "この部品に対する発注書明細で当該仕入先が受け入れる最小数量。計画はこれに四捨五入します。"
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
-msgstr "このポータルアカウントを所有する選択されたカスタマーの特定の連絡先。彼らのメールはサインイン識別子になります。"
+msgstr "このポータルアカウントを所有する得意先の特定の担当者。そのメールがサインイン識別子になります。"
 
 msgid "The specific contact on the selected supplier who will own this portal account; their email becomes the sign-in identifier."
-msgstr "このポータルアカウントを所有する選択されたサプライヤーの特定の連絡先。彼らのメールはサインイン識別子になります。"
+msgstr "このポータルアカウントを所有する仕入先の特定の担当者。そのメールがサインイン識別子になります。"
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "このPO行が購入している上記のジョブの特定の操作。外部処理としてマークされた操作のみが選択可能です。"
+msgstr "このPO明細が購買する上記製造指図上の特定の工程。外注加工とマークされた工程のみ選択可能です。"
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "このレシートが転記される特定のPO、返品、または転送。利用可能なIDは上記のソースドキュメントタイプに依存します。"
+msgstr "この入荷が転記される特定のPO、返品、または転送。利用可能なIDは上記の参照伝票タイプによります。"
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "この出荷が転記される特定のSO、転送、またはRMA。利用可能なIDは上記のソースドキュメントタイプに依存します。"
+msgstr "この出荷が転記される特定のSO、転送、またはRMA。利用可能なIDは上記の参照伝票タイプによります。"
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "あなたの材料が在庫されている標準的な寸法"
+msgstr "材料が在庫される標準ディメンション"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "標準係数（時間、分、個数）このワークセンターの操作はデフォルトで測定されます。操作ごとのオーバーライドは設定時に機能します。"
+msgstr "この作業区の工程がデフォルトで測定される標準係数（時間、分、個数）。工程別の上書きが設定されている場合は優先します。"
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
-msgstr "このプロセスを測定するために使用される標準係数 - 時間、分、ピース、平方フィート - その操作が推定および見積もりされた場合。"
+msgstr "この工法の工程が見積もられて原価計算される場合に使用される標準係数（時間、分、個数、平方フィート）。"
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "この見積もり行のステータス - ドラフト、見積なし、完了。見積なしは理由フィールドを表示し、見積もり合計から行を除外します。"
+msgstr "この見積明細の状態 — 下書き、見積辞退、完了。見積辞退は理由フィールドを表示し、当該明細を見積合計から除外します。"
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "このグループ下のすべてのアカウントが使用するステートメントバケット。"
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "ステップの設定。この実行は、使用された値の記録より前のものです。"
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "このマテリアルが購入および保持されるストック サイズ。各サイズはジョブとPOの個別の選択可能なバリアントになります。"
+msgstr "材料が購買および保持されている在庫サイズ。各サイズは製造指図とPO上で独立した選択可能なバリアントになります。"
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "この行がピッキングする保存ビン。空白の場合、ピッキングはアイテムのデフォルト保存ユニットを使用します。"
+msgstr "この明細がピッキングするストレージビン。空白の場合、ピッキングは品目のデフォルト保管ユニットを使用します。"
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "ストレージサービスが時間内に応答しませんでした。もう一度お試しください。"
@@ -15421,25 +15421,25 @@ msgid "The substances your materials are made of"
 msgstr "あなたの材料が作られている物質"
 
 msgid "The supplier planning suggests first when this item needs to be bought; other suppliers stay available in the dropdown on each PO line."
-msgstr "このアイテムを購入する必要がある場合、計画が最初に提案するサプライヤー。他のサプライヤーは各PO行のドロップダウンで利用できたままです。"
+msgstr "このアイテムが購買される必要があるときに計画が最初に提案する仕入先。他の仕入先は各PO明細のドロップダウンで利用可能なままです。"
 
 msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
-msgstr "このポータルアカウントがリンクされているサプライヤーレコード。そのサプライヤー上にすでにある連絡先のみが、以下のアカウント所有者として選択できます。"
+msgstr "このポータルアカウントがリンクする仕入先レコード。その仕入先上にある担当者のみが以下のアカウント保有者として選択できます。"
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "サプライヤーの独自の引用/提案番号。このクォートから変換されるPOのトレーサビリティのために記録されます。"
+msgstr "仕入先独自の見積/提案番号。この見積から変換されるPOのトレーサビリティのために記録されます。"
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
-msgstr "このオーダーのサプライヤーの独自の参照（彼らのシステム上の彼らのSO番号）。監査のために記録され、レシートに表示されます。"
+msgstr "この注文の仕入先独自の参照（彼らのシステム上の彼らのSO番号）。監査用に記録され、入荷に表示されます。"
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "監査のために記録されたサプライヤーの梱包伝票または出荷番号。任意の転記ロジックでは使用されません。"
+msgstr "仕入先のパッキングスリップまたは出荷番号。監査用に記録されます。転記ロジックでは使用されません。"
 
 msgid "The suppliers and vendors you buy from"
 msgstr "あなたが購入する仕入先とベンダー"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "このRFQを受け取るサプライヤー。各者はRFQ上の独自の行を取得し、独自の価格設定で応答します。"
+msgstr "この見積依頼を受け取る仕入先。各仕入先は見積依頼上で独自の明細を受け取り、独自の価格設定で応答します。"
 
 msgid "The surface finishes available on your materials"
 msgstr "あなたの材料で利用可能な表面仕上げ"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "システムは、設定されたシステム内のすべてのスコープ内受け入れテストに合格し、データが検証され、サインオフされます。その後、本番環境に移行します。"
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "販売RFQ、その見積もり、および結果の販売注文をリンクするスレッド—結合であり、独自のステータスを持つドキュメントではありません。"
+msgstr "販売見積依頼、その見積、および結果の受注をリンクするスレッド — 独自ステータスを持つ文書ではなく、結合です。"
 
 msgid "The timer starts automatically"
 msgstr "タイマーが自動的に開始されます"
@@ -15457,70 +15457,70 @@ msgid "The timer starts manually"
 msgstr "タイマーが手動で開始されます"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "あなたの業務が依存する工具と治具"
+msgstr "あなたの工程が依存する工具と治具。"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "このバルク バッチで作成されたすべてのジョブで製造される合計。作成するジョブ数を決定するために、ジョブあたりの数量と組み合わされます。"
+msgstr "このバルクバッチで作成されるすべての製造指図を通じて作成する合計。1製造指図あたりの数量と組み合わせて、作成する製造指図の数を決定します。"
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "キャリブレーション値が比較された追跡可能な参照（例：NIST標準、マスターゲージシリアル番号）。"
+msgstr "校正値が比較された追跡可能な参照（例：NIST 標準、標準器シリアル番号）"
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "トラベラーは部品表の各項目とその数量をリストアップします。"
+msgstr "現品票は部品表上の各品目をその数量と共にリストします。"
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "タイプは新しい従業員が受け取るデフォルトの権限を制御します。ここで選択すると、タイプのテンプレートから権限マトリックスが事前に入力されます。"
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "このプロセスのためにこのサプライヤーに仕事を送ってから戻ってくるまでの典型的な日数。サプライヤーを選択する際、計画はこの量だけ需要をオフセットします。"
+msgstr "この工法についてこの仕入先に仕事を送信してから返却されるまでの典型的な日数。仕入先を選択する際、計画はこれだけ所要量をオフセットします。"
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "この物理ユニットの一意の識別子。シリアル番号ごとに1行、数量は常に1です。"
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "ルーティング時間が表現される単位（時間/個またはトータル時間など）で、Carbonが時間が数量に応じてスケーリングするか、実行ごとに固定されるかを判断します。"
+msgstr "工順時間が表現される単位で、例えば「時間/個」または「総時間」など、時間が数量に応じてスケールするか、実行単位で固定されるかを示します。"
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "購入時のアイテムの単価"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
-msgstr "サプライヤーがこのアイテムに価格と配送を行う単位（在庫単位と異なる場合）（例：ケース対各個）。換算係数と組み合わされます。"
+msgstr "仕入先が価格設定および発送する単位で、在庫単位と異なる場合（例：ケース対個別）に使用されます。換算係数と組み合わせて使用します。"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each)."
-msgstr "サプライヤーがこのアイテムに価格と配送を行う単位（在庫単位と異なる場合）（例：ケース対各個）。"
+msgstr "仕入先が価格設定および発送する単位で、在庫単位と異なる場合（例：ケース対個別）に使用されます。"
 
 msgid "The units of measure you buy, stock, and sell in"
 msgstr "購入、在庫、販売する単位"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "IRS資産等級表を備えた米国税務償却システムは、簿価スケジュールとともに別個の税務スケジュールとして実行されます。"
+msgstr "米国の税務減価償却制度で、IRS固定資産分類表を使用し、帳簿的減価償却スケジュールと並行して別税務スケジュールとして実行されます。"
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "このグループのユーザー。グループスコープの権限と通知は各メンバーに適用され、ユーザーは複数のグループに属することができます（有効な権限は組合です）。"
 
 msgid "The version of the new document"
-msgstr "新しいドキュメントのバージョン"
+msgstr "新しい文書のバージョン"
 
 msgid "The version of the new procedure"
-msgstr "新しい手順のバージョン"
+msgstr "新しい手順書のバージョン"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "このドキュメントのバージョンスタンプ。新しいバージョンは、前のバージョンを削除せずに置き換えるコピーを作成します。"
+msgstr "この文書のバージョンスタンプ。新しいバージョンは前のバージョンを削除せずに、それに取って代わるコピーを作成します。"
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "この手順のバージョンスタンプ。新しいバージョンは、前のバージョンを削除せずに置き換えるコピーを作成します。"
+msgstr "この手順書のバージョン識別子。新しいバージョンは前のバージョンを削除せずに置き換える新しいコピーを作成します。"
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "この注文の商品が配送される倉庫。カスタマーの配送ロケーションが到着地です。"
+msgstr "この注文から出荷される倉庫。得意先の出荷拠点がそれらの到着地点です。"
 
 msgid "The warehouse goods on this quote will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "このクォートの商品が配送される倉庫。カスタマーの配送ロケーションが到着地です。"
+msgstr "この見積から出荷される倉庫。得意先の出荷拠点がそれらの到着地点です。"
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "機器が故障する方法、保守と品質追跡用"
+msgstr "設備障害の形式（保全および品質追跡用）"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "ワークセンター独自のビン。ピック済みの材料は本番環境で取り出すためにステージされます。倉庫のソースシェルフとは異なります。"
+msgstr "作業区が持つ自身のビンで、ピッキング済の材料が生産で引き出されるようにステージングされる場所です。倉庫の仕入元の棚とは異なります。"
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "スケジューリングを駆動する勤務時間とカレンダー"
@@ -15535,10 +15535,10 @@ msgid "Then by"
 msgstr "次に"
 
 msgid "There are no active supplier quotes to compare for this RFQ."
-msgstr "このRFQに比較するアクティブなサプライヤー見積もりがありません。"
+msgstr "このRFQに対して比較する有効な仕入先見積がありません。"
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "このジョブに関連付けられた外部オペレーションにはサプライヤーがありません。リリースする前に、各外部オペレーションにサプライヤーを割り当ててください。"
+msgstr "この製造指図に関連する外注工程があり、それらに仕入先が割り当てられていません。リリースする前に、各外注工程に仕入先を割り当ててください。"
 
 msgid "There's nothing outstanding to apply these credits to."
 msgstr "これらのクレジットを適用する未処理項目がありません。"
@@ -15547,19 +15547,19 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "これらのカスタムフィールドは、同じタグを持つエンティティでのみ利用可能です"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "これらの書類は総勘定元帳に転記されていないため、それらの金額は当期から欠落しています。各書類を転記するか無効にしてください。無日付書類は、転記時に転記日の日付を受け取ります。"
+msgstr "これらの文書は総勘定元帳に転記されていないため、この期間の金額が不足しています。各文書を転記または取消してください。日付なしの文書は転記時に転記日の日付を受け取ります。"
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
-msgstr "これらのメールアドレスは、サプライヤーに送信されるすべてのメール（見積書、発注書など）に自動的にCC送信されます。"
+msgstr "これらのメールアドレスは、仕入先に送信されたすべてのメール（見積、発注書など）に自動的に CC 付けされます。"
 
 msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
-msgstr "これらのメールアドレスは、顧客に送信されるすべての見積メールに自動的にCC送信されます。"
+msgstr "これらのメールアドレスは、得意先に送信されたすべての見積メールに自動的に CC 付けされます。"
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
-msgstr "これらのアイテムはまだピッキングすべき材料があります。今完了するとリストが部分的になります。"
+msgstr "これらの品目にはまだピッキングする材料があります。今完成にマークすると、リストを「一部」に設定します。"
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "これらのジョブにはこのワークセンターに割り当てられた操作があります:"
+msgstr "これらの製造指図には、この作業区に割り当てられた工程があります。"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "これらの仕訳はまだ下書きであるため、それらの借方と貸方は当期の元帳に含まれていません。各仕訳を転記するか、後の開いている期間に再度日付を付け直してください。"
@@ -15568,7 +15568,7 @@ msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an adm
 msgstr "この Carbon インスタンスには Onshape の OAuth 認証情報がありません。管理者に設定を依頼してください。"
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "この変更通知は実装中であるため、変更がロックされています。編集するために再度開いてください。"
+msgstr "この変更通知は実施中のため、その変更はロック中です。編集するために再オープンしてください。"
 
 msgid "This change notice is closed, so its changes are read-only."
 msgstr "この変更通知は閉じられているため、変更は読み取り専用です。"
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "これはDiscoveryステップを完了します。"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "この担当者はメールアドレスを持っていません"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "この取引先には未払い金がありません。支払いは掛け金として記録されます。"
@@ -15586,13 +15586,13 @@ msgid "This download link is invalid or has been tampered with."
 msgstr "このダウンロードリンクは無効であるか、改ざんされています。"
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "このファイルは利用できなくなっているか、ダウンロード権限がありません。"
+msgstr "このファイルはもう利用できないか、またはそれをダウンロードする権限がありません。"
 
 msgid "This Fiscal Year"
 msgstr "この会計年度"
 
 msgid "This information will be used on document headers"
-msgstr "この情報はドキュメントヘッダーで使用されます"
+msgstr "この情報は文書ヘッダーで使用されます"
 
 msgid "This information will be visible to all users, so be careful what you share."
 msgstr "この情報はすべてのユーザーに表示されるため、共有する内容に注意してください。"
@@ -15605,22 +15605,22 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "この{0}への参加への招待は期限切れです。新しい招待をメールで送信されるようにリクエストできます。"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "この請求書には使用可能な期日がありません。Stripeの場合は、期日を選択してください。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "この請求書は、この Carbon 得意先にすでにリンクされている Stripe 顧客に請求されます。詳細を変更するには、Stripe ダッシュボードで編集してください。"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "これは管理環境のため、認証アプリが必須です。"
 
 msgid "This is a controlled environment, so two-factor authentication is required for everyone and cannot be turned off."
-msgstr "これは管理環境のため、全員に2要素認証が必須で、無効にできません。"
+msgstr "これは管理されたリソースのため、二要素認証は全員に必須であり、無効にすることはできません。"
 
 msgid "This is a purchased item — it has no BoM/BoP; only its attributes and documents can change."
-msgstr "これは購入アイテムです。BoM/BoP はありません。属性と文書のみ変更できます。"
+msgstr "これは購買品目です。BOM/BoPはありません。属性とドキュメントのみが変更できます。"
 
 msgid "This is a unique identifier for the webhook"
-msgstr "これはウェブフックの一意の識別子です"
+msgstr "これはWebhookの一意識別子です"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
 msgstr "これはITAR管理環境です。アクセスは米国人に限定されています。"
@@ -15638,16 +15638,16 @@ msgid "this item"
 msgstr "このアイテム"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "このアイテムはコンフィグレータを使用して構築され、注文ごとにコンポーネントを解決します。このために作成されたジョブは、コンフィグレータの解決されたBOMを継承します。"
+msgstr "この品目はコンフィグレータを通じて構築され、その部品は注文ごとに解決されます。これに対して作成された製造指図は、コンフィグレータの解決されたBOMを継承します。"
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "このアイテムの部品表には、棚卸し有効期限が有効になっている入力がないため、BOMから有効期限は計算されません。"
+msgstr "この品目の部品表には棚寿命が有効な入力がないため、BOM から使用期限は計算されません。"
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "このジョブはインベントリに受け取られます。ショップフロアで利用できなくなります。"
+msgstr "この製造指図は在庫に入庫されます。製造現場では利用できなくなります。"
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "このジョブはショップフロアで利用できなくなります。"
+msgstr "この製造指図は製造現場では利用できなくなります。"
 
 msgid "This job's own required quantity for the material."
 msgstr "この材料に対するこのジョブ自体の必要数量。"
@@ -15665,7 +15665,7 @@ msgid "This Month"
 msgstr "今月"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "このページのImplementation Hubは現在構築中です。完成するまでコマンドセンターから始めてください。"
+msgstr "実施ハブのこのページは構築中です。完成するまでコマンドセンターから開始してください。"
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "このパーツはこの場所に{quantityOnHand}個あります。「在庫なし」は計画にも消費にも含まれないことを意味します。"
@@ -15680,7 +15680,7 @@ msgid "This part is obsolete (No Stock)."
 msgstr "このパーツは廃止されています（在庫なし）。"
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "このパーツは廃止予定であり、「Stock Only」に設定されています。予備部品の予備フロアまで補充され、需要とは無関係に運用されます。"
+msgstr "この部品は置き換えられ、「在庫のみ」に設定されています。スペア予備床にまで補充され、所要量とは無関係です。"
 
 msgid "This path only decides what runs next"
 msgstr "このパスは次に何が実行されるかだけを決定します"
@@ -15695,13 +15695,13 @@ msgid "This Quarter"
 msgstr "今四半期"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "認証アプリを削除するため、次のサインインはマジックリンクのみで必要になります。認証アプリへのアクセスを失った場合に使用してください。所属する全コンパニーのサインインに影響します。"
+msgstr "これにより認証器アプリが削除されるため、次回のサインインはマジックリンクのみが必要になります。認証器へのアクセスを失った場合にこれを使用してください。彼らが属するすべての会社のサインインに影響します。"
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "このリビジョンはリリース済み（本番環境）です。変更は通常、変更通知を通じて実施されるべきです。"
+msgstr "このリビジョンはリリース済（生産）です。変更は通常、変更通知を介してフローする必要があります。"
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "このリビジョンはリリース済み（本番環境）です。変更通知を開いて変更してください。"
+msgstr "このリビジョンはリリース済（生産）です。それを修正するために変更通知を開いてください。"
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "この実行には、ここに表示するよりも多くのステップがあります。最初の {MAX_RUN_STEPS} のみが表示されます。"
@@ -15710,17 +15710,17 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "これはワークフローを実際に実行します。ライブ実行と同じようにレコードを作成し、通知を送信し、任意の webhook を呼び出します。これは元に戻せません。"
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "この販売注文には関連するジョブがあります。それらをどうするかを選択してください。"
+msgstr "この受注には関連する製造指図があります。それらで何をするかを選択してください。"
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "この販売注文には、ジョブを作成する必要があるラインがあります"
+msgstr "この受注には製造指図の作成が必要な明細があります"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "このストレージタイプは現在{usageCount}個のストレージユニット{0}で使用されています。"
+msgstr "このストレージタイプは現在{usageCount}個の保管ユニット{0}で使用されています。"
 
 msgid "this supplier"
-msgstr "このサプライヤー"
+msgstr "この仕入先"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
 msgstr "この工具は、変更通知 {activationLockId} がリリースされると有効になります。"
@@ -15729,7 +15729,7 @@ msgid "This updates the theme for all users of the application"
 msgstr "これはアプリケーションのすべてのユーザーのテーマを更新します"
 
 msgid "This user does not have two-factor authentication enabled."
-msgstr "このユーザーは2要素認証が有効になっていません。"
+msgstr "このユーザーは二要素認証が有効になっていません。"
 
 msgid "This usually takes a few seconds. You can leave the page — it keeps running."
 msgstr "これは通常数秒かかります。ページを離れることができます。実行され続けます。"
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "このバージョンは開くことができません"
 
 msgid "This version is published"
-msgstr ""
+msgstr "このバージョンは公開済です"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "このバージョンは公開済です。編集するには新しいバージョンを作成してください。"
 
 msgid "This version's definition could not be read."
 msgstr "このバージョンの定義を読み取ることができませんでした。"
@@ -15766,12 +15766,12 @@ msgid "This will overwrite the existing quote method"
 msgstr "これは既存の見積方法を上書きします"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "これにより、アクティブな製造方法の部品表とプロセスからバッチサイズを使用して単価が再計算されます。現在のコストは上書きされます。続行しますか？"
+msgstr "このバッチサイズを使用して、有効な製造方法の部品表とプロセスから単位原価を再計算します。現在の原価は上書きされます。続行しますか？"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "これにより{0}から{1}へのリンクが削除されます。ジョブは販売注文の下に表示されなくなり、出荷はそれを見つけることができなくなります。"
+msgstr "これにより {0} と {1} へのリンクが削除されます。製造指図は受注の下に表示されなくなり、出荷では見つかりません。"
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "これにより、他のリビジョンのすべてのメソッドマテリアルがこのリビジョンに置き換わります。"
@@ -15786,7 +15786,7 @@ msgid "This will write off the remaining book value of the asset."
 msgstr "これはアセットの残りの帳簿価額を償却します。"
 
 msgid "Three-way match"
-msgstr "3者照合"
+msgstr "三点照合"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Tie-Outは利用できません"
 
 msgid "Tightened"
-msgstr "厳しい"
+msgstr "きつい検査"
 
 msgid "Time of day"
 msgstr "時間"
@@ -15859,19 +15859,19 @@ msgid "To Location"
 msgstr "到着地"
 
 msgid "To reactivate, use the row menu and choose Send Invite. The employee becomes active once they accept."
-msgstr "再度有効化するには、行メニューを使用して、招待を送信を選択します。従業員が受け入れるとアクティブになります。"
+msgstr "再度有効にするには、行メニューを使用して「招待を送信」を選択してください。従業員が承諾したら有効になります。"
 
 msgid "To Receive"
-msgstr "受け取り予定"
+msgstr "入荷待ち"
 
 msgid "To Ship"
-msgstr "発送予定"
+msgstr "出荷待ち"
 
 msgid "To Ship and Receive"
-msgstr "配送と受取"
+msgstr "出荷待ちおよび入荷待ち"
 
 msgid "To Storage Unit"
-msgstr "保管単位へ"
+msgstr "保管ユニットへ"
 
 msgid "To supplier"
 msgstr "仕入先へ"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "切り替え"
 
 msgid "Toggle Assignee"
-msgstr "割り当て先を切り替え"
+msgstr "担当者を切り替える"
 
 msgid "Toggle break active"
 msgstr "ブレークアクティブを切り替える"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "ツール"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "トップレベルの分類（資産/負債/資本/収益/費用）。ルートグループにのみ設定され、子に継承されます。"
+msgstr "トップレベルの分類（資産/負債/純資産/売上高/費用）；ルートグループにのみ設定され、子に継承されます。"
 
 msgid "Topic"
 msgstr "トピック"
@@ -15955,13 +15955,13 @@ msgid "Total Amount"
 msgstr "合計金額"
 
 msgid "Total capitalized cost of the asset (purchase price plus freight, install, and other costs that become part of book value)."
-msgstr "資産の総資本化コスト（購入価格、運送、設置、および帳簿価額の一部となるその他のコスト）。"
+msgstr "資産の総資本化原価（購入価格、運賃、設置、および帳簿価額の一部となるその他のコスト）。"
 
 msgid "Total discount"
-msgstr "合計割引"
+msgstr "合計値引"
 
 msgid "Total expected production units for units-of-production depreciation; cost is spread per unit produced."
-msgstr "生産ユニット償却の総予想生産ユニット。コストは生産ユニットごとに分散されます。"
+msgstr "生産単位償却の予想生産個数。原価は生産された個数当たりで配分されます。"
 
 msgid "Total Hours"
 msgstr "合計時間"
@@ -15976,10 +15976,10 @@ msgid "Total Quantity"
 msgstr "合計数量"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "このロケーションのすべての保管単位における品目の手持ち総数量。手持ち数量と入荷予定の合計が総需要を満たせない場合は赤くなります。"
+msgstr "この拠点のすべての保管ユニット全体にわたる品目の現在庫数。現在庫と入荷合計が総所要量をカバーできない場合は赤くなります。"
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "このロケーションのすべての進行中ジョブおよび受注で必要とされる総数量 — このジョブだけではありません。"
+msgstr "この拠点の全有効製造指図および受注で必要な総数量—このジョブのみではありません。"
 
 msgid "Total scrap quantity"
 msgstr "合計スクラップ数量"
@@ -16006,28 +16006,28 @@ msgid "Track"
 msgstr "追跡"
 
 msgid "Track changes to key business entities including invoices, orders, customers, suppliers, and more."
-msgstr "請求書、注文、顧客、仕入先など、主要なビジネスエンティティへの変更を追跡します。"
+msgstr "請求書、注文、得意先、仕入先など、主要なビジネスエンティティへの変更を追跡します。"
 
 msgid "Track every change to your orders, invoices, customers, and more."
-msgstr "ご注文、請求書、顧客情報など、すべての変更を追跡します。"
+msgstr "注文、請求書、得意先など、すべての変更を追跡します。"
 
 msgid "Track every change to your orders, invoices, customers, suppliers, and more."
-msgstr "ご注文、請求書、顧客、仕入先など、すべての変更を追跡します。"
+msgstr "注文、請求書、得意先、仕入先など、すべての変更を追跡します。"
 
 msgid "Track real-time inventory by location and bin"
 msgstr "リアルタイムで場所とビンごとに在庫を追跡する"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "シリアル/ロット番号を追跡し、販売注文を履行します。"
+msgstr "シリアル/ロット番号を追跡し、受注を履行します。"
 
 msgid "Track tax depreciation separately"
-msgstr "税務償却を個別に追跡"
+msgstr "税務減価償却を個別に追跡"
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "税務償却と簿価償却を分けて追跡し、繰延税金負債仕訳を自動的に転記します。"
+msgstr "税務減価償却を帳簿減価償却と別個に追跡し、繰延税金負債エントリを自動的に転記します。"
 
 msgid "Track transactions by segment (cost center, project, service line)"
-msgstr "セグメント（コストセンター、プロジェクト、サービスライン）別にトランザクションを追跡"
+msgstr "トランザクションをセグメント（原価センター、プロジェクト、サービスライン）別に追跡します。"
 
 msgid "Track when batches or serials of this item expire."
 msgstr "このアイテムのバッチまたはシリアルの有効期限を追跡します。"
@@ -16036,7 +16036,7 @@ msgid "Tracked Entities"
 msgstr "追跡対象エンティティ"
 
 msgid "Tracked entity"
-msgstr "追跡されたエンティティ"
+msgstr "追跡対象"
 
 msgid "Tracked Entity"
 msgstr "追跡対象エンティティ"
@@ -16081,19 +16081,19 @@ msgid "Train the rest of your team (after train-the-trainer)"
 msgstr "残りのチームメンバーをトレーニングする（トレーナー育成後）"
 
 msgid "Training"
-msgstr "トレーニング"
+msgstr "教育訓練"
 
 msgid "Training Assignments"
-msgstr "研修割り当て"
+msgstr "教育訓練の割り当て"
 
 msgid "Training Plan"
-msgstr "トレーニング計画"
+msgstr "教育訓練計画"
 
 msgid "Training your team via the Academy and in-app guides"
-msgstr "Academy とアプリ内ガイドを通じたチームのトレーニング"
+msgstr "アカデミーとアプリ内ガイドを使用してチームを教育訓練します。"
 
 msgid "Trainings"
-msgstr "トレーニング"
+msgstr "教育訓練"
 
 msgid "Transactions will create journal entries and update the general ledger."
 msgstr "トランザクションは仕訳帳エントリを作成し、総勘定元帳を更新します。"
@@ -16111,13 +16111,13 @@ msgid "Transfer ID"
 msgstr "転送ID"
 
 msgid "Transfer Lines"
-msgstr "転送ライン"
+msgstr "転送明細"
 
 msgid "Transfer Ownership"
 msgstr "所有権を譲渡"
 
 msgid "Transfer ownership of this company to another user"
-msgstr "このカンパニーの所有権を別のユーザーに譲渡する"
+msgstr "この会社の所有権を別のユーザーに転送します。"
 
 msgid "Transfer To"
 msgstr "転送先"
@@ -16150,7 +16150,7 @@ msgid "Two-Factor"
 msgstr "2要素認証"
 
 msgid "Two-factor authentication"
-msgstr "2要素認証"
+msgstr "二要素認証"
 
 msgid "Two-factor authentication disabled"
 msgstr "二要素認証が無効になりました"
@@ -16159,7 +16159,7 @@ msgid "Two-factor authentication enabled"
 msgstr "二要素認証が有効になりました"
 
 msgid "Two-Factor Authentication Enforcement"
-msgstr "2要素認証の強制実行"
+msgstr "二要素認証の強制"
 
 msgid "Two-factor authentication is not enabled."
 msgstr "二要素認証は有効になっていません。"
@@ -16177,7 +16177,7 @@ msgid "Type a message..."
 msgstr "メッセージを入力..."
 
 msgid "Type an email and press Enter to add an external recipient"
-msgstr "メールアドレスを入力してEnterキーを押すと、外部の受信者を追加できます"
+msgstr "メールを入力して Enter キーを押し、社外受取人を追加します"
 
 msgid "Type of Permission Update"
 msgstr "権限更新のタイプ"
@@ -16204,7 +16204,7 @@ msgid "Unapplied:"
 msgstr "未適用:"
 
 msgid "Unapproved Supplier"
-msgstr "未承認サプライヤー"
+msgstr "未承認の仕入先"
 
 msgid "Unassign rule"
 msgstr "ルールの割り当てを解除"
@@ -16219,7 +16219,7 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未計数行は投稿時に変更されないままです — ゼロにはなりません。"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "需要ベースの再注文の下では、計画は補充数量を計算する際にこのローリングウィンドウ内の需要を合計します。"
+msgstr "所要量ベースの再発注では、補給数量を計算する際、計画はこのローリングウィンドウ内の所要量を合計します。"
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
 msgstr "固定再発注数量の場合、再発注点がトリガされるたびに正確な数量の計画注文が発生します。"
@@ -16240,7 +16240,7 @@ msgid "Unit"
 msgstr "単位"
 
 msgid "Unit Cost"
-msgstr "単価"
+msgstr "単位原価"
 
 msgid "unit of measure"
 msgstr "測定単位"
@@ -16270,7 +16270,7 @@ msgid "Units"
 msgstr "単位"
 
 msgid "Units of base currency per one unit of this currency; used to translate amounts on posting."
-msgstr "この通貨の1単位あたりの基本通貨単位; ポスティング時の金額の変換に使用されます。"
+msgstr "この通貨の1単位あたりの基軸通貨の単位数。転記時の金額変換に使用します。"
 
 msgid "units of measure"
 msgstr "測定単位"
@@ -16279,7 +16279,7 @@ msgid "Units of measure"
 msgstr "測定単位"
 
 msgid "Units reported as unrecoverable at an operation, with a reason — the alternative to rework."
-msgstr "操作で回復不可能として報告される単位(理由付き) — 再作業の代替案。"
+msgstr "工程で回復不可能として報告された単位数（理由付き）。手直しの代替案です。"
 
 msgid "Unknown"
 msgstr "不明"
@@ -16291,16 +16291,16 @@ msgid "unknown location"
 msgstr "不明な場所"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "無制限の機能サポート"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "無制限のレコード"
 
 msgid "Unlink"
 msgstr "リンク解除"
 
 msgid "Unlink job from sales order?"
-msgstr "販売注文からジョブのリンクを解除しますか？"
+msgstr "製造指図を受注から切り離しますか？"
 
 msgid "Unlock"
 msgstr "ロック解除"
@@ -16336,13 +16336,13 @@ msgid "Unpin {0}"
 msgstr "{0}をピン留め解除"
 
 msgid "Unposted Documents"
-msgstr "未転記書類"
+msgstr "転記されていない文書"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "非公開にする"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "{name}を非公開にしますか？"
 
 msgid "Unreceived POs"
 msgstr "未受領PO"
@@ -16360,7 +16360,7 @@ msgid "Unshipped orders"
 msgstr "未発送注文"
 
 msgid "Unsupported source document type: {sourceDocument}"
-msgstr "サポートされていないソースドキュメントタイプ: {sourceDocument}"
+msgstr "対応していない参照伝票タイプ：{sourceDocument}"
 
 msgid "Untitled Diagram"
 msgstr "無題の図"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "無題の行"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "作業センターから倉庫に戻された未使用の仕分け材料。"
+msgstr "未使用のピッキング済み材料が作業区から倉庫に戻されました。"
 
 msgid "UoM"
 msgstr "UoM"
@@ -16378,13 +16378,13 @@ msgid "Update"
 msgstr "更新"
 
 msgid "Update a customer"
-msgstr "顧客を更新"
+msgstr "得意先を更新する"
 
 msgid "Update a job"
 msgstr "仕事を更新"
 
 msgid "Update a purchase order"
-msgstr "購入注文を更新"
+msgstr "発注書を更新する"
 
 msgid "Update a quote"
 msgstr "見積もりを更新"
@@ -16393,13 +16393,13 @@ msgid "Update a receipt"
 msgstr "領収書を更新"
 
 msgid "Update a sales order"
-msgstr "販売注文を更新"
+msgstr "受注を更新する"
 
 msgid "Update a shipment"
-msgstr "発送を更新"
+msgstr "出荷を更新する"
 
 msgid "Update a supplier"
-msgstr "サプライヤーを更新"
+msgstr "仕入先を更新する"
 
 msgid "Update an issue"
 msgstr "問題を更新"
@@ -16408,7 +16408,7 @@ msgid "Update an item"
 msgstr "アイテムを更新"
 
 msgid "Update costs on"
-msgstr "コストを更新"
+msgstr "原価を更新"
 
 msgid "Update Inventory"
 msgstr "在庫を更新"
@@ -16417,7 +16417,7 @@ msgid "Update Jira issue"
 msgstr "Jiraの問題を更新"
 
 msgid "Update Kanban"
-msgstr "カンバンを更新"
+msgstr "かんばんを更新"
 
 msgid "Update Linear issue"
 msgstr "Linear イシューを更新"
@@ -16441,13 +16441,13 @@ msgid "Update Rule"
 msgstr "ルールを更新"
 
 msgid "Update source document quantities"
-msgstr "ソース文書の数量を更新"
+msgstr "参照伝票の数量を更新"
 
 msgid "Update the kanban information for scan-based replenishment."
-msgstr "スキャンベースの補充のためのカンバン情報を更新します。"
+msgstr "スキャンベースの補充用かんばん情報を更新します。"
 
 msgid "Update the purchase order quantities"
-msgstr "購買注文数量を更新"
+msgstr "発注書の数量を更新"
 
 msgid "Updated"
 msgstr "更新済み"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "アップロード中…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "変換をクリックすると、以下の内部部品番号で部品が作成されます:"
+msgstr "変換をクリックすると、以下の社内部品番号で部品が作成されます："
 
 msgid "URL"
 msgstr "URL"
@@ -16549,13 +16549,13 @@ msgid "Use a different email"
 msgstr "別のメールアドレスを使用"
 
 msgid "Use metric system for default material dimensions."
-msgstr "デフォルトの材料寸法にメートル法を使用します。"
+msgstr "デフォルト材料ディメンションにメートル法を使用してください。"
 
 msgid "Used In"
 msgstr "使用されている"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "ナビゲーションおよび販売注文などのドキュメントで使用されます"
+msgstr "ナビゲーションと受注などのドキュメントで使用されます"
 
 msgid "Used in the navigation in dark mode"
 msgstr "ダークモードのナビゲーションで使用されます"
@@ -16594,10 +16594,10 @@ msgid "Users"
 msgstr "ユーザー"
 
 msgid "Users and groups allowed to open or download this document; the uploader is always included."
-msgstr "このドキュメントを開いたりダウンロードしたりできるユーザーとグループ。アップロードしたユーザーは常に含まれます。"
+msgstr "この文書を開くまたはダウンロードできるユーザーおよびグループ。アップローダーは常に含まれます。"
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "このドキュメントの名前変更、差し替え、ラベル付け直しができるユーザーとグループ。アップロードしたユーザーは常に含まれ、編集権限は閲覧権限を含みます。"
+msgstr "この文書の名前変更、置き換え、または再ラベル付けが許可されているユーザーおよびグループ。アップローダーは常に含まれ、編集アクセスは表示アクセスを意味します。"
 
 msgid "Users can update this value for themselves"
 msgstr "ユーザーは自分でこの値を更新できます"
@@ -16642,7 +16642,7 @@ msgid "Values"
 msgstr "値"
 
 msgid "Values apply today's unit costs to historical quantities."
-msgstr "値は今日の単価を履歴数量に適用します。"
+msgstr "値は本日の単位原価を過去の数量に適用します。"
 
 msgid "Values in this run have been summarised. Full detail is kept for 7 days."
 msgstr "このランの値が要約されました。詳細は7日間保持されます。"
@@ -16657,7 +16657,7 @@ msgid "Variance between actual and standard BOM component consumption"
 msgstr "実際のBOM部品消費と標準消費の差異"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "実際のルーティング時間と標準ルーティング時間・レートの差異"
+msgstr "実績と標準工順時間およびレートの差異"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "実際の購入価格と標準原価の差異"
@@ -16669,7 +16669,7 @@ msgid "Variance from physical inventory count adjustments"
 msgstr "物理的在庫数カウント調整からの差異"
 
 msgid "Variance in outside processing costs"
-msgstr "外部処理コストの差異"
+msgstr "外注加工原価の差異"
 
 msgid "Variance only"
 msgstr "差異のみ"
@@ -16678,7 +16678,7 @@ msgid "VAT Number"
 msgstr "VAT番号"
 
 msgid "Vendor Write-Off Income"
-msgstr "仕入先償却益"
+msgstr "仕入先償却収益"
 
 msgid "Verification Error"
 msgstr "認証エラー"
@@ -16703,7 +16703,7 @@ msgstr "バージョン"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "バージョン {0} は現在公開済であり、置き換えられます。"
 
 msgid "Version:"
 msgstr "バージョン:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "表示"
 
 msgid "View Active Jobs"
-msgstr "アクティブなジョブを表示"
+msgstr "有効な製造指図を表示"
 
 msgid "View Active Quotes"
 msgstr "アクティブな見積もりを表示"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "資産を表示"
 
 msgid "View Assigned Jobs"
-msgstr "割り当てられたジョブを表示"
+msgstr "割当済の製造指図を表示"
 
 msgid "View Attachment"
 msgstr "添付ファイルを表示"
@@ -16748,7 +16748,7 @@ msgid "View Certificate"
 msgstr "証明書を表示"
 
 msgid "View Contact"
-msgstr "連絡先を表示"
+msgstr "担当者を表示"
 
 msgid "View Contained Issues"
 msgstr "含まれた問題を表示"
@@ -16760,7 +16760,7 @@ msgid "View Custom Fields"
 msgstr "カスタムフィールドを表示"
 
 msgid "View Customers"
-msgstr "顧客を表示"
+msgstr "得意先を表示"
 
 msgid "View Employees"
 msgstr "従業員を表示"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "アイテムマスターを表示"
 
 msgid "View Journal Entry"
-msgstr "仕訳帳エントリを表示"
+msgstr "仕訳行を表示"
 
 msgid "View Lists"
 msgstr "リストを表示"
 
 msgid "View maintenance dispatch"
-msgstr "メンテナンスディスパッチを表示"
+msgstr "保全指示を表示"
 
 msgid "View Memo"
 msgstr "メモを表示"
@@ -16796,7 +16796,7 @@ msgid "View missing values"
 msgstr "欠落値を表示"
 
 msgid "View notes"
-msgstr "ノートを表示"
+msgstr "メモを表示"
 
 msgid "View Open"
 msgstr "開く"
@@ -16823,7 +16823,7 @@ msgid "View Open RFQs"
 msgstr "オープンなRFQを表示"
 
 msgid "View Payables"
-msgstr "支払い義務を表示"
+msgstr "買掛金を表示"
 
 msgid "View Payment"
 msgstr "支払いを表示"
@@ -16841,13 +16841,13 @@ msgid "View Picking List"
 msgstr "ピッキングリストを表示"
 
 msgid "View Prints"
-msgstr "プリントを表示"
+msgstr "印刷を表示"
 
 msgid "View Production Events"
 msgstr "生産イベントを表示"
 
 msgid "View Purchase Invoice"
-msgstr "購買請求書を表示"
+msgstr "仕入先請求書を表示"
 
 msgid "View Reactive"
 msgstr "反応型を表示"
@@ -16877,7 +16877,7 @@ msgid "View Suggestion"
 msgstr "提案を表示"
 
 msgid "View Suppliers"
-msgstr "サプライヤーを表示"
+msgstr "仕入先を表示"
 
 msgid "View the workflow"
 msgstr "ワークフローを表示"
@@ -16901,28 +16901,28 @@ msgid "Visible on a user's public profile"
 msgstr "ユーザーの公開プロフィールに表示されます"
 
 msgid "Void"
-msgstr "無効化"
+msgstr "取消"
 
 msgid "Void Invoice"
-msgstr "請求書を無効にする"
+msgstr "請求書を取消"
 
 msgid "Void Purchase Invoice"
-msgstr "購入請求書を無効にする"
+msgstr "仕入先請求書を取消"
 
 msgid "Void Receipt"
-msgstr "領収書を無効にする"
+msgstr "入荷を取消"
 
 msgid "Void Sales Invoice"
-msgstr "売上請求書を無効にする"
+msgstr "売上請求書を取消"
 
 msgid "Void Shipment"
-msgstr "出荷をキャンセル"
+msgstr "出荷を取消"
 
 msgid "Voided"
-msgstr "無効"
+msgstr "取消済"
 
 msgid "Voiding this purchase invoice will:"
-msgstr "この購買請求書を無効にすると、以下のようになります:"
+msgstr "この仕入先請求書を取消すると："
 
 msgid "Voiding this receipt will:"
 msgstr "このレシートを無効にすると:"
@@ -16931,7 +16931,7 @@ msgid "Voiding this shipment will:"
 msgstr "この出荷をキャンセルすると、以下のようになります:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "各エリアをチャンピオンと一緒に確認し、スコープ外のものはすべてトグルしてください。コードはModule.Area.Number形式で読みます（ACC.GL.01 = Accounting、General Ledger、item 1）。"
+msgstr "各エリアをチャンピオンと一緒に確認し、スコープ外のものをチェック解除してください。コードの読み方はModule.Area.Numberです（ACC.GL.01 = 会計、総勘定元帳、項目1）。"
 
 msgid "Walk your current process, systems, and data"
 msgstr "現在のプロセス、システム、データを確認する"
@@ -16958,7 +16958,7 @@ msgid "Warn but allow"
 msgstr "警告するが許可する"
 
 msgid "Warn this many days before expiry"
-msgstr "有効期限の前にこの日数だけ警告する"
+msgstr "使用期限の何日前に警告"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "受け取った人と同じ人が受け入れ品を検査する場合に警告します。"
@@ -16973,7 +16973,7 @@ msgid "Watch full video"
 msgstr "フル動画を視聴"
 
 msgid "We auto-matched each column. Review the values below before continuing."
-msgstr "各列を自動的にマッチングしました。続行する前に、以下の値を確認してください。"
+msgstr "各列を自動マッチングしました。続行する前に下の値を確認してください。"
 
 msgid "We triage and fix issues fast while your team settles in"
 msgstr "チームが新しいシステムに慣れている間、問題を素早く分類して修正します"
@@ -16988,7 +16988,7 @@ msgid "We've sent you a magic link to sign in to your account."
 msgstr "あなたのアカウントにサインインするためのマジックリンクを送信しました。"
 
 msgid "Webhook"
-msgstr "ウェブフック"
+msgstr "Webhook"
 
 msgid "Webhook Body"
 msgstr "Webhook本体"
@@ -17006,7 +17006,7 @@ msgid "Webhook URL"
 msgstr "Webhook URL"
 
 msgid "Webhooks"
-msgstr "ウェブフック"
+msgstr "Webhooks"
 
 msgid "Webhooks Docs"
 msgstr "Webhooks ドキュメント"
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "毎週"
 
 msgid "Weekly demand"
-msgstr "週次需要"
+msgstr "毎週所要量"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17068,7 +17068,7 @@ msgid "Weighted Average"
 msgstr "加重平均"
 
 msgid "Weighted average cost over last year calculated when the invoice is posted"
-msgstr "請求書が転記されるときに計算された過去1年間の加重平均コスト"
+msgstr "過去1年間の加重平均原価は請求書が転記されるときに計算されます"
 
 msgid "Welcome to Carbon"
 msgstr "Carbonへようこそ"
@@ -17077,7 +17077,7 @@ msgid "Welcome, {companyName}"
 msgstr "ようこそ、{companyName}"
 
 msgid "What category of failure this is — Mechanical, Electrical, Software, Operator, Material, etc.; rolls up into the failure-mode pareto report so the category breakdown is meaningful."
-msgstr "これはどの種類の故障か — 機械的、電気的、ソフトウェア、オペレータ、材料など。故障モードパレート報告書に集約され、カテゴリー分類が有意になります。"
+msgstr "障害のカテゴリー（機械的、電気的、ソフトウェア、作業者、材料など）を指定します。障害モードパレート報告書に集計されるため、カテゴリー分類が意味のあるものになります。"
 
 msgid "What changes day to day"
 msgstr "日々変わること"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "在庫の増減を駆動した要因（ディメンション別）"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "ジャーナルがロックされた期間に日付が付けられた場合、何が起こるか"
+msgstr "仕訳をロック中の期間に付けたときの処理"
 
 msgid "What is {translatedTerm}?"
 msgstr "{translatedTerm}とは何ですか?"
@@ -17101,19 +17101,19 @@ msgid "What it is"
 msgstr "それが何であるか"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "このフレーズの変更内容：バージョンは部品の製造方法を更新し、改訂版はその詳細とドキュメントを改訂し、交換部品は古い部品に取って代わる新しい部品番号に交換し、新部品は先行する部品がない純新規部品を導入します。"
+msgstr "変更の種類：バージョン（製造方法の更新）、リビジョン（詳細とドキュメントの修正）、代替部品（古い部品番号を新しい部品番号に置き換え）、新規部品（先行のない新しい部品の導入）。"
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "このエントリが記録する出力のタイプ — 生産(良好ユニット)、スクラップ(回復不可)、または再作業(修正のために返送)。スクラップの場合、スクラップの理由を表示します。"
+msgstr "このエントリが記録するアウトプットの種類 — 生産（良品）、スクラップ（回収不可）、または手直し（修正のため返品）。スクラップの場合、不良理由が表示されます。"
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "これはどのタイプのPOか — 標準商品、サービス、外部処理、またはブランケット契約; ラインレイアウトとGL転記ルールを決定します。"
+msgstr "このPOの種類（標準商品、外注サービス、外注加工、または包括的な契約）を指定します。明細行レイアウトと総勘定元帳転記ルールが決定されます。"
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
-msgstr "これはどのタイプの見積もりか — 標準サプライヤー見積もり、ブランケット契約価格見積もり、または契約製造見積もり。変換時のPOラインレイアウトを決定します。"
+msgstr "この見積の種類 — 標準仕入先見積、ブランケット契約価格見積、または契約製造見積。変換時にPOラインレイアウトを決定します。"
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
-msgstr "この次元が許可される値をどの出所から取得するか(カスタムリストまたは顧客、場所、従業員などの既存エンティティ)。"
+msgstr "このディメンションが許可された値を引き出すソース（カスタムリストまたは得意先、拠点、従業員などの既存エンティティ）。"
 
 msgid "What the due-date countdown starts from (invoice date, end of month, etc.)."
 msgstr "期日カウントダウンが開始される内容(請求書日付、月末など)。"
@@ -17125,13 +17125,13 @@ msgid "What this receipt is fulfilling — a purchase order, a return, an inboun
 msgstr "この領収書が満たしているもの — 発注書、返品、受信転送、または親のない手動領収書。"
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "この出荷が満たしているもの — 販売注文、送信転送、RMA返品、または手動出荷。"
+msgstr "この出荷が処理しているもの — 受注、拠点間転送、RMA返品、または手動出荷。"
 
 msgid "What this task means"
 msgstr "このタスクの意味"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "このタイムエントリがカウント — 労働(オペレータ時間)、機械(実行時間)、またはセットアップ(交換時間);各率の下に集約されます。"
+msgstr "このタイムエントリが計算される対象 — 労務（作業者時間）、機械（加工時間）、または段取り（段取り時間）。各々は異なるレート下にロールアップされます。"
 
 msgid "What to set up"
 msgstr "セットアップする内容"
@@ -17155,91 +17155,91 @@ msgid "When {name} changes"
 msgstr "{name}が変更されるとき"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "完成品の賞味期限が「計算」に設定されている場合、計算に使用される消費入力を選択します。"
+msgstr "完成品の保存期間が「計算」に設定されている場合、計算に使用される消費材料を選択してください。"
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
 msgstr "シリアルまたはバッチが期限切れになるとき、およびその後使用された場合に何が起こるか — 会社のポリシーは警告、ブロック、またはブロック上書きできます。"
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
-msgstr "カーボンが商品の到着を約束したいつ。配送方法の輸送日数と組み合わせると、出荷日の逆算を実行します。"
+msgstr "Carbonが商品の到着を約束した日付。出荷方法の輸送日数と組み合わせて、発送日の逆算を決定します。"
 
 msgid "When expired stock is used"
 msgstr "期限切れの在庫が使用される場合"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "MRPが新しい需要に対して後継品を使用する場合"
+msgstr "MRPが新しい所要量に対して後継品目を使用する場合"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "有効にすると、このカテゴリーの属性がユーザーの公開プロフィールに表示されます。そうでない場合は、管理者のみが表示できます。"
 
 msgid "When on, employees can edit this attribute's value on their own profile; otherwise only admins can."
-msgstr "有効にすると、従業員は自分のプロフィールでこのアトリビュートの値を編集できます。そうでない場合は、管理者のみが編集できます。"
+msgstr "オンの場合、従業員は自分のプロフィールでこの属性の値を編集できます。そうでない場合は、管理者のみが可能です。"
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "有効にすると、価格設定ルール(ボリュームディスカウント、プロモーション)がこのオーバーライドの上に引き続き適用されます。無効にすると、このオーバーライドが最終価格です。"
+msgstr "オンのとき、価格設定ルール（数量割引、プロモーション）はこの上書き値の上から適用されます。オフのとき、この上書き値が最終価格になります。"
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
-msgstr "有効にすると、このプロセスの操作バーコードをスキャンすると、残りのすべての未処理数量が1つのアクションで完了としてレポートされます。オペレータが定期的に部分を報告する場合は無効にします。"
+msgstr "オンのとき、この工法の工程バーコードをスキャンすると、残りのすべてのオープンな数量が1つのアクションで完了として報告されます。作業者が定期的に一部を報告する場合はオフにしてください。"
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
 msgstr "有効にすると、この当事者の請求書は税計算をスキップします。当事者は免税証明書を最新の状態に保つ責任があります。"
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "有効にすると、この価格オーバーライドは一致する注文に適用されます。無効にすると、監査履歴を保持するためにオーバーライドは削除されずに保持されます。"
+msgstr "オンの場合、この価格上書きは一致する注文に適用されます。削除せずにオフにすると、監査用に履歴が保持されます。"
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "オンの場合、このルールはそのタイプのすべてのターゲットに対して発火します。割り当て行は無視されますが保持されます。"
 
 msgid "When supplier responses are expected back; suppliers see this date on the RFQ portal and Carbon stops accepting late responses after it (configurable)."
-msgstr "サプライヤーの応答が期待される場合。サプライヤーはRFQポータルでこの日付を確認でき、Carbonはその後の遅い応答を受け付けません(設定可能)。"
+msgstr "仕入先の回答が返信予定の日付。仕入先は見積依頼ポータルでこの日付を確認できます。Carbonはこの日付後の遅い回答の受け入れを中止します（設定可能）。"
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "買い手が商品を要求した時。サプライヤーは承諾日に別の何かを約束し、配送日に再び別の何かを転記できます。"
+msgstr "購買担当者が商品をリクエストした日付。仕入先は回答納期に異なる日付を約束し、納期に再び別の日付を記録することができます。"
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "買い手がこの行の商品をドックで必要とするとき。計画はこの日付を在庫可用性と外部処理スケジューリングに使用します。"
+msgstr "購買担当者がこの明細の商品をドックに必要とする日付。計画はこの日付を在庫可用性と外注加工スケジュール用に使用します。"
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "顧客が配送を要求した時。注文は承諾日に約束されます。これは異なる場合があります。"
+msgstr "顧客が納入を依頼したとき。注文は回答納期にコミットします。これは異なる場合があります。"
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "顧客が商品を受け取りたい場合。見積もりは顧客が受け入れた場合、この日付に約束されます。"
+msgstr "顧客が商品受け取りを依頼したとき。顧客が承諾した場合、見積はこの日付にコミットします。"
 
 msgid "When the customer asked to receive the goods."
-msgstr "顧客が商品を受け取りたい場合。"
+msgstr "顧客が商品受け取りを依頼したとき。"
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
-msgstr "顧客がこのRFQを提出したいつ。応答時計がこの日付から開始されます。"
+msgstr "顧客がこの見積依頼を提出したとき。応答時間はこの日付から開始されます。"
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "顧客の要求が最新ではなくなったとき。この日付の後、RFQは自動的にクローズされ、再度開かない限り見積もり応答を受け付けません。"
+msgstr "顧客のリクエストが現在でなくなったとき。この日付を過ぎると、見積依頼は自動的にクローズされ、再度開かない限り見積応答を受け付けません。"
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
-msgstr "商品が実際に到着したとき。領収書に記録され、サプライヤーのオンタイム配送スコアリングに使用されます。"
+msgstr "商品が実際に到着した日時。入荷に記録され、仕入先の定時配達スコアリングに使用されます。"
 
 msgid "When the kanban card is scanned, the job is automatically moved out of draft and released to the floor."
-msgstr "かんばんカードをスキャンするとき、ジョブは自動的にドラフトから削除され、フロアにリリースされます。"
+msgstr "かんばんカードがスキャンされると、製造指図は自動的に下書きから移動され、フロアにリリース済となります。"
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "受け取り場所が在庫到着を期待するとき。目的地でのMRP可用性を駆動します。"
+msgstr "入荷拠点が在庫到着を予想する日時。目的地でのMRP在庫可用性を決定します。"
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
-msgstr "サプライヤーが配送を約束したいつ。計画はこの日付を入庫在庫到着予測に使用します。"
+msgstr "仕入先が配達を約束した日時。計画はこの日付を使用して入庫在庫到着の予測を行います。"
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "サプライヤーの価格設定が尊重されなくなったとき。この日付の後にこの見積もりをPOに変換すると、再引用が必要になる場合があります。"
+msgstr "仕入先の価格設定が有効でなくなる日時。この日付以降にこの見積をPOに変換する場合、再見積が必要な場合があります。"
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "このゲージがキャリブレーション期限を迎える場合。期限を過ぎると「キャリブレーション外」と読みます。"
+msgstr "この測定器が校正の対象日となる日時。期限を過ぎるとOut-of-Calibrationと表示されます。"
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "このゲージが最後に正常にキャリブレーションされたいつ。次のキャリブレーション日付はこの値とプラスの間隔から再計算されます。"
+msgstr "この測定器が最後に正常に校正された日時。次の校正日はこの値とインターバルの合計から再計算されます。"
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "これが正しく見えたら、同意済みとしてマークしてください。これでコマンドセンターの検出ステップが完了します。"
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "この特定の行がシップメント用に約束されるとき。分割出荷のための注文ヘッダーの約束日の行ごとのオーバーライド。"
+msgstr "この特定の明細が出荷される予定日。分割出荷の場合の注文ヘッダーの回答納期の明細ごとの上書き。"
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
 msgstr "この特定のロット/シリアルが期限切れになるとき。FEFO ピッキングと消費時のシェルフライフポリシーを駆動します。"
@@ -17254,13 +17254,13 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "ワークフロー通知が配信される場所 — アプリ内は常に送信されますが、メールはビジネスプランまたはパートナープランが必要で、Slackはワークスペースが接続されている必要があります。"
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "操作が実行される場所。労働と見積もりレート、オーバーヘッドはそれらの違いです。"
+msgstr "工程を実行する場所。労務率と見積率を持ち、間接費がその差です。"
 
 msgid "Where and how you make things."
 msgstr "あなたが物を作る場所と方法。"
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "このPOの商品がサプライヤーによってデフォルトで配送される場所。PO上の行ごとの配送場所は、ドロップシップおよび分割配送シナリオのためにこれを上書きします。"
+msgstr "このPO上の商品がデフォルトで出荷される場所。PO上の明細ごとの配送場所は、直送と分割配送のシナリオでこれを上書きします。"
 
 msgid "Where it lives today"
 msgstr "今日どこにあるか"
@@ -17275,16 +17275,16 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "影響を受けるアイテムがシステム全体でどこで使用されているか。情報提供 - ここに何もリリースをブロックしません。"
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "このエントリーの出所(手動入力、販売/購買からのポスティング、反復テンプレートなど)。"
+msgstr "このエントリーの発生元（手動入力、販売/購買からの転記、定期テンプレートなど）。"
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
-msgstr "この問題がどこで提起されたか — 内部QA、顧客の苦情、サプライヤー監査など。レポートに使用され、ワークフローをブロックしません。"
+msgstr "この問題がどこから提起されたか（内部QA、顧客クレーム、仕入先監査など）。報告に使用されますが、ワークフローをゲートしません。"
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "この行の商品が受取時に在庫でランドされる場所。空白の場合、領収書はアイテムのデフォルトストレージユニットを使用します。"
+msgstr "この明細の商品が入荷時に在庫として格納される場所。空白の場合、入荷は品目のデフォルト保管ユニットを使用します。"
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "このメンテナンスリクエストの発生箇所 — オペレータによって報告、スケジュール、状態監視トリガー、ジョブ後検査;メンテナンスレポートの発生源の内訳を駆動します。"
+msgstr "この保全リクエストの発生元—作業者報告、スケジュール、状態監視トリガー、作業後検査。保全レポートのソース内訳を決定します。"
 
 msgid "Where you are today"
 msgstr "今日のあなたの状況"
@@ -17296,7 +17296,7 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "金額を明細価格に対する割合として解釈するか、固定の通貨額として解釈するか。"
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Carbon が各ユニット（Serial）、各ロット（Batch）、数量（Inventory）、または追跡なし（Non-Inventory）のいずれを追跡するか。"
+msgstr "Carbonが各単位（Serial）、各ロット（バッチ）、数量（Inventory）、またはトラッキングなし（非在庫）のいずれを追跡するかどうか。"
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "選択したプロセスの開始時にカウントを開始するか、完了時に開始するか。"
@@ -17305,19 +17305,19 @@ msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail 
 msgstr "このロット/シリアルが検査に合格（Pass）するか不合格（Fail）になるか。Fail の場合、在庫が利用可能在庫として受け入れられなくなります。"
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "このプロセスが内部ワークセンター（Process、Assembly、またはInspection）で実行されるか、外部サプライヤー（Outside Processing）で実行されるか。異なるダウンストリームフィールドを表示し、このプロセスの計画ルートの動作方法を変更し、新しい操作のデフォルト操作タイプを設定します。"
+msgstr "この工法が内部作業区（工程、組立、または検査）または外部仕入先（外注加工）で実行されるかどうか。異なるダウンストリームフィールドが表示され、この工法の計画ルーティング方法が変わり、新しい工程の工程タイプがデフォルトになります。"
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "この作業が生産をブロックするか(ダウン)、それを低下させるか(影響)、計画されたダウンタイムウィンドウ(計画)にあるか、または生産への影響がない(影響なし)。スケジューリングとカスタマーフェーシングダウンタイム通信に通知します。"
+msgstr "この作業が生産をブロック（ダウン）するか、低下させるか（影響）、計画されたダウンタイムウィンドウにあるか（計画済）、または生産に影響がない（影響なし）かを指定します。スケジューリングと顧客向けのダウンタイム通信を通知します。"
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
-msgstr "選択されたアクセス許可が各ユーザーが既に持っているものに追加されるか、または以下の選択で各ユーザーのアクセス許可セットを置き換えることで更新されるか。"
+msgstr "選択した権限を各ユーザーが既に持っているものに追加するか、または各ユーザーの権限セット全体を下記の選択で置き換えて更新するかどうか。"
 
 msgid "Which document drives each inspection flow for this item."
-msgstr "このアイテムの各検査フローを駆動するドキュメント。"
+msgstr "どの文書がこの品目の各検査フローを駆動するか。"
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "送信するリクエストの種類：GETは何かを読み取り、POSTは作成し、PUTとPATCHは更新し、DELETEは削除します。新しいステップはGETで始まり、POSTとPUTとPATCHのみがボディを含みます。"
+msgstr "送信するリクエストの種類を選択します：GETは何かを読み取り、POSTは作成、PUTおよびPATCHは更新、DELETEは削除します。新しいステップはGETで開始され、POST、PUT、およびPATCHのみがボディを持ちます。"
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "どの製造イベントが保存期間時計を開始するか — たとえば、塗りつぶし、シール、または最終QC。"
@@ -17338,34 +17338,34 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "見積、注文、購買の承認が必要な人と時期"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "メンテナンス関連のディスパッチについて、誰が通知を受け取るべきですか？"
+msgstr "保全関連の保全指示の通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "運用関連のディスパッチについて、誰が通知を受け取るべきですか？"
+msgstr "工程関連の保全指示の通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "他のディスパッチの通知を受け取るべき人は誰ですか？"
+msgstr "その他の保全指示の通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "品質関連のディスパッチについて通知を受け取るべき人は誰ですか？"
+msgstr "品質関連の保全指示の通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "デジタル見積が受け入れられた、または期限切れになった場合、誰が通知を受け取るべきですか？"
+msgstr "デジタル見積が承諾済または期限切れになったときに通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "ゲージが校正範囲外になったときに、誰が通知を受け取るべきですか？"
+msgstr "測定器が校正から外れたとき、誰が通知を受け取るべきですか？"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "新しい提案が送信されたときに、誰が通知を受け取るべきですか？"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "RFQが見積もり準備完了とマークされたときに、誰が通知を受け取るべきですか？"
+msgstr "見積依頼が見積準備完了としてマークされたときに通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications when a sales job is completed?"
-msgstr "営業ジョブが完了したときに、誰が通知を受け取るべきですか？"
+msgstr "販売製造指図が完了したときに通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
-msgstr "サプライヤーの見積もりが送信されたときに、誰が通知を受け取るべきですか？"
+msgstr "仕入先見積が提出されたときに通知を受け取る必要があるのは誰ですか？"
 
 msgid "Who should receive notifications when an inventory job is completed?"
 msgstr "在库存工作完成时，谁应该收到通知？"
@@ -17386,10 +17386,10 @@ msgid "Why is this included?"
 msgstr "なぜこれが含まれていますか？"
 
 msgid "Why is this locked?"
-msgstr "なぜこれはロックされていますか？"
+msgstr "なぜこれはロック中ですか？"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "在庫が変わる理由 — ポジティブ(見つかった)、ネガティブ(失われた/スクラップ)、または設定(カウントを測定値に置き換え)。"
+msgstr "在庫が変わっている理由 — 正（見つかった）、負（失った/スクラップ）、または設定（カウントを測定値で置き換える）。"
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "この行が拒否されている理由。印刷可能な見積もりに表示され、win-loss報告用に記録されます。"
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "仕掛品"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "ピッキングリストがない場合、オペレーターは「スキャン」タブから材料をピックします。"
+msgstr "ピッキングリストがない場合、作業者はスキャンタブから材料をピッキングします。"
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17424,25 +17424,25 @@ msgid "Wordmark Light Mode"
 msgstr "ワードマーク ライトモード"
 
 msgid "work center"
-msgstr "ワークセンター"
+msgstr "作業区"
 
 msgid "Work center"
-msgstr "ワークセンター"
+msgstr "作業区"
 
 msgid "Work Center"
-msgstr "ワークセンター"
+msgstr "作業区"
 
 msgid "Work Center Utilization"
-msgstr "ワークセンター稼働率"
+msgstr "作業区利用率"
 
 msgid "work centers"
-msgstr "ワークセンター"
+msgstr "作業区"
 
 msgid "Work centers"
-msgstr "作業センター"
+msgstr "作業区"
 
 msgid "Work Centers"
-msgstr "作業センター"
+msgstr "作業区"
 
 msgid "Work in process (WIP)"
 msgstr "仕掛品(WIP)"
@@ -17454,13 +17454,13 @@ msgid "Work in Progress (default)"
 msgstr "進行中の作業(デフォルト)"
 
 msgid "Work in Progress (WIP)"
-msgstr "進行中の作業(WIP)"
+msgstr "仕掛品（WIP）"
 
 msgid "Work instruction"
-msgstr "作業指示"
+msgstr "作業手順書"
 
 msgid "Work Instructions"
-msgstr "作業指示"
+msgstr "作業手順書"
 
 msgid "Work Phone"
 msgstr "仕事用電話"
@@ -17503,10 +17503,10 @@ msgid "Write-off for {0}"
 msgstr "{0}の償却"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "検査不合格とNCR処置によってスクラップまたは返品された在庫の償却"
+msgstr "検査不合格とNCR処置を通じてスクラップまたは返却された在庫の償却"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "資産の価値をその耐用年数にわたって削減する — 作成、ドラフトとしてレビュー、その後ポストするメンバッチ。"
+msgstr "資産の価値を耐用年数にわたって減額する―毎月作成し、下書きとしてレビューしてから転記するバッチです。"
 
 msgid "Year"
 msgstr "年"
@@ -17518,13 +17518,13 @@ msgid "Yes"
 msgstr "はい"
 
 msgid "Yes, Accept"
-msgstr "はい、承認する"
+msgstr "はい、承諾"
 
 msgid "Yes, also delete every nested storage unit."
-msgstr "はい、ネストされたすべてのストレージユニットも削除します。"
+msgstr "はい、ネストされたすべての保管ユニットも削除"
 
 msgid "Yes, Reject"
-msgstr "はい、拒否します"
+msgstr "はい、却下"
 
 msgid "Yes, Update IDs"
 msgstr "はい、IDを更新"
@@ -17533,7 +17533,7 @@ msgid "You"
 msgstr "あなた"
 
 msgid "You belong to more than one company. Pick where to work."
-msgstr "複数の企業に属しています。どこで働くかを選択してください。"
+msgstr "複数の会社に属しています。作業する会社を選択してください。"
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "テーマ設定からいつでもUIスタイルを変更できます"
@@ -17560,23 +17560,23 @@ msgid "You don't have permission to edit this bill of material."
 msgstr "この部品表を編集する権限がありません。"
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "このプロセス一覧を編集する権限がありません。"
+msgstr "この工程表を編集する権限がありません。"
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "あなたが主導し、私たちが確実に正しく実行します。セットアップ、データ、本番稼働に関する専門家の目が入ります。"
+msgstr "あなたが主導し、私たちはそれが正しく完了することを確認します。あなたの環境設定、データ、およびゴーライブに関する専門家の目。"
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
 msgstr "あなたは、PDFから抽出された{0}行を持っていますが、これらはインベントリアイテムにマップされていません。"
 
 msgid "You haven't created any contacts yet."
-msgstr "まだ連絡先を作成していません。"
+msgstr "まだ担当者を作成していません。"
 
 msgid "You lead"
 msgstr "あなたがリード"
 
 msgid "You name a project owner with decision authority"
-msgstr "プロジェクトオーナーを指定し、その人に決定権を与えます"
+msgstr "意思決定権を持つプロジェクト責任者を指名します"
 
 msgid "You received this item"
 msgstr "あなたがこのアイテムを受け取りました"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Carbonで本番稼働中です"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "ワークスペースの1ステップ手前です。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "あなた自身のペースでCarbonをセットアップしています"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "あなたは{hoursElapsed}時間クロックインしています。クロックアウトするのを忘れましたか？"
+msgstr "{hoursElapsed}時間作業しています。作業終了を忘れましたか?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "ログインが盗まれてもアカウントは安全です"
@@ -17603,13 +17603,13 @@ msgid "Your books and how money flows."
 msgstr "あなたの帳簿とお金の流れ。"
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "変更内容は、この変更通知でリリースされた新しいドラフトバージョンに反映されます。"
+msgstr "変更内容は、この変更通知とともにリリースされた新しい下書きバージョンに組み込まれます。"
 
 msgid "Your Console PIN"
 msgstr "あなたのコンソールPIN"
 
 msgid "Your customer list"
-msgstr "顧客リスト"
+msgstr "あなたの得意先リスト"
 
 msgid "Your customer-facing price lists"
 msgstr "顧客向けの価格表"
@@ -17627,19 +17627,19 @@ msgid "Your GL accounts"
 msgstr "あなたのGL勘定"
 
 msgid "your Implementation Lead"
-msgstr "あなたの実装リード"
+msgstr "あなたの実施リード"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "ご招待が無効であるか、既に受け入れられています。これがエラーだと思われる場合は、サポートにお問い合わせください。"
+msgstr "あなたの招待は無効であるか、既に承認されています。これがエラーだと思われる場合は、サポートにお問い合わせください。"
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "ここでのあなたの仕事：各行の実際のサンプルを確認してから、検証済みとしてマークしてください。基礎データが最初に読み込まれ、次にマスターレコード、その後カットオーバー時にオープントランザクションが読み込まれます。"
 
 msgid "Your legal name, addresses, branding, and document defaults"
-msgstr "あなたの法的名称、住所、ブランディング、およびドキュメントのデフォルト設定"
+msgstr "法人名、住所、ブランディング、文書デフォルト"
 
 msgid "Your main point of contact"
-msgstr "あなたの主な連絡先"
+msgstr "主な連絡先担当者"
 
 msgid "Your Name"
 msgstr "お名前"
@@ -17663,7 +17663,7 @@ msgid "Your real data is loaded and you have checked a sample and approved it."
 msgstr "あなたの実際のデータが読み込まれ、サンプルを確認して承認しました。"
 
 msgid "Your session was locked after inactivity."
-msgstr "セッションは非アクティブ後にロックされました。"
+msgstr "非アクティブのためセッションがロック中になりました。"
 
 msgid "Your source data is accessible and reasonably clean"
 msgstr "あなたのソースデータはアクセス可能で、適切にクリーンです"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "自分自身"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Z1.4検査レベル(I / II / III);高いレベルは同じロットのより大きなサンプルサイズを意味します。"
+msgstr "Z1.4検査水準（I / II / III）；高いレベルほど、同じロットのサンプルサイズが大きくなります。"
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4の重大度(通常/厳格化/削減);最近のロット受け入れ履歴に基づいてルールで切り替えます。"
+msgstr "Z1.4重大度（通常/きつい検査/ゆるい検査）；最近のロット承諾履歴に基づいてルールで切り替わります。"
 
 msgid "Zoom Box"
 msgstr "ズームボックス"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -8935,7 +8935,7 @@ msgid "Map Lines Now"
 msgstr "今すぐラインをマップ"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "勘定科目表をプロバイダーのものにマップしてください。転記デフォルトと費用アカウントは必須としてマークされています。転記されたジャーナルはマップされたプロバイダーアカウントコードを使用してプッシュされます。"
+msgstr "勘定科目表をプロバイダーの表にマップしてください。転記用デフォルト科目と費用科目は「必須」とマークされています。転記済の仕訳はマップされたプロバイダー科目を使用して送信されます。"
 
 msgid "Map your current process, systems, and data"
 msgstr "現在のプロセス、システム、データをマップする"
@@ -11619,7 +11619,7 @@ msgid "Protect training time and attend"
 msgstr "教育訓練の時間を確保して参加する"
 
 msgid "Protect your company with advanced security controls like two-factor authentication enforcement."
-msgstr "二段階認証の強制などの高度なセキュリティ管理で会社を保護してください。"
+msgstr "二要素認証の強制などの高度なセキュリティ制御で会社を保護します。"
 
 msgid "Protects your company's data"
 msgstr "会社データを保護します"
@@ -12499,7 +12499,7 @@ msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "サインイン時に認証器アプリから6桁のコードが必要です。"
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected."
-msgstr "このカンパニーを開く前に、認証アプリが必須です。他のカンパニーは影響を受けません。"
+msgstr "この会社にアクセスするにはオーセンティケーターアプリが必須です。他の会社は影響を受けません。"
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
 msgstr "このアプリケーション認証器を要求して、誰もがこの会社を開く前に認証を要求します。他の会社は影響を受けません。<0>従業員アカウントページ</0>にアクセスして、各個人のステータスを確認してください。"
@@ -14347,20 +14347,20 @@ msgid "Stripe Due Date"
 msgstr "Stripe期日"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr "Stripeは請求書を得意先にメール送信するため、住所が必要です。これはCarbonの担当者にも保存されます。"
+msgstr "Stripeは得意先に請求書をメール送信するため、住所が必須です。これはCarbonの担当者にも保存されます。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "このCarbonの得意先に対してまだStripeの顧客がありません。転記すると接続されたアカウントに顧客が作成されます。"
+msgstr "StripeにはこのCarbon得意先に対応する顧客がまだありません。転記すると、接続済みアカウント上に作成されます。"
 msgstr "Stripeにはこのメールアドレスを持つカスタマーが既に存在します"
 
 msgid "Stripe Due Date"
 msgstr "Stripe支払期日"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr "Stripeはカスタマーに請求書をメール送信するため、アドレスが必要です。これはCarbonの連絡先にも保存されます。"
+msgstr "Stripeは得意先に請求書をメール送信するため、住所が必須です。これはCarbonの担当者にも保存されます。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "StripeにはこのCarbonカスタマーのカスタマーがまだありません。投稿するとあなたの接続されたアカウントに1つ作成されます。"
+msgstr "StripeにはこのCarbon得意先に対応する顧客がまだありません。転記すると、接続済みアカウント上に作成されます。"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "かんばんテーブルに表示するかんばん出力のスタイル"
@@ -15671,11 +15671,11 @@ msgid "This invoice has no usable due date — choose one for Stripe."
 msgstr "この請求書には使用可能な期日がありません。Stripeの場合は、期日を選択してください。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "この請求書は、この Carbon 得意先にすでにリンクされている Stripe 顧客に請求されます。詳細を変更するには、Stripe ダッシュボードで編集してください。"
+msgstr "この請求書は、すでにこのCarbon得意先にリンクされているStripe顧客に請求されます。詳細を変更するには、Stripeダッシュボードで編集してください。"
 msgstr "この請求書には使用可能な支払期日がありません — Stripeのために1つ選択してください。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "この請求書は、このCarbonカスタマーに既にリンクされているStripeカスタマーに請求されます。その詳細を変更するには、Stripeダッシュボードで編集してください。"
+msgstr "この請求書は、すでにこのCarbon得意先にリンクされているStripe顧客に請求されます。詳細を変更するには、Stripeダッシュボードで編集してください。"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "これは管理環境のため、認証アプリが必須です。"
@@ -15819,7 +15819,7 @@ msgstr "このバージョンは公開済です。編集するには新しいバ
 msgstr "このバージョンは公開されています"
 
 msgid "This version is published. Create a new version to edit."
-msgstr "このバージョンは公開されています。編集するために新しいバージョンを作成してください。"
+msgstr "このバージョンは公開済です。編集するには新しいバージョンを作成してください。"
 
 msgid "This version's definition could not be read."
 msgstr "このバージョンの定義を読み取ることができませんでした。"
@@ -16224,7 +16224,7 @@ msgid "Two-factor authentication"
 msgstr "二要素認証"
 
 msgid "Two-Factor Authentication"
-msgstr "2要素認証"
+msgstr "二要素認証"
 
 msgid "Two-factor authentication disabled"
 msgstr "二要素認証が無効になりました"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -520,7 +520,6 @@ msgstr "とにかく完了"
 
 msgid "Finish setting up your account"
 msgstr "アカウントのセットアップを完了する"
-msgstr "アカウント設定を完了する"
 
 msgid "Finish with material unpicked?"
 msgstr "材料がピッキングされていない状態で終了しますか?"
@@ -533,7 +532,6 @@ msgstr "操作に戻る"
 
 msgid "Go to onboarding"
 msgstr "オンボーディングに移動"
-msgstr "オンボーディングへ進む"
 
 msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
@@ -1516,7 +1514,6 @@ msgstr "作業開始から{hoursElapsed}時間が経過しています。作業�
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "あなたのアカウントはまだ会社に属していません。継続するには、Carbon ERP でオンボーディングを完了してください。"
-msgstr "アカウントはまだ企業に属していません。Carbon ERPでオンボーディングを完了して続行してください。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "あなたの組織は認証器アプリが必要です。Carbonで設定してから、ここに戻ってください。"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -44,7 +44,7 @@ msgstr "{0} / {1} 完了済み"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr "{0} 待機中"
+msgstr "{0}件がキュー待ちです"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
@@ -67,13 +67,13 @@ msgid "About"
 msgstr "バージョン情報"
 
 msgid "Accept"
-msgstr "受け入れ"
+msgstr "承諾"
 
 msgid "Accept Lot"
-msgstr "ロットを受け入れ"
+msgstr "ロット承諾"
 
 msgid "Accept lot?"
-msgstr "ロットを受け入れますか？"
+msgstr "ロットを承諾しますか？"
 
 msgid "Account Settings"
 msgstr "アカウント設定"
@@ -103,7 +103,7 @@ msgid "Add Sample"
 msgstr "サンプルを追加"
 
 msgid "Add Spare Part"
-msgstr "スペアパーツを追加"
+msgstr "予備品を追加"
 
 msgid "All"
 msgstr "すべて"
@@ -112,7 +112,7 @@ msgid "All clear"
 msgstr "異常なし"
 
 msgid "All rework"
-msgstr "すべて再加工"
+msgstr "全て手直し"
 
 msgid "All scrap"
 msgstr "すべてスクラップ"
@@ -160,7 +160,7 @@ msgid "Batch"
 msgstr "バッチ"
 
 msgid "Batch is not available"
-msgstr "バッチは利用できません"
+msgstr "バッチは利用可能ではありません"
 
 #. placeholder {0}: index + 1
 msgid "Batch Number {0}"
@@ -210,16 +210,16 @@ msgid "Clear"
 msgstr "クリア"
 
 msgid "Clear Filters"
-msgstr "フィルターをクリア"
+msgstr "絞り込みをクリア"
 
 msgid "Clear Search"
 msgstr "検索をクリア"
 
 msgid "Clock In"
-msgstr "出勤打刻"
+msgstr "作業開始"
 
 msgid "Clock Out"
-msgstr "退勤打刻"
+msgstr "作業終了"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/>からクロックイン中"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "すべて完了"
 
 msgid "Complete passed"
-msgstr "完了済みを完了"
+msgstr "合格を完了する"
 
 msgid "Completed"
 msgstr "完了済み"
@@ -282,7 +282,7 @@ msgstr "消費期限切れ"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr "計画外メンテナンスのコスト（過去{0}日間）"
+msgstr "過去{0}日間の未計画保全原価"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -296,13 +296,13 @@ msgid "Create Quality Issue"
 msgstr "品質問題を作成"
 
 msgid "Create Rework"
-msgstr "リワーク作成"
+msgstr "手直しを作成"
 
 msgid "Current work"
 msgstr "現在の作業"
 
 msgid "Customer"
-msgstr "顧客"
+msgstr "得意先"
 
 msgid "Dark Mode"
 msgstr "ダークモード"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "詳細"
 
 msgid "Dispatch not found"
-msgstr "ディスパッチが見つかりません"
+msgstr "保全指示が見つかりません"
 
 msgid "Display"
 msgstr "表示"
@@ -353,14 +353,14 @@ msgid "Down"
 msgstr "停止"
 
 msgid "Down for maintenance"
-msgstr "メンテナンスのため停止中"
+msgstr "保全中のため停止"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr "メンテナンスのため停止中 · {0}"
+msgstr "保全中のため停止 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "計画的メンテナンスのため停止中"
+msgstr "計画済保全中のため停止"
 
 msgid "Download"
 msgstr "ダウンロード"
@@ -388,7 +388,7 @@ msgid "Due {0}"
 msgstr "期限 {0}"
 
 msgid "Due Date"
-msgstr "納期"
+msgstr "期日"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
@@ -398,10 +398,10 @@ msgid "Due today?"
 msgstr "本日が納期か?"
 
 msgid "Duplicate batch number"
-msgstr "バッチ番号が重複しています"
+msgstr "バッチ番号の複製"
 
 msgid "Duplicate serial number"
-msgstr "シリアル番号が重複しています"
+msgstr "シリアル番号の複製"
 
 msgid "Duration"
 msgstr "時間"
@@ -416,7 +416,7 @@ msgid "Email Address"
 msgstr "メールアドレス"
 
 msgid "Empty work centers"
-msgstr "空の作業センター"
+msgstr "作業区が空です"
 
 msgid "End Operations"
 msgstr "工程を終了"
@@ -500,13 +500,13 @@ msgid "Files"
 msgstr "ファイル"
 
 msgid "Files related to the job and the opportunity line."
-msgstr "ジョブおよび案件明細に関連するファイル。"
+msgstr "製造指図と商談明細に関連するファイル。"
 
 msgid "Filter"
-msgstr "フィルター"
+msgstr "絞り込み"
 
 msgid "Filter by location"
-msgstr "ロケーションで絞り込む"
+msgstr "拠点で絞り込み"
 
 msgid "Finish"
 msgstr "完了"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "とにかく完了"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "アカウントのセットアップを完了する"
 
 msgid "Finish with material unpicked?"
 msgstr "材料がピッキングされていない状態で終了しますか?"
 
 msgid "Forgot to Clock Out?"
-msgstr "退勤打刻を忘れましたか？"
+msgstr "作業終了を忘れていませんか？"
 
 msgid "Go back to operation"
 msgstr "操作に戻る"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "オンボーディングに移動"
 
 msgid "How many were actually picked?"
 msgstr "実際にはいくつ選ばれましたか？"
@@ -616,10 +616,10 @@ msgid "Job Details"
 msgstr "ジョブ詳細"
 
 msgid "Job Traveler"
-msgstr "ジョブトラベラー"
+msgstr "製造指図現品票"
 
 msgid "Jobs"
-msgstr "ジョブ"
+msgstr "製造指図"
 
 msgid "Keep picking"
 msgstr "ピッキングを続ける"
@@ -628,7 +628,7 @@ msgid "Kit"
 msgstr "キット"
 
 msgid "Labor"
-msgstr "作業"
+msgstr "労務"
 
 msgid "Last completed"
 msgstr "最後に完了"
@@ -691,16 +691,16 @@ msgid "Machine"
 msgstr "機械"
 
 msgid "Machine down for maintenance now?"
-msgstr "マシンは今メンテナンスのため停止しているか?"
+msgstr "機械が今保全中ですか？"
 
 msgid "Maintenance"
-msgstr "メンテナンス"
+msgstr "保全"
 
 msgid "Maintenance Completed"
-msgstr "メンテナンス完了"
+msgstr "保全完了"
 
 msgid "Maintenance overdue"
-msgstr "メンテナンス期限超過"
+msgstr "保全が期限超過"
 
 msgid "Make a replacement"
 msgstr "代替品を作成"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "手動で在庫に品目を追加"
 
 msgid "Manually remove items from inventory"
-msgstr "手動で在庫から品目を削除"
+msgstr "在庫から品目を手動で除去"
 
 msgid "Mark Short"
 msgstr "短い数量をマーク"
@@ -773,22 +773,22 @@ msgid "No"
 msgstr "いいえ"
 
 msgid "No active job at this work center"
-msgstr "このワークセンターにアクティブなジョブはありません"
+msgstr "この作業区に実行中の製造指図がありません"
 
 msgid "No active maintenance dispatches"
-msgstr "アクティブなメンテナンスディスパッチはありません"
+msgstr "有効な保全指示がありません"
 
 msgid "No active operations"
 msgstr "アクティブな工程はありません"
 
 msgid "No active work centers at this location."
-msgstr "この場所にはアクティブなワークセンターがありません。"
+msgstr "この拠点には有効な作業区がありません。"
 
 msgid "No assigned operations"
 msgstr "割り当てられた工程はありません"
 
 msgid "No available filters"
-msgstr "利用可能なフィルターはありません"
+msgstr "利用可能な絞り込みはありません。"
 
 msgid "No available serial numbers found"
 msgstr "利用可能なシリアル番号が見つかりません"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "利用可能な追跡対象エンティティが見つかりません"
 
 msgid "No dispatches assigned to you"
-msgstr "あなたに割り当てられたディスパッチはありません"
+msgstr "あなたに割り当てられた保全指示はありません。"
 
 msgid "No files"
 msgstr "ファイルなし"
@@ -809,7 +809,7 @@ msgid "No issue types configured"
 msgstr "構成されたイシュータイプがありません"
 
 msgid "No maintenance scheduled for today"
-msgstr "本日のメンテナンス予定はありません"
+msgstr "本日の保全予定はありません。"
 
 msgid "No matches. Type to create one."
 msgstr "一致するものがありません。入力して新しく作成してください。"
@@ -818,13 +818,13 @@ msgid "No materials"
 msgstr "材料なし"
 
 msgid "No open jobs"
-msgstr "オープンなジョブはありません"
+msgstr "オープンな製造指図はありません。"
 
 msgid "No open units to allocate"
 msgstr "割り当てるオープンユニットがありません"
 
 msgid "No operators"
-msgstr "オペレーターなし"
+msgstr "作業者がいません。"
 
 msgid "No option found."
 msgstr "オプションが見つかりません。"
@@ -866,7 +866,7 @@ msgid "No serial numbers found"
 msgstr "シリアル番号が見つかりません"
 
 msgid "No spare parts added yet"
-msgstr "スペアパーツはまだ追加されていません"
+msgstr "予備品はまだ追加されていません。"
 
 msgid "No stock"
 msgstr "在庫なし"
@@ -881,22 +881,22 @@ msgid "No Work Center"
 msgstr "作業区未設定"
 
 msgid "No work centers are blocked"
-msgstr "ブロックされているワークセンターはありません"
+msgstr "ブロックされた作業区はありません。"
 
 msgid "No work centers exist"
-msgstr "ワークセンターがありません"
+msgstr "作業区が存在しません。"
 
 msgid "None"
 msgstr "なし"
 
 msgid "Notes"
-msgstr "備考"
+msgstr "メモ"
 
 msgid "Nothing running"
 msgstr "稼働中の作業はありません"
 
 msgid "Nothing scheduled at this work center"
-msgstr "このワークセンターにはスケジュールされたものはありません"
+msgstr "この作業区には予定がありません。"
 
 msgid "Nothing to scrap"
 msgstr "スクラップするものがない"
@@ -921,13 +921,13 @@ msgid "Open"
 msgstr "未対応"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "ワークセンターに取り付けられた画面にディスプレイを開き、実行し続けます。各ボードは自動的に更新されます。"
+msgstr "作業区に設置されたスクリーン上にディスプレイを表示して、実行し続けてください。各ボードは自動的に更新されます。"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "MRB処分用のNCRを開く"
+msgstr "MRB処置のためにNCRを開く"
 
 msgid "Open Jobs"
-msgstr "オープンジョブ"
+msgstr "オープンな製造指図"
 
 msgid "Operations"
 msgstr "工程"
@@ -936,10 +936,10 @@ msgid "Operations ended"
 msgstr "工程が終了しました"
 
 msgid "Operator"
-msgstr "オペレーター"
+msgstr "作業者"
 
 msgid "Operator Performed"
-msgstr "オペレーター実施"
+msgstr "作業者が実施"
 
 msgid "Optional"
 msgstr "オプション"
@@ -960,10 +960,10 @@ msgid "Part"
 msgstr "パーツ"
 
 msgid "Partial"
-msgstr "部分的"
+msgstr "一部"
 
 msgid "Partial Disposition"
-msgstr "部分的な処分"
+msgstr "一部処置"
 
 msgid "Passed Inspection"
 msgstr "検査合格"
@@ -1026,7 +1026,7 @@ msgid "Priority"
 msgstr "優先度"
 
 msgid "Procedure"
-msgstr "手順"
+msgstr "手順書"
 
 msgid "Process"
 msgstr "プロセス"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "キューが空です"
 
 msgid "Reason for rework"
-msgstr "リワークの理由"
+msgstr "手直しの理由"
 
 msgid "Recent"
 msgstr "最近"
@@ -1072,7 +1072,7 @@ msgid "Record only"
 msgstr "記録のみ"
 
 msgid "Record Partial"
-msgstr "部分的に記録"
+msgstr "一部を記録"
 
 msgid "Reject"
 msgstr "却下"
@@ -1081,31 +1081,31 @@ msgid "Reject Lot"
 msgstr "ロットを却下"
 
 msgid "Remove"
-msgstr "削除"
+msgstr "除去"
 
 msgid "Remove filter"
-msgstr "フィルターを削除"
+msgstr "絞り込みを除去"
 
 msgid "Remove Inventory"
-msgstr "在庫削除"
+msgstr "在庫を除去"
 
 msgid "Remove part"
-msgstr "パーツを削除"
+msgstr "部品を除去"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "サブアセンブリを再度開いて代替ユニットを作成"
+msgstr "サブアセンブリを再オープンし、代替品を作成"
 
 msgid "Result"
 msgstr "結果"
 
 msgid "Rework"
-msgstr "リワーク"
+msgstr "手直し"
 
 msgid "Rework created successfully"
-msgstr "リワーク作成に成功しました"
+msgstr "手直しが正常に作成されました"
 
 msgid "Rework quantity"
-msgstr "リワーク数量"
+msgstr "手直し数量"
 
 msgid "Running"
 msgstr "実行中"
@@ -1120,13 +1120,13 @@ msgid "Scan"
 msgstr "スキャン"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "スキャンして追跡エンティティを追加し、最初のサンプル列を追加してください。"
+msgstr "追跡対象をスキャンして、最初のサンプル列を追加します。"
 
 msgid "Scan or enter serial number"
 msgstr "シリアル番号をスキャンまたは入力"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "追跡エンティティID、シリアル番号、またはバッチをスキャンまたは入力してください"
+msgstr "追跡対象のID、シリアル番号、またはバッチをスキャンまたは入力"
 
 msgid "Scan or enter tracking number"
 msgstr "スキャンまたは追跡番号を入力"
@@ -1135,13 +1135,13 @@ msgid "Scan or search serial number..."
 msgstr "シリアル番号をスキャンまたは検索..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "このロットから追跡エンティティをスキャンまたは選択してサンプル列として追加し、グリッドにその結果を記録してください。"
+msgstr "このロットから追跡対象をスキャンまたは選択してサンプル列として追加し、グリッドに結果を記録します。"
 
 msgid "Schedule"
 msgstr "スケジュール"
 
 msgid "Scrap"
-msgstr "廃棄"
+msgstr "スクラップ"
 
 msgid "Scrap {readableId}"
 msgstr "{readableId} をスクラップ"
@@ -1153,7 +1153,7 @@ msgid "Scrap quantity"
 msgstr "スクラップ数量"
 
 msgid "Scrap Reason"
-msgstr "スクラップ理由"
+msgstr "不良理由"
 
 msgid "Scrapped"
 msgstr "スクラップ済み"
@@ -1171,7 +1171,7 @@ msgid "Search by job or item ID"
 msgstr "ジョブまたはアイテムIDで検索"
 
 msgid "Search operators..."
-msgstr "オペレーターを検索..."
+msgstr "作業者を検索..."
 
 msgid "Search..."
 msgstr "検索..."
@@ -1215,7 +1215,7 @@ msgid "Select Serial Number"
 msgstr "シリアル番号を選択"
 
 msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
-msgstr "戻る操作を選択してください。その時点から現在の操作までのすべての操作が再度実行されます。"
+msgstr "戻る工程を選択します。その時点から現在の工程までのすべての工程が再度実行されます。"
 
 msgid "Selected"
 msgstr "選択済み"
@@ -1234,7 +1234,7 @@ msgid "Serial Number {0}"
 msgstr "シリアル番号 {0}"
 
 msgid "Serial number is not available"
-msgstr "シリアル番号は利用できません"
+msgstr "シリアル番号が利用可能ではありません"
 
 msgid "Serial number is required"
 msgstr "シリアル番号は必須です"
@@ -1246,10 +1246,10 @@ msgid "Serial Numbers"
 msgstr "シリアル番号"
 
 msgid "Session locked"
-msgstr "セッションがロックされています"
+msgstr "セッションはロック中です。"
 
 msgid "Set Clock Out"
-msgstr "退勤時間を設定"
+msgstr "作業終了を設定"
 
 msgid "Set clock-out time"
 msgstr "退勤時間を設定"
@@ -1300,10 +1300,10 @@ msgid "Source"
 msgstr "ソース"
 
 msgid "Spare Parts"
-msgstr "スペアパーツ"
+msgstr "予備品"
 
 msgid "Spare Parts Used"
-msgstr "使用済みスペアパーツ"
+msgstr "使用予備品"
 
 msgid "Start"
 msgstr "開始"
@@ -1316,7 +1316,7 @@ msgstr "ステーション: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "統計的受け入れに失敗したため、{0}の全ロットは不適合と見なされます(ISO 9001:2015 §8.7) — {passes}件のサンプル合格と{fails}件の不合格。以下のユニットをスクラップまたは再加工にルーティングするか、判定のみを記録してください。"
+msgstr "統計的抜取検査に失敗したため、{0}全体のロットが不適合と見なされます(ISO 9001:2015 §8.7) — {passes}件合格、{fails}件失敗。下記のユニットをスクラップまたは手直しにルーティングするか、判定のみを記録してください。"
 
 msgid "Status"
 msgstr "ステータス"
@@ -1334,10 +1334,10 @@ msgid "Steps are missing"
 msgstr "ステップが未記録です"
 
 msgid "Storage Unit"
-msgstr "保管場所"
+msgstr "保管ユニット"
 
 msgid "Submit anonymously"
-msgstr "匿名で送信"
+msgstr "匿名で提出"
 
 msgid "Suggestion"
 msgstr "提案"
@@ -1346,7 +1346,7 @@ msgid "Support Required"
 msgstr "サポート必要"
 
 msgid "Switch Operator"
-msgstr "オペレーターを切替"
+msgstr "作業者を切り替える"
 
 msgid "Tag"
 msgstr "タグ"
@@ -1367,16 +1367,16 @@ msgid "There are serial or batch tracked materials on the bill of material that 
 msgstr "部品表にシリアルまたはバッチ追跡対象の材料が完全に払い出されていません。払出なしで完了すると、トレーサビリティ記録が不正確になる可能性があります。"
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
-msgstr "これらのアイテムにはまだピッキング対象の材料があります。今完了すると、リストは部分的としてマークされます。"
+msgstr "これらの品目にはまだピッキングする材料があります。今、完了するとリストが一部としてマークされます。"
 
 msgid "This lot is expired and can't be picked."
 msgstr "このロットは期限切れであり、ピックできません。"
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "この部品は注文に応じて製造されました。これをスクラップすると、代替品を製造するためにそのルーティングを再度開くことができます。"
+msgstr "この部品は受注生産で製造されました。スクラップすると、その工順を再オープンして交換部品を製造できます。"
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "この部品は在庫からスクラップされます。その要件は開いたままなので、代替品を発行できます。"
+msgstr "この部品は在庫からスクラップされます。その要求事項は開いたままなので、代替品を出庫できます。"
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "このユニットは永久にスクラップされ、代替シリアル番号が作成されます。"
@@ -1409,7 +1409,7 @@ msgid "Total: {0}"
 msgstr "合計: {0}"
 
 msgid "Tracked Entity"
-msgstr "追跡エンティティ"
+msgstr "追跡対象"
 
 msgid "Tracking"
 msgstr "追跡"
@@ -1446,11 +1446,11 @@ msgid "Unpick {0}"
 msgstr "ピック解除 {0}"
 
 msgid "Unplanned downtime"
-msgstr "計画外のダウンタイム"
+msgstr "計画外の停止時間"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr "計画外メンテナンス項目（過去{0}日間）"
+msgstr "計画外の保全指示、過去{0}日間"
 
 msgid "Unsaved changes"
 msgstr "未保存の変更"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "確認"
 
 msgid "View maintenance dispatch"
-msgstr "メンテナンスディスパッチを表示"
+msgstr "保全指示を表示"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "アカウントにサインインするためのマジックリンクをお送りしました。"
@@ -1498,10 +1498,10 @@ msgid "WIP"
 msgstr "仕掛品"
 
 msgid "Work Center"
-msgstr "ワークセンター"
+msgstr "作業区"
 
 msgid "Work Center Displays"
-msgstr "ワークセンター ディスプレイ"
+msgstr "作業区ディスプレイ"
 
 msgid "Yes"
 msgstr "はい"
@@ -1510,13 +1510,13 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "あなたは<0/>にクロックインしました。下記でクロックアウト時間を編集するか、まだ作業中であることを確認できます。"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "{hoursElapsed} 時間出勤中です。退勤打刻を忘れていませんか？"
+msgstr "作業開始から{hoursElapsed}時間が経過しています。作業終了を忘れていませんか？"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "あなたのアカウントはまだ会社に属していません。継続するには、Carbon ERP でオンボーディングを完了してください。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "あなたの組織は認証器アプリが必要です。Carbonで設定してから、ここに戻ってください。"
 
 msgid "Your session was locked after inactivity."
-msgstr "非アクティブ後、セッションがロックされました。"
+msgstr "無操作のためセッションがロック中になりました。"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -27,13 +27,13 @@ msgstr ", {years}년"
 
 #. placeholder {0}: fieldDef?.label ?? condition.field
 msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
-msgstr "\"{0}\"은(는) 선택한 표면(들)에서 사용할 수 없습니다. 다른 필드를 선택하세요."
+msgstr "\"{0}\"은(는) 선택한 표면에서 사용할 수 없습니다. 다른 필드를 선택하세요."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "\"{storageUnitName}\"에는 {childCount}개의 직속 하위 저장 단위가 있습니다. 삭제하면 이들과 그 하위 항목도 모두 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr "\"{storageUnitName}\"에는 {childCount}개의 직접 중첩 보관 단위가 있습니다. 이를 삭제하면 해당 단위 및 그 아래의 모든 항목도 삭제됩니다. 이 작업은 실행 취소할 수 없습니다."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "\"{storageUnitName}\"에는 1개의 직속 하위 저장 단위가 있습니다. 삭제하면 해당 단위와 그 하위 항목도 모두 삭제됩니다. 이 작업은 되돌릴 수 없습니다."
+msgstr "\"{storageUnitName}\"에는 1개의 직접 중첩 보관 단위가 있습니다. 이를 삭제하면 해당 단위 및 그 아래의 모든 항목도 삭제됩니다. 이 작업은 실행 취소할 수 없습니다."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -50,7 +50,7 @@ msgstr "(이 고객에게는 제외됨)"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
-msgstr "{0, plural, one {이 품목은 1개의 미완료 변경 공지에 포함되어 있습니다} other {이 품목은 #개의 미완료 변경 공지에 포함되어 있습니다}}"
+msgstr "{0, plural, one {이 품목은 1개의 미결 변경 통지에 포함되어 있습니다} other {이 품목은 # 개의 미결 변경 통지에 포함되어 있습니다}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -79,11 +79,11 @@ msgstr "{0}이(가) 삭제되었습니다"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0}건의 임시 분개"
+msgstr "{0}개의 초안 분개"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0}개 작업이 생성됨"
+msgstr "{0}개의 작업 지시 생성됨"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -92,7 +92,7 @@ msgstr "매핑할 라인 {0}개"
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
-msgstr "{0}개의 {1} 게시 계정 매핑됨"
+msgstr "{0}개의 {1}개 전기 계정 매핑됨"
 
 #. placeholder {0}: rows.length
 msgid "{0} of {maxSlots} provider slots used"
@@ -104,7 +104,7 @@ msgstr "주문 {0}건"
 
 #. placeholder {0}: issues.length
 msgid "{0} problems — not published"
-msgstr "{0}개 문제 — 발행되지 않음"
+msgstr "{0}개의 문제 — 게시되지 않음"
 
 #. placeholder {0}: selectedProcesses.length
 msgid "{0} Processes"
@@ -112,7 +112,7 @@ msgstr "공정 {0}개"
 
 #. placeholder {0}: result.credentialName ?? "Passkey"
 msgid "{0} registered"
-msgstr "{0}이 등록되었습니다"
+msgstr "{0} 등록됨"
 
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
@@ -120,7 +120,7 @@ msgstr "잔액이 있는 공급업체 {0}곳"
 
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
-msgstr "샘플링되지 않은 개체 {0}개가 사용 가능 상태로 전환됩니다. 샘플링에서 합격한 항목은 사용 가능 상태를 유지하고, 불합격한 항목은 반려 상태를 유지합니다."
+msgstr "{0}개의 미검사 항목이 가용으로 릴리스됩니다. 검사 합격 항목은 가용으로 유지되고 검사 불합격 항목은 거부됨으로 유지됩니다."
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0}개 값 누락"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount}개 부품이 건너뜀 — 이미 활성 작업이 있음"
+msgstr "{alreadyPlannedItemCount}개 부품 건너뜀 — 이미 미결 작업 지시가 있음"
 
 msgid "{apOverduePct}% of payables"
 msgstr "매입채무의 {apOverduePct}%"
@@ -166,10 +166,10 @@ msgid "{from}–{to} of {count}"
 msgstr "{count}개 중 {from}–{to}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}–{to} / {count}개 작업"
+msgstr "{from}–{to}/{count} 공정"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount}개 추가: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "총액이 일치하지 않는 {mismatchCount}개월"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "공급자에서 누락된 {missingCount}개 분개"
+msgstr "{missingCount}개의 전표가 공급자에서 누락됨"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount}개 누락된 분개 및 {mismatchCount}개 일치하지 않는 월"
+msgstr "{missingCount}개의 누락된 전표 및 {mismatchCount}개의 불일치 월"
 
 msgid "{name} deleted"
 msgstr "{name} 삭제됨"
@@ -199,7 +199,7 @@ msgstr "{noDemandItemCount}개 부품이 건너뜀 — 만들 것이 없음"
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel}이(가) 리비전 {0}으로 편집을 위해 다시 열립니다. 공급자에게 이미 보낸 문서는 주문을 확정하고 재전송할 때까지 변경되지 않습니다."
+msgstr "{orderLabel}은(는) 리비전 {0}으로 편집하기 위해 다시 열립니다. 이미 공급업체로 전송된 문서는 리비전을 완료하고 다시 전송할 때까지 변경되지 않습니다."
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining}단계 남음"
@@ -208,7 +208,7 @@ msgid "{scopeCount} permissions"
 msgstr "권한 {scopeCount}개"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "귀사가 Carbon을 도입하기까지 {total}단계가 있습니다. 각 단계는 체크포인트로 마무리됩니다."
+msgstr "회사를 Carbon에 가동시키기 위한 {total}개 단계. 각 단계는 체크포인트에서 종료됩니다."
 
 msgid "{total} phases to go live"
 msgstr "도입까지 {total}단계"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount}개 작업이 업데이트됨"
+msgstr "{updatedJobCount}개의 작업 지시 업데이트됨"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} 업로드됨 — 문서에서 필드가 채워졌습니다."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "예상 수량과 다른 라인 {variances}개"
+msgstr "{variances, plural, one {# 라인이 예상 수량과 다릅니다} other {# 라인이 예상 수량과 다릅니다}}"
 
 msgid "{years}yr"
 msgstr "{years}년"
@@ -246,10 +246,10 @@ msgid "↩ {0} redirected from superseded {1}"
 msgstr "↩ 대체된 {1}에서 {0}(으)로 전환됨"
 
 msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
-msgstr "이 품목에 <0>공급업체 부품 추가</0>를 하여 선호 공급업체를 설정하세요."
+msgstr "<0>이 품목에 공급업체 부품 추가</0>하여 우선 공급업체를 설정하세요."
 
 msgid "0 operations"
-msgstr "0개 작업"
+msgstr "0개 공정"
 
 msgid "0-4 weeks"
 msgstr "0-4주"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1일"
 
 msgid "1 draft journal entry"
-msgstr "1건의 임시 분개"
+msgstr "1개의 초안 분개"
 
 msgid "1 job created"
 msgstr "1개 작업이 생성됨"
@@ -273,7 +273,7 @@ msgid "1 part skipped — nothing to make"
 msgstr "1개 부품이 건너뜀 — 만들 것이 없음"
 
 msgid "1 problem — not published"
-msgstr "1개 문제 — 발행되지 않음"
+msgstr "1개의 문제 — 게시되지 않음"
 
 msgid "1 unposted document"
 msgstr "1건의 미전기 문서"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4시간"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "최소 5명의 사용자"
 
 msgid "5-8 weeks"
 msgstr "5-8주"
 
 msgid "52-week demand"
-msgstr "52주 수요"
+msgstr "52주 소요량"
 
 msgid "5MB file limit"
 msgstr "5MB 파일 제한"
@@ -330,10 +330,10 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Carbon이 진행하는 데이터 마이그레이션 — 직접 데이터를 업로드"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "변경 공지는 엔지니어링 또는 제조 변경 사항을 검토 및 구현 단계를 거쳐 추적합니다."
+msgstr "변경 통지는 제어된 엔지니어링 또는 제조 변경사항을 검토 및 실행을 통해 추적합니다."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
-msgstr "입고되었으나 아직 청구되지 않은 재화의 금액을 보관하는 경과 계정으로, 공급업체 인보이스가 처리되면 정산됩니다."
+msgstr "수신한 상품이지만 아직 청구되지 않은 상품의 가치를 보유하는 정산 계정이며, 공급업체 송장이 이를 정산합니다."
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
 msgstr "다른 회사의 사양에 따라 부품을 만드는 대신, 자사의 완제품을 처음부터 끝까지 직접 설계하고 제작하는 회사(여기서는 휴머노이드 로봇을 만드는 업체)."
@@ -345,7 +345,7 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "핵심 테이블(고객, 부품, 주문)에 첨부된 회사 정의 추가 필드로서, 레코드 양식에 표시되고 기본 제공 필드와 함께 저장되며 API를 통해 쿼리할 수 있습니다."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "일지 라인에 첨부된 회사 정의 태그 축으로서, 동일한 계정을 계정 차트를 늘리지 않고 위치, 부서 또는 사용자 정의 축으로 분류할 수 있습니다."
+msgstr "같은 계정을 계정과목표를 중복 없이 사업장, 부서 또는 기타 사용자 정의 축으로 구분할 수 있도록 분개에 첨부된 회사 정의 태그 축입니다."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "회사 범위의 할인 또는 마진(백분율 또는 고정 금액)으로서, 라인이 규칙의 수량, 날짜, 항목 및 고객 조건과 일치할 때 라인의 가격을 상향 또는 하향 조정합니다."
@@ -354,13 +354,13 @@ msgid "A completed job's output, received into inventory at the job's actual acc
 msgstr "완료된 작업의 산출물로, 해당 작업에 누적된 실제 재공품(WIP) 원가로 재고에 입고됩니다."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "소모품은 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+msgstr "소모품은 여러 작업 지시에 걸쳐 사용할 수 있는 부품을 만드는 데 사용되는 물리적 항목입니다."
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "계약직은 특정 역량과 가용 시간을 가진 공급업체 담당자입니다"
+msgstr "외주 인력은 특정 역량과 가용 시간을 가진 공급업체 담당자입니다."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "귀사의 필요를 충족하는 맞춤형 솔루션"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "고객은 귀사의 부품이나 서비스를 구매하는 회사 또는 개인입니다."
@@ -393,28 +393,28 @@ msgid "A customer's type changes"
 msgstr "고객의 유형이 변경됨"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "게이지가 추적 가능한 표준에 대해 확인되었음을 증명하는 날짜가 있는 기록으로서, 조치 필요, 조정 필요 또는 수리 필요 플래그가 선택되지 않은 한 통과하며 게이지의 다음 기한 날짜를 재설정합니다."
+msgstr "계측기가 추적 가능한 표준에 대해 확인되었음을 증명하는 날짜가 있는 기록입니다. 조치 필요, 조정 필요 또는 수리 필요 플래그가 체크되지 않으면 합격이며, 계측기의 다음 만료일을 재설정합니다."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
 msgstr "전기가 속하는 날짜 기간으로서, 그 종료 상태는 열림 → 잠김 → 종료로 이동하며, 종료된 기간은 새로운 전기에 대해 고정됩니다."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
-msgstr "매 기간 잔존 장부가액의 일정 비율을 상각하는 방법으로, 초반에 많이, 후반에 적게 상각됩니다."
+msgstr "각 기간마다 남은 장부가액의 고정 비율을 청구하는 감가상각 방법입니다. 초기에 크고 나중에 작습니다."
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
-msgstr "자산의 내용연수 동안 매 기간 동일한 금액을 상각하는 방법입니다."
+msgstr "자산의 내용연수에 걸쳐 매 기간마다 동일한 금액을 청구하는 감가상각 방법입니다."
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
-msgstr "고객에게 납품하기로 확정된 약속으로, 완료 상태에 이르기 전에 이행 상태가 출하와 인보이스 발행으로 나뉩니다."
+msgstr "배송을 위한 확정된 고객 약정이며, 이행 상태는 완료됨에 도달하기 전에 배송 및 송장에 걸쳐 진행됩니다."
 
 msgid "A firm order to a supplier; status moves through receive and invoice before Completed as goods and bills arrive."
-msgstr "공급업체에 대한 확정 주문으로, 재화와 청구서가 도착함에 따라 상태가 입고와 인보이스 처리를 거쳐 완료로 이동합니다."
+msgstr "공급업체에 대한 확정 발주이며, 상태는 완료됨에 도달하기 전에 수령 및 송장을 통해 진행되며 상품 및 청구서가 도착합니다."
 
 msgid "A formal acceptance / sign-off phase"
 msgstr "공식 승인/서명 단계"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "역할이 마스터인 게이지로서, 정기적인 점검에 사용되는 것이 아니라 다른 게이지가 교정되는 기준이 됩니다."
+msgstr "역할이 표준기인 계측기 — 정기적인 확인에 사용되는 계측기가 아니라 다른 계측기를 교정하는 데 사용되는 참조 표준입니다."
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "이슈 레코드는 품질 이슈와 그 해결 과정을 추적합니다."
@@ -432,7 +432,7 @@ msgid "A job is released"
 msgstr "작업이 해제됨"
 
 msgid "A job operation is completed"
-msgstr "작업 작업이 완료됨"
+msgstr "작업 지시 공정이 완료됨"
 
 msgid "A job's assignee changes"
 msgstr "작업의 담당자가 변경됨"
@@ -450,10 +450,10 @@ msgid "A job's quantity changes"
 msgstr "작업의 수량이 변경됨"
 
 msgid "A job's scrap quantity changes"
-msgstr "작업의 폐기 수량이 변경됨"
+msgstr "작업 지시의 스크랩 수량이 변경됨"
 
 msgid "A job's start date changes"
-msgstr "작업의 시작 날짜가 변경됨"
+msgstr "작업 지시의 시작일이 변경됨"
 
 msgid "A job's status changes"
 msgstr "작업의 상태가 변경됨"
@@ -467,31 +467,31 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "목록이 {0}에 연결되어 있으므로 이 단계는 그 안의 각 항목마다 한 번씩 실행됩니다 — 최대 {MAX_LIST_ITEMS}개까지."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "상위 빌드 내에서 자체 작업과 공정을 갖는 주문생산(Make to Order) 구성품입니다."
+msgstr "주문 생산 부품으로 모품목 생산 시에 자신의 작업 지시와 라우팅을 갖습니다."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "부품이 상위 작업에 함께 투입되는 주문생산(Make to Order) 구성품으로, 별도의 빌드가 없습니다."
+msgstr "주문 생산 부품으로 부품이 모품목 작업 지시로 함께 불출되며 별도 생산은 없습니다."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "관리형 클라우드 호스팅 Carbon 버전"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "모든 고급 기능을 갖춘 관리형 버전"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "자재는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+msgstr "자재는 부품을 만드는 데 사용되는 물리적 품목으로 여러 작업 지시에서 사용할 수 있습니다."
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "측정 기기(캘리퍼, 마이크로미터, 핀 게이지, CMM)로서 레코드로 추적되고 반복 교정 일정을 유지합니다."
+msgstr "계측기(캘리퍼, 마이크로미터, 핀 게이지, CMM)로 기록으로 추적되며 반복되는 교정 일정을 유지합니다."
 
 msgid "A name is required to save a view"
 msgstr "보기를 저장하려면 이름이 필요합니다"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "특정 항목에 대해 협상한 가격으로서, 고객별, 고객 유형별 또는 모든 고객에 대해 기본 가격을 완전히 대체하며, 필요에 따라 수량 할인이 적용될 수 있습니다."
+msgstr "특정 품목에 대해 협상으로 고정된 가격으로 고객, 고객 유형 또는 모든 고객 기준으로 기본 가격을 완전히 대체하며 선택적으로 수량 구간을 포함합니다."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "공급업체별로 새 구매주문이 생성됩니다. 또는 외주 공정을 추가할 기존 초안 구매주문을 선택할 수도 있습니다."
+msgstr "각 공급업체별로 새 발주서가 생성됩니다. 또는 공급업체의 기존 초안 발주서를 선택하여 외주 작업을 추가할 수 있습니다."
 
 msgid "A new revision will be created using a copy of the current revision"
 msgstr "현재 리비전을 복사하여 새 리비전이 생성됩니다"
@@ -500,88 +500,88 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "현재 사이즈를 복사하여 새 사이즈가 생성됩니다"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "새 Stripe 고객이 생성됩니다."
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "인보이스를 이유 계정에 대해 정산하는 비현금 문서로서, 신용은 지불액을 낮추고 차변은 올립니다."
+msgstr "비현금 문서로 송장을 이유 계정에 대해 결제합니다: 대변은 미지급액을 낮추고 차변은 높입니다."
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
 msgstr "공급업체와 공유되는 부적합 사항으로서 로그인이 필요 없는 /share/scar 링크를 통해 공유되므로 Carbon 외부에서 문제에 응답하고 작업을 업데이트할 수 있습니다."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "라인에 추가되는 비과세 추가요금(예: 허가 수수료 같은 상환 가능 비용)으로, 과세표준에서 제외됩니다."
+msgstr "세금이 아닌 할증료(예: 허가비 같은 회수 가능한 비용)로 라인에 추가되며 세금 기반에서 제외됩니다."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "확인된 근본 원인을 해결하는 부적합 조치로, 예방 조치나 즉각적인 격리 조치와는 구분됩니다."
+msgstr "부적합 작업으로 확정된 근본 원인을 수정합니다 — 예방 또는 즉시 격리 조치와는 다릅니다."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "다른 곳에서 동일 문제가 재발하지 않도록 막는 부적합 조치로, 시정 조치 및 격리 조치와는 구분됩니다."
+msgstr "부적합 작업으로 다른 곳에서 문제 재발을 방지합니다 — 시정 수정 및 격리와는 구별됩니다."
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "품목(Part)은 구매하거나 제조할 수 있는 특정 아이템에 대한 정보를 담고 있습니다."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "재고와 함께 있는 인쇄된 카드 또는 QR 코드인 물리적 풀 신호로서, 스캔된 순간 구매 주문 또는 작업을 발생시켜 빈을 보충합니다."
+msgstr "실제 풀 신호로 재고와 함께 있는 인쇄된 카드 또는 QR 코드로 스캔되는 순간 발주서 또는 작업 지시를 생성하여 빈을 보충합니다."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "워크플로우가 모니터링할 수 있는 Carbon의 자체 흐름의 한 지점 — 작업 해제, 견적 수락, 배송 게시 — 원시 필드 변경과 달리; 관련 레코드를 ID로 워크플로우에 전달합니다."
+msgstr "Carbon 자체 흐름의 한 지점으로 워크플로가 감시할 수 있습니다 — 작업 지시 릴리스됨, 견적서 수락됨, 출하 전기됨 — 원시 필드 변경과는 다릅니다; 워크플로에 관련 레코드를 ID로 제공합니다."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
 msgstr "전기된 회계 전표로, 헤더와 총계정원장 계정에 대한 차변/대변 라인으로 구성됩니다."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "고객으로부터의 영수증 또는 공급업체로의 지출인 전기된 현금 거래로서, 정산을 통해 인보이스에 적용되며 초안 → 전기 → 무효로 이동합니다."
+msgstr "전기된 현금 거래로 고객으로부터의 수납 또는 공급업체로의 지급을 송장에 결제 방식으로 적용하며 초안 → 전기됨 → 무효 처리됨으로 이동합니다."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "이 워크플로를 사용하는 모든 이슈에 삽입되는 미리 작성된 설명으로, {itemId}, {location} 같은 플레이스홀더는 생성 시 실제 값으로 대체됩니다."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "가격이 책정된 판매 견적으로, 초안 → 발송 → 주문 순으로 진행되거나 실주/만료/취소로 종료됩니다."
+msgstr "가격이 책정된 판매 견적으로 초안 → 전송됨 → 발주됨 또는 실주, 만료됨, 취소됨으로 끝납니다."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
-msgstr "구매 인보이스는 구매한 제품이나 서비스와 그에 해당하는 비용을 명시하는 문서입니다."
+msgstr "매입 송장은 구매한 제품 또는 서비스와 해당 금액을 지정하는 문서입니다."
 
 msgid "A purchase invoice is posted"
-msgstr "구매 송장이 게시됨"
+msgstr "매입 송장이 전기됩니다."
 
 msgid "A purchase order is created"
-msgstr "구매 주문이 생성됨"
+msgstr "발주서가 생성됩니다."
 
 msgid "A purchase order is deleted"
-msgstr "구매 주문이 삭제됨"
+msgstr "발주서가 삭제됩니다."
 
 msgid "A purchase order's assignee changes"
-msgstr "구매 주문의 담당자가 변경됨"
+msgstr "발주서의 담당자가 변경됩니다."
 
 msgid "A purchase order's order date changes"
-msgstr "구매 주문의 주문 날짜가 변경됨"
+msgstr "발주서의 발주 일자가 변경됩니다."
 
 msgid "A purchase order's status changes"
-msgstr "구매 주문의 상태가 변경됨"
+msgstr "발주서의 상태가 변경됩니다."
 
 msgid "A purchase order's supplier changes"
-msgstr "구매 주문의 공급자가 변경됨"
+msgstr "발주서의 공급업체가 변경됩니다."
 
 msgid "A purchase order's supplier location changes"
-msgstr "구매 주문의 공급자 위치가 변경됨"
+msgstr "발주서의 공급업체 사업장이 변경됩니다."
 
 msgid "A purchase order's supplier reference changes"
-msgstr "구매 주문의 공급자 참조가 변경됨"
+msgstr "발주서의 공급업체 참조가 변경됩니다."
 
 msgid "A purchase order's tags changes"
-msgstr "구매 주문의 태그가 변경됨"
+msgstr "발주서의 태그가 변경됩니다."
 
 msgid "A purchase order's type changes"
-msgstr "구매 주문의 유형이 변경됨"
+msgstr "발주서의 유형이 변경됩니다."
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "품질 이슈 — 조사 및 조치 작업으로 구성된 설정 가능한 워크플로를 통해 기록되는 일탈 또는 결함입니다."
+msgstr "품질 불량으로 기록된 특채 또는 결함이며 조사 및 작업의 구성 가능한 워크플로를 갖습니다."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
-msgstr "동일한 수량의 유닛이 하나의 추적 개체와 배치 번호를 공유합니다 — 하나의 개체, 다수의 유닛."
+msgstr "동일한 품목의 여러 개가 하나의 추적 대상 및 배치 번호를 공유하며, 하나의 추적 대상으로 많은 개를 갖습니다."
 
 msgid "A quote is a set of prices for specific parts and quantities."
-msgstr "견적은 특정 품목과 수량에 대한 가격의 집합입니다."
+msgstr "견적서는 특정 부품 및 수량에 대한 가격 집합입니다."
 
 msgid "A quote is accepted"
 msgstr "견적이 수락됨"
@@ -596,7 +596,7 @@ msgid "A quote is sent"
 msgstr "견적이 전송되었습니다"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "견적 라인에는 특정 품목의 가격과 리드타임이 포함됩니다"
+msgstr "견적 라인은 특정 부품의 가격 책정 및 리드타임을 포함합니다."
 
 msgid "A quote's assignee changes"
 msgstr "견적의 담당자가 변경되었습니다"
@@ -635,13 +635,13 @@ msgid "A receipt's assignee changes"
 msgstr "입고의 담당자가 변경되었습니다"
 
 msgid "A receipt's invoiced changes"
-msgstr "입고의 인보이스 처리가 변경되었습니다"
+msgstr "입고의 송장 발행됨 상태가 변경됩니다."
 
 msgid "A receipt's location changes"
 msgstr "입고의 위치가 변경되었습니다"
 
 msgid "A receipt's posting date changes"
-msgstr "입고의 기록 날짜가 변경되었습니다"
+msgstr "입고의 전기 일자가 변경됩니다."
 
 msgid "A receipt's source document changes"
 msgstr "입고의 원본 문서가 변경되었습니다"
@@ -650,115 +650,115 @@ msgid "A receipt's status changes"
 msgstr "입고의 상태가 변경되었습니다"
 
 msgid "A receipt's supplier changes"
-msgstr "입고의 공급자가 변경되었습니다"
+msgstr "입고의 공급업체가 변경됩니다."
 
 msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
-msgstr "공정에 연결된, 버전 관리가 되는 재사용 가능한 작업 지시서 모음으로, 공정작업이 기록·확인할 순서화된 단계와 실행 파라미터를 제공합니다."
+msgstr "공법에 첨부된 재사용 가능하고 버전이 지정된 작업 표준서 집합으로 공정에 기록 및 확인할 순서가 지정된 단계와 실행 매개변수를 제공합니다."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "릴리즈된 작업의 공정 단계로, 공정작업을 작업 자체가 복사해 갖고 있으며, 현장에서 할 일부터 완료까지 상태를 진행시킵니다."
+msgstr "릴리스됨 작업 지시의 라우팅 단계로 공정의 작업 지시 자체 복사본이며 현장이 완료 대기에서 완료로 진행하는 상태를 갖습니다."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "판매 인보이스(고객에게 청구) 또는 구매 인보이스(공급업체가 청구)로서, 결제 및 신용 또는 차변 메모를 적용하여 정산됩니다."
+msgstr "매출 송장(고객에게 청구) 또는 매입 송장(공급업체가 청구)으로 지불 및 대변 또는 차변 메모를 적용하여 결제됩니다."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
-msgstr "판매 인보이스는 고객에게 판매한 제품이나 서비스와 그에 해당하는 비용을 명시하는 문서입니다."
+msgstr "매출 송장은 고객에게 판매된 제품 또는 서비스와 해당 금액을 지정하는 문서입니다."
 
 msgid "A sales invoice is posted"
-msgstr "판매 인보이스가 기록되었습니다"
+msgstr "매출 송장이 전기됨"
 
 msgid "A sales invoice line contains invoice details for a particular item"
-msgstr "판매 인보이스 라인에는 특정 품목에 대한 인보이스 세부 정보가 포함됩니다"
+msgstr "매출 송장 라인은 특정 품목에 대한 송장 세부 정보를 포함합니다"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "판매주문에는 회사와 특정 고객 간 부품 및 서비스에 대한 합의 정보가 포함됩니다."
+msgstr "수주에는 회사와 특정 고객 사이의 부품 및 서비스에 대한 합의 정보가 포함됩니다."
 
 msgid "A sales order is created"
-msgstr "판매 주문이 생성되었습니다"
+msgstr "수주가 생성됨"
 
 msgid "A sales order is deleted"
-msgstr "판매 주문이 삭제되었습니다"
+msgstr "수주가 삭제됨"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "판매주문 라인에는 특정 품목에 대한 주문 세부 정보가 포함됩니다"
+msgstr "수주 라인은 특정 품목에 대한 주문 세부 정보를 포함합니다"
 
 msgid "A sales order's assignee changes"
-msgstr "판매 주문의 담당자가 변경되었습니다"
+msgstr "수주의 담당자가 변경됨"
 
 msgid "A sales order's completed date changes"
-msgstr "판매 주문의 완료 날짜가 변경되었습니다"
+msgstr "수주의 완료 날짜가 변경됨"
 
 msgid "A sales order's customer changes"
-msgstr "판매 주문의 고객이 변경되었습니다"
+msgstr "수주의 고객이 변경됨"
 
 msgid "A sales order's customer reference changes"
-msgstr "판매 주문의 고객 참조번호가 변경되었습니다"
+msgstr "수주의 고객 참조 정보가 변경됨"
 
 msgid "A sales order's location changes"
-msgstr "판매 주문의 위치가 변경되었습니다"
+msgstr "수주의 사업장이 변경됨"
 
 msgid "A sales order's order date changes"
-msgstr "판매 주문의 주문 날짜가 변경되었습니다"
+msgstr "수주의 주문 날짜가 변경됨"
 
 msgid "A sales order's salesperson changes"
-msgstr "판매 주문의 영업담당자가 변경되었습니다"
+msgstr "수주의 영업 담당자가 변경됨"
 
 msgid "A sales order's status changes"
-msgstr "판매 주문의 상태가 변경되었습니다"
+msgstr "수주의 상태가 변경됨"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "판매 견적요청(RFQ)은 특정 품목과 수량에 대한 가격 문의로, 견적으로 이어질 수 있습니다."
+msgstr "영업 견적 요청(RFQ)은 일정한 부품 및 수량에 대한 가격 책정을 위한 고객 문의입니다. 이는 견적서로 이어질 수 있습니다."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
-msgstr "판매 RFQ(고객이 견적을 요청) 또는 구매 RFQ(귀사가 공급업체에 요청)이며, 둘 다 기회(opportunity) 스레드에 반영됩니다."
+msgstr "영업 견적 요청(고객이 견적을 요청) 또는 구매 견적 요청(공급업체에 견적을 요청); 둘 다 영업 기회로 이어집니다."
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
 msgstr "carbon-key 요청 헤더에서 전송되는 범위 제한 암호로서, Carbon에 대한 프로그래밍 방식 호출을 인증하며 사용자 세션의 권한이 아닌 자체 권한 및 속도 제한을 전달합니다."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "세무 신고용 별도 상각 스케줄로, 세법이 장부상 감가상각과 다른 방법을 요구할 때 사용합니다."
+msgstr "세금 규칙이 장부 감가상각과 다른 방법을 요구할 때 세금 보고를 위한 별도의 일정입니다."
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "서비스는 구매하거나 수행되는 청구 가능한 활동이며, 절대 배송되거나 수령되거나 재고되지 않습니다"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "하나의 소유주 아래 있는 여러 회사가 계정과목표, 통화, 차원 등 그룹 범위 설정을 공유하여, 그룹 내 모든 회사에 동일한 회계 설정이 적용되도록 합니다."
+msgstr "한 소유자 아래의 회사 집합으로, 그룹 범위의 설정(계정과목표, 통화, 차원)을 공유하므로 동일한 회계 설정이 그룹의 모든 회사에 걸쳐 있습니다."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "작업의 미처리 자재를 창고에서 가져와 라인 옆에 준비하는 지시 세트로서, 피킹은 자재를 소비하지 않고 사용 지점으로 옮깁니다."
+msgstr "작업 지시의 미처리 자재를 창고에서 인출하여 라인사이드에 배치하기 위한 지시사항 집합; 피킹은 재고를 소비하지 않고 사용 지점으로 이동합니다."
 
 msgid "A shipment is created"
-msgstr "배송이 생성되었습니다"
+msgstr "출하가 생성됨"
 
 msgid "A shipment is deleted"
-msgstr "배송이 삭제되었습니다"
+msgstr "출하가 삭제됨"
 
 msgid "A shipment is posted"
-msgstr "배송이 기록되었습니다"
+msgstr "출하가 전기됨"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
 msgstr "귀사의 창고를 거치지 않고 공급업체에서 고객에게 직접 발송되는 출하 라인으로, 헤더가 아닌 라인 단위로 설정합니다."
 
 msgid "A shipment's assignee changes"
-msgstr "배송의 담당자가 변경되었습니다"
+msgstr "출하의 담당자가 변경됨"
 
 msgid "A shipment's customer changes"
-msgstr "배송의 고객이 변경되었습니다"
+msgstr "출하의 고객이 변경됨"
 
 msgid "A shipment's location changes"
-msgstr "배송의 위치가 변경되었습니다"
+msgstr "출하의 사업장이 변경됨"
 
 msgid "A shipment's posting date changes"
-msgstr "배송의 기록 날짜가 변경되었습니다"
+msgstr "출하의 전기 날짜가 변경됨"
 
 msgid "A shipment's shipping method changes"
-msgstr "배송의 배송 방법이 변경되었습니다"
+msgstr "출하의 배송 방법이 변경됨"
 
 msgid "A shipment's status changes"
-msgstr "배송의 상태가 변경되었습니다"
+msgstr "출하의 상태가 변경됨"
 
 msgid "A shipment's tracking number changes"
-msgstr "배송 추적 번호가 변경됨"
+msgstr "출하의 추적 번호가 변경됨"
 
 msgid "A step needs a name."
 msgstr "단계에 이름이 필요합니다."
@@ -788,22 +788,22 @@ msgid "A supplier's status changes"
 msgstr "공급업체의 상태가 변경됨"
 
 msgid "A supplier's tax percent changes"
-msgstr "공급업체의 세율이 변경됨"
+msgstr "공급업체의 세금율이 변경됨"
 
 msgid "A supplier's type changes"
 msgstr "공급업체의 유형이 변경됨"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "라인에 추가되는 과세 대상 추가요금(취급료, 셋업비, 유류비 등)으로, 과세표준에 포함됩니다."
+msgstr "라인에 추가된 과세 부과금(취급, 셋업, 연료); 세금 기초에 포함됩니다."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "작업의 공정작업에 대해 기록되는 셋업/노무/기계 작업의 시간 기록으로, 소요 시간이 공정작업의 실제 원가에 합산됩니다."
+msgstr "작업 지시 공정에 기록된 셋업, 노무 또는 기계 작업의 시간 기록으로, 그 기간은 공정의 실제 비용으로 집계됩니다."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "공구는 여러 작업에 걸쳐 사용할 수 있는, 부품 제작에 쓰이는 실물 품목입니다"
+msgstr "공구는 여러 작업 지시에 걸쳐 사용될 수 있는 부품을 만드는 데 사용되는 물리적 품목입니다"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "재화가 입고될 때 사용자가 각 배치 또는 일련번호에 유효기한을 기록합니다. 공급업체가 서로 다른 유효기한의 로트를 출하할 때 사용하세요."
+msgstr "사용자는 상품을 수령할 때 각 배치 또는 시리얼의 유통기한을 기록합니다. 공급업체가 다른 유통기한을 가진 로트로 배송할 때 사용합니다."
 
 msgid "abilities"
 msgstr "역량"
@@ -827,13 +827,13 @@ msgid "Academy"
 msgstr "아카데미"
 
 msgid "Accept Lot"
-msgstr "로트 승인"
+msgstr "로트 수락"
 
 msgid "Accept lot?"
-msgstr "로트를 승인하시겠습니까?"
+msgstr "로트 수락?"
 
 msgid "Accept Quote"
-msgstr "견적 승인"
+msgstr "견적서 수락"
 
 msgid "Acceptable Quality Level — the highest defect rate that's still considered passable under the Z1.4 / ISO 2859-1 tables."
 msgstr "합격품질수준(AQL) — Z1.4 / ISO 2859-1 표에서 합격으로 간주되는 최대 결함률."
@@ -846,7 +846,7 @@ msgstr "승인 통과"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
-msgstr "{0}에 승인됨"
+msgstr "수락됨 {0}"
 
 msgid "Account"
 msgstr "계정"
@@ -858,7 +858,7 @@ msgid "Account balances with debits and credits"
 msgstr "차변과 대변이 포함된 계정 잔액"
 
 msgid "Account for advance payments made before goods or services are received"
-msgstr "재화나 서비스를 받기 전에 지급한 선급금 계정"
+msgstr "상품 또는 서비스를 수령하기 전에 지급된 선금을 회계 처리합니다"
 
 msgid "Account for production orders not yet completed"
 msgstr "아직 완료되지 않은 생산주문 계정"
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "회계"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "회계는 현재 베타 버전입니다. 보고, 분개, 회계 기간, 고정 자산 등을 활성화하려면 액세스를 요청하세요."
+msgstr "회계는 현재 베타 단계입니다. 보고, 전표, 회계 기간, 고정자산 등을 사용하려면 액세스를 요청하세요."
 
 msgid "Accounting is disabled"
 msgstr "회계가 비활성화됨"
@@ -924,7 +924,7 @@ msgid "Accounts"
 msgstr "계정"
 
 msgid "Accounts for recording differences between actual and standard costs"
-msgstr "실제 비용과 표준 비용의 차이를 기록하는 계정"
+msgstr "실제 원가와 표준원가의 차이를 기록하는 계정"
 
 msgid "Accounts Payable"
 msgstr "매입채무"
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "고객이 지급할 금액에 대한 매출채권"
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "게시 기본값 또는 분개 기록에서 참조되지만 공급자 매핑이 아직 없는 계정입니다."
+msgstr "전기 기본값이나 전표 이력에서 참조하는 계정 중 공급 업체 매핑이 아직 없는 것"
 
 msgid "Accumulated Depreciation"
 msgstr "감가상각누계액"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "활성"
 
 msgid "Active Jobs"
-msgstr "진행 중인 작업"
+msgstr "진행 중인 작업 지시"
 
 msgid "Active Statuses"
 msgstr "활성 상태"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "댓글 추가..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "수량, 가격, 배송비, 리드타임, 세금을 재정의할 사용자 정의 가격 행을 추가하세요"
+msgstr "수량, 가격, 배송, 리드타임 및 세금을 재정의하기 위한 사용자 정의 가격 책정 라인 추가"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "자재 섹션을 추가하여 자재 명세서의 각 항목과 수량을 나열합니다."
@@ -1095,7 +1095,7 @@ msgid "Add Calibration Record"
 msgstr "교정 기록 추가"
 
 msgid "Add Child Storage Unit"
-msgstr "하위 저장 단위 추가"
+msgstr "하위 보관 단위 추가"
 
 msgid "Add clause"
 msgstr "조건 추가"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "조건 추가"
 
 msgid "Add Contractor"
-msgstr "계약직 추가"
+msgstr "외주 인력 추가"
 
 msgid "Add cost center"
 msgstr "원가 센터 추가"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "메모 추가"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "이 유지보수 작업지시에 대한 메모와 문서를 추가하세요"
+msgstr "이 유지보수 지시에 대한 메모 및 문서 추가"
 
 msgid "Add Operation"
 msgstr "공정작업 추가"
@@ -1221,7 +1221,7 @@ msgid "Add Step"
 msgstr "단계 추가"
 
 msgid "Add steps to preview the operator view."
-msgstr "운영자 보기를 미리 보기 위해 단계를 추가하세요."
+msgstr "작업자 보기 미리보기를 위해 단계 추가"
 
 msgid "Add Stock Transfer"
 msgstr "재고 이전 추가"
@@ -1249,7 +1249,7 @@ msgid "Add-On"
 msgstr "애드온"
 
 msgid "Add-On Cost"
-msgstr "애드온 비용"
+msgstr "추가 비용"
 
 msgid "Added"
 msgstr "추가됨"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "모든 조치가 선택됨"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "모든 고급 기능 이용 가능"
 
 msgid "All Audit Logs"
 msgstr "모든 감사 로그"
@@ -1364,7 +1364,7 @@ msgid "All members of selected groups and selected individuals will be able to a
 msgstr "선택한 그룹의 모든 구성원과 선택한 개인이 요청을 승인할 수 있습니다"
 
 msgid "All posting accounts are mapped"
-msgstr "모든 게시 계정이 매핑됨"
+msgstr "모든 전기 계정이 매핑됨"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "모든 행을 가져왔습니다 — {inserted}개 추가, {updated}개 업데이트."
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "금액"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "이 라인에서 자산/비용을 증가시키거나 부채/자본/수익을 감소시키는 금액입니다."
+msgstr "이 라인에서 자산/비용을 증가시키거나 부채/자본/매출을 감소시키는 금액"
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "이 라인에서 부채/자본/수익을 증가시키거나 자산/비용을 감소시키는 금액입니다."
+msgstr "이 라인에서 부채/자본/매출을 증가시키거나 자산/비용을 감소시키는 금액"
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1425,13 +1425,13 @@ msgid "An accounting bucket that groups expenses by department or function so th
 msgstr "부서나 기능별로 비용을 그룹화하여 총계정원장이 계정뿐 아니라 그룹별로도 지출을 보고할 수 있게 하는 회계 버킷입니다."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "비용 처리 대신 감가상각하는 자본화 항목의 회계 기록으로, 초안 → 활성 → 완전상각 → 처분 순으로 진행됩니다."
+msgstr "비용 처리가 아닌 감가상각하는 자본화된 품목에 대한 회계 기록; 초안 → 활성 → 상각 완료 → 처분됨"
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "누군가의 주의가 필요함을 알리는 경보로서, carbon/notify 이벤트에서 앱 내 받은편지함과 선택적 이메일 및 Slack으로 확산되며, 사용자별 주제별로 음소거할 수 있습니다."
 
 msgid "An approval requirement on a non-conformance whose reviewers (seeded Engineering and Quality) must sign off before the issue can close."
-msgstr "부적합 사항에 대한 승인 요구 사항으로서, 검토자(씨드된 엔지니어링 및 품질)가 문제를 종료하기 전에 서명해야 합니다."
+msgstr "부적합에 대한 승인 요구사항으로, 미리 설정된 설계 및 품질 검토자가 부적합을 마감하기 전에 서명해야 함"
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
 msgstr "자산의 취득원가에서 감가상각누계액을 뺀 값 — 장부상 남은 가치이며 처분 시 사용되는 금액입니다."
@@ -1440,7 +1440,7 @@ msgid "An automation you build on a canvas: one trigger, then steps that check c
 msgstr "캔버스에서 빌드하는 자동화: 하나의 트리거와 조건을 확인하고 레코드를 조회한 후 누군가에게 알림을 보내거나 레코드를 생성 또는 업데이트하거나 외부 URL을 호출하는 단계들."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "엔지니어링 변경: 초안에서 방법이 수정되고 함께 릴리스되는 영향받는 항목으로, 이들이 대체하는 버전을 무효화합니다."
+msgstr "설계 변경: 초안에서 방법이 수정되고 함께 릴리스되어 대체하는 버전을 대체하는 영향을 받는 품목"
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "워크플로우가 해당 단계에 도달할 때 Carbon이 귀사의 시스템으로 보내는 https 요청으로, 구성한 헤더 및 본문을 전달합니다."
@@ -1500,16 +1500,16 @@ msgid "An item's assignee changes"
 msgstr "항목의 담당자가 변경됩니다"
 
 msgid "An item's default method type changes"
-msgstr "항목의 기본 방법 유형이 변경됩니다"
+msgstr "품목의 기본 공급 방식 변경"
 
 msgid "An item's name changes"
 msgstr "항목의 이름이 변경됩니다"
 
 msgid "An item's replenishment system changes"
-msgstr "항목의 재보충 시스템이 변경됩니다"
+msgstr "품목의 조달 방식 변경"
 
 msgid "An item's revision status changes"
-msgstr "항목의 개정 상태가 변경됩니다"
+msgstr "품목의 리비전 상태 변경"
 
 msgid "An item's tracking type changes"
 msgstr "항목의 추적 유형이 변경됩니다"
@@ -1518,10 +1518,10 @@ msgid "An item's unit of measure changes"
 msgstr "항목의 측정 단위가 변경됩니다"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "사내 작업장이 아닌 외부 공급업체가 수행하는 공정작업으로, 외주 구매주문으로 처리됩니다."
+msgstr "사내 작업장이 아닌 외부 공급업체에서 수행되고 외주 발주서로 커버되는 공정"
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "작업 센터의 작업 대기열에서 작업의 위치(현장이 작업을 선택하는 순서)로서, 날짜를 변경하지 않고 Work Centers 보드에서 카드를 재정렬하여 설정합니다."
+msgstr "작업장 보드에서 카드를 재정렬하여 날짜를 변경하지 않고 설정되는 공정의 작업장 대기열 위치(현장에서 작업을 선택하는 순서)"
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Onshape에 연결하는 중 예기치 않은 오류가 발생했습니다. 다시 연결해 보세요."
@@ -1561,10 +1561,10 @@ msgid "Annotation updated"
 msgstr "주석이 업데이트됨"
 
 msgid "Another cost center this one rolls up into, letting you nest a sub-department under its parent for hierarchical cost reporting."
-msgstr "이 원가센터가 합산되는 상위 원가센터로, 계층적 원가 보고를 위해 하위 부서를 상위 부서 아래에 중첩할 수 있게 합니다."
+msgstr "이 원가 센터가 롤업되는 다른 원가 센터로, 계층적 원가 보고를 위해 부서를 상위 항목 아래에 중첩시킬 수 있게 함"
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "이 저장 단위가 속한 상위 저장 단위(예: 랙 안의 빈)로, 동일한 위치에 있어야 합니다."
+msgstr "이것이 중첩되는 다른 보관 단위 (예: 랙 내의 빈); 같은 사업장에 있어야 함"
 
 msgid "Any item group"
 msgstr "모든 품목 그룹"
@@ -1576,10 +1576,10 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "위 범위에 명시적으로 나열되지 않은 모든 사항"
 
 msgid "AP"
-msgstr "AP"
+msgstr "매입채무"
 
 msgid "AP Aging"
-msgstr "AP 에이징"
+msgstr "매입채무 기간별 분석"
 
 msgid "AP Clerk"
 msgstr "매입채무 담당자"
@@ -1588,7 +1588,7 @@ msgid "AP Outstanding"
 msgstr "매입채무 미결제액"
 
 msgid "AP Overdue"
-msgstr "매입채무 연체"
+msgstr "매입채무 기한 초과"
 
 msgid "API Docs"
 msgstr "API 문서"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon 데이터에 프로그래밍 방식으로 접근하기 위한 API 키입니다."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, 웹훅 및 연동"
 
 msgid "Applied"
 msgstr "적용됨"
@@ -1643,13 +1643,13 @@ msgid "Apply a demo template"
 msgstr "데모 템플릿 적용"
 
 msgid "Apply available credits"
-msgstr "사용 가능한 크레딧 적용"
+msgstr "가용 크레딧 적용"
 
 msgid "Apply credits"
 msgstr "크레딧 적용"
 
 msgid "Apply payments and track aging"
-msgstr "결제를 적용하고 연체 기간을 추적"
+msgstr "지불 적용 및 기간별 분석 추적"
 
 msgid "Apply pricing rules"
 msgstr "가격 규칙 적용"
@@ -1664,10 +1664,10 @@ msgid "Apply To"
 msgstr "적용 대상"
 
 msgid "Apply to invoice"
-msgstr "인보이스에 적용"
+msgstr "송장에 적용"
 
 msgid "Apply to invoices"
-msgstr "인보이스에 적용"
+msgstr "송장에 적용"
 
 msgid "Applying"
 msgstr "적용 중"
@@ -1685,7 +1685,7 @@ msgid "Approval is required at or above this amount, up to the next rule's minim
 msgstr "이 금액 이상부터 다음 규칙의 최소값 미만까지는 승인이 필요합니다"
 
 msgid "Approval requirements"
-msgstr "승인 요구 사항"
+msgstr "승인 요구사항"
 
 msgid "Approval Requirements"
 msgstr "승인 요구사항"
@@ -1709,13 +1709,13 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL(Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "매출채권"
 
 msgid "AR / AP representation"
-msgstr "AR / AP 표현"
+msgstr "매출채권 / 매입채무 표현"
 
 msgid "AR Aging"
-msgstr "AR 에이징"
+msgstr "매출채권 기간별 분석"
 
 msgid "AR Clerk"
 msgstr "매출채권 담당자"
@@ -1724,10 +1724,10 @@ msgid "AR Outstanding"
 msgstr "매출채권 미결제액"
 
 msgid "AR Overdue"
-msgstr "매출채권 연체"
+msgstr "매출채권 기한 초과"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "매출채권/매입채무"
 
 msgid "Archive"
 msgstr "보관"
@@ -1744,17 +1744,17 @@ msgstr "보관된 로그"
 #. placeholder {0}: getQuoteDisplayId(quote)
 #. placeholder {1}: formatter.format(total)
 msgid "Are you sure you want to accept quote {0} for {1}?"
-msgstr "{1}에 대한 견적 {0}을(를) 승인하시겠습니까?"
+msgstr "견적서 {0}을(를) {1}에 대해 수락하시겠습니까?"
 
 msgid "Are you sure you want to activate the process: {name}? It will appear in dropdowns again."
 msgstr "공정 {name}을(를) 활성화하시겠습니까? 드롭다운에 다시 표시됩니다."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "이 측정기를 활성화하시겠습니까?"
+msgstr "이 계측기를 활성화하시겠습니까?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "{0}을(를) 취소하시겠습니까? 취소되면 다시 열 때까지 닫힌 상태로 읽기 전용이 됩니다."
+msgstr "{0}를 취소하시겠습니까? 다시 열기할 때까지 마감되고 읽기 전용이 됩니다."
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
@@ -1764,7 +1764,7 @@ msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "{orderLabel}을(를) 취소하시겠습니까? 주문이 종료됩니다."
 
 msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
-msgstr "이 작업을 취소하시겠습니까? 더 이상 현장에서 사용할 수 없게 됩니다."
+msgstr "이 작업 지시를 취소하시겠습니까? 현장에서 더 이상 가용하지 않습니다."
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
 msgstr "{propertyName} 속성을 변경하시겠습니까? 자동 생성된 자재 ID를 사용하고 있으므로, 이 변경으로 해당 품목의 품목 ID와 관련된 모든 리비전이 변경됩니다."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "이 재고 이동을 완료하시겠습니까?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "이 판매주문을 확정하시겠습니까? 주문을 확정하면 공급과 수요 계산에 사용되는 주문 수량에 영향을 줍니다."
+msgstr "이 수주를 확인하시겠습니까? 수주를 확인하면 공급 및 소요량 계산에 사용되는 주문 수량에 영향을 미칩니다."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "이 RFQ를 견적으로 전환하시겠습니까?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "이 판매주문에 대한 작업을 생성하시겠습니까? 아직 작업이 없는 모든 라인에 대해 작업이 생성됩니다."
+msgstr "이 수주에 대해 작업 지시를 생성하시겠습니까? 이미 작업 지시가 없는 모든 라인에 대해 작업 지시를 생성합니다."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "이 사용자들을 비활성화하시겠습니까?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "이 측정기를 비활성화하시겠습니까?"
+msgstr "이 계측기를 비활성화하시겠습니까?"
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "이 사용자를 비활성화하시겠습니까?"
@@ -1863,14 +1863,14 @@ msgstr "자산 클래스: {0}를 삭제하시겠습니까? 이 작업은 실행 
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "변경 공지 작업 {0}을(를) 삭제하시겠습니까? 이 작업은 실행 취소할 수 없습니다."
+msgstr "변경 통지 작업을 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "변경 공지 카테고리 {0}을(를) 삭제하시겠습니까? 이 작업은 실행 취소할 수 없습니다."
+msgstr "변경 통지 카테고리를 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "계약직 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "외주 인력을 삭제하시겠습니까: {name}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "고장 모드 {name}을(를) 삭제하시겠습니까? 이 작업은 되
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "측정기 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "계측기 유형을 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1933,11 +1933,11 @@ msgstr "유지보수 일정 {name}을(를) 삭제하시겠습니까? 이 작업�
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "자재 치수 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "자재 치수를 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "자재 표면처리 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "표면 처리를 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
@@ -1945,7 +1945,7 @@ msgstr "자재 형태 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "자재 등급 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "재질 등급을 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "자재 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "견적 불가 사유 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "견적 거절 사유를 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "파트너 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "결제조건 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "지불 조건을 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1977,27 +1977,27 @@ msgstr "프린터 \"{0}\"을(를) 삭제하시겠습니까? 이 프린터를 참
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "{0} {1}의 구매 인보이스 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "매입 송장 라인을 삭제하시겠습니까: {0} {1}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "{0} {1}의 판매 인보이스 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "매출 송장 라인을 삭제하시겠습니까: {0} {1}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "{0} {1}의 판매주문 라인을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "수주 라인을 삭제하시겠습니까: {0} {1}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
 msgstr "스크랩 사유 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "{itemLabel}의 시리얼 번호 시퀀스를 삭제하시겠습니까? 이 작업은 실행 취소할 수 없습니다."
+msgstr "시리얼 번호 채번 규칙을 삭제하시겠습니까: {itemLabel}? 이 작업은 취소할 수 없습니다."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
-msgstr "{locationName}의 교대 {name}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "교대조를 삭제하시겠습니까: {name} (사업장: {locationName})? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
@@ -2009,7 +2009,7 @@ msgstr "저장 유형 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "저장 단위 {0}을(를) 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "보관 단위를 삭제하시겠습니까: {0}? 이 작업은 취소할 수 없습니다."
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
@@ -2031,10 +2031,10 @@ msgid "Are you sure you want to delete this approval rule? This cannot be undone
 msgstr "이 승인 규칙을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "이 변경 공지를 삭제하시겠습니까?"
+msgstr "이 변경 통지를 삭제하시겠습니까?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "이 측정기를 삭제하시겠습니까?"
+msgstr "이 계측기를 삭제하시겠습니까?"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "이 검사 계획을 삭제하시겠습니까?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "이 칸반 카드를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "이 유지보수 작업지시를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
+msgstr "이 유지보수 지시를 삭제하시겠습니까? 이 작업은 취소할 수 없습니다."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "이 패스키를 삭제하시겠습니까? 더 이상 로그인할 수 없습니다."
@@ -2079,7 +2079,7 @@ msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "이 근무기록을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 msgid "Are you sure you want to delete this workflow? Its versions and run history go with it."
-msgstr "이 워크플로우를 삭제하시겠습니까? 해당 버전 및 실행 기록도 함께 삭제됩니다."
+msgstr "이 워크플로를 삭제하시겠습니까? 그 버전과 실행 이력이 함께 삭제됩니다."
 
 msgid "Are you sure you want to finalize the quote?"
 msgstr "견적을 확정하시겠습니까?"
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "{0}을(를) 영구적으로 삭제하시겠습니까?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "공급업체 공정을 영구적으로 삭제하시겠습니까?"
+msgstr "공급업체 공법을 영구적으로 삭제하시겠습니까?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "이 입고를 전기하시겠습니까?"
@@ -2109,10 +2109,10 @@ msgid "Are you sure you want to post this shipment?"
 msgstr "이 출하를 전기하시겠습니까?"
 
 msgid "Are you sure you want to reject this quote?"
-msgstr "이 견적을 반려하시겠습니까?"
+msgstr "이 견적서를 거부하시겠습니까?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "이 작업을 릴리즈하시겠습니까? 현장에서 사용할 수 있게 되며 구매와 생산을 유발합니다."
+msgstr "이 작업 지시를 릴리스하시겠습니까? 현장에서 가용하게 되며 구매 및 생산을 드라이브합니다."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "이 사용자에게 초대를 보내시겠습니까?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "이 구매 인보이스를 무효화하시겠습니까? 이 작업은 모든 재무 거래를 취소하며 되돌릴 수 없습니다."
+msgstr "이 매입 송장을 무효 처리하시겠습니까? 이 작업은 모든 재무 거래를 역입금하며 취소할 수 없습니다."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "이 입고를 무효화하시겠습니까? 이 작업은 모든 재고 거래를 취소하며 되돌릴 수 없습니다."
+msgstr "이 입고를 무효 처리하시겠습니까? 이 작업은 모든 재고 관리 거래를 역입금하며 취소할 수 없습니다."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "이 판매 인보이스를 무효화하시겠습니까? 이 작업은 모든 재무 거래를 취소하며 되돌릴 수 없습니다."
+msgstr "이 매출 송장을 무효 처리하시겠습니까? 이 작업은 모든 재무 거래를 역입금하며 취소할 수 없습니다."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "이 출하를 무효화하시겠습니까? 이 작업은 모든 재고 거래를 취소하며 되돌릴 수 없습니다."
+msgstr "이 출하를 무효 처리하시겠습니까? 이 작업은 모든 재고 관리 거래를 역입금하며 취소할 수 없습니다."
 
 msgid "Are you sure?"
 msgstr "확실합니까?"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "기준:"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "회사 소유자로서 다른 직원에게 소유권을 이전할 수 있습니다. 이전 시 해당 직원에게 결제 및 관리 설정에 대한 전체 액세스 권한이 부여됩니다."
+msgstr "회사의 책임자로서 다른 직원에게 책임을 이전할 수 있습니다. 이렇게 하면 청구 및 행정 설정에 완전히 액세스할 수 있게 됩니다."
 
 msgid "Ascending"
 msgstr "오름차순"
@@ -2206,19 +2206,19 @@ msgid "Asset Acquisition Cost (default)"
 msgstr "자산 취득원가(기본값)"
 
 msgid "asset class"
-msgstr "자산 유형"
+msgstr "자산 클래스"
 
 msgid "Asset class"
-msgstr "자산 유형"
+msgstr "자산 클래스"
 
 msgid "Asset Class"
-msgstr "자산 유형"
+msgstr "자산 클래스"
 
 msgid "asset classes"
-msgstr "자산 유형"
+msgstr "자산 클래스"
 
 msgid "Asset Classes"
-msgstr "자산 유형"
+msgstr "자산 클래스"
 
 msgid "Asset Cost on Disposal"
 msgstr "처분 시 자산 원가"
@@ -2236,13 +2236,13 @@ msgid "Assets, liabilities and equity as of a date"
 msgstr "특정 날짜 기준 자산, 부채 및 자본"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
-msgstr "위치에 프린터를 배정하세요. 출하, 입고, 작업장은 재정의되지 않는 한 위치의 기본값을 상속받습니다."
+msgstr "사업장에 프린터를 할당합니다. 출하, 입고, 및 작업장은 사업장 기본값을 상속하며 재정의할 수 있습니다."
 
 msgid "Assign To"
-msgstr "담당자 지정"
+msgstr "할당"
 
 msgid "Assign to Groups"
-msgstr "그룹에 배정"
+msgstr "그룹에 할당"
 
 msgid "Assigned"
 msgstr "배정됨"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "배정"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "이 저장 단위를 작업장(라인사이드)에 배정합니다"
+msgstr "이 보관 단위를 작업장(라인사이드)에 할당합니다"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "이 단위를 라인사이드 자재용으로 작업장에 배정하여 작업자가 생산 화면에서 볼 수 있게 합니다. 상위 단위에서 설정된 경우 이를 상속받습니다."
+msgstr "라인사이드 자재를 위해 이 보관 단위를 작업장에 할당하므로 작업자들이 생산 화면에서 볼 수 있습니다. 부모 단위에 설정되면 상속됩니다."
 
 msgid "At each gate"
 msgstr "각 게이트마다"
@@ -2281,10 +2281,10 @@ msgid "Attach File"
 msgstr "파일 첨부"
 
 msgid "Attachment"
-msgstr "첨부파일"
+msgstr "첨부 파일"
 
 msgid "Attachments"
-msgstr "첨부파일"
+msgstr "첨부 파일"
 
 msgid "Attempts"
 msgstr "시도"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "속성"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "입고 검사에서 로트 샘플 크기와 합격/불합격 개수를 산출하는 데 사용되는 속성 샘플링 표준입니다."
+msgstr "수입 검사에서 로트 샘플 크기와 수락/거부 수를 계산하는 데 사용되는 속성 샘플링 보통 검사입니다."
 
 msgid "Attributes"
 msgstr "속성"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "감사 로그"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "감사 로깅"
 
 msgid "Audit Logging"
 msgstr "감사 로깅"
@@ -2338,10 +2338,10 @@ msgid "Auto arrange"
 msgstr "자동 정렬"
 
 msgid "Auto Release"
-msgstr "자동 릴리즈"
+msgstr "자동 릴리스"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "작업을 자동으로 시작하려면 자동 릴리즈가 활성화되어 있어야 합니다"
+msgstr "작업 지시를 자동으로 시작하려면 자동 릴리스를 활성화해야 합니다"
 
 msgid "Auto Start Job"
 msgstr "작업 자동 시작"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "자동 생성된 QR 코드"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "주문, 작업, 품목 등에 대한 자동 번호 매기기 형식"
+msgstr "주문, 작업 지시, 부품 등의 자동 번호 지정 형식"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "수요와 재주문점을 기반으로 구매를 자동 제안"
+msgstr "소요량 및 재주문점에서 구매를 자동 제안합니다"
 
 msgid "Automate"
 msgstr "자동화"
@@ -2377,29 +2377,29 @@ msgid "Automatic Updates"
 msgstr "자동 업데이트"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "자동 업데이트 및 백업"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
-msgstr "산출물이 보고될 때 작업의 미추적 자재를 비례 배분하여 자동으로 소비합니다 — 추적 자재는 수동으로 출고됩니다."
+msgstr "출력이 보고될 때 작업 지시의 추적되지 않는 자재의 자동 배분 소모 — 추적되는 자재는 수동으로 발급됩니다."
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "칸반이 스캔되면 작업을 자동으로 릴리즈"
+msgstr "칸반이 스캔될 때 작업 지시를 자동으로 릴리스합니다"
 
 msgid "Automatically start the job when the kanban is scanned"
 msgstr "칸반이 스캔되면 작업을 자동으로 시작"
 
 msgid "available"
-msgstr "사용 가능"
+msgstr "가용"
 
 msgid "Available"
-msgstr "사용 가능"
+msgstr "가용"
 
 msgid "Available Actions (click to add)"
-msgstr "사용 가능한 조치(클릭하여 추가)"
+msgstr "사용 가능한 조치(추가하려면 클릭)"
 
 #. placeholder {0}: port.label
 msgid "Available after {0}"
-msgstr "{0} 후에 사용 가능"
+msgstr "{0} 이후에 사용 가능"
 
 msgid "Avatar url"
 msgstr "아바타 URL"
@@ -2414,7 +2414,7 @@ msgid "Back"
 msgstr "뒤로"
 
 msgid "Back to traceability"
-msgstr "이력추적으로 돌아가기"
+msgstr "추적성으로 돌아가기"
 
 msgid "Backflush"
 msgstr "백플러시"
@@ -2426,7 +2426,7 @@ msgid "Balance"
 msgstr "잔액"
 
 msgid "Balance Sheet"
-msgstr "대차대조표"
+msgstr "재무상태표"
 
 msgid "Balanced"
 msgstr "균형"
@@ -2465,10 +2465,10 @@ msgid "Bank account denominated in the local currency"
 msgstr "자국통화로 표시된 은행 계좌"
 
 msgid "Bank and financial service charge expenses"
-msgstr "은행 및 금융 서비스 수수료 비용"
+msgstr "은행 및 금융 서비스 요금 비용"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "막대는 매주의 흐름을 나타냅니다: <0>공급</0>은 재고를 끌어올리고, <1>수요</1>는 재고를 끌어내립니다. <2>선</2>은 예상 보유 재고이며, <3>안전재고</3> 아래로 내려가면 위험하고, 0 미만이 되면 <4>재고소진</4> 상태입니다."
+msgstr "막대는 매주의 흐름을 보여줍니다: <0>공급</0>은 재고를 올리고, <1>소요량</1>은 내립니다. <2>라인</2>은 예상 현재고 — <3>안전 재고</3> 아래로 떨어지면 위험에 처해 있고, 0 아래는 <4>재고 부족</4>입니다."
 
 msgid "Base Currency"
 msgstr "기준 통화"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "기본 가격"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "기본 ERP, MES 및 QMS 기능"
 
 msgid "Basic Information"
 msgstr "기본 정보"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "배치/일련번호"
 
 msgid "Batch items require a sales order"
-msgstr "배치 품목에는 판매주문이 필요합니다"
+msgstr "배치 품목은 수주가 필요합니다"
 
 msgid "Batch number"
 msgstr "배치 번호"
@@ -2514,28 +2514,28 @@ msgstr "시작"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Being phased out — successor: <0>{0}</0>"
-msgstr "단계적으로 폐지 중 — 후속: <0>{0}</0>"
+msgstr "단계적으로 폐기 중 — 후속 품목: <0>{0}</0>"
 
 msgid "Below safety stock"
-msgstr "안전재고 미만"
+msgstr "안전 재고 아래"
 
 msgid "Beta"
 msgstr "베타"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "이유, 품목 또는 작업 센터별 스크랩의 가장 큰 원인"
+msgstr "이유, 품목 또는 작업장별 스크랩의 가장 큰 원인"
 
 msgid "Bill of Material"
 msgstr "자재명세서"
 
 msgid "Bill of materials"
-msgstr "자재명세서"
+msgstr "자재 명세서"
 
 msgid "Bill of Materials"
-msgstr "자재명세서"
+msgstr "자재 명세서"
 
 msgid "Bill of Process"
-msgstr "공정(BOP)"
+msgstr "공정 목록"
 
 msgid "Bill To"
 msgstr "청구 대상"
@@ -2587,7 +2587,7 @@ msgid "Bonus Depreciation %"
 msgstr "추가 감가상각률 %"
 
 msgid "Book a call to discuss guided implementation"
-msgstr "가이드 도입에 대해 상담 예약"
+msgstr "가이드된 실행에 대해 논의하기 위한 통화를 예약합니다"
 
 msgid "Book a call with Carbon"
 msgstr "Carbon과 상담 예약"
@@ -2608,19 +2608,19 @@ msgid "Breadcrumb"
 msgstr "이동 경로"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Carbon의 가져오기 도구, CSV, 또는 LLM의 도움으로 품목, BOM, 공정(BOP), 원가 정보를 가져오세요."
+msgstr "부품, BOM, 공정 목록 및 원가 계산을 가져오기 — Carbon의 가져오기 도구, CSV 또는 LLM 도움을 사용합니다."
 
 msgid "Browse library"
 msgstr "라이브러리 둘러보기"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "게시된 버전을 읽기 전용으로 찾아봅니다. 여전히 단계를 재정렬하여 레이아웃을 정돈할 수 있습니다."
 
 msgid "Bucket"
 msgstr "버킷"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
-msgstr "누적 기간 내 소비 급증을 흡수하기 위해 수요 기반 정책이 확보해두는 완충 재고입니다."
+msgstr "누적 기간 내에 소모 스파이크를 흡수하기 위해 수요 기반 정책이 유지하는 안전 재고입니다."
 
 msgid "Bugs and changes"
 msgstr "버그와 변경 사항"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "연동과 커스터마이징 구축"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "실시간 품목, 원가, 공정(BOP) 데이터를 반영한 견적 작성"
+msgstr "부품, 원가 및 공정 목록 데이터를 가져와서 견적서를 작성합니다"
 
 msgid "Build role-based training materials"
 msgstr "역할 기반 교육 자료 제작"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "일괄 가져오기"
 
 msgid "Bulk Jobs"
-msgstr "일괄 작업"
+msgstr "대량 작업 지시"
 
 msgid "Business moment"
 msgstr "비즈니스 순간"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "구매"
 
 msgid "Buy and Make"
-msgstr "구매 및 제조"
+msgstr "구매 및 사내 생산"
 
 msgid "Buyer"
-msgstr "구매담당자"
+msgstr "구매 담당자"
 
 msgid "Buyer, Planner"
-msgstr "구매담당자, 계획담당자"
+msgstr "구매 담당자, 계획 담당자"
 
 msgid "by {byUser}"
 msgstr "{byUser}"
@@ -2683,7 +2683,7 @@ msgid "By Document Date"
 msgstr "문서 날짜 기준"
 
 msgid "By Due Date"
-msgstr "만기일 기준"
+msgstr "마감일 기준"
 
 msgid "By field"
 msgstr "필드별"
@@ -2704,7 +2704,7 @@ msgid "Calculate from BOM"
 msgstr "BOM에서 계산"
 
 msgid "Calculated finished-good expiry"
-msgstr "계산된 완제품 유효기한"
+msgstr "계산된 완성품 유통기한"
 
 msgid "Calculation Method"
 msgstr "계산 방법"
@@ -2755,10 +2755,10 @@ msgid "Cancel"
 msgstr "취소"
 
 msgid "Cancel change notice"
-msgstr "변경 공지 취소"
+msgstr "변경 통지 취소"
 
 msgid "Cancel Change Notice"
-msgstr "변경 공지 취소"
+msgstr "변경 통지 취소"
 
 msgid "Cancel Job"
 msgstr "작업 취소"
@@ -2767,10 +2767,10 @@ msgid "Cancel Order"
 msgstr "주문 취소"
 
 msgid "Cancel Purchase Order"
-msgstr "구매주문 취소"
+msgstr "발주서 취소"
 
 msgid "Cancel Sales Order"
-msgstr "판매주문 취소"
+msgstr "수주 취소"
 
 msgid "Cancel SO"
 msgstr "판매주문 취소"
@@ -2809,25 +2809,25 @@ msgid "Cannot convert RFQ to quote"
 msgstr "RFQ를 견적으로 전환할 수 없습니다"
 
 msgid "Cannot move to parts bucket without item ID"
-msgstr "품목 ID 없이는 품목 버킷으로 이동할 수 없습니다"
+msgstr "품목 ID 없이 부품 버킷으로 이동할 수 없습니다"
 
 msgid "Cannot place order - no supplier associated with this item"
 msgstr "주문할 수 없습니다 - 이 품목에 연결된 공급업체가 없습니다"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "전기할 수 없습니다 — 출하에 유효기한이 만료된 추적 개체가 포함되어 있습니다."
+msgstr "전기할 수 없습니다 — 출하에 만료된 추적 대상이 포함되어 있습니다."
 
 msgid "Cannot send RFQ"
 msgstr "RFQ를 보낼 수 없습니다"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe를 통해 전송할 수 없습니다"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "업로드할 수 없습니다 — 공급업체 상호작용이 아직 생성되지 않았습니다"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "품목 ID 없이는 품목 버킷에 업로드할 수 없습니다"
+msgstr "품목 ID 없이 부품 버킷에 업로드할 수 없습니다"
 
 msgid "Caption"
 msgstr "캡션"
@@ -2845,7 +2845,7 @@ msgid "Carbon client is not available"
 msgstr "Carbon 클라이언트를 사용할 수 없습니다"
 
 msgid "Carbon client not available"
-msgstr "Carbon 클라이언트 사용 불가"
+msgstr "Carbon 클라이언트를 사용할 수 없습니다"
 
 msgid "Carbon client not found"
 msgstr "Carbon 클라이언트를 찾을 수 없음"
@@ -2854,7 +2854,7 @@ msgid "Carbon column"
 msgstr "Carbon 열"
 
 msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
-msgstr "Carbon이 귀사의 운영 방식에 맞게 설정되었고, 데이터가 적재되었으며, 팀이 자신 있게 사용할 수 있는 상태입니다. 이 조건이 충족되면 실제 운영을 시작할 준비가 된 것입니다."
+msgstr "Carbon은 귀사가 운영하는 방식으로 구성되고 데이터가 로드되며 팀이 자신감 있게 사용할 수 있을 때 라이브로 전환할 준비가 된 것입니다."
 
 msgid "Carbon leads"
 msgstr "Carbon 주도"
@@ -2882,25 +2882,25 @@ msgid "Carbon-only"
 msgstr "Carbon 전용"
 
 msgid "Carbon-only · fill in real targets for this customer. They see the values, locked."
-msgstr "Carbon 전용 · 이 고객의 실제 목표값을 입력하세요. 고객에게는 값이 잠긴 상태로 표시됩니다."
+msgstr "Carbon 전용 · 이 고객을 위한 실제 목표를 입력하십시오. 고객은 값을 봅니다(잠김)."
 
 msgid "Carbon-only · the customer sees this text, locked."
-msgstr "Carbon 전용 · 고객에게는 이 텍스트가 잠긴 상태로 표시됩니다."
+msgstr "Carbon 전용 · 고객은 이 텍스트를 볼 수 있습니다(잠김)."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "자재명세서(BOM)와 공정(BOP)을 아우르는 Carbon의 용어로, 품목을 만드는 구성품과 공정작업을 합친 것을 말합니다."
+msgstr "Carbon에서 부품을 만드는 자재 명세서 및 공정 목록(라우팅)의 명칭으로, 구성요소와 공정을 포함합니다."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Carbon의 계획 실행(planning run)은 공급과 수요를 상계하고 제조방법을 전개하여 부족분을 표면화하지만, 그 자체로 주문을 생성하지는 않습니다."
+msgstr "Carbon의 계획 실행은 공급과 소요량을 상쇄하고 방법을 전개하여 부족분을 표면화하지만 주문을 직접 생성하지는 않습니다."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Carbon의 생산주문 — 하나의 작업(Job)이 자체적으로 복사한 제조방법과 공정을 사용하여 하나의 품목을 지정된 수량만큼 생산합니다."
+msgstr "Carbon의 생산 주문 — 하나의 작업 지시는 자신의 복사된 방법과 라우팅으로부터 하나의 품목의 수량을 구축합니다."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "운영자가 실시간으로 작업을 실행하고, 수량을 보고하고, 자재를 출고하고, 릴리스된 작업에 대해 시간을 기록하는 Carbon의 현장 앱입니다."
+msgstr "Carbon의 현장 앱으로 작업자가 공정을 실행하고, 수량을 보고하고, 자재를 불출하며, 릴리스된 작업 지시에 대해 실시간으로 시간을 기록합니다."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "부품 번호가 있는 모든 것에 대한 Carbon의 단일 기록 — 부품, 자재, 공구, 서비스, 소모품 또는 고정물 — 작업, 방법, 주문 및 재고가 모두 가리키는 것입니다."
+msgstr "Carbon의 부품 번호를 가진 모든 것에 대한 단일 레코드 — 부품, 자재, 공구, 서비스, 소모품 또는 지그 — 작업 지시, 방법, 주문 및 재고 관리가 모두 참조합니다."
 
 msgid "Cards"
 msgstr "카드"
@@ -2948,7 +2948,7 @@ msgid "Chain"
 msgstr "체인"
 
 msgid "Champion users are available for training and data validation"
-msgstr "챔피언 사용자가 교육과 데이터 검증에 참여할 수 있습니다"
+msgstr "주요 사용자는 교육 및 데이터 검증에 사용 가능합니다"
 
 msgid "Champion(s)"
 msgstr "챔피언"
@@ -2966,25 +2966,25 @@ msgid "Change Inspection Plan"
 msgstr "검사 계획 변경"
 
 msgid "Change notice"
-msgstr "변경 공지"
+msgstr "변경 통지"
 
 msgid "Change Notice"
-msgstr "변경 공지"
+msgstr "변경 통지"
 
 msgid "Change Notice Actions"
-msgstr "변경 공지 작업"
+msgstr "변경 통지 조치"
 
 msgid "Change Notice Types"
-msgstr "변경 공지 유형"
+msgstr "변경 통지 유형"
 
 msgid "Change Notices"
-msgstr "변경 공지"
+msgstr "변경 통지"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "변경 공지를 로드할 수 없어 새 버전과 개정이 차단되었습니다. 다시 로드하세요."
+msgstr "변경 통지를 로드할 수 없으므로 새 버전과 리비전이 차단되었습니다. 다시 시도하려면 새로 고침하십시오."
 
 msgid "Change order"
-msgstr "변경 주문"
+msgstr "변경 오더"
 
 msgid "Change status"
 msgstr "상태 변경"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "채팅"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "기간 종료 시점의 음수 수량 보유 항목에 대해 항목 원장을 확인하십시오. 일반적으로 누락된 수령증이나 순서 대로 포기된 게시로 인해 재고 가치와 판매 원가가 왜곡됩니다. 검토 후 완료로 표시하거나 사유와 함께 건너뜁니다."
+msgstr "기간 종료 기준 음수 현재고 수량이 있는 품목에 대해 품목 장부를 확인하십시오 — 일반적으로 입고 누락 또는 순서 없는 전기로 인해 재고 관리 가치 및 매출원가가 왜곡됩니다. 검토 후 완료로 표시하거나 사유를 포함하여 건너뜁니다."
 
 msgid "Check your email"
 msgstr "이메일을 확인하세요"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "이 고객의 Stripe 확인 중…"
 
 msgid "Checkpoint ·"
 msgstr "체크포인트 ·"
@@ -3047,13 +3047,13 @@ msgid "Choose a row on the left to see where its stock can come from."
 msgstr "왼쪽의 행을 선택하여 해당 재고가 어디서 올 수 있는지 확인하세요."
 
 msgid "Choose a serial number"
-msgstr "일련번호를 선택하세요"
+msgstr "시리얼 번호를 선택하십시오"
 
 msgid "Choose another file"
 msgstr "다른 파일을 선택하세요"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "인쇄된 작업 일지에 표시할 내용을 선택합니다."
+msgstr "인쇄된 작업 이동표에 나타날 내용을 선택하십시오."
 
 msgid "Choose your preferred language for the interface."
 msgstr "인터페이스에 사용할 언어를 선택하세요."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "클래스(상속됨)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "라우팅 작업을 분류합니다: 프로세스, 어셈블리, 검사 작업은 MES의 자체 작업장에서 실행됩니다 — 어셈블리는 안내식 어셈블리 보기를 받고 검사는 품질 확인을 수행합니다 — 외부 처리 작업은 공급업체에 외주되며 구매 주문을 생성합니다; 프로세스는 동일한 유형을 가지며 새 작업에 기본값을 설정합니다."
+msgstr "라우팅 공정을 분류합니다: 공정, 조립 및 검사 공정은 MES의 현장에서 실행됩니다 — 조립은 가이드 조립 보기를 받고 검사는 품질 검사를 받습니다 — 한편 외주 가공 공정은 공급업체에 하청되고 발주서를 생성합니다; 공법은 동일한 유형을 가지며 새로운 공정에 기본값으로 설정됩니다."
 
 msgid "Clean and approve the migrated data"
 msgstr "마이그레이션된 데이터를 정리하고 승인하세요"
@@ -3080,7 +3080,7 @@ msgid "Clear"
 msgstr "지우기"
 
 msgid "Clear due date"
-msgstr "기한 지우기"
+msgstr "마감일 지우기"
 
 msgid "Clear Filters"
 msgstr "필터 지우기"
@@ -3095,16 +3095,16 @@ msgid "Clear selection"
 msgstr "선택 해제"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "이 인보이스를 현금뿐 아니라 거래처의 전기된 크레딧으로도 정리하세요. 크레딧은 별도 전기 없이 바로 적용됩니다."
+msgstr "이 송장을 거래처의 전기된 대변 및 현금으로 상계하십시오. 대변은 직접 적용됩니다 — 전기가 필요하지 않습니다."
 
 msgid "Clear value"
 msgstr "값 지우기"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "입고와 공급업체 인보이스 사이의 경과 계정으로, 둘 다 전기되면 잔액이 상계됩니다."
+msgstr "입고 및 공급업체 송장 간의 상계 계정; 둘 다 전기되면 균형을 맞춥니다."
 
 msgid "Clearing account for goods received / invoice received matching"
-msgstr "입고/인보이스 수취 매칭을 위한 경과 계정"
+msgstr "입고 / 송장 수령 매칭을 위한 상계 계정"
 
 msgid "Clearing demo data"
 msgstr "데모 데이터 삭제 중"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "클릭하여 PDF 도면을 업로드하세요"
 
 msgid "Clock In"
-msgstr "출근"
+msgstr "작업 시작"
 
 msgid "Clock Out"
-msgstr "퇴근"
+msgstr "작업 종료"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/> 이후로 근무 중"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "클라우드 또는 자체 호스팅 환경."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC 준수"
 
 msgid "Code"
 msgstr "코드"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "각 영역에 챔피언 사용자를 지정하세요"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "입고, 출하, 인보이스를 확정하면 수량이 이동하고 전표가 원장에 반영되며 상태가 '전기됨'으로 변경됩니다."
+msgstr "입고, 출하, 송장 확정: 수량이 이동하고 분개가 원장에 기록되며 상태가 전기됨으로 변경됩니다."
 
 msgid "Community support"
-msgstr ""
+msgstr "커뮤니티 지원"
 
 msgid "Companies"
 msgstr "회사"
@@ -3357,25 +3357,25 @@ msgid "Configure Item"
 msgstr "품목 설정"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "측정기가 교정 기한을 벗어났을 때의 알림을 설정하세요."
+msgstr "계측기가 교정 기준을 벗어났을 때 알림을 구성합니다."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "작업이 완료되었을 때의 알림을 설정하세요."
+msgstr "작업 지시가 완료되었을 때 알림을 구성합니다."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "현장에서 유지보수 작업지시가 생성되었을 때의 알림을 설정하세요. 알림은 고장 모드 유형에 따라 전달됩니다."
+msgstr "현장에서 유지보수 지시가 생성될 때 알림을 구성합니다. 알림은 장애 모드 유형에 따라 라우팅됩니다."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "새 제안이 제출되었을 때의 알림을 설정하세요."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "사이트, 작업장, 공정(BOP), BOM, 원가, 역할 설정"
+msgstr "사이트, 작업장, 공정 목록, BOM, 원가 계산, 역할 구성"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "시스템 전반의 다양한 거래 유형에 사용되는 기본 계정을 설정하세요"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "회계연도 및 세무연도의 시작 월을 설정하세요"
+msgstr "재정 연도 및 세금 연도의 시작월 구성"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "공급업체 거래로부터 구매 품목 원가를 언제 업데이트할지 설정하세요."
@@ -3424,7 +3424,7 @@ msgid "Confirm disconnect"
 msgstr "연결 해제 확인"
 
 msgid "Confirm how your company runs and lock the scope."
-msgstr "귀사의 운영 방식을 확인하고 범위를 고정하세요."
+msgstr "회사 운영 방식을 확정하고 범위를 잠금."
 
 msgid "Confirm ID Change"
 msgstr "ID 변경 확인"
@@ -3445,13 +3445,13 @@ msgid "Confirm Skip"
 msgstr "건너뛰기 확인"
 
 msgid "Confirmed incoming stock — purchase & production orders (bars above zero)."
-msgstr "확정된 입고 재고 — 구매주문 및 생산주문(0 이상 막대)."
+msgstr "확정된 입고 — 발주서 및 생산 지시(0 이상의 막대)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "확정된 출고 재고 — 판매주문 및 작업 자재(0 이하 막대)."
+msgstr "확정된 출고 — 수주 및 작업 지시 자재(0 이하의 막대)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "기간 내 모든 전기된 분개의 차변과 대변이 일치하는지 확인합니다. 어떤 분개라도 불균형이면 시산표가 맞지 않으므로 기간을 종료하기 전에 수정해야 합니다."
+msgstr "기간 내 전기된 모든 분개가 차변과 대변이 일치하는지 확인합니다. 불균형인 분개가 있으면 시산표가 맞지 않으므로 기간을 마감하기 전에 정정해야 합니다."
 
 msgid "Conflict reason"
 msgstr "충돌 이유"
@@ -3466,13 +3466,13 @@ msgid "Connect Linear issue"
 msgstr "Linear 이슈 연결"
 
 msgid "Connect Slack under Settings → Integrations first."
-msgstr "먼저 설정 → 통합 아래에서 Slack을 연결하세요."
+msgstr "설정 → 연동에서 먼저 Slack을 연결합니다."
 
 msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "조건이 일치하지 않을 때 실행할 노드에 Otherwise 핸들을 연결합니다."
 
 msgid "Connect the outside tools your company already runs on"
-msgstr "귀사가 이미 사용 중인 외부 도구와 연동하세요"
+msgstr "회사에서 이미 사용 중인 외부 도구 연결"
 
 msgid "Connected to"
 msgstr "연결 대상"
@@ -3481,7 +3481,7 @@ msgid "Console Mode"
 msgstr "콘솔 모드"
 
 msgid "Console mode has been enabled. Use this PIN to identify yourself at MES terminals."
-msgstr "콘솔 모드가 활성화되었습니다. MES 단말기에서 본인 확인용으로 이 PIN을 사용하세요."
+msgstr "콘솔 모드가 활성화되었습니다. MES 터미널에서 이 PIN으로 자신을 확인합니다."
 
 msgid "Console mode is disabled"
 msgstr "콘솔 모드가 비활성화됨"
@@ -3490,7 +3490,7 @@ msgid "Console mode is enabled"
 msgstr "콘솔 모드가 활성화됨"
 
 msgid "Console Operator"
-msgstr "콘솔 운영자"
+msgstr "콘솔 작업자"
 
 msgid "consumable"
 msgstr "소모품"
@@ -3514,7 +3514,7 @@ msgid "Consumed"
 msgstr "소진됨"
 
 msgid "Consuming material from inventory into a job, which writes a Consumption entry to the item ledger."
-msgstr "재고에서 작업으로 자재를 투입하는 것으로, 품목 원장에 소비(Consumption) 항목이 기록됩니다."
+msgstr "재고에서 작업 지시로 자재를 소모하여 소모 항목을 품목 원장에 기록합니다."
 
 msgid "contact"
 msgstr "담당자"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "담당자(선택)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "문의하기"
 
 msgid "contacts"
 msgstr "담당자"
@@ -3553,31 +3553,31 @@ msgid "Contra-asset account for total depreciation of fixed assets"
 msgstr "고정자산 총 감가상각액에 대한 자산 차감 계정"
 
 msgid "Contra-revenue account for discounts given on sales"
-msgstr "매출 할인에 대한 수익 차감 계정"
+msgstr "판매 할인용 대수익계정"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
-msgstr "고객 인보이스에 대한 할인액을 반영하는 수익 차감 총계정원장 계정입니다."
+msgstr "고객 송장 할인용 대수익 계정과목."
 
 msgid "Contractor"
-msgstr "계약직"
+msgstr "외주 인력"
 
 msgid "Contractors"
-msgstr "계약직"
+msgstr "외주 인력"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "리비전/ECO로 설계 변경을 관리하세요"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "작업장에서 작업자가 자재를 선택하고 시간을 추적하는 방식을 제어합니다."
+msgstr "현장에서 작업자의 자재 피킹 및 시간 추적 방식을 제어합니다."
 
 msgid "Controller, Accountant"
 msgstr "컨트롤러, 회계 담당자"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "단종 예정 품목을 계획에서 어떻게 처리할지 결정합니다: '우선 소진(Consume First)'은 후속 품목으로 전환하기 전에 보유 재고를 먼저 소진하고, '신규 우선(Prefer New)'은 신규 수요를 즉시 후속 품목으로 돌리며, '재고만 유지(Stock Only)'는 최소 서비스 재고만 남기고, '재고 없음(No Stock)'은 해당 품목을 계획에서 완전히 제외합니다."
+msgstr "계획이 단종 품목을 처리하는 방식을 제어합니다: 우선 소진은 후속 품목으로 전환하기 전에 현재고를 소진하고, 신규 우선은 새로운 소요량을 즉시 후속 품목으로 리디렉트하며, 재고만은 최소 서비스 예비만 유지하고, 재고 없음은 계획에서 품목을 완전히 제거합니다."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "출시된(생산) 개정의 자재명세서 및 공정표를 변경주문 외부에서 편집할 수 있는지 제어합니다."
+msgstr "릴리스된 (생산) 리비전의 BOM 및 공정 목록을 변경 오더 외부에서 편집할 수 있는지 제어합니다."
 
 msgid "Convention"
 msgstr "명명 규칙"
@@ -3598,16 +3598,16 @@ msgid "Convert"
 msgstr "전환"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "재입력 없이 견적을 판매주문으로 전환하세요"
+msgstr "견적서를 재입력 없이 수주로 전환"
 
 msgid "Convert Line to Job"
 msgstr "라인을 작업으로 전환"
 
 msgid "Convert Lines to Jobs"
-msgstr "라인을 작업으로 전환"
+msgstr "라인을 작업 지시로 전환"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "MRP 제안을 구매주문 및 작업으로 전환합니다."
+msgstr "MRP 제안을 발주서 및 작업 지시로 전환합니다."
 
 msgid "Convert to Quote"
 msgstr "견적으로 전환"
@@ -3616,7 +3616,7 @@ msgid "Converting…"
 msgstr "변환 중…"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "구매주문, 입고, 청구서 라인에서 공급업체의 구매 단위를 귀사의 재고 단위로 변환합니다 — 12개들이 카톤으로 구매하고 낱개로 재고 관리."
+msgstr "공급업체의 구매 단위를 발주서, 입고, 송장 라인에서 귀사의 재고 단위로 전환합니다 — 12개 상자 단위로 구매하고 개별 단위로 재고에 보관합니다."
 
 msgid "Copied link to clipboard"
 msgstr "링크가 클립보드에 복사됨"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "복사"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "모든 품목과 가격을 다른 고객 또는 유형으로 복사합니다."
+msgstr "모든 품목 및 가격 책정을 다른 고객 또는 유형으로 복사합니다."
 
 msgid "Copy API Key"
 msgstr "API 키 복사"
@@ -3637,10 +3637,10 @@ msgid "Copy consumable number"
 msgstr "소모품 번호 복사"
 
 msgid "Copy dispatch ID"
-msgstr "작업지시 ID 복사"
+msgstr "유지보수 지시 ID 복사"
 
 msgid "Copy dispatch number"
-msgstr "작업지시 번호 복사"
+msgstr "유지보수 지시 번호 복사"
 
 msgid "Copy document name"
 msgstr "문서 이름 복사"
@@ -3664,13 +3664,13 @@ msgid "Copy link"
 msgstr "링크 복사"
 
 msgid "Copy link to change notice"
-msgstr "변경 공지 링크 복사"
+msgstr "변경 통지 링크 복사"
 
 msgid "Copy link to consumable"
 msgstr "소모품 링크 복사"
 
 msgid "Copy link to dispatch"
-msgstr "작업지시 링크 복사"
+msgstr "유지보수 지시 링크 복사"
 
 msgid "Copy link to document"
 msgstr "문서 링크 복사"
@@ -3688,7 +3688,7 @@ msgid "Copy link to part"
 msgstr "품목 링크 복사"
 
 msgid "Copy link to procedure"
-msgstr "절차 링크 복사"
+msgstr "절차서 링크 복사"
 
 msgid "Copy link to service"
 msgstr "서비스 링크 복사"
@@ -3718,19 +3718,19 @@ msgid "Copy PIN"
 msgstr "PIN 복사"
 
 msgid "Copy pricing to a single customer"
-msgstr "단일 고객에게 가격 복사"
+msgstr "단일 고객에게 가격 책정 복사"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "해당 유형의 모든 고객에게 가격 복사"
+msgstr "유형별 모든 고객에게 가격 책정 복사"
 
 msgid "Copy Procedure"
-msgstr "절차 복사"
+msgstr "절차서 복사"
 
 msgid "Copy procedure name"
-msgstr "절차 이름 복사"
+msgstr "절차서 이름 복사"
 
 msgid "Copy procedure unique identifier"
-msgstr "절차 고유 식별자 복사"
+msgstr "절차서 고유 식별자 복사"
 
 msgid "Copy Quality Document"
 msgstr "품질 문서 복사"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "서비스 고유 식별자 복사"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "이 품목의 가격을 다른 범위로 복사합니다."
+msgstr "이 품목의 가격 책정을 다른 범위로 복사합니다."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "이 링크를 복사하여 고객과 견적을 공유하세요"
@@ -3799,22 +3799,22 @@ msgid "Corrective action"
 msgstr "시정 조치"
 
 msgid "cost center"
-msgstr "원가센터"
+msgstr "원가 센터"
 
 msgid "Cost center"
-msgstr "원가센터"
+msgstr "원가 센터"
 
 msgid "Cost Center"
-msgstr "원가센터"
+msgstr "원가 센터"
 
 msgid "Cost Center Name"
 msgstr "원가 센터 이름"
 
 msgid "cost centers"
-msgstr "원가센터"
+msgstr "원가 센터"
 
 msgid "Cost Centers"
-msgstr "원가센터"
+msgstr "원가 센터"
 
 msgid "Cost History"
 msgstr "원가 이력"
@@ -3829,7 +3829,7 @@ msgid "Cost of Goods Sold (default)"
 msgstr "매출원가(기본값)"
 
 msgid "Cost of Sales"
-msgstr "매출원가"
+msgstr "매출 원가"
 
 msgid "Costing"
 msgstr "원가 계산"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "문서를 불러올 수 없습니다"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "관련 문서를 불러올 수 없습니다. 중복 생성을 방지하려면 새로 만들기 전에 새로고침하세요."
+msgstr "관련 문서를 로드할 수 없습니다. 새 문서를 생성하기 전에 새로고침하여 복제를 피하십시오."
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "제공자의 차원 대상을 로드할 수 없습니다 — 연결을 확인하고 다시 로드하세요."
@@ -3885,7 +3885,7 @@ msgid "Count"
 msgstr "실사"
 
 msgid "Count History"
-msgstr "계산 기록"
+msgstr "재고조사 이력"
 
 msgid "Count ID"
 msgstr "실사 ID"
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "생성 및 스냅샷"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "새 개정본을 위한 변경 공지를 만들고 엽니다"
+msgstr "새 리비전에 대한 변경 통지를 생성하고 엽니다."
 
 msgid "Create a job"
 msgstr "작업 생성"
@@ -3930,25 +3930,25 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "스캔 기반 보충을 위한 새 칸반 카드를 생성합니다."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "장비 수리 및 유지보수 활동을 추적할 새 유지보수 작업지시를 생성합니다"
+msgstr "설비 수리 및 유지보수 활동을 추적하기 위해 새 유지보수 지시를 생성합니다."
 
 msgid "Create a new production job to fulfill the sales order"
-msgstr "판매주문을 이행할 새 생산 작업을 생성합니다"
+msgstr "수주를 이행하기 위해 새 생산 작업 지시를 생성합니다."
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "대신 새 Stripe 고객을 생성합니다."
 
 msgid "Create a new version"
-msgstr "새 버전 만들기"
+msgstr "새 버전을 생성합니다."
 
 msgid "Create a purchase order"
-msgstr "구매 주문 생성"
+msgstr "발주서를 생성합니다."
 
 msgid "Create a quote with a new quote ID"
 msgstr "새 견적 ID로 견적을 생성합니다"
 
 msgid "Create a sales order"
-msgstr "판매 주문 생성"
+msgstr "수주를 생성합니다."
 
 msgid "Create Account"
 msgstr "계정 생성"
@@ -3963,19 +3963,19 @@ msgid "Create an issue"
 msgstr "문제 생성"
 
 msgid "Create and approve purchase orders"
-msgstr "구매주문 생성 및 승인"
+msgstr "발주서를 생성하고 승인합니다."
 
 msgid "Create audit trail entries"
 msgstr "감사 추적 항목 생성"
 
 msgid "Create Change Notice"
-msgstr "변경 공지 만들기"
+msgstr "변경 통지 생성"
 
 msgid "Create Issue"
 msgstr "이슈 생성"
 
 msgid "Create Jobs"
-msgstr "작업 생성"
+msgstr "작업 지시 생성"
 
 msgid "Create Kanban"
 msgstr "칸반 생성"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "계정 생성됨"
 
 msgid "Created asset class"
-msgstr "자산 분류 생성됨"
+msgstr "자산 클래스가 생성되었습니다."
 
 msgid "Created at"
 msgstr "생성 날짜"
@@ -4038,10 +4038,10 @@ msgid "Created By"
 msgstr "생성자"
 
 msgid "Created change notice action"
-msgstr "변경 공지 작업 생성됨"
+msgstr "변경 통지 조치가 생성되었습니다."
 
 msgid "Created change notice type"
-msgstr "변경 공지 유형 생성됨"
+msgstr "변경 통지 유형이 생성되었습니다."
 
 msgid "Created consumable"
 msgstr "소모품 생성됨"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "고장 모드 생성됨"
 
 msgid "Created gauge type"
-msgstr "측정기 유형 생성됨"
+msgstr "계측기 유형이 생성되었습니다."
 
 msgid "Created item group"
 msgstr "품목 그룹 생성됨"
@@ -4084,16 +4084,16 @@ msgid "Created material"
 msgstr "자재 생성됨"
 
 msgid "Created material dimension"
-msgstr "자재 치수 생성됨"
+msgstr "자재 차원이 생성되었습니다."
 
 msgid "Created material finish"
-msgstr "자재 표면처리 생성됨"
+msgstr "표면 처리가 생성되었습니다."
 
 msgid "Created material form"
 msgstr "자재 형태 생성됨"
 
 msgid "Created material grade"
-msgstr "자재 등급 생성됨"
+msgstr "재질 등급이 생성되었습니다."
 
 msgid "Created material substance"
 msgstr "자재 재질 생성됨"
@@ -4102,7 +4102,7 @@ msgid "Created material type"
 msgstr "자재 유형 생성됨"
 
 msgid "Created no quote reason"
-msgstr "견적 불가 사유 생성됨"
+msgstr "견적 거절 사유가 생성되었습니다."
 
 msgid "Created non conformance type"
 msgstr "부적합 유형 생성됨"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "품목 생성됨"
 
 msgid "Created payment term"
-msgstr "결제조건 생성됨"
+msgstr "지불 조건이 생성되었습니다."
 
 msgid "Created process"
 msgstr "공정 생성됨"
@@ -4129,7 +4129,7 @@ msgid "Created shipping method"
 msgstr "배송 방법 생성됨"
 
 msgid "Created stock transfer line"
-msgstr "재고 이동 라인 생성됨"
+msgstr "재고 이송 라인이 생성되었습니다."
 
 msgid "Created storage type"
 msgstr "저장 유형 생성됨"
@@ -4176,10 +4176,10 @@ msgid "Credit account when labor/machine time is absorbed into WIP"
 msgstr "노무/기계 시간이 재공품(WIP)에 흡수될 때의 대변 계정"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "제조 간접비가 진행 중인 작업(WIP)에 흡수될 때의 외상 계정"
+msgstr "간접비가 재공품에 편입될 때의 대변 계정"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "제조 비용이 진행 중인 작업(WIP)에 흡수될 때 사용되는 외상 계정"
+msgstr "제조 원가가 재공품에 편입될 때 사용되는 대변 계정"
 
 msgid "Credit Memo"
 msgstr "대변전표"
@@ -4251,7 +4251,7 @@ msgid "Custom {label}"
 msgstr "사용자 정의 {label}"
 
 msgid "Custom attributes you track against your people"
-msgstr "직원에 대해 추적하는 사용자 정의 속성"
+msgstr "인원에 대해 추적하는 사용자 정의 속성"
 
 msgid "Custom development beyond what's listed"
 msgstr "나열된 항목 외의 맞춤 개발"
@@ -4269,7 +4269,7 @@ msgid "Custom Fields"
 msgstr "사용자 정의 필드"
 
 msgid "Custom fields are not available for items yet."
-msgstr "사용자 정의 필드는 아직 항목에 사용할 수 없습니다."
+msgstr "사용자 정의 필드는 품목에 아직 사용할 수 없습니다."
 
 msgid "Custom SOW · we manage"
 msgstr "맞춤 SOW · 저희가 관리"
@@ -4287,7 +4287,7 @@ msgid "Customer Accounts"
 msgstr "고객 계정"
 
 msgid "Customer contact"
-msgstr "고객 연락처"
+msgstr "고객 담당자"
 
 msgid "Customer Contact"
 msgstr "고객 담당자"
@@ -4311,7 +4311,7 @@ msgid "Customer ID cannot be changed after creation"
 msgstr "고객 ID는 생성 후 변경할 수 없습니다"
 
 msgid "Customer Invoice Number"
-msgstr "고객 인보이스 번호"
+msgstr "고객 송장 번호"
 
 msgid "Customer location"
 msgstr "고객 위치"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "고객 부품"
 
 msgid "Customer Part ID"
-msgstr "고객 부품 ID"
+msgstr "고객 품번"
 
 msgid "Customer Part Number"
 msgstr "고객 부품 번호"
@@ -4338,10 +4338,10 @@ msgid "Customer Parts"
 msgstr "고객 부품"
 
 msgid "Customer Payment Discounts"
-msgstr "고객 결제 할인"
+msgstr "고객 지불 할인"
 
 msgid "Customer Payment Discounts (default)"
-msgstr "고객 결제 할인(기본값)"
+msgstr "고객 지불 할인 (기본값)"
 
 msgid "Customer PO"
 msgstr "고객 PO"
@@ -4356,7 +4356,7 @@ msgid "Customer Portals"
 msgstr "고객 포털"
 
 msgid "Customer pricing"
-msgstr "고객 가격"
+msgstr "고객 가격 책정"
 
 msgid "Customer reference"
 msgstr "고객 참조"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "고객 유형"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "고객 대손상각(대손채권)"
+msgstr "고객 대손 처리 (부실채권)"
 
 msgid "customers"
 msgstr "고객"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "고객"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "사용자정의, 교육 및 연동"
 
 msgid "Customize"
 msgstr "사용자 지정"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "전환 지원"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "감사 추적과 함께 순환 재고조사 및 조정"
+msgstr "순환 실사로 감사추적과 함께 조정"
 
 msgid "Daily"
 msgstr "매일"
@@ -4443,7 +4443,7 @@ msgid "Daily summary"
 msgstr "일일 요약"
 
 msgid "Daily Usage"
-msgstr "일일 사용량"
+msgstr "일일 사용 현황"
 
 msgid "Dark"
 msgstr "다크"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "만기 일수"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "부품을 주문한 시점부터 사용 가능해지기까지의 일수로, 계획 시 이 기간만큼 수요를 앞당겨 반영합니다."
+msgstr "부품 주문부터 가용까지의 일수이며, 계획 오프셋이 소요량을 이만큼 뒤로 이동합니다."
 
 msgid "Days Off"
 msgstr "휴무일"
@@ -4587,7 +4587,7 @@ msgid "Debits"
 msgstr "차변"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "작업자가 이미 만료된 배치 또는 일련번호를 출고하려 할 때 표시할 내용을 결정하세요."
+msgstr "작업자가 이미 만료된 배치 또는 시리얼을 불출하려고 할 때 표시할 내용을 결정합니다."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
 msgstr "작업자가 아직 선택되지 않은 재료가 있는 상태에서 현장에서 완료를 누를 때 발생할 사항을 결정하십시오."
@@ -4605,7 +4605,7 @@ msgid "Default"
 msgstr "기본값"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "인보이스의 매출 수익을 전기할 기본 계정"
+msgstr "송장에서 매출을 전기하기 위한 기본 계정"
 
 msgid "Default Accounts"
 msgstr "기본 계정"
@@ -4620,7 +4620,7 @@ msgid "Default accounts for long-term assets and depreciation"
 msgstr "장기자산 및 감가상각에 대한 기본 계정"
 
 msgid "Default accounts for sales and income"
-msgstr "매출 및 수익에 대한 기본 계정"
+msgstr "영업 및 수익의 기본 계정"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "세금 관련 거래에 대한 기본 계정"
@@ -4632,7 +4632,7 @@ msgid "Default Approver"
 msgstr "기본 승인자"
 
 msgid "Default Attachments"
-msgstr "기본 첨부파일"
+msgstr "기본 첨부 파일"
 
 msgid "Default cash account for transactions in non-base currencies."
 msgstr "기준 통화 이외 통화 거래에 사용할 기본 현금 계정입니다."
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "이 분류의 신규 자산에 미리 채워지는 기본 방법입니다(자산별로 수정 가능)."
 
 msgid "Default method type"
-msgstr "기본 방법 유형"
+msgstr "기본 공급 방식"
 
 msgid "Default Method Type"
-msgstr "기본 방법 유형"
+msgstr "기본 공급 방식"
 
 msgid "Default Permissions"
 msgstr "기본 권한"
@@ -4680,7 +4680,7 @@ msgid "Default Priority"
 msgstr "기본 우선순위"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "판매 인보이스가 전기될 때 대변에 기록되는 기본 수익 총계정원장 계정입니다."
+msgstr "매출 송장이 전기될 때 대변되는 기본 매출 계정과목"
 
 msgid "Default Sampling"
 msgstr "기본 샘플링"
@@ -4692,10 +4692,10 @@ msgid "Default Source"
 msgstr "기본 소스"
 
 msgid "Default Storage Unit"
-msgstr "기본 저장 단위"
+msgstr "기본 보관 단위"
 
 msgid "Default tax depreciation method for new assets in this class."
-msgstr "이 분류의 신규 자산에 적용되는 기본 세무 감가상각 방법입니다."
+msgstr "이 분류의 새 자산에 대한 기본 세금 감가상각 방법"
 
 msgid "Default tax-book life for new assets in this class."
 msgstr "이 분류의 신규 자산에 적용되는 기본 세무 장부 내용연수입니다."
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "먼저 제조 공정작업을 정의하세요."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "다단계 자재명세서(BOM)와 공정(BOP)을 정의하세요(제작 방법)"
+msgstr "다단계 BOM 및 공정 목록(생산 방법) 정의"
 
 msgid "Delete"
 msgstr "삭제"
@@ -4771,7 +4771,7 @@ msgid "Delete Category"
 msgstr "카테고리 삭제"
 
 msgid "Delete Change Notice"
-msgstr "변경 공지 삭제"
+msgstr "변경 통지 삭제"
 
 msgid "Delete Consumable"
 msgstr "소모품 삭제"
@@ -4780,7 +4780,7 @@ msgid "Delete Contact"
 msgstr "담당자 삭제"
 
 msgid "Delete Contractor"
-msgstr "계약직 삭제"
+msgstr "외주 인력 삭제"
 
 msgid "Delete Count"
 msgstr "재고조사 삭제"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "차원 삭제"
 
 msgid "Delete Dispatch"
-msgstr "작업지시 삭제"
+msgstr "유지보수 지시 삭제"
 
 msgid "Delete Document"
 msgstr "문서 삭제"
@@ -4849,13 +4849,13 @@ msgid "Delete Material"
 msgstr "자재 삭제"
 
 msgid "Delete Material Dimension"
-msgstr "자재 치수 삭제"
+msgstr "자재 차원 삭제"
 
 msgid "Delete Material Finish"
-msgstr "자재 표면처리 삭제"
+msgstr "표면 처리 삭제"
 
 msgid "Delete Material Grade"
-msgstr "자재 등급 삭제"
+msgstr "재질 등급 삭제"
 
 msgid "Delete Material Shape"
 msgstr "자재 형상 삭제"
@@ -4879,10 +4879,10 @@ msgid "Delete Passkey"
 msgstr "패스키 삭제"
 
 msgid "Delete Payment"
-msgstr "결제 삭제"
+msgstr "지불 삭제"
 
 msgid "Delete Payment Term"
-msgstr "결제조건 삭제"
+msgstr "지불 조건 삭제"
 
 msgid "Delete Period"
 msgstr "기간 삭제"
@@ -4900,19 +4900,19 @@ msgid "Delete Pricing Rule"
 msgstr "가격 규칙 삭제"
 
 msgid "Delete Procedure"
-msgstr "절차 삭제"
+msgstr "절차서 삭제"
 
 msgid "Delete Process"
 msgstr "공정 삭제"
 
 msgid "Delete Purchase Invoice"
-msgstr "구매 인보이스 삭제"
+msgstr "매입 송장 삭제"
 
 msgid "Delete Purchase Order"
-msgstr "구매주문 삭제"
+msgstr "발주서 삭제"
 
 msgid "Delete Purchase Orders"
-msgstr "구매주문 삭제"
+msgstr "발주서 삭제"
 
 msgid "Delete Question"
 msgstr "질문 삭제"
@@ -4945,10 +4945,10 @@ msgid "Delete Rule"
 msgstr "규칙 삭제"
 
 msgid "Delete Sales Invoice"
-msgstr "판매 인보이스 삭제"
+msgstr "매출 송장 삭제"
 
 msgid "Delete Sales Order"
-msgstr "판매주문 삭제"
+msgstr "수주 삭제"
 
 msgid "Delete Schedule"
 msgstr "일정 삭제"
@@ -4957,7 +4957,7 @@ msgid "Delete Service"
 msgstr "서비스 삭제"
 
 msgid "Delete Shift"
-msgstr "교대 삭제"
+msgstr "교대조 삭제"
 
 msgid "Delete Shipment"
 msgstr "출하 삭제"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "저장 유형 삭제"
 
 msgid "Delete Storage Unit"
-msgstr "저장 단위 삭제"
+msgstr "보관 단위 삭제"
 
 msgid "Delete Substance"
 msgstr "재질 삭제"
@@ -5018,7 +5018,7 @@ msgid "Delete Transfer"
 msgstr "이동 삭제"
 
 msgid "Delete Transfer Line"
-msgstr "이동 라인 삭제"
+msgstr "이송 라인 삭제"
 
 msgid "Delete Type"
 msgstr "유형 삭제"
@@ -5042,31 +5042,31 @@ msgid "Delete Workflow"
 msgstr "워크플로우 삭제"
 
 msgid "Delivery Date"
-msgstr "배송일"
+msgstr "납기일"
 
 msgid "Delivery Location"
 msgstr "배송지"
 
 msgid "Demand"
-msgstr "수요"
+msgstr "소요량"
 
 msgid "Demand forecast"
-msgstr "수요예측"
+msgstr "소요량 예측"
 
 msgid "Demand Forecast"
-msgstr "수요예측"
+msgstr "소요량 예측"
 
 msgid "Demand Forecast — Driven by"
-msgstr "수요예측 — 기준"
+msgstr "소요량 예측 — 기반:"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "수요예측 = 미완료 판매주문, 진행 중인 작업, 생산 예측치를 BOM 전개하여 산출한 수요."
+msgstr "소요량 예측 = 미결 수주, 활동 중인 작업 지시, 및 생산 예상으로부터 BOM 전개된 소요량"
 
 msgid "Demand projection"
-msgstr "수요 예측"
+msgstr "소요량 예상"
 
 msgid "Demand Projections"
-msgstr "수요 예측치"
+msgstr "소요량 예상"
 
 msgid "Demand-Based"
 msgstr "수요 기반"
@@ -5102,13 +5102,13 @@ msgid "Depreciation"
 msgstr "감가상각"
 
 msgid "Depreciation Expense"
-msgstr "감가상각비"
+msgstr "감가상각 비용"
 
 msgid "Depreciation Expense (default)"
-msgstr "감가상각비(기본값)"
+msgstr "감가상각 비용 (기본값)"
 
 msgid "Depreciation Expense Account"
-msgstr "감가상각비 계정"
+msgstr "감가상각 비용 계정"
 
 msgid "Depreciation Method"
 msgstr "감가상각 방법"
@@ -5120,13 +5120,13 @@ msgid "Depreciation reversal when a fixed asset is disposed"
 msgstr "고정자산 처분 시 감가상각 환입"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "이 기간에 끝나는 감가상각이 아직 임시 상태라면 전기해야 기간에 올바른 감가상각비와 누적감가상각이 반영됩니다. 이 기간에 감가상각이 적용되지 않으면 사유와 함께 건너뛸 수 있습니다."
+msgstr "이 기간에 종료되는 감가상각 실행이 아직 초안 상태인 경우 해당 기간이 올바른 감가상각 비용과 감가상각누계액을 반영하도록 전기되어야 합니다. 이 기간에 감가상각이 적용되지 않으면 사유를 기록하고 건너뜁니다."
 
 msgid "Depreciation Start Date"
 msgstr "감가상각 시작일"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "위의 '일수' 필드를 무시하고, 이 품목의 유효기간을 구성품 중 가장 짧은 유효기간으로 산출합니다."
+msgstr "이 품목의 보존 기간을 위의 Days 필드를 무시하고 구성 요소의 가장 짧은 보존 기간에서 도출합니다."
 
 msgid "Description"
 msgstr "설명"
@@ -5156,10 +5156,10 @@ msgid "Digital Quote"
 msgstr "디지털 견적"
 
 msgid "Digital quote accepted by"
-msgstr "디지털 견적서 승인자"
+msgstr "디지털 견적서 수락됨 대상:"
 
 msgid "Digital quote accepted by email"
-msgstr "이메일로 디지털 견적서 승인"
+msgstr "이메일로 수락된 디지털 견적서"
 
 msgid "Digital quote rejected by"
 msgstr "디지털 견적서 거절자"
@@ -5171,22 +5171,22 @@ msgid "Digital Quotes"
 msgstr "디지털 견적"
 
 msgid "dimension"
-msgstr "치수"
+msgstr "차원"
 
 msgid "Dimension"
-msgstr "치수"
+msgstr "차원"
 
 msgid "Dimension slots"
 msgstr "차원 슬롯"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "아직 제공자 매핑이 없는 게시된 저널의 차원 값입니다."
+msgstr "아직 제공자 매핑이 없는 전기된 전표의 차원 값"
 
 msgid "dimensions"
-msgstr "치수"
+msgstr "차원"
 
 msgid "Dimensions"
-msgstr "치수"
+msgstr "차원"
 
 msgid "Direct"
 msgstr "직접"
@@ -5235,10 +5235,10 @@ msgid "Discount Percentage"
 msgstr "할인율"
 
 msgid "Discounts earned for early payment to suppliers"
-msgstr "공급업체에 조기 결제 시 받는 할인"
+msgstr "공급업체에 대한 조기 지불 할인"
 
 msgid "Discounts given to customers for early payment"
-msgstr "고객에게 조기 결제 시 제공하는 할인"
+msgstr "고객에게 조기 지불로 제공된 할인"
 
 msgid "Discovery"
 msgstr "발견"
@@ -5247,16 +5247,16 @@ msgid "Dismiss"
 msgstr "닫기"
 
 msgid "Dispatch"
-msgstr "작업지시"
+msgstr "유지보수 지시"
 
 msgid "Dispatch ID"
-msgstr "작업지시 ID"
+msgstr "유지보수 지시 ID"
 
 msgid "Dispatch priority"
-msgstr "배송 우선순위"
+msgstr "유지보수 지시 우선순위"
 
 msgid "Dispatches"
-msgstr "작업지시"
+msgstr "유지보수 지시"
 
 msgid "Display Settings"
 msgstr "표시 설정"
@@ -5277,10 +5277,10 @@ msgid "Disposed"
 msgstr "폐기됨"
 
 msgid "Disposition"
-msgstr "처리"
+msgstr "처분 결정"
 
 msgid "Dispositions"
-msgstr "처리"
+msgstr "처분 결정"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
 msgstr "이 직원 유형의 기본 권한으로 사용자의 현재 권한을 덮어쓰시겠습니까?"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "문서"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "문서는 송장, 청구서 및 지불을 기본 공급자 문서로 푸시하고, 해당 분개는 문서에서 다룬 것으로 기록됩니다. 또한 공급자에 기록된 지불을 Carbon으로 다시 끌어와 일치하는 청구서 또는 송장을 마감하고 Carbon GL 분개를 게시합니다. Off는 이를 의도적으로 제외된 것으로 기록합니다."
+msgstr "문서는 송장, 청구서 및 지불을 기본 제공자 문서로 푸시합니다. 해당 전표는 문서로 커버되는 것으로 기록됩니다. 또한 제공자에 기록된 지불을 Carbon으로 다시 가져와 일치하는 송장 또는 청구서를 닫고 Carbon 총계정원장 전표를 전기합니다. 끄기는 이를 의도적으로 제외된 것으로 기록합니다."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "열어본 문서는 빠른 접근을 위해 여기에 표시됩니다."
@@ -5359,13 +5359,13 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "초안은 수정 가능하고, 활성은 사용 중이므로 변경하려면 새 버전이 필요하며, 보관됨은 더 이상 사용하지 않는 상태입니다."
 
 msgid "Draft Journal Entries"
-msgstr "임시 분개"
+msgstr "초안 전표"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "파일을 드래그 앤 드롭하거나 클릭하여 찾아보세요"
 
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
-msgstr "구매주문 PDF를 여기에 드래그 앤 드롭하거나 클릭하여 파일을 선택하세요"
+msgstr "발주서 PDF를 여기에 끌어서 놓거나 파일을 선택하려면 클릭하세요."
 
 msgid "Drag handle"
 msgstr "드래그 핸들"
@@ -5417,25 +5417,25 @@ msgid "Due {0}"
 msgstr "기한 {0}"
 
 msgid "Due date"
-msgstr "만기일"
+msgstr "마감일"
 
 msgid "Due Date"
-msgstr "기한일"
+msgstr "마감일"
 
 msgid "Due Date (job)"
-msgstr "만기일 (작업)"
+msgstr "마감일 (작업 지시)"
 
 msgid "Due Date of First Job"
-msgstr "첫 작업 기한일"
+msgstr "첫 번째 작업 지시의 마감일"
 
 msgid "Due Date of Last Job"
-msgstr "마지막 작업 기한일"
+msgstr "마지막 작업 지시의 마감일"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "일괄 배치에서 가장 이른 작업의 기한일로, 이후 작업들은 이 날짜와 '마지막 작업 기한일' 사이에 균등하게 배치됩니다."
+msgstr "일괄 배치에서 가장 이른 작업 지시의 마감일이며, 이후 작업 지시는 이 날짜와 마지막 작업 지시의 마감일 사이에 균등하게 배치됩니다."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "일괄 배치에서 마지막 작업의 기한일로, '첫 작업 기한일'과 함께 작업들을 균등하게 배치하는 데 사용됩니다."
+msgstr "일괄 배치에서 최종 작업 지시의 마감일이며, 첫 번째 작업 지시의 마감일과 함께 사용하여 작업 지시를 균등하게 배치합니다."
 
 msgid "Due Days"
 msgstr "기한 일수"
@@ -5522,7 +5522,7 @@ msgid "Each operation's unused material returns as soon as the operation is done
 msgstr "각 작업의 미사용 재료는 해당 작업이 완료되는 즉시 반환됩니다."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
-msgstr "각 실물 유닛은 고유한 추적 개체와 번호를 부여받습니다 — 하나의 개체, 하나의 유닛."
+msgstr "각 물리적 개는 자신의 추적 대상과 고유 번호를 받습니다 — 하나의 추적 대상, 하나의 개."
 
 msgid "Each, lb, ft…"
 msgstr "개, lb, ft…"
@@ -5534,247 +5534,247 @@ msgid "Easier to extend"
 msgstr "확장이 더 쉬움"
 
 msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
-msgstr "경제운영자 등록 및 식별 번호(EORI)로, EU/영국 국경을 통과하는 재화에 필요합니다."
+msgstr "경제 운영자 등록 및 식별 번호; EU/UK의 관세 국경을 넘는 물품에 필수입니다."
 
 msgid "Edit"
-msgstr "수정"
+msgstr "편집"
 
 msgid "Edit <0>Issue</0> Workflow"
-msgstr "<0>이슈</0> 워크플로 수정"
+msgstr "<0>불출</0> 워크플로 편집"
 
 msgid "Edit Account"
-msgstr "계정 수정"
+msgstr "계정 편집"
 
 msgid "Edit Action"
 msgstr "작업 편집"
 
 msgid "Edit API Key"
-msgstr "API 키 수정"
+msgstr "API 키 편집"
 
 msgid "Edit Approval Rule"
-msgstr "승인 규칙 수정"
+msgstr "승인 규칙 편집"
 
 msgid "Edit Asset"
 msgstr "자산 편집"
 
 msgid "Edit Asset Class"
-msgstr "자산 분류 수정"
+msgstr "자산 클래스 편집"
 
 msgid "Edit Assignment"
-msgstr "배정 수정"
+msgstr "할당 편집"
 
 msgid "Edit Attribute"
-msgstr "속성 수정"
+msgstr "속성 편집"
 
 msgid "Edit Attribute Category"
-msgstr "속성 카테고리 수정"
+msgstr "속성 카테고리 편집"
 
 msgid "Edit Category"
-msgstr "카테고리 수정"
+msgstr "카테고리 편집"
 
 msgid "Edit Change Notice"
-msgstr "변경 공지 편집"
+msgstr "변경 통지 편집"
 
 msgid "Edit Change Notice Action"
-msgstr "변경 공지 작업 편집"
+msgstr "변경 통지 조치 편집"
 
 msgid "Edit Change Notice Type"
-msgstr "변경 공지 유형 편집"
+msgstr "변경 통지 유형 편집"
 
 msgid "Edit column visibility"
-msgstr "열 표시 여부 수정"
+msgstr "열 표시 여부 편집"
 
 msgid "Edit Contact"
-msgstr "담당자 수정"
+msgstr "담당자 편집"
 
 msgid "Edit Contractor"
-msgstr "계약직 수정"
+msgstr "외주 인력 편집"
 
 msgid "Edit Cost Center"
 msgstr "원가 센터 편집"
 
 msgid "Edit Count"
-msgstr "카운트 수정"
+msgstr "수량 편집"
 
 msgid "Edit Currency"
-msgstr "통화 수정"
+msgstr "통화 편집"
 
 msgid "Edit Custom Field"
-msgstr "사용자 정의 필드 수정"
+msgstr "사용자 정의 필드 편집"
 
 msgid "Edit Customer Part"
-msgstr "고객 부품 수정"
+msgstr "고객 부품 편집"
 
 msgid "Edit Customer Status"
-msgstr "고객 상태 수정"
+msgstr "고객 상태 편집"
 
 msgid "Edit Customer Type"
-msgstr "고객 유형 수정"
+msgstr "고객 유형 편집"
 
 msgid "Edit Department"
-msgstr "부서 수정"
+msgstr "부서 편집"
 
 msgid "Edit Dimension"
-msgstr "치수 수정"
+msgstr "차원 편집"
 
 msgid "Edit Dispatch"
-msgstr "작업지시 수정"
+msgstr "유지보수 지시 편집"
 
 msgid "Edit Employee"
-msgstr "직원 수정"
+msgstr "직원 편집"
 
 msgid "Edit Employee Type"
-msgstr "직원 유형 수정"
+msgstr "직원 유형 편집"
 
 msgid "Edit expiration date"
-msgstr "유효기한 수정"
+msgstr "만료일 편집"
 
 msgid "Edit Expiry"
-msgstr "유효기한 수정"
+msgstr "유통기한 편집"
 
 msgid "Edit Failure Mode"
-msgstr "고장 모드 수정"
+msgstr "고장 모드 편집"
 
 msgid "Edit Fixed Asset"
-msgstr "고정자산 수정"
+msgstr "고정자산 편집"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "측정기 교정 기록 수정"
+msgstr "계측기 교정 기록 편집"
 
 msgid "Edit Gauge Type"
-msgstr "측정기 유형 수정"
+msgstr "계측기 유형 편집"
 
 msgid "Edit Group"
-msgstr "그룹 수정"
+msgstr "그룹 편집"
 
 msgid "Edit Holiday"
-msgstr "휴일 수정"
+msgstr "휴일 편집"
 
 msgid "Edit Inspection Plan"
 msgstr "검사 계획 편집"
 
 msgid "Edit Item Group"
-msgstr "품목 그룹 수정"
+msgstr "품목 그룹 편집"
 
 msgid "Edit Journal Entry"
 msgstr "분개장 항목 편집"
 
 msgid "Edit Kanban"
-msgstr "칸반 수정"
+msgstr "칸반 편집"
 
 msgid "Edit Line"
-msgstr "라인 수정"
+msgstr "라인 편집"
 
 msgid "Edit Location"
-msgstr "위치 수정"
+msgstr "사업장 편집"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "유지보수 작업지시 수정"
+msgstr "유지보수 지시 편집"
 
 msgid "Edit Material"
-msgstr "자재 수정"
+msgstr "자재 편집"
 
 msgid "Edit Material Dimension"
-msgstr "자재 치수 수정"
+msgstr "자재 차원 편집"
 
 msgid "Edit Material Finish"
-msgstr "자재 표면처리 수정"
+msgstr "표면 처리 편집"
 
 msgid "Edit Material Grade"
-msgstr "자재 등급 수정"
+msgstr "재질 등급 편집"
 
 msgid "Edit Material Shape"
-msgstr "자재 형태 수정"
+msgstr "형상 편집"
 
 msgid "Edit Material Substance"
-msgstr "자재 재질 수정"
+msgstr "재질 편집"
 
 msgid "Edit Material Type"
-msgstr "자재 유형 수정"
+msgstr "자재 유형 편집"
 
 msgid "Edit Memo"
-msgstr "메모 수정"
+msgstr "메모 편집"
 
 msgid "Edit Non Conformance Type"
-msgstr "부적합 유형 수정"
+msgstr "부적합 유형 편집"
 
 msgid "Edit Part"
-msgstr "품목 수정"
+msgstr "부품 편집"
 
 msgid "Edit Partner"
-msgstr "파트너 수정"
+msgstr "파트너 편집"
 
 msgid "Edit Passkey"
 msgstr "패스키 편집"
 
 msgid "Edit Payment"
-msgstr "결제 수정"
+msgstr "지불 편집"
 
 msgid "Edit Payment Term"
-msgstr "결제조건 수정"
+msgstr "지불 조건 편집"
 
 msgid "Edit permissions"
-msgstr "권한 수정"
+msgstr "권한 편집"
 
 msgid "Edit Permissions"
-msgstr "권한 수정"
+msgstr "권한 편집"
 
 msgid "Edit Picking List"
-msgstr "피킹 리스트 수정"
+msgstr "피킹 리스트 편집"
 
 msgid "Edit Portal"
-msgstr "포털 수정"
+msgstr "포털 편집"
 
 msgid "Edit Price Override"
-msgstr "가격 재정의 수정"
+msgstr "가격 재정의 편집"
 
 msgid "Edit Pricing"
-msgstr "가격 수정"
+msgstr "가격 책정 편집"
 
 msgid "Edit Pricing Rule"
-msgstr "가격 규칙 수정"
+msgstr "가격 규칙 편집"
 
 msgid "Edit Process"
-msgstr "공정 수정"
+msgstr "공법 편집"
 
 msgid "Edit Production Event"
-msgstr "생산 이벤트 수정"
+msgstr "생산 이벤트 편집"
 
 msgid "Edit Production Projection"
-msgstr "생산 예측 수정"
+msgstr "생산 예측 편집"
 
 msgid "Edit Production Quantity"
-msgstr "생산 수량 수정"
+msgstr "생산 수량 편집"
 
 msgid "Edit purchase order line type"
-msgstr "구매주문 라인 유형 수정"
+msgstr "발주서 라인 유형 편집"
 
 msgid "Edit Question"
-msgstr "질문 수정"
+msgstr "질문 편집"
 
 msgid "Edit Reason"
-msgstr "사유 수정"
+msgstr "이유 편집"
 
 msgid "Edit Receipt"
-msgstr "입고 수정"
+msgstr "입고 편집"
 
 msgid "Edit Revision"
-msgstr "리비전 수정"
+msgstr "리비전 편집"
 
 msgid "Edit rule"
-msgstr "규칙 수정"
+msgstr "규칙 편집"
 
 msgid "Edit Rule"
-msgstr "규칙 수정"
+msgstr "규칙 편집"
 
 msgid "Edit Schedule"
-msgstr "일정 수정"
+msgstr "일정 편집"
 
 msgid "Edit Scheduled Maintenance"
-msgstr "예정된 유지보수 수정"
+msgstr "예정된 유지보수 편집"
 
 msgid "Edit Sequence"
-msgstr "순서 수정"
+msgstr "채번 규칙 편집"
 
 msgid "Edit Serial Number"
 msgstr "시리얼 번호 편집"
@@ -5783,79 +5783,79 @@ msgid "Edit Service"
 msgstr "서비스 편집"
 
 msgid "Edit Shift"
-msgstr "교대 수정"
+msgstr "교대조 편집"
 
 msgid "Edit Shipment"
-msgstr "출하 수정"
+msgstr "출하 편집"
 
 msgid "Edit Shipping"
-msgstr "배송비 수정"
+msgstr "배송 편집"
 
 msgid "Edit Shipping Method"
-msgstr "배송 방법 수정"
+msgstr "배송 방법 편집"
 
 msgid "Edit Size"
-msgstr "사이즈 수정"
+msgstr "크기 편집"
 
 msgid "Edit Step"
-msgstr "단계 수정"
+msgstr "단계 편집"
 
 msgid "Edit Stock Transfer"
-msgstr "재고 이동 수정"
+msgstr "재고 이송 편집"
 
 msgid "Edit Storage Type"
-msgstr "저장 유형 수정"
+msgstr "보관 유형 편집"
 
 msgid "Edit Storage Unit"
-msgstr "저장 단위 수정"
+msgstr "보관 단위 편집"
 
 msgid "Edit Substance"
-msgstr "재질 수정"
+msgstr "물질 편집"
 
 msgid "Edit Supplier"
-msgstr "공급업체 수정"
+msgstr "공급업체 편집"
 
 msgid "Edit Supplier Part"
-msgstr "공급업체 부품 수정"
+msgstr "공급업체 부품 편집"
 
 msgid "Edit supplier process"
-msgstr "공급업체 공정 수정"
+msgstr "공급업체 공법 편집"
 
 msgid "Edit Supplier Type"
-msgstr "공급업체 유형 수정"
+msgstr "공급업체 유형 편집"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "\"전체에 적용\" 플래그를 제거하려면 규칙을 수정하세요"
+msgstr "규칙을 편집하여 「모든 항목에 적용」 플래그를 제거하세요"
 
 msgid "Edit Timecard"
-msgstr "근무기록 수정"
+msgstr "타임카드 편집"
 
 msgid "Edit Tool"
-msgstr "공구 수정"
+msgstr "공구 편집"
 
 msgid "Edit Training"
-msgstr "교육 수정"
+msgstr "교육 편집"
 
 msgid "Edit Transfer"
-msgstr "이동 수정"
+msgstr "이송 편집"
 
 msgid "Edit Transfer Line"
-msgstr "이동 라인 수정"
+msgstr "이송 라인 편집"
 
 msgid "Edit Type"
 msgstr "유형 편집"
 
 msgid "Edit Unit of Measure"
-msgstr "측정 단위 수정"
+msgstr "단위 편집"
 
 msgid "Edit View"
-msgstr "보기 수정"
+msgstr "보기 편집"
 
 msgid "Edit Webhook"
-msgstr "웹훅 수정"
+msgstr "웹훅 편집"
 
 msgid "Edit Work Center"
-msgstr "작업장 수정"
+msgstr "작업장 편집"
 
 msgid "Eliminated"
 msgstr "제거됨"
@@ -5876,7 +5876,7 @@ msgid "Email Address"
 msgstr "이메일 주소"
 
 msgid "Email notifications are not included in your company's current plan; email preferences will apply if they are enabled."
-msgstr "이메일 알림은 귀사의 현재 플랜에 포함되지 않습니다. 이메일 알림이 활성화되면 이메일 환경설정이 적용됩니다."
+msgstr "이메일 알림은 회사의 현재 요금제에 포함되어 있지 않습니다. 이메일 환경 설정이 활성화된 경우 적용됩니다."
 
 msgid "Email notifications not configured"
 msgstr "이메일 알림이 설정되지 않음"
@@ -5924,7 +5924,7 @@ msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "데이터 변경 사항 추적을 시작하려면 설정에서 감사 로깅을 활성화하세요."
 
 msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
-msgstr "귀사에 디지털 견적을 활성화하세요. 이를 통해 고객에게 디지털 견적을 발송할 수 있고, 고객은 온라인으로 이를 승인할 수 있습니다."
+msgstr "회사의 디지털 견적서를 활성화하세요. 이렇게 하면 고객에게 디지털 견적서를 보낼 수 있으며, 고객이 온라인에서 수락할 수 있습니다."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
 msgstr "전표, 재무 보고서, 총계정원장 전기를 포함한 완전 발생주의 회계를 활성화하세요."
@@ -5936,13 +5936,13 @@ msgid "Enable notifications when an RFQ is marked as ready for quote."
 msgstr "RFQ가 견적 준비 완료로 표시될 때 알림을 활성화하세요."
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
-msgstr "MES 단말기에 공유 워크스테이션 모드를 활성화하세요. 작업자는 작업 수행 전에 PIN으로 본인을 인증합니다."
+msgstr "MES 터미널의 공유 워크스테이션 모드를 활성화하세요. 작업자는 작업을 수행하기 전에 PIN을 통해 신원을 확인합니다."
 
 msgid "Enable this rule to automatically require approval for matching documents"
 msgstr "이 규칙을 활성화하면 조건에 맞는 문서에 대해 자동으로 승인이 필요해집니다"
 
 msgid "Enable timecard tracking for work shifts."
-msgstr "교대 근무에 대한 근무기록 추적을 활성화하세요."
+msgstr "작업 교대조의 시간 카드 추적을 활성화하세요."
 
 msgid "Enable to allow shared workstation mode."
 msgstr "공유 워크스테이션 모드를 허용하려면 활성화하세요."
@@ -5960,10 +5960,10 @@ msgid "Enable to start tracking changes to your data."
 msgstr "데이터 변경 사항 추적을 시작하려면 활성화하세요."
 
 msgid "Enable to start tracking work shifts."
-msgstr "교대 근무 추적을 시작하려면 활성화하세요."
+msgstr "작업 교대조 추적을 시작하려면 활성화하세요."
 
 msgid "Enable to use metric units for material dimensions."
-msgstr "자재 치수에 미터법 단위를 사용하려면 활성화하세요."
+msgstr "자재 치수에 메트릭 단위를 사용하려면 활성화하세요."
 
 msgid "Enabled"
 msgstr "활성화됨"
@@ -6003,10 +6003,10 @@ msgid "Engineering"
 msgstr "엔지니어링"
 
 msgid "Engineering changes and CAD"
-msgstr "엔지니어링 변경 및 CAD"
+msgstr "설계 변경 및 CAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "엔지니어링 변경 및 CAD"
+msgstr "설계 변경 및 CAD"
 
 msgid "Engineering Contact"
 msgstr "엔지니어링 담당자"
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "등록"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "유효기한을 설정하기 전에 배치 번호를 입력하세요"
+msgstr "만료일을 설정하기 전에 배치 번호를 입력하세요."
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "1과 {0} 사이의 수량을 입력하세요."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "구매주문(PO)에 대한 공급업체 청구서를 입력하고 승인하세요(3자 대조)"
+msgstr "PO에 대한 공급업체 청구서를 입력하고 승인하세요 (3자 대사)."
 
 msgid "Enter number…"
 msgstr "숫자 입력…"
@@ -6061,7 +6061,7 @@ msgid "Entity"
 msgstr "개체"
 
 msgid "Entity certification: Accepted"
-msgstr "법인 인증: 승인됨"
+msgstr "법인 인증: 수락됨"
 
 msgid "Entity certification: Expired"
 msgstr "법인 인증: 만료됨"
@@ -6091,7 +6091,7 @@ msgid "Equity account for accumulated profits or losses"
 msgstr "누적 손익에 대한 자본 계정"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "환산차손익(CTA)에 대한 자본 계정"
+msgstr "통화 환산 조정용 자본 계정 (CTA)"
 
 msgid "Error"
 msgstr "오류"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "공급업체 데이터 조회 오류"
 
 msgid "Error loading assigned dispatches"
-msgstr "배정된 작업지시 로딩 오류"
+msgstr "할당된 유지보수 지시 로드 오류"
 
 msgid "Error loading assigned documents"
 msgstr "배정된 문서 로딩 오류"
@@ -6121,7 +6121,7 @@ msgid "Error loading job tree."
 msgstr "작업 트리 로딩 오류."
 
 msgid "Error loading make method"
-msgstr "제조 방법 로딩 오류"
+msgstr "생산 방법 로드 오류"
 
 msgid "Error moving file"
 msgstr "파일 이동 오류"
@@ -6145,10 +6145,10 @@ msgid "Error removing model from RFQ line"
 msgstr "RFQ 라인에서 모델 제거 오류"
 
 msgid "Error removing model from sales invoice line"
-msgstr "판매 인보이스 라인에서 모델 제거 오류"
+msgstr "매출 송장 라인에서 모델 제거 오류"
 
 msgid "Error removing model from sales order line"
-msgstr "판매주문 라인에서 모델 제거 오류"
+msgstr "수주 라인에서 모델 제거 오류"
 
 msgid "Escalate to the project leads"
 msgstr "프로젝트 책임자에게 에스컬레이션"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "모든 일치"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "기간을 종료하기 전에 모든 필수 작업을 완료하거나 건너뛰어야 합니다."
+msgstr "기간을 마감하기 전에 모든 필수 작업을 완료하거나 건너뛰어야 합니다."
 
 msgid "Every row was imported successfully."
 msgstr "모든 행이 성공적으로 가져와졌습니다."
@@ -6211,7 +6211,7 @@ msgid "Everything else"
 msgstr "그 외 모든 것"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "그 외 모든 것은 사람, 가져오기, 통합 및 API를 포함합니다 — 워크플로우가 아닌 모든 항목입니다."
+msgstr "그 외 모든 것은 인원, 가져오기, 연동 및 API를 다룹니다 — 워크플로 중 하나가 아닌 모든 것입니다."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "총 {PO_EMAIL_ATTACHMENT_LIMIT_MB}MB를 초과합니다 — 발송하려면 일부 첨부 파일을 제거하세요."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "기존 매핑입니다. 다시 매핑하려면 다른 제공자 옵션을 선택하세요."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "기존 Stripe 고객"
 
 msgid "Expand"
 msgstr "펼치기"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "하위 트리 펼치기"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "판매 주문이 존재하기 전에 주간 단위로 입력된 제조 부품의 예상 미래 수요로서, 계획은 이를 공급에 대해 차감하고 방법을 확장하여 부품을 미리 주문합니다."
+msgstr "판매 주문이 존재하기 전에 주별로 입력되는 사내 생산 부품에 대한 예상 향후 소요량입니다. 계획이 공급과 대사하고 구성 요소를 미리 주문하기 위해 방법을 분해합니다."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "품목에 대한 예상 미래 수요로, 기간별로 구분되며 계획 실행 시 실제 수요와 함께 채워집니다."
+msgstr "기간별로 버킷화된 품목에 대한 예상 향후 소요량으로, 계획 실행 중에 실제 소요량과 함께 입력됩니다."
 
 msgid "Expected Receipt"
 msgstr "예상 입고"
@@ -6299,10 +6299,10 @@ msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "감가상각에 대한 이연법인세 조정 비용 계정"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "장비 및 시설 유지보수 비용 계정"
+msgstr "설비 및 시설 유지보수 비용 계정"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
-msgstr "외화 인보이스를 불리한 환율로 결제할 때 발생하는 외환 손실 비용 계정"
+msgstr "결제가 불리한 환율로 외화 송장을 결제할 때의 FX 손실 비용 계정"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
 msgstr "비재고 구매(서비스, 소모품)에 대한 비용 계정"
@@ -6314,7 +6314,7 @@ msgid "Expense GL account debited when inventory is shipped/issued against a sal
 msgstr "판매에 따라 재고가 출하/불출될 때 차변에 기록되는 비용 총계정원장 계정입니다."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "이연법인세 변동의 비용 측면(이연법인세부채와 짝을 이룸)입니다."
+msgstr "이연법인세 변동의 비용 측면 (이연법인세 채무와 쌍을 이룸)."
 
 msgid "Expenses"
 msgstr "비용"
@@ -6326,10 +6326,10 @@ msgid "Expiration date"
 msgstr "만료일"
 
 msgid "Expiration Date"
-msgstr "유효기한"
+msgstr "만료일"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "유효기한(이 라인의 모든 일련번호에 적용)"
+msgstr "만료일 (이 라인의 모든 일련번호에 적용)"
 
 msgid "Expired"
 msgstr "만료됨"
@@ -6362,16 +6362,16 @@ msgid "Expiring first"
 msgstr "먼저 만료되는 순"
 
 msgid "Expiry"
-msgstr "만료"
+msgstr "유통기한"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "선택한 공정이 완료되면 만료 기간이 시작됩니다."
+msgstr "유통기한은 선택된 공법이 완료될 때 시작됩니다."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "선택한 공정이 시작되면 만료 기간이 시작됩니다."
+msgstr "유통기한은 선택된 공법이 시작될 때 시작됩니다."
 
 msgid "Expiry trace"
-msgstr "만료 추적"
+msgstr "유통기한 추적"
 
 msgid "Export"
 msgstr "내보내기"
@@ -6416,13 +6416,13 @@ msgid "Extra fields to capture data Carbon doesn't track by default"
 msgstr "Carbon이 기본적으로 추적하지 않는 데이터를 담기 위한 추가 필드"
 
 msgid "Extra information sent with the request, such as an authorization key; header values are hidden in run history, though the names stay readable."
-msgstr "요청과 함께 보내진 추가 정보(예: 인증 키); 헤더 값은 실행 기록에서 숨겨지지만 이름은 읽을 수 있습니다."
+msgstr "요청과 함께 전송되는 추가 정보(예: 인증 키); 실행 이력에서 헤더 값은 숨겨지지만 이름은 읽을 수 있습니다."
 
 msgid "Extra tags for slicing your GL reporting"
 msgstr "총계정원장 보고를 세분화하기 위한 추가 태그"
 
 msgid "Fail"
-msgstr "실패"
+msgstr "불합격"
 
 msgid "Failed"
 msgstr "실패"
@@ -6468,7 +6468,7 @@ msgstr "고장 모드 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "측정기 유형 생성 실패: {0}"
+msgstr "계측기 유형 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6484,11 +6484,11 @@ msgstr "유지보수 일정 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
-msgstr "자재 치수 생성 실패: {0}"
+msgstr "자재 차원 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "자재 표면처리 생성 실패: {0}"
+msgstr "표면 처리 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
@@ -6496,7 +6496,7 @@ msgstr "자재 형태 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "자재 등급 생성 실패: {0}"
+msgstr "재질 등급 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
@@ -6512,7 +6512,7 @@ msgstr "자재 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "견적 불가 사유 생성 실패: {0}"
+msgstr "견적 거절 사유 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "품목 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "결제조건 생성 실패: {0}"
+msgstr "지불 조건 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6536,7 +6536,7 @@ msgstr "배송 방법 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "재고 이동 라인 생성 실패: {0}"
+msgstr "재고 이송 라인 생성 실패: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "데이터를 불러오지 못했습니다"
 
 msgid "Failed to load inbound inspections"
-msgstr "입고 검사를 불러오지 못했습니다"
+msgstr "수입 검사 로드 실패"
 
 msgid "Failed to load item data"
 msgstr "품목 데이터를 불러오지 못했습니다"
@@ -6607,16 +6607,16 @@ msgid "Failed to load item details"
 msgstr "품목 세부정보를 불러오지 못했습니다"
 
 msgid "Failed to load job operations"
-msgstr "작업 공정작업을 불러오지 못했습니다"
+msgstr "작업 지시 공정 로드 실패"
 
 msgid "Failed to load jobs"
-msgstr "작업을 불러오지 못했습니다"
+msgstr "작업 지시 로드 실패"
 
 msgid "Failed to load purchase order lines"
-msgstr "구매주문 라인을 불러오지 못했습니다"
+msgstr "발주서 라인 로드 실패"
 
 msgid "Failed to load purchase orders"
-msgstr "구매주문을 불러오지 못했습니다"
+msgstr "발주서 로드 실패"
 
 msgid "Failed to load receipt lines"
 msgstr "입고 라인을 불러오지 못했습니다"
@@ -6625,10 +6625,10 @@ msgid "Failed to load receipts"
 msgstr "입고를 불러오지 못했습니다"
 
 msgid "Failed to load sales order lines"
-msgstr "판매주문 라인을 불러오지 못했습니다"
+msgstr "수주 라인 로드 실패"
 
 msgid "Failed to load sales orders"
-msgstr "판매주문을 불러오지 못했습니다"
+msgstr "수주 로드 실패"
 
 msgid "Failed to load shipment lines"
 msgstr "출하 라인을 불러오지 못했습니다"
@@ -6653,16 +6653,16 @@ msgid "Failed to register passkey"
 msgstr "패스키 등록에 실패했습니다"
 
 msgid "Failed to remove image: {errorMessage}"
-msgstr "이미지를 삭제하지 못했습니다: {errorMessage}"
+msgstr "이미지 제거 실패: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "모델 썸네일을 삭제하지 못했습니다"
+msgstr "모델 썸네일 제거 실패"
 
 msgid "Failed to remove purchase order"
-msgstr "구매주문을 삭제하지 못했습니다"
+msgstr "발주서 제거 실패"
 
 msgid "Failed to remove thumbnail"
-msgstr "썸네일을 삭제하지 못했습니다"
+msgstr "썸네일 제거 실패"
 
 msgid "Failed to resize image"
 msgstr "이미지 크기를 조정하지 못했습니다"
@@ -6710,7 +6710,7 @@ msgid "Failed to update item cost"
 msgstr "품목 원가를 업데이트하지 못했습니다"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "구매주문으로 기회를 업데이트하지 못했습니다"
+msgstr "발주서로 영업 기회 업데이트 실패"
 
 msgid "Failed to update quote line"
 msgstr "견적 라인을 업데이트하지 못했습니다"
@@ -6835,10 +6835,10 @@ msgid "Files"
 msgstr "파일"
 
 msgid "Files attached here ride along on every purchase order email by default. Suppliers will receive them alongside the PO PDF."
-msgstr "여기에 첨부한 파일은 기본적으로 모든 구매주문 이메일에 함께 전송됩니다. 공급업체는 PO PDF와 함께 이 파일들을 받게 됩니다."
+msgstr "여기에 첨부된 파일은 기본적으로 모든 발주서 이메일에 포함됩니다. 공급업체는 PO PDF와 함께 이 파일을 받게 됩니다."
 
 msgid "Files attached here ride along on every purchase order email sent to this supplier (in addition to company-wide defaults)."
-msgstr "여기에 첨부한 파일은 이 공급업체에 전송되는 모든 구매주문 이메일에 함께 전송됩니다(회사 전체 기본 첨부파일에 추가로)."
+msgstr "여기에 첨부된 파일은 이 공급업체로 전송되는 모든 발주서 이메일에 포함됩니다(회사 전체 기본값 외에)."
 
 msgid "Fill this company with a realistic industry story so every screen has something in it. You can put back what was here before."
 msgstr "이 회사를 현실적인 산업 시나리오로 채워서 모든 화면에 데이터가 표시되도록 합니다. 이전 상태로 복원할 수 있습니다."
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "확정"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "열림 → 잠김 → 종료 라이프사이클을 통해 회계 월을 마무리하는 것으로서, 종료된 기간은 고정되고 잔액은 스냅샷되며 명시적 재개를 통해서만 취소할 수 있습니다."
+msgstr "회계 월을 미결 → 잠김 → 마감됨 생명주기를 통해 최종화하는 중입니다. 마감된 기간은 동결되고 잔액이 스냅샷되며 명시적인 다시 열기로만 되돌릴 수 있습니다."
 
 msgid "Financial Statements"
 msgstr "재무제표"
@@ -6874,10 +6874,10 @@ msgid "Finished goods"
 msgstr "완제품"
 
 msgid "Finished Goods"
-msgstr "완성품"
+msgstr "완제품"
 
 msgid "Finished Goods (default)"
-msgstr "완성품 (기본값)"
+msgstr "완제품 (기본)"
 
 msgid "finishes"
 msgstr "마감"
@@ -6937,7 +6937,7 @@ msgid "Fixed Assets"
 msgstr "고정자산"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "배치 크기가 표준과 다를 때 발생하는 고정비 상각 차이"
+msgstr "배치 크기가 표준과 다를 때 고정 원가 상각 차이"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "회계 기간이 게시되거나 종료되면 고정됩니다. 변경하려면 모든 공개 기간을 삭제하십시오."
@@ -6946,13 +6946,13 @@ msgid "Fixed Reorder"
 msgstr "고정 재주문"
 
 msgid "Fixed Shelf Life"
-msgstr "고정 유효기간"
+msgstr "고정 보존 기간"
 
 msgid "Fixture"
-msgstr "픽스처"
+msgstr "지그"
 
 msgid "Fixture ID"
-msgstr "픽스처 ID"
+msgstr "지그 ID"
 
 msgid "Flags"
 msgstr "플래그"
@@ -6962,16 +6962,16 @@ msgstr "무엇이든지요. 적임자를 연결해 드립니다."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "예측 방법: <0>{0}</0>. 이 행은 진행 중인 작업에서 파생되지 않았으므로 상위 소스를 사용할 수 없습니다."
+msgstr "예측 방법: <0>{0}</0>. 이 라인은 진행 중인 작업 지시에서 파생되지 않았으므로 상위 소스를 사용할 수 없습니다."
 
 msgid "Forgot to Clock Out?"
-msgstr "퇴근 체크를 잊으셨나요?"
+msgstr "작업 종료를 잊으셨습니까?"
 
 msgid "Format"
 msgstr "형식"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "현장 배치 엔지니어"
 
 msgid "Foundation"
 msgstr "파운데이션"
@@ -7018,19 +7018,19 @@ msgid "from on-account credit"
 msgstr "미수금 크레딧에서"
 
 msgid "From Storage Unit"
-msgstr "출발 저장 단위"
+msgstr "보관 단위에서"
 
 msgid "Fulfillment Location"
-msgstr "이행 위치"
+msgstr "출하 사업장"
 
 msgid "Full name"
 msgstr "전체 이름"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "완전한 셋업 및 마이그레이션"
 
 msgid "Fully Depreciated"
-msgstr "완전 감가상각"
+msgstr "상각 완료"
 
 msgid "Fully trained for"
 msgstr "다음에 대해 완전히 교육됨"
@@ -7051,31 +7051,31 @@ msgid "Gains recognized on disposal of fixed assets"
 msgstr "고정자산 처분 시 인식된 이익"
 
 msgid "gauge"
-msgstr "측정기"
+msgstr "계측기"
 
 msgid "Gauge"
-msgstr "측정기"
+msgstr "계측기"
 
 msgid "Gauge Calibration Notifications"
-msgstr "측정기 교정 알림"
+msgstr "계측기 교정 알림"
 
 msgid "Gauge ID"
-msgstr "측정기 ID"
+msgstr "계측기 ID"
 
 msgid "Gauge not found"
-msgstr "측정기를 찾을 수 없습니다"
+msgstr "계측기를 찾을 수 없습니다"
 
 msgid "Gauge Type"
-msgstr "측정기 유형"
+msgstr "계측기 유형"
 
 msgid "Gauge Types"
-msgstr "측정기 유형"
+msgstr "계측기 유형"
 
 msgid "gauges"
-msgstr "측정기"
+msgstr "계측기"
 
 msgid "Gauges"
-msgstr "측정기"
+msgstr "계측기"
 
 msgid "Genealogy"
 msgstr "계보"
@@ -7096,10 +7096,10 @@ msgid "Generate"
 msgstr "생성"
 
 msgid "Generate a new 4-digit PIN. Share it with the operator so they can pin in at MES terminals."
-msgstr "새 4자리 PIN을 생성합니다. 오퍼레이터에게 전달하여 MES 단말기에서 PIN으로 로그인할 수 있게 하세요."
+msgstr "새로운 4자리 PIN을 생성하세요. 작업자와 공유하여 MES 터미널에서 PIN으로 로그인할 수 있도록 하세요."
 
 msgid "Generate and send customer invoices"
-msgstr "고객 인보이스 생성 및 발송"
+msgstr "고객 송장 생성 및 발송"
 
 msgid "Generate fiscal year"
 msgstr "회계연도 생성"
@@ -7114,7 +7114,7 @@ msgid "Generate new PIN"
 msgstr "새 PIN 생성"
 
 msgid "Generate Picking List"
-msgstr "피킹 목록 생성"
+msgstr "피킹 리스트 생성"
 
 msgid "Generated IDs are disabled"
 msgstr "자동 생성 ID가 비활성화됨"
@@ -7129,7 +7129,7 @@ msgid "Get live on Carbon: one system running quoting, purchasing, the shop floo
 msgstr "Carbon으로 전환하세요: 견적, 구매, 현장, 재고, 재무를 하나의 시스템에서 운영하여 기존 도구들을 대체합니다."
 
 msgid "Get Method"
-msgstr "GET 메서드"
+msgstr "방법 가져오기"
 
 msgid "Get started"
 msgstr "시작하기"
@@ -7144,7 +7144,7 @@ msgid "Getting set up"
 msgstr "설정하기"
 
 msgid "Give it an owner and a date"
-msgstr "담당자와 날짜를 지정하세요"
+msgstr "책임자와 날짜를 지정하세요"
 
 msgid "GL"
 msgstr "총계정원장"
@@ -7171,10 +7171,10 @@ msgid "GL account credited to remove the asset's original cost when it is dispos
 msgstr "자산 처분 시 원래 취득원가를 제거하기 위해 대변에 기록되는 총계정원장 계정입니다."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "공급업체 인보이스가 전기될 때 대변에 기록되는 총계정원장 계정입니다(매입채무 잔액)."
+msgstr "공급업체 송장이 전기될 때 계정과목이 대변됩니다(매입채무 잔액)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "노무비 또는 기계비가 생산 작업에 흡수될 때 대변에 기록되는 총계정원장 계정입니다."
+msgstr "노무 또는 기계 원가가 생산 작업 지시에 배치될 때 계정과목이 대변됩니다."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "제조간접비가 생산 작업에 흡수될 때 대변에 기록되는 총계정원장 계정입니다."
@@ -7183,25 +7183,25 @@ msgid "GL account debited to clear accumulated depreciation when an asset is dis
 msgstr "자산 처분 시 감가상각누계액을 정산하기 위해 차변에 기록되는 총계정원장 계정입니다."
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
-msgstr "고객 인보이스가 전기될 때 차변에 기록되며, 고객이 결제하면 정산되는 총계정원장 계정입니다."
+msgstr "고객 송장이 전기될 때 계정과목이 차변됩니다. 고객이 지불할 때 정산됩니다."
 
 msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
 msgstr "고정자산 취득 시(구매 또는 자본화 원가) 차변에 기록되는 총계정원장 계정입니다."
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "은행 수수료 및 유사 비용을 위한 총계정원장 계정입니다."
+msgstr "은행 서비스 요금 및 유사 수수료를 위한 계정과목입니다."
 
 msgid "GL account for interest income or expense."
 msgstr "이자 수익 또는 비용을 위한 총계정원장 계정입니다."
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
-msgstr "공급업체에 지급한(또는 환급 가능한) 매입세를 위한 총계정원장 계정입니다."
+msgstr "공급업체에 납부한 매입세(또는 환급 가능)를 위한 계정과목입니다."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "매입자가 스스로 신고하는 대리납부(리버스차지) 규정에 따라 발생하는 세금을 위한 총계정원장 계정입니다."
+msgstr "구매자가 자체 평가하는 역과세 규칙에 따라 발생한 세금을 위한 계정과목입니다."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "세무상 시점 차이(예: 가속 세무 감가상각과 장부 감가상각의 차이)를 위한 총계정원장 계정입니다."
+msgstr "세금 회계와 장부 감가상각의 차이(예: 가속 감가상각)를 위한 계정과목입니다."
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "실사 수량이 시스템 재고와 다를 때 기록되는 총계정원장 계정입니다."
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "자산의 최초 취득원가를 기록하는 총계정원장(GL) 계정 — 취득 시 차변에 기록되고, 처분 또는 매각 시 총원가(gross) 전액이 대변에 기록된다."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "생산 중인 작업의 금액을 완제품으로 전기되기 전까지 보관하는 총계정원장 계정입니다."
+msgstr "생산 중인 작업 지시의 가치를 보유하다가 완제품으로 전기될 때까지 보관하는 계정과목입니다."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "제조 상품(완성품)의 가치를 보유하는 GL 계정입니다. 작업 완료 시 차변, 출하 시 대변입니다."
@@ -7231,7 +7231,7 @@ msgid "GL account that holds the value of purchased stock and components (Buy it
 msgstr "구매한 재고 및 부품(구매품)의 가치를 보유하는 GL 계정입니다. 입고 시 차변, 출고/출하 시 대변입니다."
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
-msgstr "고객이 인보이스 발행 전에 결제할 때 사용되며, 인보이스가 전기되면 정산되는 총계정원장 계정입니다."
+msgstr "고객이 송장이 발행되기 전에 지불할 때 사용되는 계정과목입니다. 송장이 전기될 때 정산됩니다."
 
 msgid "GL account where early-payment discounts given to customers are recorded."
 msgstr "고객에게 제공한 조기결제 할인이 기록되는 총계정원장 계정입니다."
@@ -7240,7 +7240,7 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "공급업체로부터 받은 조기결제 할인이 기록되는 총계정원장 계정입니다."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "매 기간 감가상각이 계상될 때 대변에 기록되고, 자산이 매각되거나 폐기될 때 전액 차변에 기록되는 감가상각누계액에 해당하는 GL 차감계정(자산 차감계정)."
+msgstr "각 기간에 감가상각이 전기될 때 대변되고 자산이 판매 또는 폐기될 때 전액 차변되는 자산 상계 계정과목입니다."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
 msgstr "고정자산에 대해 계상된 감가상각이 누적되는 총계정원장 자산 차감 계정입니다."
@@ -7249,19 +7249,19 @@ msgid "GL equity account (CTA reserve) that holds unrealized FX differences from
 msgstr "기말에 외화 잔액을 재환산할 때 발생하는 미실현 외환 차이를 보관하는 총계정원장 자본 계정(CTA 적립금)으로, 손익계산서상 실현 외환손익과는 구분됩니다."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "회계연도 말에 당기순이익이 마감되는 총계정원장 자본 계정입니다."
+msgstr "회계 연도 말에 순이익이 마감되는 자본 계정과목입니다."
 
 msgid "GL expense account debited each period when depreciation posts."
 msgstr "매 기간 감가상각이 전기될 때 차변에 기록되는 총계정원장 비용 계정입니다."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "자산의 장부가액이 손상으로 인해 감소할 때, 즉 회수가능액이 순장부가액(NBV)보다 낮아질 때 차변에 기록되는 GL 비용계정."
+msgstr "자산의 장부가액이 손상 평가로 인해 회수 가능 금액 이하로 감소할 때 차변되는 비용 계정과목입니다."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
 msgstr "비재고성 구매(소모품, 서비스)를 위한 총계정원장 비용 계정입니다."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "고객으로부터 징수한 판매세에 대해 대변에 기록되는 총계정원장 부채 계정입니다."
+msgstr "고객에게서 징수한 판매세를 위해 대변되는 부채 계정과목입니다."
 
 msgid "GL tie-out"
 msgstr "총계정원장 대사"
@@ -7277,7 +7277,7 @@ msgid "Go to {0}"
 msgstr "{0}(으)로 이동"
 
 msgid "Go to implementation hub"
-msgstr "구축 허브로 이동"
+msgstr "실행 허브로 이동"
 
 msgid "Go-Live"
 msgstr "도입"
@@ -7313,7 +7313,7 @@ msgid "Google Places API key not configured"
 msgstr "Google Places API 키가 설정되지 않았습니다"
 
 msgid "GR/IR (goods received, not invoiced)"
-msgstr "GR/IR(입고됨, 미청구)"
+msgstr "GR/IR (송장 미발행 상태의 수령 상품)"
 
 msgid "GR/IR Clearing"
 msgstr "GR/IR 정산"
@@ -7355,7 +7355,7 @@ msgid "Guided"
 msgstr "가이드형"
 
 msgid "Guided implementation"
-msgstr "가이드형 구현"
+msgstr "안내된 실행"
 
 msgid "Handle recurring and reversing journal entries"
 msgstr "반복 및 역분개 전표 처리"
@@ -7409,7 +7409,7 @@ msgid "History"
 msgstr "이력"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "수정할 수 있도록 경고로 저널을 보류합니다."
+msgstr "수정할 경고로 전표를 보류하세요."
 
 msgid "Holiday"
 msgstr "휴일"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "시간/개"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "품목이 전반적으로 보충되는 방식(구매, 제조, 또는 구매 및 제조)으로, 라인별 방법 유형과 달리 품목별로 설정됩니다."
+msgstr "품목을 전체적으로 재보충하는 방법(구매, 사내 생산 또는 구매 및 사내 생산)입니다. 라인별 공급 방식과 달리 품목별로 설정됩니다."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "품목이 보충되는 방식: 수동 재주문, 수요 기반 재주문, 고정 재주문 수량, 또는 최대 수량."
@@ -7451,7 +7451,7 @@ msgid "How an item is sourced when added to a method or BOM line."
 msgstr "품목이 공정(BOP) 또는 BOM 라인에 추가될 때 조달되는 방식입니다."
 
 msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
-msgstr "품목의 단가가 평가되는 방식: 표준, 평균, FIFO, 또는 LIFO. 품목별로 설정됩니다."
+msgstr "품목의 단위 원가를 평가하는 방법입니다: 표준, 이동평균, 선입선출 또는 후입선출입니다. 품목별로 설정됩니다."
 
 msgid "How items roll up for posting and reporting"
 msgstr "품목이 전기 및 보고를 위해 합산되는 방식"
@@ -7469,16 +7469,16 @@ msgid "How many days a serial or batch of this item stays usable after its start
 msgstr "이 품목의 일련번호 또는 배치가 시작 이벤트 이후 사용 가능한 상태로 유지되는 일수로, 이 날짜가 지난 후의 처리는 유효기간 정책에서 결정됩니다."
 
 msgid "How many days after the calculation date the early-payment discount is still available."
-msgstr "계산일로부터 조기 결제 할인이 유효한 일수입니다."
+msgstr "계산일 이후 조기 지불 할인이 유효한 일수입니다."
 
 msgid "How many days after the calculation date the full amount is due."
 msgstr "계산일로부터 전체 금액이 만기되는 일수입니다."
 
 msgid "How many days from invoice date this customer is given to pay; drives the default due date on customer invoices."
-msgstr "이 고객에게 결제를 위해 주어지는, 인보이스 발행일로부터의 일수로, 고객 인보이스의 기본 만기일을 결정합니다."
+msgstr "이 고객이 송장 날짜로부터 지불하는 데 주어진 일수입니다. 고객 송장의 기본 마감일을 결정합니다."
 
 msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
-msgstr "이 공급업체가 결제를 받기까지 기대하는, 인보이스 발행일로부터의 일수로, 청구서의 기본 만기일을 결정합니다."
+msgstr "이 공급업체가 송장 날짜로부터 지불을 예상하는 일수입니다. 청구서의 기본 마감일을 결정합니다."
 
 msgid "How many fractional digits to keep when rounding amounts in this currency."
 msgstr "이 통화의 금액을 반올림할 때 유지할 소수 자릿수입니다."
@@ -7487,7 +7487,7 @@ msgid "How many of the successor replace one old part"
 msgstr "이전 품목 하나를 대체하는 후속 품목의 수량"
 
 msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
-msgstr "작업의 상위 품목 하나를 만드는 데 필요한 이 자재의 수량으로, 작업 수량과 곱해져 소요량이 계산됩니다."
+msgstr "작업 지시의 부모 품목 1개를 만드는 데 필요한 이 자재의 개수입니다. 작업 수량에 곱해서 소모량을 결정합니다."
 
 msgid "How many units each individual job in the bulk batch builds; the last job's quantity may be smaller if Total Quantity doesn't divide evenly."
 msgstr "대량 배치 내 개별 작업 각각이 생산하는 수량으로, 총수량이 균등하게 나누어지지 않으면 마지막 작업의 수량이 더 적을 수 있습니다."
@@ -7496,16 +7496,16 @@ msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "이 측정기가 재교정되어야 하는 주기로, 마지막 교정일과 결합되어 다음 교정일이 자동으로 계산됩니다."
+msgstr "이 계측기를 재교정해야 하는 빈도입니다. 마지막 교정 날짜와 함께 사용하여 다음 교정 날짜를 자동으로 계산합니다."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "이 유지보수가 반복되는 주기 — 매일, 매주, 매월, 사이클 카운트 시; 매일을 선택하면 요일 선택기가 표시되고, 나머지는 더 단순한 간격 계산을 사용합니다."
+msgstr "이 유지보수가 반복되는 빈도입니다 — 매일, 매주, 매월, 순환 실사 시; 매일을 선택하면 요일 선택 옵션이 표시되고 나머지는 더 간단한 간격 계산을 사용합니다."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
-msgstr "만기일이 얼마나 엄격한지를 나타냅니다 — 하드 데드라인은 이를 넘는 일정을 차단하고, 소프트 데드라인은 경고와 함께 일정 지연을 허용하며, 데드라인 없음은 완전히 무시합니다."
+msgstr "마감일 준수 수준입니다 — 강제 마감일은 그 이후 스케줄링을 차단하고, 경고 마감일은 계획 연기를 경고와 함께 허용하며, 마감일 없음은 이를 완전히 무시합니다."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "자재가 조달되는 방식(제조, 구매, 또는 재고에서 인출)과 인출되는 저장 단위입니다."
+msgstr "자재 구매 방식(사내 생산, 구매 또는 재고 사용) 및 자재를 보관하는 보관 단위."
 
 msgid "How the resolved price was calculated."
 msgstr "확정된 가격이 계산된 방식입니다."
@@ -7514,7 +7514,7 @@ msgid "How the sample size is decided — Inspect All, Inspect First N, Percenta
 msgstr "샘플 크기를 결정하는 방식 — 전수 검사, 처음 N개 검사, 로트 비율, 또는 AQL(Z1.4 / ISO 2859-1). 각 모드는 아래에 고유한 파라미터 필드를 표시합니다."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "이 게이지의 사용 방식으로서, 표준(정기적인 점검) 또는 마스터(다른 게이지 교정)입니다."
+msgstr "이 계측기의 사용 방식 — 보통 검사(정기 점검) 또는 표준기(다른 계측기 교정)."
 
 msgid "How this price was calculated"
 msgstr "이 가격이 계산된 방식"
@@ -7526,13 +7526,13 @@ msgid "How to read this chart"
 msgstr "이 차트 읽는 방법"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "이 작업지시의 긴급도 — 낮음/보통/높음/긴급; 우선순위 및 OEE 영향과 결합되어 일정 슬롯을 결정합니다."
+msgstr "이 유지보수 지시의 긴급도 — 낮음 / 보통 / 높음 / 심각; 우선순위 및 OEE 영향과 함께 일정 슬롯을 결정합니다."
 
 msgid "How we know we're done"
 msgstr "완료 여부를 판단하는 방법"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
-msgstr "저희가 서로 협업 상태를 유지하고 이슈를 해결하는 방법입니다. 귀하의 역할: 주간 통화에 참석하고, 지연으로 이어지기 전에 걸림돌을 조기에 제기해 주세요."
+msgstr "우리가 어떻게 정렬을 유지하고 문제가 어떻게 해결되는지. 당신의 책임: 매주 회의에 참석하고 지연이 되기 전에 문제를 조기에 제기하세요."
 
 msgid "How We Work"
 msgstr "저희의 협업 방식"
@@ -7541,10 +7541,10 @@ msgid "How We Work Together"
 msgstr "저희가 함께 일하는 방식"
 
 msgid "How your company's process maps to Carbon"
-msgstr "귀사의 프로세스가 Carbon에 매핑되는 방식"
+msgstr "당신의 회사의 공법이 Carbon에 어떻게 매핑되는지"
 
 msgid "How your quotes, orders, and invoices look when they go out"
-msgstr "귀사의 견적, 주문, 인보이스가 발송될 때의 모습"
+msgstr "당신의 견적서, 주문 및 송장이 발송될 때 어떻게 보이는지"
 
 msgid "How your team is organized into departments"
 msgstr "귀사의 팀이 부서로 조직되는 방식"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "하이퍼케어: 초기 몇 주간의 집중 지원"
 
 msgid "I (reduced)"
-msgstr "I(축소)"
+msgstr "I (수월한 검사)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "나는 이 개인이 22 CFR 120.62에서 정의한 미국인이라고 합리적으로 믿을 이유가 있습니다"
@@ -7595,7 +7595,7 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "다음 통화까지 기다릴 수 없는 경우, 양측 담당자가 결정합니다."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "작업을 막고 있거나 일정이 위험한 경우, 담당자를 지정해 추적합니다."
+msgstr "문제가 되거나 날짜가 위험에 처하면 책임자가 지정되고 추적됩니다."
 
 msgid "If items already exist"
 msgstr "품목이 이미 존재하는 경우"
@@ -7607,13 +7607,13 @@ msgid "If something is off track"
 msgstr "일정에서 벗어난 경우"
 
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
-msgstr "품목 번호를 변경하려면 취소를 클릭하고, 전환하기 전에 각 라인 항목에 대해 품목을 수동으로 지정하세요."
+msgstr "부품 번호를 변경하려면 취소를 클릭하고 변환 전에 각 라인의 부품을 수동으로 할당하세요."
 
 msgid "II (normal default)"
 msgstr "II(일반 기본값)"
 
 msgid "III (tightened)"
-msgstr "III(강화)"
+msgstr "III (까다로운 검사)"
 
 msgid "Impact"
 msgstr "영향"
@@ -7622,13 +7622,13 @@ msgid "Imperial"
 msgstr "야드파운드법"
 
 msgid "Implementation"
-msgstr "구현"
+msgstr "실행"
 
 msgid "Implementation Hub"
-msgstr "구현 허브"
+msgstr "실행 허브"
 
 msgid "Implementation Lead"
-msgstr "구현 리드"
+msgstr "실행 리드"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV 가져오기"
@@ -7644,7 +7644,7 @@ msgid "in {0}"
 msgstr "{0} 안에"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "Onshape에서 이 OAuth 애플리케이션의 권한에 \"Application can write to your documents\"를 포함하도록 편집한 후 다시 연결하세요."
+msgstr "Onshape에서 이 OAuth 애플리케이션의 권한을 편집하여 「Application can write to your documents」를 포함하도록 한 후 다시 연결하세요."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "이 RFQ를 견적으로 전환하려면 모든 라인에 내부 품목 번호가 있어야 합니다."
@@ -7701,7 +7701,7 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "비활성 조치는 선택 목록에 표시되지 않습니다"
 
 msgid "Inbound inspection"
-msgstr "입고 검사"
+msgstr "수입 검사"
 
 msgid "Inbox"
 msgstr "받은함"
@@ -7716,10 +7716,10 @@ msgid "Included"
 msgstr "포함됨"
 
 msgid "Includes tax and shipping costs"
-msgstr "세금 및 배송비 포함"
+msgstr "세금 및 운송비 포함"
 
 msgid "Income / Balance (inherited)"
-msgstr "손익/재무상태(상속됨)"
+msgstr "수익 / 잔액 (상속됨)"
 
 msgid "Income Statement"
 msgstr "손익계산서"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "소득세"
 
 msgid "Income/Balance"
-msgstr "손익/재무상태"
+msgstr "수익/잔액"
 
 msgid "incoming"
 msgstr "입고"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "상위 항목에서 상속됨"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "그룹에서 상속됨: 최상위 분류(자산, 부채, 자본, 수익, 비용)."
+msgstr "그룹에서 상속됨: 최상위 분류(자산, 부채, 자본, 매출, 비용)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "그룹에서 상속됨: 이 계정이 재무제표에 표시되는 위치."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "그룹에서 상속됨: 이 계정이 이익잉여금으로 마감되는지(손익) 또는 이월되는지(재무상태) 여부."
+msgstr "그룹에서 상속됨: 이 계정이 이익잉여금(수익)으로 종료되는지 또는 이월(잔액)되는지 여부."
 
 msgid "Inherited from the parent group."
 msgstr "상위 그룹에서 상속됨."
@@ -7845,10 +7845,10 @@ msgid "Instructions"
 msgstr "지시사항"
 
 msgid "Instructions are inherited from the procedure."
-msgstr "지시사항은 절차에서 상속됩니다."
+msgstr "지시사항은 절차서에서 상속됩니다."
 
 msgid "Integration"
-msgstr "통합"
+msgstr "연동"
 
 msgid "Integration not found"
 msgstr "연동을 찾을 수 없습니다"
@@ -7968,79 +7968,79 @@ msgid "Invited"
 msgstr "초대됨"
 
 msgid "Invoice"
-msgstr "인보이스"
+msgstr "송장"
 
 msgid "Invoice Contact"
-msgstr "인보이스 담당자"
+msgstr "송장 담당자"
 
 msgid "Invoice customer"
-msgstr "청구 고객"
+msgstr "송장 고객"
 
 msgid "Invoice Customer"
-msgstr "인보이스 고객"
+msgstr "송장 고객"
 
 msgid "Invoice customer contact"
-msgstr "청구 고객 연락처"
+msgstr "송장 고객 담당자"
 
 msgid "Invoice Customer Contact"
-msgstr "인보이스 고객 담당자"
+msgstr "송장 고객 담당자"
 
 msgid "Invoice customer location"
-msgstr "청구 고객 위치"
+msgstr "송장 고객 사업장"
 
 msgid "Invoice Customer Location"
-msgstr "인보이스 고객 위치"
+msgstr "송장 고객 사업장"
 
 msgid "Invoice ID"
-msgstr "인보이스 ID"
+msgstr "송장 ID"
 
 msgid "Invoice Location"
-msgstr "인보이스 위치"
+msgstr "송장 사업장"
 
 msgid "Invoice Number"
-msgstr "인보이스 번호"
+msgstr "송장 번호"
 
 msgid "Invoice settlement"
-msgstr "인보이스 정산"
+msgstr "송장 결제"
 
 msgid "Invoice supplier"
-msgstr "청구 공급자"
+msgstr "송장 공급업체"
 
 msgid "Invoice Supplier"
-msgstr "인보이스 공급업체"
+msgstr "송장 공급업체"
 
 msgid "Invoice supplier contact"
-msgstr "청구 공급자 연락처"
+msgstr "송장 공급업체 담당자"
 
 msgid "Invoice Supplier Contact"
-msgstr "인보이스 공급업체 담당자"
+msgstr "송장 공급업체 담당자"
 
 msgid "Invoice supplier location"
-msgstr "청구 공급자 위치"
+msgstr "송장 공급업체 사업장"
 
 msgid "Invoice Supplier Location"
-msgstr "인보이스 공급업체 위치"
+msgstr "송장 공급업체 사업장"
 
 msgid "Invoice Total"
-msgstr "인보이스 합계"
+msgstr "송장 총계"
 
 msgid "Invoiced"
-msgstr "인보이스 발행됨"
+msgstr "송장 발행됨"
 
 msgid "Invoiced Amount:"
-msgstr "인보이스 금액:"
+msgstr "송장 발행 금액:"
 
 msgid "Invoiced Statuses"
-msgstr "인보이스 상태"
+msgstr "송장 발행됨 상태"
 
 msgid "Invoices"
-msgstr "인보이스"
+msgstr "송장"
 
 msgid "Invoices this memo has been applied to. Click a row to open the document."
-msgstr "이 메모가 적용된 인보이스입니다. 행을 클릭하면 문서가 열립니다."
+msgstr "이 메모가 적용된 송장입니다. 행을 클릭하여 문서를 엽니다."
 
 msgid "Invoicing"
-msgstr "인보이스 발행"
+msgstr "송장 관리"
 
 msgid "is"
 msgstr "같음"
@@ -8049,7 +8049,7 @@ msgid "is any of"
 msgstr "다음 중 하나임"
 
 msgid "Is console operator"
-msgstr "콘솔 운영자인가"
+msgstr "콘솔 작업자입니다"
 
 msgid "Is customer org group"
 msgstr "고객 조직 그룹인가"
@@ -8064,10 +8064,10 @@ msgid "Is identity group"
 msgstr "신원 그룹인가"
 
 msgid "Is supplier org group"
-msgstr "공급자 조직 그룹인가"
+msgstr "공급업체 조직 그룹입니다"
 
 msgid "Is supplier type group"
-msgstr "공급자 유형 그룹인가"
+msgstr "공급업체 유형 그룹입니다"
 
 msgid "Issue"
 msgstr "이슈"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "이슈"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "다시 버전을 게시할 때까지 실행이 중지됩니다. 삭제된 내용은 없습니다."
 
 msgid "ITAR Certifications"
 msgstr "ITAR 인증"
@@ -8166,10 +8166,10 @@ msgid "Item Master"
 msgstr "품목 마스터"
 
 msgid "Item Master and Make Methods"
-msgstr "품목 마스터 및 제조 방법"
+msgstr "품목 정보 및 생산 방법"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "품목 마스터, BOM, 공정(BOP)"
+msgstr "품목 정보, BOM 및 공정 목록"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "품목은 선택한 유형과 선택한 그룹을 모두 충족해야 합니다"
@@ -8205,10 +8205,10 @@ msgid "Items inside this window get a yellow badge."
 msgstr "이 기간 내의 항목에는 노란색 배지가 표시됩니다."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "품목: 품목 마스터, BOM, 공정(BOP), 설계 변경, CAD"
+msgstr "품목: 품목 정보, BOM, 공정 목록, 설계 변경, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "변경 공지가 발행되기 전에 설계가 변경될 수 있습니다."
+msgstr "변경 통지가 발행되기 전에 설계가 변경될 수 있습니다."
 
 msgid "Job"
 msgstr "작업"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "작업 위치"
 
 msgid "Job make method"
-msgstr "작업 제조 방법"
+msgstr "작업 지시 생산 방법"
 
 msgid "Job Materials"
-msgstr "작업 자재"
+msgstr "작업 지시 자재"
 
 msgid "Job operation"
-msgstr "작업 공정작업"
+msgstr "작업 지시 공정"
 
 msgid "Job Operation"
-msgstr "작업 공정작업"
+msgstr "작업 지시 공정"
 
 msgid "Job Operations"
-msgstr "작업 공정작업"
+msgstr "작업 지시 공정"
 
 msgid "Job Priority"
 msgstr "작업 우선순위"
@@ -8244,19 +8244,19 @@ msgid "Job readable"
 msgstr "작업 가독성"
 
 msgid "Job Traveler"
-msgstr "작업 일지"
+msgstr "작업 이동표"
 
 msgid "Jobs"
-msgstr "작업"
+msgstr "작업 지시"
 
 msgid "Jobs Assigned to Me"
-msgstr "내게 배정된 작업"
+msgstr "내게 할당된 작업 지시"
 
 msgid "Jobs Required"
-msgstr "필요한 작업"
+msgstr "필요한 작업 지시"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "자재명세서에 이 품목이 포함된 작업"
+msgstr "자재 명세서에 이 품목이 있는 작업 지시"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
@@ -8269,13 +8269,13 @@ msgid "Journal Entries"
 msgstr "전표 내역"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "이 기간에 날짜가 지정된 임시 분개들은 전기되거나 나중의 개방된 기간으로 재날짜되어야 합니다. 임시 분개는 총계정원장의 일부가 아니므로 그 차변과 대변이 종료에서 누락될 것입니다."
+msgstr "이 기간에 날짜가 있고 아직 초안인 전표는 전기되어야 하거나 나중의 미결 기간으로 날짜를 변경해야 합니다. 초안 전표는 원장의 일부가 아니므로 차변과 대변이 마감에서 누락됩니다."
 
 msgid "Journal Entry"
 msgstr "분개"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "이 날짜 이전의 분개는 잠금으로 처리됩니다. 둘 다 존재하면 공급자에서 보고한 잠금 날짜와 병합됩니다."
+msgstr "이 날짜 또는 이전 날짜의 전표는 잠김으로 처리됩니다. 둘 다 존재할 때 공급자 보고 잠금 날짜와 병합됩니다."
 
 msgid "Just one"
 msgstr "정확히 하나"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "현재 값 유지"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "기존 가격은 유지하고 새 품목만 추가"
+msgstr "기존 가격 책정을 유지하고 새 품목만 추가합니다."
 
 msgid "Keep only items where…"
 msgstr "...인 항목만 유지"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "열린 상태 유지"
 
 msgid "Keep picking"
-msgstr "계속 선택"
+msgstr "피킹 유지"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "주문, 견적 및 설정을 이중 확인으로 보호합니다"
@@ -8357,7 +8357,7 @@ msgid "Labor & Machine Variance (default)"
 msgstr "노무 및 기계 차이(기본값)"
 
 msgid "Labor rate"
-msgstr "노동비율"
+msgstr "노무 요금"
 
 msgid "Labor Rate"
 msgstr "노무 단가"
@@ -8366,13 +8366,13 @@ msgid "Labor Rate (Hourly)"
 msgstr "노무 단가(시간당)"
 
 msgid "Labor time"
-msgstr "노동 시간"
+msgstr "노무 시간"
 
 msgid "Labor Time"
 msgstr "노무 시간"
 
 msgid "Labor unit"
-msgstr "노동 단위"
+msgstr "노무 단위"
 
 msgid "Labor Unit"
 msgstr "노무 단위"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "수작업 감소, 오류 감소"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "제조해 봅시다"
 
 msgid "Let's build something"
 msgstr "무언가를 만들어봅시다"
@@ -8501,10 +8501,10 @@ msgid "Letter"
 msgstr "레터"
 
 msgid "Liability account for deferred taxes from accelerated depreciation"
-msgstr "가속상각으로 인한 이연법인세 부채 계정"
+msgstr "가속 감가상각으로 인한 이연법인세 부채 계정"
 
 msgid "Liability account for sales tax collected from customers"
-msgstr "고객으로부터 징수한 판매세 부채 계정"
+msgstr "고객으로부터 수집한 판매세 부채 계정"
 
 msgid "Liability account for tax paid on purchases"
 msgstr "구매 시 납부한 세금 부채 계정"
@@ -8525,7 +8525,7 @@ msgid "Light Mode"
 msgstr "라이트 모드"
 
 msgid "Likelihood"
-msgstr "가능성"
+msgstr "발생 가능성"
 
 msgid "Line description (optional)"
 msgstr "행 설명 (선택 사항)"
@@ -8552,13 +8552,13 @@ msgid "Lines need prices or lead times"
 msgstr "가격 또는 리드타임이 필요한 라인"
 
 msgid "Lineside"
-msgstr "라인 옆"
+msgstr "라인사이드"
 
 msgid "Link"
 msgstr "링크"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "링크(선택 사항) — 예: /x/settings/…"
+msgstr "링크 (선택 사항) — 예: /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Jira 이슈 연결"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Linear 이슈 연결"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "이 Carbon 고객을 그 중 하나에 연결하거나 별도의 Stripe 고객을 생성합니다."
 
 msgid "Link to sales order line"
-msgstr "판매주문 라인에 연결"
+msgstr "수주 라인으로 링크"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "전환 시점에 마지막으로 불러와 잔액이 최신 상태로 유지됩니다."
 
 msgid "Loading associated jobs..."
-msgstr "연관된 작업을 불러오는 중..."
+msgstr "관련 작업 지시를 로딩 중..."
 
 msgid "Loading current quantity…"
 msgstr "현재 수량 로드 중…"
@@ -8658,16 +8658,16 @@ msgid "Lock Period"
 msgstr "기간 잠금"
 
 msgid "Locked"
-msgstr "잠금"
+msgstr "잠김"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "잠금하면 기간이 운영 문서(수령, 배송, 송장)에 대해 읽기 전용이 되며 감가상각 및 처분과 같은 회계 조정은 여전히 허용됩니다. 기간을 종료하려면 먼저 잠금해야 합니다."
+msgstr "잠금은 기간을 회계 조정(감가상각, 처분 등)은 여전히 허용하면서 운영 문서(입고, 출하, 송장)에 대해 읽기 전용으로 만듭니다. 기간은 마감되기 전에 반드시 잠겨야 합니다."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "부적합을 기록하고 CAPA를 진행하세요"
 
 msgid "Login or create a new account"
-msgstr "로그인 또는 새 계정 만들기"
+msgstr "로그인 또는 새 계정 생성"
 
 msgid "Logo"
 msgstr "로고"
@@ -8683,7 +8683,7 @@ msgstr "로고"
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "Logs older than {0} days are automatically archived."
-msgstr "{0}일이 지난 로그는 자동으로 보관됩니다."
+msgstr "{0}일보다 오래된 로그는 자동으로 보관됩니다."
 
 msgid "Long Description"
 msgstr "상세 설명"
@@ -8728,7 +8728,7 @@ msgid "Lot Size:"
 msgstr "로트 크기:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "샘플링 계획에 따라 수령한 상품에 대한 로트 기반 검사로서, 단위는 수령 시 보류로 게시되고 로트가 승인된 것으로 처리되어야만 사용 가능으로 릴리스됩니다."
+msgstr "로트 기반의 샘플링 계획에 따른 입고 물품 검사입니다. 유닛은 입고 시 보류 상태로 전기되며, 로트가 수락됨으로 처분 결정된 후에만 가용 상태로 릴리스됩니다."
 
 msgid "Low"
 msgstr "낮음"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "유지보수"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "유지보수 작업지시 알림"
+msgstr "유지보수 지시 알림"
 
 msgid "Maintenance Dispatches"
-msgstr "유지보수 작업지시"
+msgstr "유지보수 지시"
 
 msgid "Maintenance Expense"
 msgstr "유지보수 비용"
@@ -8809,17 +8809,17 @@ msgid "Make Inactive"
 msgstr "비활성으로 설정"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "제조 품목은 직접 인보이스 처리할 수 없습니다. 계속하려면 방법을 피킹으로 변경하세요."
+msgstr "사내 생산으로 설정된 품목은 직접 송장을 발행할 수 없습니다. 계속하려면 공급 방식을 변경하세요."
 
 msgid "Make Method Version"
-msgstr "제조방법 버전"
+msgstr "생산 방법 버전"
 
 msgid "Make Payment"
-msgstr "지급"
+msgstr "지불"
 
 #. placeholder {0}: selectedInvoices.length
 msgid "Make Payment · {0} invoices"
-msgstr "지급 · 인보이스 {0}건"
+msgstr "지불 · {0}개 송장"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make revision {0} default?"
@@ -8836,10 +8836,10 @@ msgid "Make the go / no-go decision"
 msgstr "진행 여부를 결정하세요"
 
 msgid "Make to Order"
-msgstr "주문생산"
+msgstr "주문 생산"
 
 msgid "Make tracked entities available again"
-msgstr "추적 개체를 다시 사용 가능 상태로 전환"
+msgstr "추적되는 항목을 다시 가용하게 합니다"
 
 msgid "Makes this document active again."
 msgstr "이 문서를 다시 활성 상태로 만듭니다."
@@ -8851,7 +8851,7 @@ msgid "Manage"
 msgstr "관리"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "재고 전반에서 유효기간을 추적, 계산, 적용하는 방식을 관리합니다."
+msgstr "보존 기간이 재고 전체에서 어떻게 추적, 계산 및 적용되는지 관리합니다."
 
 msgid "Manage Ownership"
 msgstr "소유권 관리"
@@ -8884,10 +8884,10 @@ msgid "Map accounts"
 msgstr "계정 매핑"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Carbon 계정을 공급자의 계정 과목표에 매핑합니다. 게시된 분개는 매핑된 공급자 계정 코드를 사용하여 푸시됩니다."
+msgstr "Carbon 계정을 공급자의 계정과목표에 매핑합니다. 전기된 전표는 매핑된 공급자 계정 코드를 사용하여 전송됩니다."
 
 msgid "Map Extracted Invoice Lines"
-msgstr "추출된 인보이스 라인 매핑"
+msgstr "추출한 송장 라인 매핑"
 
 msgid "Map Extracted Lines"
 msgstr "추출된 라인 매핑"
@@ -8906,7 +8906,7 @@ msgstr "매핑된 값"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "\"{0}\"을(를) 합격으로 표시하시겠습니까?"
+msgstr "\"{0}\"을(를) 통과로 표시하시겠습니까?"
 
 msgid "Mark all as configured"
 msgstr "모두 설정됨으로 표시"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "삭제 대상으로 표시"
 
 msgid "Master gauge"
-msgstr "마스터 게이지"
+msgstr "표준기"
 
 msgid "Master records"
 msgstr "마스터 레코드"
@@ -8999,28 +8999,28 @@ msgid "Material"
 msgstr "자재"
 
 msgid "Material Dimension"
-msgstr "자재 치수"
+msgstr "자재 차원"
 
 msgid "Material Dimensions"
-msgstr "자재 치수"
+msgstr "자재 차원"
 
 msgid "Material dimensions use metric units."
-msgstr "자재 치수는 미터법 단위를 사용합니다."
+msgstr "자재 차원은 미터법 단위를 사용합니다."
 
 msgid "Material Finish"
-msgstr "자재 표면처리"
+msgstr "표면 처리"
 
 msgid "Material Finishes"
-msgstr "자재 표면처리"
+msgstr "표면 처리"
 
 msgid "Material Form"
 msgstr "자재 형태"
 
 msgid "Material Grade"
-msgstr "자재 등급"
+msgstr "재질 등급"
 
 msgid "Material Grades"
-msgstr "자재 등급"
+msgstr "재질 등급"
 
 msgid "Material ID"
 msgstr "자재 ID"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "자재 속성"
 
 msgid "Material Review Board (MRB)"
-msgstr "자재 검토 위원회(MRB)"
+msgstr "MRB 위원회"
 
 msgid "Material Shape"
 msgstr "자재 형상"
@@ -9116,7 +9116,7 @@ msgid "Media Size"
 msgstr "매체 크기"
 
 msgid "Medium"
-msgstr "중간"
+msgstr "보통"
 
 msgid "Meeting cadence"
 msgstr "미팅 주기"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "제조방법 공정작업"
 
 msgid "Method type"
-msgstr "제조방법 유형"
+msgstr "공급 방식"
 
 msgid "Method Type"
-msgstr "제조방법 유형"
+msgstr "공급 방식"
 
 msgid "Methods"
 msgstr "제조방법"
@@ -9188,7 +9188,7 @@ msgid "Minimum Amount"
 msgstr "최소 금액"
 
 msgid "Minimum Cost"
-msgstr "최소 비용"
+msgstr "최소 원가"
 
 msgid "Minimum Order Quantity"
 msgstr "최소 주문 수량"
@@ -9221,7 +9221,7 @@ msgid "Missing Operations"
 msgstr "누락된 공정작업"
 
 msgid "Missing Shipping Costs"
-msgstr "누락된 배송비"
+msgstr "누락된 운송비"
 
 msgid "Missing Suppliers"
 msgstr "누락된 공급업체"
@@ -9275,7 +9275,7 @@ msgid "Monthly"
 msgstr "월간"
 
 msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
-msgstr "MACRS를 사용하지 않을 경우, 이 자산을 세무상 상각하는 개월 수입니다."
+msgstr "이 자산이 세무상 감가상각되는 개월 수입니다(MACRS를 사용하지 않을 때)."
 
 msgid "More"
 msgstr "더 보기"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "품목 이동"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "MRB가 각 부분을 별도로 판정할 수 있도록(예: 일부는 폐기, 일부는 재작업) 수량 일부를 새 처분 행으로 이동하세요."
+msgstr "수량의 일부를 새로운 처분 결정 행으로 할당하여 MRB가 각 부분을 별도로 결정할 수 있도록 합니다(예: 일부는 스크랩, 일부는 재작업)."
 
 msgid "Move to"
 msgstr "이동 대상"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "이름"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "의사결정 권한을 가진 내부 프로젝트 담당자를 지정하세요"
+msgstr "결정 권한이 있는 내부 프로젝트 책임자를 지정하십시오."
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "허브 전체에서 해당 역할이 참조되는 곳마다 이름이 자동으로 채워집니다."
@@ -9364,7 +9364,7 @@ msgid "Navigate"
 msgstr "이동"
 
 msgid "NCRs by Type"
-msgstr "유형별 부적합보고서"
+msgstr "유형별 NCR"
 
 msgid "Need by"
 msgstr "필요일"
@@ -9391,7 +9391,7 @@ msgid "Net book value"
 msgstr "순장부가액"
 
 msgid "Net Book Value"
-msgstr "순 장부 가치"
+msgstr "순장부가액"
 
 msgid "Net Change"
 msgstr "순변동"
@@ -9418,7 +9418,7 @@ msgid "New Approval Rule"
 msgstr "신규 승인 규칙"
 
 msgid "New Asset Class"
-msgstr "신규 자산 분류"
+msgstr "새 자산 클래스"
 
 msgid "New Assignment"
 msgstr "신규 배정"
@@ -9430,22 +9430,22 @@ msgid "New Attribute Category"
 msgstr "신규 속성 카테고리"
 
 msgid "New Change Notice"
-msgstr "새 변경 공지"
+msgstr "신규 변경 통지"
 
 msgid "New Change Notice Action"
-msgstr "새 변경 공지 작업"
+msgstr "신규 변경 통지 조치"
 
 msgid "New Change Notice Type"
-msgstr "새 변경 공지 유형"
+msgstr "신규 변경 통지 유형"
 
 msgid "New Consumable"
 msgstr "신규 소모품"
 
 msgid "New Contractor"
-msgstr "신규 계약직"
+msgstr "신규 외주 인력"
 
 msgid "New Cost Center"
-msgstr "새 비용 센터"
+msgstr "신규 원가 센터"
 
 msgid "New Credit / Debit Memo"
 msgstr "신규 대변/차변 메모"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "신규 직원 유형"
 
 msgid "New expiration date"
-msgstr "새 유효기한"
+msgstr "신규 만료일"
 
 msgid "New Failure Mode"
 msgstr "신규 고장 모드"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "신규 고정자산"
 
 msgid "New Gauge"
-msgstr "신규 측정기"
+msgstr "신규 계측기"
 
 msgid "New Gauge Calibration Record"
-msgstr "신규 측정기 교정 기록"
+msgstr "신규 계측기 교정 기록"
 
 msgid "New Gauge Type"
-msgstr "신규 측정기 유형"
+msgstr "신규 계측기 유형"
 
 msgid "New Group"
 msgstr "신규 그룹"
@@ -9505,7 +9505,7 @@ msgid "New Inventory Count"
 msgstr "신규 재고 실사"
 
 msgid "New Invoice"
-msgstr "신규 인보이스"
+msgstr "신규 송장"
 
 msgid "New Issue"
 msgstr "새 이슈"
@@ -9526,19 +9526,19 @@ msgid "New Location"
 msgstr "새 위치"
 
 msgid "New Maintenance Dispatch"
-msgstr "새 유지보수 작업지시"
+msgstr "신규 유지보수 지시"
 
 msgid "New Material"
 msgstr "새 자재"
 
 msgid "New Material Dimension"
-msgstr "새 자재 치수"
+msgstr "신규 자재 차원"
 
 msgid "New Material Finish"
-msgstr "새 자재 표면처리"
+msgstr "신규 표면 처리"
 
 msgid "New Material Grade"
-msgstr "새 자재 등급"
+msgstr "신규 재질 등급"
 
 msgid "New Material Shape"
 msgstr "새 자재 형상"
@@ -9553,19 +9553,19 @@ msgid "New Non Conformance Type"
 msgstr "새 부적합 유형"
 
 msgid "New Owner"
-msgstr "새 소유자"
+msgstr "신규 책임자"
 
 msgid "New Part"
-msgstr "새 품목"
+msgstr "신규 부품"
 
 msgid "New Password"
 msgstr "새 비밀번호"
 
 msgid "New Payment"
-msgstr "새 결제"
+msgstr "신규 지불"
 
 msgid "New Payment Term"
-msgstr "새 결제조건"
+msgstr "신규 지불 조건"
 
 msgid "New Picking List"
 msgstr "새 피킹 리스트"
@@ -9583,7 +9583,7 @@ msgid "New Pricing Rule"
 msgstr "새 가격 규칙"
 
 msgid "New Procedure"
-msgstr "새 절차"
+msgstr "신규 절차서"
 
 msgid "New Process"
 msgstr "새 공정"
@@ -9619,16 +9619,16 @@ msgid "New Rule"
 msgstr "새 규칙"
 
 msgid "New Sales Invoice"
-msgstr "새 판매 인보이스"
+msgstr "신규 매출 송장"
 
 msgid "New Sales Invoice Line"
-msgstr "새 판매 인보이스 라인"
+msgstr "신규 매출 송장 라인"
 
 msgid "New Sales Order"
-msgstr "새 판매주문"
+msgstr "신규 수주"
 
 msgid "New Sales Order Line"
-msgstr "새 판매주문 라인"
+msgstr "신규 수주 라인"
 
 msgid "New Scheduled Maintenance"
 msgstr "새 예정된 유지보수"
@@ -9640,7 +9640,7 @@ msgid "New Service"
 msgstr "새 서비스"
 
 msgid "New Shift"
-msgstr "새 교대"
+msgstr "신규 교대조"
 
 msgid "New Shipment"
 msgstr "새 출하"
@@ -9655,7 +9655,7 @@ msgid "New Storage Type"
 msgstr "새 저장 유형"
 
 msgid "New Storage Unit"
-msgstr "새 저장 단위"
+msgstr "신규 보관 단위"
 
 msgid "New Supplier"
 msgstr "새 공급업체"
@@ -9676,7 +9676,7 @@ msgid "New Transfer"
 msgstr "새 이동"
 
 msgid "New Transfer Line"
-msgstr "새 이동 라인"
+msgstr "신규 이송 라인"
 
 msgid "New Unit of Measure"
 msgstr "새 측정 단위"
@@ -9715,13 +9715,13 @@ msgid "Next Due"
 msgstr "다음 예정일"
 
 msgid "Next Due Date"
-msgstr "다음 만료 날짜"
+msgstr "다음 마감일"
 
 msgid "Next page"
 msgstr "다음 페이지"
 
 msgid "Next Sequence"
-msgstr "다음 순번"
+msgstr "다음 채번 규칙"
 
 msgid "Next step"
 msgstr "다음 단계"
@@ -9738,7 +9738,7 @@ msgstr "{0}이(가) 없습니다"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "{0} 동기화 작업 없음"
+msgstr "{0} 동기화 작업이 없습니다"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "선택된 조치가 없습니다"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "이 판매주문에 대한 진행 중인 작업이 없습니다. 주문이 바로 취소됩니다."
+msgstr "이 수주에 진행 중인 작업이 없습니다. 주문이 직접 취소됩니다."
 
 msgid "No active plan"
 msgstr "활성 요금제 없음"
@@ -9781,20 +9781,20 @@ msgid "No affected items."
 msgstr "영향받는 항목이 없습니다."
 
 msgid "No applications. Payment will be on-account."
-msgstr "적용 내역이 없습니다. 결제는 계정 잔액으로 처리됩니다."
+msgstr "적용이 없습니다. 지불은 외상 처리됩니다."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "아직 보관된 로그가 없습니다. {0}일이 지난 로그는 자동으로 보관되며 이곳에서 다운로드할 수 있습니다."
+msgstr "아카이브된 로그가 아직 없습니다. {0}일보다 오래된 로그는 자동으로 아카이브되어 여기에서 다운로드할 수 있습니다."
 
 msgid "No attachments."
-msgstr "첨부파일이 없습니다."
+msgstr "첨부 파일이 없습니다."
 
 msgid "No available filters"
-msgstr "사용 가능한 필터가 없습니다"
+msgstr "사용 가능한 필터가 없습니다."
 
 msgid "No available tracked entities found"
-msgstr "사용 가능한 추적 개체가 없습니다"
+msgstr "추적 가능한 항목을 찾을 수 없습니다."
 
 msgid "No BOM input has a shelf-life policy"
 msgstr "BOM 투입 항목 중 유효기간 정책이 설정된 항목이 없습니다"
@@ -9815,10 +9815,10 @@ msgid "No clauses yet. Use Add clause above."
 msgstr "아직 절이 없습니다. 위의 절 추가를 사용하세요."
 
 msgid "No comments yet. Be the first to add a comment."
-msgstr "아직 댓글이 없습니다. 첫 댓글을 남겨보세요."
+msgstr "아직 댓글이 없습니다. 첫 번째 댓글을 추가하세요."
 
 msgid "No completed jobs within range"
-msgstr "해당 기간 내 완료된 작업이 없습니다"
+msgstr "범위 내에 완료된 작업이 없습니다."
 
 msgid "No condition may match"
 msgstr "조건이 하나도 일치하지 않을 수 있습니다"
@@ -9839,7 +9839,7 @@ msgid "No days off scheduled"
 msgstr "예정된 휴무가 없습니다"
 
 msgid "No default attachments yet."
-msgstr "아직 기본 첨부파일이 없습니다."
+msgstr "기본 첨부 파일이 아직 없습니다."
 
 msgid "No dimension slots configured"
 msgstr "구성된 차원 슬롯이 없습니다"
@@ -9848,10 +9848,10 @@ msgid "No dimension values mapped yet"
 msgstr "아직 매핑된 차원 값이 없습니다"
 
 msgid "No draft make method for this item yet."
-msgstr "이 항목에 대한 초안 제작 방법이 아직 없습니다."
+msgstr "이 품목에 대한 초안 생산 방법이 아직 없습니다."
 
 msgid "No draft versions available"
-msgstr "사용 가능한 초안 버전이 없습니다"
+msgstr "사용 가능한 초안 버전이 없습니다."
 
 msgid "No due date"
 msgstr "마감일 없음"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "업로드된 파일이 없습니다"
 
 msgid "No Gauge Selected"
-msgstr "선택된 측정기 없음"
+msgstr "선택된 계측기 없음"
 
 msgid "No grouped notifications"
 msgstr "그룹화된 알림이 없습니다"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "아직 여기에 재고 활동이 있는 항목이 없습니다."
 
 msgid "No jobs were created"
-msgstr "생성된 작업이 없음"
+msgstr "생성된 작업 지시가 없음"
 
 msgid "No journal lines in scope for this period"
-msgstr "이 기간에 대한 범위 내 분개선이 없습니다"
+msgstr "이 기간의 범위 내 전표 라인이 없음"
 
 msgid "No lines to map"
 msgstr "매핑할 라인이 없습니다"
@@ -9932,7 +9932,7 @@ msgid "No lines yet"
 msgstr "아직 줄이 없습니다"
 
 msgid "No list variables available upstream."
-msgstr "업스트림에서 사용 가능한 목록 변수가 없습니다."
+msgstr "상위에서 사용 가능한 목록 변수가 없습니다."
 
 msgid "No locations found."
 msgstr "위치가 없습니다."
@@ -9947,7 +9947,7 @@ msgid "No matches for \"{query}\". Try a different search term."
 msgstr "\"{query}\"에 대해 일치하는 항목이 없습니다. 다른 검색어를 시도해 보세요."
 
 msgid "No matches. Type to create one."
-msgstr "일치하는 항목 없음. 입력하여 새로 만드세요."
+msgstr "일치하는 항목이 없습니다. 입력하여 하나를 생성하세요."
 
 msgid "No matching bins"
 msgstr "일치하는 빈이 없습니다"
@@ -9959,16 +9959,16 @@ msgid "No notes"
 msgstr "메모 없음"
 
 msgid "No open invoices"
-msgstr "미결 인보이스가 없습니다"
+msgstr "미결 송장이 없습니다."
 
 msgid "No open orders for this item are available to link."
-msgstr "이 항목에 연결할 수 있는 미결 주문이 없습니다."
+msgstr "이 품목의 연결 가능한 미결 주문이 없습니다."
 
 msgid "No open sales order lines"
-msgstr "미결 판매주문 라인이 없습니다."
+msgstr "미결 수주 라인이 없습니다."
 
 msgid "No operations found."
-msgstr "작업을 찾을 수 없습니다."
+msgstr "공정을 찾을 수 없습니다."
 
 msgid "No operations require picking at this location"
 msgstr "이 위치에서 피킹이 필요한 공정작업이 없습니다"
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "옵션이 없습니다."
 
 msgid "No other bins hold this item"
-msgstr "다른 보관함에 이 항목이 없습니다"
+msgstr "다른 빈에 이 품목이 없습니다."
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "다른 직원이 없습니다. 소유권 이전을 활성화하려면 직원을 추가하세요."
@@ -10010,19 +10010,19 @@ msgid "No payables"
 msgstr "매입채무가 없습니다"
 
 msgid "No payments yet."
-msgstr "아직 결제가 없습니다."
+msgstr "아직 지불이 없습니다."
 
 msgid "No planning data"
 msgstr "계획 데이터가 없습니다"
 
 msgid "No posted journals in this period for this account"
-msgstr "이 계정의 현재 기간에 게시된 저널이 없습니다"
+msgstr "이 계정의 이 기간에 전기된 전표가 없습니다."
 
 msgid "No pricing for selected quantity"
-msgstr "선택한 수량에 대한 가격이 없습니다"
+msgstr "선택한 수량에 대한 가격 책정이 없습니다."
 
 msgid "No pricing options found"
-msgstr "가격 옵션이 없습니다"
+msgstr "가격 책정 옵션을 찾을 수 없습니다."
 
 msgid "No printer configured"
 msgstr "설정된 프린터가 없습니다"
@@ -10040,13 +10040,13 @@ msgid "No purchases in this period"
 msgstr "이 기간에 구매가 없습니다"
 
 msgid "No Quote"
-msgstr "견적 없음"
+msgstr "견적 거절"
 
 msgid "No Quote Reason"
-msgstr "견적 불가 사유"
+msgstr "견적 거절 사유"
 
 msgid "No Quote Reasons"
-msgstr "견적 불가 사유"
+msgstr "견적 거절 사유"
 
 msgid "No receivables"
 msgstr "매출채권이 없습니다"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "검색 결과와 일치하는 보고서가 없습니다."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "이 회사의 대표자가 아직 Carbon GovCloud Rider를 승인하지 않았습니다. 누구든지 Carbon에 접근하기 전에 이 회사의 관리자가 승인해야 합니다 — Carbon 직원은 귀사를 대신하여 승인할 수 없습니다."
+msgstr "이 회사를 대표하는 사람이 아직 Carbon GovCloud Rider에 동의하지 않았습니다. 누구든 Carbon에 접근하기 전에 이 회사의 관리자가 이를 수락해야 합니다 — Carbon 직원은 귀사를 대신하여 수락할 수 없습니다."
 
 msgid "No results"
 msgstr "결과 없음"
@@ -10091,16 +10091,16 @@ msgid "No stock at this location"
 msgstr "이 위치에 재고가 없습니다"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "향후 48주간 재고 소진이 예상되지 않습니다"
+msgstr "향후 48주 내에 재고 부족이 예상되지 않습니다."
 
 msgid "No storage unit"
-msgstr "저장 단위 없음"
+msgstr "보관 단위가 없습니다."
 
 msgid "No suppliers yet"
 msgstr "아직 공급업체가 없습니다"
 
 msgid "No sync operations yet"
-msgstr "아직 동기화 작업 없음"
+msgstr "동기화 작업이 아직 없습니다."
 
 msgid "No time entries for this week"
 msgstr "이번 주 시간 기록이 없습니다"
@@ -10124,13 +10124,13 @@ msgid "No value needed"
 msgstr "값이 필요하지 않습니다"
 
 msgid "No values available"
-msgstr "사용 가능한 값이 없습니다"
+msgstr "사용 가능한 값이 없습니다."
 
 msgid "No variable matches {query}"
 msgstr "{query}와 일치하는 변수가 없습니다"
 
 msgid "No variables available"
-msgstr "사용 가능한 변수가 없습니다"
+msgstr "사용 가능한 변수가 없습니다."
 
 msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
 msgstr "이 품목에 대한 창고 재고 기록이 없습니다. 그래도 피킹할 수 있으며, 실사로 수량이 조정될 때까지 보유수량이 음수로 표시됩니다."
@@ -10172,7 +10172,7 @@ msgid "Non-operating income account credited when an asset in this class is sold
 msgstr "이 자산군에 속한 자산이 순장부가액보다 높은 가격으로 판매될 때 입금되는 영업외수익 계정입니다."
 
 msgid "Non-Taxable Add-On Cost"
-msgstr "비과세 애드온 비용"
+msgstr "비과세 추가 원가"
 
 msgid "Non-working days that scheduling and capacity respect"
 msgstr "일정 및 용량 계산에 반영되는 비근무일"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "일반"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "테이블이 아니라 총계정원장 잔액입니다. 작업 자재가 투입되면서 원가가 누적되고, 작업이 재고로 입고되면 정산됩니다."
+msgstr "표가 아니라 총계정원장 잔액입니다: 작업 지시 자재가 지급될 때 원가가 누적되고 작업 지시가 재고로 입고될 때 원가가 소거됩니다."
 
 msgid "Not certified"
 msgstr "인증되지 않음"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "수량을 충족할 만큼 작업이 충분하지 않습니다"
+msgstr "수량을 충당하기에 충분한 작업 지시가 없습니다."
 
 msgid "Not reached"
 msgstr "도달하지 않음"
@@ -10275,22 +10275,22 @@ msgid "Number of lines"
 msgstr "라인 수"
 
 msgid "Number of open operations"
-msgstr "열린 작업 수"
+msgstr "미결 공정의 수"
 
 msgid "Number of open tasks"
 msgstr "열린 작업 수"
 
 msgid "Number of operations"
-msgstr "작업 수"
+msgstr "공정의 수"
 
 msgid "Numbering sequence"
-msgstr "번호 시퀀스"
+msgstr "채번 규칙"
 
 msgid "OEE Impact"
 msgstr "OEE 영향"
 
 msgid "OEM (original equipment manufacturer)"
-msgstr "OEM(주문자상표부착생산)"
+msgstr "OEM (원본 장비 제조업체)"
 
 msgid "of"
 msgstr "중"
@@ -10329,28 +10329,28 @@ msgid "On Hold"
 msgstr "보류"
 
 msgid "On Jobs"
-msgstr "작업 배정"
+msgstr "작업 지시에"
 
 msgid "On order"
 msgstr "주문중"
 
 msgid "On Production Demand"
-msgstr "생산 수요"
+msgstr "생산 소요량에"
 
 msgid "On Purchase Order"
-msgstr "구매주문에서"
+msgstr "발주서에"
 
 msgid "On Sales Order"
-msgstr "판매주문에서"
+msgstr "수주에"
 
 msgid "On Storage Unit"
-msgstr "저장 단위에서"
+msgstr "보관 단위에"
 
 msgid "On this operation"
 msgstr "이 작업 시"
 
 msgid "On-account credit available"
-msgstr "사용 가능한 외상 크레딧"
+msgstr "계정상 가용 신용"
 
 msgid "On-hand counts"
 msgstr "보유 재고 실사"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "보유 재고가 남아 있습니다"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "GL 검증이 포함된 위치 또는 항목별 현재고 가치"
+msgstr "사업장 또는 품목별 보유 가치, 총계정원장 조정 포함"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "제조 상품(완성품)의 현재 재고 가치"
@@ -10374,22 +10374,22 @@ msgid "On-time delivery"
 msgstr "정시 납품"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "워크플로우의 한 번의 실행이 기록되며, 각 단계에서 사용하고 생성한 값과 함께 단계별로 기록되고, 워크플로우 소유자의 권한으로 전체적으로 작동합니다."
+msgstr "워크플로의 한 번 실행으로, 각 단계가 사용하고 생성한 값을 단계별로 기록하며 워크플로 책임자의 권한으로 전체적으로 작동합니다."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Carbon이 개별적으로 추적하는 하나의 일련번호 유닛 또는 배치로, 유효기한과 같은 자체 상태와 속성을 가집니다."
+msgstr "Carbon이 개별적으로 추적하는 하나의 일련 단위 또는 하나의 배치로, 유통기한과 같은 자체 상태와 속성을 가집니다."
 
 msgid "One set of numbers"
 msgstr "하나의 번호 집합"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "작업 공정(BOP)의 한 단계로, 공정과 작업장을 지정하며 자체 셋업, 노무, 기계 시간 및 요율을 가집니다."
+msgstr "작업 지시의 라우팅에서 한 단계로, 공법과 작업장을 지정하고 각자의 셋업, 노무, 기계 시간 및 요금을 포함합니다."
 
 msgid "One system from quote to cash"
-msgstr "견적부터 수금까지 하나의 시스템으로"
+msgstr "견적에서 현금까지 통합 시스템"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "초안 상태의 절차만 수정할 수 있습니다. 활성 또는 보관된 절차를 변경하려면 새 버전을 생성하세요."
+msgstr "초안 절차서만 편집 가능합니다. 활성 또는 보관됨 절차서를 변경하려면 새로운 버전을 생성하세요."
 
 msgid "Only empty, open periods can be deleted."
 msgstr "비어있는 열린 기간만 삭제할 수 있습니다."
@@ -10413,7 +10413,7 @@ msgid "Onshape Status"
 msgstr "Onshape 상태"
 
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
-msgstr "이런! 접근하려는 링크가 만료되었거나 더 이상 유효하지 않습니다."
+msgstr "죄송합니다! 액세스하려는 링크가 만료되었거나 더 이상 유효하지 않습니다."
 
 msgid "Oops! The link you're trying to access is not valid."
 msgstr "이런! 접근하려는 링크가 유효하지 않습니다."
@@ -10422,13 +10422,13 @@ msgid "Open"
 msgstr "열림"
 
 msgid "Open a change notice"
-msgstr "변경 공지 열기"
+msgstr "변경 통지 열기"
 
 msgid "Open Actions"
 msgstr "미결 조치"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "MRB 처리를 위한 NCR 개설"
+msgstr "MRB 처분 결정을 위해 NCR 열기"
 
 msgid "Open AP"
 msgstr "미결 매입채무"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "개설일"
 
 msgid "Open Dispatches"
-msgstr "미결 작업지시"
+msgstr "미결 유지보수 지시"
 
 msgid "Open in Carbon"
 msgstr "Carbon에서 열기"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "변경 공지 {ids}에서 열기. 새 버전 또는 개정본을 만들려면 이를 릴리스하십시오."
+msgstr "변경 통지 {ids}에서 열기. 새로운 버전 또는 리비전을 생성하려면 릴리스하세요."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "변경 공지 {ids}에서 열기. 새 버전 또는 개정본을 만들려면 이들을 릴리스하십시오."
+msgstr "변경 통지 {ids}에서 열기. 새로운 버전 또는 리비전을 생성하려면 릴리스하세요."
 
 msgid "Open in MES"
 msgstr "MES에서 열기"
@@ -10464,25 +10464,25 @@ msgid "Open Issues"
 msgstr "미결 이슈"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "미결 작업 수요에 이 보관함에서 미완료된 이전을 더합니다"
+msgstr "작업 지시 소요량 더하기 이 빈에서의 미결 이송"
 
 msgid "Open jobs"
-msgstr "미결 작업"
+msgstr "미결 작업 지시"
 
 msgid "Open menu"
 msgstr "메뉴 열기"
 
 msgid "Open payables by supplier and age"
-msgstr "공급자 및 기간별 미지급금"
+msgstr "공급업체 및 기간별 미결 매입채무"
 
 msgid "Open Purchase Invoices"
-msgstr "미결 구매 인보이스"
+msgstr "미결 매입 송장"
 
 msgid "Open purchase orders"
-msgstr "미결 구매주문"
+msgstr "미결 발주서"
 
 msgid "Open Purchase Orders"
-msgstr "미결 구매주문"
+msgstr "미결 발주서"
 
 msgid "Open Quotes"
 msgstr "미결 견적"
@@ -10491,16 +10491,16 @@ msgid "Open Reactive"
 msgstr "미결 반응형 정비"
 
 msgid "Open receivables by customer and age"
-msgstr "고객 및 기간별 미수금"
+msgstr "고객 및 기간별 미결 매출채권"
 
 msgid "Open RFQs"
 msgstr "미결 견적요청"
 
 msgid "Open sales orders"
-msgstr "미결 판매주문"
+msgstr "미결 수주"
 
 msgid "Open Sales Orders"
-msgstr "미결 판매주문"
+msgstr "미결 수주"
 
 msgid "Open Scheduled"
 msgstr "미결 예약 정비"
@@ -10533,16 +10533,16 @@ msgid "Operating Expenses"
 msgstr "영업비용"
 
 msgid "Operating Income"
-msgstr "영업이익"
+msgstr "영업 수익"
 
 msgid "Operation"
 msgstr "공정작업"
 
 msgid "Operation lead time"
-msgstr "작업 리드 타임"
+msgstr "공정 리드타임"
 
 msgid "Operation minimum cost"
-msgstr "작업 최소 비용"
+msgstr "공정 최소 원가"
 
 msgid "Operation order"
 msgstr "작업 순서"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "작업 수량"
 
 msgid "Operation supplier process"
-msgstr "작업 공급자 프로세스"
+msgstr "공정 공급업체 공법"
 
 msgid "Operation type"
 msgstr "작업 유형"
@@ -10563,7 +10563,7 @@ msgid "Operation Type"
 msgstr "공정작업 유형"
 
 msgid "Operation unit cost"
-msgstr "작업 단위 비용"
+msgstr "공정 단위 원가"
 
 msgid "Operations"
 msgstr "공정작업"
@@ -10599,7 +10599,7 @@ msgid "Operators start the timer themselves when they begin an operation."
 msgstr "작업자가 작업을 시작할 때 직접 타이머를 시작합니다."
 
 msgid "Opportunity"
-msgstr "기회"
+msgstr "영업 기회"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
 msgstr "빠른 미리보기에 최적화됨 — 다운로드는 항상 원본 업로드 파일을 제공합니다."
@@ -10648,7 +10648,7 @@ msgid "Order Multiple"
 msgstr "주문 배수"
 
 msgid "Order Parts"
-msgstr "품목 주문"
+msgstr "부품 발주"
 
 msgid "Order Qty"
 msgstr "주문 수량"
@@ -10684,16 +10684,16 @@ msgid "Original Count"
 msgstr "원본 계산"
 
 msgid "Other Expense"
-msgstr "기타 비용"
+msgstr "영업외비용"
 
 msgid "Other Income"
-msgstr "기타 수익"
+msgstr "영업외수익"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "외화 인보이스가 더 유리한 환율로 결제될 때 발생하는 환차익에 대한 기타수익 계정"
+msgstr "지불이 외화 송장을 더 유리한 환율로 결제할 때 FX 이익에 대한 영업외수익 계정"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "매입채무 정산 시 전액 지급 없이 상계된 거래처 잔액에 대한 기타수익 계정"
+msgstr "AP 결제 시 전액 지불 없이 정산된 공급업체 잔액에 대한 영업외수익 계정"
 
 msgid "Other Type"
 msgstr "기타 유형"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "산출물"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "산출물의 유효기한은 원자재의 유효기한을 넘지 않습니다. 투입 자재에 유효기한이 없으면 고정 기간이 적용됩니다."
+msgstr "산출물은 절대 원자재를 초과할 수 없습니다. 입력물에 유통기한이 없을 때 고정 기간으로 폴백합니다."
 
 msgid "Outside operation"
 msgstr "외주 공정작업"
@@ -10723,16 +10723,16 @@ msgid "Overall result"
 msgstr "전체 결과"
 
 msgid "Overdue"
-msgstr "연체"
+msgstr "기한 초과"
 
 msgid "Overhead Absorption"
-msgstr "간접비 흡수"
+msgstr "간접비 배부"
 
 msgid "Overhead Absorption (default)"
-msgstr "간접비 흡수 (기본값)"
+msgstr "간접비 배부 (기본값)"
 
 msgid "Overhead rate"
-msgstr "오버헤드 비율"
+msgstr "간접비 비율"
 
 msgid "Overhead Rate"
 msgstr "제조간접비율"
@@ -10747,7 +10747,7 @@ msgid "Overhead Variance (default)"
 msgstr "제조간접비 차이(기본값)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "재정의하려면 inventory:update 권한과 사유가 필요합니다."
+msgstr "재정의는 inventory:update 권한과 사유가 필요합니다."
 
 msgid "Override Price"
 msgstr "가격 재정의"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "대상 제조 방법을 견적 방법으로 덮어쓰기"
 
 msgid "Owner"
-msgstr "소유자"
+msgstr "책임자"
 
 msgid "Owner (cost center)"
-msgstr "소유자(원가센터)"
+msgstr "책임자 (원가 센터)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10808,16 +10808,16 @@ msgid "Parameters"
 msgstr "파라미터"
 
 msgid "Parameters are inherited from the procedure."
-msgstr "파라미터는 절차로부터 상속됩니다."
+msgstr "매개변수는 절차서에서 상속됩니다."
 
 msgid "Params"
 msgstr "파라미터"
 
 msgid "Parent cost center"
-msgstr "상위 원가센터"
+msgstr "상위 원가 센터"
 
 msgid "Parent Cost Center"
-msgstr "상위 비용 센터"
+msgstr "상위 원가 센터"
 
 msgid "Parent Department"
 msgstr "상위 부서"
@@ -10832,7 +10832,7 @@ msgid "Parent items. (If you click into one of the parent parts below, you'll se
 msgstr "상위 품목. (아래의 상위 부품 중 하나를 클릭하면, 이 품목이 자재명세서에 구성품으로 포함되어 있는 것을 보실 수 있습니다.)"
 
 msgid "Parent Storage Unit"
-msgstr "상위 저장 단위"
+msgstr "상위 보관 단위"
 
 msgid "Pareto by Type"
 msgstr "유형별 파레토"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "오류로 보관"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "값이 매핑될 때까지 경고와 함께 저널을 보류합니다"
+msgstr "값이 매핑될 때까지 경고와 함께 전표를 대기시킵니다"
 
 msgid "part"
 msgstr "품목"
@@ -10874,16 +10874,16 @@ msgid "Partners"
 msgstr "파트너"
 
 msgid "parts"
-msgstr "품목"
+msgstr "부품"
 
 msgid "Parts"
-msgstr "품목"
+msgstr "부품"
 
 msgid "Parts & items"
-msgstr "품목 및 아이템"
+msgstr "부품 & 품목"
 
 msgid "Parts, materials, and how you classify them."
-msgstr "품목, 자재 및 이를 분류하는 방법입니다."
+msgstr "부품, 자재 및 이를 분류하는 방법."
 
 msgid "Party Type"
 msgstr "당사자 유형"
@@ -10892,7 +10892,7 @@ msgid "Pass"
 msgstr "합격"
 
 msgid "Passed"
-msgstr "합격됨"
+msgstr "통과"
 
 msgid "Passkey name"
 msgstr "패스키 이름"
@@ -10916,7 +10916,7 @@ msgid "Payables"
 msgstr "매입채무"
 
 msgid "Payables (AP)"
-msgstr "미지급금 (AP)"
+msgstr "매입채무 (매입채무)"
 
 msgid "Payables (default)"
 msgstr "매입채무(기본값)"
@@ -10925,40 +10925,40 @@ msgid "Payables aging"
 msgstr "매입채무 연령분석"
 
 msgid "Payment"
-msgstr "결제"
+msgstr "지불"
 
 msgid "Payment Applications"
-msgstr "결제 적용"
+msgstr "지불 적용"
 
 msgid "Payment Date"
-msgstr "결제일"
+msgstr "지불 날짜"
 
 msgid "Payment ID"
-msgstr "결제 ID"
+msgstr "지불 ID"
 
 msgid "payment term"
-msgstr "결제조건"
+msgstr "지불 조건"
 
 msgid "Payment term"
 msgstr "지불 조건"
 
 msgid "Payment Term"
-msgstr "결제조건"
+msgstr "지불 조건"
 
 msgid "payment terms"
-msgstr "결제조건"
+msgstr "지불 조건"
 
 msgid "Payment Terms"
-msgstr "결제조건"
+msgstr "지불 조건"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "Net 30 또는 수령 즉시 지급과 같은 결제조건"
+msgstr "Net 30 또는 입고 시 만기와 같은 지불 조건"
 
 msgid "Payments"
-msgstr "결제"
+msgstr "지불"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "이 인보이스에 적용된 결제 및 크레딧입니다. 행을 클릭하면 원본 문서가 열립니다."
+msgstr "이 송장에 적용된 지불 및 대변. 행을 클릭하여 원본 문서를 엽니다."
 
 msgid "PDF"
 msgstr "PDF"
@@ -10982,16 +10982,16 @@ msgid "Pending"
 msgstr "대기 중"
 
 msgid "people"
-msgstr "인력"
+msgstr "인원"
 
 msgid "People"
-msgstr "인력"
+msgstr "인원"
 
 msgid "Per Unit"
 msgstr "단위당"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "주문 헤더의 이행 위치를 라인별로 재정의한 값으로, 분할 출하 및 직송에 사용됩니다."
+msgstr "주문 헤더의 출하 사업장에 대한 라인별 재정의; 분할 출하 및 직송에 사용됨."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
 msgstr "구매주문 헤더의 납품 위치를 라인별로 재정의한 값으로, 여러 창고로의 분할 납품이나 직송에 사용됩니다."
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "기간 잠금 정책"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "고정자산에 대한 정기 감가상각비"
+msgstr "고정자산에 대한 정기적인 감가상각 비용"
 
 msgid "Permanently Delete"
 msgstr "영구 삭제"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "단계 소요 기간"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "품목을 단계적으로 단종하고 후속 품목으로 전환하여, 계획 시 기존 품목의 수요를 전환계수를 적용해 신규 품목으로 재배정합니다."
+msgstr "품목을 후속 품목으로 단계적으로 폐지하므로 계획에서 구품목의 소요량에 환산 계수를 곱한 값을 신규품목으로 리다이렉트합니다."
 
 msgid "Phone"
 msgstr "전화번호"
@@ -11048,7 +11048,7 @@ msgid "Photo uploaded successfully"
 msgstr "사진이 업로드되었습니다"
 
 msgid "Physical printers available for assignment."
-msgstr "배정 가능한 실물 프린터입니다."
+msgstr "할당할 수 있는 물리적 프린터."
 
 msgid "Pick"
 msgstr "피킹"
@@ -11060,7 +11060,7 @@ msgid "Pick a column to sort by"
 msgstr "정렬할 열을 선택하세요"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "가격을 확인할 고객 또는 고객 유형을 선택하세요."
+msgstr "고객 또는 고객 유형을 선택하여 가격 책정을 봅니다."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "날짜를 선택하거나 비워두어 지우세요."
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "피킹 순서"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "재고가 필요한 상자를 선택한 후 가져올 상자를 선택하세요."
+msgstr "재고가 필요한 빈을 선택한 다음, 재고를 가져올 빈을 선택합니다."
 
 msgid "Pick tracked item"
 msgstr "추적 품목 선택"
@@ -11105,19 +11105,19 @@ msgid "Picking Lines"
 msgstr "피킹 라인"
 
 msgid "Picking list"
-msgstr "픽킹 리스트"
+msgstr "피킹 리스트"
 
 msgid "Picking List"
-msgstr "피킹 목록"
+msgstr "피킹 리스트"
 
 msgid "Picking List ID"
-msgstr "피킹 목록 ID"
+msgstr "피킹 리스트 ID"
 
 msgid "Picking List Notes"
-msgstr "피킹 목록 메모"
+msgstr "피킹 리스트 메모"
 
 msgid "Picking Lists"
-msgstr "피킹 목록"
+msgstr "피킹 리스트"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
 msgstr "피킹 시 추적 개체를 유효기한이 빠른 순으로 제시하여, 기본적으로 유효기한이 가장 임박한 재고가 먼저 출고됩니다."
@@ -11164,10 +11164,10 @@ msgid "Planned Order"
 msgstr "계획 주문"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "계획주문 = 품목의 재주문 정책에 기반해 예상 수요를 충족하기 위한 MRP 제안(또는 수동으로 추가한 주문)입니다."
+msgstr "계획된 주문 = 품목의 재주문 정책(또는 수동으로 추가됨)에 따라 예상 소요량을 충당하기 위한 MRP 제안."
 
 msgid "Planned purchase order"
-msgstr "계획 구매주문"
+msgstr "계획된 발주서"
 
 msgid "Planned Start"
 msgstr "계획 시작"
@@ -11230,7 +11230,7 @@ msgid "Policy"
 msgstr "정책"
 
 msgid "Policy & Procedure"
-msgstr "정책 및 절차"
+msgstr "정책 & 절차서"
 
 msgid "Portal Link"
 msgstr "포털 링크"
@@ -11248,7 +11248,7 @@ msgid "Post Comment"
 msgstr "댓글 게시"
 
 msgid "Post Invoice"
-msgstr "인보이스 전기"
+msgstr "송장 전기"
 
 msgid "Post journal entries with proper account and description codes"
 msgstr "올바른 계정 및 설명 코드로 전표를 전기"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "전기자"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "이러한 소스 유형의 게시된 저널은 항상 동기화됩니다. 일일 요약은 하루의 저널을 계정별로 하나의 공급자 항목으로 그룹화합니다."
+msgstr "이러한 원본 유형을 가진 전기된 전표는 항상 동기화됩니다. 매일 요약은 하루의 전표를 계정당 하나의 공급자 항목으로 그룹화합니다."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "한 번 게시되었으며 {corrections}번 수정되었습니다."
@@ -11293,7 +11293,7 @@ msgid "Posting"
 msgstr "전기"
 
 msgid "Posting date"
-msgstr "게시 날짜"
+msgstr "전기 날짜"
 
 msgid "Posting Date"
 msgstr "전기일"
@@ -11302,10 +11302,10 @@ msgid "Potential Data Loss"
 msgstr "데이터 손실 가능성"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "유효기한이 고정 기간일 때 새 품목에 자동으로 미리 입력됩니다."
+msgstr "유통기한이 고정 기간일 때 새 품목에 대해 미리 입력됨."
 
 msgid "Preferred Supplier"
-msgstr "선호 공급업체"
+msgstr "우선 공급업체"
 
 msgid "Prefix"
 msgstr "접두사"
@@ -11326,7 +11326,7 @@ msgid "Preventive action"
 msgstr "예방 조치"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "설비의 예방 정비 일정"
+msgstr "설비 예방 유지보수 일정"
 
 msgid "Preview"
 msgstr "미리보기"
@@ -11372,7 +11372,7 @@ msgid "Price Lists"
 msgstr "가격표"
 
 msgid "Price override"
-msgstr "가격 재설정"
+msgstr "가격 재정의"
 
 msgid "Prices"
 msgstr "가격"
@@ -11381,7 +11381,7 @@ msgid "Pricing"
 msgstr "가격 책정"
 
 msgid "Pricing rule"
-msgstr "가격 책정 규칙"
+msgstr "가격 규칙"
 
 msgid "Pricing Rule"
 msgstr "가격 규칙"
@@ -11390,7 +11390,7 @@ msgid "Pricing Rules"
 msgstr "가격 규칙"
 
 msgid "Pricing Trace"
-msgstr "가격 추적"
+msgstr "가격 책정 추적"
 
 msgid "Primary cash account for bank transactions"
 msgstr "은행 거래를 위한 기본 현금 계정"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "{0} 라벨 인쇄"
 
 msgid "Print Jobs"
-msgstr "인쇄 작업"
+msgstr "인쇄 작업 지시"
 
 msgid "Print Label"
 msgstr "라벨 인쇄"
@@ -11437,16 +11437,16 @@ msgid "Private"
 msgstr "비공개"
 
 msgid "procedure"
-msgstr "절차"
+msgstr "절차서"
 
 msgid "Procedure"
-msgstr "절차"
+msgstr "절차서"
 
 msgid "procedures"
-msgstr "절차"
+msgstr "절차서"
 
 msgid "Procedures"
-msgstr "절차"
+msgstr "절차서"
 
 msgid "process"
 msgstr "공정"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "프로젝트"
 
 msgid "Project owner"
-msgstr "프로젝트 담당자"
+msgstr "프로젝트 책임자"
 
 msgid "Project Plan"
 msgstr "프로젝트 계획"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "프로젝트 시작"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "BOM과 예측을 전개하여 산출한 예상 수요입니다."
+msgstr "BOM 및 예측으로부터 전개된 예상 소요량."
 
 msgid "Projected inventory"
 msgstr "예상 재고"
@@ -11543,14 +11543,14 @@ msgstr "예상 재고"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "{0} 주에 재고 소진 예상"
+msgstr "{0} 주의 예상 재고 부족"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
-msgstr "{0} 주에 안전재고 미만으로 떨어질 것으로 예상됨"
+msgstr "{0} 주에 안전 재고 아래로 떨어질 것으로 예상"
 
 msgid "Projected to stay above safety stock"
-msgstr "안전재고 이상을 유지할 것으로 예상됨"
+msgstr "안전 재고 위에 머물 것으로 예상"
 
 msgid "Projection"
 msgstr "예측"
@@ -11608,13 +11608,13 @@ msgid "Published"
 msgstr "게시됨"
 
 msgid "Published by Carbon"
-msgstr "Carbon에서 게시함"
+msgstr "Carbon에 의해 게시됨"
 
 msgid "Published Version"
-msgstr ""
+msgstr "게시된 버전"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
-msgstr "게시된 버전은 편집할 수 없습니다. 읽기 전용으로 둘러보거나 새 버전을 분기하여 변경하세요."
+msgstr "게시된 버전은 편집할 수 없습니다. 읽기 전용으로 살펴보거나 변경을 하려면 새 버전을 분기하세요."
 
 msgid "Pull"
 msgstr "가져오기"
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "회계에서 가져오기"
 
 msgid "Pull from Inventory"
-msgstr "재고에서 가져오기"
+msgstr "재고 사용"
 
 msgid "Pull, map, and load your data"
 msgstr "데이터를 가져와서 매핑하고 로드하세요"
@@ -11638,55 +11638,55 @@ msgid "Purchase History"
 msgstr "구매 이력"
 
 msgid "Purchase invoice"
-msgstr "구매 송장"
+msgstr "매입 송장"
 
 msgid "Purchase Invoice"
-msgstr "구매 인보이스"
+msgstr "매입 송장"
 
 msgid "Purchase Invoice Amount"
-msgstr "구매 인보이스 금액"
+msgstr "매입 송장 금액"
 
 msgid "Purchase Invoice Line"
-msgstr "구매 인보이스 라인"
+msgstr "매입 송장 라인"
 
 msgid "Purchase Invoices"
-msgstr "구매 인보이스"
+msgstr "매입 송장"
 
 msgid "Purchase order"
-msgstr "구매주문"
+msgstr "발주서"
 
 msgid "Purchase Order"
-msgstr "구매주문"
+msgstr "발주서"
 
 msgid "Purchase Order Amount"
-msgstr "구매주문 금액"
+msgstr "발주서 금액"
 
 msgid "Purchase Order approval rule"
-msgstr "구매주문 승인 규칙"
+msgstr "발주서 승인 규칙"
 
 msgid "Purchase Order ID"
-msgstr "구매주문 ID"
+msgstr "발주서 ID"
 
 msgid "Purchase Order Line"
-msgstr "구매주문 라인"
+msgstr "발주서 라인"
 
 msgid "Purchase Order Location"
-msgstr "구매주문 위치"
+msgstr "발주서 사업장"
 
 msgid "Purchase order removed successfully"
-msgstr "구매주문이 삭제되었습니다"
+msgstr "발주서가 성공적으로 제거되었습니다"
 
 msgid "Purchase Order Type"
-msgstr "구매주문 유형"
+msgstr "발주서 유형"
 
 msgid "Purchase Orders"
-msgstr "구매주문"
+msgstr "발주서"
 
 msgid "Purchase Orders and Planning"
-msgstr "구매주문 및 계획"
+msgstr "발주서 및 계획"
 
 msgid "Purchase orders required"
-msgstr "구매주문 필요"
+msgstr "발주서가 필요합니다"
 
 msgid "Purchase planning"
 msgstr "구매 계획"
@@ -11704,13 +11704,13 @@ msgid "Purchase Qty"
 msgstr "구매 수량"
 
 msgid "Purchase Tax Payable"
-msgstr "매입세액"
+msgstr "매입 세금 미지급"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "매입세액(기본값)"
+msgstr "매입 세금 미지급 (기본값)"
 
 msgid "Purchase to Order"
-msgstr "주문구매"
+msgstr "주문 구매"
 
 msgid "Purchase Unit of Measure"
 msgstr "구매 단위"
@@ -11743,7 +11743,7 @@ msgid "Purchasing Contact"
 msgstr "구매 담당자"
 
 msgid "Purchasing Invoices"
-msgstr "구매 인보이스"
+msgstr "구매 송장"
 
 msgid "Purchasing Unit of Measure"
 msgstr "구매 단위"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "레코드 변경 사항이 발생하는 즉시 외부 시스템으로 전송합니다."
 
 msgid "Push the journal without the dimension"
-msgstr "차원 없이 저널을 푸시합니다"
+msgstr "차원 없이 전표를 전기하세요"
 
 msgid "Push to accounting"
 msgstr "회계로 푸시"
@@ -11819,7 +11819,7 @@ msgid "Quantity"
 msgstr "수량"
 
 msgid "Quantity arriving — on open purchase orders plus on production (make) orders."
-msgstr "입고 예정 수량 — 미결 구매주문과 생산(제작) 주문을 합한 수량입니다."
+msgstr "도착 예정 수량 — 미결 발주서 및 생산(사내 생산) 작업 지시상의 수량입니다."
 
 msgid "Quantity Breaks"
 msgstr "수량 구간"
@@ -11831,7 +11831,7 @@ msgid "Quantity Completed"
 msgstr "완료 수량"
 
 msgid "Quantity in transit to the storage unit via open stock transfers."
-msgstr "미결 재고 이동을 통해 해당 저장 단위로 운송 중인 수량입니다."
+msgstr "미결 재고 이송을 통해 보관 단위로 운송 중인 수량입니다."
 
 msgid "Quantity is derived from completed serials/batches in MES and cannot be edited."
 msgstr "수량은 MES에서 완료된 일련번호/배치로부터 산출되며 수정할 수 없습니다."
@@ -11840,28 +11840,28 @@ msgid "Quantity must be greater than 0"
 msgstr "수량은 0보다 커야 합니다"
 
 msgid "Quantity on hand"
-msgstr "보유 수량"
+msgstr "현재고"
 
 msgid "Quantity on Hand"
-msgstr "보유 수량"
+msgstr "현재고"
 
 msgid "Quantity on Jobs"
-msgstr "작업 수량"
+msgstr "작업 지시상 수량"
 
 msgid "Quantity on Purchase Order"
-msgstr "구매주문 수량"
+msgstr "발주서상 수량"
 
 msgid "Quantity on Sales Order"
-msgstr "판매주문 수량"
+msgstr "수주상 수량"
 
 msgid "Quantity Per Job"
 msgstr "작업당 수량"
 
 msgid "Quantity per Parent"
-msgstr "상위당 수량"
+msgstr "모품목당 수량"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "자재에 지정된 저장 단위(선반)에 실제로 있는 수량입니다. 해당 단위가 공급해야 할 수량보다 적으면 빨간색으로 표시됩니다."
+msgstr "자재의 지정된 보관 단위(선반)에 있는 물리적 수량입니다. 해당 단위가 공급해야 하는 수량보다 적으면 빨간색으로 표시됩니다."
 
 msgid "Quantity Range"
 msgstr "수량 범위"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "수량 유형"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "이 재정의에 대한 수량 기반 가격 등급으로, 주문 라인이 충족하는 최소 수량이 가장 큰 행의 단가가 적용됩니다."
+msgstr "이 재정의에 대한 수량 기반 가격 책정 단계입니다. 적용된 단가는 주문 라인이 만족하는 최대 최소 수량 행입니다."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11895,16 +11895,16 @@ msgid "Question"
 msgstr "질문"
 
 msgid "Queued"
-msgstr "대기 중"
+msgstr "대기열"
 
 msgid "Quote"
 msgstr "견적"
 
 msgid "Quote Accepted By"
-msgstr "견적 승인자"
+msgstr "견적서 수락자"
 
 msgid "Quote Accepted By Email"
-msgstr "견적 승인자 이메일"
+msgstr "견적서 수락자 이메일"
 
 msgid "Quote expired"
 msgstr "견적 만료됨"
@@ -11919,7 +11919,7 @@ msgid "Quote Line"
 msgstr "견적 라인"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "자재명세서에 이 품목을 포함하는 견적 라인"
+msgstr "이 품목을 포함하는 자재 명세서를 가진 견적 라인"
 
 msgid "Quote Location"
 msgstr "견적 위치"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "견적 번호"
 
 msgid "Quote to cash"
-msgstr "견적에서 수금까지"
+msgstr "견적서에서 수금까지"
 
 msgid "Quote Type"
 msgstr "견적 유형"
@@ -11949,13 +11949,13 @@ msgid "Quotes"
 msgstr "견적"
 
 msgid "Quoting and sales orders"
-msgstr "견적 및 판매주문"
+msgstr "견적서 작성 및 수주"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "견적, 주문, 주문형 구성(Configure-to-Order)"
 
 msgid "Raise it at the weekly status call"
-msgstr "주간 진행 상황 회의에서 제기하세요"
+msgstr "매주 상태 검토 회의에서 제기하세요"
 
 msgid "raise it early and raise it plainly. A problem named in week 2 is a small fix; the same problem at go-live is a delay."
 msgstr "문제는 일찍, 명확하게 제기하세요. 2주 차에 언급된 문제는 작은 수정이지만, 오픈 시점에 같은 문제가 나오면 지연으로 이어집니다."
@@ -11994,10 +11994,10 @@ msgid "Readable"
 msgstr "읽을 수 있음"
 
 msgid "Readable ID"
-msgstr "읽을 수 있는 ID"
+msgstr "표시 ID"
 
 msgid "Readable id with revision"
-msgstr "개정판이 포함된 읽을 수 있는 ID"
+msgstr "리비전이 있는 표시 ID"
 
 msgid "Reading the document..."
 msgstr "문서를 읽는 중..."
@@ -12009,7 +12009,7 @@ msgid "Ready for Quote"
 msgstr "견적 준비 완료"
 
 msgid "ready to keep or revert"
-msgstr "유지 또는 복원 준비 완료"
+msgstr "유지하거나 되돌릴 준비됨"
 
 msgid "Real-time inventory and shop-floor visibility"
 msgstr "실시간 재고 및 현장 가시성"
@@ -12042,13 +12042,13 @@ msgid "Reasons"
 msgstr "사유"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "이 행의 특정 추적 개체를 다른 처리 행으로 재배정합니다."
+msgstr "이 행의 추적된 특정 항목을 다른 처분 결정 행으로 재할당하세요."
 
 msgid "Recalculate"
 msgstr "재계산"
 
 msgid "Recalculate Unit Cost"
-msgstr "단가 재계산"
+msgstr "원가 재계산"
 
 msgid "Recalculating…"
 msgstr "재계산 중…"
@@ -12075,13 +12075,13 @@ msgid "Receipts"
 msgstr "입고"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "수령, 배송, 판매 송장, 구매 송장, 지급, 대변/차변전표 중 아직 임시 또는 보류 중인 것들은 전기되거나 취소되어야 합니다. 이 기간에 날짜가 지정된 문서와 전기될 때 날짜를 받을 미날짜 문서 모두 해당됩니다. 전기될 때까지 그 금액이 총계정원장에 없으므로 기간이 과소계상될 것입니다."
+msgstr "입고, 출하, 매출 송장, 매입 송장, 지불 및 신용증/차감증이 여전히 초안 또는 대기 중이면 전기되거나 무효 처리되어야 합니다. 이 기간에 날짜가 지정된 문서와 전기 시 이 기간의 날짜를 받을 문서 모두. 전기될 때까지 해당 금액이 총계정원장에 반영되지 않으므로 해당 기간이 과소 집계됩니다."
 
 msgid "Receivables"
 msgstr "매출채권"
 
 msgid "Receivables (AR)"
-msgstr "미수금 (AR)"
+msgstr "매출채권(AR)"
 
 msgid "Receivables (default)"
 msgstr "매출채권(기본값)"
@@ -12100,11 +12100,11 @@ msgid "Receive against a PO and update inventory"
 msgstr "구매주문에 대해 입고하고 재고를 업데이트"
 
 msgid "Receive Payment"
-msgstr "결제 수령"
+msgstr "지불 수령"
 
 #. placeholder {0}: selectedInvoices.length
 msgid "Receive Payment · {0} invoices"
-msgstr "결제 수령 · 인보이스 {0}건"
+msgstr "지불 수령 · {0} 송장"
 
 msgid "Receive to Inventory"
 msgstr "재고로 입고"
@@ -12127,13 +12127,13 @@ msgid "Received Qty"
 msgstr "입고 수량"
 
 msgid "Receiving Location"
-msgstr "입고 위치"
+msgstr "입고 사업장"
 
 msgid "Recent"
 msgstr "최근"
 
 msgid "Recent payments"
-msgstr "최근 결제"
+msgstr "최근 지불"
 
 msgid "Recently Created"
 msgstr "최근 생성됨"
@@ -12145,16 +12145,16 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "조정 중에 공급자와의 불일치를 발견했습니다"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "구매주문을 실제 입고 및 청구 내역과 대조하는 작업 — Carbon에서는 라인 수량과 GR/IR 잔액을 통해 암묵적으로 처리됩니다."
+msgstr "발주서를 입고 및 송장 발행된 항목에 대해 조정하기 — Carbon에서 암묵적으로 라인 수량 및 GR/IR 잔액을 통해 수행됩니다."
 
 msgid "Record"
 msgstr "기록"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "고객 또는 공급업체에 대한 대변/차변 메모를 기록합니다. 특정 인보이스에 대한 적용은 메모 생성 후 추가됩니다."
+msgstr "고객 또는 공급업체에 대해 신용증 또는 차감증을 기록하세요. 특정 송장에 대한 적용은 메모가 생성된 후에 추가됩니다."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "고객으로부터 받은 현금(입금) 또는 공급업체에 지급한 현금(지급)을 기록합니다. 특정 인보이스에 대한 적용은 결제 생성 후 추가됩니다."
+msgstr "고객으로부터 수령한 현금 또는 공급업체에 지급한 현금을 기록하세요. 특정 송장에 대한 적용은 지불이 생성된 후에 추가됩니다."
 
 msgid "Record deleted"
 msgstr "레코드가 삭제됨"
@@ -12166,13 +12166,13 @@ msgid "Record type"
 msgstr "기록 유형"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "게이지의 읽음값을 신뢰하기 전에 수리가 필요하다는 것이 교정에 기록됨."
+msgstr "판독값을 신뢰할 수 있기 전에 계측기가 수리가 필요하다고 교정에 기록되었습니다."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "이 교정 이후 후속 조치가 필요함을 기록합니다. 이 측정기가 미결 조치 대기열에 표시됩니다."
+msgstr "이 교정 후 후속 조치가 필요하다고 기록되었습니다. 이 계측기를 미결 작업 대기열에 표시합니다."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "이 교정 중 측정기가 조정되었음을 기록합니다. 이는 교정 주기 재계산 방식에 영향을 줍니다."
+msgstr "이 교정 중에 계측기가 조정되었다고 기록되었습니다. 교정 주기를 다시 계산하는 방식에 영향을 줍니다."
 
 msgid "Records"
 msgstr "레코드"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "인증 페이지로 이동 중..."
 
 msgid "Reduced"
-msgstr "감소됨"
+msgstr "수월한 검사"
 
 msgid "Reference"
 msgstr "참조"
@@ -12217,13 +12217,13 @@ msgid "Registration Number"
 msgstr "등록 번호"
 
 msgid "Reject"
-msgstr "반려"
+msgstr "거부"
 
 msgid "Reject Lot"
-msgstr "로트 반려"
+msgstr "로트 거부"
 
 msgid "Reject Quote"
-msgstr "견적 반려"
+msgstr "견적서 거부"
 
 msgid "Rejected"
 msgstr "반려됨"
@@ -12241,13 +12241,13 @@ msgid "Relative timeline · dates set in Setup & Controls"
 msgstr "상대적 타임라인 · 설정 및 관리에서 날짜 지정됨"
 
 msgid "Relative timeline · dates to be confirmed"
-msgstr "상대적 타임라인 · 날짜 확정 예정"
+msgstr "상대적 일정 · 확인할 날짜"
 
 msgid "Release"
-msgstr "릴리즈"
+msgstr "릴리스"
 
 msgid "Release change notice"
-msgstr "변경 공지 릴리스"
+msgstr "변경 통지 릴리스"
 
 msgid "Release control"
 msgstr "릴리스 제어"
@@ -12256,7 +12256,7 @@ msgid "Release Control"
 msgstr "릴리스 제어"
 
 msgid "Release Job"
-msgstr "작업 릴리즈"
+msgstr "작업 지시 릴리스"
 
 msgid "Released"
 msgstr "릴리즈됨"
@@ -12268,7 +12268,7 @@ msgid "Released revision"
 msgstr "릴리스된 리비전"
 
 msgid "Released revision is locked"
-msgstr "릴리스된 리비전이 잠금됨"
+msgstr "발행된 리비전은 잠겨 있습니다"
 
 msgid "Remaining"
 msgstr "남음"
@@ -12277,7 +12277,7 @@ msgid "Remaining after split stays on the original row."
 msgstr "분할 후 남은 수량은 원래 행에 유지됩니다."
 
 msgid "Remember this PIN. You will need it to exit console mode on MES terminals."
-msgstr "이 PIN을 기억해 두세요. MES 단말기에서 콘솔 모드를 종료할 때 필요합니다."
+msgstr "이 PIN을 기억하세요. MES 터미널에서 콘솔 모드를 종료하려면 필요합니다."
 
 msgid "Remove"
 msgstr "제거"
@@ -12335,7 +12335,7 @@ msgid "Remove sort by column"
 msgstr "열 정렬 제거"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "이 저장 유형을 참조하는 모든 저장 단위에서 제거하고 삭제합니다. 이 작업은 되돌릴 수 없습니다."
+msgstr "이 저장소 유형을 모든 참조 보관 단위에서 제거하고 삭제합니다. 이는 실행 취소할 수 없습니다."
 
 msgid "Remove tool"
 msgstr "도구 제거"
@@ -12396,7 +12396,7 @@ msgid "Reordering Policy"
 msgstr "재주문 정책"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "작업지시 순서와 작업장만 재정렬하며, 일정은 변경하지 않습니다. 날짜는 날짜 보드에서 변경하세요."
+msgstr "작업 순서 및 작업장만 재정렬합니다 — 일정을 재설정하지 않습니다. 일정 보드에서 날짜를 변경합니다."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "{inputLabel}의 각 항목에 대해 한 번씩 반복됩니다"
@@ -12405,7 +12405,7 @@ msgid "Replace drawing?"
 msgstr "도면을 교체하시겠습니까?"
 
 msgid "Replace existing pricing with source values"
-msgstr "기존 가격을 원본 값으로 교체"
+msgstr "기존 가격 책정을 원본 값으로 바꾸기"
 
 msgid "Replace PDF"
 msgstr "PDF 교체"
@@ -12420,10 +12420,10 @@ msgid "Replenishment"
 msgstr "보충"
 
 msgid "Replenishment system"
-msgstr "보충 시스템"
+msgstr "조달 방식"
 
 msgid "Replenishment System"
-msgstr "보충 시스템"
+msgstr "조달 방식"
 
 msgid "Report"
 msgstr "보고서"
@@ -12462,7 +12462,7 @@ msgid "Require approval before suppliers can be set to Active"
 msgstr "공급업체를 활성 상태로 설정하기 전에 승인 필요"
 
 msgid "Require approval for purchase orders based on amount thresholds"
-msgstr "금액 기준에 따라 구매주문에 승인 필요"
+msgstr "금액 임계값을 기준으로 발주서에 대한 승인 필요"
 
 msgid "Require approval for quality documents in your workflow"
 msgstr "워크플로 내 품질 문서에 승인 필요"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "필수 조치(순서대로)"
 
 msgid "Required Date"
-msgstr "필요일"
+msgstr "소요일"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "통제된 환경에서 필수입니다 — 감사 로깅을 끌 수 없습니다."
@@ -12541,31 +12541,31 @@ msgid "Reset view"
 msgstr "보기 초기화"
 
 msgid "Residual value"
-msgstr "잔존가치"
+msgstr "잔존가액"
 
 msgid "Residual Value %"
-msgstr "잔존가치 %"
+msgstr "잔존가액 %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "NCR을 완료하기 전에 다음을 해결하세요: 모든 행에 대기 중이 아닌 처리 상태가 지정되어야 하며, 연결된 개체 수량이 행 수량과 일치해야 합니다."
+msgstr "NCR을 완료하기 전에 이를 해결합니다: 모든 행에는 대기 중이 아닌 처분 결정이 있어야 하고, 연결된 엔티티 수량이 행 수량과 일치해야 합니다."
 
 msgid "Resolved Price"
 msgstr "확정 가격"
 
 msgid "resources"
-msgstr "리소스"
+msgstr "자원"
 
 msgid "Resources"
-msgstr "리소스"
+msgstr "자원"
 
 msgid "Restore from Trash"
 msgstr "휴지통에서 복원"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "이 항목을 폐기 전 보관 위치 및 원가의 사용 가능한 재고로 복원합니다."
+msgstr "이 엔티티를 스크랩 전의 빈과 원가로 가용 재고에 복원합니다."
 
 msgid "Restore tracked entities to available"
-msgstr "추적 개체를 사용 가능 상태로 복원"
+msgstr "추적된 엔티티를 가용으로 복원"
 
 msgid "Restoring files"
 msgstr "파일 복원 중"
@@ -12616,34 +12616,34 @@ msgid "Rev {revision}"
 msgstr "Rev {revision}"
 
 msgid "Revenue"
-msgstr "수익"
+msgstr "매출"
 
 msgid "Revenue and expenses over a period"
-msgstr "일정 기간의 수익 및 비용"
+msgstr "기간별 매출 및 비용"
 
 msgid "Reverse all inventory adjustments"
 msgstr "모든 재고 조정 취소"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "모든 분개 및 원가 원장 항목 취소"
+msgstr "모든 전표 및 원가 원장 항목을 역분개합니다."
 
 msgid "Reverse any item ledger entries from this invoice"
-msgstr "이 인보이스의 모든 품목 원장 항목 취소"
+msgstr "이 송장에서 모든 품목 원장 항목을 역분개합니다."
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "역청구"
 
 msgid "Reverse Charge Sales Tax"
-msgstr "매입자 납부 판매세(Reverse Charge)"
+msgstr "역청구 판매세"
 
 msgid "Reverse Charge Sales Tax (default)"
-msgstr "매입자 납부 판매세(기본값)"
+msgstr "역청구 판매세 (기본값)"
 
 msgid "Reverse the related journal entries"
-msgstr "관련 분개 취소"
+msgstr "관련 전표를 역분개합니다."
 
 msgid "Reversed"
-msgstr "역순됨"
+msgstr "역분개됨"
 
 msgid "Revert"
 msgstr "복원"
@@ -12658,7 +12658,7 @@ msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "각 항목의 변경 사항을 검토한 후 확인하세요 — 릴리스는 실행 취소할 수 없습니다."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "기간의 대차대조표와 손익계산서를 검토하고 수치가 올바른지 확인하세요. 이것은 수동 승인입니다. 검토가 끝나면 완료로 표시하세요."
+msgstr "기간의 재무상태표 및 손익계산서를 검토하고 수치가 올바른지 확인합니다. 이는 수동 승인입니다 — 검토한 후 완료로 표시합니다."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
 msgstr "적용하기 전에 제안된 매칭을 검토하세요. 이는 최선의 추측입니다 — 각 항목이 올바른지 확인하세요."
@@ -12674,7 +12674,7 @@ msgid "Revision {0}"
 msgstr "리비전 {0}"
 
 msgid "Revision status"
-msgstr "개정판 상태"
+msgstr "리비전 상태"
 
 msgid "Revisions"
 msgstr "리비전"
@@ -12695,7 +12695,7 @@ msgid "RFQ"
 msgstr "RFQ"
 
 msgid "RFQ (request for quote)"
-msgstr "RFQ(견적요청)"
+msgstr "RFQ (견적 요청)"
 
 msgid "RFQ Date"
 msgstr "RFQ 날짜"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "RFQ"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "게시된 저널에 Carbon 차원을 함께 탑승하세요. 각 슬롯은 하나의 Carbon 차원을 하나의 제공자 분석 대상에 매핑합니다. 아래 값 매핑은 개별 차원 값을 제공자 옵션과 쌍으로 만듭니다."
+msgstr "Carbon 차원을 푸시된 전표에 함께 전달합니다. 각 슬롯은 하나의 Carbon 차원을 하나의 제공자 분석 대상에 매핑합니다. 아래 값 매핑은 개별 차원 값을 제공자 옵션과 쌍을 이룹니다."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12732,7 +12732,7 @@ msgid "Risk"
 msgstr "리스크"
 
 msgid "Risk register"
-msgstr "리스크 레지스터"
+msgstr "리스크 등록부"
 
 msgid "Risks"
 msgstr "리스크"
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "반올림 계정(기본값)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "모든 매입채무 인보이스를 개별 구매자가 아닌 하나의 주소(예: 본사)로 전달합니다."
+msgstr "모든 매입채무 송장을 개별 구매자 대신 한 주소(예: 기업 본사)로 라우팅합니다."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "모든 매출채권 인보이스를 개별 위치가 아닌 하나의 주소(예: 본사)로 전달합니다."
+msgstr "모든 매출채권 송장을 개별 사업장 대신 한 주소(예: 기업 본사)로 라우팅합니다."
 
 msgid "Routing"
-msgstr "공정(BOP)"
+msgstr "라우팅"
 
 msgid "rows"
 msgstr "행"
@@ -12822,7 +12822,7 @@ msgid "Run month-end close and standard reconciliations"
 msgstr "월마감 및 표준 조정 작업을 수행하세요"
 
 msgid "Run payment batches and track aging"
-msgstr "결제 배치를 실행하고 연체 기간을 추적하세요"
+msgstr "지불 배치를 실행하고 에이징을 추적합니다."
 
 msgid "Run test"
 msgstr "테스트 실행"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "인수 체크리스트를 통과할 때까지 진행하세요"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "태블릿으로 현장을 운영하세요: 근무 시간 기록, 진행 상황 보고, 작업 지시 확인"
+msgstr "태블릿에서 작업장을 실행합니다: 노무를 기록하고, 진행 상황을 보고하고, 지침을 확인합니다."
 
 msgid "Run this workflow now?"
 msgstr "이 워크플로우를 지금 실행하시겠습니까?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "실행 중"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "매주 공급과 수요를 반영해 갱신되는 재고 — 그 라인입니다."
+msgstr "매주 공급 및 소요량 이후의 누계 재고 — 라인."
 
 msgid "Running Total"
 msgstr "누계"
@@ -12867,92 +12867,92 @@ msgid "S-4 (finest special)"
 msgstr "S-4(가장 엄격한 특별수준)"
 
 msgid "Safety stock"
-msgstr "안전재고"
+msgstr "안전 재고"
 
 msgid "Safety Stock"
-msgstr "안전재고"
+msgstr "안전 재고"
 
 #. placeholder {0}: numberFormatter.format(safetyStockValue)
 msgid "Safety stock ({0})"
-msgstr "안전재고({0})"
+msgstr "안전 재고 ({0})"
 
 msgid "Safety Stock:"
-msgstr "안전재고:"
+msgstr "안전 재고:"
 
 msgid "Sale Price"
 msgstr "판매가"
 
 msgid "sales"
-msgstr "판매"
+msgstr "영업"
 
 msgid "Sales"
-msgstr "판매"
+msgstr "영업"
 
 msgid "Sales (default)"
-msgstr "판매(기본값)"
+msgstr "영업 (기본값)"
 
 msgid "Sales & Quoting"
-msgstr "판매 및 견적"
+msgstr "영업 및 견적"
 
 msgid "Sales & Revenue"
-msgstr "판매 및 매출"
+msgstr "영업 및 매출"
 
 msgid "Sales contact"
-msgstr "영업 연락처"
+msgstr "영업 담당자"
 
 msgid "Sales Contact"
-msgstr "판매 담당자"
+msgstr "영업 담당자"
 
 msgid "Sales Discounts"
-msgstr "판매 할인"
+msgstr "영업 할인"
 
 msgid "Sales Discounts (default)"
-msgstr "판매 할인(기본값)"
+msgstr "영업 할인 (기본값)"
 
 msgid "Sales Funnel"
 msgstr "영업 퍼널"
 
 msgid "Sales invoice"
-msgstr "판매 송장"
+msgstr "매출 송장"
 
 msgid "Sales Invoice"
-msgstr "판매 인보이스"
+msgstr "매출 송장"
 
 msgid "Sales Invoice Line"
-msgstr "판매 인보이스 라인"
+msgstr "매출 송장 라인"
 
 msgid "Sales Invoices"
-msgstr "판매 인보이스"
+msgstr "매출 송장"
 
 msgid "Sales Job Notifications"
-msgstr "판매 작업 알림"
+msgstr "영업 작업 지시 알림"
 
 msgid "Sales order"
-msgstr "판매주문"
+msgstr "수주"
 
 msgid "Sales Order"
-msgstr "판매주문"
+msgstr "수주"
 
 msgid "Sales Order ID"
-msgstr "판매주문 ID"
+msgstr "수주 ID"
 
 msgid "Sales order line"
-msgstr "판매 주문 라인"
+msgstr "수주 라인"
 
 msgid "Sales Order Line"
-msgstr "판매주문 라인"
+msgstr "수주 라인"
 
 msgid "Sales Order Line (job)"
-msgstr "판매 주문 라인 (작업)"
+msgstr "수주 라인 (작업 지시)"
 
 msgid "Sales Order Location"
-msgstr "판매주문 위치"
+msgstr "수주 사업장"
 
 msgid "Sales Order Number"
-msgstr "판매주문 번호"
+msgstr "수주 번호"
 
 msgid "Sales Orders"
-msgstr "판매주문"
+msgstr "수주"
 
 msgid "Sales Person"
 msgstr "영업 담당자"
@@ -12961,16 +12961,16 @@ msgid "Sales Revenue"
 msgstr "매출"
 
 msgid "Sales Tax Payable"
-msgstr "미지급 판매세"
+msgstr "매출 세금 납부"
 
 msgid "Sales Tax Payable (default)"
-msgstr "미지급 판매세(기본값)"
+msgstr "매출 세금 납부 (기본값)"
 
 msgid "Sales, Estimator"
 msgstr "영업, 견적 담당자"
 
 msgid "Sales, quoting, and configure-to-order"
-msgstr "판매, 견적, 구성주문(Configure-to-Order)"
+msgstr "영업, 견적 및 주문형 구성"
 
 msgid "Salesperson"
 msgstr "영업사원"
@@ -13009,7 +13009,7 @@ msgid "Save applications"
 msgstr "애플리케이션 저장"
 
 msgid "Save contacts"
-msgstr "연락처 저장"
+msgstr "담당자 저장"
 
 msgid "Save dimension settings"
 msgstr "차원 설정 저장"
@@ -13048,10 +13048,10 @@ msgid "Scan or choose a batch number"
 msgstr "배치 번호를 스캔하거나 선택하세요"
 
 msgid "Scan or choose a serial number"
-msgstr "일련 번호를 스캔하거나 선택하세요"
+msgstr "시리얼 번호 스캔 또는 선택"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "추적 개체 ID, 일련번호 또는 배치를 스캔하거나 입력하세요"
+msgstr "추적 대상 ID, 시리얼 번호 또는 배치 스캔 또는 입력"
 
 msgid "Scan or enter tracking number"
 msgstr "추적 번호를 스캔하거나 입력하세요"
@@ -13060,7 +13060,7 @@ msgid "Scan or search..."
 msgstr "스캔 또는 검색..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "이 로트에서 추적 엔티티를 스캔하거나 선택하여 샘플 열로 추가한 후 그리드에 결과를 기록하세요."
+msgstr "이 로트에서 추적 대상을 스캔하거나 선택하여 표본 열로 추가한 후, 그리드에 그 결과를 기록하세요."
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
 msgstr "인증 앱(예: Google Authenticator 또는 1Password)으로 이 QR 코드를 스캔한 후 표시된 6자리 코드를 입력하세요."
@@ -13072,13 +13072,13 @@ msgid "SCAR"
 msgstr "SCAR"
 
 msgid "SCAR (supplier corrective action request)"
-msgstr "SCAR (공급자 시정 조치 요청)"
+msgstr "SCAR (공급업체 시정 조치 요청)"
 
 msgid "Schedule"
 msgstr "일정"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "작업장 용량에 맞춰 작업 일정을 계획하세요"
+msgstr "작업 센터 용량에 따라 작업 지시 일정 계획"
 
 msgid "Schedule Name"
 msgstr "일정 이름"
@@ -13117,13 +13117,13 @@ msgid "Scrap Percent"
 msgstr "스크랩 비율"
 
 msgid "Scrap percentage"
-msgstr "폐기 백분율"
+msgstr "불량률"
 
 msgid "Scrap Qty"
 msgstr "스크랩 수량"
 
 msgid "Scrap quantity"
-msgstr "폐기 수량"
+msgstr "스크랩 수량"
 
 msgid "Scrap Quantity"
 msgstr "스크랩 수량"
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "기존 항목을 검색하거나 새로 생성하세요"
 
 msgid "Search items or bins"
-msgstr "항목 또는 보관함 검색"
+msgstr "품목 또는 빈 검색"
 
 msgid "Search Job"
 msgstr "작업 검색"
@@ -13192,7 +13192,7 @@ msgid "Search list variables…"
 msgstr "목록 변수 검색…"
 
 msgid "Search operations…"
-msgstr "작업 검색…"
+msgstr "공정 검색…"
 
 msgid "Search operators..."
 msgstr "작업자 검색..."
@@ -13240,7 +13240,7 @@ msgid "Security"
 msgstr "보안"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "고객 가격 및 조건을 결정하는 세그먼트"
+msgstr "고객 가격 책정과 계약 조건을 좌우하는 구분 항목"
 
 msgid "Select"
 msgstr "선택"
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "문서 선택"
 
 msgid "Select a new owner"
-msgstr "새 소유자 선택"
+msgstr "새 책임자 선택"
 
 msgid "Select a new parent group for this account."
 msgstr "이 계정의 새 상위 그룹을 선택하세요."
@@ -13271,7 +13271,7 @@ msgid "Select a plan to get started. You won't be charged for the first {0} days
 msgstr "시작하려면 플랜을 선택하세요. 처음 {0}일 동안은 요금이 청구되지 않습니다. 언제든지 변경하거나 취소할 수 있습니다."
 
 msgid "Select a process first to choose its supplier."
-msgstr "공급자를 선택하려면 먼저 프로세스를 선택하세요."
+msgstr "먼저 공법을 선택하여 공급업체를 선택하세요."
 
 msgid "Select a project"
 msgstr "프로젝트 선택"
@@ -13286,13 +13286,13 @@ msgid "Select a reason for why the quote was not created."
 msgstr "견적이 생성되지 않은 사유를 선택하세요."
 
 msgid "Select a shape first to see available options"
-msgstr "먼저 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
+msgstr "먼저 형태를 선택하여 가용 옵션을 확인하세요."
 
 msgid "Select a substance and shape first to see available options"
-msgstr "먼저 재질과 형상을 선택하면 사용 가능한 옵션이 표시됩니다"
+msgstr "먼저 재질과 형태를 선택하여 가용 옵션을 확인하세요."
 
 msgid "Select a substance first to see available options"
-msgstr "먼저 재질을 선택하면 사용 가능한 옵션이 표시됩니다"
+msgstr "먼저 재질을 선택하여 가용 옵션을 확인하세요."
 
 msgid "Select a team"
 msgstr "팀 선택"
@@ -13361,19 +13361,19 @@ msgid "Select field"
 msgstr "필드 선택"
 
 msgid "Select Gauge"
-msgstr "측정기 선택"
+msgstr "계측기 선택"
 
 msgid "Select groups or individuals"
 msgstr "그룹 또는 개인 선택"
 
 msgid "Select invoice"
-msgstr "인보이스 선택"
+msgstr "송장 선택"
 
 msgid "Select invoices from a single counterparty"
-msgstr "단일 거래처의 인보이스를 선택하세요"
+msgstr "동일 거래처의 송장만 선택하세요."
 
 msgid "Select invoices in a single currency"
-msgstr "단일 통화의 인보이스를 선택하세요"
+msgstr "단일 통화의 송장만 선택하세요."
 
 msgid "Select Item Type"
 msgstr "품목 유형 선택"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "이 교육을 완료해야 하는 그룹을 선택하세요"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "이 결제로 정산할 인보이스를 선택하세요. 할인과 대손상각은 인보이스 통화 기준입니다."
+msgstr "이 지불로 결제되는 송장을 선택하세요. 할인과 대손 처리는 송장 통화로 표시됩니다."
 
 msgid "Select value"
 msgstr "값 선택"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "자체 관리"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "자체 호스팅 또는 관리형"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "자체 온보딩"
 
 msgid "Self-paced"
 msgstr "자율 학습"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "이메일 알림이 켜져 있는 각 수신자에게 전송됩니다."
 
 msgid "Sequences"
-msgstr "시퀀스"
+msgstr "채번 규칙"
 
 msgid "Serial"
 msgstr "일련번호"
@@ -13500,13 +13500,13 @@ msgid "Serial / Batch"
 msgstr "일련번호/배치"
 
 msgid "Serial items require a sales order"
-msgstr "일련번호 품목에는 판매주문이 필요합니다"
+msgstr "일련번호 품목은 수주가 필요합니다."
 
 msgid "Serial Number"
-msgstr "일련번호"
+msgstr "시리얼 번호"
 
 msgid "Serial Number:"
-msgstr "일련번호:"
+msgstr "시리얼 번호:"
 
 msgid "Serial Numbers"
 msgstr "시리얼 번호"
@@ -13527,7 +13527,7 @@ msgid "Serial/Batch #"
 msgstr "일련번호/배치 #"
 
 msgid "Serialize & sell your parts"
-msgstr "품목에 일련번호를 부여하고 판매하세요"
+msgstr "부품에 일련번호를 부여하고 판매하세요."
 
 msgid "service"
 msgstr "서비스"
@@ -13554,16 +13554,16 @@ msgid "Services"
 msgstr "서비스"
 
 msgid "Session locked"
-msgstr "세션이 잠겼습니다"
+msgstr "세션 잠김"
 
 msgid "Set a target"
 msgstr "목표 설정"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "귀사의 운영 방식에 맞춰 Carbon을 설정하세요: 사이트, 품목, BOM, 공정(BOP), 그리고 사용할 흐름까지."
+msgstr "회사의 운영 방식에 맞게 Carbon을 설정하세요: 사업장, 부품, BOM, 공정 목록 및 사용 워크플로우"
 
 msgid "Set Clock Out"
-msgstr "퇴근 처리"
+msgstr "작업 종료 설정"
 
 msgid "Set clock-out time"
 msgstr "퇴근 시간 설정"
@@ -13575,13 +13575,13 @@ msgid "Set default markup percentages for each cost category on new quote lines"
 msgstr "새 견적 라인의 각 원가 카테고리에 대한 기본 마진율을 설정하세요"
 
 msgid "Set demand projection values for each week"
-msgstr "주별 수요 예측치를 설정하세요"
+msgstr "각 주별 소요량 예측 값 설정"
 
 msgid "Set due date"
-msgstr "기한 설정"
+msgstr "마감일 설정"
 
 msgid "Set Pricing"
-msgstr "가격 설정"
+msgstr "가격 책정 설정"
 
 msgid "Set Quantity"
 msgstr "수량 설정"
@@ -13596,20 +13596,20 @@ msgid "Set up two-factor authentication"
 msgstr "2단계 인증 설정"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "설정, 데이터, 교육, 도입까지 단계별 실행 계획으로 귀사를 구축하세요."
+msgstr "설정, 데이터, 교육, 런칭을 포함한 단계별 실행 계획으로 회사를 설정하세요."
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "가져오기 도구와 LLM 지원으로 직접 데이터를 구축하세요"
 
 msgid "Set up your resources and settings"
-msgstr "리소스와 설정을 구성하세요"
+msgstr "자원 및 설정 구성"
 
 #. placeholder {0}: selectedVersion.version
 msgid "Set Version {0} as Active Version?"
 msgstr "버전 {0}을(를) 활성 버전으로 설정하시겠습니까?"
 
 msgid "Set your default location in profile settings to pick a storage unit."
-msgstr "저장 단위를 선택하려면 프로필 설정에서 기본 위치를 설정하세요."
+msgstr "프로필 설정에서 기본 사업장을 설정하여 보관 단위를 선택하세요."
 
 msgid "Settings"
 msgstr "설정"
@@ -13630,7 +13630,7 @@ msgid "Setup Map"
 msgstr "설정 맵"
 
 msgid "Setup time"
-msgstr "설정 시간"
+msgstr "셋업 시간"
 
 msgid "Setup Time"
 msgstr "셋업 시간"
@@ -13681,13 +13681,13 @@ msgid "Shared Sections"
 msgstr "공유 섹션"
 
 msgid "Shelf life"
-msgstr "유통기한"
+msgstr "보존 기간"
 
 msgid "Shelf Life (Days)"
-msgstr "유통기한(일)"
+msgstr "보존 기간 (일)"
 
 msgid "Shelf Life Start Process"
-msgstr "유통기한 시작 공정"
+msgstr "보존 기간 시작 공법"
 
 msgid "Shelf-Life"
 msgstr "유통기한"
@@ -13696,19 +13696,19 @@ msgid "Shelf-Life History"
 msgstr "유통기한 이력"
 
 msgid "shift"
-msgstr "교대"
+msgstr "교대조"
 
 msgid "Shift"
-msgstr "교대"
+msgstr "교대조"
 
 msgid "Shift Name"
-msgstr "교대명"
+msgstr "교대조 이름"
 
 msgid "shifts"
-msgstr "교대"
+msgstr "교대조"
 
 msgid "Shifts"
-msgstr "교대"
+msgstr "교대조"
 
 msgid "Ship"
 msgstr "출하"
@@ -13753,7 +13753,7 @@ msgid "Shipping Contact"
 msgstr "배송 담당자"
 
 msgid "Shipping Cost"
-msgstr "배송비"
+msgstr "운송비"
 
 msgid "Shipping Customer"
 msgstr "배송 고객"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "처음 500줄을 표시하고 있습니다"
 
 msgid "Showing the newest 200 journals"
-msgstr "최신 200개 저널 표시 중"
+msgstr "최신 200개 전표 표시 중"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "금액별 상위 1,000개 그룹을 표시하고 있습니다"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "이 규칙이 실패할 때 사용자에게 표시됩니다."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon에 로그인"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "매직 링크 대신 생체 인식으로 로그인하세요. 패스키는 Face ID, Touch ID 또는 기기 PIN으로 보호됩니다."
@@ -13955,16 +13955,16 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "위치, 품목 또는 모든 차원별 자산 활동 분석"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "위치, 비용 센터 또는 모든 차원별 비용 분석"
+msgstr "비용을 사업장, 원가 센터 또는 모든 차원으로 분할"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "고객, 고객 유형 또는 모든 차원별 수익 분석"
+msgstr "매출을 고객, 고객 유형 또는 모든 차원으로 분할"
 
 msgid "Smoke-test the core daily flows end to end"
-msgstr "핵심 일일 업무 흐름을 처음부터 끝까지 스모크 테스트하세요"
+msgstr "핵심 매일 흐름의 종단 간 스모크 테스트"
 
 msgid "so you can assign it here."
-msgstr "그러면 여기서 배정할 수 있습니다."
+msgstr "그래서 여기에 할당할 수 있습니다."
 
 msgid "Solutions Engineer"
 msgstr "솔루션 엔지니어"
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "곧"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "모든 자재 중 가장 이른 유효기한이 완제품의 유효기한이 됩니다."
+msgstr "모든 자재의 가장 빠른 유통기한이 완제품을 결정합니다."
 
 msgid "Sort"
 msgstr "정렬"
@@ -14006,10 +14006,10 @@ msgid "Source document"
 msgstr "원본 문서"
 
 msgid "Source Document"
-msgstr "소스 문서"
+msgstr "원본 문서"
 
 msgid "Source Document ID"
-msgstr "소스 문서 ID"
+msgstr "원본 문서 ID"
 
 msgid "Source document readable"
 msgstr "원본 문서 읽기 가능"
@@ -14042,7 +14042,7 @@ msgid "Spare Part Consumption"
 msgstr "예비 부품 소모"
 
 msgid "Spare Part Cost"
-msgstr "예비 부품 비용"
+msgstr "예비 부품 원가"
 
 msgid "Spec"
 msgstr "사양"
@@ -14057,7 +14057,7 @@ msgid "Specific Items"
 msgstr "특정 품목"
 
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
-msgstr "공급업체, 품목 또는 카테고리별 지출 — 가장 큰 비용 동인"
+msgstr "공급업체, 품목 또는 범주별 지출 — 가장 큰 비용 동인"
 
 msgid "Split"
 msgstr "분할"
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "출하 라인 분할"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "호스팅 구축"
@@ -14087,10 +14087,10 @@ msgid "Standard"
 msgstr "표준"
 
 msgid "Standard cloud Carbon fits how your company runs"
-msgstr "표준 클라우드 Carbon이 귀사의 운영 방식에 맞습니다"
+msgstr "표준 클라우드 Carbon은 회사의 운영 방식에 맞습니다"
 
 msgid "Standard Cost Variances"
-msgstr "표준 비용 편차"
+msgstr "표준원가 차이"
 
 msgid "Standard factor"
 msgstr "표준 계수"
@@ -14109,7 +14109,7 @@ msgid "Start counting"
 msgstr "실사 시작"
 
 msgid "Start date"
-msgstr "시작 날짜"
+msgstr "시작일"
 
 msgid "Start Date"
 msgstr "시작일"
@@ -14133,7 +14133,7 @@ msgid "Start of Fiscal Year"
 msgstr "회계연도 시작"
 
 msgid "Start of Tax Year"
-msgstr "세무연도 시작"
+msgstr "회계연도 시작"
 
 msgid "Start Time"
 msgstr "시작 시간"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "재고 이동 ID"
 
 msgid "Stock Transfer Lines"
-msgstr "재고 이동 라인"
+msgstr "재고 이송 라인"
 
 msgid "Stock Transfer Notes"
 msgstr "재고 이동 메모"
@@ -14233,7 +14233,7 @@ msgid "Stockout"
 msgstr "재고 부족"
 
 msgid "Stop raising purchase orders after this date"
-msgstr "이 날짜 이후에는 구매주문을 생성하지 않습니다"
+msgstr "이 날짜 이후로 발주서를 발행하지 마십시오"
 
 msgid "Stop Receiving"
 msgstr "수령 중지"
@@ -14257,49 +14257,49 @@ msgid "Storage Types"
 msgstr "저장 유형"
 
 msgid "storage unit"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Storage unit"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Storage Unit"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Storage Unit (optional)"
-msgstr "저장 단위(선택사항)"
+msgstr "보관 단위 (선택 사항)"
 
 msgid "storage units"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Storage Units"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 생성될 때(또는 설정된 경우 트리거 프로세스가 실행될 때) 설정됩니다."
+msgstr "이 품목에 고정 일수를 저장합니다. 유통기한 시작일은 각 배치 또는 시리얼이 생성될 때(또는 트리거 공법이 실행될 때, 설정된 경우) 설정됩니다."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 입고되거나 생성될 때(또는 설정된 경우 트리거 프로세스가 실행될 때) 설정됩니다."
+msgstr "이 품목에 고정 일수를 저장합니다. 유통기한 시작일은 각 배치 또는 시리얼이 수령되거나 생성될 때(또는 트리거 공법이 실행될 때, 설정된 경우) 설정됩니다."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "이 품목에 고정된 일수를 저장합니다. 유효기한 시작일은 배치 또는 일련번호가 입고될 때 설정됩니다."
+msgstr "이 품목에 고정 일수를 저장합니다. 유통기한 시작일은 각 배치 또는 시리얼이 수령될 때 설정됩니다."
 
 msgid "Straight line"
 msgstr "정액법"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe에 이미 이 이메일을 가진 고객이 있습니다"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe 마감일"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe은 송장을 고객에게 이메일로 전송하므로 주소가 필요합니다. 이것은 Carbon의 담당자에게도 저장됩니다."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe은 아직 이 Carbon 고객에 대한 고객이 없습니다. 전기하면 연결된 계정에 하나가 생성됩니다."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "칸반 테이블에 표시할 칸반 출력 스타일"
@@ -14311,7 +14311,7 @@ msgid "Sub-Departments"
 msgstr "하위 부서"
 
 msgid "Subassembly"
-msgstr "하위 조립품"
+msgstr "서브어셈블리"
 
 msgid "Subcontracting Variance"
 msgstr "외주 차이"
@@ -14329,7 +14329,7 @@ msgid "Submit anonymously"
 msgstr "익명으로 제출"
 
 msgid "Submit for approval"
-msgstr "승인 요청"
+msgstr "승인을 위해 제출"
 
 msgid "Submit Inspection"
 msgstr "검사 제출"
@@ -14371,10 +14371,10 @@ msgid "Successfully created a new revision"
 msgstr "새 리비전이 생성되었습니다"
 
 msgid "Successor effectivity"
-msgstr "후속 유효성"
+msgstr "후속 품목 유효 시점"
 
 msgid "Successor Effectivity Date"
-msgstr "후속 적용일"
+msgstr "후속 품목 유효 시점"
 
 msgid "Successor Part"
 msgstr "후속 품목"
@@ -14434,7 +14434,7 @@ msgid "Supplier added and selected"
 msgstr "공급업체가 추가되고 선택되었습니다"
 
 msgid "Supplier contact"
-msgstr "공급업체 연락처"
+msgstr "공급업체 담당자"
 
 msgid "Supplier Contact"
 msgstr "공급업체 담당자"
@@ -14449,7 +14449,7 @@ msgid "Supplier interaction"
 msgstr "공급업체 상호작용"
 
 msgid "Supplier Invoice Number"
-msgstr "공급업체 인보이스 번호"
+msgstr "공급업체 송장 번호"
 
 msgid "Supplier location"
 msgstr "공급업체 위치"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "공급업체 부품"
 
 msgid "Supplier Part ID"
-msgstr "공급업체 부품 ID"
+msgstr "공급업체 품번"
 
 msgid "Supplier Part Number"
 msgstr "공급업체 부품 번호"
@@ -14479,22 +14479,22 @@ msgid "Supplier Parts"
 msgstr "공급업체 부품"
 
 msgid "Supplier Payment Discounts"
-msgstr "공급업체 결제 할인"
+msgstr "공급업체 지불 할인"
 
 msgid "Supplier Payment Discounts (default)"
-msgstr "공급업체 결제 할인(기본값)"
+msgstr "공급업체 지불 할인 (기본값)"
 
 msgid "Supplier Prepayments"
-msgstr "공급업체 선금"
+msgstr "공급업체 선급금"
 
 msgid "supplier process"
-msgstr "공급업체 공정"
+msgstr "공급업체 공법"
 
 msgid "supplier processes"
-msgstr "공급업체 공정"
+msgstr "공급업체 공법"
 
 msgid "Supplier Processes"
-msgstr "공급업체 공정"
+msgstr "공급업체 공법"
 
 msgid "Supplier Quality"
 msgstr "공급업체 품질"
@@ -14560,7 +14560,7 @@ msgid "Supply"
 msgstr "공급"
 
 msgid "Supply & Demand"
-msgstr "공급 및 수요"
+msgstr "공급 & 소요량"
 
 msgid "Support"
 msgstr "지원"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "이 허브를 고객에 맞게 조정하세요. 변경 사항은 이를 보는 모든 사람에게 즉시 적용됩니다. 이 화면은 고객에게 표시되지 않습니다."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "이 품목을 만드는 데 사용된 자재 중 가장 짧은 잔여 유통기한을 적용합니다. 제품의 유효기한이 원재료에 좌우될 때 사용하세요."
+msgstr "이 품목을 만드는 데 소모된 자재 중에서 가장 짧은 유통기한을 선택합니다. 제품의 유통기한이 재료에 따라 달라질 때 사용합니다."
 
 msgid "taken"
 msgstr "사용됨"
@@ -14651,7 +14651,7 @@ msgid "Target customers by type."
 msgstr "유형별로 고객을 대상으로 지정합니다."
 
 msgid "Target disposition row"
-msgstr "대상 처리 행"
+msgstr "처분 결정 대상 행"
 
 msgid "Target go-live"
 msgstr "목표 도입일"
@@ -14696,13 +14696,13 @@ msgid "Tax"
 msgstr "세금"
 
 msgid "Tax & Additional Costs"
-msgstr "세금 및 추가 비용"
+msgstr "세금 & 추가 원가"
 
 msgid "Tax & Shipping"
 msgstr "세금 및 배송비"
 
 msgid "Tax Amount"
-msgstr "세액"
+msgstr "세금 금액"
 
 msgid "Tax codes, rates"
 msgstr "세금 코드, 세율"
@@ -14714,10 +14714,10 @@ msgid "Tax Depreciation Method"
 msgstr "세무 감가상각 방법"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "면세"
 
 msgid "Tax Exempt"
-msgstr "세금 면제"
+msgstr "면세"
 
 msgid "Tax ID"
 msgstr "세금 ID"
@@ -14738,19 +14738,19 @@ msgid "Tax percent"
 msgstr "세금 비율"
 
 msgid "Tax Percent"
-msgstr "세율"
+msgstr "세금 비율"
 
 msgid "Tax Residual Value %"
-msgstr "세무 잔존가치 %"
+msgstr "세금 잔존가액 %"
 
 msgid "Tax Useful Life (default)"
-msgstr "세무 내용연수(기본값)"
+msgstr "세금 내용연수 (기본값)"
 
 msgid "Tax Useful Life (months)"
-msgstr "세무 내용연수(개월)"
+msgstr "세금 내용연수 (개월)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "세무 내용연수(개월)"
+msgstr "세금 내용연수 (개월)"
 
 msgid "Tax:"
 msgstr "세금:"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "팀 교육 완료"
 
 msgid "Technical support"
-msgstr ""
+msgstr "기술 지원"
 
 msgid "Temperature"
 msgstr "온도"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "템플릿"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "출하 시 자산의 순장부가액을 차변에 기록하고 청구 시 순장부가액을 대변에 기록하여, 매각 주기 동안 잔액이 0으로 상계되는 일시적 처분정리계정."
+msgstr "자산의 순장부가액 만큼 출하 시에 차변 기입되고 송장 발행 시에 대변 기입되는 임시 처분-결제 계정으로, 판매 사이클 동안 0으로 상쇄됩니다."
 
 msgid "Terms and Privacy"
 msgstr "이용약관 및 개인정보처리방침"
@@ -14823,19 +14823,19 @@ msgid "The accounts Carbon posts to automatically"
 msgstr "Carbon이 자동으로 전기하는 계정"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "저장된 방법(자재, 공정작업, 작업 지시서)을 작업 또는 견적 라인에 복사하는 작업입니다."
+msgstr "저장된 방법(자재, 공정 및 작업 표준서)을 작업 지시 또는 견적 라인에 복사하는 동작입니다."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "목록형 속성에 허용되는 값으로, 사용자는 직접 입력하는 대신 이 중에서 선택합니다."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "이 차원으로 전표를 태그할 때 사용자가 선택할 수 있는 허용 값입니다."
+msgstr "사용자가 이 차원으로 전기를 태그할 때 선택할 수 있는 허용된 값입니다."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "계산 방법 기준일로부터 현금 할인이 적용되는 일수"
+msgstr "계산 방법 이후 현금 할인을 사용할 수 있는 일수"
 
 msgid "The amount of days after the calculation method that the payment is due"
-msgstr "계산 방법 기준일로부터 결제 기한까지의 일수"
+msgstr "계산 방법 이후 지불이 만기되는 일수"
 
 msgid "The append-only record of every stock movement; on-hand is the sum of its signed entries and the source of truth."
 msgstr "모든 재고 이동을 추가 전용으로 기록한 원장으로, 보유 수량은 부호가 있는 항목들의 합이며 최종 근거 데이터입니다."
@@ -14844,16 +14844,16 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "Onshape에서 인증이 거부되었습니다. 다시 연결해 보세요."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "전기된 모든 분개 라인을 계정별로 합산한 장부로, 회사에서 회계 기능이 활성화된 경우에만 기록됩니다."
+msgstr "모든 전기된 전표 라인의 기록으로 계정별로 집계되며 회사의 회계가 활성화되었을 때만 작성됩니다."
 
 msgid "The buckets you track costs against"
-msgstr "비용을 추적하는 기준이 되는 버킷"
+msgstr "원가를 추적하는 버킷"
 
 msgid "The capital assets you own and depreciate"
 msgstr "소유하고 감가상각하는 고정자산"
 
 msgid "The Carbon user currently responsible for working this record, set per record and independent of ownership fields like Account Manager or Sales Person."
-msgstr "이 기록을 작업하는 데 현재 책임이 있는 Carbon 사용자로, 기록마다 설정되며 계정 관리자 또는 판매 담당자와 같은 소유권 필드와는 독립적입니다."
+msgstr "현재 이 레코드 작업을 담당하는 Carbon 사용자로, 레코드별로 설정되며 영업담당자 또는 판매담당자 같은 소유권 필드와 무관합니다."
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
 msgstr "이 고객 관계를 담당하는 Carbon 사용자로, 이 고객과 관련된 이메일과 알림이 이 사용자에게 전달됩니다."
@@ -14865,7 +14865,7 @@ msgid "The Carbon user who owns this RFQ; supplier responses and reminders route
 msgstr "이 RFQ를 담당하는 Carbon 사용자로, 공급업체 응답과 알림이 이 사용자에게 전달됩니다."
 
 msgid "The carrier and service a shipment goes out on, supplying the tracking-URL template that turns a tracking number into a link and the account freight charges post to."
-msgstr "배송이 나가는 운송업체 및 서비스로, 추적 번호를 링크로 변환하는 추적 URL 템플릿을 제공하고 계정 배송료가 게시됩니다."
+msgstr "출하가 진행되는 운송업체 및 서비스로, 추적 번호를 링크로 변환하는 추적 URL 템플릿과 계정 운임 요금이 전기되는 기준을 제공합니다."
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
 msgstr "이 공급업체와 별도로 재화를 배송하는 운송업체입니다(예: 공급업체는 판매만 하고 FedEx가 배송하는 경우)."
@@ -14913,7 +14913,7 @@ msgid "The code printed on the kanban card that operators scan to mark the job c
 msgstr "칸반 카드에 인쇄되는 코드로, 작업자가 스캔하여 작업 완료를 표시합니다. 비워두면 자동으로 생성됩니다."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "계약직의 주간 예상 가용 시간으로, 한 주 동안 이 계약직을 공정작업에 배정할 때 스케줄링에서 상한선으로 사용됩니다."
+msgstr "외주 인력의 예상 주간 가용성으로, 스케줄링이 이를 주 전체에서 공정에 외주 인력을 할당할 때의 상한으로 사용합니다."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "이 로트/일련번호의 수정된 유효기한으로, 변경 후 기존 보유 재고가 유통기한 정책에 따라 재평가됩니다."
@@ -14925,7 +14925,7 @@ msgid "The customer record this portal account links to; only contacts already o
 msgstr "이 포털 계정이 연결된 고객 레코드로, 아래에서 계정 소유자로 선택할 수 있는 대상은 해당 고객에 이미 등록된 담당자로 한정됩니다."
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "청구 대상 고객과 다를 경우, 재화가 실제로 배송되는 고객입니다(예: 본사에 청구하고 지점으로 배송하는 경우)."
+msgstr "청구 대상 고객과 다를 때 상품이 배송되는 고객입니다(예: 본사에 청구, 지점으로 배송)."
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
 msgstr "이 포털 링크가 발급된 대상 고객으로, 해당 고객의 담당자만 이 링크로 로그인할 수 있습니다."
@@ -14952,16 +14952,16 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "이 자산의 감가상각이 시작되는 날짜로, 일반적으로 사용 개시일입니다."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "이 날짜 이후에는 견적 가격이 더 이상 유효하지 않습니다. 이 날짜 이후 주문으로 전환하려면 재견적이 필요할 수 있습니다."
+msgstr "이 견적서의 가격이 더 이상 유효하지 않은 날짜로, 이 날짜 이후에 주문으로 변환할 때는 재견적이 필요할 수 있습니다."
 
 msgid "The date the customer expects to receive the goods"
-msgstr "고객이 재화를 수령할 것으로 예상되는 날짜"
+msgstr "고객이 상품 수령을 예상하는 날짜"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "재화가 실제로 창고를 떠나는 날짜로, 출하 전표에 기록되며 정시 출하율 산정에 사용됩니다."
+msgstr "상품이 실제로 창고를 떠나는 날짜로, 출하 전기에 기록되고 시간 내 배송 점수에 사용됩니다."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "해당 기간의 예상 수요를 충족하기 위해 품목이 현장에 필요한 날짜입니다."
+msgstr "기간의 예상 소요량을 충당하기 위해 현장에서 품목이 필요한 날짜"
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
 msgstr "이 자산이 사용 중단되는 날짜로, 이 날짜에 감가상각이 중단되고 남은 순장부가액이 처분 계정에 계상됩니다."
@@ -14979,7 +14979,7 @@ msgid "The deadline to send your quote to the customer."
 msgstr "고객에게 견적을 보내야 하는 마감일입니다."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "추적 개체를 제공할 때 피킹이 기본적으로 사용하는 순서입니다: FEFO(유효기한이 가장 빠른 것 우선), FIFO(가장 오래된 것 우선), LIFO(가장 최근 것 우선)."
+msgstr "피킹이 추적된 항목을 제공할 때 사용하는 기본 순서입니다: FEFO(가장 빨리 만료되는 것 우선), FIFO(선입선출), 또는 LIFO(최신 우선)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "이 품목을 생산할 때의 기본 생산 수량으로, 계획 시 보충량을 이 배수로 올림 처리합니다."
@@ -14994,10 +14994,10 @@ msgid "The eight-disciplines quality method, modeled with the nonconformance wor
 msgstr "8D 품질 기법으로, 하드코딩되지 않고 부적합 워크플로의 작업으로 모델링됩니다."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "이 원가센터를 책임지는 직원입니다 — 구매주문 승인이 활성화된 경우, 이 원가센터에 계상되는 지출의 승인자가 됩니다."
+msgstr "이 원가 센터를 담당하는 직원으로, 발주서 승인이 켜져 있을 때는 이에 대해 전기된 지출의 승인자입니다."
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "고객 견적부터 대금 회수까지 이어지는 전체 상거래 흐름입니다: RFQ → 견적 → 판매주문, 이후 출하, 인보이스, 결제 완료 순으로 진행됩니다."
+msgstr "고객에게 견적을 제시하고 지불을 수령하는 데까지의 전체 상거래 흐름입니다: 견적 요청에서 견적서로, 수주로 진행되고, 출하, 송장, 그리고 결제됩니다."
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "테이블이 업데이트될 때 변경된 데이터를 담은 POST 요청을 수신하는 엔드포인트"
@@ -15006,7 +15006,7 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "이 검사 계획이 연결된 엔지니어링 드로잉입니다. 이 부품에 대해 기록된 검사는 이 드로잉을 참조합니다."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "생산 중 손실될 것으로 예상되는 이 품목 산출물의 비율입니다. 계획은 이를 보정하기 위해 수요에 1 / (1 − 스크랩율)을 곱합니다."
+msgstr "생산 중 이 품목의 출력량 손실의 예상 비율로, 계획에서는 이를 보상하기 위해 소요량에 1 / (1 - 스크랩)을 곱합니다."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "이 간접비 지출 라인이 계상되는 비용 계정입니다. 간접비 라인은 계정을 도출할 품목 원장 항목이 없으므로 필수입니다."
@@ -15024,13 +15024,13 @@ msgid "The fixed-asset record this sale disposes; the line's shipment posts the 
 msgstr "이 판매로 처분되는 고정자산 레코드입니다. 이 라인의 출하는 매출원가(COGS) 대신 자산의 순장부가액 처분 항목을 계상합니다."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "자산이 감가상각되는 하한선입니다. 순장부가액이 이 값에 도달하면 자산은 완전상각 상태로 전환됩니다."
+msgstr "자산이 감가상각되는 최저선으로, 순장부가액이 이에 도달하면 자산은 상각 완료로 전환됩니다."
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "현장과 사무실이 동일한 재고 및 원가 수치를 확인합니다."
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "다음 조립품에는 공정작업이 없습니다. 릴리즈하기 전에 각 조립품에 공정작업을 지정하세요."
+msgstr "다음 조립품에는 공정이 없습니다. 릴리스하기 전에 각 조립품에 공정을 할당해주세요."
 
 msgid "The following line items are missing prices or lead times:"
 msgstr "다음 라인 항목에 가격 또는 리드타임이 누락되었습니다:"
@@ -15045,7 +15045,7 @@ msgid "The fraction of each lot to inspect; the actual count is computed from lo
 msgstr "각 로트에서 검사할 비율입니다. 실제 검사 수량은 검사 시점의 로트 크기를 기준으로 계산됩니다."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "구매주문 가격과 공급업체 청구 금액의 차이로, 인보이스가 전기될 때 차이 계정에 계상됩니다."
+msgstr "구매 발주서의 가격과 공급업체 청구서 간의 차이로, 송장이 전기될 때 차이 계정에 전기됩니다."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "이 운송업체 관련 비용이 계상되는 총계정원장 계정입니다(운임 비용, 입고/출고 운임)."
@@ -15060,10 +15060,10 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "이 계정이 합산되는 그룹 계정으로, 유형·분류·재무제표 표시 위치를 결정합니다."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "이 작업장에서 작업자 인력의 시간당 비용입니다. 기록된 노무 시간과 결합되어 작업의 재공품(WIP)에 노무비를 반영합니다."
+msgstr "이 작업장에서 작업자 노무의 시간당 원가이며, 기록된 노무 시간과 합산하여 작업 지시의 재공품에 노무 원가를 부과합니다."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "이 작업장에서 기계를 가동하는 시간당 비용입니다. 기록된 기계 시간과 결합되어 작업의 재공품(WIP)에 기계비를 반영합니다."
+msgstr "이 작업장에서 기계 운영의 시간당 원가이며, 기록된 기계 시간과 합산하여 작업 지시의 재공품에 기계 원가를 부과합니다."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
 msgstr "이 작업장에 적용되는 시간당 간접비 부담률입니다. 노무비+기계비와 전체 견적 요율의 차이를 간접비가 흡수합니다."
@@ -15072,13 +15072,13 @@ msgid "The https address a workflow's webhook step posts to — plain http, redi
 msgstr "워크플로우의 웹훅 단계가 게시하는 https 주소입니다. 평문 http, 리다이렉트 및 프라이빗 또는 링크-로컬 주소로 확인되는 호스트는 거부되며, 호출은 10초 후 포기합니다."
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "순서에서 생성되고 기록에 저장되는 사람이 읽을 수 있는 문서 번호(J000001 또는 ECO-000001 같은)로, 내부 ID와는 구별됨."
+msgstr "채번 규칙에서 발행되고 레코드에 저장된 사람이 읽을 수 있는 문서 번호(예: J000001 또는 ECO-000001)로, 내부 ID와 구별됩니다."
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "고객이 자사 PO에서 이 품목에 사용하는 식별자입니다. Carbon은 주문을 가져올 때 이를 내부 품목 ID로 변환합니다."
+msgstr "고객이 발주서에서 이 부품에 사용하는 식별자이며, Carbon은 주문 가져오기 시 이를 내부 부품 ID로 확인합니다."
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
-msgstr "공급업체가 자사 견적 및 인보이스에서 이 품목에 사용하는 식별자입니다. Carbon은 이를 내부 품목 ID로 변환합니다."
+msgstr "공급업체가 견적서와 송장에서 이 부품에 사용하는 식별자이며, Carbon은 이를 내부 부품 ID로 확인합니다."
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
 msgstr "근본 원인이 파악되기 전에 영향을 받은 재고나 작업을 격리하는 즉각적인 부적합 조치입니다."
@@ -15087,13 +15087,13 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "리스크가 발생했을 때의 영향도 등급(1=경미함 ~ 5=치명적)입니다. 발생 가능성과 결합하여 리스크 점수를 계산합니다."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "재화를 재고로 입고시키는(PO, 이동, 작업 산출물로부터) 입고 전표로, 필요한 추적 개체를 생성합니다."
+msgstr "발주서, 이송 또는 작업 지시 산출로부터 재고에 들어오는 물품을 기록하고 추적 대상 개체를 생성하는 입고 전기 문서입니다."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "이 공급업체로부터의 출하에서 운임 부담자, 위험 부담자, 소유권 이전 시점을 정하는 인코텀즈(Incoterm) 규칙(FOB, DAP, EXW, CIF 등)입니다."
+msgstr "이 공급업체에서의 출하에서 운송료를 누가 지불하고, 누가 위험을 부담하며, 소유권 이전이 어디서 발생하는지를 규정하는 인코텀즈 규칙(FOB, DAP, EXW, CIF 등)입니다."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "이 고객에게 발송되는 출하에서 운임 부담자, 위험 부담자, 소유권 이전 시점을 정하는 인코텀즈(Incoterm) 규칙(FOB, DAP, EXW, CIF 등)입니다."
+msgstr "이 고객으로의 출하에서 운송료를 누가 지불하고, 누가 위험을 부담하며, 소유권 이전이 어디서 발생하는지를 규정하는 인코텀즈 규칙(FOB, DAP, EXW, CIF 등)입니다."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
 msgstr "출하가 전기될 때 인식되는 재고 원가로, 품목의 원가 계산 방법에 따라 평가됩니다."
@@ -15105,16 +15105,16 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "이 외주 라인이 처리하는 공정작업이 속한 작업입니다. 이 라인의 입고는 해당 작업의 공정작업을 마감합니다."
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "작업의 위치 스케줄 대기열에서의 위치입니다 — Carbon이 납기일과 납기 유형에서 계산한 소수점 수이며, 낮음/높음 등급이 아닙니다."
+msgstr "작업 지시가 해당 사업장의 일정 대기열에서의 위치로, Carbon이 마감일과 마감일 유형으로부터 계산한 소수점 이하 숫자이며, 낮음/높음 등급이 아닙니다."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
 msgstr "이 규칙이 적용하는 조정 유형입니다 — 할인, 추가요금, 또는 고정 재정의 — 금액 유형과 결합되어 각 라인의 실제 증감액을 계산합니다."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "이 속성이 허용하는 값의 종류(텍스트, 숫자, 날짜, 불리언, 목록)입니다. 속성에 기록된 값이 하나라도 있으면 잠깁니다."
+msgstr "이 속성이 허용하는 값의 종류(텍스트, 숫자, 날짜, 부울값, 목록)이며, 속성에 기록된 값이 있은 후에는 잠겨 있습니다."
 
 msgid "The label and document printers your company prints to"
-msgstr "귀사가 사용하는 라벨 및 문서 프린터"
+msgstr "회사가 인쇄하는 라벨 및 문서 프린터"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
 msgstr "공급업체의 리드타임을 고려할 때, 필요일까지 도착하도록 이 PO를 발주해야 하는 최종 일자입니다."
@@ -15132,13 +15132,13 @@ msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.
 msgstr "이 고객의 생애주기 상태입니다 — 활성, 잠재고객, 비활성 등. 판매주문 선택 목록에는 활성 고객만 표시됩니다."
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "이 공급업체의 생애주기 상태입니다 — 활성, 비활성, 승인 대기 등. PO/견적 선택 목록에는 활성 공급업체만 표시됩니다."
+msgstr "이 공급업체의 생명주기 상태(활성, 비활성, 승인 대기 중 등)이며, 활성 공급업체만 발주서/견적서 선택기에 표시됩니다."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "이 위치가 시간을 기록하는 현지 시간대입니다. 사용자 브라우저의 로캘과 관계없이, 이 위치의 일정·근무기록·교대 시간은 이 시간대를 기준으로 해석됩니다."
+msgstr "이 사업장이 시간을 보고하는 로컬 시간대로, 사용자의 브라우저 로케일에 관계없이 이 사업장의 일정, 타임카드 및 교대조 시간이 이 시간대로 해석됩니다."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "이 직원의 기본 위치입니다. 근무기록의 시간대 해석과 인사 기록의 기본 교대 선택 목록에 영향을 줍니다."
+msgstr "이 직원의 기본 사업장으로, 타임카드의 시간대 해석 및 작업 지시 레코드의 기본 교대조 선택기를 결정합니다."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
 msgstr "이 주문을 처리할 위치입니다. 라인별 위치가 설정되면 이를 재정의합니다."
@@ -15150,7 +15150,7 @@ msgid "The location this RFQ would fulfill from if it converts to a quote and th
 msgstr "이 RFQ가 견적을 거쳐 주문으로 전환될 경우 처리할 위치입니다."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "모든 엔티티에 대해 제기된 위험 및 기회의 로그로, 각각 독립적인 1~5 심각도 및 가능성으로 평가되고 해결로 이끌어짐."
+msgstr "모든 개체에 대해 발생한 리스크 및 기회의 로그로, 각각 독립적인 1~5 심각도 및 발생 가능성으로 평가되고 해결에 이릅니다."
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "인쇄물 및 이메일 문서에 표시되는 로고"
@@ -15159,7 +15159,7 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "이 재고의 로트 식별자입니다. 배치당 한 행이며, 수량은 해당 로트의 보유 수량입니다."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "로트가 합격으로 표시됩니다. 기록을 위해 샘플링 불합격 {fails}건이 기록됩니다."
+msgstr "로트는 통과로 표시됩니다. {fails}개의 샘플 불합격 항목이 기록을 위해 기록됩니다."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "로트는 그대로 반려되지만, 이슈 유형이 하나 이상 설정되기 전까지는 NCR을 생성할 수 없습니다."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "로트의 특성별 샘플링 계획이 선택된 문서에서 다시 결정됩니다."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "수량과 관계없이 이 공급업체가 이 공정에 청구하는 최소 금액입니다. 손익분기 수량 미만인 작업도 최소한 이 금액만큼 비용이 발생합니다."
+msgstr "이 공급업체가 수량에 관계없이 이 공법에 대해 부과할 최소 금액으로, 손익분기점 이하의 작업 지시는 최소한 이 정도의 비용이 듭니다."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "작업이 거쳐가는 기계, 셀, 스테이션"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "귀사 회계연도가 시작되는 월입니다. 기간은 이 월부터 번호가 매겨집니다."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "귀사 세무연도가 시작되는 월입니다. 일부 관할구역에서는 회계연도와 다를 수 있습니다."
+msgstr "세금 연도가 시작하는 달로, 일부 관할권에서는 회계연도와 다를 수 있습니다."
 
 msgid "The monthly periods you post into and close"
 msgstr "게시하고 종료하는 월별 기간"
@@ -15204,19 +15204,19 @@ msgid "The new version number of the method"
 msgstr "방법의 새 버전 번호"
 
 msgid "The new version number of the procedure"
-msgstr "절차의 새 버전 번호"
+msgstr "절차서의 새로운 버전 번호"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "선호 공급업체에 PO를 발주한 시점부터 재화가 입고장에 도착하기까지의 일수입니다. 계획은 이 기간만큼 수요를 앞당겨 계산합니다."
+msgstr "우선 공급업체에 발주서를 발주한 후부터 물품이 도착할 때까지의 일수로, 계획이 수요를 이만큼 뒤로 오프셋합니다."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "이 품목 한 배치를 제작하는 데 걸리는 일수로, 작업 릴리즈부터 완료까지 측정됩니다. 계획은 이 기간만큼 수요를 앞당겨 계산합니다."
+msgstr "작업 지시 릴리스부터 완료까지 측정한 이 품목의 한 배치를 구축하는 일수로, 계획이 수요를 이만큼 뒤로 오프셋합니다."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
 msgstr "예상 스크랩을 보정하기 위해 추가로 제작할 유닛 수입니다. 계획은 자재를 예약할 때 이를 주문 수량에 더합니다."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "계약직이 주당 근무 가능한 시간 수입니다."
+msgstr "외주 인력이 일할 수 있는 주당 시간 수"
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "이 자산이 감가상각되는 개월 수입니다."
@@ -15225,22 +15225,22 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "수량 기반 정책에서 새 보충 주문을 발생시키는 보유 재고 수준입니다."
 
 msgid "The operations and steps your parts move through"
-msgstr "품목이 거쳐가는 공정작업과 단계"
+msgstr "부품이 이동하는 공정 및 단계"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
 msgstr "이 워크플로를 사용하는 이슈가 완료해야 하는 작업의 순서 목록입니다. 여기서의 순서가 이슈에 표시되는 순서입니다."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "작업이 거쳐가는 공정작업의 순서로, 방법의 공정(BOP)에서 복사됩니다."
+msgstr "작업 지시가 실행하는 공정의 순서대로, 방법의 공정 목록에서 복사됩니다."
 
 msgid "The original model file is no longer available"
-msgstr "원본 모델 파일을 더 이상 사용할 수 없습니다"
+msgstr "원본 모델 파일을 더 이상 사용할 수 없습니다."
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "재화를 재고에서 고객에게 출고시키는 출고 전표로, 진행되면서 매출원가(COGS)를 계상합니다."
+msgstr "재고에서 물품을 고객으로 빼내고 COGS를 전기하는 출고 전기 문서입니다."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "이 공정을 수행하는 외주 공급업체입니다. 각 업체는 공급업체 공정 양식에서 가격 및 리드타임 입력 행을 갖습니다."
+msgstr "이 공법을 수행하는 외부 공급업체로, 각각은 공급업체 공법 형식에서 가격 책정 및 리드타임 입력의 행을 받습니다."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "추적 개체의 상하위 연결 관계로, 해당 유닛이 무엇으로부터 만들어졌고 무엇이 되었는지를 나타냅니다."
@@ -15249,19 +15249,19 @@ msgid "The part is manufactured as its own job when the parent that needs it is 
 msgstr "상위 품목이 제작될 때 이 품목은 별도의 작업으로 제조됩니다."
 
 msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
-msgstr "상위 품목이 제작될 때 이 품목은 기존 재고에서 가져옵니다 — 새 작업이나 구매주문이 생성되지 않습니다."
+msgstr "부품은 상위 부품이 구축될 때 기존 재고에서 가져오므로, 새로운 작업 지시 또는 발주서가 없습니다."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "귀사의 도입을 진행할 Carbon 측 담당자와 연락 방법입니다."
+msgstr "실행을 진행할 Carbon 측의 담당자 및 연락 방법"
 
 msgid "The people on your team and their access to Carbon"
-msgstr "팀 구성원과 Carbon 접근 권한"
+msgstr "팀의 인원 및 Carbon에 대한 액세스 권한"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
 msgstr "문서 유형의 식별 번호를 생성하는 회사별 카운터로, 접두사, 0으로 채워진 다음 번호, 그리고 접미사를 결합하여 번호를 만들고, 각 문서가 생성될 때마다 증가합니다."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "부적합에 영향을 받은 자재에 기록되는 항목별 결과 — 대기 중, 공급자에게 반환, 재작업, 폐기 또는 있는 그대로 사용 — 각 영향을 받은 로트 또는 시리얼에 대해 개별적으로 결정됨."
+msgstr "각 영향을 받은 로트 또는 일련번호마다 독립적으로 결정되는, 부적합의 영향을 받은 자재에 기록된 항목별 결과(대기 중, 공급업체 반품, 재작업, 스크랩 또는 현상대로 사용)입니다."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
 msgstr "현금 할인 비율입니다. 할인이 없으면 0을 사용하세요."
@@ -15282,16 +15282,16 @@ msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certa
 msgstr "리스크가 발생할 확률 등급(1=드묾 ~ 5=거의 확실함)입니다. 심각도와 결합하여 리스크 점수를 계산합니다."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "이 유지보수를 수행할 때 기술자가 따르는 절차입니다. 일정이 이미 생성된 후에 교체하면 이후 발생 건에만 영향을 줍니다."
+msgstr "이 유지보수가 수행될 때 기술자가 따르는 절차서로, 일정이 이미 생성된 후 이를 교체하면 향후 인스턴스에만 영향을 미칩니다."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "이 작업장에서 수행할 수 있는 공정입니다. 공정작업을 예약할 때 공정 선택 목록에 표시되며, 이 작업장을 경유할 수 있는 작업을 제한합니다."
+msgstr "이 작업장이 실행할 수 있는 공법으로, 공정 일정 시 공법 선택기에 표시되며, 이 작업장을 통해 라우팅할 수 있는 작업 지시를 제한합니다."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "제공자가 차원 대상을 제공하지 않습니다. 먼저 제공자에서 기능을 활성화하세요(예: 추적 카테고리, 클래스 추적 또는 필드)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "이 라인의 가격이 책정되는 수량 구간입니다. 각 열은 구매자-공급업체 협상 및 후속 문서 전환을 위한 자체 단가를 갖습니다."
+msgstr "이 라인의 가격 책정이 적용되는 수량 구간으로, 각 열은 구매자-공급업체 협상 및 하위 문서로의 변환을 위한 고유한 단가를 포함합니다."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "스캔 기반 보충 시 재주문할 품목 수량입니다."
@@ -15309,7 +15309,7 @@ msgid "The raw stock and material master you buy and consume"
 msgstr "구매하고 소비하는 원자재 재고 및 자재 마스터"
 
 msgid "The reasons you record when parts get scrapped"
-msgstr "품목이 스크랩될 때 기록하는 사유"
+msgstr "부품이 스크랩될 때 기록하는 사유"
 
 msgid "The reasons you record when you decline an RFQ"
 msgstr "RFQ를 거절할 때 기록하는 사유"
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "워크플로우 알림이 가리키는 기록이며, id와 종류로 이름이 지어집니다. 비워두면 알림이 워크플로우 실행 자체에 연결됩니다."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "청구서에 지불 또는 메모를 적용하는 기록으로, 적용, 할인 및 상각 금액을 포함함."
+msgstr "송장에 지불 또는 메모를 적용하는 레코드로, 적용, 할인 및 대손 처리 금액을 포함합니다."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "추적 개체의 기록된 계보입니다 — 입고부터 출하까지, 어떤 투입물이 소비되어 어떤 산출물을 만들었는지를 나타냅니다."
@@ -15334,7 +15334,7 @@ msgstr "{0} {1}의 남은 수량이 다시 예상되고 수입 공급으로 계�
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "{0} {1}의 남은 수량은 더 이상 예상되지 않습니다. 주문 공급 및 MRP 계산이 중단됩니다. 주문 수량 및 가격은 변경되지 않습니다."
+msgstr "남은 {0}개의 {1}은 더 이상 예상되지 않습니다. 발주 공급 및 MRP가 이를 계산하지 않습니다. 발주 수량 및 가격 책정은 변경되지 않습니다."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "워크플로우 변수가 대체된 후 JSON 콘텐츠 유형으로 그대로 전송되는 요청 본문입니다(적용되는 메서드에서)."
@@ -15352,7 +15352,7 @@ msgid "The revision number of the part"
 msgstr "품목의 리비전 번호"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "이 작업이 공급하기 위해 생성된 판매 주문 라인이며, 작업을 그 뒤의 고객 수요에 연결합니다."
+msgstr "이 작업 지시를 공급하기 위해 생성된 수주 라인으로, 작업 지시를 뒤의 고객 소요량과 연결합니다."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
 msgstr "이 자산의 원가를 내용연수에 걸쳐 배분하는 데 사용되는 상각 스케줄입니다(정액법, 정률법, 생산량비례법)."
@@ -15370,10 +15370,10 @@ msgid "The size of the part"
 msgstr "품목의 크기"
 
 msgid "The skills and abilities you track for your people"
-msgstr "구성원에 대해 추적하는 기술과 역량"
+msgstr "인원에 대해 추적하는 기술 및 역량"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "이 공급업체가 이 품목의 PO 라인에서 허용하는 최소 수량입니다. 계획은 이 값으로 올림합니다."
+msgstr "이 부품에 대해 이 공급업체가 발주서 라인에서 수락할 수 있는 최소 수량입니다. 계획에서는 이 값으로 올림합니다."
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
 msgstr "이 포털 계정을 소유할, 선택한 고객의 특정 담당자입니다. 이 담당자의 이메일이 로그인 식별자가 됩니다."
@@ -15385,13 +15385,13 @@ msgid "The specific operation on the job above that this PO line is purchasing; 
 msgstr "이 PO 라인이 구매하는, 위 작업의 특정 공정작업입니다. 외주 처리로 표시된 공정작업만 선택할 수 있습니다."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "이 입고가 계상되는 특정 PO, 반품, 또는 이동입니다. 선택 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
+msgstr "이 입고가 전기되는 특정 발주서, 반품 또는 이송입니다. 사용 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "이 출하가 계상되는 특정 SO, 이동, 또는 RMA입니다. 선택 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
+msgstr "이 출하가 전기되는 특정 수주, 이송 또는 RMA입니다. 사용 가능한 ID는 위의 원본 문서 유형에 따라 달라집니다."
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "자재가 재고로 보관되는 표준 치수"
+msgstr "자재가 보관되는 표준 치수"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
 msgstr "이 작업장의 공정작업이 기본적으로 측정되는 표준 단위(시간, 분, 개수)입니다. 공정작업별 재정의가 설정되면 그것이 우선합니다."
@@ -15400,7 +15400,7 @@ msgid "The standard factor used to measure this process — hours, minutes, piec
 msgstr "이 공정을 측정하는 데 사용되는 표준 단위(시간, 분, 개수, 제곱피트)로, 공정작업의 견적 및 원가 산정에 사용됩니다."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "이 견적 라인의 상태입니다 — 초안, 견적 불가, 완료. 견적 불가를 선택하면 사유 필드가 나타나고 해당 라인은 견적 합계에서 제외됩니다."
+msgstr "이 견적 라인의 상태 — 초안, 견적 거절, 완료됨. 견적 거절은 사유 필드를 표시하고 라인을 견적 합계에서 제외합니다."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "이 그룹에 속한 모든 계정이 사용할 재무제표 구분입니다."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "단계의 설정입니다 — 이 실행은 사용한 값을 기록하기 전의 것입니다."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "이 자재가 구매되고 보관되는 재고 사이즈입니다. 각 사이즈는 작업 및 PO에서 선택 가능한 별도의 변형이 됩니다."
+msgstr "이 자재를 구매하고 보관하는 재고 크기입니다. 각 크기는 작업 지시 및 발주서에서 별도의 선택 가능한 변형이 됩니다."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "이 라인이 피킹하는 저장 빈입니다. 비워두면 품목의 기본 저장 단위에서 피킹합니다."
+msgstr "이 라인이 피킹하는 보관 빈입니다. 공백이면 피킹은 품목의 기본 보관 단위를 사용합니다."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "저장소 서비스가 제시간에 응답하지 않았습니다. 다시 시도해 주세요."
@@ -15421,13 +15421,13 @@ msgid "The substances your materials are made of"
 msgstr "자재를 구성하는 재질"
 
 msgid "The supplier planning suggests first when this item needs to be bought; other suppliers stay available in the dropdown on each PO line."
-msgstr "이 품목을 구매해야 할 때 계획에서 우선 제안하는 공급업체입니다. 다른 공급업체도 각 PO 라인의 드롭다운에서 계속 선택할 수 있습니다."
+msgstr "이 품목을 구매해야 할 때 계획이 먼저 제안하는 공급업체입니다. 다른 공급업체는 각 발주서 라인의 드롭다운에서 사용 가능하게 유지됩니다."
 
 msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
 msgstr "이 포털 계정이 연결되는 공급업체 레코드입니다. 아래에서 계정 소유자로 선택할 수 있는 것은 해당 공급업체에 이미 등록된 담당자뿐입니다."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "공급업체 자체의 견적/제안 번호입니다. 이 견적에서 전환된 PO에 이력추적을 위해 기록됩니다."
+msgstr "공급업체의 자체 견적서 / 제안 번호입니다. 이 견적서에서 변환되는 발주서에 대한 추적성을 위해 기록됩니다."
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "이 주문에 대한 공급업체 자체 참조번호(자사 시스템의 SO 번호)입니다. 감사를 위해 기록되며 입고 시 표시됩니다."
@@ -15439,16 +15439,16 @@ msgid "The suppliers and vendors you buy from"
 msgstr "구매처인 공급업체 및 벤더"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "이 RFQ를 수신하는 공급업체입니다. 각 업체는 RFQ에서 자체 라인을 받아 자사 가격으로 응답합니다."
+msgstr "이 견적 요청을 받는 공급업체입니다. 각 공급업체는 자신의 가격 책정으로 응답하는 견적 요청의 자체 라인을 받습니다."
 
 msgid "The surface finishes available on your materials"
-msgstr "자재에 적용 가능한 표면처리"
+msgstr "자재에서 사용 가능한 표면 마감"
 
 msgid "The system passes every in-scope acceptance test in your configured system, with your data; the data is validated; and you sign off. Then go-live."
 msgstr "설정된 시스템에서 귀사 데이터로 범위 내 모든 인수 테스트를 통과하고, 데이터가 검증되며, 귀사가 최종 승인합니다. 그다음 실제 가동을 시작합니다."
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "판매 RFQ, 해당 견적, 결과로 나온 판매주문을 연결하는 스레드입니다 — 자체 상태를 가진 문서가 아니라 연결 고리입니다."
+msgstr "영업 견적 요청, 그 견적서, 그리고 결과 수주를 연결하는 스레드입니다. 자체 상태가 있는 문서가 아니라 조인입니다."
 
 msgid "The timer starts automatically"
 msgstr "타이머가 자동으로 시작됨"
@@ -15457,28 +15457,28 @@ msgid "The timer starts manually"
 msgstr "타이머가 수동으로 시작됨"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "공정작업에 사용되는 공구 및 고정구"
+msgstr "공정이 의존하는 공구 및 지그"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "이 일괄 배치에서 생성되는 모든 작업에 걸쳐 제작할 총수량입니다. 작업당 수량과 결합되어 생성할 작업 수를 결정합니다."
+msgstr "이 대량 배치에서 생성된 모든 작업 지시에서 만들 총계입니다. 작업 지시당 수량과 결합하여 만들 작업 지시의 수를 결정합니다."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "교정 값을 비교한 대상이 되는 추적 가능한 기준(예: NIST 표준, 마스터 측정기 일련번호)입니다."
+msgstr "교정 값이 비교된 추적 가능한 참조(예: NIST 표준, 표준기 일련번호)"
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "일지는 자재 명세서의 각 항목과 수량을 나열합니다."
+msgstr "작업 이동표는 자재 명세서의 각 품목을 수량과 함께 나열합니다."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "이 유형은 신규 직원이 받는 기본 권한을 결정합니다. 여기서 선택하면 해당 유형의 템플릿으로 권한 매트릭스가 미리 채워집니다."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "이 공정을 위해 이 공급업체에 작업을 보낸 후 돌려받기까지 걸리는 일반적인 일수입니다. 공급업체를 선택할 때 계획은 이 기간만큼 수요를 조정합니다."
+msgstr "이 공법을 위해 이 공급업체에 작업을 보내고 돌려받는 사이의 일반적인 일수입니다. 계획은 공급업체를 선택할 때 소요량을 이만큼 오프셋합니다."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "이 실물 유닛의 고유 식별자입니다. 일련번호당 한 행이며, 수량은 항상 1입니다."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "공정 시간이 표현되는 단위(예: 시간/개 또는 총 시간)로, 시간이 수량에 비례하는지 실행당 고정인지를 Carbon에 알려줍니다."
+msgstr "라우팅 시간이 표현되는 단위(예: 시간/개 또는 총 시간)로, 시간이 수량에 따라 변하는지 또는 실행당 고정인지를 Carbon에 알려줍니다."
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "구매 시점의 품목 단가"
@@ -15493,7 +15493,7 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "구매, 재고, 판매 시 사용하는 측정 단위"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "IRS 자산 분류표를 사용하는 미국 세무 감가상각 제도로, 장부 상각 스케줄과 별도로 세무 스케줄로 운영됩니다."
+msgstr "미국 세금 감가상각 시스템으로, IRS 자산 클래스 테이블과 함께 별도의 세금 스케줄로 실행됩니다."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "이 그룹에 속한 사용자입니다. 그룹 범위의 권한과 알림이 각 구성원에게 적용되며, 사용자는 여러 그룹에 속할 수 있습니다(유효 권한은 합집합입니다)."
@@ -15502,13 +15502,13 @@ msgid "The version of the new document"
 msgstr "새 문서의 버전"
 
 msgid "The version of the new procedure"
-msgstr "새 절차의 버전"
+msgstr "새 절차서의 버전"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
 msgstr "이 문서의 버전 표시입니다. 새 버전은 이전 버전을 삭제하지 않고 대체하는 사본을 생성합니다."
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "이 절차의 버전 표시입니다. 새 버전은 이전 버전을 삭제하지 않고 대체하는 사본을 생성합니다."
+msgstr "이 절차서의 버전 스탬프입니다. 새 버전은 이전 버전을 삭제하지 않고 대체하는 사본을 생성합니다."
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
 msgstr "이 주문의 재화가 출하될 창고입니다. 고객의 배송지는 재화가 도착할 위치입니다."
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "이 견적의 재화가 출하될 창고입니다. 고객의 배송지는 재화가 도착할 위치입니다."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "유지보수 및 품질 추적을 위한 설비 고장 방식"
+msgstr "설비 실패 방식으로, 유지보수 및 품질 추적을 위해 사용됩니다."
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "생산이 인출하기 위해 픽킹된 자재가 준비되는 작업 센터 자체의 빈으로, 창고 소스 선반과는 다름."
+msgstr "작업장의 자체 빈으로, 피킹된 자재가 생산이 사용할 수 있도록 준비되는 곳이며, 창고 원본 선반과는 다릅니다."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "일정 수립의 기준이 되는 근무 시간 및 캘린더"
@@ -15538,19 +15538,19 @@ msgid "There are no active supplier quotes to compare for this RFQ."
 msgstr "이 RFQ와 비교할 활성 공급업체 견적이 없습니다."
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "이 작업에는 공급업체가 지정되지 않은 외주 공정작업이 있습니다. 릴리즈하기 전에 각 외주 공정작업에 공급업체를 지정하세요."
+msgstr "이 작업 지시와 관련된 외주 공정이 있지만 공급업체가 없습니다. 릴리스하기 전에 각 외주 공정에 공급업체를 할당하십시오."
 
 msgid "There's nothing outstanding to apply these credits to."
 msgstr "이 크레딧을 적용할 미결제 항목이 없습니다."
 
 msgid "These custom fields will only be available for entities with the same tags"
-msgstr "이 사용자 정의 필드는 동일한 태그를 가진 개체에서만 사용할 수 있습니다"
+msgstr "이 사용자 정의 필드는 동일한 태그가 있는 엔터티에서만 사용 가능합니다."
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "이 문서들은 총계정원장에 전기되지 않았으므로 그 금액이 이 기간에서 누락됩니다. 각각을 전기하거나 취소하세요. 미날짜 문서는 전기될 때 전기일의 날짜를 받습니다."
+msgstr "이 문서들이 총계정원장에 전기되지 않았으므로 이 기간에 금액이 누락되었습니다. 각 문서를 전기하거나 무효 처리하십시오 — 날짜가 없는 문서는 전기될 때 전기 날짜를 받습니다."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
-msgstr "이 이메일 주소는 공급업체에 발송되는 모든 이메일(견적, 구매주문 등)에 자동으로 참조(CC)됩니다."
+msgstr "이 이메일 주소는 공급업체에 보내는 모든 이메일에 자동으로 CC됩니다 (견적서, 발주서 등)."
 
 msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
 msgstr "이 이메일 주소는 고객에게 발송되는 모든 견적 이메일에 자동으로 참조(CC)됩니다."
@@ -15559,34 +15559,34 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "이 항목들은 여전히 선택할 자재가 있습니다. 지금 완료하면 목록이 부분으로 표시됩니다."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "다음 작업에 이 작업장이 지정된 공정작업이 있습니다:"
+msgstr "이 작업장에 할당된 공정이 있는 작업 지시:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "이 분개들은 아직 임시이므로 그 차변과 대변이 이 기간의 총계정원장에 없습니다. 각각을 전기하거나 나중의 개방된 기간으로 재날짜하세요."
+msgstr "이 전표들은 아직 초안 상태이므로 이 기간에 차변 및 대변이 원장에 없습니다. 각 전표를 전기하거나 이후 미결 기간으로 다시 날짜를 지정하십시오."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "이 Carbon 인스턴스에 Onshape OAuth 자격 증명이 없습니다. 관리자에게 설정을 요청하세요."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "이 변경 사항은 구현 중이므로 변경 사항이 잠겨 있습니다. 편집하려면 다시 열어주세요."
+msgstr "이 변경 통지가 구현 중이므로 변경 사항이 잠겨 있습니다. 편집하려면 다시 열기를 선택하십시오."
 
 msgid "This change notice is closed, so its changes are read-only."
-msgstr "이 변경 사항은 닫혀 있으므로 변경 사항이 읽기 전용입니다."
+msgstr "이 변경 통지는 마감되었으므로 변경 사항은 읽기 전용입니다."
 
 msgid "This completes the Discovery step."
 msgstr "이것으로 발견(Discovery) 단계가 완료됩니다."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "이 담당자는 이메일 주소가 없습니다."
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
-msgstr "이 거래처에는 미결제 항목이 없습니다 — 결제는 선수금으로 기록됩니다."
+msgstr "이 거래처는 미결 항목이 없으므로 지불이 외상으로 기록됩니다."
 
 msgid "This download link is invalid or has been tampered with."
 msgstr "이 다운로드 링크가 유효하지 않거나 변조되었습니다."
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "이 파일을 더 이상 사용할 수 없거나, 다운로드할 권한이 없습니다."
+msgstr "이 파일은 더 이상 사용할 수 없거나 다운로드 권한이 없습니다."
 
 msgid "This Fiscal Year"
 msgstr "이번 회계연도"
@@ -15602,13 +15602,13 @@ msgstr "이 검사 계획"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr "{0}에 참여하기 위한 이 초대권은 만료되었습니다. 이메일로 새 초대권을 보내달라고 요청할 수 있습니다."
+msgstr "{0}에 가입하라는 초대가 만료되었습니다. 이메일로 새 초대를 보내도록 요청할 수 있습니다."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "이 송장은 사용 가능한 마감일이 없습니다 — Stripe를 위해 선택하십시오."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "이 송장은 이 Carbon 고객에 이미 연결된 Stripe 고객에게 청구됩니다. 세부 정보를 변경하려면 Stripe 대시보드에서 편집하십시오."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "이것은 제어되는 환경이므로 인증자 앱이 필수입니다."
@@ -15632,28 +15632,28 @@ msgid "This is the month your fiscal year starts."
 msgstr "회계연도가 시작되는 월입니다."
 
 msgid "This is the month your tax year starts."
-msgstr "세무연도가 시작되는 월입니다."
+msgstr "세금 연도가 시작되는 월입니다."
 
 msgid "this item"
 msgstr "이 항목"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "이 품목은 컨피규레이터를 통해 제작되며 구성품을 주문별로 결정합니다. 이를 위해 생성된 작업은 컨피규레이터가 결정한 BOM을 상속받습니다."
+msgstr "이 품목은 컨피그레이터를 통해 구성되며 주문당 구성 요소를 해석합니다. 이를 위해 생성된 작업 지시는 컨피그레이터의 해석된 BOM을 상속합니다."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "이 품목의 자재명세서(BOM)에는 유효기한이 설정된 투입 자재가 없으므로, BOM으로부터 만료일이 계산되지 않습니다."
+msgstr "이 품목의 자재 명세서에는 유통기한이 활성화된 입력이 없으므로 BOM에서 유통기한이 계산되지 않습니다."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "이 작업은 재고로 입고됩니다. 더 이상 현장에서 사용할 수 없게 됩니다."
+msgstr "이 작업 지시는 재고 관리에 입고될 것입니다. 현장에서 더 이상 가용하지 않을 것입니다."
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "이 작업은 더 이상 현장에서 사용할 수 없게 됩니다."
+msgstr "이 작업 지시는 현장에서 더 이상 가용하지 않을 것입니다."
 
 msgid "This job's own required quantity for the material."
 msgstr "이 작업 자체의 자재 소요 수량입니다."
 
 msgid "This lot is expired and can't be picked."
-msgstr "이 로트는 만료되어 피킹할 수 없습니다."
+msgstr "이 로트는 만료됨이며 피킹할 수 없습니다."
 
 msgid "This may take a moment. Hang tight."
 msgstr "잠시 시간이 걸릴 수 있습니다. 잠시만 기다려 주세요."
@@ -15665,13 +15665,13 @@ msgid "This Month"
 msgstr "이번 달"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "구현 허브의 이 페이지는 준비 중입니다. 완성될 때까지 커맨드 센터에서 시작하세요."
+msgstr "실행 허브의 이 페이지는 준비 중입니다. 완성될 때까지 명령 센터에서 시작하세요."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "이 품목은 이 위치에 {quantityOnHand}개가 보유되어 있습니다. 재고 없음으로 설정하면 계획 및 소비 대상에서 제외됩니다."
 
 msgid "This part is activated when change notice {activationLockId} is released."
-msgstr "이 품목은 변경 공지 {activationLockId}이(가) 릴리즈되면 활성화됩니다."
+msgstr "이 부품은 변경 통지 {activationLockId}이 릴리스될 때 활성화됩니다."
 
 msgid "This part is being phased out."
 msgstr "이 품목은 단계적으로 단종되는 중입니다."
@@ -15680,28 +15680,28 @@ msgid "This part is obsolete (No Stock)."
 msgstr "이 품목은 단종되었습니다(재고 없음)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "이 품목은 대체되어 재고 전용으로 설정되었습니다 — 수요와 무관하게 예비 재고 하한선까지 보충됩니다."
+msgstr "이 부품은 대체되었으며 재고만으로 설정됩니다 — 소요량과 무관하게 스페어 예비 바닥까지 보충됩니다."
 
 msgid "This path only decides what runs next"
 msgstr "이 경로는 다음에 실행할 작업만 결정합니다."
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "이 기간에는 게시된 분개가 없으며 영구적으로 삭제할 수 있습니다. 이는 되돌릴 수 없습니다."
+msgstr "이 기간은 전기된 전표 항목이 없으며 영구적으로 삭제할 수 있습니다. 이를 취소할 수 없습니다."
 
 msgid "this purchase order"
-msgstr "이 구매주문"
+msgstr "이 발주서"
 
 msgid "This Quarter"
 msgstr "이번 분기"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "이것은 인증자 앱을 제거하므로 다음 로그인에는 매직 링크만 필요합니다. 인증자에 대한 액세스 권한을 잃어버렸을 때 사용하세요. 이것은 그들이 속한 모든 회사의 로그인에 영향을 줍니다."
+msgstr "이것은 그들의 인증 앱을 제거하므로 다음 로그인에는 매직 링크만 필요합니다. 그들이 인증 수단에 대한 접근을 잃었을 때 이것을 사용하세요. 이것은 그들이 속한 모든 회사에 대한 로그인에 영향을 미칩니다."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "이 개정본이 릴리스되었습니다(프로덕션). 변경 사항은 일반적으로 변경 공지를 통해 처리되어야 합니다."
+msgstr "이 리비전은 릴리스되었습니다 (생산). 변경 사항은 정상적으로 변경 통지를 통해 진행되어야 합니다."
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "이 개정본이 릴리스되었습니다(프로덕션). 수정하려면 변경 공지를 열어주십시오."
+msgstr "이 리비전은 릴리스되었습니다 (생산). 수정하려면 변경 통지를 열으세요."
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "이 실행은 여기에 표시된 것보다 더 많은 단계가 있습니다. 처음 {MAX_RUN_STEPS}개만 나열됩니다."
@@ -15710,20 +15710,20 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "이것은 워크플로우를 실제로 실행합니다. 라이브 실행과 정확히 같은 방식으로 기록을 생성하고, 알림을 전송하고, 모든 웹훅을 호출합니다. 이를 실행 취소할 수 없습니다."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "이 판매주문에는 연결된 작업이 있습니다. 처리 방법을 선택하세요."
+msgstr "이 수주는 관련 작업 지시가 있습니다. 이들을 어떻게 처리할지 선택하세요."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "이 판매주문에는 작업 생성이 필요한 라인이 있습니다"
+msgstr "이 수주는 작업 지시가 생성되어야 하는 라인이 있습니다."
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "이 저장 유형은 현재 저장 단위 {usageCount}개{0}에서 사용 중입니다."
+msgstr "이 보관 단위 유형은 현재 {usageCount}개의 보관 단위{0}에서 사용되고 있습니다."
 
 msgid "this supplier"
 msgstr "이 공급업체"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
-msgstr "이 공구는 변경 공지 {activationLockId}이(가) 릴리즈되면 활성화됩니다."
+msgstr "이 공구는 변경 통지 {activationLockId}이 릴리스될 때 활성화됩니다."
 
 msgid "This updates the theme for all users of the application"
 msgstr "이 설정은 애플리케이션의 모든 사용자에 대한 테마를 업데이트합니다"
@@ -15735,26 +15735,26 @@ msgid "This usually takes a few seconds. You can leave the page — it keeps run
 msgstr "일반적으로 몇 초가 걸립니다. 페이지를 나가도 계속 실행됩니다."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
-msgstr "이 버전은 열려 있는 <0>변경 공지</0>에 속합니다. 거기서 편집하세요."
+msgstr "이 버전은 열린 <0>변경 통지</0>에 속합니다. 거기서 편집하세요."
 
 #. placeholder {0}: lock.readableId
 msgid "This version belongs to change notice <0>{0}</0>. Edit it there."
-msgstr "이 버전은 변경 공지 <0>{0}</0>에 속합니다. 거기서 편집하세요."
+msgstr "이 버전은 변경 통지 <0>{0}</0>에 속합니다. 거기서 편집하세요."
 
 msgid "This version cannot be opened"
 msgstr "이 버전을 열 수 없습니다."
 
 msgid "This version is published"
-msgstr ""
+msgstr "이 버전은 게시되었습니다."
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "이 버전은 게시되었습니다. 편집하려면 새 버전을 생성하세요."
 
 msgid "This version's definition could not be read."
 msgstr "이 버전의 정의를 읽을 수 없습니다."
 
 msgid "This will make this version read-only and replace any material make methods with this version."
-msgstr "이렇게 하면 이 버전이 읽기 전용으로 전환되고, 자재 제조 방법이 모두 이 버전으로 교체됩니다."
+msgstr "이것은 이 버전을 읽기 전용으로 만들고 모든 자재 생산 방법을 이 버전으로 바꿉니다."
 
 msgid "This will overwrite the existing job method"
 msgstr "기존 작업 방법을 덮어씁니다"
@@ -15766,12 +15766,12 @@ msgid "This will overwrite the existing quote method"
 msgstr "기존 견적 방법을 덮어씁니다"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "배치 크기를 사용하여 활성 제조 방법의 자재명세서와 공정을 기준으로 단가를 재계산합니다. 현재 원가는 덮어써집니다. 계속하시겠습니까?"
+msgstr "이것은 배치 크기를 사용하여 활성 생산 방법의 자재 명세서 및 공법에서 단위 원가를 재계산합니다. 현재 원가가 덮어써집니다. 계속하시겠습니까?"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "{0}에서 {1}로의 연결이 제거됩니다. 이후 해당 작업은 판매주문 아래에 표시되지 않으며 출하에서도 찾을 수 없습니다."
+msgstr "이것은 {0}과(와) {1}의 연결을 제거합니다. 작업 지시는 더 이상 수주 아래에 나타나지 않을 것이고 출하가 이를 찾을 수 없을 것입니다."
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "다른 리비전의 모든 방법 자재가 이 리비전으로 교체됩니다."
@@ -15780,13 +15780,13 @@ msgid "This will replace all method materials of other sizes with this size."
 msgstr "다른 사이즈의 모든 방법 자재가 이 사이즈로 교체됩니다."
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "제조 방법의 현재 버전을 활성으로 설정하여 읽기 전용으로 만듭니다."
+msgstr "이것은 생산 방법의 현재 버전을 활성으로 설정하여 읽기 전용으로 만듭니다."
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "자산의 남은 장부가액이 상각 처리됩니다."
 
 msgid "Three-way match"
-msgstr "3자 대조"
+msgstr "3자 대사"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15814,7 +15814,7 @@ msgid "Thursday"
 msgstr "목요일"
 
 msgid "Tie shipments through to an invoice with no re-keying"
-msgstr "재입력 없이 출하를 인보이스까지 연결"
+msgstr "재입력 없이 출하를 송장과 연결하세요."
 
 msgid "Tie-out"
 msgstr "일치"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "동적 대조 불가능"
 
 msgid "Tightened"
-msgstr "강화됨"
+msgstr "까다로운 검사"
 
 msgid "Time of day"
 msgstr "하루 중 시간"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "근무기록"
 
 msgid "Timecards"
-msgstr "근무기록"
+msgstr "타임카드"
 
 msgid "Timecards are disabled"
-msgstr "근무기록이 비활성화됨"
+msgstr "타임카드가 비활성화됨"
 
 msgid "Timecards are enabled"
-msgstr "근무기록이 활성화됨"
+msgstr "타임카드가 활성화됨"
 
 msgid "Timezone"
 msgstr "시간대"
@@ -15862,16 +15862,16 @@ msgid "To reactivate, use the row menu and choose Send Invite. The employee beco
 msgstr "다시 활성화하려면 행 메뉴를 사용하여 초대 보내기를 선택하세요. 직원이 수락하면 활성화됩니다."
 
 msgid "To Receive"
-msgstr "입고 예정"
+msgstr "입고 대기"
 
 msgid "To Ship"
-msgstr "출하 예정"
+msgstr "출하 대기"
 
 msgid "To Ship and Receive"
-msgstr "출하 및 입고 예정"
+msgstr "출하 대기 및 입고 대기"
 
 msgid "To Storage Unit"
-msgstr "대상 저장 단위"
+msgstr "보관 단위로"
 
 msgid "To supplier"
 msgstr "공급업체로"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "공구"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "최상위 분류(자산/부채/자본/수익/비용)로, 루트 그룹에만 설정하며 하위 항목에 상속됩니다."
+msgstr "최상위 분류 (자산 / 부채 / 자본 / 매출 / 비용); 루트 그룹에만 설정되며 자식이 상속합니다."
 
 msgid "Topic"
 msgstr "주제"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "총 수량"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "이 위치의 모든 저장 단위에 걸친 해당 품목의 총 재고 보유 수량입니다. 보유 수량과 입고 예정 수량을 합쳐도 총 수요를 충족하지 못하면 빨간색으로 표시됩니다."
+msgstr "이 사업장의 모든 보관 단위에 있는 품목의 현재고 총 수량입니다. 현재고와 입고량의 합이 총 소요량을 충당할 수 없을 때 빨갛게 표시됩니다."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "이 작업뿐 아니라 이 위치의 모든 진행 중인 작업과 판매주문에서 필요한 총 수량입니다."
+msgstr "이 사업장의 모든 활성 작업 지시 및 수주에서 필요한 총 수량입니다 — 이 작업 지시만이 아닙니다."
 
 msgid "Total scrap quantity"
-msgstr "총 폐기량"
+msgstr "스크랩 총 수량"
 
 msgid "Total tax"
 msgstr "총 세금"
@@ -16000,34 +16000,34 @@ msgid "Totals"
 msgstr "합계"
 
 msgid "Traceability"
-msgstr "이력추적"
+msgstr "추적성"
 
 msgid "Track"
 msgstr "추적"
 
 msgid "Track changes to key business entities including invoices, orders, customers, suppliers, and more."
-msgstr "인보이스, 주문, 고객, 공급업체 등 주요 비즈니스 개체의 변경 사항을 추적합니다."
+msgstr "송장, 주문, 고객, 공급업체 등 주요 비즈니스 항목의 변경 사항을 추적하세요."
 
 msgid "Track every change to your orders, invoices, customers, and more."
-msgstr "주문, 인보이스, 고객 등 모든 변경 사항을 추적합니다."
+msgstr "주문, 송장, 고객 등의 모든 변경 사항을 추적하세요."
 
 msgid "Track every change to your orders, invoices, customers, suppliers, and more."
-msgstr "주문, 인보이스, 고객, 공급업체 등 모든 변경 사항을 추적합니다."
+msgstr "주문, 송장, 고객, 공급업체 등 모든 변경 사항을 추적합니다."
 
 msgid "Track real-time inventory by location and bin"
 msgstr "위치와 빈(bin)별로 실시간 재고를 추적"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "일련번호/로트 번호를 추적하고 판매주문을 처리합니다."
+msgstr "일련번호/로트 번호를 추적하고 수주를 이행합니다."
 
 msgid "Track tax depreciation separately"
-msgstr "세무 감가상각을 별도로 추적"
+msgstr "세금 감가상각을 별도로 추적"
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "장부 감가상각과 별도로 세무 감가상각을 추적하고, 이연법인세부채 전표를 자동으로 전기합니다."
+msgstr "세금 감가상각을 장부 감가상각과 별도로 추적하고, 자동으로 이연법인세 부채 전표를 전기합니다."
 
 msgid "Track transactions by segment (cost center, project, service line)"
-msgstr "세그먼트(원가센터, 프로젝트, 서비스 라인)별로 거래를 추적"
+msgstr "부문별(원가 센터, 프로젝트, 서비스 라인) 거래를 추적합니다"
 
 msgid "Track when batches or serials of this item expire."
 msgstr "이 품목의 배치 또는 일련번호 유효기한을 추적합니다."
@@ -16036,16 +16036,16 @@ msgid "Tracked Entities"
 msgstr "추적 개체"
 
 msgid "Tracked entity"
-msgstr "추적 개체"
+msgstr "추적 대상"
 
 msgid "Tracked Entity"
-msgstr "추적 개체"
+msgstr "추적 대상"
 
 msgid "Tracked entity ID is required but none was found"
-msgstr "추적 개체 ID가 필요하지만 찾을 수 없습니다"
+msgstr "추적 대상 ID가 필수이지만 찾을 수 없습니다"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "추적된 자재는 선택 주문(FEFO)에 따라 사전 선택되며, 피킹 목록이 없어도 됩니다."
+msgstr "추적 자재는 피킹 리스트가 없어도 피킹 순서(FEFO)에 따라 미리 선택됩니다."
 
 msgid "Tracking"
 msgstr "추적"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "교육"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "거래는 분개를 생성하고 총계정원장을 업데이트합니다."
+msgstr "거래에 따라 전표 항목이 생성되고 총계정원장이 업데이트됩니다."
 
 msgid "Transfer"
 msgstr "이동"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "이동 ID"
 
 msgid "Transfer Lines"
-msgstr "이동 라인"
+msgstr "이송 라인"
 
 msgid "Transfer Ownership"
 msgstr "소유권 이전"
@@ -16219,7 +16219,7 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "미실사 라인은 전기 시 변경되지 않고 그대로 유지되며 0으로 처리되지 않습니다."
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "수요기반 재주문 방식에서는 보충 수량을 계산할 때 이 롤링 기간 내의 수요를 합산합니다."
+msgstr "소요량 기반 재주문에서는 재주문 수량을 계산할 때 이 기간 내의 소요량을 합산합니다."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
 msgstr "고정 재주문 수량 방식에서는 재주문점에 도달할 때마다 계획이 정확히 이 수량을 주문합니다."
@@ -16291,16 +16291,16 @@ msgid "unknown location"
 msgstr "알 수 없는 위치"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "무제한 기능 지원"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "무제한 레코드"
 
 msgid "Unlink"
 msgstr "연결 해제"
 
 msgid "Unlink job from sales order?"
-msgstr "작업을 판매주문에서 연결 해제하시겠습니까?"
+msgstr "작업 지시를 수주에서 분리하시겠습니까?"
 
 msgid "Unlock"
 msgstr "잠금 해제"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "미전기 문서"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "게시 해제"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "{name}을 게시 해제하시겠습니까?"
 
 msgid "Unreceived POs"
 msgstr "미입고 구매주문"
@@ -16384,7 +16384,7 @@ msgid "Update a job"
 msgstr "작업 업데이트"
 
 msgid "Update a purchase order"
-msgstr "구매 주문 업데이트"
+msgstr "발주서 업데이트"
 
 msgid "Update a quote"
 msgstr "견적 업데이트"
@@ -16393,10 +16393,10 @@ msgid "Update a receipt"
 msgstr "영수증 업데이트"
 
 msgid "Update a sales order"
-msgstr "판매 주문 업데이트"
+msgstr "수주 업데이트"
 
 msgid "Update a shipment"
-msgstr "배송 업데이트"
+msgstr "출하 업데이트"
 
 msgid "Update a supplier"
 msgstr "공급업체 업데이트"
@@ -16447,7 +16447,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "스캔 기반 보충을 위한 칸반 정보를 업데이트합니다."
 
 msgid "Update the purchase order quantities"
-msgstr "구매주문 수량 업데이트"
+msgstr "발주서 수량 업데이트"
 
 msgid "Updated"
 msgstr "업데이트됨"
@@ -16475,7 +16475,7 @@ msgid "Upgrade to unlock {0} rules"
 msgstr "{0}개의 규칙을 사용하려면 업그레이드하세요"
 
 msgid "Upgrade to unlock audit history"
-msgstr "감사 기록을 사용하려면 업그레이드하세요"
+msgstr "업그레이드하여 감사 이력 잠금 해제"
 
 msgid "Upload"
 msgstr "업로드"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "업로드 중…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "전환을 클릭하면 다음 내부 품목 번호로 품목이 생성됩니다:"
+msgstr "전환을 클릭하면 다음의 내부 부품 번호로 부품이 생성됩니다:"
 
 msgid "URL"
 msgstr "URL"
@@ -16555,7 +16555,7 @@ msgid "Used In"
 msgstr "사용처"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "내비게이션과 판매주문 같은 문서에서 사용됩니다"
+msgstr "네비게이션과 수주 같은 문서에 사용됩니다"
 
 msgid "Used in the navigation in dark mode"
 msgstr "다크 모드의 내비게이션에서 사용됩니다"
@@ -16636,13 +16636,13 @@ msgid "Value source by surface"
 msgstr "표면별 값 소스"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
-msgstr "부가가치세 등록번호로, 대리납부(리버스차지) 또는 영세율 공급에 대한 EU 인보이스에 필수입니다."
+msgstr "부가가치세 등록 번호; 역계산 또는 영율 공급에 대한 EU 송장에 필수입니다."
 
 msgid "Values"
 msgstr "값"
 
 msgid "Values apply today's unit costs to historical quantities."
-msgstr "값은 오늘의 단가를 이전 수량에 적용합니다."
+msgstr "값은 과거 수량에 오늘의 단가를 적용합니다."
 
 msgid "Values in this run have been summarised. Full detail is kept for 7 days."
 msgstr "이 실행의 값이 요약되었습니다. 전체 세부정보는 7일간 유지됩니다."
@@ -16654,10 +16654,10 @@ msgid "Variance"
 msgstr "차이"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "실제 BOM 구성품 소비량과 표준 소비량의 차이"
+msgstr "실제와 표준 BOM 부품 소모 간의 차이"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "실제 공정 시간·단가와 표준 시간·단가의 차이"
+msgstr "실제와 표준 라우팅 시간 및 비율 간의 차이"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "실제 구매 가격과 표준원가의 차이"
@@ -16669,16 +16669,16 @@ msgid "Variance from physical inventory count adjustments"
 msgstr "실사 재고 조정으로 인한 차이"
 
 msgid "Variance in outside processing costs"
-msgstr "외주 가공비 차이"
+msgstr "외주 가공 원가의 차이"
 
 msgid "Variance only"
-msgstr "편차만"
+msgstr "차이만"
 
 msgid "VAT Number"
-msgstr "VAT 번호"
+msgstr "사업자등록번호"
 
 msgid "Vendor Write-Off Income"
-msgstr "공급업체 상각 수익"
+msgstr "공급업체 대손 처리 수익"
 
 msgid "Verification Error"
 msgstr "확인 오류"
@@ -16703,7 +16703,7 @@ msgstr "버전"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "버전 {0}이(가) 지금 게시되었으며 교체될 것입니다."
 
 msgid "Version:"
 msgstr "버전:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "보기"
 
 msgid "View Active Jobs"
-msgstr "진행 중인 작업 보기"
+msgstr "활성 작업 지시 보기"
 
 msgid "View Active Quotes"
 msgstr "활성 견적 보기"
@@ -16736,10 +16736,10 @@ msgid "View Asset"
 msgstr "자산 보기"
 
 msgid "View Assigned Jobs"
-msgstr "배정된 작업 보기"
+msgstr "할당된 작업 지시 보기"
 
 msgid "View Attachment"
-msgstr "첨부파일 보기"
+msgstr "첨부 파일 보기"
 
 msgid "View Attributes"
 msgstr "속성 보기"
@@ -16787,7 +16787,7 @@ msgid "View Lists"
 msgstr "목록 보기"
 
 msgid "View maintenance dispatch"
-msgstr "유지보수 작업지시 보기"
+msgstr "유지보수 지시 보기"
 
 msgid "View Memo"
 msgstr "메모 보기"
@@ -16805,7 +16805,7 @@ msgid "View Open Actions"
 msgstr "미결 조치 보기"
 
 msgid "View Open Invoices"
-msgstr "미결 인보이스 보기"
+msgstr "미결 송장 보기"
 
 msgid "View Open Issues"
 msgstr "미결 이슈 보기"
@@ -16826,7 +16826,7 @@ msgid "View Payables"
 msgstr "매입채무 보기"
 
 msgid "View Payment"
-msgstr "결제 보기"
+msgstr "지불 보기"
 
 msgid "View Period"
 msgstr "기간 보기"
@@ -16838,16 +16838,16 @@ msgid "View Permissions"
 msgstr "권한 보기"
 
 msgid "View Picking List"
-msgstr "피킹 목록 보기"
+msgstr "피킹 리스트 보기"
 
 msgid "View Prints"
-msgstr "출력물 보기"
+msgstr "인쇄 보기"
 
 msgid "View Production Events"
 msgstr "생산 이벤트 보기"
 
 msgid "View Purchase Invoice"
-msgstr "구매 인보이스 보기"
+msgstr "매입 송장 보기"
 
 msgid "View Reactive"
 msgstr "사후정비 보기"
@@ -16886,7 +16886,7 @@ msgid "View tie-out"
 msgstr "일치 보기"
 
 msgid "View Traceability Graph"
-msgstr "이력추적 그래프 보기"
+msgstr "추적성 그래프 보기"
 
 msgid "View Transfer"
 msgstr "이동 보기"
@@ -16901,28 +16901,28 @@ msgid "Visible on a user's public profile"
 msgstr "사용자의 공개 프로필에 표시됩니다"
 
 msgid "Void"
-msgstr "무효화"
+msgstr "무효 처리"
 
 msgid "Void Invoice"
-msgstr "인보이스 무효화"
+msgstr "송장 무효 처리"
 
 msgid "Void Purchase Invoice"
-msgstr "구매 인보이스 무효화"
+msgstr "매입 송장 무효 처리"
 
 msgid "Void Receipt"
-msgstr "입고 무효화"
+msgstr "입고 무효 처리"
 
 msgid "Void Sales Invoice"
-msgstr "판매 인보이스 무효화"
+msgstr "매출 송장 무효 처리"
 
 msgid "Void Shipment"
-msgstr "출하 무효화"
+msgstr "출하 무효 처리"
 
 msgid "Voided"
-msgstr "무효화됨"
+msgstr "무효 처리됨"
 
 msgid "Voiding this purchase invoice will:"
-msgstr "이 구매 인보이스를 무효화하면 다음과 같은 결과가 발생합니다:"
+msgstr "이 매입 송장을 무효 처리하면:"
 
 msgid "Voiding this receipt will:"
 msgstr "이 입고를 무효화하면 다음과 같은 결과가 발생합니다:"
@@ -16958,7 +16958,7 @@ msgid "Warn but allow"
 msgstr "경고 후 허용"
 
 msgid "Warn this many days before expiry"
-msgstr "만료 며칠 전에 경고"
+msgstr "유통기한 {0}일 전에 경고"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "입고 품목을 검사하는 사람이 해당 품목을 입고 처리한 사람과 동일할 경우 경고합니다."
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "매주"
 
 msgid "Weekly demand"
-msgstr "주간 수요"
+msgstr "매주 소요량"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17068,7 +17068,7 @@ msgid "Weighted Average"
 msgstr "가중평균"
 
 msgid "Weighted average cost over last year calculated when the invoice is posted"
-msgstr "인보이스가 전기될 때 계산되는 지난 1년간의 가중평균원가"
+msgstr "송장이 전기될 때 계산되는 지난 1년 가중평균 원가"
 
 msgid "Welcome to Carbon"
 msgstr "Carbon에 오신 것을 환영합니다"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "모든 차원별 재고를 높이거나 낮춘 요인"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "저널이 잠긴 기간에 날짜가 지정되면 어떻게 됩니까?"
+msgstr "전표의 일자가 잠김 기간에 있을 때 무슨 일이 발생하는가."
 
 msgid "What is {translatedTerm}?"
 msgstr "{translatedTerm}란 무엇인가요?"
@@ -17101,7 +17101,7 @@ msgid "What it is"
 msgstr "무엇인지"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "이것이 어떤 종류의 변경인지: 버전은 부품이 만들어지는 방식을 업데이트하고, 개정은 세부 사항과 문서를 수정하고, 교체 부품은 이전 부품을 대체하는 새 부품 번호로 바꾸고, 새 부품은 선행 부품이 없는 새로운 부품을 도입합니다."
+msgstr "이 변경의 종류: 버전은 부품이 제조되는 방식을 업데이트하고, 리비전은 그 세부 사항과 문서를 수정하며, 대체 부품은 이전 부품을 대체하는 새로운 부품 번호로 교환되고, 신규 부품은 선행 항목이 없는 완전히 새로운 부품을 소개합니다."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
 msgstr "이 항목이 기록하는 산출물의 종류입니다 — 생산(양품), 스크랩(복구 불가), 재작업(수정을 위해 반송) 중 하나이며, 스크랩을 선택하면 스크랩 사유가 표시됩니다."
@@ -17116,22 +17116,22 @@ msgid "What source this dimension pulls its allowed values from (custom list or 
 msgstr "이 차원이 허용 값을 가져오는 소스입니다(사용자 정의 목록 또는 고객, 위치, 직원 같은 기존 개체)."
 
 msgid "What the due-date countdown starts from (invoice date, end of month, etc.)."
-msgstr "만기일 카운트다운이 시작되는 기준입니다(인보이스 날짜, 월말 등)."
+msgstr "납기일 카운트다운이 시작되는 지점 (송장 일자, 월말 등)."
 
 msgid "What this field held before the change. Leave blank for nothing."
 msgstr "변경 전 이 필드가 보유한 내용입니다. 아무것도 없으면 비워두세요."
 
 msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
-msgstr "이 입고가 이행하는 대상입니다 — 구매주문, 반품, 입고 이동, 또는 상위 항목이 없는 수동 입고 중 하나입니다."
+msgstr "이 입고가 충족하는 것 — 발주서, 반품, 입고 이송, 또는 상위가 없는 수동 입고."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "이 출하가 이행하는 대상입니다 — 판매주문, 출고 이동, RMA 반품, 또는 수동 출하 중 하나입니다."
+msgstr "이 출하가 충족하는 것 — 수주, 출고 이송, RMA 반품, 또는 수동 출하."
 
 msgid "What this task means"
 msgstr "이 작업의 의미"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "이 시간 기록이 어떤 종류로 집계되는지입니다 — 노무(작업자 시간), 기계(가동 시간), 또는 셋업(교체 시간) 중 하나이며, 각각 다른 단가로 집계됩니다."
+msgstr "이 시간 항목이 다음 중 무엇으로 계산되는지 — 노무 (작업자 시간), 기계 (가공 시간), 또는 셋업 (교환 시간); 각각은 다른 요율로 누적됩니다."
 
 msgid "What to set up"
 msgstr "설정할 항목"
@@ -17155,7 +17155,7 @@ msgid "When {name} changes"
 msgstr "{name}이(가) 변경될 때"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "완제품의 유효기간이 계산됨으로 설정된 경우, 계산에 반영할 소비 투입물을 선택하세요."
+msgstr "완성 제품의 보존 기간이 계산됨으로 설정된 경우, 계산에 영향을 주는 소모된 입력을 선택하세요."
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
 msgstr "일련번호 또는 배치가 만료되는 시점과 만료 후 사용 시의 처리 방식입니다 — 회사 정책은 경고, 차단, 또는 승인 후 차단 중 하나로 설정할 수 있습니다."
@@ -17164,16 +17164,16 @@ msgid "When Carbon committed to having the goods arrive; combined with the shipp
 msgstr "Carbon이 재화 도착을 약속한 시점으로, 배송 방법의 운송 일수와 결합되어 출하일 역산에 사용됩니다."
 
 msgid "When expired stock is used"
-msgstr "만료된 재고가 사용되는 경우"
+msgstr "만료된 재고가 사용될 때"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "MRP가 신규 수요에 후속 품목을 사용하는 시점"
+msgstr "MRP가 새로운 소요량에 대해 후속 품목을 사용할 때"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "켜면 이 카테고리의 속성이 사용자의 공개 프로필에 표시됩니다. 끄면 관리자에게만 표시됩니다."
 
 msgid "When on, employees can edit this attribute's value on their own profile; otherwise only admins can."
-msgstr "켜면 직원이 자신의 프로필에서 이 속성 값을 직접 수정할 수 있습니다. 끄면 관리자만 수정할 수 있습니다."
+msgstr "활성화되면, 직원들은 자신의 프로필에서 이 속성의 값을 편집할 수 있으며; 그렇지 않으면 관리자만 가능합니다."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
 msgstr "켜면 가격 규칙(수량 할인, 프로모션)이 이 재정의 위에 계속 적용됩니다. 끄면 이 재정의가 최종 가격이 됩니다."
@@ -17182,7 +17182,7 @@ msgid "When on, scanning this process's operation barcode reports all remaining 
 msgstr "켜면 이 공정의 공정작업 바코드를 스캔할 때 남은 미완료 수량 전체가 한 번에 완료 처리됩니다. 작업자가 부분 완료를 자주 보고하는 경우에는 꺼두세요."
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
-msgstr "켜면 이 거래처의 인보이스는 세금 계산을 건너뜁니다. 면세 증명서를 최신 상태로 유지하는 것은 해당 거래처의 책임입니다."
+msgstr "활성화되면, 이 거래처의 송장은 세금 계산을 건너뜁니다; 거래처는 면세 증명서를 최신 상태로 유지해야 합니다."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
 msgstr "켜면 이 가격 재정의가 일치하는 주문에 적용됩니다. 삭제하지 않고 끄면 감사를 위한 이력이 보존됩니다."
@@ -17194,25 +17194,25 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "공급업체 응답이 도착할 것으로 예상되는 시점입니다. 공급업체는 RFQ 포털에서 이 날짜를 확인하며, Carbon은 이 날짜 이후의 지연 응답을 받지 않습니다(설정 가능)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "구매자가 재화를 요청한 시점입니다. 공급업체는 약속일에 다른 날짜를 약속하고, 배송일에 또 다른 날짜를 기록할 수 있습니다."
+msgstr "구매 담당자가 물품을 요청한 시점; 공급업체는 약속일에 다른 것을 약속할 수 있으며 납기일에 다시 다른 것을 전기할 수 있습니다."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "구매자가 이 라인의 재화를 하역장에서 필요로 하는 시점입니다. 계획에서는 이 날짜를 재고 가용성 및 외주 가공 일정 수립에 사용합니다."
+msgstr "구매 담당자가 이 라인의 물품을 도크에서 필요로 할 때; 계획은 이 날짜를 재고 가용성 및 외주 처리 스케줄링에 사용합니다."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
 msgstr "고객이 납품을 요청한 시점입니다. 주문은 이와 다를 수 있는 약속일을 확정합니다."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "고객이 재화 수령을 요청한 시점입니다. 고객이 견적을 수락하면 이 날짜가 확정됩니다."
+msgstr "고객이 물품 수령을 요청한 시점; 고객이 수락하면 이 견적서는 이 날짜를 기준으로 약정됩니다."
 
 msgid "When the customer asked to receive the goods."
-msgstr "고객이 재화 수령을 요청한 시점입니다."
+msgstr "고객이 물품 수령을 요청한 시점."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "고객이 이 RFQ를 제출한 시점으로, 이 날짜부터 응답 기한이 계산됩니다."
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "고객의 요청이 더 이상 유효하지 않게 되는 시점입니다. 이 날짜가 지나면 RFQ는 자동으로 종료되며, 다시 열지 않는 한 견적 응답을 받지 않습니다."
+msgstr "고객의 요청이 더 이상 유효하지 않을 때; 이 날짜가 지나면 견적 요청이 자동으로 종료되며 다시 열지 않는 한 견적 응답을 수락하지 않습니다."
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
 msgstr "재화가 실제로 도착한 시점으로, 입고에 기록되며 공급업체 정시 납품 평가에 사용됩니다."
@@ -17221,34 +17221,34 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "칸반 카드를 스캔하면 작업이 자동으로 초안 상태에서 벗어나 현장으로 릴리즈됩니다."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "입고 위치에서 재고 도착을 예상하는 시점으로, 목적지의 MRP 가용성에 반영됩니다."
+msgstr "입고 사업장이 재고가 도착할 것으로 예상할 때; 목적지의 MRP 가용성을 결정합니다."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "공급업체가 납품을 약속한 시점으로, 계획에서는 이 날짜를 입고 재고 도착 예측에 사용합니다."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "공급업체의 가격이 더 이상 유효하지 않게 되는 시점입니다. 이 날짜 이후 이 견적을 구매주문으로 전환하려면 재견적이 필요할 수 있습니다."
+msgstr "공급업체의 가격이 더 이상 유효하지 않을 때; 이 날짜 이후에 이 견적서를 발주서로 전환하는 것은 다시 견적이 필요할 수 있습니다."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "이 게이지가 교정 만료 시점; 만료 후에는 Out-of-Calibration으로 읽힘."
+msgstr "이 계측기의 교정이 만료될 때; 만료되면 Out-of-Calibration으로 표시됩니다."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "이 측정기가 마지막으로 성공적으로 교정된 시점으로, 다음 교정일은 이 값에 교정 주기를 더해 다시 계산됩니다."
+msgstr "이 계측기가 마지막으로 성공적으로 교정된 시점; 다음 교정 날짜는 이 값에 간격을 더해서 다시 계산됩니다."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "이 내용이 맞으면 합의됨으로 표시하세요. 그러면 커맨드 센터의 발견(Discovery) 단계가 완료됩니다."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "이 특정 라인의 출하가 약속된 시점으로, 분할 출하 시 주문 헤더의 약속일을 라인별로 재정의합니다."
+msgstr "이 특정 라인이 출하될 것으로 약속된 시점; 분할 출하를 위한 주문 헤더의 약속일을 라인별로 재정의."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "이 특정 로트/일련번호가 만료되는 시점으로, FEFO 피킹과 소비 시 유효기간 정책에 반영됩니다."
+msgstr "이 특정 로트/시리얼이 만료될 때; FEFO 피킹 및 소모 시 보존 기간 정책을 결정합니다."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "귀사가 납품하기로 약속한 시점으로, 계획에서는 이를 이행을 위한 수요 마감일로 취급합니다."
 
 msgid "When your fiscal and tax years start"
-msgstr "회계연도 및 세무연도가 시작되는 시기"
+msgstr "귀사의 회계연도 및 세무연도가 시작될 때"
 
 msgid "Where a workflow notification is delivered — in-app is always sent, while email needs a Business or Partner plan and Slack needs your Slack workspace connected."
 msgstr "워크플로우 알림이 전송되는 위치 — 인앱은 항상 전송되며, 이메일은 Business 또는 Partner 요금제가 필요하고 Slack은 Slack 작업 공간이 연결되어야 합니다."
@@ -17260,7 +17260,7 @@ msgid "Where and how you make things."
 msgstr "무엇을, 어떻게 만드는지."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "이 구매주문의 재화가 기본적으로 배송되는 곳으로, 직배송 및 분할배송 시나리오에서는 구매주문의 라인별 배송지가 이를 재정의합니다."
+msgstr "이 발주서의 물품이 기본적으로 배송되는 위치; 발주서의 라인별 배송 사업장은 직송 및 분할 배송 시나리오에서 이를 재정의합니다."
 
 msgid "Where it lives today"
 msgstr "현재 위치"
@@ -17275,13 +17275,13 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "영향받은 항목이 시스템 전체에서 사용되는 위치입니다. 참고 사항 — 여기의 내용은 릴리스를 막지 않습니다."
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "이 항목의 출처(수동 입력, 판매/구매에서의 전기, 반복 템플릿 등)."
+msgstr "이 항목의 출처 (수동 입력, 영업/구매의 전기, 반복 템플릿 등)."
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
 msgstr "이 이슈가 제기된 출처 — 내부 품질보증, 고객 불만, 공급업체 감사 등 — 로, 보고용으로 사용되며 워크플로를 제한하지는 않습니다."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "이 라인의 재화가 입고 시 재고에 저장되는 위치로, 비워두면 입고 시 품목의 기본 저장 단위를 사용합니다."
+msgstr "입고 시 라인의 물품이 입고되는 재고 위치; 공란인 경우 입고는 품목의 기본 보관 단위를 사용합니다."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
 msgstr "이 유지보수 요청의 출처 — 작업자 보고, 예약, 상태 모니터링 트리거, 작업 후 검사 — 로, 유지보수 보고서의 출처별 분류에 사용됩니다."
@@ -17302,13 +17302,13 @@ msgid "Whether the clock starts when the chosen process begins or when it comple
 msgstr "선택한 공정이 시작될 때 시간을 측정할지, 완료될 때 측정할지 여부입니다."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "이 로트/일련번호가 검사를 통과(합격)했는지 불합격했는지 여부로, 불합격 시 해당 재고는 사용 가능 재고로 입고되지 못합니다."
+msgstr "이 로트/시리얼이 검사를 합격하는지 또는 불합격하는지 여부; 불합격은 재고가 가용 재고로 수령되는 것을 차단합니다."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "이 프로세스가 내부 작업 센터(프로세스, 어셈블리 또는 검사)에서 실행되는지 외부 공급업체(외부 처리)에서 실행되는지 여부; 다양한 다운스트림 필드를 표시하고, 이 프로세스에 대해 계획 경로가 작동하는 방식을 변경하며, 새 작업에서 작업 유형의 기본값을 설정합니다."
+msgstr "이 공법이 내부 작업장(공법, 조립 또는 검사)에서 실행되는지 또는 외부 공급업체(외주 가공)에서 실행되는지 여부; 다양한 후속 필드를 표시하고, 이 공법에 대한 계획 라우팅 작동 방식을 변경하고, 새 공정의 공정 유형을 기본값으로 설정합니다."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "이 작업이 생산을 중단시키는지(가동중단), 저하시키는지(영향), 계획된 가동중단 구간에 해당하는지(계획됨), 또는 생산에 영향이 없는지(영향 없음) 여부로, 일정 계획 및 고객 대상 가동중단 커뮤니케이션에 활용됩니다."
+msgstr "이 작업이 생산을 차단(Down)하는지, 성능을 저하(영향)시키는지, 계획된 비가동 시간 윈도우(계획됨)에 있는지, 또는 생산에 영향(No Impact)이 없는지 여부; 스케줄링 및 고객 대면 비가동 시간 통신을 알립니다."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "선택한 권한을 각 사용자가 이미 가진 권한에 추가할지(추가), 아래 선택 항목으로 각 사용자의 권한 세트를 완전히 교체할지(업데이트) 여부입니다."
@@ -17317,7 +17317,7 @@ msgid "Which document drives each inspection flow for this item."
 msgstr "이 항목에 대한 각 검사 흐름을 운영하는 문서입니다."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "보낼 요청의 종류: GET은 읽고, POST는 만들고, PUT과 PATCH는 업데이트하고, DELETE는 제거합니다. 새 단계는 GET에서 시작하며 POST, PUT 및 PATCH만 본문을 포함합니다."
+msgstr "전송할 요청의 종류: GET은 무언가를 읽고, POST는 생성하고, PUT과 PATCH는 업데이트하고, DELETE는 제거합니다. 새 단계는 GET으로 시작하며, POST, PUT 및 PATCH만 본문을 전달합니다."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "유효기간 계산이 시작되는 제조 이벤트 — 예를 들어 충전, 밀봉, 또는 최종 품질검사."
@@ -17338,22 +17338,22 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "누가 견적, 주문, 구매를 승인해야 하는지 — 그리고 언제"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "유지보수 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+msgstr "유지보수 관련 유지보수 지시에 대한 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "공정작업 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+msgstr "공정 관련 유지보수 지시에 대한 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "기타 작업지시에 대한 알림을 누가 받아야 합니까?"
+msgstr "다른 유지보수 지시에 대한 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "품질 관련 작업지시에 대한 알림을 누가 받아야 합니까?"
+msgstr "품질 관련 유지보수 지시에 대한 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "디지털 견적이 승인되거나 만료될 때 알림을 누가 받아야 합니까?"
+msgstr "디지털 견적서가 수락되거나 만료될 때 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "측정기의 교정이 만료될 때 알림을 누가 받아야 합니까?"
+msgstr "계측기가 교정을 벗어날 때 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "새 제안이 제출될 때 알림을 누가 받아야 합니까?"
@@ -17362,7 +17362,7 @@ msgid "Who should receive notifications when a RFQ is marked ready for quote?"
 msgstr "RFQ가 견적 준비 완료로 표시될 때 알림을 누가 받아야 합니까?"
 
 msgid "Who should receive notifications when a sales job is completed?"
-msgstr "판매 작업이 완료될 때 알림을 누가 받아야 합니까?"
+msgstr "판매 작업 지시가 완료될 때 알림을 받아야 하는 사람은 누구입니까?"
 
 msgid "Who should receive notifications when a supplier quote is submitted?"
 msgstr "공급업체 견적이 제출될 때 알림을 누가 받아야 합니까?"
@@ -17386,10 +17386,10 @@ msgid "Why is this included?"
 msgstr "이것이 포함된 이유는 무엇입니까?"
 
 msgid "Why is this locked?"
-msgstr "왜 이것이 잠겨 있나요?"
+msgstr "이것이 잠긴 이유는 무엇입니까?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "재고가 변경되는 이유 — 양수(발견), 음수(분실/스크랩), 또는 설정(측정값으로 수량 대체)."
+msgstr "재고가 변경되는 이유 — 긍정(발견), 부정(손실/스크랩) 또는 설정(측정된 값으로 수량 교체)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "이 라인이 거절되는 이유로, 인쇄용 견적서에 표시되며 수주/실주 보고를 위해 기록됩니다."
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "재공품"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "피킹 목록이 없으면 작업자가 스캔 탭에서 자재를 선택합니다."
+msgstr "피킹 리스트가 없으면 작업자는 스캔 탭에서 자재를 피킹합니다."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17454,19 +17454,19 @@ msgid "Work in Progress (default)"
 msgstr "진행 중(기본값)"
 
 msgid "Work in Progress (WIP)"
-msgstr "재공품(WIP)"
+msgstr "진행 중인 작업 (WIP)"
 
 msgid "Work instruction"
-msgstr "작업 지시"
+msgstr "작업 표준서"
 
 msgid "Work Instructions"
-msgstr "작업 지시서"
+msgstr "작업 표준서"
 
 msgid "Work Phone"
 msgstr "직장 전화번호"
 
 msgid "Work shift tracking is active."
-msgstr "근무 교대 추적이 활성화되어 있습니다."
+msgstr "작업 교대 추적이 활성화되었습니다."
 
 msgid "Workflow"
 msgstr "워크플로"
@@ -17484,26 +17484,26 @@ msgid "Working sessions on configuration and data"
 msgstr "설정 및 데이터에 대한 작업 세션"
 
 msgid "Worst Performing Machines"
-msgstr "성과가 가장 저조한 설비"
+msgstr "성능이 가장 낮은 기계"
 
 msgid "Write-Down Account"
 msgstr "평가감 계정"
 
 msgid "Write-off"
-msgstr "대손상각"
+msgstr "대손 처리"
 
 msgid "Write-Off"
-msgstr "대손상각"
+msgstr "대손 처리"
 
 msgid "Write-Off Account"
-msgstr "대손상각 계정"
+msgstr "대손 처리 계정"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "{0}에 대한 대손상각"
+msgstr "{0}에 대한 대손 처리"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "검사 거부 및 NCR 처리를 통해 폐기되거나 반품된 재고의 상각"
+msgstr "검사 불합격 및 NCR 처분 결정을 통해 반품되거나 스크랩된 재고의 대손 처리"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
 msgstr "자산의 가치를 내용연수에 걸쳐 상각하는 것 — 매월 생성하여 초안으로 검토한 후 전기하는 배치 작업입니다."
@@ -17518,13 +17518,13 @@ msgid "Yes"
 msgstr "예"
 
 msgid "Yes, Accept"
-msgstr "예, 승인"
+msgstr "예, 수락"
 
 msgid "Yes, also delete every nested storage unit."
-msgstr "예, 모든 하위 저장 단위도 함께 삭제합니다."
+msgstr "예, 모든 중첩된 보관 단위도 삭제하세요."
 
 msgid "Yes, Reject"
-msgstr "예, 반려"
+msgstr "예, 거부"
 
 msgid "Yes, Update IDs"
 msgstr "예, ID 업데이트"
@@ -17551,32 +17551,32 @@ msgid ""
 "                        {0} than the\n"
 "                        ordered quantity of {1}. What would you like\n"
 "                        to do with the extra parts?"
-msgstr "주문 수량 {1}보다 {leftoverQuantity}개 더 많은 {0}을(를) 완료했습니다. 초과분을 어떻게 처리하시겠습니까?"
+msgstr "발주 수량 {1}보다 {0} {leftoverQuantity}개를 더 완료했습니다. 초과 부품을 어떻게 하시겠습니까?"
 
 msgid "You do not have permission to edit workflows"
 msgstr "워크플로우를 편집할 권한이 없습니다."
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "이 자재명세서를 수정할 권한이 없습니다."
+msgstr "이 자재 명세서를 편집할 권한이 없습니다."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "이 프로세스 명세서를 편집할 권한이 없습니다."
+msgstr "이 공정 목록을 편집할 권한이 없습니다."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "귀사가 주도하고, 저희가 제대로 되도록 확인합니다. 설정, 데이터, 도입 전반을 전문가가 점검합니다."
+msgstr "당신이 주도합니다; 우리는 올바르게 완료되도록 보장합니다. 설정, 데이터 및 가동에 대한 전문가의 검토."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
 msgstr "PDF에서 추출된 라인 중 {0}개가 재고 품목에 매핑되지 않았습니다."
 
 msgid "You haven't created any contacts yet."
-msgstr "아직 생성된 연락처가 없습니다."
+msgstr "아직 담당자를 생성하지 않았습니다."
 
 msgid "You lead"
 msgstr "귀사가 주도"
 
 msgid "You name a project owner with decision authority"
-msgstr "의사결정 권한을 가진 프로젝트 담당자를 지정하세요"
+msgstr "의사결정 권한이 있는 프로젝트 책임자를 지정합니다"
 
 msgid "You received this item"
 msgstr "이 품목을 입고받았습니다"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Carbon 도입 완료"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "작업 공간까지 한 단계 남았습니다."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "귀사가 원하는 속도로 직접 Carbon을 설정합니다"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
+msgstr "{hoursElapsed}시간 동안 작업이 진행 중입니다. 작업 종료를 잊으셨습니까?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "로그인이 도난당해도 계정은 안전하게 유지됩니다"
@@ -17603,7 +17603,7 @@ msgid "Your books and how money flows."
 msgstr "귀사의 장부와 자금 흐름."
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "변경 사항이 이 변경 공지와 함께 릴리스된 새 초안 버전으로 이동합니다."
+msgstr "변경사항이 이 변경 통지로 릴리스된 새로운 초안 버전으로 이동합니다."
 
 msgid "Your Console PIN"
 msgstr "콘솔 PIN"
@@ -17627,10 +17627,10 @@ msgid "Your GL accounts"
 msgstr "총계정원장 계정"
 
 msgid "your Implementation Lead"
-msgstr "귀사의 구축 담당자"
+msgstr "귀사의 실행 리드"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "초대가 유효하지 않거나 이미 수락되었습니다. 오류라고 생각되시면 지원팀에 문의하세요."
+msgstr "귀사의 초대장이 유효하지 않거나 이미 수락되었습니다. 오류라고 생각하면 지원팀에 문의하십시오."
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "여기서 할 일: 각 행의 실제 샘플을 확인한 후 검증 완료로 표시하세요. 기초 데이터가 먼저 로드되고, 이어서 마스터 레코드, 전환 시점의 미결 거래 순으로 로드됩니다."
@@ -17663,7 +17663,7 @@ msgid "Your real data is loaded and you have checked a sample and approved it."
 msgstr "실제 데이터가 로드되었고 샘플을 확인하여 승인했습니다."
 
 msgid "Your session was locked after inactivity."
-msgstr "비활성화 후 세션이 잠겼습니다."
+msgstr "귀하의 세션이 비활성으로 인해 잠겼습니다."
 
 msgid "Your source data is accessible and reasonably clean"
 msgstr "원본 데이터에 접근 가능하고 어느 정도 정리되어 있음"
@@ -17687,7 +17687,7 @@ msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample si
 msgstr "Z1.4 검사 수준(I / II / III)으로, 수준이 높을수록 동일 로트에 대한 샘플 크기가 커집니다."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4 검사 강도(보통/까다로움/완화)로, 최근 로트 합격 이력에 따른 규칙에 의해 전환됩니다."
+msgstr "Z1.4 심각도 (정상 / 까다로운 검사 / 수월한 검사); 최근 로트 수용 이력에 기반한 규칙에 따라 전환됩니다."
 
 msgid "Zoom Box"
 msgstr "확대 영역"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -3590,7 +3590,7 @@ msgid "Control how operators pick material and track time on the shop floor."
 msgstr "현장에서 작업자의 자재 피킹 및 시간 추적 방식을 제어합니다."
 
 msgid "Control whether item IDs (parts, materials, consumables, tools, and services) may contain lowercase characters."
-msgstr "항목 ID(부품, 재료, 소비품, 도구 및 서비스)에 소문자가 포함될 수 있는지 제어합니다."
+msgstr "품목 ID(부품, 자재, 소모품, 공구, 서비스)에 소문자 포함 여부를 제어합니다."
 
 msgid "Controller, Accountant"
 msgstr "컨트롤러, 회계 담당자"
@@ -8940,7 +8940,7 @@ msgid "Map Lines Now"
 msgstr "지금 라인 매핑"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "귀사의 계정과목을 제공자의 계정과목으로 매핑하세요. 기본 전기 계정과 비용 계정은 필수로 표시되어 있으며, 전기된 분개는 매핑된 제공자 계정 코드를 사용하여 전송됩니다."
+msgstr "계정과목표를 공급자와 매핑하세요. 전기 기본 및 비용 계정은 필수로 표시되며, 전기된 전표는 매핑된 공급자 계정 코드를 사용하여 전송됩니다."
 
 msgid "Map your current process, systems, and data"
 msgstr "현재 프로세스, 시스템, 데이터를 매핑하세요"
@@ -11624,7 +11624,7 @@ msgid "Protect training time and attend"
 msgstr "교육 시간을 확보하고 참석하세요"
 
 msgid "Protect your company with advanced security controls like two-factor authentication enforcement."
-msgstr "이중 인증 강제와 같은 고급 보안 제어로 회사를 보호하세요."
+msgstr "2단계 인증 강제와 같은 고급 보안 제어로 회사를 보호하세요."
 
 msgid "Protects your company's data"
 msgstr "회사 데이터 보호"
@@ -14349,20 +14349,20 @@ msgid "Stripe Due Date"
 msgstr "Stripe 마감일"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr "Stripe은 송장을 고객에게 이메일로 전송하므로 주소가 필요합니다. 이것은 Carbon의 담당자에게도 저장됩니다."
+msgstr "Stripe가 송장을 고객에게 이메일로 보내므로 주소가 필요합니다. 이것도 Carbon의 담당자 정보에 저장됩니다."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe은 아직 이 Carbon 고객에 대한 고객이 없습니다. 전기하면 연결된 계정에 하나가 생성됩니다."
+msgstr "이 Carbon 고객에 대한 Stripe 고객이 아직 없습니다. 전기하면 연결된 계정에 생성됩니다."
 msgstr "Stripe에는 이미 이 이메일이 있는 고객이 있습니다"
 
 msgid "Stripe Due Date"
-msgstr "Stripe 만기일"
+msgstr "Stripe 마감일"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr "Stripe는 고객에게 인보이스를 이메일로 보내므로 주소가 필요합니다. 이것은 Carbon의 연락처에도 저장됩니다."
+msgstr "Stripe가 송장을 고객에게 이메일로 보내므로 주소가 필요합니다. 이것도 Carbon의 담당자 정보에 저장됩니다."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe에는 이 Carbon 고객을 위한 고객이 아직 없습니다. 게시하면 연결된 계정에서 하나를 생성합니다."
+msgstr "이 Carbon 고객에 대한 Stripe 고객이 아직 없습니다. 전기하면 연결된 계정에 생성됩니다."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "칸반 테이블에 표시할 칸반 출력 스타일"
@@ -15672,11 +15672,11 @@ msgid "This invoice has no usable due date — choose one for Stripe."
 msgstr "이 송장은 사용 가능한 마감일이 없습니다 — Stripe를 위해 선택하십시오."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "이 송장은 이 Carbon 고객에 이미 연결된 Stripe 고객에게 청구됩니다. 세부 정보를 변경하려면 Stripe 대시보드에서 편집하십시오."
+msgstr "이 송장은 이미 이 Carbon 고객과 연결된 Stripe 고객에게 청구됩니다. 세부 사항을 변경하려면 Stripe 대시보드에서 편집하세요."
 msgstr "이 인보이스에는 사용할 수 있는 만기일이 없습니다 — Stripe에 대해 하나를 선택합니다."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "이 인보이스는 이미 이 Carbon 고객에 연결된 Stripe 고객에게 청구됩니다. 세부 정보를 변경하려면 Stripe 대시보드에서 편집합니다."
+msgstr "이 송장은 이미 이 Carbon 고객과 연결된 Stripe 고객에게 청구됩니다. 세부 사항을 변경하려면 Stripe 대시보드에서 편집하세요."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "이것은 제어되는 환경이므로 인증자 앱이 필수입니다."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -170,7 +170,6 @@ msgstr "{from}–{to}/{count} 공정"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "{hiddenCount}개 추가: {hiddenNames}"
-msgstr "{hiddenCount}개 더: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -305,7 +304,6 @@ msgstr "4시간"
 
 msgid "5 user minimum"
 msgstr "최소 5명의 사용자"
-msgstr "5명 사용자 최소"
 
 msgid "5-8 weeks"
 msgstr "5-8주"
@@ -363,7 +361,6 @@ msgstr "외주 인력은 특정 역량과 가용 시간을 가진 공급업체 �
 
 msgid "A custom solution to meet your needs"
 msgstr "귀사의 필요를 충족하는 맞춤형 솔루션"
-msgstr "당신의 요구를 충족하기 위한 맞춤형 솔루션"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "고객은 귀사의 부품이나 서비스를 구매하는 회사 또는 개인입니다."
@@ -480,7 +477,6 @@ msgstr "관리형 클라우드 호스팅 Carbon 버전"
 
 msgid "A managed version with all the advanced features"
 msgstr "모든 고급 기능을 갖춘 관리형 버전"
-msgstr "Carbon의 관리되는 클라우드 호스팅 버전"
 
 msgid "A managed version with all the advanced features"
 msgstr "모든 고급 기능이 포함된 관리되는 버전"
@@ -508,7 +504,6 @@ msgstr "현재 사이즈를 복사하여 새 사이즈가 생성됩니다"
 
 msgid "A new Stripe customer will be created"
 msgstr "새 Stripe 고객이 생성됩니다."
-msgstr "새로운 Stripe 고객이 생성됩니다"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "비현금 문서로 송장을 이유 계정에 대해 결제합니다: 대변은 미지급액을 낮추고 차변은 높입니다."
@@ -1346,7 +1341,6 @@ msgstr "모든 조치가 선택됨"
 
 msgid "All advanced features available"
 msgstr "모든 고급 기능 이용 가능"
-msgstr "모든 고급 기능 사용 가능"
 
 msgid "All Audit Logs"
 msgstr "모든 감사 로그"
@@ -1622,7 +1616,6 @@ msgstr "Carbon 데이터에 프로그래밍 방식으로 접근하기 위한 API
 
 msgid "API, webhooks, and integrations"
 msgstr "API, 웹훅 및 연동"
-msgstr "API, 웹훅 및 통합"
 
 msgid "Applied"
 msgstr "적용됨"
@@ -2631,7 +2624,6 @@ msgstr "라이브러리 둘러보기"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "게시된 버전을 읽기 전용으로 찾아봅니다. 여전히 단계를 재정렬하여 레이아웃을 정돈할 수 있습니다."
-msgstr "게시된 버전을 읽기 전용으로 탐색합니다. 여전히 단계를 재정렬하여 레이아웃을 정리할 수 있습니다."
 
 msgid "Bucket"
 msgstr "버킷"
@@ -3047,7 +3039,6 @@ msgstr "이메일을 확인하세요"
 
 msgid "Checking Stripe for this customer…"
 msgstr "이 고객의 Stripe 확인 중…"
-msgstr "이 고객의 Stripe를 확인 중입니다…"
 
 msgid "Checkpoint ·"
 msgstr "체크포인트 ·"
@@ -3189,7 +3180,6 @@ msgstr "클라우드 또는 자체 호스팅 환경."
 
 msgid "CMMC compliant"
 msgstr "CMMC 준수"
-msgstr "CMMC 규정 준수"
 
 msgid "Code"
 msgstr "코드"
@@ -3959,7 +3949,6 @@ msgstr "수주를 이행하기 위해 새 생산 작업 지시를 생성합니�
 
 msgid "Create a new Stripe customer instead"
 msgstr "대신 새 Stripe 고객을 생성합니다."
-msgstr "대신 새로운 Stripe 고객을 만듭니다"
 
 msgid "Create a new version"
 msgstr "새 버전을 생성합니다."
@@ -4431,7 +4420,6 @@ msgstr "고객"
 
 msgid "Customizations, training, and integrations"
 msgstr "사용자정의, 교육 및 연동"
-msgstr "맞춤화, 교육 및 통합"
 
 msgid "Customize"
 msgstr "사용자 지정"
@@ -6999,7 +6987,6 @@ msgstr "형식"
 
 msgid "Forward deployed engineer"
 msgstr "현장 배치 엔지니어"
-msgstr "현지 배치 엔지니어"
 
 msgid "Foundation"
 msgstr "파운데이션"
@@ -7056,7 +7043,6 @@ msgstr "전체 이름"
 
 msgid "Full setup and migrations"
 msgstr "완전한 셋업 및 마이그레이션"
-msgstr "전체 설정 및 마이그레이션"
 
 msgid "Fully Depreciated"
 msgstr "상각 완료"
@@ -8154,7 +8140,6 @@ msgstr "이슈"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "다시 버전을 게시할 때까지 실행이 중지됩니다. 삭제된 내용은 없습니다."
-msgstr "다시 버전을 게시할 때까지 실행이 중지됩니다. 삭제된 것은 없습니다."
 
 msgid "ITAR Certifications"
 msgstr "ITAR 인증"
@@ -8526,7 +8511,6 @@ msgstr "수작업 감소, 오류 감소"
 
 msgid "Let's Build"
 msgstr "제조해 봅시다"
-msgstr "구축해봅시다"
 
 msgid "Let's build something"
 msgstr "무언가를 만들어봅시다"
@@ -8608,7 +8592,6 @@ msgstr "Linear 이슈 연결"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "이 Carbon 고객을 그 중 하나에 연결하거나 별도의 Stripe 고객을 생성합니다."
-msgstr "이 Carbon 고객을 그 중 하나에 연결하거나 별도의 Stripe 고객을 만듭니다."
 
 msgid "Link to sales order line"
 msgstr "수주 라인으로 링크"
@@ -14353,7 +14336,6 @@ msgstr "Stripe가 송장을 고객에게 이메일로 보내므로 주소가 필
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "이 Carbon 고객에 대한 Stripe 고객이 아직 없습니다. 전기하면 연결된 계정에 생성됩니다."
-msgstr "Stripe에는 이미 이 이메일이 있는 고객이 있습니다"
 
 msgid "Stripe Due Date"
 msgstr "Stripe 마감일"
@@ -15641,7 +15623,6 @@ msgstr "이것으로 발견(Discovery) 단계가 완료됩니다."
 
 msgid "This contact has no email address"
 msgstr "이 담당자는 이메일 주소가 없습니다."
-msgstr "이 연락처에는 이메일 주소가 없습니다"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "이 거래처는 미결 항목이 없으므로 지불이 외상으로 기록됩니다."
@@ -15673,7 +15654,6 @@ msgstr "이 송장은 사용 가능한 마감일이 없습니다 — Stripe를 �
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "이 송장은 이미 이 Carbon 고객과 연결된 Stripe 고객에게 청구됩니다. 세부 사항을 변경하려면 Stripe 대시보드에서 편집하세요."
-msgstr "이 인보이스에는 사용할 수 있는 만기일이 없습니다 — Stripe에 대해 하나를 선택합니다."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "이 송장은 이미 이 Carbon 고객과 연결된 Stripe 고객에게 청구됩니다. 세부 사항을 변경하려면 Stripe 대시보드에서 편집하세요."
@@ -15817,7 +15797,6 @@ msgstr "이 버전은 게시되었습니다."
 
 msgid "This version is published. Create a new version to edit."
 msgstr "이 버전은 게시되었습니다. 편집하려면 새 버전을 생성하세요."
-msgstr "이 버전이 게시됩니다"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "이 버전이 게시됩니다. 편집할 새 버전을 만듭니다."
@@ -16415,7 +16394,6 @@ msgstr "게시 해제"
 
 msgid "Unpublish {name}?"
 msgstr "{name}을 게시 해제하시겠습니까?"
-msgstr "게시 취소"
 
 msgid "Unpublish {name}?"
 msgstr "게시 취소 {name}?"
@@ -16780,7 +16758,6 @@ msgstr "버전"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "버전 {0}이(가) 지금 게시되었으며 교체될 것입니다."
-msgstr "버전 {0}이 지금 게시되고 바뀔 것입니다."
 
 msgid "Version:"
 msgstr "버전:"
@@ -17666,7 +17643,6 @@ msgstr "Carbon 도입 완료"
 
 msgid "You're one step away from your workspace."
 msgstr "작업 공간까지 한 단계 남았습니다."
-msgstr "작업 공간에서 한 걸음 떨어져 있습니다."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "귀사가 원하는 속도로 직접 Carbon을 설정합니다"

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} 스크랩됨"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions}개의 합격 단위가 완료됩니다."
+msgstr "{completions}개의 통과 단위가 완료 처리될 예정입니다."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails}개의 샘플 불량이 기록되었으며 완료되지 않습니다 — 작업 메뉴에서 해결하세요."
@@ -115,7 +115,7 @@ msgid "All rework"
 msgstr "모두 재작업"
 
 msgid "All scrap"
-msgstr "모두 폐기"
+msgstr "모든 스크랩"
 
 msgid "Allocate failed units"
 msgstr "실패한 단위 할당"
@@ -151,16 +151,16 @@ msgid "Authentication Error"
 msgstr "인증 오류"
 
 msgid "available"
-msgstr "사용 가능"
+msgstr "가용"
 
 msgid "Available"
-msgstr "사용 가능"
+msgstr "가용"
 
 msgid "Batch"
 msgstr "배치"
 
 msgid "Batch is not available"
-msgstr "배치를 사용할 수 없습니다"
+msgstr "배치는 가용하지 않습니다"
 
 #. placeholder {0}: index + 1
 msgid "Batch Number {0}"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "검색 지우기"
 
 msgid "Clock In"
-msgstr "출근"
+msgstr "작업 시작"
 
 msgid "Clock Out"
-msgstr "퇴근"
+msgstr "작업 종료"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/>부터 근무 중"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "모두 완료"
 
 msgid "Complete passed"
-msgstr "완료된 합격"
+msgstr "완료 처리 통과"
 
 msgid "Completed"
 msgstr "완료됨"
@@ -278,11 +278,11 @@ msgid "Consumed"
 msgstr "소비됨"
 
 msgid "Consumed expired"
-msgstr "만료 후 소모됨"
+msgstr "소모 만료"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr "계획되지 않은 유지보수 비용, 최근 {0}일"
+msgstr "계획되지 않은 유지보수의 원가, 최근 {0}일"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -317,7 +317,7 @@ msgid "Default"
 msgstr "기본값"
 
 msgid "Default Storage Unit"
-msgstr "기본 저장 단위"
+msgstr "기본 보관 단위"
 
 msgid "Delete"
 msgstr "삭제"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "상세 정보"
 
 msgid "Dispatch not found"
-msgstr "작업지시를 찾을 수 없습니다"
+msgstr "유지보수 지시를 찾을 수 없습니다"
 
 msgid "Display"
 msgstr "표시"
@@ -379,7 +379,7 @@ msgstr "그리기 및 기능 크기 조정하려면 드래그하세요"
 
 #. placeholder {0}: active.data.current?.type
 msgid "Dragging {0} cancelled."
-msgstr "{0} 끌기가 취소되었습니다."
+msgstr "{0} 드래그 취소됨."
 
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString( operation.operationDueDate ) )
 #. placeholder {0}: formatRelativeTime( convertDateStringToIsoString(operation.jobDueDate) )
@@ -388,7 +388,7 @@ msgid "Due {0}"
 msgstr "기한 {0}"
 
 msgid "Due Date"
-msgstr "기한일"
+msgstr "마감일"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
@@ -401,13 +401,13 @@ msgid "Duplicate batch number"
 msgstr "중복된 배치 번호"
 
 msgid "Duplicate serial number"
-msgstr "중복된 일련번호"
+msgstr "중복된 시리얼 번호"
 
 msgid "Duration"
 msgstr "기간"
 
 msgid "Edit"
-msgstr "수정"
+msgstr "편집"
 
 msgid "Elapsed"
 msgstr "경과 시간"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "예상"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "모든 단위에 판정이 있습니다: {passes}개 합격 및 {fails}개 불합격. 로트는 각 단위가 자신의 결과로 라우팅되면서 종료됩니다."
+msgstr "각 개는 판정을 가집니다: {passes}개 통과하고 {fails}개 불합격합니다. 로트는 각 개가 자신의 결과로 배정되면서 마감됩니다."
 
 msgid "Expand features table"
 msgstr "기능 테이블 확장"
@@ -500,7 +500,7 @@ msgid "Files"
 msgstr "파일"
 
 msgid "Files related to the job and the opportunity line."
-msgstr "작업 및 기회 라인과 관련된 파일입니다."
+msgstr "작업 지시 및 영업 기회 라인과 관련된 파일입니다."
 
 msgid "Filter"
 msgstr "필터"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "그래도 완료"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "계정 설정을 완료하세요"
 
 msgid "Finish with material unpicked?"
 msgstr "미선택 재료가 있는 상태로 완료하시겠습니까?"
 
 msgid "Forgot to Clock Out?"
-msgstr "퇴근 체크를 잊으셨나요?"
+msgstr "작업 종료를 잊었나요?"
 
 msgid "Go back to operation"
 msgstr "공정작업으로 돌아가기"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "온보딩으로 이동"
 
 msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
@@ -616,13 +616,13 @@ msgid "Job Details"
 msgstr "작업 상세정보"
 
 msgid "Job Traveler"
-msgstr "작업 트래블러"
+msgstr "작업 이동표"
 
 msgid "Jobs"
-msgstr "작업"
+msgstr "작업 지시"
 
 msgid "Keep picking"
-msgstr "계속 선택"
+msgstr "피킹을 계속하세요"
 
 msgid "Kit"
 msgstr "키트"
@@ -691,7 +691,7 @@ msgid "Machine"
 msgstr "기계"
 
 msgid "Machine down for maintenance now?"
-msgstr "현재 유지보수로 가동 중단?"
+msgstr "기계가 지금 유지보수 중인가요?"
 
 msgid "Maintenance"
 msgstr "유지보수"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "유지보수 완료"
 
 msgid "Maintenance overdue"
-msgstr "기한이 지난 유지보수"
+msgstr "유지보수 기한 초과"
 
 msgid "Make a replacement"
 msgstr "교체품 만들기"
@@ -773,31 +773,31 @@ msgid "No"
 msgstr "아니요"
 
 msgid "No active job at this work center"
-msgstr "이 작업 센터에 활성 작업 없음"
+msgstr "이 작업장에서 진행 중인 작업 지시가 없습니다"
 
 msgid "No active maintenance dispatches"
-msgstr "진행 중인 유지보수 작업지시가 없습니다"
+msgstr "진행 중인 유지보수 지시가 없습니다"
 
 msgid "No active operations"
 msgstr "진행 중인 공정작업이 없습니다"
 
 msgid "No active work centers at this location."
-msgstr "이 위치에 활성 작업 센터 없음."
+msgstr "이 사업장에는 운영 중인 작업장이 없습니다."
 
 msgid "No assigned operations"
 msgstr "배정된 공정작업이 없습니다"
 
 msgid "No available filters"
-msgstr "사용 가능한 필터가 없습니다"
+msgstr "가용 필터가 없습니다"
 
 msgid "No available serial numbers found"
-msgstr "사용 가능한 일련번호를 찾을 수 없습니다"
+msgstr "가용 시리얼 번호를 찾을 수 없습니다"
 
 msgid "No available tracked entities found"
-msgstr "사용 가능한 추적 개체가 없습니다"
+msgstr "가용 추적 항목을 찾을 수 없습니다"
 
 msgid "No dispatches assigned to you"
-msgstr "배정된 작업지시가 없습니다"
+msgstr "당신에게 할당된 유지보수 지시가 없습니다"
 
 msgid "No files"
 msgstr "파일 없음"
@@ -812,13 +812,13 @@ msgid "No maintenance scheduled for today"
 msgstr "오늘 예정된 유지보수가 없습니다"
 
 msgid "No matches. Type to create one."
-msgstr "일치하는 항목이 없습니다. 입력하여 새로 만드세요."
+msgstr "일치항목이 없습니다. 입력하여 새로 만드세요."
 
 msgid "No materials"
 msgstr "자재 없음"
 
 msgid "No open jobs"
-msgstr "진행 중인 작업이 없습니다"
+msgstr "미결 작업 지시가 없습니다"
 
 msgid "No open units to allocate"
 msgstr "할당할 열린 단위가 없습니다"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "옵션이 없습니다."
 
 msgid "No picking lists assigned"
-msgstr "배정된 피킹 목록이 없습니다"
+msgstr "할당된 피킹 리스트가 없습니다"
 
 msgid "No printer configured"
 msgstr "설정된 프린터가 없습니다"
@@ -860,10 +860,10 @@ msgid "No scheduled time"
 msgstr "예정된 시간 없음"
 
 msgid "No serial numbers"
-msgstr "일련번호 없음"
+msgstr "시리얼 번호 없음"
 
 msgid "No serial numbers found"
-msgstr "일련번호를 찾을 수 없습니다"
+msgstr "시리얼 번호를 찾을 수 없습니다"
 
 msgid "No spare parts added yet"
 msgstr "아직 추가된 예비 부품이 없습니다"
@@ -896,10 +896,10 @@ msgid "Nothing running"
 msgstr "실행 중인 것 없음"
 
 msgid "Nothing scheduled at this work center"
-msgstr "이 작업 센터에서 예정된 것 없음"
+msgstr "이 작업장에 예정된 작업이 없습니다"
 
 msgid "Nothing to scrap"
-msgstr "폐기할 것이 없습니다"
+msgstr "스크랩할 것이 없습니다"
 
 msgid "OEE Impact"
 msgstr "OEE 영향"
@@ -912,7 +912,7 @@ msgstr "오래된순"
 
 #. placeholder {0}: batch.quantity
 msgid "Only {0} available"
-msgstr "{0}만 사용 가능"
+msgstr "{0}개만 가용합니다"
 
 msgid "Oops. You shouldn't see this page. Eventually it will be a landing page."
 msgstr "이런. 이 페이지가 보이면 안 됩니다. 나중에 랜딩 페이지가 될 예정입니다."
@@ -921,13 +921,13 @@ msgid "Open"
 msgstr "열림"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "작업 센터에 설치된 화면에 디스플레이를 열고 실행 중인 상태로 두십시오. 각 보드는 자동으로 새로고침됩니다."
+msgstr "작업장에 설치된 화면에 디스플레이를 열고 계속 실행 상태로 두세요. 각 보드는 자동으로 새로고침됩니다."
 
 msgid "Open an NCR for MRB disposition"
-msgstr "MRB 처리를 위한 NCR 열기"
+msgstr "MRB 처분 결정을 위해 NCR을 여세요"
 
 msgid "Open Jobs"
-msgstr "진행 중인 작업"
+msgstr "작업 지시 열기"
 
 msgid "Operations"
 msgstr "공정작업"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "전체 결과"
 
 msgid "Overdue PMs?"
-msgstr "기한이 지난 PM?"
+msgstr "기한 초과된 PM이 있나요?"
 
 msgid "Parameters"
 msgstr "파라미터"
@@ -963,16 +963,16 @@ msgid "Partial"
 msgstr "부분"
 
 msgid "Partial Disposition"
-msgstr "부분 처리"
+msgstr "부분 처분 결정"
 
 msgid "Passed Inspection"
-msgstr "검사 합격"
+msgstr "검사 통과"
 
 msgid "Passkey unlock failed"
 msgstr "패스키 잠금 해제 실패"
 
 msgid "Pause"
-msgstr "일시정지"
+msgstr "일시 중지"
 
 msgid "Pick"
 msgstr "피킹"
@@ -1026,7 +1026,7 @@ msgid "Priority"
 msgstr "우선순위"
 
 msgid "Procedure"
-msgstr "절차"
+msgstr "절차서"
 
 msgid "Process"
 msgstr "공정"
@@ -1093,7 +1093,7 @@ msgid "Remove part"
 msgstr "품목 제거"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "부분 조립품을 다시 열고 교체 단위를 생성합니다"
+msgstr "서브어셈블리를 다시 열고 대체 부품을 생성하세요"
 
 msgid "Result"
 msgstr "결과"
@@ -1111,7 +1111,7 @@ msgid "Running"
 msgstr "실행 중"
 
 msgid "Sales Order"
-msgstr "판매주문"
+msgstr "수주"
 
 msgid "Save"
 msgstr "저장"
@@ -1120,22 +1120,22 @@ msgid "Scan"
 msgstr "스캔"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "추적된 엔터티를 스캔하여 첫 번째 샘플 열을 추가하세요."
+msgstr "첫 번째 샘플 열을 추가하려면 추적 대상을 스캔하세요."
 
 msgid "Scan or enter serial number"
-msgstr "일련번호를 스캔하거나 입력하세요"
+msgstr "시리얼 번호를 스캔하거나 입력하세요"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "추적된 엔터티 ID, 일련번호 또는 배치를 스캔하거나 입력하세요"
+msgstr "추적 대상 ID, 시리얼 번호 또는 배치를 스캔하거나 입력하세요"
 
 msgid "Scan or enter tracking number"
 msgstr "추적 번호를 스캔하거나 입력하세요"
 
 msgid "Scan or search serial number..."
-msgstr "일련번호를 스캔하거나 검색하세요..."
+msgstr "시리얼 번호를 스캔하거나 검색하세요..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "이 로트에서 추적된 엔터티를 스캔하거나 선택하여 샘플 열로 추가한 다음 그리드에 그 결과를 기록하세요."
+msgstr "이 로트에서 추적 대상을 스캔하거나 선택하여 샘플 열로 추가한 다음 그리드에 결과를 기록하세요."
 
 msgid "Schedule"
 msgstr "일정"
@@ -1144,13 +1144,13 @@ msgid "Scrap"
 msgstr "스크랩"
 
 msgid "Scrap {readableId}"
-msgstr "{readableId} 폐기"
+msgstr "{readableId} 스크랩"
 
 msgid "Scrap material"
-msgstr "자재 폐기"
+msgstr "자재 스크랩"
 
 msgid "Scrap quantity"
-msgstr "폐기 수량"
+msgstr "스크랩 수량"
 
 msgid "Scrap Reason"
 msgstr "스크랩 사유"
@@ -1189,7 +1189,7 @@ msgid "Select a scrap quantity and reason"
 msgstr "스크랩 수량과 사유를 선택하세요"
 
 msgid "Select a serial number to continue with this operation"
-msgstr "이 공정작업을 계속하려면 일련번호를 선택하세요"
+msgstr "이 공정을 계속하려면 시리얼 번호를 선택하세요"
 
 msgid "Select an issue type"
 msgstr "문제 유형 선택"
@@ -1212,7 +1212,7 @@ msgid "Select Serial {0}"
 msgstr "일련번호 {0} 선택"
 
 msgid "Select Serial Number"
-msgstr "일련번호 선택"
+msgstr "시리얼 번호 선택"
 
 msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
 msgstr "되돌아갈 공정작업을 선택하세요. 해당 시점부터 현재 공정작업까지 모두 다시 진행됩니다."
@@ -1231,25 +1231,25 @@ msgstr "일련번호"
 
 #. placeholder {0}: index + 1
 msgid "Serial Number {0}"
-msgstr "일련번호 {0}"
+msgstr "시리얼 번호 {0}"
 
 msgid "Serial number is not available"
-msgstr "일련번호를 사용할 수 없습니다"
+msgstr "시리얼 번호를 사용할 수 없습니다"
 
 msgid "Serial number is required"
-msgstr "일련번호가 필요합니다"
+msgstr "시리얼 번호가 필요합니다"
 
 msgid "Serial numbers"
-msgstr "일련번호"
+msgstr "시리얼 번호"
 
 msgid "Serial Numbers"
-msgstr "일련번호"
+msgstr "시리얼 번호"
 
 msgid "Session locked"
-msgstr "세션이 잠겨 있음"
+msgstr "세션 잠김"
 
 msgid "Set Clock Out"
-msgstr "퇴근 처리"
+msgstr "작업 종료 설정"
 
 msgid "Set clock-out time"
 msgstr "퇴근 시간 설정"
@@ -1334,7 +1334,7 @@ msgid "Steps are missing"
 msgstr "단계가 누락되었습니다"
 
 msgid "Storage Unit"
-msgstr "저장 단위"
+msgstr "보관 단위"
 
 msgid "Submit anonymously"
 msgstr "익명으로 제출"
@@ -1355,31 +1355,31 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "이 공정작업의 완료 수량이 필요 수량 {targetQuantity}보다 적습니다."
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "로트가 합격으로 표시되고 {remaining}개의 남은 단위가 이 작업에서 완료됩니다."
+msgstr "로트는 통과로 표시되고 이 공정에서 남은 {remaining}개가 완료됩니다."
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "로트는 여전히 처리되지만 최소한 하나의 Issue Type이 구성될 때까지 NCR을 생성할 수 없습니다."
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "이 재료에 대해 사용 가능하거나 소비된 추적된 부품이 없습니다."
+msgstr "이 자재에 대해 가용 또는 소모된 추적 부품이 없습니다."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
-msgstr "자재명세서(BOM)에 아직 완전히 출고되지 않은 일련번호 또는 배치 추적 자재가 있습니다. 출고하지 않고 완료하면 이력추적 기록이 부정확해질 수 있습니다."
+msgstr "부품표(BOM)에 완전히 발행되지 않은 시리얼 또는 배치 추적 자재가 있습니다. 발행하지 않고 완료하면 잘못된 추적성 기록이 발생할 수 있습니다."
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
 msgstr "이 항목들은 아직 선택할 재료가 있습니다. 지금 완료하면 목록이 부분으로 표시됩니다."
 
 msgid "This lot is expired and can't be picked."
-msgstr "이 로트는 만료되어 피킹할 수 없습니다."
+msgstr "이 로트는 만료되었으므로 피킹할 수 없습니다."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "이 부품은 주문 제작되었습니다. 폐기하면 교체품을 만들기 위해 라우팅을 다시 열 수 있습니다."
+msgstr "이 부품은 주문 제작되었습니다. 이를 스크랩하면 라우팅을 다시 열어서 대체 부품을 만들 수 있습니다."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
 msgstr "이 부품은 재고에서 폐기됩니다. 요구사항은 열려있으므로 교체품을 발급할 수 있습니다."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
-msgstr "이 단위는 영구적으로 폐기되며 교체 일련번호가 생성됩니다."
+msgstr "이 개가 영구적으로 스크랩되고 대체 시리얼 번호가 생성됩니다."
 
 msgid "Thumbnail"
 msgstr "썸네일"
@@ -1409,7 +1409,7 @@ msgid "Total: {0}"
 msgstr "합계: {0}"
 
 msgid "Tracked Entity"
-msgstr "추적된 엔터티"
+msgstr "추적 대상"
 
 msgid "Tracking"
 msgstr "추적"
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "{0} 피킹 취소"
 
 msgid "Unplanned downtime"
-msgstr "계획되지 않은 다운타임"
+msgstr "계획되지 않은 비가동 시간"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "확인"
 
 msgid "View maintenance dispatch"
-msgstr "유지보수 작업지시 보기"
+msgstr "유지보수 지시 보기"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "계정에 로그인할 수 있는 매직 링크를 보내드렸습니다."
@@ -1501,7 +1501,7 @@ msgid "Work Center"
 msgstr "작업장"
 
 msgid "Work Center Displays"
-msgstr "작업 센터 디스플레이"
+msgstr "작업장 화면"
 
 msgid "Yes"
 msgstr "예"
@@ -1510,13 +1510,13 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "<0/>에 근무를 시작했습니다. 아래에서 퇴근 시간을 편집하거나 현재 근무 중임을 확인할 수 있습니다."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "{hoursElapsed}시간 동안 출근 상태입니다. 퇴근 처리를 잊으셨나요?"
+msgstr "{hoursElapsed}시간 동안 작업 중입니다. 작업 종료를 잊으셨나요?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "아직 회사에 속하지 않은 계정입니다. Carbon ERP에서 온보딩을 완료해 주시기 바랍니다."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "조직에서 인증 앱을 요구하고 있습니다. Carbon에서 설정한 후 여기로 돌아오세요."
 
 msgid "Your session was locked after inactivity."
-msgstr "세션이 비활성 후 잠겼습니다."
+msgstr "비활성으로 인해 세션이 잠겼습니다."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -532,7 +532,6 @@ msgstr "공정작업으로 돌아가기"
 
 msgid "Go to onboarding"
 msgstr "온보딩으로 이동"
-msgstr "온보딩으로 이동하기"
 
 msgid "How many were actually picked?"
 msgstr "실제로 몇 개를 피킹했습니까?"
@@ -1515,7 +1514,6 @@ msgstr "{hoursElapsed}시간 동안 작업 중입니다. 작업 종료를 잊으
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "아직 회사에 속하지 않은 계정입니다. Carbon ERP에서 온보딩을 완료해 주시기 바랍니다."
-msgstr "아직 계정이 회사에 속하지 않았습니다. Carbon ERP에서 온보딩을 완료하여 계속하세요."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "조직에서 인증 앱을 요구하고 있습니다. Carbon에서 설정한 후 여기로 돌아오세요."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -33,7 +33,7 @@ msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Delet
 msgstr "„{storageUnitName}\" ma {childCount} bezpośrednio zagnieżdżonych jednostek magazynowych. Usunięcie go spowoduje również usunięcie ich i wszystkiego pod nimi. Tej operacji nie można cofnąć."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "„${storageUnitName}\" ma 1 bezpośrednią zagnieżdżoną jednostkę magazynową. Usunięcie jej spowoduje również usunięcie tej jednostki i wszystkiego pod nią. Tej operacji nie można cofnąć."
+msgstr "„{storageUnitName}\" ma 1 bezpośrednią zagnieżdżoną jednostkę magazynową. Usunięcie jej spowoduje również usunięcie tej jednostki i wszystkiego pod nią. Tej operacji nie można cofnąć."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -50,7 +50,7 @@ msgstr "(wykluczone dla tego klienta)"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
-msgstr "{0, plural, one {Ten przedmiot znajduje się na 1 otwartym zgłoszeniu zmian} other {Ten przedmiot znajduje się na # otwartych zgłoszeniach zmian}}"
+msgstr "{0, plural, one {Ten artykuł jest na 1 otwartym zawiadomieniu o zmianie} other {Ten artykuł jest na # otwartych zawiadomieniach o zmianie}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -79,11 +79,11 @@ msgstr "{0} usunięty pomyślnie"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} wpisów dziennika w wersji roboczej"
+msgstr "{0} roboczych zapisów księgowych"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} zadań utworzonych"
+msgstr "{0} zleceń produkcyjnych utworzonych"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} brakujących wartości"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} części pominięto — mają już otwarte zadania"
+msgstr "{alreadyPlannedItemCount} części pominięto — już mają otwarte zlecenia produkcyjne"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% zobowiązań"
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} z {count} operacji"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} więcej: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} miesięcy z niezgodnymi sumami"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} dzienników brakuje u dostawcy"
+msgstr "Brakuje {missingCount} dowodów księgowych u dostawcy"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} brakujących dzienników i {mismatchCount} miesięcy z niezgodnościami"
+msgstr "{missingCount} brakujących dowodów księgowych i {mismatchCount} niedopasowanych miesięcy"
 
 msgid "{name} deleted"
 msgstr "{name} usunięty"
@@ -199,7 +199,7 @@ msgstr "{noDemandItemCount} części pominięto — nic do zrobienia"
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel} będzie ponownie otwarte do edycji jako wersja {0}. Dokument już wysłany do dostawcy nie zmieni się, dopóki nie sfinalizujesz i nie wyślesz ponownie zamówienia."
+msgstr "{orderLabel} zostanie ponownie otwarty do edycji jako rewizja {0}. Dokument już wysłany do dostawcy pozostaje niezmieniony, aż go sfinalizujesz i ponownie wyślesz zamówienie."
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# faza pozostała} other {# faz pozostało}}"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} zadań zaktualizowanych"
+msgstr "{updatedJobCount} zleceń produkcyjnych zaktualizowanych"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "Przesłano {uploadedFileName} — pola wypełniono na podstawie dokumentu."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "{variances, plural, one {# linia różni się od oczekiwanej ilości} other {# linii różni się od oczekiwanej ilości}}"
+msgstr "{variances, plural, one {# pozycja różni się od oczekiwanej ilości} other {# pozycje różnią się od oczekiwanej ilości}}"
 
 msgid "{years}yr"
 msgstr "{years}r"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 dzień"
 
 msgid "1 draft journal entry"
-msgstr "1 wpis dziennika w wersji roboczej"
+msgstr "1 roboczy zapis księgowy"
 
 msgid "1 job created"
 msgstr "1 zadanie utworzone"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Minimum 5 użytkowników"
 
 msgid "5-8 weeks"
 msgstr "5-8 tygodni"
 
 msgid "52-week demand"
-msgstr "Popyt 52-tygodniowy"
+msgstr "Zapotrzebowanie na 52 tygodnie"
 
 msgid "5MB file limit"
 msgstr "Limit pliku 5MB"
@@ -330,7 +330,7 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Migracja danych prowadzona przez Carbon — ty ładujesz swoje dane"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Zgłoszenie zmian śledzi kontrolowaną zmianę inżynieryjną lub produkcyjną w procesie przeglądu i wdrażania."
+msgstr "Zawiadomienie o zmianie śledzi kontrolowaną zmianę inżynieryjną lub produkcyjną przez przegląd i wdrożenie."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "Konto kompensacyjne zawierające wartość towarów otrzymanych, ale jeszcze niezafakturowanych; faktura dostawcy go wyzerowuje."
@@ -345,22 +345,22 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "Zdefiniowane przez firmę dodatkowe pole dołączone do tabeli podstawowej (klient, część, zamówienie); wyświetla się w formularzu rekordu, zapisuje się obok wbudowanych pól i można je wyszukiwać za pośrednictwem API."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Zdefiniowana przez firmę oś tagów dołączona do wierszy dziennika, dzięki czemu te same konta mogą być podzielone według lokalizacji, działu lub dowolnej osi niestandardowej bez mnożenia planu kont."
+msgstr "Zdefiniowana przez firmę oś etykiet przyłączona do linii dowodów księgowych, aby te same konta mogły być podzielone przez lokalizację, dział lub dowolną oś niestandardową bez mnożenia planu kont."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "Zdefiniowany w zakresie firmy rabat lub narzut, wyrażony w procentach lub stałą kwotą, który dostosowuje cenę wiersza w górę lub w dół, gdy wiersz spełnia warunki ilości, daty, artykułu i klienta reguły."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "Wyjście ukończonego zadania, otrzymane w zapasach przy rzeczywistym skumulowanym koszcie WIP zadania."
+msgstr "Wyjście ukończonego zlecenia produkcyjnego, przyjęte do zapasów w rzeczywistym skumulowanym koszcie produkcji w toku."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Materiał zużywalny to przedmiot fizyczny używany do wytworzenia części, którą można wykorzystać w wielu zadaniach"
+msgstr "Materiał eksploatacyjny to przedmiot fizyczny używany do wykonania części, który może być używany w wielu zleceniach produkcyjnych"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Wykonawca to kontakt dostawcy z określonymi umiejętnościami i dostępnymi godzinami"
+msgstr "Pracownik zewnętrzny to kontakt dostawcy z konkretnymi umiejętnościami i dostępnymi godzinami"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Rozwiązanie niestandardowe dostosowane do Twoich potrzeb"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Klient to firma lub osoba, która kupuje Twoje części lub usługi."
@@ -375,7 +375,7 @@ msgid "A customer's account manager changes"
 msgstr "Menedżer konta klienta zmienia się"
 
 msgid "A customer's assignee changes"
-msgstr "Przydzielony do klienta zmienia się"
+msgstr "Zmienia się osoba przypisana do klienta"
 
 msgid "A customer's currency changes"
 msgstr "Waluta klienta zmienia się"
@@ -396,7 +396,7 @@ msgid "A dated record proving a gauge was checked against a traceable standard; 
 msgstr "Datowany zapis potwierdzający, że przyrząd pomiarowy został sprawdzony względem tracjowalnego standardu; przechodzi, chyba że zaznaczono flagę wymaga działania, korekty lub naprawy, i resetuje następną datę wznowienia przyrządu."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Datowane okno, w które przypadają zapisy; status zamknięcia zmienia się z Otwarte → Zablokowane → Zamknięte, a zamknięty okres jest zamrożony przed nowymi zapisami."
+msgstr "Okno datowane, do którego wpadają zapisy; jej status zmienia się z Otwarte → Zablokowany → Zamknięto, a zamknięty okres jest zabezpieczony przed nowymi zapisami."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "Metoda amortyzacji, która obciąża stały procent pozostałej wartości księgowej każdego okresu — bardziej ciężka wcześnie, lżejsza później."
@@ -432,10 +432,10 @@ msgid "A job is released"
 msgstr "Zadanie zostaje zwolnione"
 
 msgid "A job operation is completed"
-msgstr "Operacja zadania zostaje ukończona"
+msgstr "Operacja zlecenia jest ukończona"
 
 msgid "A job's assignee changes"
-msgstr "Przydzielony do zadania zmienia się"
+msgstr "Zmienia się osoba przypisana do zlecenia produkcyjnego"
 
 msgid "A job's deadline type changes"
 msgstr "Typ terminu zadania zmienia się"
@@ -467,55 +467,55 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Lista jest podłączona do {0}, więc ten krok uruchamia się raz dla każdego elementu w niej — do {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Komponent Wytwarzaj na zamówienie, który uzyskuje własne zadanie i routing wewnątrz kompilacji nadrzędnej."
+msgstr "Komponent Produkcji na zamówienie, który otrzymuje własne zlecenie produkcyjne i marszrutę wewnątrz budowy nadrzędnej."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Komponent Wytwarzaj na zamówienie, którego części są wydawane razem do zadania nadrzędnego — bez oddzielnej kompilacji."
+msgstr "Komponent Produkcji na zamówienie, którego części są wydawane razem do zlecenia nadrzędnego — bez oddzielnej produkcji."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Zarządzana, hostowana w chmurze wersja Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Zarządzana wersja ze wszystkimi zaawansowanymi funkcjami"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Materiał to element fizyczny używany do wytworzenia części, którą można wykorzystać w wielu zadaniach"
+msgstr "Materiał to przedmiot fizyczny używany do wykonania części, który może być używany w wielu zleceniach produkcyjnych"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "Przyrząd pomiarowy (suwmiarka, mikrometr, czop pomiarowy, CMM) śledzony jako zapis i poddawany cyklicznym harmonogramom kalibracji."
+msgstr "Przyrząd pomiarowy (suwmiarka, mikrometr, czop wzorcujący, CMM) śledzony jako rekord i poddawany cyklicznym okresom wzorcowania."
 
 msgid "A name is required to save a view"
 msgstr "Nazwa jest wymagana, aby zapisać widok"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Wynegocjowana cena ustalona dla określonego artykułu — dla klienta, typu klienta lub wszystkich klientów — która całkowicie zastępuje cenę bazową, opcjonalnie z rabatami ilościowymi."
+msgstr "Wynegocjowana cena ustalona dla konkretnego artykułu — dla klienta, typu klienta lub wszystkich klientów — która w pełni zastępuje cenę bazową, opcjonalnie z progami ilościowymi."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
 msgstr "Dla każdego dostawcy zostanie utworzone nowe zamówienie zakupu. Alternatywnie możesz wybrać istniejące zamówienie zakupu w wersji roboczej dla dostawcy, aby dodać do niego operacje zewnętrzne."
 
 msgid "A new revision will be created using a copy of the current revision"
-msgstr "Nowa wersja zostanie utworzona przy użyciu kopii bieżącej wersji"
+msgstr "Nowa rewizja zostanie utworzona za pomocą kopii bieżącej rewizji"
 
 msgid "A new size will be created using a copy of the current size"
 msgstr "Nowy rozmiar zostanie utworzony przy użyciu kopii bieżącego rozmiaru"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Nowy klient Stripe zostanie utworzony"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "Dokument bezgotówkowy, który rozlicza fakturę względem konta przyczyny: kredyt obniża to, co się należy, debet to podwyższa."
+msgstr "Dokument bezgotówkowy, który wyrównuje fakturę względem konta przyczyny: ma obniża to, co jest należne, winien podwyższa."
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
 msgstr "Niezgodność udostępniona dostawcy poprzez link /share/scar bez logowania, aby mogli oni odpowiedzieć na problem i zaktualizować jego zadania spoza Carbon."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Dodatkowa opłata niepodlegająca opodatkowaniu (np. koszty zwrotne, takie jak opłaty za zezwolenie), dodawana do linii i wykluczona z podstawy opodatkowania."
+msgstr "Opłata nietaksowalna (np. wydatki odzyskiwalne takie jak opłaty za pozwolenia) dodana do pozycji; wykluczona z podstawy opodatkowania."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Zadanie niezgodności, które naprawia potwierdzoną przyczynę główną — w przeciwieństwie do działania zapobiegawczego lub natychmiastowego zatrzymania."
+msgstr "Zadanie niezgodności, które naprawia potwierdzoną przyczynę źródłową — w przeciwieństwie do działania zapobiegawczego lub natychmiastowego zabezpieczenia."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "Zadanie niezgodności, które zapobiega ponownym pojawieniu się problemu w innym miejscu — różni się od naprawy korekt ywnej i zatrzymania."
+msgstr "Zadanie niezgodności, które uniemożliwia powtarzanie się problemu gdzie indziej — różne od poprawy naprawczej i zabezpieczenia."
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "Część zawiera informacje o konkretnym artykule, który można kupić lub wyprodukować."
@@ -524,19 +524,19 @@ msgid "A physical pull signal — a printed card or QR code living with the stoc
 msgstr "Fizyczny sygnał wciągnięcia — wydrukowana karta lub kod QR umieszczony ze zapasem — który tworzy zamówienie zakupu lub zadanie w momencie jego skanowania w celu uzupełnienia pojemnika."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "Punkt w jednym z wewnętrznych przepływów Carbon, który przepływ pracy może obserwować — zadanie zwolnione, oferta zaakceptowana, przesyłka zaksięgowana — w przeciwieństwie do zmiany surowego pola; przekazuje przepływowi pracy rekordy zaangażowane po id."
+msgstr "Punkt w jednym z własnych przepływów Carbon, który przepływ pracy może śledzić — zlecenie zwolnione, oferta zaakceptowana, wysyłka zaksięgowana — w przeciwieństwie do surowej zmiany pola; przekazuje przepływowi pracy zaangażowane rekordy według id."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Zaksięgowany wpis księgowy: nagłówek plus zbilansowane linie debetowe i kredytowe dla kont GL."
+msgstr "Zaksięgowany zapis księgowy: nagłówek plus zbilansowane linie debetowe i kredytowe względem kont księgowych."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Zaksięgowana transakcja pieniężna — Paragon od klienta lub Wypłata dostawcy — zastosowana do faktur poprzez rozliczenia, przesuwając się Draft → Zaksięgowane → Anulowane."
+msgstr "Zaksięgowana transakcja gotówkowa — Przyjęcie od klienta lub Wypłata do dostawcy — zastosowana do faktur przez rozliczenia, przesuwając się z Wersja robocza → Zaksięgowano → Unieważniono."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Wstępnie napisany opis wstawiony do każdego problemu korzystającego z tego przepływu pracy; symbole zastępcze, takie jak {itemId} i {location}, są zastępowane podczas tworzenia."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "Wycena sprzedaży z ceną; Projekt → Wysłano → Zamówiono, lub kończy się Utracone, Wygasło lub Anulowane."
+msgstr "Wyceniona oferta sprzedaży; Wersja robocza → Wysłano → Zamówiono, lub kończy się Przegrana, Wygasła lub Anulowano."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
 msgstr "Faktura zakupu to dokument, który określa produkty lub usługi zakupione przez klienta i odpowiadający im koszt."
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "Zamówienie zakupu zostaje usunięte"
 
 msgid "A purchase order's assignee changes"
-msgstr "Przydzielony do zamówienia zakupu zmienia się"
+msgstr "Zmiana osoby przypisanej do zamówienia zakupu"
 
 msgid "A purchase order's order date changes"
 msgstr "Data zamówienia zakupu zmienia się"
@@ -575,7 +575,7 @@ msgid "A purchase order's type changes"
 msgstr "Typ zamówienia zakupu zmienia się"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Problem jakości — zarejestrowana odchyłka lub wada z konfigurowalnym przepływem pracy zadań badawczych i naprawczych."
+msgstr "Wydanie jakości — zalogowane odstępstwo lub wada z konfigurowalnym przepływem pracy analizy przyczyn i zadań działań."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Ilość identycznych jednostek dzieli się śledzonym obiektem i numerem partii — jeden obiekt, wiele jednostek."
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "Wycena jest wysłana"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Linia oferty zawiera ceny i czasy realizacji dla konkretnej części"
+msgstr "Pozycja oferty zawiera ustalanie cen i czasy realizacji dla konkretnej części"
 
 msgid "A quote's assignee changes"
-msgstr "Osoba przydzielona do wyceny zmienia się"
+msgstr "Zmiana osoby przypisanej do oferty"
 
 msgid "A quote's completed date changes"
 msgstr "Data ukończenia wyceny zmienia się"
@@ -614,7 +614,7 @@ msgid "A quote's estimator changes"
 msgstr "Osoba szacująca wycenę zmienia się"
 
 msgid "A quote's expiration date changes"
-msgstr "Data wygaśnięcia wyceny zmienia się"
+msgstr "Zmiana daty ważności oferty"
 
 msgid "A quote's salesperson changes"
 msgstr "Osoba handlowa wyceny zmienia się"
@@ -632,7 +632,7 @@ msgid "A receipt is posted"
 msgstr "Rachunek jest zaksięgowany"
 
 msgid "A receipt's assignee changes"
-msgstr "Osoba przydzielona do rachunku zmienia się"
+msgstr "Zmiana osoby przypisanej do przyjęcia"
 
 msgid "A receipt's invoiced changes"
 msgstr "Zafakturowanie rachunku zmienia się"
@@ -653,13 +653,13 @@ msgid "A receipt's supplier changes"
 msgstr "Dostawca rachunku zmienia się"
 
 msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
-msgstr "Zestaw wielokrotnego użytku, wersjonowany instrukcji pracy dołączonych do procesu, zapewniający operacji uporządkowane kroki do rejestracji i sprawdzenia oraz parametry, w których się wykonuje."
+msgstr "Wielokrotnie użyteczny, wersjonowany zestaw instrukcji roboczych dołączony do procesu, dający operacji uporządkowane kroki do zarejestrowania i sprawdzenia oraz parametry, przy których pracuje."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Krok routingu na zwolnionym zadaniu, własna kopia operacji zadania, niosąca status, który hala zmienia od Do zrobienia do Gotowe."
+msgstr "Krok marszruty w zwolnionym zleceniu produkcyjnym, własna kopia operacji zlecenia, zawierająca status, który piętrze kieruje od Do zrobienia do Gotowe."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Faktura sprzedażowa (wystawiasz rachunek klientowi) lub faktura zakupu (dostawca wystawia rachunek tobie), rozliczona poprzez zastosowanie płatności oraz notatek kredytowych lub debetowych."
+msgstr "Faktura sprzedaży (rachunek dla klienta) lub faktura zakupu (dostawca ci wystawia rachunek), rozliczona poprzez zastosowanie płatności i notatek kredytowych lub debetowych."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
 msgstr "Faktura sprzedaży to dokument określający produkty lub usługi sprzedane klientowi oraz odpowiadający im koszt."
@@ -680,10 +680,10 @@ msgid "A sales order is deleted"
 msgstr "Zamówienie sprzedaży jest usuwane"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "Linia zamówienia sprzedaży zawiera szczegóły zamówienia dla konkretnego artykułu"
+msgstr "Pozycja zamówienia sprzedaży zawiera szczegóły zamówienia dla konkretnego artykułu"
 
 msgid "A sales order's assignee changes"
-msgstr "Osoba przydzielona do zamówienia sprzedaży zmienia się"
+msgstr "Zmiana osoby przypisanej do zamówienia sprzedaży"
 
 msgid "A sales order's completed date changes"
 msgstr "Data ukończenia zamówienia sprzedaży zmienia się"
@@ -707,16 +707,16 @@ msgid "A sales order's status changes"
 msgstr "Status zamówienia sprzedaży zmienia się"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Zapytanie ofertowe (RFQ) to zapytanie klienta dotyczące wyceny zestawu części i ilości. Może to skutkować złożeniem oferty."
+msgstr "Zapytanie ofertowe do sprzedaży (RFQ) to zapytanie klienta o ustalanie cen na zestaw części i ilości. Może to prowadzić do oferty."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
-msgstr "RFQ sprzedażowy (klient prosi Cię o wycenę) lub RFQ zakupowy (pytasz dostawców); oba zasilają wątek oportunizmu."
+msgstr "Zapytanie ofertowe do sprzedaży (klient prosi o ofertę) lub zapytanie ofertowe do zakupów (pytasz dostawców); oba zasilają wątek szansy sprzedaży."
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
 msgstr "Tajny klucz wysyłany w nagłówku żądania carbon-key, który uwierzytelnia programowe wywołania do Carbon, niosąc własne uprawnienia i limit szybkości zamiast sesji użytkownika."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "Osobny harmonogram dla sprawozdawczości podatkowej, gdy przepisy podatkowe wymagają metody innej niż amortyzacja księgowa."
+msgstr "Odrębny harmonogram do raportowania podatków, gdy przepisy podatkowe wymagają metody innej niż amortyzacja księgowa."
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "Usługa to działalność podlegająca rozliczeniu, która jest kupowana lub wykonywana — nigdy nie jest wysyłana, odbierana ani magazynowana"
@@ -725,7 +725,7 @@ msgid "A set of companies under one owner that share group-scoped configuration 
 msgstr "Zbiór firm pod jednym właścicielem, które współdzielą konfigurację na poziomie grupy — plan kont, waluty i wymiary — dzięki czemu ta sama konfiguracja księgowa obejmuje każdą firmę w grupie."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Zestaw instrukcji do wciągnięcia zalegających materiałów zadania z magazynu i przygotowania ich na linii; pobranie przenosi zapas do punktu użycia zamiast go konsumować."
+msgstr "Zestaw instrukcji do pobrania zaległych materiałów zlecenia produkcyjnego z magazynu i przygotowania ich w magazynie przyliniowym; pobranie przenosi zapas do punktu użycia, a nie go zużywa."
 
 msgid "A shipment is created"
 msgstr "Wysyłka jest tworzona"
@@ -737,10 +737,10 @@ msgid "A shipment is posted"
 msgstr "Wysyłka jest zaksięgowana"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "Wiersz wysyłki wysłany bezpośrednio od dostawcy do klienta, omijając Twój magazyn — ustawiony na wiersz, a nie w nagłówku."
+msgstr "Pozycja wysyłki wysłana bezpośrednio od dostawcy do klienta, omijająca twój magazyn — ustawiana na każdej pozycji, a nie na nagłówku."
 
 msgid "A shipment's assignee changes"
-msgstr "Osoba przydzielona do wysyłki zmienia się"
+msgstr "Zmiana osoby przypisanej do wysyłki"
 
 msgid "A shipment's customer changes"
 msgstr "Klient wysyłki zmienia się"
@@ -752,13 +752,13 @@ msgid "A shipment's posting date changes"
 msgstr "Data księgowania wysyłki zmienia się"
 
 msgid "A shipment's shipping method changes"
-msgstr "Metoda wysyłki zmienia się"
+msgstr "Zmiana sposobu wysyłki"
 
 msgid "A shipment's status changes"
 msgstr "Status wysyłki zmienia się"
 
 msgid "A shipment's tracking number changes"
-msgstr "Numer śledzenia przesyłki się zmienia"
+msgstr "Zmiana numeru śledzenia wysyłki"
 
 msgid "A step needs a name."
 msgstr "Krok wymaga nazwy."
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "Nazwa dostawcy się zmienia"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "Wycena odpowiedzi dostawcy na RFQ zakupowy — jeden na dostawcę; Projekt → Aktywny po wysłaniu lub Odrzucony."
+msgstr "Wyceniona odpowiedź dostawcy na zapytanie ofertowe do zakupów — jeden na dostawcę; Wersja robocza → Aktywny po przesłaniu lub Odrzucony."
 
 msgid "A supplier's status changes"
 msgstr "Status dostawcy się zmienia"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "Dodatkowa opłata podlegająca opodatkowaniu (obsługa, konfiguracja, paliwo), dodawana do linii i uwzględniana w podstawie opodatkowania."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Czasowy zapis pracy Setup, Labor lub Machine zarejestrowany dla operacji zadania, którego czas trwania jest sumowany w rzeczywistym koszcie operacji."
+msgstr "Zanotowany w czasie zapis pracy Przezbrojenia, Robocizny lub Maszyny zalogowanej dla operacji zlecenia produkcyjnego, którego czas trwania sumuje się w rzeczywisty koszt operacji."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Narzędzie to element fizyczny używany do wykonania części, którą można wykorzystać w wielu zadaniach"
+msgstr "Narzędzie to rzeczywisty artykuł używany do produkcji części, które można stosować w wielu zleceniach produkcyjnych"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "Użytkownik rejestruje datę wygaśnięcia dla każdej partii lub numeru seryjnego po otrzymaniu towaru. Używaj, gdy dostawcy wysyłają partie z różnymi datami wygaśnięcia."
+msgstr "Użytkownik notuje termin ważności dla każdej partii produkcyjnej lub serii, gdy towary są odbierane. Użyj, gdy dostawcy wysyłają partie z różnymi terminami ważności."
 
 msgid "abilities"
-msgstr "możliwości"
+msgstr "umiejętności"
 
 msgid "Abilities"
 msgstr "Umiejętności"
 
 msgid "ability"
-msgstr "możliwość"
+msgstr "umiejętność"
 
 msgid "About"
 msgstr "O mnie"
@@ -842,7 +842,7 @@ msgid "Acceptance"
 msgstr "Akceptacja"
 
 msgid "Acceptance passed"
-msgstr "Akceptacja przebiegła pomyślnie"
+msgstr "Odbiór zaliczony"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
@@ -855,10 +855,10 @@ msgid "Account & Details"
 msgstr "Konto i szczegóły"
 
 msgid "Account balances with debits and credits"
-msgstr "Salda kont z debetami i kredytami"
+msgstr "Saldo kont z zapisami winiennymi i ma"
 
 msgid "Account for advance payments made before goods or services are received"
-msgstr "Rozliczaj zaliczki dokonane przed otrzymaniem towarów lub usług."
+msgstr "Konto dla płatności z góry dokonanych przed odebraniem towarów lub usług"
 
 msgid "Account for production orders not yet completed"
 msgstr "Rozliczaj zamówienia produkcyjne nie jeszcze ukończone."
@@ -894,31 +894,31 @@ msgid "Account Type (inherited)"
 msgstr "Typ konta (dziedziczony)"
 
 msgid "accounting"
-msgstr "rachunkowość"
+msgstr "księgowość"
 
 msgid "Accounting"
-msgstr "Rachunkowość"
+msgstr "Księgowość"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "Rachunkowość jest obecnie w fazie beta. Poproś o dostęp, aby włączyć raportowanie, wpisy dziennika, okresy rachunkowe, aktywa trwałe i wiele więcej."
+msgstr "Księgowość jest obecnie w wersji beta. Poproś o dostęp, aby włączyć raportowanie, dowody księgowe, okresy księgowe, środki trwałe i wiele więcej."
 
 msgid "Accounting is disabled"
-msgstr "Rachunkowość jest wyłączona"
+msgstr "Księgowość jest wyłączona"
 
 msgid "Accounting is disabled for this company."
-msgstr "Rachunkowość jest wyłączona dla tej firmy."
+msgstr "Księgowość jest wyłączona dla tej firmy."
 
 msgid "Accounting is enabled"
-msgstr "Rachunkowość jest włączona"
+msgstr "Księgowość jest włączona"
 
 msgid "Accounting period"
-msgstr "Okres rozliczeniowy"
+msgstr "Okres księgowy"
 
 msgid "Accounting Periods"
 msgstr "Okresy Księgowe"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Rachunkowość: GL, AR, AP i zamknięcie miesiąca"
+msgstr "Księgowość: Księga główna, Należności, Zobowiązania i zamknięcie na koniec miesiąca"
 
 msgid "Accounts"
 msgstr "Konta"
@@ -927,37 +927,37 @@ msgid "Accounts for recording differences between actual and standard costs"
 msgstr "Konta do rejestrowania różnic między rzeczywistymi a standardowymi kosztami"
 
 msgid "Accounts Payable"
-msgstr "Rozrachunki z dostawcami"
+msgstr "Zobowiązania"
 
 msgid "Accounts payable for amounts owed to suppliers"
-msgstr "Rozrachunki z dostawcami za kwoty należne dostawcom."
+msgstr "Zobowiązania za kwoty należne dostawcom"
 
 msgid "Accounts Receivable"
-msgstr "Rozrachunki z odbiorcami"
+msgstr "Należności"
 
 msgid "Accounts receivable for amounts owed by customers"
-msgstr "Rozrachunki z odbiorcami za kwoty należne od odbiorców."
+msgstr "Należności za kwoty należne od klientów"
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Konta przywoływane przez ustawienia domyślne księgowania lub historię dziennika, które nie mają jeszcze mapowania dostawcy."
+msgstr "Konta z domyślnych wpisów księgowych lub historii dowodów, które nie mają jeszcze mapowania dostawcy."
 
 msgid "Accumulated Depreciation"
-msgstr "Skumulowana amortyzacja"
+msgstr "Umorzenie"
 
 msgid "Accumulated Depreciation (default)"
-msgstr "Skumulowana amortyzacja (domyślnie)"
+msgstr "Umorzenie (domyślne)"
 
 msgid "Accumulated Depreciation (opening)"
-msgstr "Skumulowana amortyzacja (otwarcie)"
+msgstr "Umorzenie (otwarcia)"
 
 msgid "Accumulated Depreciation Account"
-msgstr "Konto skumulowanej amortyzacji"
+msgstr "Konto umorzenia"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Skumulowana amortyzacja przy zbyciu"
+msgstr "Umorzenie przy likwidacji"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Skumulowana amortyzacja przy zbyciu (domyślnie)"
+msgstr "Umorzenie przy likwidacji (domyślne)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Okres akumulacji (tygodnie)"
@@ -972,7 +972,7 @@ msgid "Acknowledged itar"
 msgstr "Potwierdzony itar"
 
 msgid "Acquisition Cost"
-msgstr "Koszt nabycia"
+msgstr "Cena nabycia"
 
 msgid "Acquisition Date"
 msgstr "Data nabycia"
@@ -1002,7 +1002,7 @@ msgid "Activate Process"
 msgstr "Aktywuj Proces"
 
 msgid "Activate Work Center"
-msgstr "Aktywuj Centrum Pracy"
+msgstr "Aktywuj Stanowisko robocze"
 
 msgid "Activation fee · we advise"
 msgstr "Opłata aktywacyjna · doradzamy"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "Aktywny"
 
 msgid "Active Jobs"
-msgstr "Aktywne zadania"
+msgstr "Bieżące zlecenia produkcyjne"
 
 msgid "Active Statuses"
 msgstr "Aktywne statusy"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "Dodaj komentarz..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Dodaj niestandardowy wiersz cenowy, aby zastąpić ilość, cenę, wysyłkę, czas realizacji i podatek"
+msgstr "Dodaj niestandardowy wiersz cennika, aby nadpisać ilość, cenę, wysyłkę, czas realizacji i podatek"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "Dodaj sekcję materiałów, która zawiera listę każdego elementu zestawienia materiałowego z jego ilością."
@@ -1062,7 +1062,7 @@ msgid "Add a printer in the printing settings to print labels directly."
 msgstr "Dodaj drukarkę w ustawieniach drukowania, aby drukować etykiety bezpośrednio."
 
 msgid "Add a requirement"
-msgstr "Dodaj wymóg"
+msgstr "Dodaj wymaganie"
 
 msgid "Add a row"
 msgstr "Dodaj wiersz"
@@ -1086,13 +1086,13 @@ msgid "Add any notes about your decision..."
 msgstr "Dodaj dowolne notatki dotyczące Twojej decyzji..."
 
 msgid "Add Approval Requirement"
-msgstr "Dodaj wymóg zatwierdzenia"
+msgstr "Dodaj Wymaganie Zatwierdzenia"
 
 msgid "Add Authenticator App"
 msgstr "Dodaj aplikację Authenticator"
 
 msgid "Add Calibration Record"
-msgstr "Dodaj Rekord Kalibracji"
+msgstr "Dodaj Zapis wzorcowania"
 
 msgid "Add Child Storage Unit"
 msgstr "Dodaj podrzędną jednostkę magazynową"
@@ -1107,10 +1107,10 @@ msgid "Add condition"
 msgstr "Dodaj warunek"
 
 msgid "Add Contractor"
-msgstr "Dodaj Wykonawcę"
+msgstr "Dodaj Pracownika zewnętrznego"
 
 msgid "Add cost center"
-msgstr "Dodaj centrum kosztów"
+msgstr "Dodaj miejsce powstawania kosztów"
 
 msgid "Add Entry"
 msgstr "Dodaj wpis"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Dodaj notatkę"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Dodaj notatki i dokumentację dla tego zgłoszenia serwisowego"
+msgstr "Dodaj notatki i dokumentację dla tego zlecenia utrzymania ruchu"
 
 msgid "Add Operation"
 msgstr "Dodaj operację"
@@ -1191,7 +1191,7 @@ msgid "Add Receipt"
 msgstr "Dodaj Paragon"
 
 msgid "Add Requirement"
-msgstr "Dodaj Wymóg"
+msgstr "Dodaj Wymaganie"
 
 msgid "Add Risk"
 msgstr "Dodaj ryzyko"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Wszystkie akcje zaznaczone"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Wszystkie zaawansowane funkcje dostępne"
 
 msgid "All Audit Logs"
 msgstr "Wszystkie dzienniki audytu"
@@ -1352,7 +1352,7 @@ msgid "All Documents"
 msgstr "Wszystkie dokumenty"
 
 msgid "All item types"
-msgstr "Wszystkie typy przedmiotów"
+msgstr "Wszystkie typy artykułów"
 
 msgid "All Items"
 msgstr "Wszystkie elementy"
@@ -1388,7 +1388,7 @@ msgid "All users"
 msgstr "Wszyscy użytkownicy"
 
 msgid "All Work Centers"
-msgstr "Wszystkie Centra Pracy"
+msgstr "Wszystkie stanowiska robocze"
 
 msgid "Allows acknowledge & continue"
 msgstr "Umożliwia potwierdzenie i kontynuację"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Kwota"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Kwota, która zwiększa aktywa/wydatki lub zmniejsza pasywa/kapitał/przychody w tej linii."
+msgstr "Kwota, która zwiększa aktywa/wydatki lub zmniejsza zobowiązania/kapitał własny/przychody w tym wierszu."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Kwota, która zwiększa pasywa/kapitał/przychody lub zmniejsza aktywa/wydatki w tej linii."
+msgstr "Kwota, która zwiększa zobowiązania/kapitał własny/przychody lub zmniejsza aktywa/wydatki w tym wierszu."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,25 +1422,25 @@ msgid "Amount Type"
 msgstr "Typ kwoty"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Koszyk księgowy, który grupuje wydatki według departamentu lub funkcji, aby GL mogła raportować wydatki według grupy, a nie tylko według konta."
+msgstr "Miejsce powstawania kosztów grupujące wydatki według działu lub funkcji, umożliwiające księdze głównej raportowanie wydatków wg grupy, a nie tylko wg konta."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Zapis księżowy dla elementu kapitalizowanego, który deprecjonujesz zamiast wydatkować; Wersja robocza → Aktywny → W pełni zamortyzowany → Zbywany."
+msgstr "Zapis księgowy dla elementu skapitalizowanego, który amortyzujesz, zamiast go wydatkować; Wersja robocza → Aktywny → Całkowicie zamortyzowany → Zlikwidowano."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Alert, że coś wymaga uwagi osoby, rozsiany ze zdarzenia carbon/notify do skrzynki odbiorczej w aplikacji oraz opcjonalnie poczty e-mail i Slacka, wyciszane dla każdego tematu na użytkownika."
 
 msgid "An approval requirement on a non-conformance whose reviewers (seeded Engineering and Quality) must sign off before the issue can close."
-msgstr "Wymóg zatwierdzenia dla niezgodności, której recenzenci (Engineering i Quality) muszą się zaakceptować przed zamknięciem problemu."
+msgstr "Wymaganie zatwierdzenia dla niezgodności, którego recenzenci (z wcześniej określonych działów Engineering i Quality) muszą się wypowiedzieć, zanim sprawa będzie mogła zostać zamknięta."
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "Koszt nabycia zasobu minus skumulowana amortyzacja — ile warte jest wciąż w księgach i kwota, za którą jest zbywany."
+msgstr "Cena nabycia aktywa pomniejszona o umorzenie — jego wartość netto w księgach i kwota, za którą jest likwidowane."
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "Automatyzacja, którą budujesz na kanwie: jeden wyzwalacz, a następnie kroki, które sprawdzają warunki, wyszukują rekordy i działają — powiadamiając kogoś, tworząc lub aktualizując rekord, lub wywołując zewnętrzny adres URL."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "Zmiana inżynierska: elementy dotknięte zmianą, których metody zostały zrewidowane w wersji roboczej i wydane razem, zastępując wersje, które zastępują."
+msgstr "Zmiana konstrukcyjna — artykuły objęte zmianą, których metody zostały zmienione w wersji roboczej i uwolnione razem, zastępując poprzednie wersje."
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "Żądanie https, które Carbon wysyła do Twojego systemu, gdy przepływ pracy osiągnie ten krok, zawierając nagłówki i treść, które skonfigurowałeś."
@@ -1449,7 +1449,7 @@ msgid "An integration or a custom change — the small slice that's actually cus
 msgstr "Integracja lub zmiana niestandardowa — mała część, która jest faktycznie niestandardowa."
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "Zaproszenie czeka na akceptację. Będą aktywni po zaakceptowaniu."
+msgstr "Zaproszenie czeka na odpowiedź. Staną się aktywne, gdy je zaakceptują."
 
 msgid "An issue is created"
 msgstr "Problem jest tworzony"
@@ -1500,7 +1500,7 @@ msgid "An item's assignee changes"
 msgstr "Osoba przypisana do elementu uległa zmianie"
 
 msgid "An item's default method type changes"
-msgstr "Domyślny typ metody elementu ulega zmianie"
+msgstr "Domyślny typ zasilania artykułu uległ zmianie"
 
 msgid "An item's name changes"
 msgstr "Nazwa elementu uległa zmianie"
@@ -1509,7 +1509,7 @@ msgid "An item's replenishment system changes"
 msgstr "System uzupełniania zapasów elementu ulega zmianie"
 
 msgid "An item's revision status changes"
-msgstr "Status wersji elementu ulega zmianie"
+msgstr "Status rewizji artykułu uległ zmianie"
 
 msgid "An item's tracking type changes"
 msgstr "Typ śledzenia elementu ulega zmianie"
@@ -1518,10 +1518,10 @@ msgid "An item's unit of measure changes"
 msgstr "Jednostka miary elementu uległa zmianie"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Operacja wykonana przez zewnętrznego dostawcę zamiast wewnętrznego centrum pracy, objęta zamówieniem zakupu podwykonawstwa."
+msgstr "Operacja wykonywana przez zewnętrznego dostawcę zamiast wewnętrznego stanowiska roboczego, pokryta zamówieniem na podwykonawstwo."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "Pozycja operacji w kolejce jej centrum pracy — kolejność, w której hala podjmuje pracę — ustawiana poprzez zmianę porządku kart na tablicy Centrów pracy bez zmiany dat."
+msgstr "Pozycja operacji w kolejce stanowiska roboczego — kolejność, w jakiej pracownicy podejmują pracę — ustawiana przez zmianę kolejności kart na tablicy Stanowisk roboczych bez zmiany żadnych dat."
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "Podczas łączenia z Onshape wystąpił nieoczekiwany błąd. Spróbuj połączyć się ponownie."
@@ -1561,22 +1561,22 @@ msgid "Annotation updated"
 msgstr "Adnotacja zaktualizowana"
 
 msgid "Another cost center this one rolls up into, letting you nest a sub-department under its parent for hierarchical cost reporting."
-msgstr "Inny center kosztów, do którego ten agreguje się, pozwalając Ci zagnieżdżać podcentrum kosztów poniżej jego ojca w celu raportowania kosztów hierarchicznych."
+msgstr "Inne miejsce powstawania kosztów, w które się to sumuje, pozwalające na zagnieżdżenie podrzędnego działu pod jego jednostką nadrzędną dla hierarchicznego raportowania kosztów."
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "Inny unit magazynowy, w którym ten jest zagnieżdżony (np. pojemnik w regale); musi być w tej samej lokalizacji."
+msgstr "Inna jednostka magazynowa, w której ta się zagnieżdża (np. pojemnik w regale); musi być w tej samej Lokalizacji."
 
 msgid "Any item group"
 msgstr "Dowolna grupa artykułów"
 
 msgid "Any item type"
-msgstr "Dowolny typ przedmiotu"
+msgstr "Dowolny typ artykułu"
 
 msgid "Anything not explicitly listed in scope above"
 msgstr "Wszystko, co nie jest wyraźnie wymienione w zakresie powyżej"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Zobowiązania"
 
 msgid "AP Aging"
 msgstr "Wiekowanie zobowiązań"
@@ -1588,7 +1588,7 @@ msgid "AP Outstanding"
 msgstr "Zobowiązania do zapłaty"
 
 msgid "AP Overdue"
-msgstr "AP Zaległy"
+msgstr "Zobowiązania po terminie"
 
 msgid "API Docs"
 msgstr "Dokumentacja API"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Klucze API do programowego dostępu do danych Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks i integracje"
 
 msgid "Applied"
 msgstr "Zastosowano"
@@ -1631,10 +1631,10 @@ msgid "Applies to all"
 msgstr "Dotyczy wszystkich"
 
 msgid "Applies to all work centers"
-msgstr "Dotyczy wszystkich centrów pracy"
+msgstr "Dotyczy wszystkich stanowisk roboczych"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
-msgstr "Dotyczy funkcji bez własnej reguły oraz partii, gdy ten plan prowadzi inspekcję."
+msgstr "Dotyczy funkcji, które nie mają własnej reguły, oraz partii, gdy ten plan prowadzi kontrolę."
 
 msgid "Apply"
 msgstr "Zastosuj"
@@ -1658,7 +1658,7 @@ msgid "Apply Rules On Top"
 msgstr "Zastosuj reguły na górze"
 
 msgid "Apply suggestions"
-msgstr "Zastosuj sugestie"
+msgstr "Zastosuj propozycje"
 
 msgid "Apply To"
 msgstr "Zastosuj do"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Należności"
 
 msgid "AR / AP representation"
-msgstr "Reprezentacja AR / AP"
+msgstr "Reprezentacja Należności / Zobowiązań"
 
 msgid "AR Aging"
 msgstr "Wiekowanie należności"
 
 msgid "AR Clerk"
-msgstr "Pracownik ds. rozrachunków z odbiorcami"
+msgstr "Pracownik ds. Należności"
 
 msgid "AR Outstanding"
 msgstr "Zaległości z tytułu należności"
 
 msgid "AR Overdue"
-msgstr "AR Zaległy"
+msgstr "Należności przeterminowane"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Należności/Zobowiązania"
 
 msgid "Archive"
 msgstr "Archiwum"
@@ -1750,7 +1750,7 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "Czy na pewno chcesz aktywować proces: {name}? Pojawi się ponownie w listach rozwijanych."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Czy na pewno chcesz aktywować ten miernik?."
+msgstr "Czy chcesz aktywować ten przyrząd pomiarowy?"
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
@@ -1764,22 +1764,22 @@ msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "Czy na pewno chcesz anulować {orderLabel}? Spowoduje to zamknięcie zamówienia."
 
 msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
-msgstr "Czy na pewno chcesz anulować to zadanie? Nie będzie już dostępne na hali produkcyjnej."
+msgstr "Czy chcesz anulować to zlecenie produkcyjne? Nie będzie już dostępne na hali produkcyjnej."
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
-msgstr "Czy na pewno chcesz zmienić właściwość {propertyName}? Ponieważ używasz generowanych identyfikatorów materiałów, zmieni to identyfikator części dla tej części i wszystkich powiązanych wersji."
+msgstr "Czy chcesz zmienić właściwość {propertyName}? Ponieważ używasz generowanych numerów artykułów, spowoduje to zmianę numeru artykułu tej części oraz wszystkich powiązanych rewizji."
 
 msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Czy na pewno chcesz ukończyć ten transfer zapasów?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Czy na pewno chcesz potwierdzić to zamówienie sprzedaży? Potwierdzenie zamówienia wpłynie na ilości zamówienia używane do obliczania podaży i popytu."
+msgstr "Czy chcesz potwierdzić to zamówienie sprzedaży? Potwierdzenie zamówienia wpłynie na ilości na zamówienie używane do obliczenia pokrycia i zapotrzebowania."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
-msgstr "Czy na pewno chcesz przekonwertować RFQ na ofertę?"
+msgstr "Czy chcesz przekształcić RFQ na ofertę?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Czy na pewno chcesz utworzyć zadania dla tego zamówienia sprzedaży? Spowoduje to utworzenie zadań dla wszystkich linii, które jeszcze ich nie mają."
+msgstr "Czy chcesz utworzyć zlecenia produkcyjne dla tego zamówienia sprzedaży? Spowoduje to utworzenie zleceń produkcyjnych dla wszystkich pozycji, które nie mają jeszcze zleceń."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Czy na pewno chcesz dezaktywować tych użytkowników?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Czy na pewno chcesz dezaktywować ten miernik?."
+msgstr "Czy chcesz dezaktywować ten przyrząd pomiarowy?"
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Czy na pewno chcesz dezaktywować tego użytkownika?"
@@ -1859,18 +1859,18 @@ msgstr "Czy na pewno chcesz usunąć klucz API: {0}? Tej czynności nie można c
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć klasę aktywów: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć klasę środków trwałych: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć działanie zgłoszenia zmian: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć czynność zawiadomienia o zmianie: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć kategorię zgłoszenia zmian: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć kategorię zawiadomienia o zmianie: {0}? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć wykonawcę: {name}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć pracownika zewnętrznego: {name}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "Czy na pewno chcesz usunąć tryb awarii: {name}? Tej czynności nie mo�
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć typ miernika: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć typ przyrządu: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1929,7 +1929,7 @@ msgid "Are you sure you want to delete the location: {name}? This cannot be undo
 msgstr "Czy na pewno chcesz usunąć lokalizację: {name}? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć harmonogram konserwacji: {name}? Tej operacji nie można cofnąć."
+msgstr "Czy chcesz usunąć harmonogram utrzymania ruchu: {name}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
@@ -1945,11 +1945,11 @@ msgstr "Czy na pewno chcesz usunąć formularz materiału: {0}? Tej czynności n
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć klasę materiału: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć gatunek: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć substancję materiałową: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć tworzywo: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "Czy na pewno chcesz usunąć typ materiału: {0}? Tej czynności nie mo�
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć powód braku oferty: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć powód odmowy oferty: {0}? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć partnera: {name}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć termin płatności: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć warunki płatności: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1987,21 +1987,21 @@ msgstr "Czy na pewno chcesz usunąć wiersz faktury sprzedaży dla {0} {1}? Tej 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć linię zamówienia sprzedaży dla {0} {1}? Tej operacji nie można cofnąć."
+msgstr "Czy chcesz usunąć pozycję zamówienia sprzedaży dla {0} {1}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć przyczynę braku: {0}? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć sekwencję numeru seryjnego dla {itemLabel}? Tej akcji nie można cofnąć."
+msgstr "Czy chcesz usunąć numerację numeru seryjnego dla {itemLabel}? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć zmianę: {name} z {locationName}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć metodę wysyłki: {0}? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć sposób wysyłki: {0}? Tej czynności nie można cofnąć."
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
@@ -2031,16 +2031,16 @@ msgid "Are you sure you want to delete this approval rule? This cannot be undone
 msgstr "Czy na pewno chcesz usunąć tę regułę zatwierdzania? Tej operacji nie można cofnąć."
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "Czy na pewno chcesz usunąć to zgłoszenie zmian?"
+msgstr "Czy chcesz usunąć to zawiadomienie o zmianie?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Czy na pewno chcesz usunąć ten miernik?"
+msgstr "Czy chcesz usunąć ten przyrząd pomiarowy?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "Czy na pewno chcesz usunąć ten plan inspekcji?"
+msgstr "Czy chcesz usunąć ten plan kontroli?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć ten plan inspekcji? Tej operacji nie można cofnąć."
+msgstr "Czy chcesz usunąć ten plan kontroli? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Czy na pewno chcesz usunąć ten przepływ pracy problemu?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć tę kartę kanban? Tej operacji nie można cofnąć."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć tę dyspozycję konserwacji? Tej operacji nie można cofnąć."
+msgstr "Czy chcesz usunąć to zlecenie utrzymania ruchu? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "Czy na pewno chcesz usunąć ten klucz dostępu? Nie będziesz mógł go używać do logowania."
@@ -2073,7 +2073,7 @@ msgid "Are you sure you want to delete this risk? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć to ryzyko? Tej operacji nie można cofnąć."
 
 msgid "Are you sure you want to delete this suggestion? This action cannot be undone."
-msgstr "Czy na pewno chcesz usunąć tę sugestię? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć tę propozycję? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć tę kartę czasu pracy? Tej operacji nie można cofnąć."
@@ -2106,20 +2106,20 @@ msgid "Are you sure you want to post this receipt?"
 msgstr "Czy na pewno chcesz zaksięgować ten dokument przyjęcia?"
 
 msgid "Are you sure you want to post this shipment?"
-msgstr "Czy na pewno chcesz opublikować tę przesyłkę?"
+msgstr "Czy chcesz zaksięgować tę wysyłkę?"
 
 msgid "Are you sure you want to reject this quote?"
 msgstr "Czy na pewno chcesz odrzucić tę ofertę?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "Czy na pewno chcesz zwolnić to zadanie? Będzie dostępne dla hali produkcyjnej i będzie napędzać zakupy i produkcję."
+msgstr "Czy chcesz zwolnić to zlecenie produkcyjne? Będzie dostępne na hali produkcyjnej i wpłynie na zakupy i produkcję."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć {0} jako dostawcę dla tego artykułu? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć {0} z listy dostawców dla tego artykułu? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "Czy na pewno chcesz usunąć {supplierName} jako dostawcę tego artykułu? Tej czynności nie można cofnąć."
+msgstr "Czy chcesz usunąć {supplierName} z listy dostawców dla tego artykułu? Tej czynności nie można cofnąć."
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
 msgstr "Czy na pewno chcesz usunąć ten element z listy cen? Tej operacji nie można cofnąć."
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Czy na pewno chcesz wysłać zaproszenie temu użytkownikowi?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Czy na pewno chcesz anulować tę fakturę zakupu? Ta czynność odwróci wszystkie transakcje finansowe i nie można jej cofnąć."
+msgstr "Czy chcesz unieważnić tę fakturę zakupu? Ta czynność odwróci wszystkie transakcje finansowe i nie można jej cofnąć."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Czy na pewno chcesz anulować ten paragon? Ta akcja odwróci wszystkie transakcje magazynowe i nie można jej cofnąć."
+msgstr "Czy chcesz unieważnić to przyjęcie? Ta czynność odwróci wszystkie transakcje magazynowe i nie można jej cofnąć."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Czy na pewno chcesz anulować tę fakturę sprzedaży? Ta akcja odwróci wszystkie transakcje finansowe i nie można jej cofnąć."
+msgstr "Czy chcesz unieważnić tę fakturę sprzedaży? Ta czynność odwróci wszystkie transakcje finansowe i nie można jej cofnąć."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Czy na pewno chcesz anulować tę przesyłkę? Ta akcja odwróci wszystkie transakcje magazynowe i nie można jej cofnąć."
+msgstr "Czy na pewno chcesz unieważnić tę wysyłkę? Ta akcja odwróci wszystkie transakcje magazynowe i nie będzie możliwa do cofnięcia."
 
 msgid "Are you sure?"
 msgstr "Jesteś pewny?"
@@ -2197,34 +2197,34 @@ msgid "Asset Account"
 msgstr "Konto aktywów"
 
 msgid "Asset account for advance payments made to suppliers before goods or services are received"
-msgstr "Konto aktywów dla zaliczek dokonanych dostawcom przed otrzymaniem towarów lub usług"
+msgstr "Konto dla zaliczek wpłaconych dostawcom przed otrzymaniem towarów lub usług"
 
 msgid "Asset Acquisition Cost"
-msgstr "Koszt nabycia zasobu"
+msgstr "Cena nabycia środków trwałych"
 
 msgid "Asset Acquisition Cost (default)"
-msgstr "Koszt nabycia zasobu (domyślnie)"
+msgstr "Cena nabycia środków trwałych (domyślna)"
 
 msgid "asset class"
-msgstr "klasa zasobu"
+msgstr "klasa środków trwałych"
 
 msgid "Asset class"
-msgstr "Klasa zasobu"
+msgstr "Klasa środków trwałych"
 
 msgid "Asset Class"
-msgstr "Klasa zasobu"
+msgstr "Klasa środków trwałych"
 
 msgid "asset classes"
-msgstr "klasy zasobów"
+msgstr "klasy środków trwałych"
 
 msgid "Asset Classes"
-msgstr "Klasy aktywów"
+msgstr "Klasy środków trwałych"
 
 msgid "Asset Cost on Disposal"
-msgstr "Koszt zasobu przy zbyciu"
+msgstr "Koszt środków trwałych przy likwidacji"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Koszt zasobu przy zbyciu (domyślnie)"
+msgstr "Koszt środków trwałych przy likwidacji (domyślny)"
 
 msgid "Asset ID"
 msgstr "ID aktywu"
@@ -2233,10 +2233,10 @@ msgid "Assets"
 msgstr "Aktywa"
 
 msgid "Assets, liabilities and equity as of a date"
-msgstr "Aktywa, pasywa i kapitał na dzień"
+msgstr "Aktywa, pasywa i kapitał własny na określony dzień"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
-msgstr "Przypisz drukarki do lokalizacji. Wysyłka, odbiór i centra pracy dziedziczą domyślne ustawienia lokalizacji, chyba że zostaną zastąpione."
+msgstr "Przypisz drukarki do lokalizacji. Wysyłka, otrzymywanie i stanowiska robocze dziedziczą domyślne lokalizacje, chyba że nastąpi nadpisanie."
 
 msgid "Assign To"
 msgstr "Przypisz do"
@@ -2251,7 +2251,7 @@ msgid "Assigned to Me"
 msgstr "Przypisane do mnie"
 
 msgid "Assignee"
-msgstr "Przydzielony do"
+msgstr "Osoba przypisana"
 
 msgid "Assignment"
 msgstr "Przypisanie"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Przypisania"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Przypisuje tę jednostkę magazynową do centrum pracy (lineside)"
+msgstr "Przypisuje tę jednostkę magazynową do stanowiska roboczego (magazyn przyliniowy)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Przypisuje tę jednostkę do centrum pracy do materiałów liniesidowych, aby operatorzy mogli je zobaczyć w widoku produkcji; odziedziczone z urządzenia nadrzędnego, gdy jest tam ustawione."
+msgstr "Przypisuje tę jednostkę do stanowiska roboczego dla materiału magazynu przyliniowego, aby operatorzy widzieli ją w widoku produkcji; odziedziczone z jednostki nadrzędnej, jeśli tam zostały ustawione."
 
 msgid "At each gate"
 msgstr "Na każdej bramce"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Atrybut"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Standard pobierania próbek atrybutów używany do obliczania wielkości próbek partii i liczb akceptacji/odrzucenia przy inspekcjach przychodzących."
+msgstr "Atrybut standard do wyrywkowej kontroli używany do obliczania wielkości próbki partii i liczb zaakceptuj/odrzuć w kontrolach dostaw."
 
 msgid "Attributes"
 msgstr "Atrybuty"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Dziennik audytu"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Rejestrowanie audytu"
 
 msgid "Audit Logging"
 msgstr "Rejestrowanie audytu"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Automatycznie generowany kod QR"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Formaty automatycznego numerowania dla zamówień, zadań, części i nie tylko"
+msgstr "Formaty automatycznej numeracji dla zamówień, zleceń produkcyjnych, części i więcej"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Automatycznie sugeruj zakupy na podstawie popytu i punktów ponownego zamówienia"
+msgstr "Automatyczne sugerowanie zakupów na podstawie zapotrzebowania i punktów zamawiania"
 
 msgid "Automate"
 msgstr "Automatyzuj"
@@ -2377,7 +2377,7 @@ msgid "Automatic Updates"
 msgstr "Automatyczne aktualizacje"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Automatyczne aktualizacje i kopie zapasowe"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Automatyczne, proporcjonalne zużycie materiałów nieparowanych pracy po zgłoszeniu wydajności — materiały śledzone są wydawane ręcznie."
@@ -2414,10 +2414,10 @@ msgid "Back"
 msgstr "Wstecz"
 
 msgid "Back to traceability"
-msgstr "Wróć do śledzenia"
+msgstr "Powrót do identyfikowalności"
 
 msgid "Backflush"
-msgstr "Cofnięcie"
+msgstr "Pobranie wsteczne"
 
 msgid "Backups"
 msgstr "Kopie zapasowe"
@@ -2435,7 +2435,7 @@ msgid "Balloon"
 msgstr "Balon"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "Rysunki z zaznaczeniami cech inspekcji."
+msgstr "Rysunki ze wskazaniami zawierające funkcje kontroli."
 
 msgid "Bank - Cash"
 msgstr "Bank - Gotówka"
@@ -2468,7 +2468,7 @@ msgid "Bank and financial service charge expenses"
 msgstr "Wydatki na opłaty bankowe i usługi finansowe."
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Słupki pokazują przepływ tygodniowy: &lt;0&gt;podaż&lt;/0&gt; popycha zapasy w górę, &lt;1&gt;popyt&lt;/1&gt; ciągnąć go w dół. &lt;2&gt;Linia&lt;/2&gt; to Twoja prognozowana dostępna zapasy — gdy spadnie poniżej &lt;3&gt;zapasu bezpieczeństwa&lt;/3&gt; jesteś zagrożony, a poniżej zera to &lt;4&gt;brak zapasu&lt;/4&gt;."
+msgstr "Paski pokazują przepływ każdego tygodnia: <0>pokrycie</0> zwiększa zapasy, <1>zapotrzebowanie</1> je zmniejsza. <2>Linia</2> to twoje prognozowane zapasy w magazynie — gdy spadną poniżej <3>zapasu bezpieczeństwa</3>, jesteś zagrożony, a poniżej zera to <4>brak zapasu</4>."
 
 msgid "Base Currency"
 msgstr "Waluta bazowa"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Cena bazowa"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Podstawowa funkcjonalność ERP, MES i QMS"
 
 msgid "Basic Information"
 msgstr "Informacje podstawowe"
@@ -2523,19 +2523,19 @@ msgid "Beta"
 msgstr "Beta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Największe przyczyny odpadów wg przyczyny, pozycji lub centrum pracy"
+msgstr "Największe przyczyny braków z powodu, artykułu lub stanowiska roboczego"
 
 msgid "Bill of Material"
 msgstr "Zestawienie Materiałów"
 
 msgid "Bill of materials"
-msgstr "Zestawienie materiałów"
+msgstr "lista materiałowa"
 
 msgid "Bill of Materials"
-msgstr "Zestawienie Materiałów"
+msgstr "Lista materiałowa"
 
 msgid "Bill of Process"
-msgstr "Rachunek Procesów"
+msgstr "Lista operacji"
 
 msgid "Bill To"
 msgstr "Rachunek dla"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Zablokuj z błędem"
 
 msgid "Block, allow override"
-msgstr "Blokuj, zezwól na zastąpienie"
+msgstr "Blokuj, zezwól na nadpisanie"
 
 msgid "Blocked"
 msgstr "Zablokowane"
@@ -2581,10 +2581,10 @@ msgid "BOM synced successfully"
 msgstr "BOM zsynchronizowany pomyślnie"
 
 msgid "BOMs"
-msgstr "Zestawienia materiałowe"
+msgstr "BOMy"
 
 msgid "Bonus Depreciation %"
-msgstr "Bonus deprecjacja %"
+msgstr "Bonus Amortyzacja %"
 
 msgid "Book a call to discuss guided implementation"
 msgstr "Zarezerwuj rozmowę, aby omówić wdrożenie z asystą"
@@ -2608,19 +2608,19 @@ msgid "Breadcrumb"
 msgstr "Nawigacja"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Zaimportuj swoje części, BOM-y, Bill of Process i wycenę — za pomocą narzędzi importu Carbon, CSV lub pomocy LLM."
+msgstr "Wprowadź swoje części, BOMy, Listy operacji i kalkulacje kosztów — za pomocą narzędzi importu Carbon, CSV lub pomocy LLM."
 
 msgid "Browse library"
 msgstr "Przeglądaj bibliotekę"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Przeglądaj opublikowaną wersję w trybie tylko do odczytu. Nadal możesz zmienić kolejność kroków, aby uporządkować układ."
 
 msgid "Bucket"
 msgstr "Zasobnik"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
-msgstr "Stock buforowy, który polityka oparta na popycie przechowuje, aby zaabsorbować gwałtowne wzrosty konsumpcji w ciągu okresu akumulacji."
+msgstr "Zapas buforowy utrzymywany przez politykę opartą na zapotrzebowaniu, aby pochłonąć skoki zużycia w ramach okresu akumulacji."
 
 msgid "Bugs and changes"
 msgstr "Błędy i zmiany"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Twórz integracje i dostosowania"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Twórz oferty pobierając dane części na żywo, koszty i Bill of Process"
+msgstr "Twórz oferty pobierając na żywo dane części, kosztu i Listy operacji"
 
 msgid "Build role-based training materials"
 msgstr "Twórz materiały szkoleniowe oparte na rolach"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Import zbiorczy"
 
 msgid "Bulk Jobs"
-msgstr "Zadania zbiorcze"
+msgstr "Zbiorcze Zlecenia produkcyjne"
 
 msgid "Business moment"
 msgstr "Moment biznesowy"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "Kup"
 
 msgid "Buy and Make"
-msgstr "Kupuj i Wytwarzaj"
+msgstr "Zakup i produkcja"
 
 msgid "Buyer"
-msgstr "Kupujący"
+msgstr "Kupiec"
 
 msgid "Buyer, Planner"
-msgstr "Kupujący, Planista"
+msgstr "Kupiec, Planista"
 
 msgid "by {byUser}"
 msgstr "przez {byUser}"
@@ -2683,7 +2683,7 @@ msgid "By Document Date"
 msgstr "Według daty dokumentu"
 
 msgid "By Due Date"
-msgstr "Według daty wymagalności"
+msgstr "Według terminu"
 
 msgid "By field"
 msgstr "Według pola"
@@ -2704,37 +2704,37 @@ msgid "Calculate from BOM"
 msgstr "Oblicz z BOM"
 
 msgid "Calculated finished-good expiry"
-msgstr "Obliczona data wygaśnięcia produktu gotowego"
+msgstr "Obliczony termin ważności wyrobu gotowego"
 
 msgid "Calculation Method"
 msgstr "Metoda Obliczania"
 
 msgid "Calibration"
-msgstr "Kalibracja"
+msgstr "Wzorcowanie"
 
 msgid "Calibration Attempts"
-msgstr "Próby kalibracji"
+msgstr "Próby wzorcowania"
 
 msgid "Calibration Expiration Notifications"
-msgstr "Powiadomienia o wygaśnięciu kalibracji"
+msgstr "Powiadomienia o wygaśnięciu wzorcowania"
 
 msgid "Calibration Interval (Months)"
-msgstr "Interwał kalibracji (miesiące)"
+msgstr "Okres wzorcowania (miesiące)"
 
 msgid "Calibration Record"
-msgstr "Rejestr kalibracji"
+msgstr "Zapis wzorcowania"
 
 msgid "Calibration Records"
-msgstr "Rekordy Kalibracji"
+msgstr "Zapisy wzorcowania"
 
 msgid "Calibration Status"
-msgstr "Status kalibracji"
+msgstr "Status wzorcowania"
 
 msgid "Calibration Supplier"
-msgstr "Dostawca kalibracji"
+msgstr "Dostawca usług wzorcowania"
 
 msgid "Calibrations"
-msgstr "Kalibracje"
+msgstr "Wzorcowania"
 
 msgid "Call an outside URL"
 msgstr "Wywołaj zewnętrzny adres URL"
@@ -2746,7 +2746,7 @@ msgid "Can't delete this period"
 msgstr "Nie można usunąć tego okresu"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "Nie można wyłączyć jedynego aktywnego przedziału. Dodaj inny przedział lub przełącz opcję Aktywne dla przesłonięcia."
+msgstr "Nie można wyłączyć jedynej aktywnej przerwy. Dodaj kolejną przerwę lub przełącz aktywność nadpisania."
 
 msgid "Can't download this file"
 msgstr "Nie można pobrać tego pliku"
@@ -2755,10 +2755,10 @@ msgid "Cancel"
 msgstr "Anuluj"
 
 msgid "Cancel change notice"
-msgstr "Anuluj zgłoszenie zmian"
+msgstr "Anuluj zawiadomienie o zmianie"
 
 msgid "Cancel Change Notice"
-msgstr "Anuluj Zgłoszenie Zmian"
+msgstr "Anuluj zawiadomienie o zmianie"
 
 msgid "Cancel Job"
 msgstr "Anuluj zadanie"
@@ -2806,7 +2806,7 @@ msgid "Cannot close yet"
 msgstr "Nie można zamknąć teraz"
 
 msgid "Cannot convert RFQ to quote"
-msgstr "Nie można skonwertować RFQ na ofertę"
+msgstr "Nie można przekształcić RFQ na ofertę"
 
 msgid "Cannot move to parts bucket without item ID"
 msgstr "Nie można przenieść do zasobnika części bez identyfikatora elementu"
@@ -2815,19 +2815,19 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "Nie można złożyć zamówienia - brak dostawcy powiązanego z tym artykułem"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "Nie można wysłać — przesyłka zawiera wygasłe jednostki śledzenia."
+msgstr "Nie można zaksięgować — wysyłka zawiera wygasłe jednostki śledzone."
 
 msgid "Cannot send RFQ"
 msgstr "Nie można wysłać ZZO"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Nie można wysłać przez Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
-msgstr "Nie można przesłać — interakcja z dostawcą nie została jeszcze utworzona"
+msgstr "Nie można przesłać pliku — interakcja z dostawcą nie została jeszcze utworzona"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "Nie można przesłać do zasobnika części bez identyfikatora elementu"
+msgstr "Nie można przesłać pliku do koszyka części bez ID artykułu"
 
 msgid "Caption"
 msgstr "Podpis"
@@ -2876,7 +2876,7 @@ msgstr "Wartość Carbon"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon będzie używać AI do zgadywania konta dostawcy dla każdego z Twoich {0} niezamapowanych kont. Sugestie są punktem wyjścia — możesz je przejrzeć przed zapisaniem czegokolwiek."
+msgstr "Carbon będzie używać AI do zgadnięcia konta dostawcy dla każdego z {0} niezmapowanych kont. Propozycje są punktem wyjścia — możesz je przejrzeć przed zapisaniem czegokolwiek."
 
 msgid "Carbon-only"
 msgstr "Tylko dla Carbon"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Tylko dla Carbon · klient widzi ten tekst, zablokowany."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Nazwa Carbon dla listy materiałów i listy procesów (routing): komponenty plus operacje, które wytwarzają część."
+msgstr "Nazwa Carbon dla listy materiałów i listy operacji (marszruta): komponenty plus operacje, które tworzą część."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Przebieg planowania Carbon netto dostaw w stosunku do popytu i rozszerza metody, ujawniając niedobory — ale nie tworzy samych zamówień."
+msgstr "Przebieg planowania Carbon zestawia pokrycie wobec zapotrzebowania i rozkłada metody, ujawniając braki — ale nie tworzy samych zamówień."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Zamówienie produkcyjne Carbon — jedno zadanie buduje ilość jednego towaru z własnej skopiowanej metody i routingu."
+msgstr "Zlecenie produkcji Carbon — jedno zlecenie produkcyjne tworzy ilość jednego artykułu z jego własnej skopiowanej metody i marszruty."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "Aplikacja Carbon do pracy na hali, w której operatorzy prowadzą operacje, raportują ilości, wydają materiały i rejestrują czas zadań wydanych w czasie rzeczywistym."
+msgstr "Aplikacja Carbon do pracy na hali, gdzie operatorzy uruchamiają operacje, zgłaszają ilości, wydają materiały i rejestrują czas wobec zwolnionych zleceń produkcyjnych w czasie rzeczywistym."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Pojedynczy zapis Carbon dla wszystkiego z numerem części — Część, Materiał, Narzędzie, Usługa, Zużywalny lub Wyposażenie — na które wskazują zadania, metody, zamówienia i zapasy."
+msgstr "Pojedynczy zapis Carbon dla wszystkiego z numerem części — Część, Materiał, Narzędzie, Usługa, Materiał eksploatacyjny lub Przyrząd obróbkowy — na które wskazują zlecenia, metody, zamówienia i zapasy."
 
 msgid "Cards"
 msgstr "Karty"
@@ -2963,34 +2963,34 @@ msgid "Change Document"
 msgstr "Zmień dokument"
 
 msgid "Change Inspection Plan"
-msgstr "Zmień plan inspekcji"
+msgstr "Zmień plan kontroli"
 
 msgid "Change notice"
-msgstr "Zgłoszenie zmian"
+msgstr "Zawiadomienie o zmianie"
 
 msgid "Change Notice"
-msgstr "Zgłoszenie Zmian"
+msgstr "Zawiadomienie o zmianie"
 
 msgid "Change Notice Actions"
-msgstr "Działania Zgłoszenia Zmian"
+msgstr "Działania zawiadomienia o zmianie"
 
 msgid "Change Notice Types"
-msgstr "Typy Zgłoszeń Zmian"
+msgstr "Typy zawiadomienia o zmianie"
 
 msgid "Change Notices"
-msgstr "Zgłoszenia Zmian"
+msgstr "Zawiadomienia o zmianie"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "Nie można załadować zgłoszeń zmian, dlatego nowe wersje i rewizje są zablokowane. Odśwież, aby spróbować ponownie."
+msgstr "Zawiadomienia o zmianie nie mogły być załadowane, więc nowe wersje i rewizje są zablokowane. Załaduj ponownie, aby spróbować ponownie."
 
 msgid "Change order"
-msgstr "Zmiana zamówienia"
+msgstr "Zlecenie zmiany"
 
 msgid "Change status"
 msgstr "Zmień status"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "Zmień typ przedmiotu (np. Część, Materiał, Narzędzie itp.)"
+msgstr "Zmień typ artykułu (np. Część, Materiał, Narzędzie, itp.)"
 
 msgid "Change type"
 msgstr "Zmień typ"
@@ -3011,7 +3011,7 @@ msgid "Changing this will update the part ID"
 msgstr "Zmiana tego zaktualizuje identyfikator części"
 
 msgid "Changing type resets this item's draft edits."
-msgstr "Zmiana typu resetuje edycje wersji roboczej tego elementu."
+msgstr "Zmiana typu resetuje robocze edycje tego artykułu."
 
 msgid "Chart of accounts"
 msgstr "Plan kont"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Czat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Sprawdź księgę pozycji w poszukiwaniu pozycji z ujemną ilością dostępną na koniec okresu — zwykle wynika to z brakującego przychodu lub niechronologicznego wpisu, który zniekształca wartość zapasów i koszt sprzedanych towarów. Oznacz jako wykonane po sprawdzeniu lub pomiń, podając przyczynę."
+msgstr "Sprawdź księgę artykułów pod kątem artykułów z ujemną ilością dostępną na koniec okresu — zwykle brakuje przyjęcia lub zaksięgowania poza kolejnością, które zniekształca wartość zapasów i koszt własny sprzedaży. Oznacz jako gotowe po przejrzeniu lub pomiń z uzasadnieniem."
 
 msgid "Check your email"
 msgstr "Sprawdź swoją pocztę"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Sprawdzanie Stripe dla tego klienta…"
 
 msgid "Checkpoint ·"
 msgstr "Punkt kontrolny ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Wybierz inny plik"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Wybierz, co pojawia się na wydrukowanym dokumencie postępu pracy."
+msgstr "Wybierz, co pojawia się na drukowanym przewodniku zlecenia produkcyjnego."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Wybierz preferowany język interfejsu."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Klasa (odziedziczona)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Klasyfikuje operację routingu: operacje Proces, Montaż i Inspeksja działają na Twojej hali produkcyjnej w MES — Montaż wyświetla widok montażu z przewodnikiem, a Inspeksja sprawdzenie jakości — natomiast operacja Obróbka na zewnątrz jest zlecana dostawcy i tworzy zamówienie zakupu; proces nosi ten sam typ i ustawia go domyślnie dla nowych operacji."
+msgstr "Klasyfikuje operację marszruty: operacje typu Proces, Montaż i Kontrola są wykonywane na Twojej hali produkcyjnej w systemie MES — Montaż wyświetla przewodnik montażu, a Kontrola sprawdzenie jakości — natomiast operacja Kooperacji jest zlecana dostawcy i tworzy zamówienie zakupu; operacja nosi ten sam typ i ustawia go domyślnie dla nowych operacji."
 
 msgid "Clean and approve the migrated data"
 msgstr "Wyczyść i zatwierdź migrowane dane"
@@ -3101,7 +3101,7 @@ msgid "Clear value"
 msgstr "Wyczyść wartość"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Konto rozliczeniowe między przyjęciem towaru a fakturą dostawcy; wyrównuje się, gdy oba zostały zaksięgowane."
+msgstr "Konto wyrównawcze między przyjęciem a faktury dostawcy; saldo wyrównane gdy obie pozycje zostały zaksięgowane."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Konto rozliczeniowe dla odboru towaru / dopasowania odboru faktury"
@@ -3116,13 +3116,13 @@ msgid "Click to rename"
 msgstr "Kliknij, aby zmienić nazwę"
 
 msgid "Click to upload a PDF drawing"
-msgstr "Kliknij, aby przesłać rysunek PDF"
+msgstr "Kliknij, aby przesłać plik rysunku PDF"
 
 msgid "Clock In"
-msgstr "Zarejestruj wejście"
+msgstr "Rozpoczęcie pracy"
 
 msgid "Clock Out"
-msgstr "Wyloguj się"
+msgstr "Zakończenie pracy"
 
 msgid "Clocked in since <0/>"
 msgstr "Zalogowany od <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Chmura lub Twoje środowisko hostowane samodzielnie."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Zgodny z CMMC"
 
 msgid "Code"
 msgstr "Kod"
@@ -3188,7 +3188,7 @@ msgid "Collapse features table"
 msgstr "Zwiń tabelę funkcji"
 
 msgid "Collapse Labor"
-msgstr "Zwiń Pracę"
+msgstr "Zwiń robociznę"
 
 msgid "Collapse Machine"
 msgstr "Zwiń maszynę"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "Wyznacz użytkownika-lidera dla każdego obszaru"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Zatwierdzenie paragonu, wysyłki lub faktury: ilości się poruszają, wpisy do dziennika trafiają do księgi głównej, a stan zmienia się na Zaksięgowany."
+msgstr "Zatwierdzenie przyjęcia, wysyłki lub faktury: ilości się przesuwają, zapisy księgowe trafiają do księgi głównej, a status zmienia się na Zaksięgowano."
 
 msgid "Community support"
-msgstr ""
+msgstr "Wsparcie społeczności"
 
 msgid "Companies"
 msgstr "Firmy"
@@ -3312,7 +3312,7 @@ msgid "Computed At"
 msgstr "Obliczone o"
 
 msgid "Condensed P&L with margins and key subtotals"
-msgstr "Skrócone rachunki zysków i strat z marżami i kluczowymi subtotalami"
+msgstr "Skondensowany P&L z marżami i kluczowymi sumami częściowymi"
 
 msgid "Conditions"
 msgstr "Warunki"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Skonfiguruj domyślne konta dla transakcji dostawców i sprzedawców"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Skonfiguruj domyślne konta kapitału i zysków zatrzymanych"
+msgstr "Skonfiguruj domyślne konta kapitału własnego i zysków zatrzymanych"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Skonfiguruj ustawienia domyślne dla pulpitu jakości."
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "Konfiguruj element"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Skonfiguruj powiadomienia na wypadek, gdy mierniki wyjdą z kalibracji."
+msgstr "Skonfiguruj powiadomienia, gdy przyrządy pomiarowe wychodzą ze wzorcowania."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Skonfiguruj powiadomienia na wypadek ukończenia zadań."
+msgstr "Skonfiguruj powiadomienia, gdy zlecenia produkcyjne zostają zakończone."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Skonfiguruj powiadomienia dla dyspozycji konserwacyjnych tworzonych z hali produkcyjnej. Powiadomienia są kierowane na podstawie typu trybu awarii."
+msgstr "Skonfiguruj powiadomienia, gdy zlecenia utrzymania ruchu są tworzone z hali produkcyjnej. Powiadomienia są kierowane w zależności od rodzaju awarii."
 
 msgid "Configure notifications for when new suggestions are submitted."
-msgstr "Skonfiguruj powiadomienia dla nowych przesłanych sugestii."
+msgstr "Skonfiguruj powiadomienia, gdy nowe propozycje są przesłane."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Skonfiguruj witryny, centra pracy, Bill of Process, BOM-y, wycenę, role"
+msgstr "Skonfiguruj lokalizacje, stanowiska robocze, listę operacji, BOM, kalkulację kosztów i role"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Skonfiguruj domyślne konta używane dla różnych typów transakcji w całym systemie"
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "Potwierdź {0}"
 
 msgid "Confirm & release"
-msgstr "Potwierdź i wydaj"
+msgstr "Potwierdź i zwolnij"
 
 msgid "Confirm all"
 msgstr "Potwierdź wszystkie"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Potwierdzone zapasy przychodzące — zamówienia zakupu i produkcji (słupki powyżej zera)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Potwierdzone zapasy wychodzące — zamówienia sprzedaży i materiały pracy (słupki poniżej zera)."
+msgstr "Potwierdzone zapasy wychodzące — zamówienia sprzedaży i materiały zlecenia (słupki poniżej zera)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Potwierdza, że każdy opublikowany wpis dziennika w okresie ma równe obciążenia i kredyty. Jeśli jakiś wpis jest niezrównoważony, bilans próbny się nie zgramadzi, więc musi być poprawiony przed zamknięciem okresu."
+msgstr "Potwierdza, że każdy zaksięgowany zapis księgowy w okresie ma równe debety i kredyty. Jeśli którykolwiek wpis jest niezrównoważony, saldo próbne się nie będzie zgadzać, dlatego musi zostać poprawiony przed zamknięciem okresu."
 
 msgid "Conflict reason"
 msgstr "Powód konfliktu"
@@ -3493,28 +3493,28 @@ msgid "Console Operator"
 msgstr "Operator Konsoli"
 
 msgid "consumable"
-msgstr "zużywalne"
+msgstr "materiał eksploatacyjny"
 
 msgid "Consumable"
-msgstr "Materiał zużywalny"
+msgstr "Materiał eksploatacyjny"
 
 msgid "Consumable Details"
-msgstr "Szczegóły materiału zużywalnego"
+msgstr "Szczegóły materiału eksploatacyjnego"
 
 msgid "Consumable ID"
-msgstr "ID artykułu zużywalnego"
+msgstr "ID materiału eksploatacyjnego"
 
 msgid "consumables"
-msgstr "zuż ywalne"
+msgstr "materiały eksploatacyjne"
 
 msgid "Consumables"
-msgstr "Materiały zużywalne"
+msgstr "Materiały eksploatacyjne"
 
 msgid "Consumed"
 msgstr "Zużyte"
 
 msgid "Consuming material from inventory into a job, which writes a Consumption entry to the item ledger."
-msgstr "Konsumowanie materiału z zapasów do pracy, co zapisuje wpis Konsumpcji w księdze głównej towarów."
+msgstr "Zużywanie materiału z zapasów na zlecenie produkcyjne, które tworzy wpis Zużycia w rejestrze artykułów."
 
 msgid "contact"
 msgstr "kontakt"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Kontakt (opcjonalnie)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Skontaktuj się z nami"
 
 msgid "contacts"
 msgstr "kontakty"
@@ -3538,10 +3538,10 @@ msgid "Contained"
 msgstr "Zawarte"
 
 msgid "Containment"
-msgstr "Zawieranie"
+msgstr "Zabezpieczenie"
 
 msgid "Containment action"
-msgstr "Działanie zawierające"
+msgstr "Działanie zabezpieczające"
 
 msgid "Content"
 msgstr "Zawartość"
@@ -3559,25 +3559,25 @@ msgid "Contra-revenue GL account for discounts given on customer invoices."
 msgstr "Konto GL przychodu przeciwnego dla rabatów udzielonych na fakturach klienta."
 
 msgid "Contractor"
-msgstr "Wykonawca"
+msgstr "Pracownik zewnętrzny"
 
 msgid "Contractors"
-msgstr "Kontrahenci"
+msgstr "Pracownicy zewnętrzni"
 
 msgid "Control design changes with revisions / ECOs"
-msgstr "Kontroluj zmiany projektowe za pomocą wersji / ECO"
+msgstr "Kontroluj zmiany projektowe za pomocą rewizji i ECO"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "Kontroluj, jak operatorzy zbierają materiały i śledzą czas na hali produkcyjnej."
+msgstr "Kontroluj, jak operatorzy pobierają materiał i śledzą czas na hali produkcyjnej."
 
 msgid "Controller, Accountant"
 msgstr "Kontroler, Księgowy"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "Kontroluje sposób, w jaki planowanie obsługuje wycofany artykuł: Consume First wyczerpuje dostępne zapasy przed przejściem na następcę, Prefer New natychmiast przekierowuje nowy popyt do następcy, Stock Only utrzymuje tylko minimalną rezerwę serwisową, a No Stock całkowicie usuwa artykuł z planowania."
+msgstr "Kontroluje, jak planowanie obsługuje wycofany artykuł: Najpierw zużyj wyczerpuje zapasy przed przejściem na następnika, Preferuj nowy natychmiast przekierowuje nowe zapotrzebowanie do następnika, Tylko zapas utrzymuje minimalną rezerwę serwisową, a Bez zapasu usuwa artykuł z planowania całkowicie."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Kontroluje, czy zestawienie materiałów i zestawienie procesu wydanej (Produkcyjnej) wersji może być edytowane poza zleceniem zmian."
+msgstr "Kontroluje, czy można edytować BOM i listę operacji zwolnionej rewizji (Produkcja) poza zleceniem zmiany."
 
 msgid "Convention"
 msgstr "Konwencja"
@@ -3586,37 +3586,37 @@ msgid "Conversion"
 msgstr "Konwersja"
 
 msgid "Conversion factor"
-msgstr "Współczynnik konwersji"
+msgstr "współczynnik przeliczeniowy"
 
 msgid "Conversion Factor"
-msgstr "Współczynnik konwersji"
+msgstr "Współczynnik przeliczeniowy"
 
 msgid "Conversion:"
 msgstr "Konwersja:"
 
 msgid "Convert"
-msgstr "Konwertuj"
+msgstr "Przekształć"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "Konwertuj ofertę na zamówienie sprzedaży bez ponownego wprowadzania danych"
+msgstr "Przekształć ofertę w zamówienie sprzedaży bez ponownego wprowadzania danych"
 
 msgid "Convert Line to Job"
-msgstr "Konwertuj linię na zadanie"
+msgstr "Przekształć pozycję w zlecenie produkcyjne"
 
 msgid "Convert Lines to Jobs"
-msgstr "Konwertuj linie na zadania"
+msgstr "Konwertuj pozycje na zlecenia produkcyjne"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Konwertuj sugestie MRP na zamówienia zakupu i zadania."
+msgstr "Konwertuj propozycje MRP na zamówienia zakupu i zlecenia produkcyjne."
 
 msgid "Convert to Quote"
-msgstr "Konwertuj na Ofertę"
+msgstr "Przekształć na ofertę"
 
 msgid "Converting…"
 msgstr "Konwertowanie…"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "Konwertuje jednostkę zakupu dostawcy na jednostkę zapasów w wierszu zamówienia, paragonu lub faktury — kup w kartonach po 12 sztuk, magazyn w jednostkach."
+msgstr "Konwertuje jednostkę zakupu dostawcy na jednostkę zapasów na PO, przyjęciu lub wierszu faktury — kupuj w kartonach po 12, przechowywaj w sztukach."
 
 msgid "Copied link to clipboard"
 msgstr "Skopiowano link do schowka"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "Kopiuj"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Skopiuj wszystkie pozycje i ceny do innego klienta lub typu."
+msgstr "Skopiuj wszystkie artykuły i wyceny na innego klienta lub typ."
 
 msgid "Copy API Key"
 msgstr "Skopiuj klucz API"
@@ -3634,13 +3634,13 @@ msgid "Copy company unique identifier"
 msgstr "Skopiuj unikalny identyfikator firmy"
 
 msgid "Copy consumable number"
-msgstr "Skopiuj numer artykułu zużywalnego"
+msgstr "Skopiuj numer materiału eksploatacyjnego"
 
 msgid "Copy dispatch ID"
-msgstr "Skopiuj ID dyspozycji"
+msgstr "Skopiuj identyfikator zlecenia utrzymania ruchu"
 
 msgid "Copy dispatch number"
-msgstr "Skopiuj numer dyspozycji"
+msgstr "Skopiuj numer zlecenia utrzymania ruchu"
 
 msgid "Copy document name"
 msgstr "Skopiuj nazwę dokumentu"
@@ -3664,13 +3664,13 @@ msgid "Copy link"
 msgstr "Skopiuj link"
 
 msgid "Copy link to change notice"
-msgstr "Skopiuj link do zgłoszenia zmian"
+msgstr "Skopiuj link do zawiadomienia o zmianie"
 
 msgid "Copy link to consumable"
-msgstr "Skopiuj link do materiału"
+msgstr "Skopiuj link do materiału eksploatacyjnego"
 
 msgid "Copy link to dispatch"
-msgstr "Skopiuj link do dyspozycji"
+msgstr "Skopiuj link do zlecenia utrzymania ruchu"
 
 msgid "Copy link to document"
 msgstr "Skopiuj link do dokumentu"
@@ -3718,10 +3718,10 @@ msgid "Copy PIN"
 msgstr "Skopiuj PIN"
 
 msgid "Copy pricing to a single customer"
-msgstr "Skopiuj cennik dla jednego klienta"
+msgstr "Skopiuj wycenę na jednego klienta"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Skopiuj ceny dla wszystkich klientów danego typu"
+msgstr "Skopiuj wycenę na wszystkich klientów tego typu"
 
 msgid "Copy Procedure"
 msgstr "Skopiuj Procedurę"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "Skopiuj unikalny identyfikator usługi"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Skopiuj ceny tego artykułu do innego zakresu."
+msgstr "Skopiuj wycenę tego artykułu na inny zakres."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "Skopiuj ten link, aby udostępnić ofertę klientowi"
@@ -3796,52 +3796,52 @@ msgid "Corrections"
 msgstr "Korekty"
 
 msgid "Corrective action"
-msgstr "Działanie naprawcze"
+msgstr "Działanie korygujące"
 
 msgid "cost center"
-msgstr "ośrodek kosztów"
+msgstr "miejsce powstawania kosztów"
 
 msgid "Cost center"
-msgstr "Ośrodek Kosztów"
+msgstr "Miejsce powstawania kosztów"
 
 msgid "Cost Center"
-msgstr "Centrum kosztów"
+msgstr "Miejsce powstawania kosztów"
 
 msgid "Cost Center Name"
-msgstr "Nazwa centrum kosztów"
+msgstr "Nazwa miejsca powstawania kosztów"
 
 msgid "cost centers"
-msgstr "ośrodki kosztów"
+msgstr "miejsca powstawania kosztów"
 
 msgid "Cost Centers"
-msgstr "Centra kosztów"
+msgstr "Miejsca powstawania kosztów"
 
 msgid "Cost History"
 msgstr "Historia kosztów"
 
 msgid "Cost of Goods Sold"
-msgstr "Koszt Sprzedanych Towarów"
+msgstr "Koszt własny sprzedaży"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Koszt Sprzedanych Towarów (COGS)"
+msgstr "Koszt własny sprzedaży (KWS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Koszt Sprzedanych Towarów (domyślny)"
+msgstr "Koszt własny sprzedaży (domyślny)"
 
 msgid "Cost of Sales"
 msgstr "Koszt sprzedaży"
 
 msgid "Costing"
-msgstr "Wycena"
+msgstr "Kalkulacja kosztów"
 
 msgid "Costing & Posting"
-msgstr "Wycena i księgowanie"
+msgstr "Kalkulacja kosztów i księgowanie"
 
 msgid "Costing method"
 msgstr "Metoda kalkulacji kosztów"
 
 msgid "Costing Method"
-msgstr "Metoda wyceny"
+msgstr "Metoda kalkulacji kosztów"
 
 msgid "Could not analyze cropped region"
 msgstr "Nie można było przeanalizować przycętego regionu"
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "Utwórz i Snapshot"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "Utwórz zgłoszenie zmian dla nowej wersji i otwórz je"
+msgstr "Utwórz zawiadomienie o zmianie dla nowej rewizji i otwórz je"
 
 msgid "Create a job"
 msgstr "Utwórz zadanie"
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Utwórz nową kartę kanban do uzupełniania opartego na skanowaniu."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Utwórz nową dyspozycję konserwacji, aby śledzić naprawy sprzętu i działania konserwacyjne"
+msgstr "Utwórz nowe zlecenie utrzymania ruchu, aby śledzić naprawy urządzeń i działania utrzymania"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Utwórz nowe zadanie produkcyjne, aby zrealizować zamówienie sprzedaży"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Zamiast tego utwórz nowego klienta Stripe"
 
 msgid "Create a new version"
 msgstr "Utwórz nową wersję"
@@ -3963,19 +3963,19 @@ msgid "Create an issue"
 msgstr "Utwórz problem"
 
 msgid "Create and approve purchase orders"
-msgstr "Twórz i zatwierdzaj zamówienia zakupu"
+msgstr "Utwórz i zatwierdź zamówienia zakupu"
 
 msgid "Create audit trail entries"
 msgstr "Utwórz wpisy dziennika audytu"
 
 msgid "Create Change Notice"
-msgstr "Utwórz Zgłoszenie Zmian"
+msgstr "Utwórz zawiadomienie o zmianie"
 
 msgid "Create Issue"
 msgstr "Utwórz problem"
 
 msgid "Create Jobs"
-msgstr "Utwórz zadania"
+msgstr "Utwórz zlecenia produkcyjne"
 
 msgid "Create Kanban"
 msgstr "Utwórz Kanban"
@@ -3996,10 +3996,10 @@ msgid "Create Projection"
 msgstr "Utwórz Projekcję"
 
 msgid "Create Quote Revision"
-msgstr "Utwórz wersję oferty"
+msgstr "Utwórz rewizję oferty"
 
 msgid "Create Revision"
-msgstr "Utwórz wersję"
+msgstr "Utwórz rewizję"
 
 msgid "Create Rule"
 msgstr "Utwórz Regułę"
@@ -4014,7 +4014,7 @@ msgid "Create Version"
 msgstr "Utwórz wersję"
 
 msgid "Create Work Center"
-msgstr "Utwórz Centrum Pracy"
+msgstr "Utwórz stanowisko robocze"
 
 msgid "Created"
 msgstr "Utworzono"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "Utworzono konto"
 
 msgid "Created asset class"
-msgstr "Klasa Zasobów Utworzona"
+msgstr "Utworzono klasę środków trwałych"
 
 msgid "Created at"
 msgstr "Utworzono w"
@@ -4038,16 +4038,16 @@ msgid "Created By"
 msgstr "Utworzono przez"
 
 msgid "Created change notice action"
-msgstr "Utworzone działanie zgłoszenia zmian"
+msgstr "Utworzono działanie zawiadomienia o zmianie"
 
 msgid "Created change notice type"
-msgstr "Utworzony typ zgłoszenia zmian"
+msgstr "Utworzono typ zawiadomienia o zmianie"
 
 msgid "Created consumable"
-msgstr "Utworzono materiał zużywalny"
+msgstr "Utworzono materiał eksploatacyjny"
 
 msgid "Created cost center"
-msgstr "Utworzono centrum kosztów"
+msgstr "Utworzono miejsce powstawania kosztów"
 
 msgid "Created customer portal"
 msgstr "Utworzono portal klienta"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Utworzony tryb awarii"
 
 msgid "Created gauge type"
-msgstr "Utworzono typ miernika"
+msgstr "Utworzono typ przyrządu"
 
 msgid "Created item group"
 msgstr "Utworzona grupa artykułów"
@@ -4078,7 +4078,7 @@ msgid "Created location"
 msgstr "Lokalizacja utworzona"
 
 msgid "Created maintenance schedule"
-msgstr "Utworzono harmonogram konserwacji"
+msgstr "Utworzono plan konserwacji"
 
 msgid "Created material"
 msgstr "Utworzony materiał"
@@ -4102,7 +4102,7 @@ msgid "Created material type"
 msgstr "Utworzony typ materiału"
 
 msgid "Created no quote reason"
-msgstr "Utworzono przyczynę braku oferty"
+msgstr "Utworzono przyczynę odmowy oferty"
 
 msgid "Created non conformance type"
 msgstr "Utworzono typ niezgodności"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Część utworzona"
 
 msgid "Created payment term"
-msgstr "Utworzony termin płatności"
+msgstr "Utworzono warunki płatności"
 
 msgid "Created process"
 msgstr "Proces utworzony"
@@ -4120,16 +4120,16 @@ msgid "Created required action"
 msgstr "Utworzono wymaganą akcję"
 
 msgid "Created scrap reason"
-msgstr "Utworzono przyczynę złomu"
+msgstr "Utworzono przyczynę braku"
 
 msgid "Created service"
 msgstr "Utworzona usługa"
 
 msgid "Created shipping method"
-msgstr "Utworzono metodę wysyłki"
+msgstr "Utworzono sposób wysyłki"
 
 msgid "Created stock transfer line"
-msgstr "Utworzono linię transferu zapasów"
+msgstr "Utworzono pozycję przesunięcia"
 
 msgid "Created storage type"
 msgstr "Utworzony typ magazynu"
@@ -4148,10 +4148,10 @@ msgid "Created webhook"
 msgstr "Webhook utworzony"
 
 msgid "Created work center"
-msgstr "Utworzono centrum pracy"
+msgstr "Utworzono stanowisko robocze"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "Tworzy 12 miesięcznych okresów dla roku obrachunkowego. Istniejące okresy są zachowywane."
+msgstr "Tworzy 12 okresów miesięcznych dla roku obrachunkowego. Istniejące okresy są zachowywane."
 
 msgid "Creating part..."
 msgstr "Tworzenie części..."
@@ -4164,31 +4164,31 @@ msgid "Credit ({0})"
 msgstr "Kredyt ({0})"
 
 msgid "Credit / debit memo"
-msgstr "Nota kredytowa / debetowa"
+msgstr "Faktura korygująca / Nota debetowa"
 
 msgid "Credit / Debit Memos"
-msgstr "Noty kredytowe / debetowe"
+msgstr "Faktury korygujące / Noty debetowe"
 
 msgid "Credit Account"
 msgstr "Konto Kredytowe"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Konto kredytowe, gdy czas pracy/maszyny jest absorbowany w WIP"
+msgstr "Konto kredytowe dla absorpcji robocizny/czasu maszynowego do produkcji w toku"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Konto kredytowe, gdy koszty ogólne są absorbowane do ZW"
+msgstr "Konto kredytowe dla absorpcji kosztów pośrednich do produkcji w toku"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Konta kredytowe używane, gdy koszty produkcji są absorbowane do ZW"
+msgstr "Konta kredytowe używane do absorpcji kosztów produkcji do produkcji w toku"
 
 msgid "Credit Memo"
-msgstr "Notatka kredytowa"
+msgstr "Faktura korygująca"
 
 msgid "Credits"
 msgstr "Kredyty"
 
 msgid "Credits & Debits"
-msgstr "Kredyty i Debety"
+msgstr "Ma i Winien"
 
 msgid "Credits applied"
 msgstr "Zastosowane kredyty"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "Kod waluty"
 
 msgid "Currency Translation"
-msgstr "Translacja Walutowa"
+msgstr "Przeliczenie walut"
 
 msgid "Currency Translation (default)"
-msgstr "Translacja Walutowa (domyślna)"
+msgstr "Przeliczenie walut (domyślne)"
 
 msgid "current"
 msgstr "bieżący"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "Bieżący"
 
 msgid "Current Net Book Value:"
-msgstr "Bieżąca Wartość Netto w Księdze:"
+msgstr "Bieżąca Wartość księgowa netto:"
 
 msgid "Current Password"
 msgstr "Bieżące hasło"
@@ -4326,13 +4326,13 @@ msgid "Customer Part"
 msgstr "Część klienta"
 
 msgid "Customer Part ID"
-msgstr "Identyfikator części klienta"
+msgstr "Numer artykułu klienta"
 
 msgid "Customer Part Number"
 msgstr "Numer części klienta"
 
 msgid "Customer Part Revision"
-msgstr "Wersja części klienta"
+msgstr "Rewizja artykułu klienta"
 
 msgid "Customer Parts"
 msgstr "Części klienta"
@@ -4356,7 +4356,7 @@ msgid "Customer Portals"
 msgstr "Portale klientów"
 
 msgid "Customer pricing"
-msgstr "Ceny dla klientów"
+msgstr "Ustalanie cen dla klienta"
 
 msgid "Customer reference"
 msgstr "Odniesienie klienta"
@@ -4365,7 +4365,7 @@ msgid "Customer Reference"
 msgstr "Odniesienie Klienta"
 
 msgid "Customer Revision"
-msgstr "Wersja klienta"
+msgstr "Rewizja klienta"
 
 msgid "Customer RFQ"
 msgstr "RFQ klienta"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Typy klientów"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Odpis klienta (Nieściągalne należności)"
+msgstr "Spisanie należności klienta (Nieściągalna wierzytelność)"
 
 msgid "customers"
 msgstr "klienci"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Klienci"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Dostosowania, szkolenia i integracje"
 
 msgid "Customize"
 msgstr "Dostosuj"
@@ -4425,13 +4425,13 @@ msgid "Cutover checklist"
 msgstr "Lista kontrolna przejścia"
 
 msgid "Cutover step"
-msgstr "Etap przejścia"
+msgstr "Krok przejścia"
 
 msgid "Cutover support"
 msgstr "Wsparcie przejścia"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "Inwentaryzacja cykliczna i korekta ze ścieżką audytu"
+msgstr "Inwentaryzacja ciągła i korekta ze ścieżką audytu"
 
 msgid "Daily"
 msgstr "Codziennie"
@@ -4440,10 +4440,10 @@ msgid "Daily check-ins while your team finds its feet on the live system"
 msgstr "Codzienne spotkania kontrolne, podczas gdy Twój zespół oswaja się z systemem na żywo"
 
 msgid "Daily summary"
-msgstr "Podsumowanie dzienne"
+msgstr "Codzienne podsumowanie"
 
 msgid "Daily Usage"
-msgstr "Dzienne użycie"
+msgstr "Codzienne zużycie"
 
 msgid "Dark"
 msgstr "Ciemny"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Dni do zapłaty"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Dni od zamówienia części do jej dostępności; planowanie przesunięcia wstecz popytu o tę ilość."
+msgstr "Dni od zamówienia części do jej dostępności. Przesunięcie planistyczne przesuwa zapotrzebowanie wstecz o tę liczbę dni."
 
 msgid "Days Off"
 msgstr "Dni wolne"
@@ -4562,7 +4562,7 @@ msgid "Deactivate Users"
 msgstr "Dezaktywuj użytkowników"
 
 msgid "Deactivate Work Center"
-msgstr "Dezaktywuj Centrum Pracy"
+msgstr "Dezaktywuj stanowisko robocze"
 
 msgid "Deadline type"
 msgstr "Typ terminu"
@@ -4571,35 +4571,35 @@ msgid "Deadline Type"
 msgstr "Typ terminu"
 
 msgid "Debit"
-msgstr "Obciążenie"
+msgstr "Winien"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Debit ({0})"
-msgstr "Debet ({0})"
+msgstr "Winien ({0})"
 
 msgid "Debit Account"
-msgstr "Konto Obciążeniowe"
+msgstr "Konto Winien"
 
 msgid "Debit Memo"
-msgstr "Notatka debetowa"
+msgstr "Nota debetowa"
 
 msgid "Debits"
-msgstr "Debety"
+msgstr "Winien"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
 msgstr "Zdecyduj, co operator widzi, jeśli spróbuje wydać partię lub numer seryjny, który już wygasł."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Zdecyduj, co się stanie, gdy operator naciśnie Zakończ na hali produkcji z materiałem, który wciąż nie został pobrany."
+msgstr "Określ, co się stanie, gdy operator naciśnie przycisk Zakończ na hali produkcyjnej z materiałem jeszcze niepobieranym."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "Zdecyduj, kiedy materiał pobrany do stanowiska pracy, ale nie zużyty, wraca do magazynu."
+msgstr "Zdecyduj, kiedy materiał pobrany na stanowisko robocze, ale niezużyty, wraca do magazynu."
 
 msgid "Decimal Places"
 msgstr "Miejsca Dziesiętne"
 
 msgid "Declining balance"
-msgstr "Malejący Bilans"
+msgstr "Metoda degresywna"
 
 msgid "Default"
 msgstr "Domyślnie"
@@ -4620,13 +4620,13 @@ msgid "Default accounts for long-term assets and depreciation"
 msgstr "Domyślne konta dla aktywów długoterminowych i amortyzacji"
 
 msgid "Default accounts for sales and income"
-msgstr "Domyślne konta dla sprzedaży i dochodów"
+msgstr "Domyślne konta księgowe dla sprzedaży i przychodów"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "Domyślne konta dla transakcji związanych z podatkami"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Domyślne konta dla kosztu sprzedanych towarów i zakupów pośrednich"
+msgstr "Domyślne konta księgowe dla kosztu własnego sprzedaży i zakupów pośrednich"
 
 msgid "Default Approver"
 msgstr "Domyślny Zatwierdzający"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "Domyślni odbiorcy DW"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "Domyślne konto księgi głównej uznawane, gdy zbycie środka trwałego skutkuje zyskiem."
+msgstr "Domyślne konto księgowe, które jest kredytowane w przypadku zysku ze zbycia środka trwałego."
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "Domyślne konto księgi głównej obciążane, gdy zbycie środka trwałego skutkuje stratą."
+msgstr "Domyślne konto księgowe, które jest obciążane w przypadku straty ze zbycia środka trwałego."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
 msgstr "Domyślne konto GL używane do transakcji gotówkowych, gdy nie wybrano określonego konta bankowego."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Domyślne konto GL wydatków dla konserwacji sprzętu i urządzeń."
+msgstr "Domyślne konto wydatków w księdze głównej dla konserwacji urządzeń i pomieszczeń."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Domyślne konto GL wydatków dla okresowych przebiegów amortyzacji."
+msgstr "Domyślne konto wydatków w księdze głównej dla okresowych rozliczeń amortyzacji."
 
 msgid "Default Method"
 msgstr "Metoda domyślna"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Domyślna metoda, która jest wstępnie wypełniana na nowych zasobach w tej klasie (nadal edytowalna dla każdego zasobu)."
 
 msgid "Default method type"
-msgstr "Domyślny typ metody"
+msgstr "Domyślny typ zasilania"
 
 msgid "Default Method Type"
-msgstr "Domyślny typ metody"
+msgstr "Domyślny typ zasilania"
 
 msgid "Default Permissions"
 msgstr "Uprawnienia domyślne"
@@ -4683,7 +4683,7 @@ msgid "Default revenue GL account credited when a sales invoice posts."
 msgstr "Domyślne konto GL przychodu kredytowane po zaksięgowaniu faktury sprzedaży."
 
 msgid "Default Sampling"
-msgstr "Domyślne pobieranie próbek"
+msgstr "Domyślna kontrola wyrywkowa"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Domyślny czas trwania przydatności (dni)"
@@ -4704,7 +4704,7 @@ msgid "Default Unit"
 msgstr "Jednostka domyślna"
 
 msgid "Default useful life that pre-fills on new assets in this class."
-msgstr "Domyślny okres przydatności, który jest wstępnie wypełniany na nowych zasobach w tej klasie."
+msgstr "Domyślny okres użytkowania, który jest automatycznie wypełniany dla nowych środków w tej klasie."
 
 msgid "Defaults"
 msgstr "Ustawienia domyślne"
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "Najpierw zdefiniuj operację produkcyjną."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Definiuj wielopoziomowe BOM i Bill of Process (metody produkcji)"
+msgstr "Zdefiniuj wielopoziomowe BOM i listy operacji (metody produkcji)"
 
 msgid "Delete"
 msgstr "Usuń"
@@ -4756,7 +4756,7 @@ msgid "Delete Asset"
 msgstr "Usuń aktywa"
 
 msgid "Delete Asset Class"
-msgstr "Usuń klasę aktywów"
+msgstr "Usuń klasę środków trwałych"
 
 msgid "Delete Assignment"
 msgstr "Usuń przypisanie"
@@ -4771,7 +4771,7 @@ msgid "Delete Category"
 msgstr "Usuń kategorię"
 
 msgid "Delete Change Notice"
-msgstr "Usuń Zgłoszenie Zmian"
+msgstr "Usuń zawiadomienie o zmianie"
 
 msgid "Delete Consumable"
 msgstr "Usuń materiał eksploatacyjny"
@@ -4780,7 +4780,7 @@ msgid "Delete Contact"
 msgstr "Usuń Kontakt"
 
 msgid "Delete Contractor"
-msgstr "Usuń Wykonawcę"
+msgstr "Usuń pracownika zewnętrznego"
 
 msgid "Delete Count"
 msgstr "Usuń Liczenie"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "Usuń wymiar"
 
 msgid "Delete Dispatch"
-msgstr "Usuń Dyspozycję"
+msgstr "Usuń zlecenie utrzymania ruchu"
 
 msgid "Delete Document"
 msgstr "Usuń dokument"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Usuń Święto"
 
 msgid "Delete Inspection Plan"
-msgstr "Usuń plan inspekcji"
+msgstr "Usuń plan kontroli"
 
 msgid "Delete Issue"
 msgstr "Usuń Problem"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Usuń grupę artykułów"
 
 msgid "Delete Journal Entry"
-msgstr "Usuń wpis dziennika"
+msgstr "Usuń zapis księgowy"
 
 msgid "Delete line"
 msgstr "Usuń linię"
@@ -4888,13 +4888,13 @@ msgid "Delete Period"
 msgstr "Usuń Okres"
 
 msgid "Delete Picking List"
-msgstr "Usuń listę pobrania"
+msgstr "Usuń listę kompletacyjną"
 
 msgid "Delete Portal"
 msgstr "Usuń Portal"
 
 msgid "Delete Price Break"
-msgstr "Usuń przerwę cenową"
+msgstr "Usuń próg cenowy"
 
 msgid "Delete Pricing Rule"
 msgstr "Usuń regułę cenową"
@@ -4963,10 +4963,10 @@ msgid "Delete Shipment"
 msgstr "Usuń wysyłkę"
 
 msgid "Delete shipment line"
-msgstr "Usuń linię wysyłki"
+msgstr "Usuń pozycję wysyłki"
 
 msgid "Delete Shipping Method"
-msgstr "Usuń metodę wysyłki"
+msgstr "Usuń sposób wysyłki"
 
 msgid "Delete step"
 msgstr "Usuń krok"
@@ -4987,7 +4987,7 @@ msgid "Delete Substance"
 msgstr "Usuń substancję"
 
 msgid "Delete Suggestion"
-msgstr "Usuń sugestię"
+msgstr "Usuń propozycję"
 
 msgid "Delete supplier"
 msgstr "Usuń dostawcę"
@@ -5003,7 +5003,7 @@ msgstr "Usuń typ dostawcy"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Usunąć przerwę cenową dla ilości {0}? Tej operacji nie można cofnąć."
+msgstr "Usunąć próg cenowy dla ilości {0}? Nie można cofnąć tej akcji."
 
 msgid "Delete Timecard"
 msgstr "Usuń kartę czasu pracy"
@@ -5018,7 +5018,7 @@ msgid "Delete Transfer"
 msgstr "Usuń Transfer"
 
 msgid "Delete Transfer Line"
-msgstr "Usuń linię transferu"
+msgstr "Usuń pozycję przesunięcia"
 
 msgid "Delete Type"
 msgstr "Usuń typ"
@@ -5048,25 +5048,25 @@ msgid "Delivery Location"
 msgstr "Lokalizacja dostawy"
 
 msgid "Demand"
-msgstr "Popyt"
+msgstr "Zapotrzebowanie"
 
 msgid "Demand forecast"
-msgstr "Prognoza Popytu"
+msgstr "Prognoza zapotrzebowania"
 
 msgid "Demand Forecast"
-msgstr "Prognoza popytu"
+msgstr "Prognoza zapotrzebowania"
 
 msgid "Demand Forecast — Driven by"
-msgstr "Prognoza popytu — Napędzane przez"
+msgstr "Prognoza zapotrzebowania — Napędzane przez"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Prognoza popytu = popyt wyeksplodowany z BOM z otwartych zamówień sprzedaży, aktywnych zleceń i prognoz produkcji."
+msgstr "Prognoza zapotrzebowania = Zapotrzebowanie rozwinięte z BOM pochodzące z otwartych zamówień sprzedaży, aktywnych zleceń produkcyjnych i projekcji produkcji."
 
 msgid "Demand projection"
-msgstr "Prognoza popytu"
+msgstr "Projekcja zapotrzebowania"
 
 msgid "Demand Projections"
-msgstr "Prognozy popytu"
+msgstr "Projekcje zapotrzebowania"
 
 msgid "Demand-Based"
 msgstr "Oparte na popycie"
@@ -5084,7 +5084,7 @@ msgid "Demo data was applied to this company. Keep it, or revert to put back exa
 msgstr "Dane demonstracyjne zostały zastosowane do tej firmy. Zachowaj je lub przywróć dokładnie to, co tu było wcześniej."
 
 msgid "department"
-msgstr "departament"
+msgstr "dział"
 
 msgid "Department"
 msgstr "Dział"
@@ -5093,7 +5093,7 @@ msgid "Department Name"
 msgstr "Nazwa Działu"
 
 msgid "departments"
-msgstr "departamenty"
+msgstr "działy"
 
 msgid "Departments"
 msgstr "Działy"
@@ -5120,13 +5120,13 @@ msgid "Depreciation reversal when a fixed asset is disposed"
 msgstr "Wycofanie amortyzacji w przypadku pozbywania się środka trwałego"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "Przebiegi amortyzacji kończące się w tym okresie, które są w wersji roboczej, powinny być opublikowane, aby okres odzwierciedlał prawidłowy koszt amortyzacji i skumulowaną amortyzację. Pomiń z uzasadnieniem, jeśli amortyzacja nie ma zastosowania w tym okresie."
+msgstr "Rozliczenia amortyzacji kończące się w tym okresie, które są wciąż w wersji roboczej, powinny być zaksięgowane, aby okres odzwierciedlał prawidłowy wydatek amortyzacyjny i umorzenie. Pomiń z uzasadnieniem, jeśli amortyzacja nie ma zastosowania w tym okresie."
 
 msgid "Depreciation Start Date"
 msgstr "Data Rozpoczęcia Amortyzacji"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Wyprowadź trwałość tego artykułu z najkrótszej trwałości jego komponentów, ignorując powyższe pole Dni."
+msgstr "Oblicz okres przydatności tego artykułu na podstawie najkrótszego okresu przydatności jego komponentów, ignorując powyższe pole Dni."
 
 msgid "Description"
 msgstr "Opis"
@@ -5180,7 +5180,7 @@ msgid "Dimension slots"
 msgstr "Sloty wymiarów"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Wartości wymiarów z opublikowanych dzienników, które nie mają jeszcze mapowania dostawcy."
+msgstr "Wartości wymiarów dla zaksięgowanych dowodów księgowych, które nie mają jeszcze mapowania dostawcy."
 
 msgid "dimensions"
 msgstr "wymiary"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Odrzuć"
 
 msgid "Dispatch"
-msgstr "Wysyłka"
+msgstr "Zlecenie utrzymania ruchu"
 
 msgid "Dispatch ID"
-msgstr "ID Dyspozycji"
+msgstr "ID zlecenia utrzymania ruchu"
 
 msgid "Dispatch priority"
-msgstr "Priorytet wysyłki"
+msgstr "Priorytet zlecenia utrzymania ruchu"
 
 msgid "Dispatches"
-msgstr "Wysyłki"
+msgstr "Zlecenia utrzymania ruchu"
 
 msgid "Display Settings"
 msgstr "Ustawienia wyświetlania"
 
 msgid "Disposal"
-msgstr "Zbycie"
+msgstr "Likwidacja"
 
 msgid "Disposal Date"
-msgstr "Data Zbycia"
+msgstr "Data likwidacji"
 
 msgid "Dispose"
 msgstr "Zbywać"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Dokumenty"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Dokumenty wysyła faktury, rachunki i płatności jako dokumenty dostawcy; ich dzienniki są rejestrowane jako pokryte dokumentem. Pobiera również płatności zarejestrowane u dostawcy z powrotem do Carbon, zamykając pasującą fakturę lub rachunek i publikując dziennik GL Carbon. Off rejestruje je jako celowo wyłączone."
+msgstr "Dokumenty wysyłają faktury, rachunki i płatności jako natywne dokumenty dostawcy; ich dowody księgowe są zapisywane jako objęte dokumentem. Pobiera również płatności zarejestrowane u dostawcy z powrotem do Carbon, zamykając pasującą fakturę lub rachunek i księgując dowód księgowy w Księdze głównej Carbon. Off je zapisuje jako celowo wykluczone."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Dokumenty, które otworzysz, pojawią się tutaj w celu szybkiego dostępu."
@@ -5359,7 +5359,7 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "Wersja robocza jest edytowalna; Aktywna jest w użyciu i wymaga nowej wersji do zmiany; Zarchiwizowana jest wycofana."
 
 msgid "Draft Journal Entries"
-msgstr "Wpisy dziennika w wersji roboczej"
+msgstr "Wersje robocze zapisów księgowych"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "Przeciągnij i upuść pliki, lub kliknij aby przeglądać"
@@ -5420,22 +5420,22 @@ msgid "Due date"
 msgstr "Termin płatności"
 
 msgid "Due Date"
-msgstr "Data wymagalności"
+msgstr "Termin"
 
 msgid "Due Date (job)"
 msgstr "Termin (zadanie)"
 
 msgid "Due Date of First Job"
-msgstr "Data ukończenia pierwszego zadania"
+msgstr "Termin pierwszego zlecenia produkcyjnego"
 
 msgid "Due Date of Last Job"
-msgstr "Data ukończenia ostatniego zadania"
+msgstr "Termin ostatniego zlecenia produkcyjnego"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Data wymagalności najwcześniejszego zadania w partii; późniejsze zadania są rozłożone równomiernie między tą datą a datą wymagalności ostatniego zadania."
+msgstr "Termin pierwszego zlecenia produkcyjnego w partii produkcyjnej; późniejsze zlecenia są rozmieszczane równomiernie między ten termin a Termin ostatniego zlecenia produkcyjnego."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Data wymagalności ostatniego zadania w partii; połączona z datą wymagalności pierwszego zadania, aby równomiernie rozłożyć zadania."
+msgstr "Termin ostatniego zlecenia produkcyjnego w partii produkcyjnej; w połączeniu z Terminem pierwszego zlecenia produkcyjnego do równomiernego rozmieszczenia zleceń."
 
 msgid "Due Days"
 msgstr "Dni Wymagalności"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "np. Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Nieużywany materiał każdej operacji wraca natychmiast po zakończeniu operacji."
+msgstr "Niewykorzystany materiał z każdej operacji powraca natychmiast po zakończeniu operacji."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "Każda jednostka fizyczna otrzymuje swoją własną jednostkę śledzenia i unikalny numer — jedna jednostka, jedna jednostka."
@@ -5558,7 +5558,7 @@ msgid "Edit Asset"
 msgstr "Edytuj aktywa"
 
 msgid "Edit Asset Class"
-msgstr "Edytuj Klasę Zasobów"
+msgstr "Edytuj klasę środków trwałych"
 
 msgid "Edit Assignment"
 msgstr "Edytuj przypisanie"
@@ -5573,13 +5573,13 @@ msgid "Edit Category"
 msgstr "Edytuj kategorię"
 
 msgid "Edit Change Notice"
-msgstr "Edytuj Zgłoszenie Zmian"
+msgstr "Edytuj zawiadomienie o zmianie"
 
 msgid "Edit Change Notice Action"
-msgstr "Edytuj Działanie Zgłoszenia Zmian"
+msgstr "Edytuj działanie zawiadomienia o zmianie"
 
 msgid "Edit Change Notice Type"
-msgstr "Edytuj Typ Zgłoszenia Zmian"
+msgstr "Edytuj typ zawiadomienia o zmianie"
 
 msgid "Edit column visibility"
 msgstr "Edytuj widoczność kolumn"
@@ -5588,10 +5588,10 @@ msgid "Edit Contact"
 msgstr "Edytuj Kontakt"
 
 msgid "Edit Contractor"
-msgstr "Edytuj Wykonawcę"
+msgstr "Edytuj pracownika zewnętrznego"
 
 msgid "Edit Cost Center"
-msgstr "Edytuj centrum kosztów"
+msgstr "Edytuj miejsce powstawania kosztów"
 
 msgid "Edit Count"
 msgstr "Edytuj Liczenie"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "Edytuj Wymiar"
 
 msgid "Edit Dispatch"
-msgstr "Edytuj Dyspozycję"
+msgstr "Edytuj zlecenie utrzymania ruchu"
 
 msgid "Edit Employee"
 msgstr "Edytuj pracownika"
@@ -5627,22 +5627,22 @@ msgid "Edit Employee Type"
 msgstr "Edytuj typ pracownika"
 
 msgid "Edit expiration date"
-msgstr "Edytuj datę wygaśnięcia"
+msgstr "Edytuj datę ważności"
 
 msgid "Edit Expiry"
-msgstr "Edytuj datę ważności"
+msgstr "Edytuj termin ważności"
 
 msgid "Edit Failure Mode"
 msgstr "Edytuj tryb awarii"
 
 msgid "Edit Fixed Asset"
-msgstr "Edytuj Zasób Trwały"
+msgstr "Edytuj środek trwały"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Edytuj Rekord Kalibracji Miernika"
+msgstr "Edytuj zapis wzorcowania przyrządu pomiarowego"
 
 msgid "Edit Gauge Type"
-msgstr "Edytuj typ miernika"
+msgstr "Edytuj typ przyrządu"
 
 msgid "Edit Group"
 msgstr "Edytuj grupę"
@@ -5651,13 +5651,13 @@ msgid "Edit Holiday"
 msgstr "Edytuj Święto"
 
 msgid "Edit Inspection Plan"
-msgstr "Edytuj plan inspekcji"
+msgstr "Edytuj plan kontroli"
 
 msgid "Edit Item Group"
 msgstr "Edytuj grupę pozycji"
 
 msgid "Edit Journal Entry"
-msgstr "Edytuj wpis dziennika"
+msgstr "Edytuj zapis księgowy"
 
 msgid "Edit Kanban"
 msgstr "Edytuj Kanban"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Edytuj lokalizację"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Edytuj Dyspozycję Konserwacji"
+msgstr "Edytuj zlecenie utrzymania ruchu"
 
 msgid "Edit Material"
 msgstr "Edytuj materiał"
@@ -5687,7 +5687,7 @@ msgid "Edit Material Shape"
 msgstr "Edytuj kształt materiału"
 
 msgid "Edit Material Substance"
-msgstr "Edytuj Substancję Materiałową"
+msgstr "Edytuj tworzywo"
 
 msgid "Edit Material Type"
 msgstr "Edytuj Typ Materiału"
@@ -5714,22 +5714,22 @@ msgid "Edit Payment Term"
 msgstr "Edytuj Warunki Płatności"
 
 msgid "Edit permissions"
-msgstr "Uprawnienia do edycji"
+msgstr "Edytuj uprawnienia"
 
 msgid "Edit Permissions"
-msgstr "Uprawnienia do edycji"
+msgstr "Edytuj uprawnienia"
 
 msgid "Edit Picking List"
-msgstr "Edytuj listę pobrania"
+msgstr "Edytuj listę kompletacyjną"
 
 msgid "Edit Portal"
 msgstr "Edytuj Portal"
 
 msgid "Edit Price Override"
-msgstr "Edytuj Przesłonięcie Ceny"
+msgstr "Edytuj nadpisanie ceny"
 
 msgid "Edit Pricing"
-msgstr "Edytuj Cenę"
+msgstr "Edytuj ustalanie cen"
 
 msgid "Edit Pricing Rule"
 msgstr "Edytuj regułę cenową"
@@ -5759,7 +5759,7 @@ msgid "Edit Receipt"
 msgstr "Edytuj Paragon"
 
 msgid "Edit Revision"
-msgstr "Edytuj Wersję"
+msgstr "Edytuj rewizję"
 
 msgid "Edit rule"
 msgstr "Edytuj regułę"
@@ -5771,10 +5771,10 @@ msgid "Edit Schedule"
 msgstr "Edytuj harmonogram"
 
 msgid "Edit Scheduled Maintenance"
-msgstr "Edytuj zaplanowaną konserwację"
+msgstr "Edytuj zaplanowane utrzymanie ruchu"
 
 msgid "Edit Sequence"
-msgstr "Edytuj sekwencję"
+msgstr "Edytuj numerację"
 
 msgid "Edit Serial Number"
 msgstr "Edytuj numer seryjny"
@@ -5786,13 +5786,13 @@ msgid "Edit Shift"
 msgstr "Edytuj zmianę"
 
 msgid "Edit Shipment"
-msgstr "Edytuj Przesyłkę"
+msgstr "Edytuj wysyłkę"
 
 msgid "Edit Shipping"
 msgstr "Edytuj Wysyłkę"
 
 msgid "Edit Shipping Method"
-msgstr "Edytuj metodę wysyłki"
+msgstr "Edytuj sposób wysyłki"
 
 msgid "Edit Size"
 msgstr "Edytuj rozmiar"
@@ -5825,7 +5825,7 @@ msgid "Edit Supplier Type"
 msgstr "Edytuj typ dostawcy"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "Edytuj regułę, aby usunąć flagę \"Dotyczy wszystkich\""
+msgstr "Edytuj regułę, aby usunąć flagę „Dotyczy wszystkich\""
 
 msgid "Edit Timecard"
 msgstr "Edytuj Kartę Czasu Pracy"
@@ -5840,7 +5840,7 @@ msgid "Edit Transfer"
 msgstr "Edytuj Transfer"
 
 msgid "Edit Transfer Line"
-msgstr "Edytuj linię transferu"
+msgstr "Edytuj Pozycję przesunięcia"
 
 msgid "Edit Type"
 msgstr "Edytuj typ"
@@ -5855,7 +5855,7 @@ msgid "Edit Webhook"
 msgstr "Edytuj Webhook"
 
 msgid "Edit Work Center"
-msgstr "Edytuj Centrum Pracy"
+msgstr "Edytuj Stanowisko robocze"
 
 msgid "Eliminated"
 msgstr "Wyeliminowane"
@@ -5918,7 +5918,7 @@ msgid "Empty list"
 msgstr "Pusta lista"
 
 msgid "Empty work centers"
-msgstr "Puste centra pracy"
+msgstr "Puste stanowiska robocze"
 
 msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "Włącz rejestrowanie audytu w ustawieniach, aby rozpocząć śledzenie zmian w Twoich danych."
@@ -5927,13 +5927,13 @@ msgid "Enable digital quotes for your company. This will allow you to send digit
 msgstr "Włącz cyfrowe oferty dla swojej firmy. Umożliwi to wysyłanie cyfrowych ofert do klientów i pozwoli im zaakceptować je online."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Włącz pełne rachunkowość memoriałową z wpisami dziennika, raportami finansowymi i księgowaniem w księdze głównej."
+msgstr "Włącz pełną księgowość memoriałową z wpisami dowodów księgowych, raportami finansowymi i księgowaniem do księgi głównej."
 
 msgid "Enable in Settings"
 msgstr "Włącz w Ustawieniach"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "Włącz powiadomienia, gdy RFQ zostanie oznaczone jako gotowe do wyceny."
+msgstr "Włącz powiadomienia, gdy RFQ jest oznaczony jako gotowy do oferty."
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
 msgstr "Włącz tryb wspólnej stacji roboczej dla terminali MES. Operatorzy identyfikują się za pomocą PIN przed wykonaniem pracy."
@@ -5951,7 +5951,7 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "Włącz, aby automatycznie księgować transakcje w księdze głównej."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "Włącz, aby skonfigurować metody amortyzacji specyficzne dla podatku na klasach aktywów (np. MACRS, przyspieszony)."
+msgstr "Włącz konfigurację metod amortyzacji specyficznych dla podatków w klasach środków trwałych (np. MACRS, przyspieszona)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
 msgstr "Włącz, aby generować identyfikatory i opisy dla surowców."
@@ -5991,7 +5991,7 @@ msgid "Ending ({0})"
 msgstr "Koniec ({0})"
 
 msgid "Enforce — edits are blocked"
-msgstr "Egzekwuj — edycje są zablokowane"
+msgstr "Wymuś — edycje są zablokowane"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
 msgstr "Wymuszaj walidację i wytyczne dla każdej pozycji w paragonach, wysyłkach, transferach i korektach."
@@ -6003,10 +6003,10 @@ msgid "Engineering"
 msgstr "Inżynieria"
 
 msgid "Engineering changes and CAD"
-msgstr "Zmiany inżynierskie i CAD"
+msgstr "Zmiany konstrukcyjne i CAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "Zmiany projektowe i CAD"
+msgstr "Zmiany Konstrukcyjne i CAD"
 
 msgid "Engineering Contact"
 msgstr "Kontakt Inżynierski"
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "Zarejestruj"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "Wprowadź numer partii przed ustawieniem daty wygaśnięcia"
+msgstr "Wpisz numer partii produkcyjnej przed ustawieniem daty ważności"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "Wprowadź ilość między 1 a {0}."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Wprowadź i zatwierdź faktury od dostawców względem PO (trójstronna weryfikacja)"
+msgstr "Wprowadź i zatwierdź faktury od dostawców względem zamówienia zakupu (uzgodnienie trójstronne)"
 
 msgid "Enter number…"
 msgstr "Wprowadź liczbę…"
@@ -6088,10 +6088,10 @@ msgid "Equity"
 msgstr "Kapitał Własny"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "Konto kapitału na skumulowane zyski lub straty"
+msgstr "Konto kapitału własnego dla skumulowanych zysków lub strat"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Konto kapitału na różnice z przeliczenia walutowego (CTA)"
+msgstr "Konto kapitału własnego dla korekt przeliczenia walut (CTA)"
 
 msgid "Error"
 msgstr "Błąd"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Błąd podczas pobierania danych dostawcy"
 
 msgid "Error loading assigned dispatches"
-msgstr "Błąd podczas ładowania przypisanych dyspozycji"
+msgstr "Błąd przy wczytywaniu przypisanych zleceń utrzymania ruchu"
 
 msgid "Error loading assigned documents"
 msgstr "Błąd podczas ładowania przypisanych dokumentów"
@@ -6139,7 +6139,7 @@ msgid "Error removing model from job"
 msgstr "Błąd podczas usuwania modelu z zadania"
 
 msgid "Error removing model from quote line"
-msgstr "Błąd podczas usuwania modelu z linii oferty"
+msgstr "Błąd podczas usuwania modelu z pozycji oferty"
 
 msgid "Error removing model from RFQ line"
 msgstr "Błąd podczas usuwania modelu z linii RFQ"
@@ -6148,7 +6148,7 @@ msgid "Error removing model from sales invoice line"
 msgstr "Błąd podczas usuwania modelu z linii faktury sprzedaży"
 
 msgid "Error removing model from sales order line"
-msgstr "Błąd podczas usuwania modelu z linii zamówienia sprzedaży"
+msgstr "Błąd podczas usuwania modelu z pozycji zamówienia sprzedaży"
 
 msgid "Escalate to the project leads"
 msgstr "Eskaluj do liderów projektu"
@@ -6166,10 +6166,10 @@ msgid "Estimated Duration (minutes)"
 msgstr "Szacunkowy czas trwania (minuty)"
 
 msgid "Estimated Scrap Quantity"
-msgstr "Szacunkowa ilość złomu"
+msgstr "Szacunkowa Ilość Braków"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Szacunkowa ilość odpadków zastosowana do każdego zadania w partii."
+msgstr "Szacunkowa ilość braków stosowana do każdego zlecenia produkcyjnego w zbiorczej partii produkcyjnej."
 
 msgid "Estimated time"
 msgstr "Szacowany czas"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Każde dopasowanie"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Każde wymagane zadanie musi być oznaczone jako Wykonane lub Pominięte zanim okres będzie mógł być zamknięty."
+msgstr "Każde wymagane zadanie musi być Gotowe lub Pominięte zanim okres zostanie zamknięty."
 
 msgid "Every row was imported successfully."
 msgstr "Każdy wiersz został pomyślnie zaimportowany."
@@ -6211,10 +6211,10 @@ msgid "Everything else"
 msgstr "Wszystko inne"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "Wszystko inne dotyczy osób, importów, integracji i API — czegokolwiek, co nie jest jednym z Twoich przepływów pracy."
+msgstr "Wszystko inne obejmuje pracowników, importy, integracje i API — wszystko, co nie jest jednym z twoich przepływów pracy."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "Przekracza {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB łącznie — usuń niektóre załączniki, aby wysłać."
+msgstr "Przekracza {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB łącznie — usuń kilka załączników, aby wysłać."
 
 msgid "Exchange rate"
 msgstr "Kurs wymiany"
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Istniejące mapowania. Wybierz inną opcję dostawcy, aby przezmapować."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Istniejący klient Stripe"
 
 msgid "Expand"
 msgstr "Rozwiń"
@@ -6269,7 +6269,7 @@ msgid "Expand features table"
 msgstr "Rozwiń tabelę funkcji"
 
 msgid "Expand Labor"
-msgstr "Rozwiń Pracę"
+msgstr "Rozwiń Robociznę"
 
 msgid "Expand Machine"
 msgstr "Rozwiń Maszynę"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "Rozwiń poddrzewo"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Oczekiwany przyszły popyt na wyprodukowaną część wpisany tydzień po tygodniu przed istnieniem jakiegokolwiek zamówienia sprzedażowego; planowanie sieciuje go względem podaży i wybucha metodę zamówienia komponentów z wyprzedzeniem."
+msgstr "Spodziewane przyszłe zapotrzebowanie na artykuł do produkcji wpisywane tydzień za tygodniem zanim pojawi się zamówienie sprzedaży; planowanie bilansuje to względem pokrycia i rozkłada metodę do zamawiania komponentów z wyprzedzeniem."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "Oczekiwany przyszły popyt na artykuł, pogrupowany według okresu, wypełniony przez uruchomienie planowania wraz z rzeczywistym popytem."
+msgstr "Spodziewane przyszłe zapotrzebowanie na artykuł, pogrupowane w przedziały czasowe, wypełniane podczas przebiegu planowania obok rzeczywistego zapotrzebowania."
 
 msgid "Expected Receipt"
 msgstr "Oczekiwane Potwierdzenie Odbioru"
@@ -6293,28 +6293,28 @@ msgid "Expected Receipt Date"
 msgstr "Oczekiwana data przyjęcia"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Konto wydatków dla sald klientów odpisanych jako nieściągalne w rozliczeniu AR"
+msgstr "Konto wydatków dla sald klientów odpisanych jako nieściągalne przy rozliczeniu należności"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
-msgstr "Konto wydatków na wyrównania podatku odroczonego od amortyzacji"
+msgstr "Konto wydatków dla korekt podatku odroczonego na amortyzacji"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "Konto wydatków na konserwację sprzętu i obiektu"
+msgstr "Konto wydatków dla utrzymania sprzętu i obiektów"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
 msgstr "Konto wydatków dla strat walutowych, gdy płatność rozlicza fakturę w walucie obcej po mniej korzystnym kursie"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Konto wydatków na zakupy poza magazynem (usługi, materiały)"
+msgstr "Konto wydatków dla zakupów niemagazynowych (usług, materiałów eksploatacyjnych)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Konto wydatków GL obciążane, gdy zapasy są wysyłane/wydawane w stosunku do sprzedaży."
+msgstr "Konto wydatków dla kosztów sprzedanych artykułów"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Strona wydatków ruchu podatku odroczonego (sparowany z zobowiązaniem z tytułu podatku odroczonego)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Nie udało się utworzyć klasy zasobu: {0}"
+msgstr "Strona wydatkowa ruchu podatków odroczonych (sparowana z zobowiązaniem z tytułu podatku odroczonego)."
 
 msgid "Expenses"
 msgstr "Wydatki"
@@ -6323,13 +6323,13 @@ msgid "Expert guidance"
 msgstr "Fachowe wskazówki"
 
 msgid "Expiration date"
-msgstr "Data wygaśnięcia"
+msgstr "Data ważności"
 
 msgid "Expiration Date"
-msgstr "Data wygaśnięcia"
+msgstr "Data Ważności"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Data wygaśnięcia (dotyczy wszystkich numerów seryjnych w tej linii)"
+msgstr "Data Ważności (dotyczy wszystkich seriali w tej pozycji)"
 
 msgid "Expired"
 msgstr "Wygasło"
@@ -6362,16 +6362,16 @@ msgid "Expiring first"
 msgstr "Wygasające pierwsze"
 
 msgid "Expiry"
-msgstr "Wygaśnięcie"
+msgstr "Termin ważności"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "Wygaśnięcie rozpoczyna się po zakończeniu wybranego procesu."
+msgstr "Termin ważności rozpoczyna się, gdy wybrany proces zostanie ukończony."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "Wygaśnięcie rozpoczyna się, gdy wybrany proces się zaczyna."
+msgstr "Termin ważności rozpoczyna się, gdy wybrany proces się uruchamia."
 
 msgid "Expiry trace"
-msgstr "Ślad wygaśnięcia"
+msgstr "Śledzenie ważności"
 
 msgid "Export"
 msgstr "Eksportuj"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Dodatkowe informacje wysyłane wraz z żądaniem, takie jak klucz autoryzacyjny; wartości nagłówków są ukryte w historii uruchomień, ale nazwy pozostają czytelne."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Dodatkowe tagi do dzielenia raportów GL"
+msgstr "Dodatkowe tagi do segmentacji raportów Księgi Głównej"
 
 msgid "Fail"
-msgstr "Nie powiodło się"
+msgstr "Niezgodny"
 
 msgid "Failed"
 msgstr "Nieudane"
@@ -6432,7 +6432,7 @@ msgstr "Cechy nie powiodły się"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (pierwsza data ważności, pierwsza wychodzi)"
+msgstr "Nie udało się utworzyć klasy środków trwałych: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6440,7 +6440,7 @@ msgstr "Nie udało się utworzyć materiału eksploatacyjnego: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create cost center: {0}"
-msgstr "Nie udało się utworzyć centrum kosztów: {0}"
+msgstr "Nie udało się utworzyć miejsca powstawania kosztów: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer portal: {0}"
@@ -6460,7 +6460,7 @@ msgstr "Nie udało się utworzyć klienta: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create department: {0}"
-msgstr "Nie udało się utworzyć departamentu: {0}"
+msgstr "Nie udało się utworzyć działu: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create failure mode: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Nie udało się utworzyć trybu awarii: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Nie udało się utworzyć typu miernika: {0}"
+msgstr "Nie udało się utworzyć typu przyrządu: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6480,7 +6480,7 @@ msgstr "Nie udało się utworzyć lokalizacji: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "Nie udało się utworzyć harmonogramu konserwacji: {0}"
+msgstr "Nie udało się utworzyć harmonogramu utrzymania ruchu: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
@@ -6496,7 +6496,7 @@ msgstr "Nie udało się utworzyć formularza materiału: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "Nie udało się utworzyć klasy materiału: {0}"
+msgstr "Nie udało się utworzyć gatunku: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
@@ -6512,7 +6512,7 @@ msgstr "Nie udało się utworzyć materiału: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Nie udało się utworzyć przyczyny braku oferty: {0}"
+msgstr "Nie udało się utworzyć przyczyny odmowy oferty: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6532,11 +6532,11 @@ msgstr "Nie udało się utworzyć usługi: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create shipping method: {0}"
-msgstr "Nie udało się utworzyć metody wysyłki: {0}"
+msgstr "Nie udało się utworzyć sposobu wysyłki: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "Nie udało się utworzyć linii transferu zapasów: {0}"
+msgstr "Nie udało się utworzyć pozycji przesunięcia zapasu: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6556,13 +6556,13 @@ msgstr "Nie udało się utworzyć webhook: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
-msgstr "Nie udało się utworzyć centrum pracy: {0}"
+msgstr "Nie udało się utworzyć stanowiska roboczego: {0}"
 
 msgid "Failed to delete file from old location"
 msgstr "Nie udało się usunąć pliku ze starej lokalizacji"
 
 msgid "Failed to download file for moving"
-msgstr "Nie udało się pobrać pliku do przeniesienia"
+msgstr "Nie udało się pobrać pliku do przesunięcia"
 
 msgid "Failed to fetch item costs"
 msgstr "Nie udało się pobrać kosztów pozycji"
@@ -6574,7 +6574,7 @@ msgid "Failed to fetch risks"
 msgstr "Nie udało się pobrać ryzyk"
 
 msgid "Failed to fetch suggestions"
-msgstr "Nie udało się pobrać sugestii"
+msgstr "Nie udało się pobrać propozycji"
 
 msgid "Failed to get options"
 msgstr "Nie udało się pobrać opcji"
@@ -6583,7 +6583,7 @@ msgid "Failed to initialize Carbon client"
 msgstr "Nie udało się zainicjować klienta Carbon"
 
 msgid "Failed to insert quote line"
-msgstr "Nie udało się wstawić linii oferty"
+msgstr "Nie udało się wstawić pozycji oferty"
 
 msgid "Failed to insert supplier quote line"
 msgstr "Nie udało się wstawić linii oferty dostawcy"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Nie udało się załadować danych"
 
 msgid "Failed to load inbound inspections"
-msgstr "Nie udało się załadować inspekcji przychodzących"
+msgstr "Nie udało się załadować kontroli dostaw"
 
 msgid "Failed to load item data"
 msgstr "Nie udało się załadować danych elementu"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "Nie udało się załadować szczegółów artykułu"
 
 msgid "Failed to load job operations"
-msgstr "Nie udało się załadować operacji zadania"
+msgstr "Nie udało się załadować operacji zleceń"
 
 msgid "Failed to load jobs"
-msgstr "Nie udało się załadować zadań"
+msgstr "Nie udało się załadować zleceń produkcyjnych"
 
 msgid "Failed to load purchase order lines"
 msgstr "Nie udało się załadować linii zamówienia zakupu"
@@ -6625,16 +6625,16 @@ msgid "Failed to load receipts"
 msgstr "Nie udało się załadować paragonów"
 
 msgid "Failed to load sales order lines"
-msgstr "Nie udało się załadować linii zamówienia sprzedaży"
+msgstr "Nie udało się załadować pozycji zamówienia sprzedaży"
 
 msgid "Failed to load sales orders"
 msgstr "Nie udało się załadować zamówień sprzedaży"
 
 msgid "Failed to load shipment lines"
-msgstr "Nie udało się załadować linii wysyłki"
+msgstr "Nie udało się załadować pozycji wysyłki"
 
 msgid "Failed to load shipments"
-msgstr "Nie udało się załadować przesyłek"
+msgstr "Nie udało się załadować wysyłek"
 
 msgid "Failed to load supplier part details"
 msgstr "Nie udało się załadować szczegółów części dostawcy"
@@ -6710,10 +6710,10 @@ msgid "Failed to update item cost"
 msgstr "Nie udało się zaktualizować kosztu pozycji"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "Nie udało się zaktualizować okazji za pomocą zamówienia zakupu"
+msgstr "Nie udało się zaktualizować szansy sprzedaży za pomocą zamówienia zakupu"
 
 msgid "Failed to update quote line"
-msgstr "Nie udało się zaktualizować linii oferty"
+msgstr "Nie udało się zaktualizować pozycji oferty"
 
 msgid "Failed to update supplier quote line"
 msgstr "Nie udało się zaktualizować linii oferty dostawcy"
@@ -6723,7 +6723,7 @@ msgstr "Nie udało się zaktualizować ścieżki miniatury"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
-msgstr "Nie udało się przesłać {0}"
+msgstr "Nie udało się przesłać pliku {0}"
 
 msgid "Failed to upload certificate"
 msgstr "Nie udało się przesłać certyfikatu"
@@ -6743,7 +6743,7 @@ msgid "Failed to upload file: {0}"
 msgstr "Nie udało się przesłać pliku: {0}"
 
 msgid "Failed to upload image"
-msgstr "Nie udalo sie przeslac obrazu"
+msgstr "Nie udało się przesłać obrazu"
 
 msgid "Failed to upload logo: {errorMessage}"
 msgstr "Nie udało się przesłać logo: {errorMessage}"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Opłaty"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Wykończenie"
+msgstr "FEFO (pierwszy ważny – pierwszy wychodzący)"
 
 msgid "Fetch"
 msgstr "Pobierz"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "Sfinalizuj"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Finalizowanie miesiąca obrachunkowego przez cykl życia Otwarte → Zablokowane → Zamknięte; zamknięty okres jest zamrożony i jego salda są zdjęte, odwracalne tylko przez jawne ponowne otwarcie."
+msgstr "Finalizowanie miesiąca obrachunkowego poprzez cykl Otwarte → Zablokowany → Zamknięto; zamknięty okres jest zamrożony i jego salda są utrwalone; zmiana możliwa jest tylko poprzez jawne ponowne otwarcie."
 
 msgid "Financial Statements"
 msgstr "Sprawozdania finansowe"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "Zakończyć bez rozliczenia materiału?"
 
 msgid "Finished goods"
-msgstr "Wykończenia"
+msgstr "wyroby gotowe"
 
 msgid "Finished Goods"
 msgstr "Wyroby gotowe"
@@ -6904,7 +6904,7 @@ msgid "First-year additional deduction taken before the regular MACRS schedule b
 msgstr "Środek Trwały"
 
 msgid "Fiscal year"
-msgstr "Rok obrachunkowy"
+msgstr "rok obrachunkowy"
 
 msgid "Fiscal Year"
 msgstr "Rok obrachunkowy"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Stałe"
 
 msgid "Fixed asset"
-msgstr "Wariancja amortyzacji kosztów stałych, gdy wielkość partii różni się od normy"
+msgstr "Środek trwały"
 
 msgid "Fixed Asset"
 msgstr "Środek trwały"
@@ -6937,10 +6937,10 @@ msgid "Fixed Assets"
 msgstr "Środki trwałe"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Zyski i Straty"
+msgstr "Odchylenie amortyzacji kosztu stałego gdy wielkość partii produkcyjnej różni się od normy"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
-msgstr "Ustalony po wpisaniu lub zamknięciu okresów obrachunkowych. Aby go zmienić, usuń wszystkie otwarte okresy."
+msgstr "Ustalone po zaksięgowaniu lub zamknięciu okresów księgowych. Aby zmienić, usuń wszystkie otwarte okresy."
 
 msgid "Fixed Reorder"
 msgstr "Stałe Zamówienie"
@@ -6949,10 +6949,10 @@ msgid "Fixed Shelf Life"
 msgstr "Stały okres przydatności"
 
 msgid "Fixture"
-msgstr "Oprawa"
+msgstr "Przyrząd obróbkowy"
 
 msgid "Fixture ID"
-msgstr "ID Oprawy"
+msgstr "ID przyrządu obróbkowego"
 
 msgid "Flags"
 msgstr "Flagi"
@@ -6962,16 +6962,16 @@ msgstr "w sprawie czegokolwiek. Zaangażują odpowiednią osobę."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Metoda prognozy: <0>{0}</0>. Ten wiersz nie pochodzi z aktywnych zadań, dlatego nie są dostępne żadne źródła nadrzędne."
+msgstr "Metoda prognozy: <0>{0}</0>. Ten wiersz nie został wyprowadzony ze zleceń produkcyjnych, dlatego żadne źródła nadrzędne nie są dostępne."
 
 msgid "Forgot to Clock Out?"
-msgstr "Zapomniałeś wylogować się z zegara?"
+msgstr "Zapomniałeś o zakończeniu pracy?"
 
 msgid "Format"
 msgstr "Format"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Inżynier wdrażający"
 
 msgid "Foundation"
 msgstr "Fundament"
@@ -6983,10 +6983,10 @@ msgid "Freeze the old system, no new transactions"
 msgstr "Zamroź stary system, brak nowych transakcji"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "Fracht rozliczana klientowi za tę linię, oddzielnie od ceny jednostkowej linii."
+msgstr "Koszty przesyłki rozliczane klientowi dla tej pozycji, odrębnie od ceny jednostkowej tej pozycji."
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
-msgstr "Fracht pobierana przez tego dostawcę za tę linię, gdy wyszczególnia wysyłkę zamiast включать ją w cenę jednostkową."
+msgstr "Koszty przesyłki naliczane przez tego dostawcę dla tej pozycji, gdy wydzielnie rozlicza wysyłkę zamiast wliczać do ceny jednostkowej."
 
 msgid "Frequencies"
 msgstr "Częstotliwości"
@@ -7027,7 +7027,7 @@ msgid "Full name"
 msgstr "Pełne imię i nazwisko"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Pełne przezbrojenie i migracje"
 
 msgid "Fully Depreciated"
 msgstr "Całkowicie zamortyzowane"
@@ -7039,52 +7039,52 @@ msgid "FX G/L"
 msgstr "FX Z/S"
 
 msgid "Gain on Disposal"
-msgstr "Zysk ze zbycia"
+msgstr "Zysk na likwidacji"
 
 msgid "Gain on Disposal (default)"
-msgstr "Zysk ze zbycia (domyślnie)"
+msgstr "Zysk na likwidacji (domyślnie)"
 
 msgid "Gain on Disposal Account"
-msgstr "Konto zysku ze zbycia"
+msgstr "Konto zysku na likwidacji"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "Zyski ujęte przy zbyciu środków trwałych"
+msgstr "Zyski ujęte przy likwidacji środków trwałych"
 
 msgid "gauge"
-msgstr "Wymiary"
+msgstr "przyrząd pomiarowy"
 
 msgid "Gauge"
-msgstr "Miernik"
+msgstr "Przyrząd pomiarowy"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Powiadomienia o kalibracji mierników"
+msgstr "Powiadomienia o wzorcowaniu przyrządów pomiarowych"
 
 msgid "Gauge ID"
-msgstr "ID Miernika"
+msgstr "ID przyrządu pomiarowego"
 
 msgid "Gauge not found"
-msgstr "Czujnik nie znaleziony"
+msgstr "Przyrząd pomiarowy nie znaleziony"
 
 msgid "Gauge Type"
-msgstr "Typ miernika"
+msgstr "Typ przyrządu"
 
 msgid "Gauge Types"
-msgstr "Typy mierników"
+msgstr "Typy przyrządów"
 
 msgid "gauges"
-msgstr "Genealogia"
+msgstr "przyrządy pomiarowe"
 
 msgid "Gauges"
-msgstr "Mierniki"
+msgstr "Przyrządy pomiarowe"
 
 msgid "Genealogy"
-msgstr "Księga Główna"
+msgstr "Genealogia"
 
 msgid "General"
 msgstr "Ogólne"
 
 msgid "General ledger"
-msgstr "Konto GL przechwytujące różnice kosztów w operacjach obróbki zewnętrznej."
+msgstr "Księga główna"
 
 msgid "General Ledger"
 msgstr "Księga główna"
@@ -7102,10 +7102,10 @@ msgid "Generate and send customer invoices"
 msgstr "Generuj i wysyłaj faktury dla klientów"
 
 msgid "Generate fiscal year"
-msgstr "Generuj rok obrachunkowy"
+msgstr "Generuj rok obrotowy"
 
 msgid "Generate Fiscal Year"
-msgstr "Generuj Rok Obrachunkowy"
+msgstr "Generuj Rok obrotowy"
 
 msgid "Generate material IDs and descriptions based on the properties of the material."
 msgstr "Generuj identyfikatory materiałów i opisy na podstawie właściwości materiału."
@@ -7114,7 +7114,7 @@ msgid "Generate new PIN"
 msgstr "Wygeneruj nowy PIN"
 
 msgid "Generate Picking List"
-msgstr "Generuj listę pobrania"
+msgstr "Generuj Listę kompletacyjną"
 
 msgid "Generated IDs are disabled"
 msgstr "Wygenerowane identyfikatory są wyłączone"
@@ -7123,10 +7123,10 @@ msgid "Generated IDs are enabled"
 msgstr "Wygenerowane identyfikatory są włączone"
 
 msgid "Generating suggestions…"
-msgstr "Generowanie sugestii…"
+msgstr "Generowanie propozycji…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "Uruchom Carbon: jeden system obsługujący wycenę, zakupy, halę produkcyjną, magazyn i finanse, zastępujący obecne narzędzia."
+msgstr "Przejdź na żywo w Carbon: jeden system obsługujący ofertowanie, zakupy, halę produkcyjną, zapasy i finanse, zastępując obecne narzędzia."
 
 msgid "Get Method"
 msgstr "Pobierz metodę"
@@ -7147,7 +7147,7 @@ msgid "Give it an owner and a date"
 msgstr "Przydziel właściciela i datę"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Księga główna"
 
 msgid "GL Account"
 msgstr "Konto księgi głównej"
@@ -7156,31 +7156,31 @@ msgid "GL account capturing cost differences on outside-processing operations."
 msgstr "Konto GL przechwytujące różnice kosztów na operacjach kooperacji zewnętrznej (outside-processing)."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Konto GL przechwytujące różnice między zastosowanymi a rzeczywistymi kosztami ogólnymi produkcji."
+msgstr "Konto księgowe ujmujące różnice między zastosowanymi a rzeczywistymi kosztami pośrednimi produkcji."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Konto GL przechwytujące różnice między materiałami oczekiwanymi w BOM a rzeczywiście zużytymi."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Konto GL przechwytujące różnice między czasem pracy/maszyny oczekiwanym w routingu a rzeczywistym."
+msgstr "Konto księgowe ujmujące różnice między oczekiwanym a rzeczywistym czasem robocizny/czasem maszynowym."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Konto GL przechwytujące różnice kosztów stałych, gdy rzeczywista wielkość partii różni się od planowanej."
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "Konto GL uznawane w celu usunięcia pierwotnego kosztu środka trwałego przy jego zbyciu."
+msgstr "Konto księgowe kredytowane w celu usunięcia pierwotnego kosztu środka trwałego w momencie jego likwidacji."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
 msgstr "Konto GL uznawane, gdy faktura dostawcy jest księgowana (saldo zobowiązań)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Konto GL uznawane, gdy koszt pracy lub maszyny jest wchłonięty w zadanie produkcyjne."
+msgstr "Konto księgowe kredytowane gdy koszt robocizny lub maszynowy jest wchłonięty do zlecenia produkcyjnego."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
-msgstr "Konto GL zarachowane, gdy koszty ogólne produkcji są absorbowane do zadania produkcyjnego."
+msgstr "Konto księgowe kredytowane gdy koszty pośrednie produkcji są wchłonięte do zlecenia produkcyjnego."
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "Konto GL obciążane w celu wyczyszczenia skumulowanej amortyzacji w momencie likwidacji zasobu."
+msgstr "Konto księgowe obciążane w celu usunięcia umorzenia gdy środek trwały jest likwidowany."
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
 msgstr "Konto GL obciążane, gdy faktura klienta jest księgowana; wyczyszczane, gdy klient płaci."
@@ -7192,13 +7192,13 @@ msgid "GL account for bank service charges and similar fees."
 msgstr "Konto GL dla opłat za usługi bankowe i podobnych opłat."
 
 msgid "GL account for interest income or expense."
-msgstr "Konto GL dla przychodów lub kosztów odsetek."
+msgstr "Konto księgowe dla przychodów lub wydatków z odsetek."
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "Konto GL dla podatku zakupu zapłaconego dostawcom (lub podatku podlegającego odliczeniu)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "Konto GL dla podatku naliczonego zgodnie z zasadami odwrotnego obciążenia, gdy nabywca rozlicza go samodzielnie."
+msgstr "Konto księgowe dla podatku naliczonego w ramach zasad odwrotnego obciążenia, gdzie kupiec samodzielnie dokonuje oceny."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "Konto GL dla różnic czasowych podatku (np. przyspieszona amortyzacja podatkowa kontra amortyzacja księgowa)."
@@ -7207,10 +7207,10 @@ msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Konto GL obciążane, gdy wyniki spisu z natury różnią się od stanu magazynowego w systemie."
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "Konto GL w spółce źródłowej do obciążenia dla tej transakcji między spółkami."
+msgstr "Konto księgowe w firmie źródłowej do obciążenia dla tej transakcji między firmami."
 
 msgid "GL account in the target company to credit for this intercompany transaction."
-msgstr "Konto GL w spółce docelowej do uznania dla tej transakcji między spółkami."
+msgstr "Konto księgowe w docelowej firmie do uznania dla tej transakcji między firmami."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
 msgstr "Konto GL, które wchłania różnice zaokrąglenia poniżej grosza przy księgowaniu."
@@ -7219,10 +7219,10 @@ msgid "GL account that captures the difference between standard cost and actual 
 msgstr "Konto GL, które przechwytuje różnicę między kosztem standardowym a rzeczywistym kosztem zakupu."
 
 msgid "GL account that carries an asset's original acquisition cost — debited when acquired and credited at full gross cost when it is disposed or sold."
-msgstr "Konto GL, na którym ujmowany jest pierwotny koszt nabycia środka trwałego (zakup lub koszt skapitalizowany) — obciążane przy nabyciu, a uznawane pełną wartością brutto, gdy środek trwały zostaje zbyty lub sprzedany."
+msgstr "Konto księgowe, które zawiera pierwotną cenę nabycia środka trwałego — obciążane przy nabyciu i uznawane w pełnym koszcie brutto, gdy jest zlikwidowany lub sprzedany."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Konto GL, które przechowuje wartość prac w produkcji do momentu ich zaksięgowania jako produktów gotowych."
+msgstr "Konto księgowe, które przechowuje wartość zleceń produkcyjnych w produkcji, dopóki nie zostaną zaksięgowane do wyrobów gotowych."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "Konto GL, które przechowuje wartość wyrobów wytworzonych (Pozycje produkcyjne); obciążane po zakończeniu zadania, uznawane przy wysyłce."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "Konto GL, na którym rejestruje się rabaty na wcześniejsze płatności uzyskane od dostawców."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Konto GL korygujące aktywa, uznawane w miarę księgowania amortyzacji w każdym okresie i obciążane w pełnej wysokości, gdy środek trwały zostaje sprzedany lub zezłomowany."
+msgstr "Konto księgowe contra-aktywów, które jest uznawane, gdy amortyzacja jest zaksięgowywana w każdym okresie, i obciążane w całości, gdy środek trwały jest sprzedany lub złomowany."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Konto GL aktywów przeciwnych, które gromadzi amortyzację zaksięgowaną wobec środków trwałych."
+msgstr "Konto księgowe contra-aktywów, które akumuluje amortyzację zaksięgowaną przeciwko środkom trwałym."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Konto GL kapitału (rezerwa CTA), które przechowuje niezrealizowane różnice FX wynikające z przetłumaczenia sald w obcej walucie na koniec okresu; oddzielnie od zrealizowanego zysku/straty FX w P&L."
+msgstr "Konto księgowe kapitału własnego (rezerwa CTA), które przechowuje niezrealizowane różnice FX z przeliczenia sald w walutach obcych na koniec okresu; oddzielone od zrealizowanego zysku/straty FX w rachunku zysków i strat."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Konto GL kapitału, na którym dochód netto zostaje zamknięty na koniec roku obrachunkowego."
+msgstr "Konto księgowe kapitału własnego, na którym dochód netto jest zamykany na koniec roku obrachunkowego."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Konto GL wydatków obciążane każdy okres, gdy amortyzacja jest księgowana."
+msgstr "Konto księgowe wydatków obciążane w każdym okresie, gdy amortyzacja jest zaksięgowywana."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Konto GL kosztów obciążane, gdy wartość bilansowa środka trwałego ulega obniżeniu w wyniku utraty wartości, tzn. gdy jego wartość odzyskiwalna spada poniżej wartości księgowej netto."
+msgstr "Konto księgowe wydatków obciążane, gdy wartość bilansowa środka trwałego jest zmniejszana z powodu utraty wartości, czyli gdy jego kwota możliwa do odzyskania spada poniżej wartości księgowej netto."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Konto GL wydatków dla zakupów spoza zapasów (materiały, usługi)."
+msgstr "Konto księgowe wydatków dla zakupów niemagazynowych (materiały, usługi)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Konto GL zobowiązań kredytowane dla podatku od sprzedaży pobranego od klientów."
+msgstr "Konto księgowe zobowiązań uznawane dla podatku od sprzedaży zebranego od klientów."
 
 msgid "GL tie-out"
-msgstr "Uzgodnienie GL"
+msgstr "Wyrównanie Księgi głównej"
 
 msgid "GL Tie-Out"
-msgstr "Uzgodnienie GL"
+msgstr "Wyrównanie Księgi Głównej"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Wdrażaj bez błędów za pierwszym razem — z naszym zespołem u boku"
@@ -7355,10 +7355,10 @@ msgid "Guided"
 msgstr "Wspomagane"
 
 msgid "Guided implementation"
-msgstr "Wdrażanie z przewodnikiem"
+msgstr "Wdrożenie z przewodnikiem"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Obsługuj powtarzające się i odwracające wpisy dziennika"
+msgstr "Obsługuj powtarzające się i odwracające dowody księgowe"
 
 msgid "Hands-on"
 msgstr "Praktyczne"
@@ -7409,7 +7409,7 @@ msgid "History"
 msgstr "Historia"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Zatrzymaj dziennik jako ostrzeżenie do naprawy."
+msgstr "Wstrzymaj dowód księgowy jako ostrzeżenie do naprawy."
 
 msgid "Holiday"
 msgstr "Święto"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Godziny/Sztuka"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Jak artykuł jest uzupełniany ogólnie (Kupuj, Produkuj lub Kupuj i Produkuj), ustawiony na artykuł, w przeciwieństwie do typu metody dla każdego wiersza."
+msgstr "Jak artykuł jest uzupełniany ogółem (Zakup, Produkcja lub Zakup i produkcja), ustawione na artykuł, w odróżnieniu od typu zasilania dla każdej pozycji."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Jak artykuł jest uzupełniany: Manualny Reorder, Reorder na Podstawie Popytu, Stała Ilość Reordera lub Ilość Maksymalna."
@@ -7460,7 +7460,7 @@ msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank
 msgstr "Jak długo trwa każda faza, w tygodniach. Określa oś czasu planu; pozostaw puste, aby użyć wartości domyślnej."
 
 msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
-msgstr "Jak długo trwa zwykle jedno wykonanie tego harmonogramu; planowanie blokuje centrum pracy na tę ilość minut dla każdego zaplanowanego wystąpienia."
+msgstr "Jak długo trwa typowo jedno wykonanie tego harmonogramu; planowanie blokuje stanowisko robocze na tę liczbę minut przy każdym zaplanowanym uruchomieniu."
 
 msgid "How many"
 msgstr "Ile"
@@ -7496,10 +7496,10 @@ msgid "How many were actually picked?"
 msgstr "Ile faktycznie pobrano?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Jak często ten układ musi być ponownie kalibrowany; połączony z ostatnią datą kalibracji w celu automatycznego przeliczenia następnej daty kalibracji."
+msgstr "Jak często ten przyrząd pomiarowy musi być wzorcowany; połączone z datą ostatniego wzorcowania w celu automatycznego przeliczenia daty następnego wzorcowania."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Jak często to utrzymanie się powtarza — Codziennie, Cotygodniowo, Miesięcznie, Przy Liczeniu Cyklu; Codziennie ujawnia selektor dnia tygodnia, pozostałe używają prostszej matematyki interwałów."
+msgstr "Jak często to utrzymanie ruchu się powtarza — Codziennie, Co tydzień, Co miesiąc, Podczas inwentaryzacji ciągłej; Opcja Codziennie ujawnia selektor dnia tygodnia, inne używają prostszej arytmetyki interwałów."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Jak surowy jest termin — Hard Deadline blokuje planowanie, Soft Deadline pozwala planowaniu przesunąć się z ostrzeżeniem, No Deadline ignoruje to całkowicie."
@@ -7514,7 +7514,7 @@ msgid "How the sample size is decided — Inspect All, Inspect First N, Percenta
 msgstr "Jak decyduje się o wielkości próbki — Sprawdzić Wszystko, Sprawdzić Pierwsze N, Procent Partii lub AQL (Z1.4 / ISO 2859-1). Każdy tryb ujawnia poniżej swoje własne pola parametrów."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Jak ten przyrząd jest używany — Standard (regularne kontrole) lub Master (kalibruje inne przyrządy)."
+msgstr "Jak ten przyrząd pomiarowy jest używany — Normalna (regularne sprawdzenia) czy Wzorzec (wzorcuje inne przyrządy pomiarowe)."
 
 msgid "How this price was calculated"
 msgstr "Jak ta cena została obliczona"
@@ -7526,13 +7526,13 @@ msgid "How to read this chart"
 msgstr "Jak czytać ten wykres"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Jak pilna jest ta wysyłka — Niska / Średnia / Wysoka / Krytyczna; połączone z Priorytetem i Wpływem OEE w celu decyzji o slocie harmonogramu."
+msgstr "Jak pilne jest to zlecenie utrzymania ruchu — Niski / Średni / Wysoki / Krytyczny; połączone z Priorytetem i Wpływem OEE w celu określenia przedziału harmonogramu."
 
 msgid "How we know we're done"
 msgstr "Jak wiemy, że skończyliśmy"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
-msgstr "Jak pozostajemy w zgodzie i jak rozwiązywane są problemy. Twoja rola: pojaw się na cotygodniowym spotkaniu i zgłaszaj przeszkody wcześnie, zanim staną się opóźnieniami."
+msgstr "Jak pozostajemy w zgodzie i jak problemy zostają rozwiązane. Twoja rola: pojawiaj się na tygodniowym spotkaniu i zgłaszaj utrudnienia wcześnie, zanim staną się opóźnieniami."
 
 msgid "How We Work"
 msgstr "Jak pracujemy"
@@ -7547,7 +7547,7 @@ msgid "How your quotes, orders, and invoices look when they go out"
 msgstr "Jak wyglądają Twoje oferty, zamówienia i faktury, gdy są wysyłane"
 
 msgid "How your team is organized into departments"
-msgstr "Jak Twój zespół jest zorganizowany w departamenty"
+msgstr "Jak twój zespół jest zorganizowany w działy"
 
 msgid "Humidity"
 msgstr "Wilgotność"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "Hypercare: intensywne wsparcie w pierwszych tygodniach"
 
 msgid "I (reduced)"
-msgstr "I (zmniejszony)"
+msgstr "I (Ulgowa)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "Mam uzasadnioną podstawę, aby wierzyć, że ta osoba jest osobą ze Stanów Zjednoczonych zgodnie z definicją w 22 CFR 120.62"
@@ -7577,7 +7577,7 @@ msgid "ID"
 msgstr "ID"
 
 msgid "Ideas, suggestions or problems?"
-msgstr "Pomysly, sugestie lub problemy?"
+msgstr "Pomysły, sugestie czy problemy?"
 
 msgid "Idempotency key"
 msgstr "Klucz idempotencji"
@@ -7595,7 +7595,7 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "Jeśli nie może czekać do następnego spotkania, decydują liderzy z obu stron."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "Jeśli blokuje postęp lub termin jest zagrożony, przypisywany jest właściciel i śledzony."
+msgstr "Jeśli coś blokuje lub data jest zagrożona, przydzielany jest właściciel i jest śledzony."
 
 msgid "If items already exist"
 msgstr "Jeśli elementy już istnieją"
@@ -7613,7 +7613,7 @@ msgid "II (normal default)"
 msgstr "II (normalne domyślne)"
 
 msgid "III (tightened)"
-msgstr "III (zaostrzony)"
+msgstr "III (Obostrzona)"
 
 msgid "Impact"
 msgstr "Wpływ"
@@ -7622,13 +7622,13 @@ msgid "Imperial"
 msgstr "Imperialny"
 
 msgid "Implementation"
-msgstr "Wdrażanie"
+msgstr "Wdrożenie"
 
 msgid "Implementation Hub"
-msgstr "Centrum wdrażania"
+msgstr "Hub Wdrażania"
 
 msgid "Implementation Lead"
-msgstr "Lider Wdrażania"
+msgstr "Lider Wdrożenia"
 
 msgid "Import {label} CSV"
 msgstr "Importuj {label} CSV"
@@ -7644,16 +7644,16 @@ msgid "in {0}"
 msgstr "za {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "W Onshape edytuj uprawnienia tej aplikacji OAuth, aby zawierały „Application can write to your documents”, a następnie połącz się ponownie."
+msgstr "W Onshape edytuj uprawnienia tej aplikacji OAuth, aby uwzględnić „Aplikacja może pisać w twoje dokumenty”, a następnie połącz się ponownie."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
-msgstr "Aby przekonwertować to RFQ na ofertę, wszystkie linie muszą mieć wewnętrzny numer części."
+msgstr "Aby przekształcić to RFQ w ofertę, wszystkie pozycje muszą mieć wewnętrzny numer części."
 
 msgid "In order to convert this RFQ to a quote, it must be associated with a customer."
-msgstr "Aby przekonwertować to RFQ na ofertę, musi być powiązane z klientem."
+msgstr "Aby przekształcić to RFQ w ofertę, musi być powiązany z klientem."
 
 msgid "In order to convert this RFQ to a quote, it must have a customer."
-msgstr "Aby przekonwertować to RFQ na ofertę, musi być powiązane z klientem."
+msgstr "Aby przekształcić to RFQ w ofertę, musi mieć klienta."
 
 msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
 msgstr "Aby wysłać to zapytanie ofertowe do dostawców, musisz najpierw dodać dostawców do zapytania ofertowego."
@@ -7662,10 +7662,10 @@ msgid "In Process Only"
 msgstr "Tylko w trakcie"
 
 msgid "In progress"
-msgstr "W trakcie"
+msgstr "W toku"
 
 msgid "In Progress"
-msgstr "W trakcie"
+msgstr "W toku"
 
 msgid "in scope"
 msgstr "w zakresie"
@@ -7701,7 +7701,7 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Nieaktywne akcje nie będą wyświetlane na listach wyboru"
 
 msgid "Inbound inspection"
-msgstr "Inspekcja przychodząca"
+msgstr "Kontrola dostaw"
 
 msgid "Inbox"
 msgstr "Skrzynka odbiorcza"
@@ -7719,7 +7719,7 @@ msgid "Includes tax and shipping costs"
 msgstr "Obejmuje podatki i koszty wysyłki"
 
 msgid "Income / Balance (inherited)"
-msgstr "Dochód / Saldo (odziedziczone)"
+msgstr "Przychody / Saldo (odziedziczone)"
 
 msgid "Income Statement"
 msgstr "Rachunek zysków i strat"
@@ -7728,7 +7728,7 @@ msgid "Income Tax"
 msgstr "Podatek dochodowy"
 
 msgid "Income/Balance"
-msgstr "Dochód/Saldo"
+msgstr "Przychody/Saldo"
 
 msgid "incoming"
 msgstr "przychodzący"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Odziedziczone z elementu nadrzędnego"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Odziedziczone z grupy: klasyfikacja najwyższego poziomu (aktywa, pasywa, kapitał, przychody, wydatki)."
+msgstr "Odziedziczone z grupy: klasyfikacja główna (aktywa, pasywa, kapitał własny, przychody, wydatki)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Odziedziczone z grupy: gdzie to konto pojawia się w sprawozdaniach finansowych."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Odziedziczone z grupy: czy to konto zamyka się do zysków zatrzymanych (przychody), czy przenosi (bilans)."
+msgstr "Odziedziczone z grupy: czy to konto zamyka się do zysków zatrzymanych (przychody) czy przenosi się w przód (saldo)."
 
 msgid "Inherited from the parent group."
 msgstr "Odziedziczone z grupy nadrzędnej."
@@ -7803,37 +7803,37 @@ msgid "Inspect Item"
 msgstr "Sprawdź element"
 
 msgid "Inspection"
-msgstr "Inspekcja"
+msgstr "Kontrola"
 
 msgid "Inspection document"
-msgstr "Dokument inspekcji"
+msgstr "Dokument kontroli"
 
 msgid "Inspection Level"
 msgstr "Poziom kontroli"
 
 msgid "Inspection Plan"
-msgstr "Plan inspekcji"
+msgstr "Plan kontroli"
 
 msgid "Inspection Plan Assignments"
-msgstr "Przypisania planu inspekcji"
+msgstr "Przypisania planu kontroli"
 
 msgid "Inspection Plans"
-msgstr "Plany inspekcji"
+msgstr "Plany kontroli"
 
 msgid "Inspection Status"
-msgstr "Stan kontroli"
+msgstr "Status kontroli"
 
 msgid "Inspections"
-msgstr "Inspekcje"
+msgstr "Kontrole"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Inspekcje, niezgodności i CAPA"
+msgstr "Kontrole, niezgodności i CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Inspekcje, Niezgodności, CAPA"
+msgstr "Kontrole, Niezgodności, CAPA"
 
 msgid "Inspections: Require Different Inspector"
-msgstr "Inspekcje: Wymagaj innego inspektora"
+msgstr "Kontrole: Wymagaj innego inspektora"
 
 msgid "Install"
 msgstr "Zainstaluj"
@@ -7872,7 +7872,7 @@ msgid "Intercompany Transactions"
 msgstr "Transakcje międzyspółkowe"
 
 msgid "Intercompany transactions involving this company that are still Unmatched should be matched and eliminated, so consolidated results don't double-count activity between entities."
-msgstr "Transakcje między spółkami dotyczące tej spółki, które są jeszcze niepasujące, powinny być dopasowane i wyeliminowane, aby skonsolidowane wyniki nie liczyły dwukrotnie działalności między jednostkami."
+msgstr "Transakcje między firmami, w które zaangażowana jest ta firma i które są nadal niedopasowane, powinny być dopasowane i wyeliminowane, aby skonsolidowane wyniki nie liczyły aktywności między jednostkami podwójnie."
 
 msgid "Interest"
 msgstr "Odsetki"
@@ -7881,7 +7881,7 @@ msgid "Interest (default)"
 msgstr "Odsetki (domyślne)"
 
 msgid "Interest income or expense from banking activities"
-msgstr "Dochód lub wydatek z tytułu odsetek z działalności bankowej"
+msgstr "Dochody lub wydatki z odsetek z czynności bankowych"
 
 msgid "Internal"
 msgstr "Wewnętrzne"
@@ -7983,7 +7983,7 @@ msgid "Invoice customer contact"
 msgstr "Kontakt klienta faktury"
 
 msgid "Invoice Customer Contact"
-msgstr "Kontakt odbiorcy faktury"
+msgstr "Kontakt klienta faktury"
 
 msgid "Invoice customer location"
 msgstr "Lokalizacja klienta faktury"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "Przepływy pracy problemów"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "Przepływy pracy problemów zdefiniowały wstępnie ustawione wartości problemu. Na przykład możesz mieć przepływ pracy 8D lub przepływ pracy zawierania."
+msgstr "Przepływy pracy niezgodności definiują wstępnie ustawione wartości dla niezgodności. Na przykład możesz mieć przepływ pracy 8D lub przepływ pracy zabezpieczenia."
 
 msgid "Issued"
 msgstr "Wydane"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Problemy"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "To przestanie działać, dopóki nie opublikujesz wersji ponownie. Nic nie jest usunięte."
 
 msgid "ITAR Certifications"
 msgstr "Certyfikacje ITAR"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Główny katalog artykułów i metody produkcji"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Główny katalog pozycji, BOM i Karta Procesu"
+msgstr "Wzorzec artykułów, BOM i Lista operacji"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "Element musi pasować do wybranego typu I wybranej grupy"
@@ -8184,13 +8184,13 @@ msgid "Item Scope"
 msgstr "Zakres Pozycji"
 
 msgid "Item Type"
-msgstr "Typ przedmiotu"
+msgstr "Typ artykułu"
 
 msgid "Item Type (optional)"
-msgstr "Typ przedmiotu (opcjonalnie)"
+msgstr "Typ artykułu (opcjonalnie)"
 
 msgid "Item types"
-msgstr "Typy przedmiotów"
+msgstr "Typy artykułów"
 
 msgid "items"
 msgstr "elementy"
@@ -8205,10 +8205,10 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Elementy w tym oknie otrzymują żółty znaczek."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Pozycje: główny katalog pozycji, BOM, Bill of Process, zmiany inżynierskie, CAD"
+msgstr "Artykuły: wzorzec artykułów, BOM, Lista operacji, zmiany konstrukcyjne, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Projekt może ulec zmianie przed wydaniem zgłoszenia zmian."
+msgstr "Jego projekt może się zmienić przed wydaniem zawiadomienia o zmianie."
 
 msgid "Job"
 msgstr "Zadanie"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "Lokalizacja Zadania"
 
 msgid "Job make method"
-msgstr "Metoda wykonania zadania"
+msgstr "Metoda produkcji zlecenia"
 
 msgid "Job Materials"
-msgstr "Materiały zadania"
+msgstr "Materiały zlecenia"
 
 msgid "Job operation"
-msgstr "Operacja zadania"
+msgstr "Operacja zlecenia"
 
 msgid "Job Operation"
-msgstr "Operacja zadania"
+msgstr "Operacja zlecenia"
 
 msgid "Job Operations"
-msgstr "Operacje Zadań"
+msgstr "Operacje zlecenia"
 
 msgid "Job Priority"
 msgstr "Priorytet zadania"
@@ -8244,38 +8244,38 @@ msgid "Job readable"
 msgstr "Czytelne zadanie"
 
 msgid "Job Traveler"
-msgstr "Dokument postępu pracy"
+msgstr "Przewodnik zlecenia"
 
 msgid "Jobs"
-msgstr "Zadania"
+msgstr "Zlecenia produkcyjne"
 
 msgid "Jobs Assigned to Me"
-msgstr "Zadania przypisane do mnie"
+msgstr "Zlecenia produkcyjne przypisane do mnie"
 
 msgid "Jobs Required"
-msgstr "Wymagane zadania"
+msgstr "Wymagane zlecenia produkcyjne"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Zadania zawierające ten przedmiot w zestawieniu materiałów"
+msgstr "Zlecenia produkcyjne, które mają ten artykuł na swojej liście materiałowej"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Dołącz do {0}"
 
 msgid "Journal"
-msgstr "Dziennik"
+msgstr "Dowód księgowy"
 
 msgid "Journal Entries"
-msgstr "Wpisy dziennika"
+msgstr "Wpisy dowodu księgowego"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "Wpisy dziennika datowane w tym okresie, które są w wersji roboczej, muszą być opublikowane lub przedatowane na późniejszy otwarty okres. Wpisy w wersji roboczej nie są częścią księgi, więc ich obciążenia i kredyty byłyby brakujące w zamknięciu."
+msgstr "Wpisy dowodu księgowego datowane w tym okresie, które są nadal w wersji roboczej, muszą być zaksięgowane lub przesunięte na datę w późniejszym otwartym okresie. Wpisy w wersji roboczej nie są częścią ksiąg, więc ich debety i kredyty byłyby nieobecne przy zamknięciu."
 
 msgid "Journal Entry"
-msgstr "Wpis dziennika"
+msgstr "Zapis księgowy"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Dzienniki datowane na lub przed tą datą są traktowane jako zablokowane. Scalane z datą blokady zgłoszoną przez dostawcę, gdy obie istnieją."
+msgstr "Dowody księgowe datowane na dzień lub wcześniej są traktowane jako zablokowane. Scalane z datą blokady zgłoszoną przez dostawcę, gdy oba istnieją."
 
 msgid "Just one"
 msgstr "Tylko jeden"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Zachowaj bieżące"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Zachowaj istniejące ceny, dodaj tylko nowe pozycje"
+msgstr "Zachowaj istniejące ceny, dodaj tylko nowe artykuły"
 
 msgid "Keep only items where…"
 msgstr "Zachowaj tylko przedmioty gdzie…"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "Utrzymaj otwarte"
 
 msgid "Keep picking"
-msgstr "Kontynuuj pobieranie"
+msgstr "Zachowaj kompletację"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Utrzymuje zamówienia, oferty i ustawienia za drugą weryfikacją"
@@ -8342,40 +8342,40 @@ msgid "Labels"
 msgstr "Etykiety"
 
 msgid "Labor"
-msgstr "Praca"
+msgstr "Robocizna"
 
 msgid "Labor & Machine Absorption"
-msgstr "Absorpcja Pracy i Maszyny"
+msgstr "Robocizna i pochłanianie maszyn"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "Absorpcja Pracy i Maszyny (domyślna)"
+msgstr "Robocizna i pochłanianie maszyn (domyślnie)"
 
 msgid "Labor & Machine Variance"
-msgstr "Wariancja Pracy i Maszyny"
+msgstr "Robocizna i odchylenie maszyn"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Wariancja Pracy i Maszyny (domyślna)"
+msgstr "Robocizna i odchylenie maszyn (domyślnie)"
 
 msgid "Labor rate"
-msgstr "Stawka pracy"
+msgstr "Stawka robocizny"
 
 msgid "Labor Rate"
-msgstr "Stawka pracy"
+msgstr "Stawka robocizny"
 
 msgid "Labor Rate (Hourly)"
-msgstr "Stawka pracy (godzinowo)"
+msgstr "Stawka robocizny (godzinowa)"
 
 msgid "Labor time"
-msgstr "Czas pracy"
+msgstr "Czas robocizny"
 
 msgid "Labor Time"
-msgstr "Czas pracy"
+msgstr "Czas robocizny"
 
 msgid "Labor unit"
-msgstr "Jednostka pracy"
+msgstr "Jednostka robocizny"
 
 msgid "Labor Unit"
-msgstr "Jednostka pracy"
+msgstr "Jednostka robocizny"
 
 msgid "Language"
 msgstr "Język"
@@ -8390,16 +8390,16 @@ msgid "Last Attempt"
 msgstr "Ostatnia Próba"
 
 msgid "Last Calibration"
-msgstr "Ostatnia Kalibracja"
+msgstr "Ostatnie wzorcowanie"
 
 msgid "Last Calibration Date"
-msgstr "Data ostatniej kalibracji"
+msgstr "Data ostatniego wzorcowania"
 
 msgid "Last day"
 msgstr "Ostatni dzień"
 
 msgid "Last Fiscal Year"
-msgstr "Ostatni rok obrachunkowy"
+msgstr "Ostatni rok obrotowy"
 
 msgid "Last Login"
 msgstr "Ostatnie logowanie"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Szerokość geograficzna"
 
 msgid "Lead time"
-msgstr "Czas Dostawy"
+msgstr "Czas realizacji"
 
 msgid "Lead Time"
-msgstr "Czas dostawy"
+msgstr "Czas realizacji"
 
 msgid "Lead time (days)"
-msgstr "Czas dostawy (dni)"
+msgstr "Czas realizacji (dni)"
 
 msgid "Lead Time (Days)"
 msgstr "Czas realizacji (dni)"
 
 msgid "Lead Time:"
-msgstr "Czas dostawy:"
+msgstr "Czas realizacji:"
 
 msgid "Learn"
 msgstr "Dowiedz się"
@@ -8459,7 +8459,7 @@ msgid "Leave blank for built-in"
 msgstr "Pozostaw puste dla wbudowanego"
 
 msgid "Leave blank to use the next revision automatically"
-msgstr "Pozostaw puste, aby automatycznie używać następnej wersji"
+msgstr "Pozostaw puste, aby automatycznie użyć następnej rewizji"
 
 msgid "Leave empty for exact match"
 msgstr "Pozostaw puste dla dokładnego dopasowania"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Mniej pracy ręcznej, mniej błędów"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Zbudujmy"
 
 msgid "Let's build something"
 msgstr "Zbudujmy coś"
@@ -8552,13 +8552,13 @@ msgid "Lines need prices or lead times"
 msgstr "Linie wymagają cen lub czasów realizacji"
 
 msgid "Lineside"
-msgstr "Na linii"
+msgstr "Magazyn przyliniowy"
 
 msgid "Link"
 msgstr "Łącze"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "Link (opcjonalnie) — np. /x/settings/…"
+msgstr "Łącze (opcjonalne) — np. /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Połącz problem Jiry"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Połącz problem Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Połącz tego klienta Carbon z jednym z nich, lub utwórz osobnego klienta Stripe."
 
 msgid "Link to sales order line"
-msgstr "Połącz z linią zamówienia sprzedaży"
+msgstr "Łącze do pozycji zamówienia sprzedaży"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Załadowane ostatnie, tuż przy przejściu, aby salda były aktualne."
 
 msgid "Loading associated jobs..."
-msgstr "Ładowanie powiązanych zadań..."
+msgstr "Ładowanie powiązanych zleceń produkcyjnych..."
 
 msgid "Loading current quantity…"
 msgstr "Ładowanie bieżącej ilości…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Zablokowany"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "Zablokowanie uczynia okres tylko do odczytu dla dokumentów operacyjnych (pokwitowania, przesyłki, faktury), jednocześnie umożliwiając korekty księgowe, takie jak amortyzacja i zbycie. Okres musi być zablokowany, zanim będzie można go zamknąć."
+msgstr "Zablokowanie powoduje, że okres jest tylko do odczytu dla dokumentów operacyjnych (przyjęcia, wysyłki, faktury), jednocześnie pozwalając na korekty księgowe, takie jak amortyzacja i likwidacja. Okres musi być zablokowany zanim będzie można go zamknąć."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Rejestruj niezgodności i prowadź CAPA"
@@ -8683,7 +8683,7 @@ msgstr "Logotypy"
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "Logs older than {0} days are automatically archived."
-msgstr "Dzienniki starsze niż {0} dni są automatycznie archiwizowane."
+msgstr "Logi starsze niż {0} dni są automatycznie archiwizowane."
 
 msgid "Long Description"
 msgstr "Długi opis"
@@ -8701,13 +8701,13 @@ msgid "Loss on Disposal (default)"
 msgstr "Strata ze zbycia (domyślnie)"
 
 msgid "Loss on Disposal Account"
-msgstr "Konto straty ze zbycia"
+msgstr "Konto strat ze zbycia"
 
 msgid "Losses recognized on disposal of fixed assets"
 msgstr "Straty ujęte przy zbyciu środków trwałych"
 
 msgid "Lost"
-msgstr "Utracone"
+msgstr "Przegrana"
 
 msgid "Lot"
 msgstr "Partia"
@@ -8716,19 +8716,19 @@ msgid "Lot size"
 msgstr "Wielkość partii"
 
 msgid "Lot Size"
-msgstr "Rozmiar partii"
+msgstr "Wielkość partii"
 
 msgid "Lot Size Variance"
-msgstr "Wariancja Wielkości Partii"
+msgstr "Odchylenie wielkości partii"
 
 msgid "Lot Size Variance (default)"
-msgstr "Wariancja Wielkości Partii (domyślna)"
+msgstr "Odchylenie wielkości partii (domyślnie)"
 
 msgid "Lot Size:"
-msgstr "Rozmiar partii:"
+msgstr "Wielkość partii:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Inspekcja oparta na partiach otrzymanych towarów względem planu poboru próby; jednostki są wysyłane jako Wstrzymane przy odbiorze i uwalniają się do Dostępne dopiero po dyspozycji partii jako zaakceptowanej."
+msgstr "Kontrola partijna wyrobów otrzymanych względem planu kontroli wyrywkowej; jednostki są wstrzymane przy przyjęciu i są zwalniane do stanu Dostępny dopiero po tym, gdy partia zostanie dyspozycjonowana jako zaakceptowana."
 
 msgid "Low"
 msgstr "Niska"
@@ -8776,25 +8776,25 @@ msgid "Maintain a single part and item master"
 msgstr "Utrzymuj pojedynczy katalog części i artykułów"
 
 msgid "Maintenance"
-msgstr "Konserwacja"
+msgstr "Utrzymanie ruchu"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Powiadomienia o wysyłce konserwacji"
+msgstr "Powiadomienia dotyczące zleceń utrzymania ruchu"
 
 msgid "Maintenance Dispatches"
-msgstr "Dyspozycje Konserwacji"
+msgstr "Zlecenia utrzymania ruchu"
 
 msgid "Maintenance Expense"
-msgstr "Wydatek na Konserwację"
+msgstr "Wydatek utrzymania ruchu"
 
 msgid "Maintenance Expense (default)"
-msgstr "Wydatek na Konserwację (domyślne)"
+msgstr "Wydatek utrzymania ruchu (domyślny)"
 
 msgid "Maintenance Schedules"
-msgstr "Harmonogramy konserwacji"
+msgstr "Harmonogramy utrzymania ruchu"
 
 msgid "Maintenance Type"
-msgstr "Typ konserwacji"
+msgstr "Typ utrzymania ruchu"
 
 msgid "Make"
 msgstr "Wytwórz"
@@ -8806,10 +8806,10 @@ msgid "Make Default"
 msgstr "Ustaw jako domyślne"
 
 msgid "Make Inactive"
-msgstr "Dezaktywuj"
+msgstr "Ustaw jako nieaktywne"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "Artykuły Make nie mogą być fakturowane bezpośrednio. Zmień metodę na Pick, aby kontynuować."
+msgstr "Artykuły wytwarzane nie mogą być fakturowane bezpośrednio. Zmień metodę na Pobranie, aby kontynuować."
 
 msgid "Make Method Version"
 msgstr "Wersja metody produkcji"
@@ -8823,7 +8823,7 @@ msgstr "Dokonaj płatności · {0} faktury"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make revision {0} default?"
-msgstr "Uczynić wersję {0} domyślną?"
+msgstr "Ustaw rewizję {0} jako domyślną?"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make size {0} default?"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Podjąć decyzję go / no-go"
 
 msgid "Make to Order"
-msgstr "Wytwarzanie na zamówienie"
+msgstr "Produkcja na zamówienie"
 
 msgid "Make tracked entities available again"
 msgstr "Udostępnij śledzone jednostki ponownie"
@@ -8884,10 +8884,10 @@ msgid "Map accounts"
 msgstr "Zmapuj konta"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Mapuj konta Carbon na plan kont dostawcy. Opublikowane dzienniki są wysyłane przy użyciu zmapowanego kodu konta dostawcy."
+msgstr "Mapuj konta Carbon na plan kont dostawcy. Zaksięgowane dowody księgowe będą przesyłane, używając zmapowanego kodu konta dostawcy."
 
 msgid "Map Extracted Invoice Lines"
-msgstr "Mapuj wyodrębnione linie faktury"
+msgstr "Mapuj wyekstrahowane pozycje faktury"
 
 msgid "Map Extracted Lines"
 msgstr "Mapuj Wyodrębnione Linie"
@@ -8906,7 +8906,7 @@ msgstr "Zmapowane wartości"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "Oznaczyć „{0}\" jako ukończone?"
+msgstr "Oznacz \"{0}\" jako zaliczony?"
 
 msgid "Mark all as configured"
 msgstr "Oznacz wszystko jako skonfigurowane"
@@ -8924,7 +8924,7 @@ msgid "Mark as Unpaid"
 msgstr "Oznacz jako nieopłacone"
 
 msgid "Mark checkpoint passed"
-msgstr "Oznacz punkt kontrolny jako ukończony"
+msgstr "Oznacz punkt kontrolny jako zaliczony"
 
 msgid "Mark Complete"
 msgstr "Oznacz jako ukończone"
@@ -8936,13 +8936,13 @@ msgid "Mark done"
 msgstr "Oznacz jako gotowe"
 
 msgid "Mark Done"
-msgstr "Oznacz jako Wykonane"
+msgstr "Oznacz jako gotowe"
 
 msgid "Mark Light Mode"
 msgstr "Znak w trybie jasnym"
 
 msgid "Mark not done"
-msgstr "Oznacz jako niezrobione"
+msgstr "Oznacz jako niegotowe"
 
 msgid "Mark scope as agreed"
 msgstr "Oznacz zakres jako uzgodniony"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "Oznacz do usunięcia"
 
 msgid "Master gauge"
-msgstr "Przyrząd standardowy"
+msgstr "Wzorzec pomiarowy"
 
 msgid "Master records"
 msgstr "Rekordy główne"
@@ -9020,7 +9020,7 @@ msgid "Material Grade"
 msgstr "Gatunek materiału"
 
 msgid "Material Grades"
-msgstr "Klasy materiałów"
+msgstr "Gatunki"
 
 msgid "Material ID"
 msgstr "Identyfikator materiału"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "Właściwości materiału"
 
 msgid "Material Review Board (MRB)"
-msgstr "Komisja Przeglądu Materiałów (MRB)"
+msgstr "Komisja oceny materiałów (MRB)"
 
 msgid "Material Shape"
 msgstr "Kształt materiału"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Kształty materiałów"
 
 msgid "Material Substance"
-msgstr "Substancja materiałowa"
+msgstr "Tworzywo"
 
 msgid "Material Substances"
-msgstr "Substancje materiałowe"
+msgstr "Tworzywa"
 
 msgid "material type"
 msgstr "Typ Materiału"
@@ -9062,10 +9062,10 @@ msgid "Material Types"
 msgstr "Typy materiałów"
 
 msgid "Material Usage Variance"
-msgstr "Wariancja Użycia Materiału"
+msgstr "Odchylenie zużycia materiału"
 
 msgid "Material Usage Variance (default)"
-msgstr "Wariancja Użycia Materiału (domyślna)"
+msgstr "Odchylenie zużycia materiału (domyślne)"
 
 msgid "materials"
 msgstr "Materiały"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "Średni czas naprawy"
 
 msgid "Measurement Standard"
-msgstr "Standard Pomiaru"
+msgstr "Wzorzec pomiarowy"
 
 msgid "Media Size"
 msgstr "Rozmiar nośnika"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Operacje metody"
 
 msgid "Method type"
-msgstr "Typ Metody"
+msgstr "Typ zasilania"
 
 msgid "Method Type"
-msgstr "Typ metody"
+msgstr "Typ zasilania"
 
 msgid "Methods"
 msgstr "Metody"
@@ -9248,7 +9248,7 @@ msgid "Model removed from line"
 msgstr "Model usunięty z linii"
 
 msgid "Model upload"
-msgstr "Przesyłanie modelu"
+msgstr "Przesłanie modelu"
 
 msgid "Modified"
 msgstr "Zmodyfikowane"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Przesuń element"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Przenieś część ilości do nowego wiersza dyspozycji, aby MRB mógł zdecydować o każdej części osobno (np. złom część, przerabiaj część)."
+msgstr "Przenieś część ilości do nowego wiersza dyspozycji, aby komisja oceny materiałów mogła podjąć decyzję dla każdej części osobno (np. części na braki, części na poprawę)."
 
 msgid "Move to"
 msgstr "Przenieś do"
@@ -9388,7 +9388,7 @@ msgid "Negative Adjustment"
 msgstr "Ujemna Korekta"
 
 msgid "Net book value"
-msgstr "Wartość Netto w Księdze"
+msgstr "Wartość księgowa netto"
 
 msgid "Net Book Value"
 msgstr "Wartość netto w księgach"
@@ -9397,7 +9397,7 @@ msgid "Net Change"
 msgstr "Zmiana netto"
 
 msgid "Net Income"
-msgstr "Dochód netto"
+msgstr "Przychody netto"
 
 msgid "Never"
 msgstr "Nigdy"
@@ -9418,7 +9418,7 @@ msgid "New Approval Rule"
 msgstr "Nowa Reguła Zatwierdzenia"
 
 msgid "New Asset Class"
-msgstr "Nowa Klasa Zasobu"
+msgstr "Nowa klasa środków trwałych"
 
 msgid "New Assignment"
 msgstr "Nowe przypisanie"
@@ -9430,25 +9430,25 @@ msgid "New Attribute Category"
 msgstr "Nowa Kategoria Atrybutu"
 
 msgid "New Change Notice"
-msgstr "Nowe Zgłoszenie Zmian"
+msgstr "Nowe zawiadomienie o zmianie"
 
 msgid "New Change Notice Action"
-msgstr "Nowe Działanie Zgłoszenia Zmian"
+msgstr "Nowe działanie zawiadomienia o zmianie"
 
 msgid "New Change Notice Type"
-msgstr "Nowy Typ Zgłoszenia Zmian"
+msgstr "Nowy typ zawiadomienia o zmianie"
 
 msgid "New Consumable"
-msgstr "Nowy materiał zużywalny"
+msgstr "Nowy materiał eksploatacyjny"
 
 msgid "New Contractor"
-msgstr "Nowy Wykonawca"
+msgstr "Nowy pracownik zewnętrzny"
 
 msgid "New Cost Center"
-msgstr "Nowe centrum kosztów"
+msgstr "Nowe miejsce powstawania kosztów"
 
 msgid "New Credit / Debit Memo"
-msgstr "Nowy Dokument Kredytowy / Debetowy"
+msgstr "Nowa Nota Kredytowa / Debetowa"
 
 msgid "New Custom Field"
 msgstr "Nowe pole niestandardowe"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "Nowy typ pracownika"
 
 msgid "New expiration date"
-msgstr "Nowa data wygaśnięcia"
+msgstr "Nowa data ważności"
 
 msgid "New Failure Mode"
 msgstr "Nowy tryb awarii"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Nowy Środek Trwały"
 
 msgid "New Gauge"
-msgstr "Nowy Miernik"
+msgstr "Nowy Przyrząd pomiarowy"
 
 msgid "New Gauge Calibration Record"
-msgstr "Nowy Rekord Kalibracji Miernika"
+msgstr "Nowy Zapis wzorcowania Przyrządu pomiarowego"
 
 msgid "New Gauge Type"
-msgstr "Nowy typ miernika"
+msgstr "Nowy Typ przyrządu"
 
 msgid "New Group"
 msgstr "Nowa Grupa"
@@ -9499,7 +9499,7 @@ msgid "New IC Transaction"
 msgstr "Nowa Transakcja IC"
 
 msgid "New Inspection Plan"
-msgstr "Nowy plan inspekcji"
+msgstr "Nowy Plan kontroli"
 
 msgid "New Inventory Count"
 msgstr "Nowa inwentaryzacja"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "Nowa Lokalizacja"
 
 msgid "New Maintenance Dispatch"
-msgstr "Nowa Dyspozycja Konserwacji"
+msgstr "Nowe Zlecenie utrzymania ruchu"
 
 msgid "New Material"
 msgstr "Nowy Materiał"
@@ -9544,7 +9544,7 @@ msgid "New Material Shape"
 msgstr "Nowy Kształt Materiału"
 
 msgid "New Material Substance"
-msgstr "Nowa Substancja Materiałowa"
+msgstr "Nowe Tworzywo"
 
 msgid "New Material Type"
 msgstr "Nowy typ materiału"
@@ -9565,10 +9565,10 @@ msgid "New Payment"
 msgstr "Nowa Płatność"
 
 msgid "New Payment Term"
-msgstr "Nowy Termin Płatności"
+msgstr "Nowe Warunki płatności"
 
 msgid "New Picking List"
-msgstr "Nowa Lista Pobrania"
+msgstr "Nowa Lista kompletacyjna"
 
 msgid "New PIN"
 msgstr "Nowy PIN"
@@ -9577,7 +9577,7 @@ msgid "New PO"
 msgstr "Nowe ZO"
 
 msgid "New Price Override"
-msgstr "Nowe Zastąpienie Ceny"
+msgstr "Nowe Nadpisanie ceny"
 
 msgid "New Pricing Rule"
 msgstr "Nowa Reguła Cenowa"
@@ -9598,7 +9598,7 @@ msgid "New Quote"
 msgstr "Nowa Oferta"
 
 msgid "New Quote Line"
-msgstr "Nowa linia oferty"
+msgstr "Nowa Pozycja oferty"
 
 msgid "New Receipt"
 msgstr "Nowy Paragon"
@@ -9607,7 +9607,7 @@ msgid "New record created"
 msgstr "Nowy rekord utworzony"
 
 msgid "New Revision"
-msgstr "Nowa Wersja"
+msgstr "Nowa Rewizja"
 
 msgid "New RFQ"
 msgstr "Nowe RFQ"
@@ -9628,10 +9628,10 @@ msgid "New Sales Order"
 msgstr "Nowe Zamówienie Sprzedaży"
 
 msgid "New Sales Order Line"
-msgstr "Nowa linia zamówienia sprzedaży"
+msgstr "Nowa Pozycja zamówienia sprzedaży"
 
 msgid "New Scheduled Maintenance"
-msgstr "Nowa zaplanowana konserwacja"
+msgstr "Nowe Zaplanowane Utrzymanie ruchu"
 
 msgid "New Serial Number"
 msgstr "Nowy numer seryjny"
@@ -9643,10 +9643,10 @@ msgid "New Shift"
 msgstr "Nowa zmiana"
 
 msgid "New Shipment"
-msgstr "Nowa Przesyłka"
+msgstr "Nowa Wysyłka"
 
 msgid "New Shipping Method"
-msgstr "Nowa metoda wysyłki"
+msgstr "Nowy Sposób wysyłki"
 
 msgid "New Size"
 msgstr "Nowy rozmiar"
@@ -9676,7 +9676,7 @@ msgid "New Transfer"
 msgstr "Nowy Transfer"
 
 msgid "New Transfer Line"
-msgstr "Nowa linia transferu"
+msgstr "Nowa Pozycja przesunięcia"
 
 msgid "New Unit of Measure"
 msgstr "Nowa jednostka miary"
@@ -9691,7 +9691,7 @@ msgid "New Webhook"
 msgstr "Nowy Webhook"
 
 msgid "New Work Center"
-msgstr "Nowe Centrum Pracy"
+msgstr "Nowe Stanowisko robocze"
 
 msgid "New Workflow"
 msgstr "Nowy przepływ pracy"
@@ -9703,10 +9703,10 @@ msgid "Next"
 msgstr "Dalej"
 
 msgid "Next Calibration"
-msgstr "Następna Kalibracja"
+msgstr "Następne Wzorcowanie"
 
 msgid "Next Calibration Date"
-msgstr "Data następnej kalibracji"
+msgstr "Następna Data wzorcowania"
 
 msgid "Next Date"
 msgstr "Następna data"
@@ -9715,13 +9715,13 @@ msgid "Next Due"
 msgstr "Następny termin"
 
 msgid "Next Due Date"
-msgstr "Następna data wymagalności"
+msgstr "Następny Termin"
 
 msgid "Next page"
 msgstr "Następna strona"
 
 msgid "Next Sequence"
-msgstr "Następna Sekwencja"
+msgstr "Następna Numeracja"
 
 msgid "Next step"
 msgstr "Następny krok"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Nie wybrano żadnych akcji"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Nie znaleziono aktywnych zadań dla tego zamówienia sprzedaży. Zamówienie zostanie anulowane bezpośrednio."
+msgstr "Nie znaleziono żadnych aktywnych zleceń produkcyjnych dla tego zamówienia sprzedaży. Zamówienie będzie anulowane bezpośrednio."
 
 msgid "No active plan"
 msgstr "Brak aktywnego planu"
@@ -9785,7 +9785,7 @@ msgstr "Brak aplikacji. Płatność będzie na rachunek."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Brak zarchiwizowanych dzienników. Dzienniki starsze niż {0} dni będą automatycznie archiwizowane i dostępne do pobrania tutaj."
+msgstr "Brak zarchiwizowanych dzienników. Dzienniki starsze niż {0} dni będą automatycznie zarchiwizowane i dostępne do pobrania tutaj."
 
 msgid "No attachments."
 msgstr "Brak załączników."
@@ -9803,7 +9803,7 @@ msgid "No CAD model to preview."
 msgstr "Brak modelu CAD do podglądu."
 
 msgid "No calibration records found"
-msgstr "Nie znaleziono rekordów kalibracji"
+msgstr "Nie znaleziono zapisów wzorcowania"
 
 msgid "No changes recorded"
 msgstr "Brak zarejestrowanych zmian"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Brak komentarzy. Bądź pierwszy i dodaj komentarz."
 
 msgid "No completed jobs within range"
-msgstr "Brak ukończonych zadań w wybranym zakresie"
+msgstr "Nie znaleziono zakończonych zleceń produkcyjnych w danym zakresie"
 
 msgid "No condition may match"
 msgstr "Żaden warunek nie może się zgadzać"
@@ -9848,7 +9848,7 @@ msgid "No dimension values mapped yet"
 msgstr "Nie ma jeszcze zmapowanych wartości wymiarów"
 
 msgid "No draft make method for this item yet."
-msgstr "Brak jeszcze wersji roboczej metody wytwarzania dla tego elementu."
+msgstr "Brak wersji roboczej metody produkcji dla tego artykułu."
 
 msgid "No draft versions available"
 msgstr "Brak dostępnych wersji roboczych"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Brak przesłanych plików"
 
 msgid "No Gauge Selected"
-msgstr "Nie wybrano miernika"
+msgstr "Nie wybrano Przyrządu pomiarowego"
 
 msgid "No grouped notifications"
 msgstr "Brak zgrupowanych powiadomień"
@@ -9908,7 +9908,7 @@ msgid "No image"
 msgstr "Brak obrazu"
 
 msgid "No inspection plans"
-msgstr "Brak planów inspekcji"
+msgstr "Brak planów kontroli"
 
 msgid "No issue types configured"
 msgstr "Brak skonfigurowanych typów problemów"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Brak aktywności magazynowej tutaj."
 
 msgid "No jobs were created"
-msgstr "Nie utworzono żadnych zadań"
+msgstr "Nie utworzono zleceń produkcyjnych"
 
 msgid "No journal lines in scope for this period"
-msgstr "Brak wierszy dziennika w zakresie dla tego okresu"
+msgstr "Brak pozycji dowodu księgowego dla tego okresu"
 
 msgid "No lines to map"
 msgstr "Brak linii do mapowania"
@@ -9956,7 +9956,7 @@ msgid "No new notifications"
 msgstr "Brak nowych powiadomień"
 
 msgid "No notes"
-msgstr "Brak notek"
+msgstr "Brak notatek"
 
 msgid "No open invoices"
 msgstr "Brak otwartych faktur"
@@ -9965,13 +9965,13 @@ msgid "No open orders for this item are available to link."
 msgstr "Brak dostępnych otwartych zamówień dla tego produktu do powiązania."
 
 msgid "No open sales order lines"
-msgstr "Brak otwartych linii zamówień sprzedaży"
+msgstr "Brak otwartych pozycji zamówienia sprzedaży"
 
 msgid "No operations found."
 msgstr "Nie znaleziono operacji."
 
 msgid "No operations require picking at this location"
-msgstr "Żadne operacje nie wymagają pobrania w tej lokalizacji"
+msgstr "Żadne operacje nie wymagają kompletacji w tej lokalizacji"
 
 msgid "No operators."
 msgstr "Brak operatorów."
@@ -10016,13 +10016,13 @@ msgid "No planning data"
 msgstr "Brak danych planowania"
 
 msgid "No posted journals in this period for this account"
-msgstr "Brak zaksięgowanych dzienników w tym okresie dla tego konta"
+msgstr "Brak zaksięgowanych dowodów księgowych w tym okresie dla tego konta"
 
 msgid "No pricing for selected quantity"
-msgstr "Brak cen dla wybranej ilości"
+msgstr "Brak wyceny dla wybranej ilości"
 
 msgid "No pricing options found"
-msgstr "Nie znaleziono opcji cenowych"
+msgstr "Nie znaleziono opcji ceny"
 
 msgid "No printer configured"
 msgstr "Brak skonfigurowanej drukarki"
@@ -10040,13 +10040,13 @@ msgid "No purchases in this period"
 msgstr "Brak zakupów w tym okresie"
 
 msgid "No Quote"
-msgstr "Brak oferty"
+msgstr "Odmowa oferty"
 
 msgid "No Quote Reason"
-msgstr "Brak powodu oferty"
+msgstr "Powód odmowy oferty"
 
 msgid "No Quote Reasons"
-msgstr "Brak powodów oferty"
+msgstr "Przyczyny odmowy oferty"
 
 msgid "No receivables"
 msgstr "Brak należności"
@@ -10136,10 +10136,10 @@ msgid "No warehouse stock is on record for this item. You can still pick it — 
 msgstr "Brak zapasu w magazynie dla tego artykułu. Możesz go mimo tego pobrać — dostępna ilość będzie ujemna do czasu uzgodnienia stanu."
 
 msgid "No work center utilization data within range"
-msgstr "Brak danych wykorzystania centrum pracy w zakresie"
+msgstr "Brak danych o wykorzystaniu stanowiska roboczego w podanym zakresie"
 
 msgid "No work centers exist"
-msgstr "Nie istnieją żadne centra pracy"
+msgstr "Nie istnieją stanowiska robocze"
 
 msgid "Nom"
 msgstr "Nom"
@@ -10160,10 +10160,10 @@ msgid "Non-conformance (issue)"
 msgstr "Niezgodność (problem)"
 
 msgid "Non-Inventory"
-msgstr "Poza zapasami"
+msgstr "Niemagazynowy"
 
 msgid "Non-Inventory Tracking"
-msgstr "Śledzenie poza magazynem"
+msgstr "Śledzenie niemagazynowe"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Konto wydatków niezwiązanych z działalnością obciążane, gdy składnik aktywów z tej klasy jest sprzedany lub złomowany poniżej jego wartości netto w księgach."
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normalny"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Nie tabela, ale saldo księgi głównej: koszt gromadzi się w miarę wystawiania materiałów zadania i jest czyszczony po otrzymaniu zadania na magazyn."
+msgstr "To nie jest tabela, lecz saldo konta głównego: koszt gromadzi się gdy materiały zlecenia produkcyjnego są wydawane i czyszczą się gdy zlecenie jest przyjęte do zapasów."
 
 msgid "Not certified"
 msgstr "Nie certyfikowany"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Niewystarczająca liczba zadań do pokrycia ilości"
+msgstr "Niewystarczająco zleceń produkcyjnych aby pokryć ilość"
 
 msgid "Not reached"
 msgstr "Nieosiągnięty"
@@ -10284,7 +10284,7 @@ msgid "Number of operations"
 msgstr "Liczba operacji"
 
 msgid "Numbering sequence"
-msgstr "Sekwencja numerowania"
+msgstr "Sekwencja numeracji"
 
 msgid "OEE Impact"
 msgstr "Wpływ OEE"
@@ -10299,7 +10299,7 @@ msgid "Off — handled outside the sync"
 msgstr "Wyłączone — obsługiwane poza synchronizacją"
 
 msgid "Off — released revisions stay editable"
-msgstr "Wyłączone — wydane wersje pozostają edytowalne"
+msgstr "Wyłączone — zwolnione rewizje pozostają edytowalne"
 
 msgid "OK"
 msgstr "OK"
@@ -10329,7 +10329,7 @@ msgid "On Hold"
 msgstr "Wstrzymane"
 
 msgid "On Jobs"
-msgstr "Na zadaniach"
+msgstr "Na zleceniach produkcyjnych"
 
 msgid "On order"
 msgstr "Zamówione"
@@ -10377,13 +10377,13 @@ msgid "One firing of a workflow, recorded step by step with the values each step
 msgstr "Jedno wykonanie przepływu pracy, zarejestrowane krok po kroku z wartościami, które każdy krok użył i wygenerował, działając z uprawnieniami właściciela przepływu pracy."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Jedna jednostka szeregowa lub jedna partia, którą Carbon śledzi indywidualnie, mając własny status i atrybuty, takie jak data ważności."
+msgstr "Jedna jednostka o numerze seryjnym lub jedna partia produkcyjna, którą Carbon śledzi indywidualnie, posiadająca własny status i atrybuty takie jak termin ważności."
 
 msgid "One set of numbers"
 msgstr "Jeden zestaw liczb"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Jeden krok w trasie pracy, który wymienia proces i centrum pracy i nosi własne czasy i stawki instalacji, pracy i maszyny."
+msgstr "Jeden krok w marszrucie zlecenia produkcyjnego, określający proces i stanowisko robocze, posiadający własne przezbrojenie, robociznę, czasy maszynowe i stawki."
 
 msgid "One system from quote to cash"
 msgstr "Jeden system od oferty do gotówki"
@@ -10422,7 +10422,7 @@ msgid "Open"
 msgstr "Otwórz"
 
 msgid "Open a change notice"
-msgstr "Otwórz zgłoszenie zmian"
+msgstr "Otwórz zawiadomienie o zmianie"
 
 msgid "Open Actions"
 msgstr "Otwarte Działania"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Data otwarcia"
 
 msgid "Open Dispatches"
-msgstr "Otwarte Dyspozycje"
+msgstr "Otwarte zlecenia utrzymania ruchu"
 
 msgid "Open in Carbon"
 msgstr "Otwórz w Carbon"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "Otwórz w zgłoszeniu zmian {ids}. Wydaj je, aby utworzyć nowe wersje lub rewizje."
+msgstr "Otwarte w zawiadomieniu o zmianie {ids}. Zwolnij to aby utworzyć nowe wersje lub rewizje."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "Otwórz w zgłoszeniach zmian {ids}. Wydaj je, aby utworzyć nowe wersje lub rewizje."
+msgstr "Otwarte w zawiadomieniach o zmianie {ids}. Zwolnij je aby utworzyć nowe wersje lub rewizje."
 
 msgid "Open in MES"
 msgstr "Otwórz w MES"
@@ -10464,10 +10464,10 @@ msgid "Open Issues"
 msgstr "Otwarte problemy"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Otwarte żądanie zadania plus zaległe transfery z tego pojemnika"
+msgstr "Otwarte zapotrzebowanie ze zleceń plus pozostające przesunięcia z tego pojemnika"
 
 msgid "Open jobs"
-msgstr "Otwarte zadania"
+msgstr "Otwarte zlecenia produkcyjne"
 
 msgid "Open menu"
 msgstr "Otwórz menu"
@@ -10491,7 +10491,7 @@ msgid "Open Reactive"
 msgstr "Otwarte reaktywne"
 
 msgid "Open receivables by customer and age"
-msgstr "Otwarte należności wg odbiorcy i wieku"
+msgstr "Otwarte należności wg klienta i okresu"
 
 msgid "Open RFQs"
 msgstr "Otwarte Zapytania Ofertowe"
@@ -10530,10 +10530,10 @@ msgid "Opening balance of depreciation already booked before this asset was adde
 msgstr "Saldo otwarcia amortyzacji już zaksięgowanej przed dodaniem tego zasobu do Carbon (użyj 0 dla nowych przejęć)."
 
 msgid "Operating Expenses"
-msgstr "Koszty Operacyjne"
+msgstr "Koszty operacyjne"
 
 msgid "Operating Income"
-msgstr "Dochód z działalności operacyjnej"
+msgstr "Przychody operacyjne"
 
 msgid "Operation"
 msgstr "Operacja"
@@ -10599,7 +10599,7 @@ msgid "Operators start the timer themselves when they begin an operation."
 msgstr "Operatorzy uruchamiają timer sami, gdy zaczynają operację."
 
 msgid "Opportunity"
-msgstr "Okazja"
+msgstr "Szansa sprzedaży"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
 msgstr "Zoptymalizowane pod kątem szybkich podglądów — pobieranie zawsze dostarcza oryginalnie przesłany plik"
@@ -10684,16 +10684,16 @@ msgid "Original Count"
 msgstr "Oryginalne Liczenie"
 
 msgid "Other Expense"
-msgstr "Inne wydatki"
+msgstr "Pozostałe koszty"
 
 msgid "Other Income"
-msgstr "Inne przychody"
+msgstr "Pozostałe przychody"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "Konto dochodów pozostałych dla zysków walutowych, gdy płatność rozlicza fakturę w walucie obcej po kursie bardziej korzystnym"
+msgstr "Konto przychodów pozostałych dla zysków walutowych gdy płatność rozlicza fakturę w walucie obcej po bardziej korzystnym kursie"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Konto dochodów pozostałych dla sald dostawców rozliczonych bez pełnej płatności przy rozliczeniu zobowiązań"
+msgstr "Konto przychodów pozostałych dla sald dostawców umorzonych bez pełnej płatności w rozliczeniu zobowiązań"
 
 msgid "Other Type"
 msgstr "Inny typ"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Wyjście"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "Produkt nigdy nie przetrwa dłużej niż jego surowce. Powraca do stałego okresu, gdy żaden materiał wejściowy nie ma daty wygaśnięcia."
+msgstr "Produkcja nigdy nie przetrwa dłużej niż jej surowce. Przyjmuje stały czas trwania gdy żaden materiał wejściowy nie ma terminu ważności."
 
 msgid "Outside operation"
 msgstr "Odchylenie Kosztów Pośrednich"
@@ -10723,43 +10723,43 @@ msgid "Overall result"
 msgstr "Ogólny wynik"
 
 msgid "Overdue"
-msgstr "Zaległy"
+msgstr "Po terminie"
 
 msgid "Overhead Absorption"
-msgstr "Absorpcja Kosztów Ogólnych"
+msgstr "Rozliczenie kosztów pośrednich"
 
 msgid "Overhead Absorption (default)"
-msgstr "Absorpcja Kosztów Ogólnych (domyślnie)"
+msgstr "Rozliczenie kosztów pośrednich (domyślnie)"
 
 msgid "Overhead rate"
-msgstr "Stawka narzutów"
+msgstr "Stawka kosztów pośrednich"
 
 msgid "Overhead Rate"
-msgstr "Stawka narzutu"
+msgstr "Stawka kosztów pośrednich"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "Stawka kosztów ogólnych (godzinowo)"
+msgstr "Stawka kosztów pośrednich (godzinowa)"
 
 msgid "Overhead Variance"
 msgstr "Odchylenie Kosztów Pośrednich (domyślne)"
 
 msgid "Overhead Variance (default)"
-msgstr "Właściciel (centrum kosztów)"
+msgstr "Odchylenie kosztów pośrednich (domyślnie)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "Zastąpienie wymaga uprawnień inventory:update i uzasadnienia."
+msgstr "Nadpisanie wymaga uprawnienia inventory:update oraz powodu."
 
 msgid "Override Price"
-msgstr "Cena zastępująca"
+msgstr "Nadpisanie ceny"
 
 msgid "Override price for a single customer"
-msgstr "Zastąp cenę dla jednego klienta"
+msgstr "Nadpisz cenę dla jednego klienta"
 
 msgid "Override price for all customers of a type"
-msgstr "Zastosuj cenę dla wszystkich klientów danego typu"
+msgstr "Nadpisz cenę dla wszystkich klientów danego typu"
 
 msgid "Override the expiration on {label}."
-msgstr "Zastąp datę wygaśnięcia dla {label}."
+msgstr "Nadpisz termin ważności na {label}."
 
 msgid "Overtime"
 msgstr "Nadgodziny"
@@ -10780,7 +10780,7 @@ msgid "Owner"
 msgstr "Właściciel"
 
 msgid "Owner (cost center)"
-msgstr "Nadrzędne centrum kosztów"
+msgstr "Właściciel (miejsce powstawania kosztów)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,10 +10814,10 @@ msgid "Params"
 msgstr "Parametry"
 
 msgid "Parent cost center"
-msgstr "część"
+msgstr "Nadrzędne miejsce powstawania kosztów"
 
 msgid "Parent Cost Center"
-msgstr "Nadrzędne centrum kosztów"
+msgstr "Nadrzędne Miejsce Powstawania Kosztów"
 
 msgid "Parent Department"
 msgstr "Dział Nadrzędny"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Zaparkuj jako błąd"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Zatrzymaj dziennik z ostrzeżeniem aż do zmapowania wartości"
+msgstr "Wstrzymaj dowód księgowy z ostrzeżeniem do czasu mapowania wartości"
 
 msgid "part"
 msgstr "części"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Partnerzy"
 
 msgid "parts"
-msgstr "Zobowiązania"
+msgstr "części"
 
 msgid "Parts"
 msgstr "Części"
@@ -10919,7 +10919,7 @@ msgid "Payables (AP)"
 msgstr "Zobowiązania (AP)"
 
 msgid "Payables (default)"
-msgstr "warunek płatności"
+msgstr "Zobowiązania (domyślnie)"
 
 msgid "Payables aging"
 msgstr "Wiekowanie zobowiązań"
@@ -10946,7 +10946,7 @@ msgid "Payment Term"
 msgstr "Warunki Płatności"
 
 msgid "payment terms"
-msgstr "osoby"
+msgstr "warunki płatności"
 
 msgid "Payment Terms"
 msgstr "Warunki Płatności"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "Oczekujące"
 
 msgid "people"
-msgstr "Okresowy wydatek amortyzacyjny na aktywa trwałe"
+msgstr "pracownicy"
 
 msgid "People"
 msgstr "Pracownicy"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Na jednostkę"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Zastąpienie dla każdej linii lokalizacji realizacji nagłówka zamówienia; używane dla podzielonych przesyłek i drop-shipów."
+msgstr "Nadpisanie na poziomie pozycji lokalizacji realizacji z nagłówka zamówienia; używane dla podzielonych wysyłek i dostaw bezpośrednich."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Zastąpienie dla każdej linii lokalizacji dostawy nagłówka PO; używane dla podzielonych dostaw do wielu magazynów lub drop-shipów."
+msgstr "Nadpisanie na poziomie pozycji lokalizacji dostawy z nagłówka zamówienia zakupu; używane dla podzielonych dostaw do wielu magazynów lub dostaw bezpośrednich."
 
 msgid "Percentage"
 msgstr "Procent"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "Polityka blokady okresu"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Kompletacja oferuje śledziane jednostki w kolejności najwcześniejszego wygaśnięcia, więc zapasy wygasające najwcześniej są domyślnie wydawane jako pierwsze."
+msgstr "Okresowy wydatek amortyzacyjny dla środków trwałych"
 
 msgid "Permanently Delete"
 msgstr "Trwale usunąć"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Czasy trwania faz"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Wycofywanie pozycji na rzecz części zastępczej, dzięki czemu planowanie przekierowuje zapotrzebowanie starej pozycji — pomnożone przez współczynnik konwersji — do nowej."
+msgstr "Wycofywanie artykułu na rzecz następnika, dzięki czemu planowanie przekierowuje zapotrzebowanie starego artykułu — pomnożone przez współczynnik przeliczeniowy — do nowego."
 
 msgid "Phone"
 msgstr "Telefon"
@@ -11102,25 +11102,25 @@ msgid "Picked quantity"
 msgstr "Pobrana ilość"
 
 msgid "Picking Lines"
-msgstr "Linie pobrania"
+msgstr "Pozycje kompletacji"
 
 msgid "Picking list"
-msgstr "Lista pobrania"
+msgstr "lista kompletacyjna"
 
 msgid "Picking List"
-msgstr "Lista pobrania"
+msgstr "Lista kompletacyjna"
 
 msgid "Picking List ID"
-msgstr "ID listy pobrań"
+msgstr "ID listy kompletacyjnej"
 
 msgid "Picking List Notes"
-msgstr "Notatki listy pobrania"
+msgstr "Notatki listy kompletacyjnej"
 
 msgid "Picking Lists"
-msgstr "Listy pobrań"
+msgstr "Listy kompletacyjne"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Zaplanowany"
+msgstr "Kompletacja oferuje śledzone jednostki, począwszy od tych z najwcześniejszym terminem ważności; zapas zbliżający się do wygaśnięcia jest pobierany jako pierwszy domyślnie."
 
 msgid "Pieces/Hour"
 msgstr "Sztuk/Godzina"
@@ -11164,7 +11164,7 @@ msgid "Planned Order"
 msgstr "Zaplanowane Zamówienie"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "Planowane zamówienie = sugestia MRP pokrywająca prognozowany popyt na podstawie polityki zamawiania pozycji (lub dodane ręcznie)."
+msgstr "Zaplanowane zamówienie = Propozycja MRP na pokrycie przewidywanego zapotrzebowania na podstawie polityki ponownego zamówienia artykułu (lub dodanego ręcznie)."
 
 msgid "Planned purchase order"
 msgstr "Zaplanowane zamówienie zakupu"
@@ -11251,13 +11251,13 @@ msgid "Post Invoice"
 msgstr "Zaksięguj fakturę"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "Księguj wpisy dziennika z właściwymi kodami kont i opisów"
+msgstr "Zaksięguj wpisy dowodu księgowego z odpowiednimi kodami konta i opisu"
 
 msgid "Post Receipt"
 msgstr "Zaksięguj Paragon"
 
 msgid "Post Shipment"
-msgstr "Wyślij Przesyłkę"
+msgstr "Zaksięguj wysyłkę"
 
 msgid "Postal code"
 msgstr "Kod pocztowy"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Opublikowano przez"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Zaksięgowane dzienniki z tymi typami źródeł zawsze się synchronizują. Dzienne podsumowanie grupuje dzienniki z jednego dnia w jeden wpis dostawcy na konto."
+msgstr "Zaksięgowane dowody księgowe z tymi typami źródeł zawsze się synchronizują. Codzienne podsumowanie grupuje dowody księgowe jednego dnia w jeden wpis dostawcy na konto."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Opublikowane raz, poprawione {corrections} razy."
@@ -11290,10 +11290,10 @@ msgid "Posted once, no corrections."
 msgstr "Opublikowane raz, bez korekt."
 
 msgid "Posting"
-msgstr "Przedpłaty"
+msgstr "Księgowanie"
 
 msgid "Posting date"
-msgstr "Data publikacji"
+msgstr "Data księgowania"
 
 msgid "Posting Date"
 msgstr "Data księgowania"
@@ -11302,7 +11302,7 @@ msgid "Potential Data Loss"
 msgstr "Potencjalna utrata danych"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "Wstępnie wypełniane dla nowego artykułu, gdy okres przydatności jest ustalony na Stały czas trwania."
+msgstr "Wstępnie wypełnione dla nowego artykułu, gdy termin ważności to Stały okres."
 
 msgid "Preferred Supplier"
 msgstr "Preferowany dostawca"
@@ -11311,10 +11311,10 @@ msgid "Prefix"
 msgstr "Prefiks"
 
 msgid "Prepayments"
-msgstr "Przedpłaty (domyślnie)"
+msgstr "Zaliczki"
 
 msgid "Prepayments (default)"
-msgstr "Działanie zapobiegawcze"
+msgstr "Zaliczki (domyślnie)"
 
 msgid "Present Week"
 msgstr "Bieżący tydzień"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "Poprz"
 
 msgid "Preventive action"
-msgstr "Konto główne do wyceny zapasów dostępnych"
+msgstr "Działanie zapobiegawcze"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "Harmonogramy konserwacji zapobiegawczej dla Twojego sprzętu"
+msgstr "Harmonogramy zapobiegawczego utrzymania ruchu dla twojego urządzenia"
 
 msgid "Preview"
 msgstr "Podgląd"
@@ -11354,10 +11354,10 @@ msgid "Previous value of {0}"
 msgstr "Poprzednia wartość {0}"
 
 msgid "Price break actions"
-msgstr "Akcje podziału ceny"
+msgstr "Działania progu cenowego"
 
 msgid "Price Break History"
-msgstr "Historia podziału ceny"
+msgstr "Historia progu cenowego"
 
 msgid "Price Breaks"
 msgstr "Progi cenowe"
@@ -11372,16 +11372,16 @@ msgid "Price Lists"
 msgstr "Cenniki"
 
 msgid "Price override"
-msgstr "Zastąpienie ceny"
+msgstr "Nadpisanie ceny"
 
 msgid "Prices"
 msgstr "Ceny"
 
 msgid "Pricing"
-msgstr "Wycena"
+msgstr "Ustalanie cen"
 
 msgid "Pricing rule"
-msgstr "Reguła wyceny"
+msgstr "Reguła cenowa"
 
 msgid "Pricing Rule"
 msgstr "Reguła cenowa"
@@ -11390,10 +11390,10 @@ msgid "Pricing Rules"
 msgstr "Reguły cenowe"
 
 msgid "Pricing Trace"
-msgstr "Śledzenie cen"
+msgstr "Śledzenie ustalania cen"
 
 msgid "Primary cash account for bank transactions"
-msgstr "procedura"
+msgstr "Główne konto gotówki dla transakcji bankowych"
 
 msgid "Print"
 msgstr "Drukuj"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Procedura"
 
 msgid "procedures"
-msgstr "proces"
+msgstr "procedury"
 
 msgid "Procedures"
 msgstr "Procedury"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Ilość Produkcji"
 
 msgid "Production variance"
-msgstr "Prognozowany popyt rozłożony z list składowych i prognoz."
+msgstr "Odchylenie produkcji"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Produkcja: aplikacja hali produkcyjnej i planowanie"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Początek projektu"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Zapasy Prognozowane"
+msgstr "Zapotrzebowanie prognozowane rozłożone z BOM-ów i prognoz."
 
 msgid "Projected inventory"
 msgstr "Dostępny Prognozowany"
@@ -11543,14 +11543,14 @@ msgstr "Prognozowany zapas"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Prognozuje się spadek poniżej poziomu bezpieczeństwa w tygodniu {0}"
+msgstr "Projekcja braku zapasu na tydzień {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
-msgstr "Prognozuje się pozostanie powyżej poziomu bezpieczeństwa"
+msgstr "Projekcja spadku poniżej zapasu bezpieczeństwa na tydzień {0}"
 
 msgid "Projected to stay above safety stock"
-msgstr "Zamówienie Zakupowe"
+msgstr "Projekcja pozostania powyżej zapasu bezpieczeństwa"
 
 msgid "Projection"
 msgstr "Projekcja"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "Prognozy"
 
 msgid "Promised Date"
-msgstr "Data obiecana"
+msgstr "Data potwierdzona"
 
 msgid "Properties"
 msgstr "Właściwości"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Opublikowano przez Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Opublikowana wersja"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Opublikowane wersje nie mogą być edytowane. Przeglądaj tylko do odczytu lub utwórz nową wersję, aby wprowadzić zmiany."
@@ -11653,7 +11653,7 @@ msgid "Purchase Invoices"
 msgstr "Faktury Zakupu"
 
 msgid "Purchase order"
-msgstr "Odchylenie Ceny Zakupu"
+msgstr "Zamówienie zakupu"
 
 msgid "Purchase Order"
 msgstr "Zamówienie Zakupu"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Odchylenie Ceny Zakupu (domyślne)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Podatek od Zakupów do Zapłacenia"
+msgstr "Odchylenie ceny zakupu (domyślnie)"
 
 msgid "Purchase Qty"
 msgstr "Ilość zakupu"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "Podatek od Zakupów do Zapłacenia (domyślnie)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "zakupy"
+msgstr "Podatek zakupu należny (domyślnie)"
 
 msgid "Purchase to Order"
-msgstr "Zakup na Zamówienie"
+msgstr "Zakup pod zamówienie"
 
 msgid "Purchase Unit of Measure"
 msgstr "Jednostka miary zakupu"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Wyślij zmiany rekordów do systemów zewnętrznych w momencie ich wystąpienia."
 
 msgid "Push the journal without the dimension"
-msgstr "Wyślij dziennik bez wymiaru"
+msgstr "Wyślij dowód księgowy bez wymiaru"
 
 msgid "Push to accounting"
 msgstr "Wyślij do systemu księgowego"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Ilość. Złomowana"
 
 msgid "quality"
-msgstr "Od Wyceny do Płatności"
+msgstr "jakość"
 
 msgid "Quality"
 msgstr "Jakość"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "Typ Jakości"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "Jakość: inspekcje, niezgodności, CAPA"
+msgstr "Jakość: kontroli, niezgodności, CAPA"
 
 msgid "Quantities"
 msgstr "Ilości"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Ilość przychodząca — z otwartych zamówień zakupu oraz ze zleceń produkcyjnych (produkcja)."
 
 msgid "Quantity Breaks"
-msgstr "Przerwy Ilości"
+msgstr "Progi ilościowe"
 
 msgid "Quantity complete"
 msgstr "Ilość ukończona"
@@ -11840,13 +11840,13 @@ msgid "Quantity must be greater than 0"
 msgstr "Ilość musi być większa niż 0"
 
 msgid "Quantity on hand"
-msgstr "Ilość dostępna"
+msgstr "stan magazynowy"
 
 msgid "Quantity on Hand"
-msgstr "Ilość w magazynie"
+msgstr "Stan magazynowy"
 
 msgid "Quantity on Jobs"
-msgstr "Ilość w zadaniach"
+msgstr "Ilość na zleceniach produkcyjnych"
 
 msgid "Quantity on Purchase Order"
 msgstr "Ilość na zamówieniu zakupu"
@@ -11858,10 +11858,10 @@ msgid "Quantity Per Job"
 msgstr "Ilość na zadanie"
 
 msgid "Quantity per Parent"
-msgstr "Ilość na jednostkę nadrzędną"
+msgstr "Ilość na wyrób nadrzędny"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Ilość fizycznie znajdująca się w przypisanej do materiału jednostce magazynowej (półce). Staje się czerwona, gdy jest poniżej tego, co ta jednostka musi dostarczyć."
+msgstr "Ilość fizycznie na jednostce magazynowej (półce) przypisanej do materiału. Zmienia kolor na czerwony, gdy ilość jest poniżej tego, co ta jednostka musi dostarczyć."
 
 msgid "Quantity Range"
 msgstr "Zakres Ilości"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Typ ilości"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Poziomy cen oparte na ilości dla tego zastąpienia; zastosowana cena jednostkowa to wiersz z największą ilością minimalną, którą spełnia wiersz zamówienia."
+msgstr "Strefy cenowe oparte na ilości dla tego nadpisania; zastosowana cena jednostkowa jest wierszem z największą minimalną ilością, którą spełnia pozycja zamówienia."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11913,13 +11913,13 @@ msgid "Quote ID"
 msgstr "ID Oferty"
 
 msgid "Quote line"
-msgstr "Linia oferty"
+msgstr "pozycja oferty"
 
 msgid "Quote Line"
-msgstr "Linia oferty"
+msgstr "Pozycja oferty"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "Linie oferty, których zestawienie materiałów zawiera ten przedmiot"
+msgstr "Pozycje oferty, których lista materiałowa zawiera ten artykuł"
 
 msgid "Quote Location"
 msgstr "Lokalizacja oferty"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Numer oferty"
 
 msgid "Quote to cash"
-msgstr "Należności"
+msgstr "Od oferty do gotówki"
 
 msgid "Quote Type"
 msgstr "Typ Oferty"
@@ -11997,7 +11997,7 @@ msgid "Readable ID"
 msgstr "Czytelny identyfikator"
 
 msgid "Readable id with revision"
-msgstr "Czytelny identyfikator z wersją"
+msgstr "Czytelny identyfikator z rewizją"
 
 msgid "Reading the document..."
 msgstr "Czytanie dokumentu..."
@@ -12006,7 +12006,7 @@ msgid "Ready"
 msgstr "Gotowe"
 
 msgid "Ready for Quote"
-msgstr "Gotowy do wyceny"
+msgstr "Gotowe do oferty"
 
 msgid "ready to keep or revert"
 msgstr "gotowe do zachowania lub przywrócenia"
@@ -12066,7 +12066,7 @@ msgid "Receipt Lines"
 msgstr "Linie przyjęcia"
 
 msgid "Receipt Promised Date"
-msgstr "Data obiecanej dostawy"
+msgstr "Data potwierdzona przyjęcia"
 
 msgid "Receipt Requested Date"
 msgstr "Data żądanego odbioru"
@@ -12075,7 +12075,7 @@ msgid "Receipts"
 msgstr "Paragony"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Pokwitowania, przesyłki, faktury sprzedaży, faktury zakupu, płatności i noty kredytowe/debetowe, które są w wersji roboczej lub oczekujące, muszą być opublikowane lub unieważnione — zarówno dokumenty datowane w tym okresie, jak i niezdatowane dokumenty, które otrzymałyby datę w nim po opublikowaniu. Dopóki nie zostaną opublikowane, ich kwoty nie znajdują się w księdze głównej, więc okres byłby niedoszacowany."
+msgstr "Przyjęcia, wysyłki, faktury sprzedaży, faktury zakupu, płatności i noty kredytowe/debetowe, które są w stanie Wersja robocza lub Oczekujące, muszą być zaksięgowane lub unieważnione — zarówno dokumenty datowane w tym okresie, jak i niedatowane dokumenty, które otrzymałyby datę w nim po zaksięgowaniu. Dopóki nie zostaną zaksięgowane, ich kwoty nie są w księdze głównej, więc okres byłby niedoszacowany."
 
 msgid "Receivables"
 msgstr "Należności (domyślnie)"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "Należności (AR)"
 
 msgid "Receivables (default)"
-msgstr "Uzgodnienie zamówienia zakupowego z tym, co zostało odebrane i zafakturowane — niejawnie w Carbon, przez ilości wierszy i saldo GR/IR."
+msgstr "Należności (domyślnie)"
 
 msgid "Receivables aging"
 msgstr "Starzenie się należności"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "Otrzymana Ilość"
 
 msgid "Receiving Location"
-msgstr "Lokalizacja odbioru"
+msgstr "Lokalizacja przyjęcia"
 
 msgid "Recent"
 msgstr "Ostatnie"
@@ -12145,7 +12145,7 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "Reconcyliacja wykazała rozbieżności z dostawcą"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Okres Odzysku"
+msgstr "Uzgadnianie zamówienia zakupu z tym, co zostało przyjęte i zafakturowane — niejawne w Carbon, poprzez ilości pozycji i saldo GR/IR."
 
 msgid "Record"
 msgstr "Nagrywaj"
@@ -12160,19 +12160,19 @@ msgid "Record deleted"
 msgstr "Rekord usunięty"
 
 msgid "Record inspections tied to a part and a job"
-msgstr "Rejestruj inspekcje powiązane z częścią i zadaniem"
+msgstr "Zarejestruj kontrole powiązane z częścią i zleceniem produkcyjnym"
 
 msgid "Record type"
 msgstr "Typ rekordu"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Zanotowano podczas kalibracji, że przyrząd potrzebuje naprawy, zanim jego odczyty będą godne zaufania."
+msgstr "Zanotowano na wzorcowaniu, że przyrząd pomiarowy wymaga naprawy, zanim będzie można ufać jego odczytom."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Zarejestrowano, że wymagane jest obserwowanie po tej kalibracji; umieszcza ten miernik w kolejce otwartych działań."
+msgstr "Zanotowano, że kontynuacja jest potrzebna po tym wzorcowaniu; wyświetla ten przyrząd pomiarowy w kolejce otwartych działań."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Zarejestrowano, że miernik został wyregulowany podczas tej kalibracji; wpływa na sposób przeliczania interwału kalibracji."
+msgstr "Zanotowano, że przyrząd pomiarowy został dostrojony podczas tego wzorcowania; wpływa na sposób, w jaki okres wzorcowania się przelicza."
 
 msgid "Records"
 msgstr "Rekordy"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "Przekierowanie na stronę weryfikacji..."
 
 msgid "Reduced"
-msgstr "Zmniejszone"
+msgstr "Ulgowa"
 
 msgid "Reference"
 msgstr "Odniesienie"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Zarejestrowany"
 
 msgid "Registered"
-msgstr "Punkt Ponownego Zamówienia"
+msgstr "Zarejestrowano"
 
 msgid "Registration failed"
 msgstr "Rejestracja nie powiodła się"
@@ -12247,13 +12247,13 @@ msgid "Release"
 msgstr "Zwolnienie"
 
 msgid "Release change notice"
-msgstr "Wydaj zgłoszenie zmian"
+msgstr "Zwolnij zawiadomienie o zmianie"
 
 msgid "Release control"
-msgstr "Kontrola wydania"
+msgstr "Kontrola zwolnienia"
 
 msgid "Release Control"
-msgstr "Kontrola Wydania"
+msgstr "Kontrola Zwolnienia"
 
 msgid "Release Job"
 msgstr "Zwolnij zadanie"
@@ -12265,10 +12265,10 @@ msgid "Released date"
 msgstr "Data wydania"
 
 msgid "Released revision"
-msgstr "Wydana wersja"
+msgstr "Zwolniona rewizja"
 
 msgid "Released revision is locked"
-msgstr "Wydana wersja jest zablokowana"
+msgstr "Zwolniona rewizja jest zablokowana"
 
 msgid "Remaining"
 msgstr "Pozostało"
@@ -12280,68 +12280,68 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "Zapamiętaj ten PIN. Będziesz go potrzebować, aby wyjść z trybu konsoli na terminalach MES."
 
 msgid "Remove"
-msgstr "Usuń"
+msgstr "Usuń z listy"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "Usuń {0}"
+msgstr "Usuń z listy {0}"
 
 msgid "Remove {label}"
-msgstr "Usuń {label}"
+msgstr "Usuń z listy {label}"
 
 msgid "Remove authenticator app"
-msgstr "Usuń aplikację Authenticator"
+msgstr "Usuń z listy aplikację uwierzytelniającą"
 
 msgid "Remove clause"
-msgstr "Usuń klauzulę"
+msgstr "Usuń z listy klauzulę"
 
 msgid "Remove condition"
-msgstr "Usuń warunek"
+msgstr "Usuń z listy warunek"
 
 msgid "Remove filter"
-msgstr "Usuń filtr"
+msgstr "Usuń z listy filtr"
 
 msgid "Remove Filters"
-msgstr "Usuń filtry"
+msgstr "Usuń z listy Filtry"
 
 msgid "Remove from Price List"
 msgstr "Usuń z listy cen"
 
 msgid "Remove line"
-msgstr "Usuń wiersz"
+msgstr "Usuń z listy pozycję"
 
 msgid "Remove order"
-msgstr "Usuń zamówienie"
+msgstr "Usuń z listy zamówienie"
 
 msgid "Remove pair"
-msgstr "Usuń parę"
+msgstr "Usuń z listy parę"
 
 msgid "Remove part"
-msgstr "Usuń część"
+msgstr "Usuń z listy część"
 
 msgid "Remove path"
-msgstr "Usuń ścieżkę"
+msgstr "Usuń z listy ścieżkę"
 
 msgid "Remove row"
-msgstr "Usuń wiersz"
+msgstr "Usuń z listy wiersz"
 
 msgid "Remove slide"
-msgstr "Usuń slajd"
+msgstr "Usuń z listy slajd"
 
 msgid "Remove slot"
-msgstr "Usuń slot"
+msgstr "Usuń z listy gniazdo"
 
 msgid "Remove sort by column"
-msgstr "Usuń sortowanie według kolumny"
+msgstr "Usuń z listy sortowanie po kolumnie"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Usuń ten typ magazynu ze wszystkich jednostek magazynowych, które się do niego odwołują, i usuń go. Tej operacji nie można cofnąć."
+msgstr "Usuń ten typ magazynowania ze wszystkich jednostek magazynowych, które go wykorzystują, i go usuń. Tej operacji nie można cofnąć."
 
 msgid "Remove tool"
-msgstr "Usuń narzędzie"
+msgstr "Usuń z listy narzędzie"
 
 msgid "Remove two-factor authentication"
-msgstr "Usuń uwierzytelnianie dwuskładnikowe"
+msgstr "Usuń z listy uwierzytelnianie dwuskładnikowe"
 
 msgid "Removed"
 msgstr "Usunięte"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "Zmień kolejność grupy"
 
 msgid "Reorder point"
-msgstr "Punkt Ponownego Zamówienia"
+msgstr "Punkt zamawiania"
 
 msgid "Reorder Point"
-msgstr "Punkt ponownego zamówienia"
+msgstr "Punkt Zamawiania"
 
 msgid "Reorder Point:"
-msgstr "Punkt ponownego zamówienia:"
+msgstr "Punkt Zamawiania:"
 
 msgid "Reorder Policy"
 msgstr "Polityka Zamawiania"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "Ilość do ponownego zamówienia:"
 
 msgid "Reordering policy"
-msgstr "Polityka zamawiania"
+msgstr "Zasady zamawiania"
 
 msgid "Reordering Policy"
-msgstr "Polityka zamawiania"
+msgstr "Zasady Zamawiania"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Zmienia kolejność tylko sekwencji wysyłki i centrum roboczego — nie przeplanowuje. Zmień daty na tablicy dat."
+msgstr "Zmienia tylko kolejność wysyłania i stanowiska roboczego — nie zmienia harmonogramu. Zmień daty na planszy Daty."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Powtarza się raz dla każdego elementu w {inputLabel}"
@@ -12405,7 +12405,7 @@ msgid "Replace drawing?"
 msgstr "Zastąpić rysunek?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Zastąp istniejące ceny wartościami ze źródła"
+msgstr "Zastąp istniejące ustalanie cen wartościami ze źródła"
 
 msgid "Replace PDF"
 msgstr "Zamień PDF"
@@ -12414,7 +12414,7 @@ msgid "Replace this company's data with a demo dataset — snapshotted first, so
 msgstr "Zastąp dane tej firmy zestawem danych demonstracyjnych — najpierw migawka, aby móc przywrócić."
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "Zastąpienie pliku PDF usuwa wszystkie umieszczenia balonów w tym dokumencie. Wiersze funkcji i ich wartości pozostają; możesz ponownie umieścić balony na nowym rysunku."
+msgstr "Zamiana pliku PDF usuwa wszystkie umieszczenia dymków na tym dokumencie. Wiersze funkcji i ich wartości pozostają; możesz ponownie umieścić dymki na nowym rysunku."
 
 msgid "Replenishment"
 msgstr "Uzupełnianie"
@@ -12486,13 +12486,13 @@ msgid "Required Actions (in order)"
 msgstr "Wymagane Działania (w porządku)"
 
 msgid "Required Date"
-msgstr "Data wymagana"
+msgstr "Data Zapotrzebowania"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Wymagane w kontrolowanym środowisku — rejestrowanie audytu nie może być wyłączone."
 
 msgid "Requirement"
-msgstr "Wymóg"
+msgstr "Wymaganie"
 
 msgid "Requirements"
 msgstr "Wymagania"
@@ -12507,7 +12507,7 @@ msgid "Requires Action"
 msgstr "Wymaga działania"
 
 msgid "Requires Adjustment"
-msgstr "Wymaga regulacji"
+msgstr "Wymaga Korekty"
 
 msgid "Requires Repair"
 msgstr "Wymaga naprawy"
@@ -12541,10 +12541,10 @@ msgid "Reset view"
 msgstr "Resetuj widok"
 
 msgid "Residual value"
-msgstr "Wartość resztkowa"
+msgstr "Wartość rezydualna"
 
 msgid "Residual Value %"
-msgstr "Wartość resztkowa %"
+msgstr "Wartość Rezydualna %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Rozwiąż to przed ukończeniem NCR: każdy wiersz musi mieć dyspozycję inną niż Oczekująca, a ilości połączonych jednostek muszą odpowiadać ilości wiersza."
@@ -12616,22 +12616,22 @@ msgid "Rev {revision}"
 msgstr "Wer. {revision}"
 
 msgid "Revenue"
-msgstr "Przychody"
+msgstr "Przychody ze sprzedaży"
 
 msgid "Revenue and expenses over a period"
-msgstr "Przychody i wydatki w danym okresie"
+msgstr "Przychody ze sprzedaży i wydatki za okres"
 
 msgid "Reverse all inventory adjustments"
 msgstr "Odwróć wszystkie korekty zapasów"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "Odwróć wszystkie wpisy dziennika i księgi kosztów"
+msgstr "Wycofaj wszystkie wpisy w dowodach księgowych i księdze kosztów"
 
 msgid "Reverse any item ledger entries from this invoice"
 msgstr "Odwróć wszystkie wpisy rejestru pozycji z tej faktury"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Odwrotne obciążenie"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Odwrotne obciążenie podatkiem od sprzedaży"
@@ -12640,10 +12640,10 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "Odwrotne obciążenie podatkiem od sprzedaży (domyślnie)"
 
 msgid "Reverse the related journal entries"
-msgstr "Odwróć powiązane wpisy w dzienniku"
+msgstr "Wycofaj powiązane wpisy w dowodach księgowych"
 
 msgid "Reversed"
-msgstr "Wycofane"
+msgstr "Wystornowano"
 
 msgid "Revert"
 msgstr "Przywróć"
@@ -12655,29 +12655,29 @@ msgid "Review"
 msgstr "Przegląd"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "Przejrzyj zmiany każdego elementu, a następnie potwierdź — wydanie nie może być cofnięte."
+msgstr "Przejrzyj zmiany w każdym artykule, a następnie potwierdź — uwolnienie nie może być cofnięte."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Przejrzyj bilans i rachunek zysków i strat okresu i potwierdź, że liczby wyglądają prawidłowo. To jest ręczne zatwierdzenie — oznacz jako gotowe po ich przejrzeniu."
+msgstr "Przejrzyj bilans i rachunek zysków i strat za okres i potwierdź, że liczby wyglądają prawidłowo. Jest to ręczne podpisanie — oznacz jako gotowe po ich przejrzeniu."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "Przejrzyj sugerowane dopasowania przed zastosowaniem. To są najlepsze zgadywanki — potwierdź, że każde jest poprawne."
+msgstr "Przejrzyj sugerowane dopasowania przed zastosowaniem. To jest najlepsze przypuszczenie — potwierdź, że każde jest prawidłowe."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Przejrzyj ostrzeżenia poniżej, a następnie opublikuj liczenie, aby zastosować korekty."
+msgstr "Przejrzyj ostrzeżenia poniżej, a następnie zaksięguj liczbę, aby zastosować korekty."
 
 msgid "Revision"
-msgstr "Wersja"
+msgstr "Rewizja"
 
 #. placeholder {0}: revision.revision
 msgid "Revision {0}"
-msgstr "Wersja {0}"
+msgstr "Rewizja {0}"
 
 msgid "Revision status"
-msgstr "Status wersji"
+msgstr "Status rewizji"
 
 msgid "Revisions"
-msgstr "Wersje"
+msgstr "Rewizje"
 
 msgid "Revoke"
 msgstr "Odwołaj"
@@ -12689,7 +12689,7 @@ msgid "Revoke Invites"
 msgstr "Odwołaj zaproszenia"
 
 msgid "Rework"
-msgstr "Przeróbka"
+msgstr "Poprawka"
 
 msgid "RFQ"
 msgstr "RFQ"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "Zapytania ofertowe"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Dołącz wymiary Carbon do wysyłanych dzienników. Każdy slot mapuje jeden wymiar Carbon na jeden cel analityki dostawcy; mapowanie wartości poniżej łączy poszczególne wartości wymiarów z opcjami dostawcy."
+msgstr "Dołącz wymiary Carbon do wysyłanych dowodów księgowych. Każde miejsce mapuje jeden wymiar Carbon na jeden cel analityki dostawcy; poniższe mapowanie wartości kojarzy poszczególne wartości wymiaru z opcjami dostawcy."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "Konto zaokrąglające (domyślnie)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Kieruj wszystkie faktury AP na jeden adres (np. siedzibę główną) zamiast do poszczególnych nabywców."
+msgstr "Kieruj wszystkie faktury zobowiązań na jeden adres (np. siedzibę korporacyjną) zamiast na poszczególnych nabywców."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Kieruj wszystkie faktury AR na jeden adres (np. siedzibę główną) zamiast na poszczególne lokalizacje."
+msgstr "Kieruj wszystkie faktury należności na jeden adres (np. siedzibę korporacyjną) zamiast na poszczególne lokalizacje."
 
 msgid "Routing"
-msgstr "Trasa operacyjna"
+msgstr "Marszruta"
 
 msgid "rows"
 msgstr "wiersze"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Uruchom listę kontrolną akceptacji do pozytywnego wyniku"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Zarządzaj halą produkcyjną na tabletach: rejestruj pracę, raportuj postęp, przeglądaj instrukcje"
+msgstr "Uruchom halę na tabletach: rejestruj robociznę, zgłaszaj postęp, zobacz instrukcje"
 
 msgid "Run this workflow now?"
 msgstr "Uruchomić ten przepływ pracy teraz?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "Uruchomione"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "Zapasy uruchomiane po tygodniowej podaży i popycie — linia."
+msgstr "Stan zapasów po każdym tygodniu pokrycia i zapotrzebowania — linia."
 
 msgid "Running Total"
 msgstr "Suma bieżąca"
@@ -12898,7 +12898,7 @@ msgid "Sales & Revenue"
 msgstr "Sprzedaż i przychód"
 
 msgid "Sales contact"
-msgstr "Kontakt handlowy"
+msgstr "Kontakt sprzedaży"
 
 msgid "Sales Contact"
 msgstr "Kontakt sprzedażowy"
@@ -12937,13 +12937,13 @@ msgid "Sales Order ID"
 msgstr "Numer zamówienia sprzedaży"
 
 msgid "Sales order line"
-msgstr "Linia zamówienia sprzedaży"
+msgstr "pozycja zamówienia sprzedaży"
 
 msgid "Sales Order Line"
-msgstr "Linia Zamówienia Sprzedaży"
+msgstr "Pozycja zamówienia sprzedaży"
 
 msgid "Sales Order Line (job)"
-msgstr "Linia zamówienia sprzedaży (zadanie)"
+msgstr "Pozycja zamówienia sprzedaży (zlecenie produkcyjne)"
 
 msgid "Sales Order Location"
 msgstr "Lokalizacja Zamówienia Sprzedaży"
@@ -12982,16 +12982,16 @@ msgid "Sample"
 msgstr "Próbka"
 
 msgid "Sample Size"
-msgstr "Rozmiar próbki"
+msgstr "Wielkość próbki"
 
 msgid "Sampling"
-msgstr "Pobieranie próbek"
+msgstr "Kontrola wyrywkowa"
 
 msgid "Sampling — Feature {featureLabel}"
-msgstr "Pobieranie próbek — Funkcja {featureLabel}"
+msgstr "Kontrola wyrywkowa — Funkcja {featureLabel}"
 
 msgid "Sampling Standard"
-msgstr "Standard pobierania próbek"
+msgstr "Normalna kontrola wyrywkowa"
 
 msgid "Saturday"
 msgstr "Sobota"
@@ -13072,22 +13072,22 @@ msgid "SCAR"
 msgstr "SCAR"
 
 msgid "SCAR (supplier corrective action request)"
-msgstr "SCAR (żądanie działania naprawczego od dostawcy)"
+msgstr "SCAR (wniosek o działanie korygujące dostawcy)"
 
 msgid "Schedule"
 msgstr "Harmonogram"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Planuj zadania względem pojemności centrum pracy"
+msgstr "Zaplanuj zlecenia produkcyjne względem pojemności centrum pracy"
 
 msgid "Schedule Name"
 msgstr "Nazwa harmonogramu"
 
 msgid "Scheduled Maintenance"
-msgstr "Zaplanowana konserwacja"
+msgstr "Zaplanowane utrzymanie ruchu"
 
 msgid "Scheduled Maintenances"
-msgstr "Zaplanowane konserwacje"
+msgstr "Zaplanowane utrzymania ruchu"
 
 msgid "Schedules"
 msgstr "Harmonogramy"
@@ -13108,40 +13108,40 @@ msgid "Scopes"
 msgstr "Zakresy"
 
 msgid "Scrap"
-msgstr "Złom"
+msgstr "Braki"
 
 msgid "Scrap / Cost of Quality"
-msgstr "Złom / Koszt jakości"
+msgstr "Braki / Koszt jakości"
 
 msgid "Scrap Percent"
-msgstr "Procent odpadów"
+msgstr "Procent braków"
 
 msgid "Scrap percentage"
-msgstr "Procent złomu"
+msgstr "procent braków"
 
 msgid "Scrap Qty"
-msgstr "Ilość złomu"
+msgstr "Ilość braków"
 
 msgid "Scrap quantity"
-msgstr "Ilość złomu"
+msgstr "ilość braków"
 
 msgid "Scrap Quantity"
-msgstr "Ilość złomu"
+msgstr "Ilość braków"
 
 msgid "Scrap Quantity Per Job"
-msgstr "Ilość odpadów na zadanie"
+msgstr "Ilość braków na zlecenie produkcyjne"
 
 msgid "scrap reason"
-msgstr "Przyczyna złomu"
+msgstr "przyczyna braku"
 
 msgid "Scrap Reason"
-msgstr "Przyczyna złomu"
+msgstr "Przyczyna braku"
 
 msgid "scrap reasons"
-msgstr "Przyczyny złomu"
+msgstr "przyczyny braku"
 
 msgid "Scrap Reasons"
-msgstr "Przyczyny złomu"
+msgstr "Przyczyny braku"
 
 msgid "Scrapped"
 msgstr "Złomowany"
@@ -13240,13 +13240,13 @@ msgid "Security"
 msgstr "Bezpieczeństwo"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "Segmenty, które wpływają na ceny i warunki dla klientów"
+msgstr "Segmenty, które określają ceny i warunki dla klientów"
 
 msgid "Select"
 msgstr "Wybierz"
 
 msgid "Select a assignee"
-msgstr "Wybierz osobę przydzieloną"
+msgstr "Wybierz osobę przypisaną"
 
 msgid "Select a default approver"
 msgstr "Wybierz domyślnego zatwierdzającego"
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "Wybierz ofertę"
 
 msgid "Select a quote line"
-msgstr "Wybierz linię oferty"
+msgstr "Wybierz pozycję oferty"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "Wybierz powód, dla którego oferta nie została utworzona."
@@ -13307,7 +13307,7 @@ msgid "Select an action…"
 msgstr "Wybierz akcję…"
 
 msgid "Select an assignee"
-msgstr "Wybierz osobę przydzieloną"
+msgstr "Wybierz osobę przypisaną"
 
 msgid "Select an event…"
 msgstr "Wybierz wydarzenie…"
@@ -13331,7 +13331,7 @@ msgid "Select an option"
 msgstr "Wybierz opcję"
 
 msgid "Select at least one line to convert"
-msgstr "Wybierz co najmniej jeden wiersz do konwersji"
+msgstr "Wybierz co najmniej jedną pozycję do przekształcenia"
 
 msgid "Select Contact"
 msgstr "Wybierz kontakt"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Wybierz pole"
 
 msgid "Select Gauge"
-msgstr "Wybierz Miernik"
+msgstr "Wybierz przyrząd pomiarowy"
 
 msgid "Select groups or individuals"
 msgstr "Wybierz grupy lub osoby"
@@ -13376,7 +13376,7 @@ msgid "Select invoices in a single currency"
 msgstr "Wybierz faktury w jednej walucie"
 
 msgid "Select Item Type"
-msgstr "Wybierz typ elementu"
+msgstr "Wybierz typ artykułu"
 
 msgid "Select items"
 msgstr "Wybierz artykuły"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Wybierz grupy, które powinny ukończyć to szkolenie"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Wybierz faktury, które ta płatność rozlicza. Rabat i odpis są w walucie faktury."
+msgstr "Wybierz faktury, które ta płatność rozlicza. Rabat i spisanie są w walucie faktury."
 
 msgid "Select value"
 msgstr "Wybierz wartość"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Samodzielnie zarządzane"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Samodzielnie hostowana lub zarządzana"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Samodzielne wdrażanie"
 
 msgid "Self-paced"
 msgstr "Samodzielne tempo"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "Wysłane do każdego odbiorcy, który ma włączone powiadomienia e-mail."
 
 msgid "Sequences"
-msgstr "Sekwencje"
+msgstr "Numeracja"
 
 msgid "Serial"
 msgstr "Seryjny"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Ustaw cel"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Skonfiguruj Carbon zgodnie z tym, jak działa Twoja firma: lokalizacje, części, BOM-y, Bill of Process i przepływy, które używasz."
+msgstr "Skonfiguruj Carbon zgodnie z tym, jak działa twoja firma: lokalizacje, części, BOM, lista operacji i przepływy, których używasz."
 
 msgid "Set Clock Out"
-msgstr "Ustaw czas wyjścia"
+msgstr "Ustaw zakończenie pracy"
 
 msgid "Set clock-out time"
 msgstr "Ustaw czas wylogowania"
@@ -13572,10 +13572,10 @@ msgid "Set Console PIN"
 msgstr "Ustaw PIN konsoli"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Ustaw domyślne procenty marż dla każdej kategorii kosztów w nowych wierszach oferty"
+msgstr "Ustaw domyślne marże procentowe dla każdej kategorii kosztów na nowych pozycjach oferty"
 
 msgid "Set demand projection values for each week"
-msgstr "Ustaw wartości projekcji popytu dla każdego tygodnia"
+msgstr "Ustaw wartości prognoz zapotrzebowania na każdy tydzień"
 
 msgid "Set due date"
 msgstr "Ustaw datę terminu"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Mapa konfiguracji"
 
 msgid "Setup time"
-msgstr "Czas konfiguracji"
+msgstr "czas przezbrojenia"
 
 msgid "Setup Time"
-msgstr "Czas przygotowania"
+msgstr "Czas przezbrojenia"
 
 msgid "Setup unit"
 msgstr "Jednostka konfiguracji"
@@ -13645,7 +13645,7 @@ msgid "Severities"
 msgstr "Ważności"
 
 msgid "Severity"
-msgstr "Ważność"
+msgstr "Waga"
 
 msgid "shape"
 msgstr "kształt"
@@ -13732,16 +13732,16 @@ msgid "Shipment ID"
 msgstr "ID wysyłki"
 
 msgid "Shipment Line"
-msgstr "Linia wysyłki"
+msgstr "Pozycja wysyłki"
 
 msgid "Shipment Lines"
-msgstr "Linie wysyłki"
+msgstr "Pozycje wysyłki"
 
 msgid "Shipment Location"
 msgstr "Lokalizacja wysyłki"
 
 msgid "Shipments"
-msgstr "Przesyłki"
+msgstr "Wysyłki"
 
 msgid "Shipped Qty"
 msgstr "Wysłana Ilość"
@@ -13762,19 +13762,19 @@ msgid "Shipping Location"
 msgstr "Lokalizacja wysyłki"
 
 msgid "shipping method"
-msgstr "metoda wysyłki"
+msgstr "sposób wysyłki"
 
 msgid "Shipping method"
-msgstr "Metoda wysyłki"
+msgstr "Sposób wysyłki"
 
 msgid "Shipping Method"
-msgstr "Metoda wysyłki"
+msgstr "Sposób wysyłki"
 
 msgid "shipping methods"
-msgstr "metody wysyłki"
+msgstr "sposoby wysyłki"
 
 msgid "Shipping Methods"
-msgstr "Metody wysyłki"
+msgstr "Sposoby wysyłki"
 
 msgid "Shipping Notes"
 msgstr "Notatki wysyłki"
@@ -13792,7 +13792,7 @@ msgid "Shop Floor and Scheduling"
 msgstr "Hala produkcyjna i planowanie"
 
 msgid "Shop Floor leads, Planner"
-msgstr "Kierownicy Hali Produkcyjnej, Planista"
+msgstr "Kierownicy hali produkcyjnej, Planista"
 
 msgid "Shop-floor app and scheduling"
 msgstr "Aplikacja hali produkcyjnej i planowanie"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Pokazywanie pierwszych 500 linii"
 
 msgid "Showing the newest 200 journals"
-msgstr "Wyświetlanie 200 najnowszych dzienników"
+msgstr "Wyświetlanie 200 najnowszych dowodów księgowych"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Pokazywanie 1000 najlepszych grup wg kwoty"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Wyświetlane użytkownikowi, gdy ta reguła się nie powiedzie."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Zaloguj się do Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Zaloguj się za pomocą biometrii zamiast linku magicznego. Klucze dostępu są zabezpieczone za pomocą Face ID, Touch ID lub numeru PIN urządzenia."
@@ -13898,7 +13898,7 @@ msgid "Sign out instead"
 msgstr "Zamiast tego wyloguj się"
 
 msgid "Sign-off review before moving to the next step"
-msgstr "Zatwierdzenie przed przejściem do następnego kroku"
+msgstr "Przegląd zatwierdzający przed przejściem do następnego kroku"
 
 msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
 msgstr "Zatwierdzenia, które muszą być zarejestrowane zanim ten problem zostanie zamknięty; oprócz wymaganych przez przepływ pracy."
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "Lokalizacje i obiekty"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "Witryny, lokalizacje, centra pracy, użytkownicy, dostawcy i ustawienia Twojej firmy — fundament, na którym buduje się wszystko inne. Zacznij od gotowych szablonów."
+msgstr "Lokalizacje, stanowiska robocze, użytkownicy, dostawcy i ustawienia firmy — fundament, na którym opiera się wszystko. Zacznij od gotowych szablonów."
 
 msgid "Size"
 msgstr "Rozmiar"
@@ -13940,7 +13940,7 @@ msgid "Skip raw-material dates set at receipt. Only inputs with their own shelf-
 msgstr "Pomiń daty materiałów surowych ustawione przy odbiorze. Liczyć się będą tylko wejścia z własną polityką przydatności do spożycia."
 
 msgid "Skip scheduled maintenance on company holidays"
-msgstr "Pomiń zaplanowaną konserwację w dni świąt firmowych"
+msgstr "Pomiń zaplanowane utrzymanie ruchu w święta firmy"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Pomiń stan zwolniony, ale nie uruchomiony - zadanie rozpoczyna się natychmiast po skanowaniu."
@@ -13955,10 +13955,10 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "Podziel aktywność aktywów według lokalizacji, pozycji lub dowolnego wymiaru"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "Podziel wydatki według lokalizacji, centrum kosztów lub dowolnego wymiaru"
+msgstr "Podziel wydatki według lokalizacji, miejsca powstawania kosztów lub dowolnego wymiaru"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Podziel przychody wg klienta, typu klienta lub dowolnego wymiaru"
+msgstr "Podziel przychody ze sprzedaży według klienta, typu klienta lub dowolnego wymiaru"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Smoke-test podstawowych codziennych przepływów od końca do końca"
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "Inżynier Rozwiązań"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "Niektóre linie wyodrębnione z pliku PDF nie mogły być automatycznie zmapowane na elementy Twojego magazynu. Przejrzyj i zmapuj każdą linię poniżej."
+msgstr "Niektóre pozycje wyodrębnione z pliku PDF nie mogły być automatycznie zmapowane do artykułów z twoich zapasów. Przejrzyj i zamapuj każdą pozycję poniżej."
 
 msgid "Something went wrong. Please try again."
 msgstr "Coś poszło nie tak. Spróbuj ponownie."
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "Wkrótce"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "Najwcześniejsza data wygaśnięcia spośród wszystkich materiałów określa produkt gotowy."
+msgstr "Najwcześniej wygasający materiał określa datę ważności wyrobu gotowego."
 
 msgid "Sort"
 msgstr "Sortuj"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "Podziel linię paragonu"
 
 msgid "Split shipment line"
-msgstr "Podziel linię wysyłki"
+msgstr "Podziel pozycję wysyłki"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Skonfiguruj hosting"
@@ -14112,7 +14112,7 @@ msgid "Start date"
 msgstr "Data rozpoczęcia"
 
 msgid "Start Date"
-msgstr "Data początkowa"
+msgstr "Data rozpoczęcia"
 
 msgid "Start Expiration"
 msgstr "Rozpocznij wygaśnięcie"
@@ -14202,7 +14202,7 @@ msgid "Steps are inherited from the assembly instruction."
 msgstr "Kroki są dziedziczone z instrukcji montażu."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "Kroki są dziedziczone z planu inspekcji."
+msgstr "Kroki są dziedziczone z planu kontroli."
 
 msgid "Stock movement corrected"
 msgstr "Ruch zapasów poprawiony"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "Identyfikator Transferu Zapasów"
 
 msgid "Stock Transfer Lines"
-msgstr "Linie Transferu Zapasów"
+msgstr "Pozycje przesunięcia zapasów"
 
 msgid "Stock Transfer Notes"
 msgstr "Notatki transferu zapasów"
@@ -14275,31 +14275,31 @@ msgid "Storage Units"
 msgstr "Jednostki magazynowe"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "Przechowuj stałą liczbę dni dla tego artykułu. Data rozpoczęcia wygaśnięcia jest ustawiana dla każdej partii lub numeru seryjnego podczas jego utworzenia (lub gdy proces wyzwalający zostanie uruchomiony, jeśli jest ustawiony)."
+msgstr "Przechowuj przez stałą liczbę dni na tym artykule. Data rozpoczęcia ważności jest ustawiana dla każdej partii produkcyjnej lub numeru seryjnego podczas jej tworzenia (lub gdy uruchomi się proces wyzwalający, jeśli jest ustawiony)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "Przechowuj stałą liczbę dni dla tego artykułu. Data rozpoczęcia wygaśnięcia jest ustawiana dla każdej partii lub numeru seryjnego po jego otrzymaniu lub utworzeniu (lub gdy proces wyzwalający zostanie uruchomiony, jeśli jest ustawiony)."
+msgstr "Przechowuj przez stałą liczbę dni na tym artykule. Data rozpoczęcia ważności jest ustawiana dla każdej partii produkcyjnej lub numeru seryjnego podczas jej odebrania lub utworzenia (lub gdy uruchomi się proces wyzwalający, jeśli jest ustawiony)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Przechowuj stałą liczbę dni dla tego artykułu. Data rozpoczęcia wygaśnięcia jest ustawiana dla każdej partii lub numeru seryjnego po otrzymaniu."
+msgstr "Przechowuj przez stałą liczbę dni na tym artykule. Data rozpoczęcia ważności jest ustawiana dla każdej partii produkcyjnej lub numeru seryjnego podczas jej odebrania."
 
 msgid "Straight line"
-msgstr "Liniowa"
+msgstr "Metoda liniowa"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe już ma klienta z tym adresem e-mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Termin Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe wysyła fakturę do klienta, dlatego wymagany jest adres. Zostanie to również zapisane w kontakcie w Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Księgowanie utworzy go na Twoim połączonym koncie."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Styl wyjścia kanban do wyświetlenia w tabeli Kanban"
@@ -14314,10 +14314,10 @@ msgid "Subassembly"
 msgstr "Podzespół"
 
 msgid "Subcontracting Variance"
-msgstr "Wariancja Podwykonawstwa"
+msgstr "Odchylenie robót podwykonawczych"
 
 msgid "Subcontracting Variance (default)"
-msgstr "Wariancja Podwykonawstwa (domyślnie)"
+msgstr "Odchylenie robót podwykonawczych (domyślne)"
 
 msgid "Subject"
 msgstr "Temat"
@@ -14326,13 +14326,13 @@ msgid "Subledger"
 msgstr "Księga pomocnicza"
 
 msgid "Submit anonymously"
-msgstr "Wyslij anonimowo"
+msgstr "Prześlij anonimowo"
 
 msgid "Submit for approval"
 msgstr "Prześlij do zatwierdzenia"
 
 msgid "Submit Inspection"
-msgstr "Prześlij Inspekcję"
+msgstr "Prześlij kontrolę"
 
 msgid "Submitted By"
 msgstr "Przesłane przez"
@@ -14353,10 +14353,10 @@ msgid "substituted from"
 msgstr "zastąpione z"
 
 msgid "Subtotal"
-msgstr "Razem netto"
+msgstr "Suma częściowa"
 
 msgid "Subtotal:"
-msgstr "Razem netto:"
+msgstr "Suma częściowa:"
 
 msgid "Succeeded"
 msgstr "Powiodło się"
@@ -14368,13 +14368,13 @@ msgid "Successfully copied quote"
 msgstr "Pomyślnie skopiowano ofertę"
 
 msgid "Successfully created a new revision"
-msgstr "Pomyślnie utworzono nową wersję"
+msgstr "Pomyślnie utworzono nową rewizję"
 
 msgid "Successor effectivity"
-msgstr "Skuteczność następcy"
+msgstr "Data obowiązywania następnika"
 
 msgid "Successor Effectivity Date"
-msgstr "Data Wejścia Następcy"
+msgstr "Data obowiązywania następnika"
 
 msgid "Successor Part"
 msgstr "Część następcza"
@@ -14395,13 +14395,13 @@ msgid "Suggested orders you haven't placed yet."
 msgstr "Sugerowane zamówienia, które jeszcze nie złożyłeś."
 
 msgid "Suggestion"
-msgstr "Sugestia"
+msgstr "Propozycja"
 
 msgid "Suggestion Notifications"
-msgstr "Powiadomienia o sugestiach"
+msgstr "Powiadomienia propozycji"
 
 msgid "Suggestions"
-msgstr "Sugestie"
+msgstr "Propozycje"
 
 msgid "Sunday"
 msgstr "Niedziela"
@@ -14416,10 +14416,10 @@ msgid "Supersession"
 msgstr "Zastąpienie"
 
 msgid "Supersession chain detected"
-msgstr "Wykryto łańcuch zastępowania"
+msgstr "Wykryto łańcuch zastąpień"
 
 msgid "Supersession Mode"
-msgstr "Tryb zastępowania"
+msgstr "Tryb zastąpienia"
 
 msgid "supplier"
 msgstr "Dostawca"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Część dostawcy"
 
 msgid "Supplier Part ID"
-msgstr "ID części dostawcy"
+msgstr "Numer artykułu dostawcy"
 
 msgid "Supplier Part Number"
 msgstr "Numer części dostawcy"
@@ -14485,7 +14485,7 @@ msgid "Supplier Payment Discounts (default)"
 msgstr "Rabaty Płatności Dostawcy (domyślnie)"
 
 msgid "Supplier Prepayments"
-msgstr "Przedpłaty Dostawców"
+msgstr "Zaliczki dla dostawców"
 
 msgid "supplier process"
 msgstr "Proces Dostawcy"
@@ -14500,7 +14500,7 @@ msgid "Supplier Quality"
 msgstr "Jakość dostawcy"
 
 msgid "Supplier quote"
-msgstr "Wycena Dostawcy"
+msgstr "Oferta dostawcy"
 
 msgid "Supplier Quote"
 msgstr "Oferta dostawcy"
@@ -14557,10 +14557,10 @@ msgid "Suppliers"
 msgstr "Dostawcy"
 
 msgid "Supply"
-msgstr "Dostawa"
+msgstr "Pokrycie"
 
 msgid "Supply & Demand"
-msgstr "Podaż i Popyt"
+msgstr "Pokrycie i zapotrzebowanie"
 
 msgid "Support"
 msgstr "Wsparcie"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "Przełącz"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "Wyłącz moduł, aby usunąć go wszędzie: Wymagania, Dane, Szkolenie, Zakres."
+msgstr "Wyłącz moduł, aby go usunąć wszędzie: Wymagania, Dane, Szkolenie, Zakres."
 
 msgid "Switch to pan mode"
 msgstr "Przełącz na tryb panoramy"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "Dostosuj ten hub dla klienta. Zmiany są stosowane na żywo dla wszystkich go przeglądających. Nigdy nie jest pokazywane klientowi tutaj."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Weź najkrótszy pozostały okres przydatności spośród materiałów zużytych do produkcji tego artykułu. Użyj, gdy okres przydatności produktu zależy od jego składników."
+msgstr "Weź najkrótszy pozostały okres przydatności spośród materiałów zużytych do utworzenia tego artykułu. Użyj, gdy termin ważności produktu zależy od jego składników."
 
 msgid "taken"
 msgstr "wzięte"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "Firma Docelowa"
 
 msgid "Target customers by type."
-msgstr "Element docelowy"
+msgstr "Kieruj się na klientów według typu."
 
 msgid "Target disposition row"
 msgstr "Docelowy wiersz dyspozycji"
@@ -14714,7 +14714,7 @@ msgid "Tax Depreciation Method"
 msgstr "Metoda Amortyzacji Podatkowej"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Zwolniony z podatku"
 
 msgid "Tax Exempt"
 msgstr "Zwolniony z Podatku"
@@ -14741,16 +14741,16 @@ msgid "Tax Percent"
 msgstr "Procent podatku"
 
 msgid "Tax Residual Value %"
-msgstr "Pozostała Wartość Podatkowa %"
+msgstr "Podatkowa wartość rezydualna %"
 
 msgid "Tax Useful Life (default)"
-msgstr "Okres Użyteczności Podatkowej (domyślnie)"
+msgstr "Okres użytkowania dla podatku (domyślnie)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Okres Użyteczności Podatkowej (miesiące)"
+msgstr "Okres użytkowania dla podatku (miesiące)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Okres Użyteczności Podatkowej (Miesiące)"
+msgstr "Okres użytkowania dla podatku (Miesiące)"
 
 msgid "Tax:"
 msgstr "Podatek:"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Zespół przeszkolony"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Pomoc techniczna"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -14805,31 +14805,31 @@ msgstr "Ta nazwa jest już używana przez inny krok."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "Faza „{0}\" sama się zaznacza, gdy wszystkie jej zadania w planie projektu są ukończone."
+msgstr "Faza \"{0}\" oznacza się jako gotowa, gdy wszystkie jej zadania w planie projektu są gotowe."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "Faza „{0}\" jest gotowa — jej punkt kontrolny „{1}\" został osiągnięty."
+msgstr "Faza \"{0}\" jest gotowa — jej punkt kontrolny \"{1}\" został zaliczony."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
 msgstr "Fazy {0} przed wdrożeniem, każda kończąca się punktem kontrolnym. Zaznaczaj każde zadanie po jego ukończeniu."
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "Wymiar rachunkowy, który kategoryzuje artykuły do raportowania i analizy."
+msgstr "Wymiar księgowy, który kategoryzuje artykuły do raportowania i analizy."
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "Konta, na które Carbon automatycznie księguje"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "Akcja, która kopiuje zapisaną metodę (jej materiały, operacje i instrukcje pracy) na wiersz zadania lub oferty."
+msgstr "Czynność kopiowania zapisanej metody (jej materiałów, operacji i instrukcji roboczych) na zlecenie produkcyjne lub pozycję oferty."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "Dozwolone wartości dla atrybutu typu lista; użytkownicy wybierają z nich zamiast pisać swobodnie."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Dozwolone wartości, które użytkownicy mogą wybrać podczas tagowania wpisów tą dimensją."
+msgstr "Dozwolone wartości, które użytkownicy mogą wybrać podczas oznaczania księgowań tym wymiarem."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
 msgstr "Liczba dni po metodzie obliczeniowej, w której dostępna jest rabat gotówkowy"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "Autoryzacja została odrzucona w Onshape. Spróbuj połączyć się ponownie."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Księga wszystkich zaksięgowanych wierszy pamiętnika, zsumowanych według konta – zapisywana tylko wtedy, gdy dla firmy jest włączona rachunkowość."
+msgstr "Księga wszystkich zaksięgowanych linii dowodu księgowego, zsumowanych na koncie — zapisywana tylko wtedy, gdy firma ma włączoną księgowość."
 
 msgid "The buckets you track costs against"
 msgstr "Zasobniki, w których śledzisz koszty"
@@ -14871,7 +14871,7 @@ msgid "The carrier that delivers goods from this supplier, when different from t
 msgstr "Przewoźnik, który dostarcza towary od tego dostawcy, gdy różni się od samego dostawcy (np. dostawca sprzedaje, FedEx wysyła)."
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "Adres URL strony śledzenia przewoźnika z {trackingNumber} jako symbolem zastępczym — Carbon zastępuje rzeczywisty numer podczas generowania linków na przesyłki."
+msgstr "URL strony śledzenia przewoźnika z {trackingNumber} jako zastępnikiem — Carbon zastępuje rzeczywisty numer podczas generowania linków na wysyłkach."
 
 msgid "The carriers and methods you ship orders with"
 msgstr "Przewoźnicy i metody wysyłki zamówień"
@@ -14880,13 +14880,13 @@ msgid "The cash discount the customer can take if they pay within the discount w
 msgstr "Rabat gotówkowy, który klient może otrzymać, jeśli zapłaci w okresie rabatu."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "Katalogowa przyczyna wyjaśniająca ten złom; łączy się w raporty złomu uporządkowane według przyczyny, a nie ilości."
+msgstr "Katalogowy powód wyjaśniający te braki; zwijają się do raportów braków według powodu, a nie ilości."
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "Katalog, na którym pracujesz. Ładuje się po załadowaniu fundamentu."
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "Kategorie zapasów dozwolone w tej jednostce; używane do egzekwowania reguł odkładania (np. łańcuch chłodniczy, niebezpieczny)."
+msgstr "Kategorie zapasów dozwolone w tej jednostce; używane do egzekwowania reguł odłożenia (np. łańcuch chłodniczy, materiały niebezpieczne)."
 
 msgid "The categories you group your suppliers into"
 msgstr "Kategorie, w które grupujesz swoich dostawców"
@@ -14904,7 +14904,7 @@ msgid "The category of this issue (e.g. Customer Complaint, Audit Finding, Produ
 msgstr "Kategoria tego problemu (na przykład Skarga Klienta, Ustalenie Audytu, Wada Produkcji); określa, jaki szablon przepływu pracy ma zastosowanie."
 
 msgid "The category this customer belongs to (OEM, distributor, end-user, internal); drives default pricing rules and GL accounts."
-msgstr "Kategoria, do której należy ten klient (OEM, dystrybutor, użytkownik końcowy, wewnętrzny); określa domyślne reguły cen i konta GL."
+msgstr "Kategoria, do której należy ten klient (OEM, dystrybutor, użytkownik końcowy, wewnętrzny); steruje domyślnymi regułami cenowymi i kontami księgowymi."
 
 msgid "The category this supplier belongs to (raw-material, services, contract-manufacturer); drives default GL accounts and reporting groupings."
 msgstr "Kategoria, do której należy ten dostawca (surowiec, usługi, producent kontraktowy); określa domyślne konta GL i grupowania raportów."
@@ -14913,7 +14913,7 @@ msgid "The code printed on the kanban card that operators scan to mark the job c
 msgstr "Kod drukowany na karcie kanban, który operatorzy skanują, aby oznaczyć zadanie jako ukończone; generowany automatycznie, jeśli pozostawiony pusty."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "Oczekiwana cotygodniowa dostępność wykonawcy; planowanie używa tego jako górnej granicy podczas przydzielania tego wykonawcy operacjom na przestrzeni tygodnia."
+msgstr "Oczekiwana dostępność pracownika zewnętrznego co tydzień; planowanie używa tego jako górnego limitu podczas przydzielania pracownika do operacji w ciągu tygodnia."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "Poprawiona data wygaśnięcia dla tego lotu/numeru seryjnego; istniejące zapasy w ręce są ponownie oceniane na podstawie polityki żywotności przechowywania po zmianie."
@@ -14925,16 +14925,16 @@ msgid "The customer record this portal account links to; only contacts already o
 msgstr "Rekord klienta, do którego jest powiązane to konto portalu; tylko kontakty już na tym kliencie mogą być wybrane jako posiadacz konta poniżej."
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "Klient, któremu dostarczane są towary, gdy różni się od klienta fakturowanego (np. rachunek do siedziby, wysyłka do oddziału)."
+msgstr "Klient, do którego dostarczane są towary, jeśli różni się od klienta, któremu wystawiana jest faktura (np. faktura dla centrali, wysyłka do filii)."
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
 msgstr "Klient, dla którego ten link portalu jest dostarczany; tylko kontakty na tym kliencie mogą zalogować się za pośrednictwem linku."
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "Własna referencja klienta dla tego dokumentu - typowo jego numer RFQ lub PO w jego systemie; wyświetlana na wydrukowalych wyjściach i przenoszona do każdego dokumentu, do którego ten się konwertuje."
+msgstr "Własna referencja klienta do tego dokumentu — zwykle ich numer RFQ lub PO w ich systemie; wyświetlana na drukowanym wyjściu i przeniesiona do dowolnego dokumentu, na który ten się zmienia."
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
-msgstr "Tag przeglądu klienta dla jego ID części, gdy różni się od naszego; przymocowany na poziomie referencji krzyżowej, a nie na naszej wersji."
+msgstr "Tag rewizji klienta dla ich numeru części, jeśli różni się od naszego; przypisany na poziomie odniesienia krzyżowego, a nie w naszej rewizji."
 
 msgid "The customers who go live fastest own these well. The full ours/yours split is below."
 msgstr "Klienci, którzy najszybciej wchodzą na rynek, doskonale to opanowują. Pełny podział nasz/wasz znajduje się poniżej."
@@ -14952,16 +14952,16 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "Data, od której rozpoczyna się amortyzacja tego zasobu; zwykle data oddania do użytku."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "Data, po której ceny z tego wyceny nie będą już honorowane; konwersja do zamówienia po tej dacie może wymagać ponownego wyceny."
+msgstr "Data, po której ceny tej oferty nie są już honorowane; zmiana na zamówienie po tej dacie może wymagać ponownego przygotowania oferty."
 
 msgid "The date the customer expects to receive the goods"
-msgstr "Data, w której klient spodziewa się otrzymać towary"
+msgstr "Data, w której klient oczekuje otrzymania towarów"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
 msgstr "Data, kiedy towary faktycznie opuszczają magazyn; zarejestrowana w księgowaniu przesyłki i używana do oceny wysyłki na czas."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "Data, do której towar musi być dostępny na miejscu, aby pokryć prognozowany popyt w danym okresie."
+msgstr "Data, w której artykuł jest wymagany na miejscu, aby pokryć prognozowane zapotrzebowanie na dany okres."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
 msgstr "Data, w której ten zasób jest wycofywany z użytku; amortyzacja kończy się w tej dacie, a pozostała wartość netto księgi jest księgowana na koncie likwidacji."
@@ -14979,13 +14979,13 @@ msgid "The deadline to send your quote to the customer."
 msgstr "Termin na wysłanie wyceny do klienta."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "Domyślne zamawianie pobrania używa do oferowania śledzone jednostki: FEFO (najwcześniejsze wygaśnięcie najpierw), FIFO (najstarsze najpierw) lub LIFO (najnowsze najpierw)."
+msgstr "Domyślny porządek, którego kompletacja używa do oferowania śledzonych jednostek: FEFO (najstarsza data ważności najpierw), FIFO (najstarsze najpierw) lub LIFO (najnowsze najpierw)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "Domyślna ilość serii, gdy ta część jest wytwarzana; rundy planowania dokładają uzupełnienie do wielokrotności tego."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "Domyślna stawka podatkowa stosowana do linii oferty i zamówienia sprzedaży tego klienta, przed zastępowaniem na linię; matematyka podatkowa specyficzna dla jurysdykcji przebiega na górze."
+msgstr "Domyślna stawka podatku stosowana do pozycji ofert i zamówień sprzedażowych tego klienta, przed nadpisaniami na poziomie pozycji; dodatkowo stosuje się matematykę podatków specyficzną dla jurysdykcji."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "Dział, pod którym ten się zlicza dla raportowania i hierarchii liczby pracowników; pozostaw puste dla departamentu najwyższego poziomu."
@@ -14994,7 +14994,7 @@ msgid "The eight-disciplines quality method, modeled with the nonconformance wor
 msgstr "Metoda jakości ośmiu dyscyplin, modelowana z zadaniami przepływu pracy niezgodności zamiast hardkodowanymi."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "Pracownik odpowiedzialny za to centrum kosztów — gdy zatwierdzenia zamówień zakupu są włączone, jest on zatwierdzającym wydatki zaksięgowane na jego rachunek."
+msgstr "Pracownik odpowiedzialny za to miejsce powstawania kosztów — gdy są włączone zatwierdzeń zamówień zakupu, jest osobą zatwierdzającą wydatki zaksięgowane na niego."
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
 msgstr "Przepływ handlowy end-to-end od wyceny klienta do zbierania płatności: zapytanie ofertowe do wyceny do zamówienia sprzedaży, a następnie wysyłka, faktura i zapłacona płatność."
@@ -15006,7 +15006,7 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "Rysunek techniczny, do którego powiązany jest ten plan inspekcji; kontrole zarejestrowane dla tej części odnoszą się do tego rysunku."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "Oczekiwany procent produkcji tego artykułu utraconej podczas produkcji; planowanie mnoży zapotrzebowanie przez 1 / (1 − złom), aby skompensować."
+msgstr "Oczekiwany procent wyniku tego artykułu utraconego podczas produkcji; planowanie mnoży zapotrzebowanie przez 1 / (1 − braki) w celu wyrównania."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Konto wydatków, na które ta linia wydatków pośrednich jest księgowana; wymagane, ponieważ linie pośrednie nie mają wpisu do księgi inwentarzowej, z którego można pochodzić konto."
@@ -15018,10 +15018,10 @@ msgid "The fixed number of units to inspect from the front of each lot, regardle
 msgstr "Stała liczba jednostek do zbadania z przodu każdej partii, niezależnie od wielkości partii."
 
 msgid "The fixed-asset record this purchase capitalizes against; the line's receipt creates the asset entry rather than an inventory entry."
-msgstr "Rekord środka trwałego, w stosunku do którego ta zakup jest kapitalizowany; rachunek linii tworzy wpis zasobu, a nie wpis inwentarza."
+msgstr "Zapis środka trwałego, na który ta linia się kapitalizuje; przyjęcie powoduje utworzenie wpisu zasobu zamiast wpisu zapasów."
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "Rekord środka trwałego, który ta sprzedaż zbywają; wysyłka linii księguje wpis zbycia wartości netto w księgach zasobu zamiast COGS."
+msgstr "Zapis środka trwałego likwidowany tą sprzedażą; wysyłka zaksięgowuje wpis likwidacji wartości netto zasobu zamiast KWS."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
 msgstr "Dolna granica, do której amortyzuje się aktywa; gdy wartość netto księgi ją osiąga, aktywo zmienia się na Całkowicie zamortyzowany."
@@ -15036,16 +15036,16 @@ msgid "The following line items are missing prices or lead times:"
 msgstr "Następujące pozycje linii nie mają cen lub czasów realizacji:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Następujące zadania nie są jeszcze ukończone:"
+msgstr "Następujące zadania nie są jeszcze gotowe:"
 
 msgid "The forms and shapes your raw materials come in"
 msgstr "Formy i kształty, w jakich dostarczane są Twoje surowce"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "Ułamek każdej partii do zbadania; rzeczywista liczba jest obliczana na podstawie wielkości partii w momencie inspekcji."
+msgstr "Ułamek każdej partii do kontroli; rzeczywistą liczbę oblicza się z wielkości partii w momencie kontroli."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "Różnica między ceną zamówienia zakupu a rachunkiem dostawcy, zaksięgowana na koncie odchylenia, gdy rachunek jest zaksięgowany."
+msgstr "Różnica między ceną zamówienia zakupu a rachunkiem dostawcy, zaksięgowana na koncie odchylenia, gdy faktura się zaksięgowuje."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "Konto GL, na które opłaty za tego przewoźnika są księgowane (wydatek na fracht, fracht we/wewnątrz)."
@@ -15060,19 +15060,19 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "Konto grupy, do którego to konto się zwijają; określa jego typ, klasę i umiejscowienie w oświadczeniu."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "Koszt godzinowy pracy operatora w tym centrum pracy; połączony z zarejestrowanymi godzinami pracy w celu obciążenia kosztu pracy w WIP zadania."
+msgstr "Godzinowy koszt robocizny operatora na tym stanowisku roboczym; połączony z zalogowanymi godzinami robocizny w celu naliczenia kosztu robocizny do produkcji w toku zlecenia."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "Koszt godzinowy uruchamiania maszyn w tym centrum pracy; połączony z zarejestrowanymi godzinami maszyn w celu obciążenia kosztu maszyn w WIP zadania."
+msgstr "Godzinowy koszt pracy maszyny na tym stanowisku roboczym; połączony z zalogowanymi godzinami maszyny w celu naliczenia kosztu maszyny do produkcji w toku zlecenia."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "Godzinowe obciążenie kosztu pośredniego zastosowane do tego centrum pracy; różnica między pracą + maszyną a pełną stawką ofertowania to to, co pochłania ogólne koszty."
+msgstr "Godzinowe obciążenie kosztów pośrednich stosowane do tego stanowiska roboczego; różnica między robocizną + maszyną a pełną stawką oferty to to, co absorbują koszty pośrednie."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "Adres https, do którego krok webhooku przepływu pracy wysyła — zwykły http, przekierowania i hosty rozpoznawane jako adresy prywatne lub link-local są odrzucane, a połączenie kończy się po dziesięciu sekundach."
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "Czytelny dla człowieka numer dokumentu (na przykład J000001 lub ECO-000001) wygenerowany z sekwencji i przechowywany w rekordzie, odrębny od jego wewnętrznego identyfikatora."
+msgstr "Czytelny dla człowieka numer dokumentu (np. J000001 lub ECO-000001) wyrażony z numeracji i przechowywany w rekordzie, różny od jego wewnętrznego identyfikatora."
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
 msgstr "Identyfikator, który klient używa dla tej części na swoich PO; Carbon rozwiązuje to do naszego wewnętrznego identyfikatora części przy imporcie zamówienia."
@@ -15087,16 +15087,16 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "Ocena wpływu w przypadku realizacji ryzyka (1 = znikoma do 5 = katastrofalna); sparowana z Prawdopodobieństwem w celu obliczenia wyniku ryzyka."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "Dokument przychodzący księgi, który przyjmuje towary do magazynu (z zamówienia, transferu lub wyjścia zadania) i tworzy śledzane jednostki."
+msgstr "Dokument księgowania przychodzącego, który przyjmuje towary do zapasów (z zamówienia zakupu, przesunięcia lub wyniku zlecenia) i tworzy wszelkie śledzone jednostki."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "Reguła Incoterms (FOB, DAP, EXW, CIF, ...), która rządzi, kto płaci za transport, kto ponosi ryzyko i gdzie dochodzi do przeniesienia własności w przesyłkach od tego dostawcy."
+msgstr "Reguła Incoterm (FOB, DAP, EXW, CIF, ...), która określa, kto płaci transport, kto ponosi ryzyko i gdzie następuje przeniesienie własności na wysyłkach od tego dostawcy."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "Reguła Incoterms (FOB, DAP, EXW, CIF, ...), która rządzi, kto płaci za transport, kto ponosi ryzyko i gdzie dochodzi do przeniesienia własności w przesyłkach do tego klienta."
+msgstr "Reguła Incoterm (FOB, DAP, EXW, CIF, ...), która określa, kto płaci transport, kto ponosi ryzyko i gdzie następuje przeniesienie własności na wysyłkach do tego klienta."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Koszt zapasów rozpoznany po zaregistrowaniu shipment'u, wyceniany metodą kosztowania artykułu."
+msgstr "Koszt zapasów uznany, gdy wysyłka się zaksięgowuje, wyceniony metodą kalkulacji kosztów artykułu."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "Klasa okresu odzyskania IRS dla tego zasobu w ramach MACRS (3, 5, 7, 10, 15, 20, 27,5, 39 lat)."
@@ -15108,10 +15108,10 @@ msgid "The job's position in its location's schedule queue — a fractional numb
 msgstr "Pozycja zadania w kolejce harmonogramu jego lokalizacji — liczba ułamkowa, którą Carbon oblicza na podstawie daty terminu i typu terminu, a nie oceny Niska/Wysoka."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "Typ korekty, którą stosuje ta zasada - zniżka, dopłata lub stały override; połączony z Typem Kwoty, aby obliczyć rzeczywistą deltę na każdej linii."
+msgstr "Rodzaj korekty, jaką ta reguła stosuje — rabat, dopłata lub stałe nadpisanie; połączone z typem kwoty w celu obliczenia rzeczywistej zmiany dla każdej pozycji."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "Typ wartości, jaką ten atrybut akceptuje (tekst, liczba, data, logiczna, lista); zablokowany po tym, jak atrybut ma zarejestrowane wartości."
+msgstr "Rodzaj wartości, jaki ten atrybut przyjmuje (tekst, liczba, data, wartość logiczna, lista); zablokowany, gdy atrybut ma jakieś zarejestrowane wartości."
 
 msgid "The label and document printers your company prints to"
 msgstr "Drukarki etykiet i dokumentów, na które drukuje Twoja firma"
@@ -15141,16 +15141,16 @@ msgid "The location this employee defaults to; drives timezone interpretation on
 msgstr "Lokalizacja, do której ten pracownik domyślnie przypisuje; napędza interpretację strefy czasowej w ich kartach pracy i domyślne selektory zmian w ich rekordzie pracy."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "Lokalizacja, z której to zamówienie będzie zrealizowane; lokalizacje per linia zastępują to po ustawieniu."
+msgstr "Lokalizacja, z której to zamówienie zostanie zrealizowane; lokalizacje na poszczególnych pozycjach zastępują to ustawienie."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "Lokalizacja, z której ta oferta będzie zrealizowana, jeśli zostanie przekonwertowana na zamówienie; używana przez planowanie do projekcji dostaw w odpowiednim magazynie."
+msgstr "Lokalizacja, z której ta oferta zostanie zrealizowana, jeśli zostanie przekształcona w zamówienie; planowanie wykorzystuje to do projekcji pokrycia w odpowiednim magazynie."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
-msgstr "Lokalizacja, z której ta oferta byłaby zrealizowana, gdyby została przekonwertowana na ofertę, a następnie na zamówienie."
+msgstr "Lokalizacja, z której to RFQ byłoby zrealizowane, jeśli zostałoby przekształcone w ofertę, a następnie w zamówienie."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "Dziennik zagrożeń i szans podnoszonych wobec każdej jednostki, każdy oceniany niezależnie w skali 1–5 pod względem ważności i prawdopodobieństwa i prowadzony do rozwiązania."
+msgstr "Rejestr zagrożeń i szans podnoszonych dla każdej jednostki, każde oceniane niezależnie w skali 1–5 wagi i prawdopodobieństwa oraz doprowadzane do rozwiązania."
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "Logotypy wyświetlane na drukowanych i wysyłanych pocztą dokumentach"
@@ -15159,16 +15159,16 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "Identyfikator lotu dla tego magazynu; jeden wiersz na partię, ilość to wręcz dla tego lotu."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "Lot zostanie oznaczony jako Zaakceptowany. {fails} próbkowanych niepowodzeń zostało zarejestrowanych dla Twoich rejestrów."
+msgstr "Partia będzie oznaczona jako Zaliczona. {fails} niepowodzenie(ń) próbkowych zostało(y) zarejestrowane dla Twoich akt."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Partia będzie nadal odrzucona, ale nie można utworzyć NCR, dopóki nie zostanie skonfigurowany co najmniej jeden typ problemu."
 
 msgid "The lot's per-feature sampling plan will be re-resolved from the selected document."
-msgstr "Plan pobierania próbek dla każdej cechy będzie ponownie ustalony na podstawie wybranego dokumentu."
+msgstr "Plan kontroli wyrywkowej partii będzie ponownie ustalony na podstawie wybranego dokumentu."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "Najniższa kwota, którą ten dostawca pobierze za ten proces, niezależnie od ilości; zadania poniżej wolumenu progu rentowności nadal kosztują co najmniej tę kwotę."
+msgstr "Minimalna kwota, którą dostawca będzie pobierać za ten proces, niezależnie od ilości; zamówienia poniżej progu rentowności będą kosztować co najmniej tyle."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Maszyny, komórki i stanowiska, przez które przechodzi Twoja praca"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "Miesiąc, w którym rozpoczyna się Twój rok obrachunkowy; okresy są numerowane od tego miesiąca."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "Miesiąc, w którym rozpoczyna się Twój rok podatkowy; może różnić się od roku obrachunkowego w niektórych jurysdykcjach."
+msgstr "Miesiąc, w którym zaczyna się Twój rok podatkowy; może różnić się od roku obrachunkowego w niektórych jurysdykcjach."
 
 msgid "The monthly periods you post into and close"
 msgstr "Miesięczne okresy, w których dokonujesz wpisów i które zamykasz"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "Najewidentnie tryb awarii, który podejrzewa żądający; technik potwierdza lub zastępuje to przy zamknięciu, a różnica między podejrzanym a rzeczywistym zaopatruje raporty niezawodności."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "Negocjowana cena za jednostkę na tej linii; ikona śledzenia wbudowanego pokazuje, która reguła ceny lub nadpisanie ją wyprodukowała."
+msgstr "Wynegocjowana cena za sztukę na tej pozycji; ikona śledzenia wbudowana pokazuje, która reguła cenowa lub nadpisanie ją wygenerowało."
 
 msgid "The new version number of the document"
 msgstr "Nowy numer wersji dokumentu"
@@ -15207,16 +15207,16 @@ msgid "The new version number of the procedure"
 msgstr "Nowy numer wersji procedury"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Liczba dni między złożeniem PO u preferowanego dostawcy a przybyciem towaru na dokę; planowanie kompensuje zapotrzebowanie do tyłu o tę ilość."
+msgstr "Liczba dni między złożeniem zamówienia u preferowanego dostawcy a przybyciem towaru; planowanie przesusza zapotrzebowanie wstecz o tę wielkość."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Liczba dni do zbudowania jednej partii tego artykułu, mierzona od zwolnienia zadania do ukończenia; planowanie kompensuje zapotrzebowanie do tyłu o tę ilość."
+msgstr "Liczba dni potrzebnych do zbudowania jednej partii produkcyjnej tego artykułu, mierzona od zwolnienia zlecenia do ukończenia; planowanie przesusza zapotrzebowanie wstecz o tę wielkość."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "Liczba dodatkowych jednostek do zbudowania w celu skompensowania oczekiwanego złomu; planowanie sumuje to z ilością zamówienia przy rezerwacji materiałów."
+msgstr "Liczba dodatkowych sztuk do zbudowania, aby zrekompensować oczekiwane braki; planowanie sumuje to z ilością zamówienia, rezerwując materiały."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "Liczba godzin na tydzień, przez którą wykonawca jest dostępny do pracy."
+msgstr "Liczba godzin tygodniowo, w które pracownik zewnętrzny jest dostępny do pracy."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "Liczba miesięcy, w ciągu których ten składnik aktywów będzie amortyzowany."
@@ -15231,16 +15231,16 @@ msgid "The ordered list of tasks issues using this workflow must complete; the o
 msgstr "Uporządkowana lista zadań, które problemy korzystające z tego przepływu pracy muszą ukończyć; kolejność tutaj to kolejność, w jakiej pojawiają się na problemie."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "Uporządkowana sekwencja operacji, przez którą przechodzi zadanie, skopiowana z listy procesów metody."
+msgstr "Uporządkowana sekwencja operacji, przez którą przechodzi zlecenie produkcyjne, skopiowana z listy operacji metody."
 
 msgid "The original model file is no longer available"
 msgstr "Oryginalny plik modelu nie jest już dostępny"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "Dokument buchowania wychodzącego, który wyjmuje towary z magazynu do klienta, księgując COGS w drodze."
+msgstr "Dokument księgowania wychodzącego, który zabiera towary z zapasu do klienta, księgując COGS w trakcie."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Dostawcy zewnętrzni wykonujący ten proces; każdy otrzymuje wiersz danych wejściowych ceny i czasu realizacji w formularzu procesu dostawcy."
+msgstr "Dostawcy zewnętrzni, którzy wykonują ten proces; każdy otrzymuje wiersz danych o ustalaniu cen i czasach dostaw w formularzu procesu dostawcy."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "Łańcuch parent-child śledzonych jednostek - z czego jednostka została zbudowana i czym się stała."
@@ -15252,16 +15252,16 @@ msgid "The part is taken from existing stock when its parent is built — no new
 msgstr "Część jest pobierana z istniejących zapasów, gdy jego rodzic jest zbudowany - bez nowego zadania lub zamówienia zakupu."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Osoby ze strony Carbon, które będą prowadzić Twoją implementację, i jak się z nimi skontaktować."
+msgstr "Pracownicy po stronie Carbon, którzy będą prowadzić Twoje wdrożenie, oraz jak ich osiągnąć."
 
 msgid "The people on your team and their access to Carbon"
-msgstr "Osoby w Twojej drużynie i ich dostęp do Carbon"
+msgstr "Pracownicy w Twoim zespole i ich dostęp do Carbon"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
 msgstr "Licznik dedykowany każdej firmie, stanowiący podstawę czytelnego numeru typu dokumentu, łączący prefiks, zerami uzupełnioną następną wartość i sufiks, zwiększający się przy każdym utworzeniu dokumentu."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "Wynik na każdą pozycję zarejestrowany na zagrożonym materiale niezgodności — Oczekujące, Zwrot do dostawcy, Przeróbka, Złom lub Użyj tak, jak jest — ustalany dla każdej zagrożonej partii lub numeru seryjnego indywidualnie."
+msgstr "Wynik dla każdego artykułu zarejestrowany na dotknięte materiale niezgodności — Oczekujące, Zwrot do Dostawcy, Poprawka, Braki lub Użyj Jak Jest — ustalony niezależnie dla każdej dotknięte partii lub numeru seryjnego."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
 msgstr "Procent rabatu gotówkowego. Użyj 0, aby nie udzielać rabatu."
@@ -15273,37 +15273,37 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Fabryki, magazyny i obiekty, w których znajduje się Twoja praca i zapasy"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "Wstępnie ustawiony pakiet zadań i wymagań zatwierdzenia zastosowanych do tego problemu; zastępuje domyślny przepływ pracy typu problemu po ustawieniu."
+msgstr "Wstępnie ustawiony pakiet zadań i wymagań zatwierdzenia stosowany do tego problemu; zastępuje domyślny przepływ pracy typu problemu, jeśli jest ustawiony."
 
 msgid "The principle:"
 msgstr "Zasada:"
 
 msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
-msgstr "Ocena prawdopodobieństwa zdarzenia ryzyka (1 = rzadkie do 5 = prawie pewne); sparowana z Ważnością w celu obliczenia wyniku ryzyka."
+msgstr "Ocena prawdopodobieństwa, że ryzyko się materializuje (1 = rzadko do 5 = prawie na pewno); połączona z Wagą do obliczenia wyniku ryzyka."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "Procedura, którą technicycy stosują podczas wykonywania tej konserwacji; zastąpienie jej po wygenerowaniu harmonogramów wpływa tylko na przyszłe instancje."
+msgstr "Procedura, którą technicy stosują podczas wykonywania tego utrzymania ruchu; zastąpienie jej po już wygenerowanych harmonogramach dotyczy tylko przyszłych instancji."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Procesy, które to centrum pracy może uruchamiać; pojawia się w selectorach procesów podczas planowania operacji i ogranicza, które zadania mogą trasować przez to centrum pracy."
+msgstr "Procesy, które to stanowisko robocze może wykonywać; pojawia się w selektor procesów podczas planowania operacji i ogranicza, które zlecenia mogą przechodzić przez to stanowisko robocze."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "Dostawca nie oferuje celów wymiarów. Najpierw włącz funkcję u dostawcy (np. kategorie śledzenia, śledzenie klasy lub pola)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "Punkty przerwania ilości, po które ta linia jest wyceniana; każda kolumna ma swoją własną cenę za jednostkę do negocjacji kupujący-dostawca i konwersji do dokumentów poniżej."
+msgstr "Punkty graniczne ilości, przy których ta pozycja jest wyceniona; każda kolumna nosi własną cenę za sztukę do negocjacji kupiec–dostawca i do konwersji na dokumenty następujące."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "Ilość przedmiotu do ponownego zamówienia w ramach uzupełniania opartego na skanowaniu."
 
 msgid "The quantity range over which this rule applies; orders outside the range fall through to the next rule."
-msgstr "Zakres ilości, do którego stosuje się ta zasada; zamówienia spoza zakresu przechodzą do następnej zasady."
+msgstr "Zakres ilości, w ramach którego obowiązuje ta reguła; zamówienia spoza zakresu przechodzą do następnej reguły."
 
 msgid "The quote has been created"
 msgstr "Oferta została utworzona"
 
 msgid "The quote will be copied with a revision suffix"
-msgstr "Oferta zostanie skopiowana z sufiksem wersji"
+msgstr "Oferta zostanie skopiowana z przyrostkiem rewizji"
 
 msgid "The raw stock and material master you buy and consume"
 msgstr "Surowy materiał i główny katalog materiałów, które kupujesz i zużywasz"
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "Rekord wskazywany przez powiadomienie przepływu pracy, nazwany jako identyfikator plus jego rodzaj; pozostaw puste, a powiadomienie będzie odsyłać do samego uruchomienia przepływu pracy."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "Rekord stosujący płatność lub notatkę do faktury, zawierający zastosowane, zdyskontowane i umorzane kwoty."
+msgstr "Rekord stosujący płatność lub notatkę do faktury, noszący zastosowane, rabat i kwoty spisania."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "Zanotowana genealogia śledzonych jednostek - które wejścia zostały zużyte do wyprodukowania których wyjść, od paragonu do wysyłki."
@@ -15329,18 +15329,18 @@ msgstr "Dane referencyjne, na których opiera się wszystko inne. Ładuje się j
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will be expected again and counted as incoming supply."
-msgstr "Pozostała {0} {1} będzie oczekiwana ponownie i policzona jako dostarczane zapasy."
+msgstr "Pozostałe {0} {1} będą oczekiwane ponownie i liczone jako pokrycie przychodzące."
 
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "Pozostała {0} {1} nie będzie już oczekiwana. Dostawy zamówione i MRP przestaną ją liczyć. Ilość zamówiona i ceny pozostają niezmienione."
+msgstr "Pozostałe {0} {1} nie będą już oczekiwane. Pokrycie na zamówienie i MRP przestaną je liczyć. Zamówiona ilość i wycena pozostają niezmienione."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "Treść żądania wysłana dosłownie z typem zawartości JSON po zastąpieniu zmiennych przepływu pracy w jego wnętrzu, na metodach, które ją zawierają."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "Pozostałe WIP, które zadanie pozostawiło przy zamknięciu, zamiecione na konto wariancji produkcji - jedyna wariancja, którą Carbon rejestruje dla zadania."
+msgstr "Rezydualna produkcja w toku, którą zlecenie ma przy zamknięciu, przenoszona na konto Odchylenia Produkcji — jedyne odchylenie, które Carbon księguje dla zlecenia."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "W odpowiedzi z Onshape brakowało wymaganych parametrów. Spróbuj połączyć się ponownie."
@@ -15349,13 +15349,13 @@ msgid "The result will not appear on the Runs page."
 msgstr "Wynik nie pojawi się na stronie Uruchomienia."
 
 msgid "The revision number of the part"
-msgstr "Numer wersji części"
+msgstr "Numer rewizji części"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "Linia zamówienia sprzedaży, dla której to zadanie zostało utworzone, powiązując zadanie z popytem klienta stojącym za nim."
+msgstr "Pozycja zamówienia sprzedaży, do której to zlecenie zostało utworzone, wiążące zlecenie z zapotrzebowaniem klienta stojącym za tym."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "Harmonogram używany do rozłożenia kosztu tego zasobu na jego okres użytkowania (linia prosta, malejący bilans, jednostki produkcji)."
+msgstr "Harmonogram używany do rozłożenia kosztu tego zasobu na jego okres użytkowania (liniowy, metoda degresywna, jednostki produkcji)."
 
 msgid "The shelves and bins where stock physically sits"
 msgstr "Półki i pojemniki, gdzie fizycznie znajduje się zapas"
@@ -15370,7 +15370,7 @@ msgid "The size of the part"
 msgstr "Rozmiar części"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Umiejętności i zdolności, które śledzisz dla swojego zespołu"
+msgstr "Umiejętności i zdolności, które śledzisz dla swoich pracowników"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "Najmniejsza ilość, którą ten dostawca zaakceptuje na linii PO dla tej części; planowanie zaokrągla się do niej."
@@ -15382,25 +15382,25 @@ msgid "The specific contact on the selected supplier who will own this portal ac
 msgstr "Specificzny kontakt na wybranym dostawcy, który będzie właścicielem tego konta portalu; jego e-mail staje się identyfikatorem logowania."
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "Konkretna operacja na zadaniu powyżej, którą ta linia PO kupuje; tylko operacje oznaczone jako przetwarzanie zewnętrzne są wybierane."
+msgstr "Konkretna operacja na zleceniu wyżej, którą ta pozycja zamówienia zakupu kupuje; tylko operacje oznaczone przerobem zewnętrznym można wybrać."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
 msgstr "Konkretne PO, zwrot lub transfer, na które ten rachunek jest księgowany; dostępne identyfikatory zależą od powyższego typu dokumentu źródłowego."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "Konkretne SO, transfer lub RMA, na które ta przesyłka jest księgowana; dostępne identyfikatory zależą od powyższego typu dokumentu źródłowego."
+msgstr "Konkretne zamówienie sprzedaży, przesunięcie, lub RMA, do którego ta wysyłka się księguje; dostępne ID zależy od typu dokumentu źródłowego powyżej."
 
 msgid "The standard dimensions your materials are stocked in"
 msgstr "Standardowe wymiary, w których materiały są magazynowane"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "Standardowy czynnik (godziny, minuty, części) operacje na tym centrum pracy są mierzone domyślnie; override na operację wygrywają po ustawieniu."
+msgstr "Standardowy czynnik (godziny, minuty, sztuki), w którym operacje na tym stanowisku roboczym są mierzone domyślnie; nadpisania dla operacji wygrywają, gdy są ustawione."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
 msgstr "Standardowy czynnik używany do pomiaru tego procesu - godziny, minuty, części, stopy kwadratowe - gdy jego operacje są szacowane i wyceniane."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "Stan tej linii cotacji - Projekt, Brak Oferty, Ukończone; Brak Oferty ujawnia pole Przyczyny i wyklucza linię z sumy oferty."
+msgstr "Stan tej pozycji oferty — Wersja robocza, Odmowa oferty, Zakończone; Odmowa oferty ujawnia pole Powód i wyklucza pozycję z sumy oferty."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Grupa sprawozdań, którą będą używać wszystkie konta w tej grupie."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "Ustawienia kroku — to uruchomienie pochodzi sprzed rejestracji wartości, które zastosowało."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Rozmiary zapasów, w których ten materiał jest kupowany i przechowywany; każdy rozmiar staje się oddzielnym wariantem możliwym do wyboru w zadaniach i PO."
+msgstr "Rozmiary zapasów, w których ten materiał jest kupowany i przechowywany; każdy rozmiar staje się oddzielnym wariantem do wyboru na zleceniach i zamówieniach."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "Pojemnik magazynowy, z którego ta linia pobiera; jeśli puste, pobieranie używa domyślnej jednostki magazynowej artykułu."
+msgstr "Pojemnik magazynowy, z którego ta pozycja pobiera; jeśli puste, kompletacja używa domyślnej jednostki magazynowej artykułu."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "Usługa magazynowania nie odpowiedziała w czasie. Spróbuj ponownie."
@@ -15427,19 +15427,19 @@ msgid "The supplier record this portal account links to; only contacts already o
 msgstr "Rekord dostawcy, do którego jest powiązane to konto portalu; tylko kontakty już na tym dostawcy mogą być wybrane jako posiadacz konta poniżej."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "Numer oferty/propozycji dostawcy; zarejestrowany pod kątem możliwości śledzenia na PO konwertowanym z tego wyceny."
+msgstr "Numer oferty lub propozycji dostawcy; rejestrowany dla identyfikowalności w zamówieniu zakupu, które konwertuje się z tej oferty."
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "Własna referencja dostawcy dla tego zamówienia (jego numer SO w jego systemie); zarejestrowana dla audytu i wyświetlana na paragonie."
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "Numer karty pakunkowej lub wysyłkowej dostawcy, zarejestrowany dla audytu; nie jest używany przez żadną logikę bookingu."
+msgstr "Numer dokumentu dostawy lub wysyłki dostawcy, rejestrowany dla audytu; nie jest używany przez logikę księgowania."
 
 msgid "The suppliers and vendors you buy from"
 msgstr "Dostawcy i sprzedawcy, od których kupujesz"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Dostawcy otrzymujący ten RFQ; każdy otrzymuje własną linię na RFQ, na którą odpowiadają z własną ceną."
+msgstr "Dostawcy otrzymujący to RFQ; każdy otrzymuje swoją pozycję w RFQ, na którą odpowiadają z własną ceną."
 
 msgid "The surface finishes available on your materials"
 msgstr "Dostępne wykończenia powierzchni Twoich materiałów"
@@ -15457,22 +15457,22 @@ msgid "The timer starts manually"
 msgstr "Timer uruchamia się ręcznie"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Narzędzia i urządzenia, na których opierają się Twoje operacje"
+msgstr "Narzędzia i przyrządy obróbkowe, na które opierają się twoje operacje"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Łączna ilość do wytworzenia na wszystkich zadaniach utworzonych w tej masowej partii; połączone z Ilością na Pracę, aby zdecydować, ile prac utworzyć."
+msgstr "Całkowita ilość do wyprodukowania we wszystkich zleceniach produkcyjnych utworzonych w tej partii produkcyjnej; połączone z Ilością na Zlecenie, aby określić ile zleceń produkcyjnych stworzyć."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "Śledzalna referencja (np. standard NIST, numer seryjny miernika wzorcowego), względem której porównywane były wartości kalibracji."
+msgstr "Odniesienie śledowalne (np. norma NIST, numer seryjny przyrządu wzorcowego), do którego porównywane były wartości wzorcowania."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "Dokument zawiera listę każdego elementu zestawienia materiałowego z jego ilością."
+msgstr "Przewodnik zawiera listę każdego artykułu z listy materiałowej wraz z jego ilością."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "Typ kontroluje jakie domyślne uprawnienia otrzymuje nowy pracownik; wybranie go tutaj wstępnie wypełnia macierz uprawnień z szablonu typu."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Typowa liczba dni między wysłaniem pracy do tego dostawcy dla tego procesu a otrzymaniem jej z powrotem; planowanie kompensuje zapotrzebowanie o tę kwotę przy wyborze dostawcy."
+msgstr "Typowa liczba dni między wysłaniem pracy do tego dostawcy na ten proces a jej odbiorem; przesunięcie planistyczne przesyła zapotrzebowanie wstecz o tę ilość dni przy wyborze dostawcy."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "Unikalny identyfikator na tej jednostce fizycznej; jeden wiersz na numer seryjny, ilość to zawsze 1."
@@ -15484,7 +15484,7 @@ msgid "The unit price of the item at the time of the purchase"
 msgstr "Cena jednostkowa towaru w momencie zakupu"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
-msgstr "Jednostka, w której dostawcy ustalają cenę i wysyłają ten artykuł, gdy różni się od jednostki inwentarzowej (np. pudełko vs. każdy); sparowana z Czynnikiem Konwersji."
+msgstr "Jednostka, w której dostawcy wyceniają i wysyłają ten artykuł, gdy różni się od jednostki zapasów (np. kartony vs sztuki); połączone ze Współczynnikiem przeliczeniowym."
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each)."
 msgstr "Jednostka, w której dostawcy ustalają cenę i wysyłają ten artykuł, gdy różni się od jednostki inwentarzowej (np. pudełko vs. każdy)."
@@ -15505,10 +15505,10 @@ msgid "The version of the new procedure"
 msgstr "Wersja nowej procedury"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "Stempel wersji dla tego dokumentu; nowe wersje tworzą kopię, która zastępuje poprzednią bez jej usuwania."
+msgstr "Znacznik wersji dla tego dokumentu; nowe wersje tworzą kopię, która zastępuje poprzednią bez jej usuwania."
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "Stempel wersji dla tej procedury; nowe wersje tworzą kopię, która zastępuje poprzednią bez jej usuwania."
+msgstr "Znacznik wersji dla tej procedury; nowe wersje tworzą kopię, która zastępuje poprzednią bez jej usuwania."
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
 msgstr "Magazyn, z którego towary z tego zamówienia będą wysłane; lokalizacja wysyłki klienta to miejsce, w którym dotrą."
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "Magazyn, z którego towary z tego wyceny będą wysłane; lokalizacja wysyłki klienta to miejsce, w którym dotrą."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "Sposoby, w jakie urządzenia ulegają awarii, do śledzenia konserwacji i jakości"
+msgstr "Sposoby, w jakie urządzenie się psuje, do śledzenia utrzymania ruchu i jakości"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Własny pojemnik centrum pracy, w którym pobrany materiał jest przygotowywany do rozliczenia w produkcji, w przeciwieństwie do jego źródłowej półki magazynowej."
+msgstr "Własny pojemnik stanowiska roboczego, gdzie umieszczany jest pobrany materiał, aby produkcja mogła go pobierać, w przeciwieństwie do jego półki magazynowej."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Godziny pracy i kalendarze, które napędzają planowanie"
@@ -15544,10 +15544,10 @@ msgid "There's nothing outstanding to apply these credits to."
 msgstr "Nie ma nic do wyrównania, do czego można by zastosować te kredyty."
 
 msgid "These custom fields will only be available for entities with the same tags"
-msgstr "Te niestandardowe pola będą dostępne tylko dla jednostek z tymi samymi tagami"
+msgstr "Te pola niestandardowe będą dostępne tylko dla encji z tymi samymi tagami"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Te dokumenty nie zostały opublikowane w księdze głównej, więc ich kwoty brakują w tym okresie. Opublikuj lub unieważnij każdy — niezdatowany dokument otrzymuje datę dnia opublikowania po opublikowaniu."
+msgstr "Te dokumenty nie zostały zaksięgowane w księdze głównej, dlatego ich kwoty brakują w tym okresie. Zaksięguj lub unieważnij każdy z nich — dokument bez daty otrzyma datę zaksięgowania, gdy zostanie zaksięgowany."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "Te adresy e-mail będą automatycznie dodawane w polu DW do wszystkich wiadomości e-mail wysyłanych do dostawców (oferty, zamówienia zakupu itp.)."
@@ -15559,25 +15559,25 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Te elementy mają jeszcze materiał do pobrania. Zakończenie teraz oznaczy listę jako Częściowa."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Te zadania mają operacje przypisane do tego centrum pracy:"
+msgstr "Te zlecenia produkcyjne mają operacje przypisane do tego stanowiska roboczego:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Te wpisy dziennika są wciąż w wersji roboczej, więc ich obciążenia i kredyty nie znajdują się w księdze w tym okresie. Opublikuj każdy lub przedatuj go na późniejszy otwarty okres."
+msgstr "Te dowody księgowe są wciąż w wersji roboczej, dlatego ich wpisy Winien i Ma nie znajdują się w księdze dla tego okresu. Zaksięguj każdy z nich lub przesyć go do późniejszego otwartego okresu."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "Ta instancja Carbon nie ma danych uwierzytelniających OAuth Onshape. Poproś administratora o ich ustawienie."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "Ta notacja zmiany jest wdrażana, więc jej zmiany są zablokowane. Otwórz ją ponownie, aby edytować."
+msgstr "To zawiadomienie o zmianie jest wdrażane, więc jego zmiany są zablokowane. Otwórz je ponownie, aby edytować."
 
 msgid "This change notice is closed, so its changes are read-only."
-msgstr "Ta notacja zmiany jest zamknięta, więc jej zmiany są tylko do odczytu."
+msgstr "To zawiadomienie o zmianie jest zamknięte, dlatego jego zmiany są tylko do odczytu."
 
 msgid "This completes the Discovery step."
 msgstr "To uzupełnia krok Discovery."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Ten kontakt nie ma adresu e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Ta strona nie ma żadnych zaległości — płatność zostanie zarejestrowana na koncie."
@@ -15589,7 +15589,7 @@ msgid "This file is no longer available, or you don't have permission to downloa
 msgstr "Ten plik nie jest już dostępny lub nie masz uprawnień do jego pobrania."
 
 msgid "This Fiscal Year"
-msgstr "Ten rok obrachunkowy"
+msgstr "Ten rok obrotowy"
 
 msgid "This information will be used on document headers"
 msgstr "Te informacje będą używane w nagłówkach dokumentów"
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Te informacje będą widoczne dla wszystkich użytkowników, więc uważaj na to, co udostępniasz."
 
 msgid "this inspection plan"
-msgstr "ten plan inspekcji"
+msgstr "ten plan kontroli"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
 msgstr "To zaproszenie do dołączenia do {0} wygasło. Możesz poprosić o wysłanie nowego zaproszenia na Twoją wiadomość e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Ta faktura nie ma użytecznego terminu — wybierz jeden dla Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Ta faktura będzie wystawiona klientowi Stripe już powiązanemu z tym klientem Carbon. Aby zmienić jego szczegóły, edytuj go na pulpicie Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "To jest kontrolowane środowisko, dlatego wymagana jest aplikacja authenticator."
@@ -15629,7 +15629,7 @@ msgid "This is taking longer than expected. It may still finish — if it doesn'
 msgstr "To trwa dłużej niż oczekiwano. Może się nadal zakończyć — jeśli nie, ponów przywracanie, aby przywrócić swoje dane."
 
 msgid "This is the month your fiscal year starts."
-msgstr "To jest miesiąc, w którym rozpoczyna się Twój rok obrachunkowy."
+msgstr "To jest miesiąc, w którym zaczyna się twój rok obrotowy."
 
 msgid "This is the month your tax year starts."
 msgstr "To jest miesiąc, w którym rozpoczyna się Twój rok podatkowy."
@@ -15638,16 +15638,16 @@ msgid "this item"
 msgstr "ten element"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Ten artykuł jest zbudowany za pośrednictwem konfiguratora i rozwiązuje jego komponenty na zamówienie; zadania dla niego dziedziczą rozwiązaną BOM konfiguratora."
+msgstr "Ten artykuł jest budowany za pośrednictwem konfiguratora i rozwiązuje jego komponenty na zamówienie; zlecenia produkcyjne utworzone dla niego dziedziczą rozwiązaną listę materiałową konfiguratora."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "Rachunek materiałów tego artykułu nie ma wejść z włączoną polityką przechowywania, dlatego żaden termin ważności nie będzie obliczony z rachunku materiałów."
+msgstr "Lista materiałowa tego artykułu nie zawiera wejść z włączonym terminem trwałości, dlatego nie będzie obliczany termin ważności na podstawie listy materiałowej."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "To zadanie zostanie przyjęte do magazynu. Nie będzie już dostępne na hali produkcyjnej."
+msgstr "To zlecenie produkcyjne będzie przyjęte do zapasów. Nie będzie już dostępne na hali produkcyjnej."
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "Ta praca nie będzie już dostępna na hali produkcyjnej."
+msgstr "To zlecenie produkcyjne nie będzie już dostępne na hali produkcyjnej."
 
 msgid "This job's own required quantity for the material."
 msgstr "Własna wymagana ilość materiału dla tego zadania."
@@ -15665,13 +15665,13 @@ msgid "This Month"
 msgstr "Ten miesiąc"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "Ta strona Twojego Implementation Hub jest w trakcie budowy. Zacznij od centrum poleceń, podczas gdy ją dokańczamy."
+msgstr "Ta strona twojego centrum wdrażania jest budowana. Zacznij od centrum dowodzenia, podczas gdy go dokańczamy."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "Ta część ma {quantityOnHand} na stanie w tej lokalizacji. Brak zapasów oznacza, że nie będzie ani planowana, ani zużywana."
 
 msgid "This part is activated when change notice {activationLockId} is released."
-msgstr "Ta część zostanie aktywowana po wydaniu zgłoszenia zmian {activationLockId}."
+msgstr "Ta część jest aktywowana, gdy zawiadomienie o zmianie {activationLockId} zostanie zwolnione."
 
 msgid "This part is being phased out."
 msgstr "Ta część jest wycofywana."
@@ -15680,13 +15680,13 @@ msgid "This part is obsolete (No Stock)."
 msgstr "Ta część jest przestarzała (Brak zapasu)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "Ta część jest zastąpiona i ustawiona na Stock Only — jest uzupełniana do poziomu rezerwy części zamiennych, niezależnie od popytu."
+msgstr "Ta część jest zastępowana i ustawiona na Tylko zapas — jest uzupełniana do poziomu rezerwy części zamiennych, niezależnie od zapotrzebowania."
 
 msgid "This path only decides what runs next"
 msgstr "Ta ścieżka decyduje tylko o tym, co uruchomi się dalej"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "Ten okres nie ma żadnych wpisów w dzienniku i może być trwale usunięty. Tej operacji nie można cofnąć."
+msgstr "Ten okres nie ma zaksięgowanych dowodów księgowych i może być trwale usunięty. Nie można tego cofnąć."
 
 msgid "this purchase order"
 msgstr "to zamówienie zakupu"
@@ -15695,13 +15695,13 @@ msgid "This Quarter"
 msgstr "Ten Kwartał"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "To usuwa ich aplikację authenticator, więc ich następne logowanie wymaga tylko magicznego linku. Użyj tego, gdy stracili dostęp do ich authenticatora. To wpływa na ich logowanie dla każdej firmy, do której należą."
+msgstr "To usuwa ich aplikację uwierzytelniającą, więc ich następny login potrzebuje tylko magicznego linku. Użyj tego, gdy stracili dostęp do swojej aplikacji uwierzytelniającej. To wpływa na ich logowanie dla każdej firmy, do której należą."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "Ta wersja jest wydana (Produkcja). Zmiany powinny normalnie przebiegać przez zgłoszenie zmian."
+msgstr "Ta rewizja jest zwolniona (Produkcja). Zmiany powinny normalnie przechodzić przez zawiadomienie o zmianie."
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "Ta wersja jest wydana (Produkcja). Otwórz zgłoszenie zmian, aby go zmodyfikować."
+msgstr "Ta rewizja jest zwolniona (Produkcja). Otwórz zawiadomienie o zmianie, aby ją zmodyfikować."
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "To uruchomienie ma więcej kroków niż pokazujemy tutaj. Wymienione są tylko pierwsze {MAX_RUN_STEPS}."
@@ -15710,10 +15710,10 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "To faktycznie uruchamia przepływ pracy. Spowoduje utworzenie rekordów, wysłanie powiadomień i wywołanie wszelkich webhooków dokładnie tak jak w uruchomieniu na żywo. Nie można tego cofnąć."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "To zamówienie sprzedaży ma powiązane zadania. Wybierz, co z nimi zrobić."
+msgstr "To zamówienie sprzedaży ma związane zlecenia produkcyjne. Wybierz, co z nimi zrobić."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "To zamówienie sprzedaży zawiera linie, które wymagają utworzenia zadań"
+msgstr "To zamówienie sprzedaży ma pozycje, które wymagają utworzenia zleceń produkcyjnych"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15723,7 +15723,7 @@ msgid "this supplier"
 msgstr "ten dostawca"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
-msgstr "To narzędzie zostanie aktywowane po wydaniu zgłoszenia zmian {activationLockId}."
+msgstr "To narzędzie jest aktywowane, gdy zawiadomienie o zmianie {activationLockId} zostanie zwolnione."
 
 msgid "This updates the theme for all users of the application"
 msgstr "To aktualizuje motyw dla wszystkich użytkowników aplikacji"
@@ -15735,20 +15735,20 @@ msgid "This usually takes a few seconds. You can leave the page — it keeps run
 msgstr "Zazwyczaj trwa to kilka sekund. Możesz opuścić stronę — nadal działa."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
-msgstr "Ta wersja należy do otwartego <0>zmiany powiadomienia</0>. Edytuj tam."
+msgstr "Ta wersja należy do otwartego <0>zawiadomienia o zmianie</0>. Edytuj tam."
 
 #. placeholder {0}: lock.readableId
 msgid "This version belongs to change notice <0>{0}</0>. Edit it there."
-msgstr "Ta wersja należy do zmiany powiadomienia <0>{0}</0>. Edytuj tam."
+msgstr "Ta wersja należy do zawiadomienia o zmianie <0>{0}</0>. Edytuj tam."
 
 msgid "This version cannot be opened"
 msgstr "Ta wersja nie może być otwarta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Ta wersja jest opublikowana"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Ta wersja jest opublikowana. Utwórz nową wersję, aby edytować."
 
 msgid "This version's definition could not be read."
 msgstr "Definicję tej wersji nie można było odczytać."
@@ -15771,22 +15771,22 @@ msgstr "To spowoduje przeliczenie kosztu jednostkowego na podstawie aktywnej met
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "To spowoduje usunięcie powiązania {0} z {1}. Zadanie nie będzie już wyświetlane w zamówieniu sprzedaży i wysyłki go nie znajdą."
+msgstr "To usunie powiązanie {0} z {1}. Zlecenie produkcyjne nie będzie już widoczne w zamówieniu sprzedaży i wysyłki go nie znajdą."
 
 msgid "This will replace all method materials of other revisions with this revision."
-msgstr "To zastąpi wszystkie materiały metody innych wersji tą wersją."
+msgstr "Spowoduje to zastąpienie wszystkich materiałów metody innych rewizji tą rewizją."
 
 msgid "This will replace all method materials of other sizes with this size."
 msgstr "To zastąpi wszystkie materiały metody innych rozmiarów tym rozmiarem."
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "Ustawi to bieżącą wersję metody wytwarzania na Aktywną, czyniąc ją tylko do odczytu."
+msgstr "Spowoduje to ustawienie bieżącej wersji metody produkcji na Aktywny, czyniąc ją tylko do odczytu."
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "Spowoduje to wpisanie pozostałej wartości netto w księgach zasobu."
 
 msgid "Three-way match"
-msgstr "Pojednanie trójstronnie"
+msgstr "Uzgodnienie trójstronne"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15814,7 +15814,7 @@ msgid "Thursday"
 msgstr "Czwartek"
 
 msgid "Tie shipments through to an invoice with no re-keying"
-msgstr "Powiąż przesyłki z fakturą bez ponownego wprowadzania danych"
+msgstr "Powiąż wysyłki z fakturą bez ponownego wpisywania danych"
 
 msgid "Tie-out"
 msgstr "Wyrównanie"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Uzgodnienie niedostępne"
 
 msgid "Tightened"
-msgstr "Ścisły"
+msgstr "Obostrzona"
 
 msgid "Time of day"
 msgstr "Pora dnia"
@@ -15862,13 +15862,13 @@ msgid "To reactivate, use the row menu and choose Send Invite. The employee beco
 msgstr "Aby ponownie aktywować, użyj menu wiersza i wybierz Wyślij zaproszenie. Pracownik staje się aktywny po zaakceptowaniu."
 
 msgid "To Receive"
-msgstr "Do Odebrania"
+msgstr "Do przyjęcia"
 
 msgid "To Ship"
-msgstr "Do wysłania"
+msgstr "Do wysyłki"
 
 msgid "To Ship and Receive"
-msgstr "Do wysłania i odebrania"
+msgstr "Do wysyłki i przyjęcia"
 
 msgid "To Storage Unit"
 msgstr "Do jednostki magazynowej"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "Przełącz"
 
 msgid "Toggle Assignee"
-msgstr "Przełącz przypisanego"
+msgstr "Przełącz osobę przypisaną"
 
 msgid "Toggle break active"
 msgstr "Przełącz aktywność podziału"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Narzędzia"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Klasyfikacja najwyższego poziomu (aktywa/pasywa/kapitał własny/przychody/wydatki); ustawiana tylko na grupach głównych, dziedziczona przez elementy podrzędne."
+msgstr "Klasyfikacja najwyższego poziomu (aktywa / pasywa / kapitał własny / przychody ze sprzedaży / wydatek) — ustawiana tylko na grupach głównych, dziedziczona przez podgrupy."
 
 msgid "Topic"
 msgstr "Temat"
@@ -15979,10 +15979,10 @@ msgid "Total quantity on hand for the item across all storage units at this loca
 msgstr "Łączna ilość dostępna dla pozycji we wszystkich jednostkach magazynowych w tej lokalizacji. Staje się czerwona, gdy stan plus przychodzące nie pokrywają całkowitego zapotrzebowania."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Łączna ilość wymagana we wszystkich aktywnych zadaniach i zamówieniach sprzedaży w tej lokalizacji — nie tylko w tym zadaniu."
+msgstr "Całkowita ilość wymagana we wszystkich trwających zleceniach produkcyjnych i zamówieniach sprzedaży w tej lokalizacji — nie tylko w tym zleceniu produkcyjnym."
 
 msgid "Total scrap quantity"
-msgstr "Całkowita ilość odpadów"
+msgstr "Całkowita ilość braków"
 
 msgid "Total tax"
 msgstr "Podatek całkowity"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "Wartość całkowita"
 
 msgid "Total Variance"
-msgstr "Wariancja całkowita"
+msgstr "Całkowite odchylenie"
 
 msgid "Total:"
 msgstr "Razem:"
@@ -16000,7 +16000,7 @@ msgid "Totals"
 msgstr "Razem"
 
 msgid "Traceability"
-msgstr "Możliwość śledzenia"
+msgstr "Identyfikowalność"
 
 msgid "Track"
 msgstr "Śledź"
@@ -16027,7 +16027,7 @@ msgid "Track tax depreciation separately from book depreciation and automaticall
 msgstr "Śledź amortyzację podatkową oddzielnie od amortyzacji księgowej i automatycznie księguj wpisy dotyczące odroczonych zobowiązań podatkowych."
 
 msgid "Track transactions by segment (cost center, project, service line)"
-msgstr "Śledź transakcje według segmentu (centrum kosztów, projekt, linia usług)"
+msgstr "Śledzenie transakcji wg segmentu (miejsce powstawania kosztów, projekt, linia usług)"
 
 msgid "Track when batches or serials of this item expire."
 msgstr "Śledź, kiedy partie lub numery seryjne tego artykułu wygasają."
@@ -16036,7 +16036,7 @@ msgid "Tracked Entities"
 msgstr "Śledzone jednostki"
 
 msgid "Tracked entity"
-msgstr "Śledzony element"
+msgstr "Jednostka śledzona"
 
 msgid "Tracked Entity"
 msgstr "Jednostka śledzona"
@@ -16045,7 +16045,7 @@ msgid "Tracked entity ID is required but none was found"
 msgstr "Identyfikator śledzonej jednostki jest wymagany, ale nie znaleziono żadnego"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "Śledzony materiał jest wstępnie wybrany według kolejności pobrania (FEFO), nawet bez listy pobrania."
+msgstr "Materiał śledzony jest wstępnie wybierany według kolejności poboru (FEFO), nawet bez listy kompletacyjnej."
 
 msgid "Tracking"
 msgstr "Śledzenie"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "Szkolenia"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "Transakcje będą tworzyć wpisy w dzienniku i aktualizować księgę główną."
+msgstr "Transakcje będą tworzyć wpisy księgowe i aktualizować księgę główną."
 
 msgid "Transfer"
 msgstr "Przesyłka"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "ID Transferu"
 
 msgid "Transfer Lines"
-msgstr "Linie Transferu"
+msgstr "Pozycje przesunięcia"
 
 msgid "Transfer Ownership"
 msgstr "Przenieś Własność"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "Kosz"
 
 msgid "Trial Balance"
-msgstr "Bilans Próbny"
+msgstr "Bilans próbny"
 
 msgid "Trigger"
 msgstr "Wyzwalacz"
@@ -16219,13 +16219,13 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Niezliczone linie pozostają niezmienione podczas wysyłki — nie są zerowane."
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "W Systemie Reorderów Opartych na Popycie planowanie sumuje popyt w tym oknie przesuwnym podczas obliczania ilości uzupełnienia."
+msgstr "W zamawianiu na podstawie zapotrzebowania planowanie sumuje zapotrzebowanie w ramach tego okna przesuwającego się w celu obliczenia ilości uzupełnienia zapasu."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "W polityce Stałej Ilości Zamówienia system planuje dokładną ilość za każdym razem, gdy zostanie osiągnięty punkt zamawiania."
+msgstr "W ramach stałej ilości zamawiania planowanie zamawia dokładnie tę ilość każdorazowo, gdy punkt zamawiania jest osiągnięty."
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "W polityce Maksymalnej Ilości system planuje do tego poziomu zapasu w dniu aktywacji punktu zamawiania."
+msgstr "W ramach polityki maksymalnej ilości planowanie zamawia do tego poziomu dostępności zapasu, gdy punkt zamawiania jest osiągnięty."
 
 msgid "Undo"
 msgstr "Cofnij"
@@ -16279,7 +16279,7 @@ msgid "Units of measure"
 msgstr "Jednostki miary"
 
 msgid "Units reported as unrecoverable at an operation, with a reason — the alternative to rework."
-msgstr "Jednostki zgłaszane jako niemożliwe do odzyskania w operacji, z przyczyną — alternatywa dla pracy powtórnej."
+msgstr "Sztuki zgłoszone jako nie do odzyskania na operacji, z podaniem przyczyny — alternatywa dla poprawki."
 
 msgid "Unknown"
 msgstr "Nieznany"
@@ -16291,10 +16291,10 @@ msgid "unknown location"
 msgstr "nieznana lokalizacja"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Nieograniczone wsparcie funkcjonalne"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Nieograniczone rekordy"
 
 msgid "Unlink"
 msgstr "Odłącz"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Nieopublikowane dokumenty"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Cofnij publikację"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Cofnąć publikację {name}?"
 
 msgid "Unreceived POs"
 msgstr "Nieprzyjęte zamówienia"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "Linia bez tytułu"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "Nieużywany pobrany materiał odprowadzony z powrotem od stanowiska pracy do magazynu."
+msgstr "Materiał pobrany, ale nieużywany, zwracany ze stanowiska roboczego do magazynu."
 
 msgid "UoM"
 msgstr "UoM"
@@ -16478,7 +16478,7 @@ msgid "Upgrade to unlock audit history"
 msgstr "Uaktualnij, aby odblokować historię audytu"
 
 msgid "Upload"
-msgstr "Prześlij"
+msgstr "Prześlij plik"
 
 msgid "Upload a PDF first"
 msgstr "Najpierw prześlij plik PDF"
@@ -16487,10 +16487,10 @@ msgid "Upload completed but no file path returned"
 msgstr "Przesyłanie zakończone, ale ścieżka pliku nie została zwrócona"
 
 msgid "Upload CSV"
-msgstr "Prześlij CSV"
+msgstr "Prześlij plik CSV"
 
 msgid "Upload failed. Please try again."
-msgstr "Przesyłanie nie powiodło się. Spróbuj ponownie."
+msgstr "Przesłanie pliku nie powiodło się. Spróbuj ponownie."
 
 msgid "Uploaded model"
 msgstr "Model przesłany"
@@ -16516,7 +16516,7 @@ msgid "Uploading…"
 msgstr "Przesyłanie…"
 
 msgid "Upon clicking Convert, parts will be created with the following internal part numbers:"
-msgstr "Po kliknięciu przycisku Konwertuj, części zostaną utworzone z następującymi numerami części wewnętrznych:"
+msgstr "Po kliknięciu Przekształć części zostaną utworzone z następującymi wewnętrznymi numerami części:"
 
 msgid "URL"
 msgstr "URL"
@@ -16528,7 +16528,7 @@ msgid "Usage/Day (90d)"
 msgstr "Użycie/dzień (90d)"
 
 msgid "Use ... to get the next consumable ID"
-msgstr "Użyj ... aby uzyskać następny identyfikator konsumpcji"
+msgstr "Użyj ... aby uzyskać następny ID materiału eksploatacyjnego"
 
 msgid "Use ... to get the next material ID"
 msgstr "Użyj ... aby uzyskać następny identyfikator materiału"
@@ -16573,13 +16573,13 @@ msgid "Used when a cell is empty or doesn't match an option above. Clear it to l
 msgstr "Używane, gdy komórka jest pusta lub nie odpowiada żadnej z powyższych opcji. Wyczyść ją, aby pozostawić te wiersze puste."
 
 msgid "Useful Life (default)"
-msgstr "Okres Użyteczności (domyślny)"
+msgstr "Okres użytkowania (domyślnie)"
 
 msgid "Useful Life (months)"
-msgstr "Okres Użyteczności (miesiące)"
+msgstr "Okres użytkowania (miesiące)"
 
 msgid "Useful Life (Months)"
-msgstr "Okres Użyteczności (Miesiące)"
+msgstr "Okres użytkowania (Miesiące)"
 
 msgid "User"
 msgstr "Użytkownik"
@@ -16597,7 +16597,7 @@ msgid "Users and groups allowed to open or download this document; the uploader 
 msgstr "Użytkownicy i grupy uprawnione do otwierania lub pobierania tego dokumentu; osoba przesyłająca jest zawsze uwzględniona."
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "Użytkownicy i grupy uprawnione do zmiany nazwy, zastąpienia lub ponownego oznaczenia tego dokumentu; osoba przesyłająca jest zawsze uwzględniona, a uprawnienie do edycji obejmuje uprawnienie do podglądu."
+msgstr "Użytkownicy i grupy uprawnieni do zmiany nazwy, zamiany lub ponownego etykietowania tego dokumentu; osoba przesyłająca jest zawsze uwzględniana, a dostęp do edycji implikuje dostęp do wyświetlania."
 
 msgid "Users can update this value for themselves"
 msgstr "Użytkownicy mogą aktualizować tę wartość dla siebie"
@@ -16654,31 +16654,31 @@ msgid "Variance"
 msgstr "Odchylenie"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Odchylenie między rzeczywistym i standardowym zużyciem komponentów listy materiałów"
+msgstr "Odchylenie między rzeczywistym a standardowym zużyciem komponentów BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Odchylenie między rzeczywistymi i standardowymi godzinami routingu oraz stawkami"
+msgstr "Odchylenie między rzeczywistymi a standardowymi godzinami i stawkami marszruty"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "Odchylenie między rzeczywistą ceną zakupu a kosztem standardowym"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Odchylenie między zastosowanym a rzeczywistym narzutem produkcyjnym"
+msgstr "Odchylenie między zastosowanymi a rzeczywistymi kosztami pośrednimi produkcji"
 
 msgid "Variance from physical inventory count adjustments"
 msgstr "Odchylenie z korekt liczenia zapasów fizycznych"
 
 msgid "Variance in outside processing costs"
-msgstr "Odchylenie w kosztach przetwarzania zewnętrznego"
+msgstr "Odchylenie kosztów kooperacji"
 
 msgid "Variance only"
-msgstr "Tylko wariancja"
+msgstr "Tylko odchylenie"
 
 msgid "VAT Number"
-msgstr "Numer VAT"
+msgstr "NIP"
 
 msgid "Vendor Write-Off Income"
-msgstr "Dochód ze sprzedaży zobowiązań dostawcy"
+msgstr "Przychody ze spisania od dostawcy"
 
 msgid "Verification Error"
 msgstr "Błąd weryfikacji"
@@ -16703,7 +16703,7 @@ msgstr "Wersja"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Wersja {0} jest teraz opublikowana i zostanie zastąpiona."
 
 msgid "Version:"
 msgstr "Wersja:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Wyświetl"
 
 msgid "View Active Jobs"
-msgstr "Wyświetl aktywne zadania"
+msgstr "Wyświetl aktywne zlecenia produkcyjne"
 
 msgid "View Active Quotes"
 msgstr "Wyświetl aktywne oferty"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Wyświetl zasób"
 
 msgid "View Assigned Jobs"
-msgstr "Wyświetl przypisane zadania"
+msgstr "Wyświetl przypisane zlecenia produkcyjne"
 
 msgid "View Attachment"
 msgstr "Wyświetl załącznik"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Wyświetl Główny Katalog Pozycji"
 
 msgid "View Journal Entry"
-msgstr "Wyświetl wpis w dzienniku"
+msgstr "Wyświetl zapis księgowy"
 
 msgid "View Lists"
 msgstr "Wyświetl listy"
 
 msgid "View maintenance dispatch"
-msgstr "Wyświetl dyspozycję konserwacji"
+msgstr "Wyświetl zlecenie utrzymania ruchu"
 
 msgid "View Memo"
 msgstr "Wyświetl Notatkę"
@@ -16838,7 +16838,7 @@ msgid "View Permissions"
 msgstr "Uprawnienia do wyświetlania"
 
 msgid "View Picking List"
-msgstr "Wyświetl listę pobrań"
+msgstr "Wyświetl listę kompletacyjną"
 
 msgid "View Prints"
 msgstr "Wyświetl wydruki"
@@ -16865,7 +16865,7 @@ msgid "View Scheduled"
 msgstr "Wyświetl zaplanowane"
 
 msgid "View Shipment"
-msgstr "Wyświetl Przesyłkę"
+msgstr "Wyświetl wysyłkę"
 
 msgid "View Status"
 msgstr "Wyświetl status"
@@ -16874,7 +16874,7 @@ msgid "View Stock Transfer"
 msgstr "Wyświetl Transfer Zapasów"
 
 msgid "View Suggestion"
-msgstr "Wyświetl sugestię"
+msgstr "Wyświetl propozycję"
 
 msgid "View Suppliers"
 msgstr "Wyświetl dostawców"
@@ -16886,7 +16886,7 @@ msgid "View tie-out"
 msgstr "Wyświetl wyrównanie"
 
 msgid "View Traceability Graph"
-msgstr "Wyświetl Graf Możliwości Śledzenia"
+msgstr "Wyświetl graf identyfikowalności"
 
 msgid "View Transfer"
 msgstr "Wyświetl Transfer"
@@ -16901,25 +16901,25 @@ msgid "Visible on a user's public profile"
 msgstr "Widoczne w publicznym profilu użytkownika"
 
 msgid "Void"
-msgstr "Anuluj"
+msgstr "Unieważnij"
 
 msgid "Void Invoice"
-msgstr "Anuluj fakturę"
+msgstr "Unieważnij fakturę"
 
 msgid "Void Purchase Invoice"
-msgstr "Anuluj Fakturę Zakupu"
+msgstr "Unieważnij fakturę zakupu"
 
 msgid "Void Receipt"
-msgstr "Anuluj Paragon"
+msgstr "Unieważnij przyjęcie"
 
 msgid "Void Sales Invoice"
-msgstr "Anuluj Fakturę Sprzedaży"
+msgstr "Unieważnij fakturę sprzedaży"
 
 msgid "Void Shipment"
-msgstr "Anuluj Wysyłkę"
+msgstr "Unieważnij wysyłkę"
 
 msgid "Voided"
-msgstr "Anulowano"
+msgstr "Unieważniono"
 
 msgid "Voiding this purchase invoice will:"
 msgstr "Anulowanie tej faktury zakupu spowoduje:"
@@ -16928,10 +16928,10 @@ msgid "Voiding this receipt will:"
 msgstr "Anulowanie tego paragonu spowoduje:"
 
 msgid "Voiding this shipment will:"
-msgstr "Anulowanie tej przesyłki spowoduje:"
+msgstr "Unieważnienie tej wysyłki spowoduje:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Przejdź przez każdy obszar ze swoim liderem i wyłącz wszystko, co jest poza zakresem. Kody czytaj jako Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Przejdź przez każdy obszar ze swoim mistrzem i przełącz wszystko, co jest poza zakresem. Kody czytają Moduł.Obszar.Numer (ACC.GL.01 = Księgowość, Księga główna, pozycja 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Przejdź przez swój obecny proces, systemy i dane"
@@ -16952,13 +16952,13 @@ msgid "Warn"
 msgstr "Ostrzeżenie"
 
 msgid "Warn — edits succeed with a warning"
-msgstr "Ostrzeżenie — edycje powodzą się z ostrzeżeniem"
+msgstr "Ostrzeż — zmiany będą wykonane z ostrzeżeniem"
 
 msgid "Warn but allow"
 msgstr "Ostrzegaj, ale pozwól"
 
 msgid "Warn this many days before expiry"
-msgstr "Ostrzegaj tyle dni przed wygaśnięciem"
+msgstr "Ostrzeż tyle dni przed terminem ważności"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Ostrzegaj, gdy osoba sprawdzająca przychodzący towar jest tą samą osobą, która go odebrała."
@@ -16973,7 +16973,7 @@ msgid "Watch full video"
 msgstr "Obejrzyj pełne wideo"
 
 msgid "We auto-matched each column. Review the values below before continuing."
-msgstr "Automatycznie dopasowaliśmy każdą kolumnę. Przejrzyj wartości poniżej przed kontynuowaniem."
+msgstr "Automatycznie dopasowaliśmy każdą kolumnę. Przejrzyj wartości poniżej przed kontynuacją."
 
 msgid "We triage and fix issues fast while your team settles in"
 msgstr "Szybko triażujemy i naprawiamy problemy, podczas gdy Twój zespół się adaptuje"
@@ -17036,10 +17036,10 @@ msgid "Week of {0}"
 msgstr "Tydzień z {0}"
 
 msgid "Weekly"
-msgstr "Tygodniowo"
+msgstr "Co tydzień"
 
 msgid "Weekly demand"
-msgstr "Popyt tygodniowy"
+msgstr "Zapotrzebowanie co tydzień"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Co spowodowało wzrost lub spadek zapasów, wg dowolnego wymiaru"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Co się dzieje, gdy dziennik jest datowany w zablokowanym okresie."
+msgstr "Co się dzieje, gdy dowód księgowy jest datowany w zablokowanym okresie."
 
 msgid "What is {translatedTerm}?"
 msgstr "Co to jest {translatedTerm}?"
@@ -17104,10 +17104,10 @@ msgid "What kind of change this is: Version updates how the part is made, Revisi
 msgstr "Jaki typ zmian to jest: Wersja aktualizuje sposób wykonania części, Rewizja zmienia jej szczegóły i dokumenty, Część zamienna wymienia nowy numer części, który zastępuje stary, a Nowa Część wprowadza zupełnie nową część bez poprzednika."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Jakie dane wyjściowe rejestruje ten wpis — Produkcja (jednostki dobre), Złom (nieodwracalny) lub Przeróbka (odesłane do korekty); ujawnia Powód złomu, gdy złom."
+msgstr "Jaki rodzaj wyniku ta pozycja rejestruje — Produkcja (dobre sztuki), Braki (nieodwracalne), czy Poprawka (do poprawy); pokazuje Przyczynę braku dla Braków."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Jaki to typ PO — towary standardowe, usługi, przetwarzanie zewnętrzne lub umowa ramowa; determinuje układ linii i zasady księgowania GL."
+msgstr "Jaki rodzaj to zamówienie — standardowy towar, usługi, kooperacja czy umowa ramowa; wpływa na układ pozycji i reguły księgowania w księdze głównej."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
 msgstr "Jaki to typ oferty — standardowa oferta dostawcy, oferta cenowa umowy ramowej lub oferta produkcji kontraktowej; determinuje układ linii PO podczas konwersji."
@@ -17131,7 +17131,7 @@ msgid "What this task means"
 msgstr "Co to zadanie oznacza"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Co ta wpis czasu liczy się jako — Praca (czas operatora), Maszyna (czas uruchomienia) lub Ustawienie (czas przezbroienia); każdy podsumowuje się na inną stawkę."
+msgstr "Co ta wpis czasu reprezentuje — Robocizna (czas operatora), Maszyna (czas obróbki), czy Przezbrojenie (czas przezbrojenia); każda kumuluje się pod inną stawką."
 
 msgid "What to set up"
 msgstr "Co skonfigurować"
@@ -17161,7 +17161,7 @@ msgid "When a serial or batch expires, and what happens if used after — a comp
 msgstr "Kiedy serial lub partia wygasa i co się dzieje, jeśli jest używany potem — polityka firmy może Ostrzec, Zablokować lub ZablokujZPrzesłonięciem."
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
-msgstr "Kiedy Carbon zobowiązała się do przywiezienia towaru; w połączeniu z dniami przesyłania metody wysyłki, powoduje to wsteczne obliczenie daty wysyłki."
+msgstr "Kiedy Carbon zobowiązał się na dostarczenie towaru; połączone z dniami tranzytu Sposobu wysyłki, determinuje to wsteczne obliczenie daty wysyłki."
 
 msgid "When expired stock is used"
 msgstr "Gdy używany jest wygasły zapas"
@@ -17176,7 +17176,7 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Gdy włączone, pracownicy mogą edytować wartość tego atrybutu w swoim własnym profilu; w przeciwnym razie mogą to zrobić tylko administratorzy."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Gdy włączone, zasady ustalania cen (rabaty objętościowe, promocje) nadal mają zastosowanie na podstawie tego zastąpienia; gdy wyłączone, to zastąpienie jest ceną ostateczną."
+msgstr "Gdy włączone, reguły cenowe (rabaty ilościowe, promocje) nadal obowiązują oprócz tego nadpisania; gdy wyłączone, to nadpisanie jest ceną ostateczną."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Gdy włączone, skanowanie kodu kreskowego operacji tego procesu zgłasza całą pozostałą otwartą ilość jako ukończoną w jednej akcji; wyłącz, gdy operatorzy regularnie zgłaszają częściowe."
@@ -17185,7 +17185,7 @@ msgid "When on, this party's invoices skip tax calculation; the party is respons
 msgstr "Gdy włączone, faktury tej strony pomijają obliczenie podatku; strona jest odpowiedzialna za utrzymanie aktualności certyfikatu zwolnienia."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Gdy włączone, to zastąpienie ceny dotyczy pasujących zamówień; gdy wyłączone, zastąpienie jest zachowywane bez usunięcia, aby zachować historię audytu."
+msgstr "Gdy włączone, to nadpisanie ceny dotyczy zgodnych zleceń; wyłączenie bez usunięcia zachowuje historię do audytu."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Gdy włączone, ta reguła uruchamia się dla każdego celu tego typu. Wiersze przypisania są ignorowane, ale zachowywane."
@@ -17194,55 +17194,55 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "Kiedy oczekuje się odpowiedzi dostawców; dostawcy widzą tę datę w portalu RFQ, a Carbon przestaje akceptować spóźnione odpowiedzi po niej (konfigurowanej)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "Kiedy kupujący poprosił o towary; dostawca może obiecać coś innego w dacie Promised i ponownie zaksięgować coś innego w dacie dostawy."
+msgstr "Gdy kupiec poprosił o towar; dostawca może obiecać coś innego w polu Data potwierdzona i dostarczyć coś innego w polu Data dostawy."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "Kiedy kupujący potrzebuje towarów tej linii na molo; planowanie wykorzystuje tę datę do dostępności zapasów i planowania przetwarzania zewnętrznego."
+msgstr "Gdy kupiec potrzebuje towaru z tej pozycji na doku; planowanie wykorzystuje tę datę do dostępności zapasu i planowania kooperacji."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "Kiedy klient poprosił o dostawę; zamówienie zobowiązuje się do daty Promised, która może być inna."
+msgstr "Gdy klient poprosił dostawę; zamówienie zobowiązuje się do Daty potwierdzonej, która może się różnić."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Kiedy klient chce otrzymać towary; oferta zobowiązuje się do tej daty, jeśli klient akceptuje."
+msgstr "Gdy klient poprosił otrzymanie towaru; oferta zobowiązuje się do tej daty, jeśli klient ją zaakceptuje."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Kiedy klient chce otrzymać towary."
+msgstr "Gdy klient poprosił otrzymanie towaru."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "Kiedy klient złożył tę RFQ; zegar odpowiedzi zaczyna się od tej daty."
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "Kiedy żądanie klienta przestaje być aktualne; po tej dacie RFQ jest automatycznie zamykana i nie akceptuje odpowiedzi na oferty, chyba że zostanie ponownie otwarta."
+msgstr "Gdy żądanie klienta przestaje być aktualne; po tej dacie RFQ jest automatycznie zamknięte i nie będzie akceptować odpowiedzi na ofertę, chyba że zostanie ponownie otwarte."
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
 msgstr "Kiedy towary faktycznie przybyły; zarejestrowane na paragonie i używane do oceny punktualności dostawy dostawcy."
 
 msgid "When the kanban card is scanned, the job is automatically moved out of draft and released to the floor."
-msgstr "Gdy karta kanban jest skanowana, zadanie jest automatycznie przenoszone z projektu i wydawane do pola."
+msgstr "Gdy karta kanban zostanie zeskanowana, zlecenie produkcyjne jest automatycznie przenoszone z wersji roboczej i zwalniane na halę."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Kiedy lokalizacja odbioru oczekuje przybycia zapasów; napędza dostępność MRP w miejscu przeznaczenia."
+msgstr "Gdy lokalizacja przyjęcia oczekuje na przybycie zapasu; napędza dostępność MRP w miejscu docelowym."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Kiedy dostawca zobowiązał się do dostawy; planowanie wykorzystuje tę datę do projekcji przybycia zapasów przychodzących."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "Kiedy ceny dostawcy przestają być honorowane; konwersja tego cytatu do PO po tej dacie może wymagać ponownego przesłania oferty."
+msgstr "Gdy wycena dostawcy przestaje być honorowana; konwersja tej oferty do PO po tej dacie może wymagać ponownego ofertowania."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Kiedy ten przyrząd staje się wymagający kalibracji; po przekroczeniu terminu odczytuje się jako Poza kalibracją."
+msgstr "Gdy ten przyrząd pomiarowy jest wymagany do wzorcowania; po upłynięciu terminu wyświetla Poza wzorcowaniem."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Kiedy ten miernik został ostatnio pomyślnie skalibrowany; data następnej kalibracji jest przeliczana z tej wartości plus interwału."
+msgstr "Gdy ten przyrząd pomiarowy był ostatnio pomyślnie wzorcowany; następna data wzorcowania jest przeliczana z tej wartości plus interwału."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
-msgstr "Gdy to będzie wyglądać prawidłowo, oznacz to jako uzgodnione. To kończy etap Discovery w Twoim centrum dowodzenia."
+msgstr "Gdy to wygląda dobrze, oznacz jako uzgodnione. To kończy krok Odkrywania w Twoim centrum dowodzenia."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Kiedy ta specificzna linia jest obiecana do wysyłki; zastąpienie per linia daty Promised w nagłówku zamówienia dla podzielonych wysyłek."
+msgstr "Gdy ta konkretna pozycja ma być wysłana; nadpisanie na poziomie pozycji Daty potwierdzonej nagłówka zamówienia dla wysyłek częściowych."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Kiedy ten konkretny lot/numer seryjny wygasa; napędza selekcję FEFO i politykę czasu przechowywania przy zużyciu."
+msgstr "Gdy ta konkretna partia/numer seryjny wygaśnie; napędza kompletację FEFO i politykę trwałości przy zużyciu."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Kiedy zobowiązałeś się do dostawy; planowanie traktuje to jako datę wymagalności popytu do spełnienia."
@@ -17254,19 +17254,19 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "Gdzie jest dostarczane powiadomienie przepływu pracy — w aplikacji jest zawsze wysyłane, podczas gdy wiadomość e-mail wymaga planu Business lub Partner, a Slack wymaga połączonej przestrzeni roboczej Slack."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Gdzie operacja przebiega; nosi stawki pracy i notowań, z ogólnymi kosztem różnicę między nimi."
+msgstr "Gdzie operacja jest uruchamiana; zawiera stawki robocizny i wyceny, a koszty pośrednie to różnica między nimi."
 
 msgid "Where and how you make things."
 msgstr "Gdzie i jak wytwarzasz rzeczy."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Gdzie towary na tym PO są domyślnie wysyłane przez dostawcę; lokalizacje dostawy per linia na PO zastępują to dla scenariuszy drop-ship i podzielonej dostawy."
+msgstr "Gdzie towar na tym PO jest domyślnie wysyłany; lokalizacje dostawy na poziomie pozycji na PO nadpisują to dla scenariuszy dostawy bezpośredniej i wysyłki częściowej."
 
 msgid "Where it lives today"
 msgstr "Gdzie znajduje się dzisiaj"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Gdzie nowy zapas tego artykułu ląduje domyślnie przy odbiorze; wybory magazynowania per linia na paragonie go zastępują."
+msgstr "Gdzie nowy zapas tego artykułu ląduje domyślnie przy przyjęciu; wybory magazynowania na poziomie pozycji przy przyjęciu nadpisują to."
 
 msgid "Where stock lives and how it ships."
 msgstr "Gdzie znajduje się zapas i jak się wysyła."
@@ -17284,7 +17284,7 @@ msgid "Where this line's goods land in stock on receipt; if blank, receipts use 
 msgstr "Gdzie towary tej linii lądują w zapasach przy odbiorze; jeśli puste, paragony używają domyślnej jednostki magazynowania artykułu."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "Skąd pochodzi ta prośba o konserwację — zgłoszone przez operatora, zaplanowane, wyzwalacz monitorowania stanu, inspekcja po pracy; napędza podział źródła w raportach konserwacji."
+msgstr "Gdzie pochodzi to żądanie utrzymania ruchu — zgłoszone przez operatora, zaplanowane, wyzwalacz monitorowania stanu, kontrola po zleceniu produkcyjnym; napędza podział źródeł w raportach utrzymania ruchu."
 
 msgid "Where you are today"
 msgstr "Gdzie jesteś dzisiaj"
@@ -17296,16 +17296,16 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Czy kwota jest interpretowana jako procent ceny pozycji, czy jako stała kwota w walucie."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Czy Carbon śledzi każdą jednostkę (Serial), każdą partię (Batch), ilość (Inventory) czy brak śledzenia (Non-Inventory)."
+msgstr "Czy Carbon śledzi każdą sztukę (Nr seryjny), każdą partię (Partia produkcyjna), ilość (Zapasy), czy brak śledzenia (Niemagazynowy)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Czy licznik czasu rozpoczyna się, gdy wybrany proces się zaczyna, czy gdy się kończy."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Czy ta partia/numer seryjny przechodzi kontrolę (Pass), czy ją oblewa (Fail); Fail blokuje przyjęcie zapasów do dostępnego magazynu."
+msgstr "Czy ta partia/numer seryjny przechodzi kontrolę (Zgodny) czy nie przechodzi (Niezgodny); Niezgodny blokuje zapas przed otrzymaniem do dostępnych zapasów."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Czy ten proces odbywa się w wewnętrznych centrach pracy (Proces, Montaż lub Inspeksja) czy u zewnętrznych dostawców (Obróbka na zewnątrz); ujawnia różne pola podrzędne, zmienia sposób działania tras planowania dla tego procesu i ustawia domyślnie typ operacji dla nowych operacji."
+msgstr "Czy ten proces jest uruchamiany na wewnętrznych stanowiskach roboczych (Proces, Montaż, lub Kontrola) czy u dostawców zewnętrznych (Kooperacja); ujawnia różne pola poniżej, zmienia sposób działania planowania dla tego procesu i ustawia domyślny typ operacji dla nowych operacji."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
 msgstr "Czy ta praca blokuje produkcję (W dół), ją degraduje (Wpływ), znajduje się w planowanym oknie czasu przestoju (Zaplanowane) lub nie ma wpływu na produkcję (Brak Wpływu); informuje planowanie i komunikację o przestojach skierowaną do klientów."
@@ -17317,7 +17317,7 @@ msgid "Which document drives each inspection flow for this item."
 msgstr "Który dokument kieruje każdym przepływem kontroli dla tego produktu."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Jaki rodzaj żądania wysłać: GET odczytuje, POST tworzy, PUT i PATCH aktualizują, DELETE usuwa. Nowy krok zaczyna się od GET, a tylko POST, PUT i PATCH noszą treść."
+msgstr "Jaki rodzaj żądania wysłać: GET odczytuje, POST tworzy, PUT i PATCH aktualizują, DELETE usuwa. Nowy krok zaczyna się od GET, a tylko POST, PUT i PATCH zawierają treść."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "Które zdarzenie produkcyjne uruchamia zegar czasu przechowywania — na przykład napełnianie, uszczelnianie lub ostateczną kontrolę jakości."
@@ -17329,7 +17329,7 @@ msgid "Who can do what"
 msgstr "Kto może robić co"
 
 msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
-msgstr "Kto robi co, na wszystkich sześciu etapach. Twoja strona jest wyróżniona na górze. Dobrze się tym zajmij, a projekt będzie się posuwać naprzód."
+msgstr "Kto robi co, przez sześć kroków. Twoja strona jest wyróżniona u góry. Weź ją na siebie dobrze, a projekt posunie się do przodu."
 
 msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
 msgstr "Kto otrzymuje szkolenie na temat czego, w jakim formacie. Twoja rola: zarezerwuj czas praktycznych sesji w kalendarzach swoich liderów jak najwcześniej. To właśnie najczęściej się przesuwane, gdy firmy są zajęte."
@@ -17338,28 +17338,28 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Kto musi zatwierdzić oferty, zamówienia i zakupy — i kiedy"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Kto powinien otrzymywać powiadomienia dotyczące dyspozycji związanych z konserwacją?"
+msgstr "Kto powinien otrzymywać powiadomienia dla zleceń utrzymania ruchu?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Kto powinien otrzymywać powiadomienia dotyczące wysyłek związanych z operacjami?"
+msgstr "Kto powinien otrzymywać powiadomienia dla zleceń związanych z operacjami?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "Kto powinien otrzymywać powiadomienia dotyczące innych wysyłek?"
+msgstr "Kto powinien otrzymywać powiadomienia dla pozostałych zleceń?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Kto powinien otrzymywać powiadomienia dotyczące wysyłek związanych z jakością?"
+msgstr "Kto powinien otrzymywać powiadomienia dla zleceń związanych z jakością?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
 msgstr "Kto powinien otrzymywać powiadomienia, gdy cyfrowa oferta zostanie zaakceptowana lub wygaśnie?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Kto powinien otrzymywać powiadomienia, gdy czujnik wyjdzie z kalibracji?"
+msgstr "Kto powinien otrzymywać powiadomienia, gdy przyrząd pomiarowy wyjdzie poza wzorcowanie?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
-msgstr "Kto powinien otrzymywać powiadomienia, gdy nowa sugestia zostanie przesłana?"
+msgstr "Kto powinien otrzymywać powiadomienia, gdy nowa propozycja zostanie przesłana?"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "Kto powinien otrzymywać powiadomienia, gdy RFQ jest oznaczony jako gotowy do wyceny?"
+msgstr "Kto powinien otrzymywać powiadomienia, gdy RFQ zostanie oznaczony jako gotowy do oferty?"
 
 msgid "Who should receive notifications when a sales job is completed?"
 msgstr "Kto powinien otrzymywać powiadomienia po zakończeniu zadania sprzedaży?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "Dlaczego to jest zablokowane?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Dlaczego zapasy się zmieniają — Pozytywnie (znaleźli), Negatywnie (zgubieni/złom) lub Ustawić (zamień ilość zmierzoną wartością)."
+msgstr "Dlaczego zapas się zmienia — Pozytywnie (odnaleziono), Negatywnie (stracone/braki), lub Ustaw (zastąp ilość zmierzoną wartością)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Dlaczego ta linia jest odrzucana; wyświetlane na drukowanym cytacie i zarejestrowane do raportowania win-loss."
@@ -17401,10 +17401,10 @@ msgid "Window:"
 msgstr "Okno:"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Produkcja w toku"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Bez listy pobrania operatorzy zbierają materiały z karty Skan."
+msgstr "Bez listy kompletacyjnej operatorzy pobierają materiał z karty Skanuj."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17424,43 +17424,43 @@ msgid "Wordmark Light Mode"
 msgstr "Logotyp Tryb Jasny"
 
 msgid "work center"
-msgstr "centrum pracy"
+msgstr "stanowisko robocze"
 
 msgid "Work center"
-msgstr "Centrum Pracy"
+msgstr "Stanowisko robocze"
 
 msgid "Work Center"
-msgstr "Centrum Pracy"
+msgstr "Stanowisko robocze"
 
 msgid "Work Center Utilization"
-msgstr "Wykorzystanie Centrum Pracy"
+msgstr "Wykorzystanie stanowiska roboczego"
 
 msgid "work centers"
-msgstr "centra pracy"
+msgstr "stanowiska robocze"
 
 msgid "Work centers"
-msgstr "Centra pracy"
+msgstr "Stanowiska robocze"
 
 msgid "Work Centers"
-msgstr "Centra pracy"
+msgstr "Stanowiska robocze"
 
 msgid "Work in process (WIP)"
-msgstr "Niedokończona Produkcja (WIP)"
+msgstr "Produkcja w toku"
 
 msgid "Work in progress"
 msgstr "Prace w toku"
 
 msgid "Work in Progress (default)"
-msgstr "Niedokończona Produkcja (domyślnie)"
+msgstr "W toku (domyślnie)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Niedokończona Produkcja (WIP)"
+msgstr "Produkcja w toku"
 
 msgid "Work instruction"
-msgstr "Instrukcja pracy"
+msgstr "Instrukcja robocza"
 
 msgid "Work Instructions"
-msgstr "Instrukcje pracy"
+msgstr "Instrukcje robocze"
 
 msgid "Work Phone"
 msgstr "Telefon służbowy"
@@ -17487,26 +17487,26 @@ msgid "Worst Performing Machines"
 msgstr "Maszyny o najgorszych wynikach"
 
 msgid "Write-Down Account"
-msgstr "Konto Obniżenia Wartości"
+msgstr "Konto odpisu aktualizującego"
 
 msgid "Write-off"
-msgstr "Odpis"
+msgstr "Spisanie"
 
 msgid "Write-Off"
-msgstr "Odpis"
+msgstr "Spisanie"
 
 msgid "Write-Off Account"
-msgstr "Konto Odpisu"
+msgstr "Konto spisania"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Odpis dla {0}"
+msgstr "Spisanie dla {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Odpis zapasów złomowanych lub zwróconych przez odrzucenia kontroli i dyspozycje NCR"
+msgstr "Spisanie zapasu odrzuconego lub zwróconego w wyniku odrzuceń w kontroli i dyspozycji NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "Zmniejszanie wartości składnika aktywów w trakcie jego użyteczności — monta miesięczny, który tworzysz, przeglądam jako wersję roboczą, a następnie księgujesz."
+msgstr "Redukcja wartości aktywu w okresie użytkowania — miesięczna seria, którą tworzysz, przeglądzasz jako wersję roboczą, a następnie zaksięgujesz."
 
 msgid "Year"
 msgstr "Rok"
@@ -17542,7 +17542,7 @@ msgid "You can only see this key once. Store it safely."
 msgstr "Możesz zobaczyć ten klucz tylko raz. Przechowuj go bezpiecznie."
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Zalogowałeś się o godzinie <0/>. Poniżej możesz zmienić czas wylogowania lub potwierdzić, że nadal pracujesz."
+msgstr "Rozpocząłeś pracę o <0/>. Możesz edytować czas zakończenia pracy poniżej lub potwierdzić, że nadal pracujesz."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity
@@ -17560,10 +17560,10 @@ msgid "You don't have permission to edit this bill of material."
 msgstr "Nie masz uprawnień do edytowania tej listy materiałów."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Nie masz uprawnień do edycji tego zamawiania technologicznego."
+msgstr "Nie masz uprawnienia do edycji tej listy operacji."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "Ty kierujesz; my upewniamy się, że wszystko jest zrobione prawidłowo. Fachowe spojrzenie na Twoją konfigurację, dane i wdrożenie."
+msgstr "Prowadzisz ty; my zapewniamy jakość. Eksperci czuwają nad Twoją konfiguracją, danymi i wdrażaniem."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
@@ -17588,7 +17588,7 @@ msgid "You're live on Carbon"
 msgstr "Jesteś na żywo w Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Jesteś o jeden krok od swojego obszaru roboczego."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Samodzielnie konfigurujesz Carbon w swoim tempie"
@@ -17603,7 +17603,7 @@ msgid "Your books and how money flows."
 msgstr "Twoje księgi i przepływ pieniędzy."
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "Twoje zmiany trafiają do nowej wersji roboczej wydanej wraz z tym zgłoszeniem zmian."
+msgstr "Zmiany trafiają do nowej wersji roboczej wydanej wraz z tym zawiadomieniem o zmianie."
 
 msgid "Your Console PIN"
 msgstr "Twój PIN konsoli"
@@ -17627,7 +17627,7 @@ msgid "Your GL accounts"
 msgstr "Twoje konta GL"
 
 msgid "your Implementation Lead"
-msgstr "twój Implementation Lead"
+msgstr "twój Kierownik Wdrażania"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
 msgstr "Twoje zaproszenie jest nieprawidłowe lub zostało już zaakceptowane. Skontaktuj się z pomocą techniczną, jeśli uważasz, że to błąd."
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "siebie"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Poziom kontroli Z1.4 (I / II / III); wyższe poziomy oznaczają większe rozmiary próbek dla tej samej partii."
+msgstr "Z1.4 poziom kontroli (I / II / III); wyższe poziomy oznaczają większe wielkości próbek dla tej samej partii."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Ważność Z1.4 (Normalna / Wzmocniona / Zmniejszona); przełącza się według reguły na podstawie ostatnich historii akceptacji partii."
+msgstr "Z1.4 waga (Normalna / Obostrzona / Ulgowa); zmienia się na podstawie reguły opartej na ostatniej historii akceptacji partii."
 
 msgid "Zoom Box"
 msgstr "Pole powiększenia"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -8929,7 +8929,7 @@ msgid "Map Lines Now"
 msgstr "Mapuj linie teraz"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Zmapuj swój plan kont na plan dostawcy. Konta Posting-default i wydatkowe są oznaczone jako Wymagane; zaksięgowane dzienniki są wysyłane przy użyciu zmapowanego kodu konta dostawcy."
+msgstr "Zmapuj swój plan kont na plan kont dostawcy. Konta domyślne dla księgowania i wydatkowe są oznaczone jako Wymagane; zaksięgowane dowody księgowe będą wysyłane przy użyciu zmapowanego kodu konta dostawcy."
 
 msgid "Map your current process, systems, and data"
 msgstr "Zmapuj swój obecny proces, systemy i dane"
@@ -14343,14 +14343,14 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe wysyła fakturę do klienta, dlatego wymagany jest adres. Zostanie to również zapisane w kontakcie w Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Księgowanie utworzy go na Twoim połączonym koncie."
+msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Księgowanie utworzy go na twoim podłączonym koncie."
 msgstr "Data płatności Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe wysyła fakturę do klienta pocztą e-mail, więc wymagany jest adres. Zostanie również zapisany w kontakcie w Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe jeszcze nie ma klienta dla tego klienta Carbon. Posting utworzy jeden na Twoim połączonym koncie."
+msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Księgowanie utworzy go na twoim podłączonym koncie."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Styl wyjścia kanban do wyświetlenia w tabeli Kanban"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -361,7 +361,6 @@ msgstr "Pracownik zewnętrzny to kontakt dostawcy z konkretnymi umiejętnościam
 
 msgid "A custom solution to meet your needs"
 msgstr "Rozwiązanie niestandardowe dostosowane do Twoich potrzeb"
-msgstr "Dostosowane rozwiązanie spełniające Twoje potrzeby"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Klient to firma lub osoba, która kupuje Twoje części lub usługi."
@@ -475,7 +474,6 @@ msgstr "Komponent Produkcji na zamówienie, którego części są wydawane razem
 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr "Zarządzana, hostowana w chmurze wersja Carbon"
-msgstr "Zarządzana wersja Carbon hostowana w chmurze"
 
 msgid "A managed version with all the advanced features"
 msgstr "Zarządzana wersja ze wszystkimi zaawansowanymi funkcjami"
@@ -1612,7 +1610,6 @@ msgstr "Klucze API do programowego dostępu do danych Carbon."
 
 msgid "API, webhooks, and integrations"
 msgstr "API, webhooks i integracje"
-msgstr "API, webhooki i integracje"
 
 msgid "Applied"
 msgstr "Zastosowano"
@@ -2481,7 +2478,6 @@ msgstr "Cena bazowa"
 
 msgid "Basic ERP, MES, and QMS functionality"
 msgstr "Podstawowa funkcjonalność ERP, MES i QMS"
-msgstr "Podstawowe funkcje ERP, MES i QMS"
 
 msgid "Basic Information"
 msgstr "Informacje podstawowe"
@@ -2622,7 +2618,6 @@ msgstr "Przeglądaj bibliotekę"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Przeglądaj opublikowaną wersję w trybie tylko do odczytu. Nadal możesz zmienić kolejność kroków, aby uporządkować układ."
-msgstr "Przeglądaj opublikowaną wersję jako tylko do odczytu. Możesz jeszcze zmienić kolejność kroków, aby uporządkować układ."
 
 msgid "Bucket"
 msgstr "Zasobnik"
@@ -2830,7 +2825,6 @@ msgstr "Nie można wysłać ZZO"
 
 msgid "Cannot send through Stripe"
 msgstr "Nie można wysłać przez Stripe"
-msgstr "Nie można wysłać za pośrednictwem Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Nie można przesłać pliku — interakcja z dostawcą nie została jeszcze utworzona"
@@ -3180,7 +3174,6 @@ msgstr "Chmura lub Twoje środowisko hostowane samodzielnie."
 
 msgid "CMMC compliant"
 msgstr "Zgodny z CMMC"
-msgstr "Zgodne z CMMC"
 
 msgid "Code"
 msgstr "Kod"
@@ -6988,7 +6981,6 @@ msgstr "Format"
 
 msgid "Forward deployed engineer"
 msgstr "Inżynier wdrażający"
-msgstr "Inżynier wdrażany on-site"
 
 msgid "Foundation"
 msgstr "Fundament"
@@ -7045,7 +7037,6 @@ msgstr "Pełne imię i nazwisko"
 
 msgid "Full setup and migrations"
 msgstr "Pełne przezbrojenie i migracje"
-msgstr "Pełne ustawienie i migracje"
 
 msgid "Fully Depreciated"
 msgstr "Całkowicie zamortyzowane"
@@ -8143,7 +8134,6 @@ msgstr "Problemy"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "To przestanie działać, dopóki nie opublikujesz wersji ponownie. Nic nie jest usunięte."
-msgstr "Przestanie działać do momentu ponownego opublikowania wersji. Nic nie jest usunięte."
 
 msgid "ITAR Certifications"
 msgstr "Certyfikacje ITAR"
@@ -8515,7 +8505,6 @@ msgstr "Mniej pracy ręcznej, mniej błędów"
 
 msgid "Let's Build"
 msgstr "Zbudujmy"
-msgstr "Zaczynamy Budować"
 
 msgid "Let's build something"
 msgstr "Zbudujmy coś"
@@ -8597,7 +8586,6 @@ msgstr "Połącz problem Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Połącz tego klienta Carbon z jednym z nich, lub utwórz osobnego klienta Stripe."
-msgstr "Połącz tego klienta Carbon z jednym z nich lub utwórz oddzielnego klienta Stripe."
 
 msgid "Link to sales order line"
 msgstr "Łącze do pozycji zamówienia sprzedaży"
@@ -12671,7 +12659,6 @@ msgstr "Odwróć wszystkie wpisy rejestru pozycji z tej faktury"
 
 msgid "Reverse charge"
 msgstr "Odwrotne obciążenie"
-msgstr "Odwrócenie opodatkowania"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Odwrotne obciążenie podatkiem od sprzedaży"
@@ -13490,7 +13477,6 @@ msgstr "Samodzielnie zarządzane"
 
 msgid "Self-hosted or managed"
 msgstr "Samodzielnie hostowana lub zarządzana"
-msgstr "Samodzielnie hostowany lub zarządzany"
 
 msgid "Self-onboarding"
 msgstr "Samodzielne wdrażanie"
@@ -14344,7 +14330,6 @@ msgstr "Stripe wysyła fakturę do klienta, dlatego wymagany jest adres. Zostani
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe nie ma jeszcze klienta dla tego klienta Carbon. Księgowanie utworzy go na twoim podłączonym koncie."
-msgstr "Data płatności Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe wysyła fakturę do klienta pocztą e-mail, więc wymagany jest adres. Zostanie również zapisany w kontakcie w Carbon."
@@ -14814,7 +14799,6 @@ msgstr "Zespół przeszkolony"
 
 msgid "Technical support"
 msgstr "Pomoc techniczna"
-msgstr "Wsparcie techniczne"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -15661,7 +15645,6 @@ msgstr "Ta faktura nie ma użytecznego terminu — wybierz jeden dla Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Ta faktura będzie wystawiona klientowi Stripe już powiązanemu z tym klientem Carbon. Aby zmienić jego szczegóły, edytuj go na pulpicie Stripe."
-msgstr "Ta faktura nie ma użytecznej daty płatności — wybierz jedną dla Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Ta faktura będzie naliczona klientowi Stripe już połączonemu z tym klientem Carbon. Aby zmienić jego szczegóły, edytuj go w pulpicie Stripe."
@@ -15805,7 +15788,6 @@ msgstr "Ta wersja jest opublikowana"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Ta wersja jest opublikowana. Utwórz nową wersję, aby edytować."
-msgstr "Ta wersja jest opublikowana. Utwórz nową wersję do edycji."
 
 msgid "This version's definition could not be read."
 msgstr "Definicję tej wersji nie można było odczytać."
@@ -17646,7 +17628,6 @@ msgstr "Jesteś na żywo w Carbon"
 
 msgid "You're one step away from your workspace."
 msgstr "Jesteś o jeden krok od swojego obszaru roboczego."
-msgstr "Jesteś jednym krokiem od swojego obszaru roboczego."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Samodzielnie konfigurujesz Carbon w swoim tempie"

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Odrzuconych"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} jednostka(e) przebiegła(y) zostanie(ą) ukończona(e)."
+msgstr "{completions} zaliczonych sztuk będzie zakończone."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} zarejestrowanych niepowodzeń będzie NIEUKOŃCZONYCH — rozwiąż je z menu akcji."
@@ -67,7 +67,7 @@ msgid "About"
 msgstr "O programie"
 
 msgid "Accept"
-msgstr "Akceptuj"
+msgstr "Zaakceptuj"
 
 msgid "Accept Lot"
 msgstr "Zaakceptuj partię"
@@ -112,10 +112,10 @@ msgid "All clear"
 msgstr "Wszystko jasne"
 
 msgid "All rework"
-msgstr "Wszystkie przeróbki"
+msgstr "Wszystkie poprawki"
 
 msgid "All scrap"
-msgstr "Wszystko do złomu"
+msgstr "Wszystkie braki"
 
 msgid "Allocate failed units"
 msgstr "Przydziel jednostki z błędami"
@@ -145,7 +145,7 @@ msgid "Assigned to Me"
 msgstr "Przypisane do mnie"
 
 msgid "Assignee"
-msgstr "Przypisany"
+msgstr "Osoba przypisana"
 
 msgid "Authentication Error"
 msgstr "Błąd uwierzytelniania"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Wyczyść wyszukiwanie"
 
 msgid "Clock In"
-msgstr "Rozpocznij zmianę"
+msgstr "Rozpoczęcie pracy"
 
 msgid "Clock Out"
-msgstr "Zakończ zmianę"
+msgstr "Zakończenie pracy"
 
 msgid "Clocked in since <0/>"
 msgstr "Zalogowany od <0/>"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "Uzupełnij wszystko"
 
 msgid "Complete passed"
-msgstr "Ukończ przebieg"
+msgstr "Zakończ zaliczone"
 
 msgid "Completed"
 msgstr "Ukończone"
@@ -282,7 +282,7 @@ msgstr "Zużyte wygasłe"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr "Koszt nieplanowanej konserwacji w ciągu ostatnich {0} dni"
+msgstr "Koszt nieplanowanego utrzymania ruchu, ostatnie {0} dni"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -296,7 +296,7 @@ msgid "Create Quality Issue"
 msgstr "Utwórz Problem Jakości"
 
 msgid "Create Rework"
-msgstr "Utwórz Przerobienie"
+msgstr "Utwórz poprawkę"
 
 msgid "Current work"
 msgstr "Bieżąca praca"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Szczegóły"
 
 msgid "Dispatch not found"
-msgstr "Nie znaleziono zlecenia"
+msgstr "Nie znaleziono zlecenia utrzymania ruchu"
 
 msgid "Display"
 msgstr "Wyświetlanie"
@@ -353,14 +353,14 @@ msgid "Down"
 msgstr "Awaria"
 
 msgid "Down for maintenance"
-msgstr "Niedostępny do konserwacji"
+msgstr "Niedostępna z powodu utrzymania ruchu"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr "Niedostępny do konserwacji · {0}"
+msgstr "Niedostępna z powodu utrzymania ruchu · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "Zamknięty na planowaną konserwację"
+msgstr "Niedostępna z powodu planowanego utrzymania ruchu"
 
 msgid "Download"
 msgstr "Pobierz"
@@ -369,7 +369,7 @@ msgid "Download Labels"
 msgstr "Pobierz etykiety"
 
 msgid "Draft"
-msgstr "Szkic"
+msgstr "Wersja robocza"
 
 msgid "Drag and drop a file here, or click to select a file"
 msgstr "Przeciągnij i upuść plik tutaj lub kliknij, aby wybrać plik"
@@ -416,7 +416,7 @@ msgid "Email Address"
 msgstr "Adres e-mail"
 
 msgid "Empty work centers"
-msgstr "Puste centra pracy"
+msgstr "Puste stanowiska robocze"
 
 msgid "End Operations"
 msgstr "Zakończ operacje"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "Szacowane"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "Każda jednostka ma werdykt: {passes} zdane i {fails} niezdane. Partia zamyka się, a każda jednostka trafia do swojego wyniku."
+msgstr "Każda sztuka ma wyrok: {passes} zaliczonych i {fails} niezaliczonych. Partia zamyka się, każda sztuka kierowana jest do jej wyniku."
 
 msgid "Expand features table"
 msgstr "Rozwiń tabelę funkcji"
@@ -500,7 +500,7 @@ msgid "Files"
 msgstr "Pliki"
 
 msgid "Files related to the job and the opportunity line."
-msgstr "Pliki powiązane ze zleceniem i pozycją zapytania."
+msgstr "Pliki powiązane ze zleceniem produkcyjnym i pozycją szansy sprzedaży."
 
 msgid "Filter"
 msgstr "Filtr"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Zakończ mimo wszystko"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Dokończ konfigurowanie swojego konta"
 
 msgid "Finish with material unpicked?"
 msgstr "Zakończyć bez wybranego materiału?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Zapomniałeś zakończyć zmianę?"
+msgstr "Zapomniano o zakończeniu pracy?"
 
 msgid "Go back to operation"
 msgstr "Wróć do operacji"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Przejdź do wdrożenia"
 
 msgid "How many were actually picked?"
 msgstr "Ile faktycznie zostało zebrane?"
@@ -546,7 +546,7 @@ msgid "I'm Still Working"
 msgstr "Nadal pracuję"
 
 msgid "Ideas, suggestions or problems?"
-msgstr "Pomysły, sugestie lub problemy?"
+msgstr "Pomysły, sugestie czy problemy?"
 
 msgid "Idle for"
 msgstr "Bezczynny przez"
@@ -616,13 +616,13 @@ msgid "Job Details"
 msgstr "Szczegóły zlecenia"
 
 msgid "Job Traveler"
-msgstr "Karta obiegowa zlecenia"
+msgstr "Przewodnik zlecenia"
 
 msgid "Jobs"
-msgstr "Zadania"
+msgstr "Zlecenia produkcyjne"
 
 msgid "Keep picking"
-msgstr "Kontynuuj wybieranie"
+msgstr "Kontynuuj kompletację"
 
 msgid "Kit"
 msgstr "Zestaw"
@@ -675,11 +675,11 @@ msgid "Log rework for {0}"
 msgstr "Rejestruj poprawki dla {0}"
 
 msgid "Log Scrap"
-msgstr "Rejestruj odpad"
+msgstr "Zarejestruj braki"
 
 #. placeholder {0}: operation.itemReadableId
 msgid "Log scrap for {0}"
-msgstr "Rejestruj odpad dla {0}"
+msgstr "Zarejestruj braki dla {0}"
 
 msgid "Login"
 msgstr "Zaloguj się"
@@ -691,7 +691,7 @@ msgid "Machine"
 msgstr "Maszyna"
 
 msgid "Machine down for maintenance now?"
-msgstr "Maszyna niedostępna do konserwacji teraz?"
+msgstr "Maszyna niedostępna z powodu utrzymania ruchu teraz?"
 
 msgid "Maintenance"
 msgstr "Utrzymanie ruchu"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Utrzymanie ruchu zakończone"
 
 msgid "Maintenance overdue"
-msgstr "Konserwacja przeterminowana"
+msgstr "Utrzymanie ruchu po terminie"
 
 msgid "Make a replacement"
 msgstr "Utwórz zamiennik"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "Ręcznie dodaj pozycje do zapasów"
 
 msgid "Manually remove items from inventory"
-msgstr "Ręcznie usuń pozycje z zapasów"
+msgstr "Ręcznie usuń artykuły z zapasów"
 
 msgid "Mark Short"
 msgstr "Oznacz jako brakujące"
@@ -773,7 +773,7 @@ msgid "No"
 msgstr "Nie"
 
 msgid "No active job at this work center"
-msgstr "Brak aktywnego zadania w tym centrum roboczym"
+msgstr "Brak bieżącego zlecenia produkcyjnego na tym stanowisku roboczym"
 
 msgid "No active maintenance dispatches"
 msgstr "Brak aktywnych zleceń utrzymania ruchu"
@@ -782,7 +782,7 @@ msgid "No active operations"
 msgstr "Brak aktywnych operacji"
 
 msgid "No active work centers at this location."
-msgstr "Brak aktywnych centrów roboczych w tej lokalizacji."
+msgstr "Brak czynnych stanowisk roboczych w tej lokalizacji."
 
 msgid "No assigned operations"
 msgstr "Brak przypisanych operacji"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Nie znaleziono dostępnych śledzonych jednostek"
 
 msgid "No dispatches assigned to you"
-msgstr "Brak zleceń przypisanych do Ciebie"
+msgstr "Brak zleceń utrzymania ruchu przydzielonych Tobie"
 
 msgid "No files"
 msgstr "Brak plików"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Brak materiałów"
 
 msgid "No open jobs"
-msgstr "Brak otwartych zadań"
+msgstr "Brak otwartych zleceń produkcyjnych"
 
 msgid "No open units to allocate"
 msgstr "Brak otwartych jednostek do przydzielenia"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "Nie znaleziono opcji."
 
 msgid "No picking lists assigned"
-msgstr "Brak przypisanych list pobrań"
+msgstr "Brak przydzielonych list kompletacyjnych"
 
 msgid "No printer configured"
 msgstr "Brak skonfigurowanej drukarki"
@@ -881,10 +881,10 @@ msgid "No Work Center"
 msgstr "Brak stanowiska roboczego"
 
 msgid "No work centers are blocked"
-msgstr "Żadne gniazda produkcyjne nie są zablokowane"
+msgstr "Brak zablokowanych stanowisk roboczych"
 
 msgid "No work centers exist"
-msgstr "Brak gniazd produkcyjnych"
+msgstr "Brak stanowisk roboczych"
 
 msgid "None"
 msgstr "Brak"
@@ -896,10 +896,10 @@ msgid "Nothing running"
 msgstr "Nic nie działa"
 
 msgid "Nothing scheduled at this work center"
-msgstr "Nic nie zaplanowano w tym centrum roboczym"
+msgstr "Nic nie zaplanowano na tym stanowisku roboczym"
 
 msgid "Nothing to scrap"
-msgstr "Nic do złomowania"
+msgstr "Nic do braków"
 
 msgid "OEE Impact"
 msgstr "Wpływ na OEE"
@@ -921,13 +921,13 @@ msgid "Open"
 msgstr "Otwarte"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "Otwórz wyświetlacz na ekranie zamontowanym w centrum roboczym i pozostaw go uruchomiony. Każda tablica odświeża się automatycznie."
+msgstr "Otwórz wyświetlacz na ekranie zainstalowanym na stanowisku roboczym i pozostaw go w działaniu. Każda tablica odświeża się automatycznie."
 
 msgid "Open an NCR for MRB disposition"
 msgstr "Otwórz NCR dla dyspozycji MRB"
 
 msgid "Open Jobs"
-msgstr "Otwarte Zadania"
+msgstr "Otwarte zlecenia produkcyjne"
 
 msgid "Operations"
 msgstr "Operacje"
@@ -966,13 +966,13 @@ msgid "Partial Disposition"
 msgstr "Częściowa dyspozycja"
 
 msgid "Passed Inspection"
-msgstr "Inspekcja zaliczona"
+msgstr "Zaliczona kontrola"
 
 msgid "Passkey unlock failed"
 msgstr "Nieudane odblokowanie klucza dostępu"
 
 msgid "Pause"
-msgstr "Pauza"
+msgstr "Wstrzymaj"
 
 msgid "Pick"
 msgstr "Pobierz"
@@ -1014,7 +1014,7 @@ msgid "Prev"
 msgstr "Poprzedni"
 
 msgid "Preventive"
-msgstr "Prewencyjne"
+msgstr "Zapobiegawcze"
 
 msgid "Print"
 msgstr "Drukuj"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "Kolejka pusta"
 
 msgid "Reason for rework"
-msgstr "Powód do przeróbki"
+msgstr "Przyczyna poprawki"
 
 msgid "Recent"
 msgstr "Ostatnie"
@@ -1099,13 +1099,13 @@ msgid "Result"
 msgstr "Wynik"
 
 msgid "Rework"
-msgstr "Przeróbka"
+msgstr "Poprawka"
 
 msgid "Rework created successfully"
-msgstr "Przeróbka utworzona pomyślnie"
+msgstr "Poprawka została pomyślnie utworzona"
 
 msgid "Rework quantity"
-msgstr "Ilość do przeróbki"
+msgstr "Ilość do poprawki"
 
 msgid "Running"
 msgstr "W trakcie"
@@ -1120,13 +1120,13 @@ msgid "Scan"
 msgstr "Skanuj"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "Zeskanuj śledzony element, aby dodać pierwszą kolumnę próbki."
+msgstr "Skanuj jednostkę śledzoną, aby dodać pierwszą kolumnę próby."
 
 msgid "Scan or enter serial number"
 msgstr "Skanuj lub wprowadź numer seryjny"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Zeskanuj lub wprowadź ID elementu, numer seryjny lub numer partii"
+msgstr "Skanuj lub wprowadź identyfikator jednostki śledzonej, numer seryjny lub partię"
 
 msgid "Scan or enter tracking number"
 msgstr "Skanuj lub wpisz numer śledzenia"
@@ -1135,25 +1135,25 @@ msgid "Scan or search serial number..."
 msgstr "Skanuj lub wyszukaj numer seryjny..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Zeskanuj lub wybierz śledzony element z tej partii, aby dodać go jako kolumnę próbki, a następnie zaznacz jego wynik w siatce."
+msgstr "Skanuj lub wybierz jednostkę śledzoną z tej partii, aby dodać ją jako kolumnę próby, a następnie zapisz jej wynik w siatce."
 
 msgid "Schedule"
 msgstr "Harmonogram"
 
 msgid "Scrap"
-msgstr "Złom"
+msgstr "Braki"
 
 msgid "Scrap {readableId}"
-msgstr "Złom {readableId}"
+msgstr "Braki {readableId}"
 
 msgid "Scrap material"
-msgstr "Złom materiału"
+msgstr "Braki materiału"
 
 msgid "Scrap quantity"
-msgstr "Ilość złomu"
+msgstr "Ilość braku"
 
 msgid "Scrap Reason"
-msgstr "Przyczyna odrzutu"
+msgstr "Przyczyna braku"
 
 msgid "Scrapped"
 msgstr "Odrzucone"
@@ -1186,7 +1186,7 @@ msgid "Select a rework quantity"
 msgstr "Wybierz ilość do poprawki"
 
 msgid "Select a scrap quantity and reason"
-msgstr "Wybierz ilość odrzutu i przyczynę"
+msgstr "Wybierz ilość braku i przyczynę"
 
 msgid "Select a serial number to continue with this operation"
 msgstr "Wybierz numer seryjny, aby kontynuować tę operację"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Sesja zablokowana"
 
 msgid "Set Clock Out"
-msgstr "Ustaw zakończenie zmiany"
+msgstr "Ustaw zakończenie pracy"
 
 msgid "Set clock-out time"
 msgstr "Ustaw czas zakończenia zmiany"
@@ -1316,7 +1316,7 @@ msgstr "Stacja: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "Statystyczna akceptacja nie powiodła się, dlatego cała partia {0} jest uważana za niezgodną (ISO 9001:2015 §8.7) — {passes} próbkowanych przejść i {fails} niepowodzenia. Skieruj jednostki poniżej do złomu lub przeróbki, lub tylko zarejestruj werdykt."
+msgstr "Akceptacja statystyczna nie powiodła się, więc cała partia {0} jest uważana za niezgodną (ISO 9001:2015 §8.7) — {passes} próbek zaliczonych i {fails} porażek. Skieruj sztuki poniżej do braku lub poprawki, lub tylko zapisz werdykt."
 
 msgid "Status"
 msgstr "Status"
@@ -1337,10 +1337,10 @@ msgid "Storage Unit"
 msgstr "Jednostka magazynowa"
 
 msgid "Submit anonymously"
-msgstr "Wyślij anonimowo"
+msgstr "Prześlij anonimowo"
 
 msgid "Suggestion"
-msgstr "Sugestia"
+msgstr "Propozycja"
 
 msgid "Support Required"
 msgstr "Wymagane wsparcie"
@@ -1355,7 +1355,7 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "Ukończona ilość dla tej operacji jest mniejsza niż wymagana ilość {targetQuantity}."
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "Partia zostanie oznaczona jako Zaakceptowana i {remaining} pozostałych jednostek zostanie ukończonych w tej operacji."
+msgstr "Partia będzie oznaczona jako zaliczona i {remaining} pozostałych sztuk będzie ukończonych w tej operacji."
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Partia będzie nadal dyspozycjonowana, ale nie można utworzyć NCR, dopóki nie zostanie skonfigurowany co najmniej jeden typ problemu."
@@ -1364,7 +1364,7 @@ msgid "There are no available or consumed tracked parts for this material."
 msgstr "Brak dostępnych lub zużytych śledzonych części dla tego materiału."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
-msgstr "Na liście materiałowej znajdują się materiały śledzone seryjnie lub partiami, które nie zostały w pełni wydane. Ukończenie bez wydania może skutkować nieprawidłowymi rekordami śledzenia."
+msgstr "Na specyfikacji materiałowej znajdują się materiały śledzone po numerze seryjnym lub partii, które nie zostały w pełni wydane. Zakończenie bez wydania może spowodować nieprawidłowe rekordy identyfikowalności."
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
 msgstr "Te pozycje mają jeszcze materiał do wybrania. Zakończenie teraz oznaczy listę jako Częściowa."
@@ -1373,10 +1373,10 @@ msgid "This lot is expired and can't be picked."
 msgstr "Ta partia wygasła i nie można jej pobrać."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Ta część została wykonana na zamówienie. Jej złomowanie może ponownie otworzyć trasę producji, aby wykonać zamiennik."
+msgstr "Ta część została wyprodukowana na zamówienie. Jej skierowanie do braku może ponownie otworzyć jej marszrutę, aby stworzyć zamiennik."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "Ta część zostanie złomowana z magazynu. Jej zapotrzebowanie pozostaje otwarte, aby można było wystawić zamiennik."
+msgstr "Ta część będzie skierowana do braku ze zapasów. Jej wymaganie pozostaje otwarte, aby można było wydać zamiennik."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "Ta jednostka zostanie bezpowrotnie złomowana i zostanie utworzony nowy numer seryjny zamiennika."
@@ -1409,7 +1409,7 @@ msgid "Total: {0}"
 msgstr "Razem: {0}"
 
 msgid "Tracked Entity"
-msgstr "Śledzony element"
+msgstr "Jednostka śledzona"
 
 msgid "Tracking"
 msgstr "Śledzenie"
@@ -1450,7 +1450,7 @@ msgstr "Nieplanowany czas przestoju"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr "Pozycje nieplanowanej konserwacji w ciągu ostatnich {0} dni"
+msgstr "Niezaplanowane prace utrzymania ruchu, ostatnie {0} dni"
 
 msgid "Unsaved changes"
 msgstr "Niezapisane zmiany"
@@ -1495,13 +1495,13 @@ msgid "What is {translatedTerm}?"
 msgstr "Co to jest {translatedTerm}?"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Produkcja w toku"
 
 msgid "Work Center"
-msgstr "Gniazdo produkcyjne"
+msgstr "Stanowisko robocze"
 
 msgid "Work Center Displays"
-msgstr "Wyświetlacze Centrum Roboczego"
+msgstr "Wyświetlacze stanowiska roboczego"
 
 msgid "Yes"
 msgstr "Tak"
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Zalogowałeś się o <0/>. Możesz edytować czas wylogowania poniżej lub potwierdzić, że nadal pracujesz."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Jesteś zalogowany od {hoursElapsed} godzin. Czy zapomniałeś zakończyć zmianę?"
+msgstr "Pracujesz od {hoursElapsed} godzin. Zapomniałeś o zakończeniu pracy?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Twoje konto nie należy jeszcze do żadnej firmy. Ukończ wdrażanie w Carbon ERP, aby kontynuować."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Twoja organizacja wymaga aplikacji uwierzytelniającej. Skonfiguruj ją w aplikacji Carbon, a następnie wróć tutaj."

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -520,7 +520,6 @@ msgstr "Zakończ mimo wszystko"
 
 msgid "Finish setting up your account"
 msgstr "Dokończ konfigurowanie swojego konta"
-msgstr "Ukończ konfigurowanie konta"
 
 msgid "Finish with material unpicked?"
 msgstr "Zakończyć bez wybranego materiału?"
@@ -533,7 +532,6 @@ msgstr "Wróć do operacji"
 
 msgid "Go to onboarding"
 msgstr "Przejdź do wdrożenia"
-msgstr "Przejdź do procesu wdrażania"
 
 msgid "How many were actually picked?"
 msgstr "Ile faktycznie zostało zebrane?"
@@ -1516,7 +1514,6 @@ msgstr "Pracujesz od {hoursElapsed} godzin. Zapomniałeś o zakończeniu pracy?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Twoje konto nie należy jeszcze do żadnej firmy. Ukończ wdrażanie w Carbon ERP, aby kontynuować."
-msgstr "Twoje konto nie jest jeszcze częścią żadnej firmy. Dokończ proces wdrażania w aplikacji Carbon ERP, aby kontynuować."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Twoja organizacja wymaga aplikacji uwierzytelniającej. Skonfiguruj ją w aplikacji Carbon, a następnie wróć tutaj."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -304,7 +304,6 @@ msgstr "4h"
 
 msgid "5 user minimum"
 msgstr "Mínimo 5 usuários"
-msgstr "Mínimo de 5 usuários"
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -475,7 +474,6 @@ msgstr "Um componente de Fabricação sob encomenda cujas peças são emitidas j
 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr "Uma versão gerenciada hospedada na nuvem do Carbon"
-msgstr "Uma versão gerenciada hospedada em nuvem do Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Uma versão gerenciada com todos os recursos avançados"
@@ -2383,7 +2381,6 @@ msgstr "Atualizações Automáticas"
 
 msgid "Automatic updates and backups"
 msgstr "Atualizações automáticas e backups"
-msgstr "Atualizações e backups automáticos"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático e rateado de materiais não rastreados de um trabalho quando a saída é relatada — os materiais rastreados são emitidos manualmente."
@@ -2484,7 +2481,6 @@ msgstr "Preço Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
 msgstr "Funcionalidade ERP, MES e QMS básica"
-msgstr "Funcionalidade básica de ERP, MES e QMS"
 
 msgid "Basic Information"
 msgstr "Informações Básicas"
@@ -2625,7 +2621,6 @@ msgstr "Procurar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Navegue pela versão publicada somente leitura. Você ainda pode reorganizar etapas para limpar o layout."
-msgstr "Navegue pela versão publicada somente leitura. Você ainda pode reorganizar as etapas para organizar o layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -3041,7 +3036,6 @@ msgstr "Verifique seu email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
-msgstr "Verificando o Stripe para este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3183,7 +3177,6 @@ msgstr "Nuvem, ou seu ambiente auto-hospedado."
 
 msgid "CMMC compliant"
 msgstr "Em conformidade com CMMC"
-msgstr "Conforme com CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -6991,7 +6984,6 @@ msgstr "Formato"
 
 msgid "Forward deployed engineer"
 msgstr "Engenheiro de campo"
-msgstr "Engenheiro implantado no local"
 
 msgid "Foundation"
 msgstr "Fundação"
@@ -8145,7 +8137,6 @@ msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Ele parará de ser executado até que você publique uma versão novamente. Nada é excluído."
-msgstr "Ele parará de ser executado até que você publique uma versão novamente. Nada é deletado."
 
 msgid "ITAR Certifications"
 msgstr "Certificações ITAR"
@@ -8598,7 +8589,6 @@ msgstr "Vincular Problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Vincule este cliente Carbon a um deles ou crie um cliente Stripe separado."
-msgstr "Vincule este cliente Carbon a um deles, ou crie um cliente Stripe separado."
 
 msgid "Link to sales order line"
 msgstr "Vincular à linha do pedido de venda"
@@ -11649,7 +11639,6 @@ msgstr "Publicado pela Carbon"
 
 msgid "Published Version"
 msgstr "Versão publicada"
-msgstr "Versão Publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "As versões publicadas não podem ser editadas. Procure somente para leitura ou ramifique uma nova versão para fazer alterações."
@@ -12673,7 +12662,6 @@ msgstr "Reverter quaisquer entradas do razão de itens desta fatura"
 
 msgid "Reverse charge"
 msgstr "Cobrança reversa"
-msgstr "Cobrança Inversa"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposto de vendas de cobrança reversa"
@@ -13495,7 +13483,6 @@ msgstr "Auto-hospedado ou gerenciado"
 
 msgid "Self-onboarding"
 msgstr "Auto-integração"
-msgstr "Integração automática"
 
 msgid "Self-paced"
 msgstr "Autoaprendizagem"
@@ -14346,7 +14333,6 @@ msgstr "O Stripe envia a fatura para o cliente, portanto um endereço é obrigat
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe ainda não tem um cliente para este cliente do Carbon. A Contabilização criará um na sua conta conectada."
-msgstr "Stripe já possui um cliente com este e-mail"
 
 msgid "Stripe Due Date"
 msgstr "Data de Vencimento Stripe"
@@ -14771,7 +14757,6 @@ msgstr "Método de depreciação fiscal"
 
 msgid "Tax exempt"
 msgstr "Isento de imposto"
-msgstr "Isento de Impostos"
 
 msgid "Tax Exempt"
 msgstr "Isento de Impostos"
@@ -15635,7 +15620,6 @@ msgstr "Isto completa a etapa de Descoberta."
 
 msgid "This contact has no email address"
 msgstr "Este contato não possui endereço de e-mail"
-msgstr "Este contato não possui um endereço de e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Este terceiro não tem nada pendente — o pagamento será registrado em conta."
@@ -15667,7 +15651,6 @@ msgstr "Esta fatura não tem uma data de vencimento utilizável — escolha uma 
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Esta fatura será cobrada do cliente Stripe já vinculado a este cliente Carbon. Para alterar seus detalhes, edite-a no painel do Stripe."
-msgstr "Esta fatura não possui uma data de vencimento utilizável — escolha uma para Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Esta fatura será cobrada do cliente Stripe já vinculado a este cliente Carbon. Para alterar seus detalhes, edite-o no painel Stripe."
@@ -15811,7 +15794,6 @@ msgstr "Esta versão é publicada."
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Esta versão é publicada. Crie uma nova versão para editar."
-msgstr "Esta versão está publicada"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "Esta versão está publicada. Crie uma nova versão para editar."
@@ -16409,7 +16391,6 @@ msgstr "Cancelar publicação"
 
 msgid "Unpublish {name}?"
 msgstr "Cancelar publicação de {name}?"
-msgstr "Cancelar Publicação"
 
 msgid "Unpublish {name}?"
 msgstr "Cancelar Publicação de {name}?"
@@ -16774,7 +16755,6 @@ msgstr "Versão"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "Versão {0} está publicada agora e será substituída."
-msgstr "A versão {0} está publicada agora e será substituída."
 
 msgid "Version:"
 msgstr "Versão:"
@@ -17660,7 +17640,6 @@ msgstr "Está ao vivo no Carbon"
 
 msgid "You're one step away from your workspace."
 msgstr "Você está a uma etapa de seu espaço de trabalho."
-msgstr "Você está a um passo do seu espaço de trabalho."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Você está configurando o Carbon por conta própria, no seu próprio ritmo"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -43,14 +43,14 @@ msgstr "\"{taskName}\" marca-se como concluída assim que seus {0} itens do Mapa
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "\"{taskName}\" está concluído — todos os {0} itens do seu Mapa de Configuração estão configurados."
+msgstr "\"{taskName}\" está feito — todos os {0} itens do seu Mapa de Setup estão configurados."
 
 msgid "(excluded for this customer)"
 msgstr "(excluído para este cliente)"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
-msgstr "{0, plural, one {Este item está em 1 aviso de mudança aberto} other {Este item está em # avisos de mudança abertos}}"
+msgstr "{0, plural, one {Este item está em 1 aviso de alteração aberto} other {Este item está em # avisos de alteração abertos}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -83,7 +83,7 @@ msgstr "{0} lançamentos de diário em rascunho"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} trabalhos criados"
+msgstr "{0} ordens de produção criadas"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -92,7 +92,7 @@ msgstr "{0} linhas para mapear"
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
-msgstr "{0} de {1} contas de lançamento mapeadas"
+msgstr "{0} de {1} contas de contabilização mapeadas"
 
 #. placeholder {0}: rows.length
 msgid "{0} of {maxSlots} provider slots used"
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} valores ausentes"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} peças ignoradas — elas já têm trabalhos abertos"
+msgstr "{alreadyPlannedItemCount} peças ignoradas — elas já têm ordens de produção abertas"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% de contas a pagar"
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} de {count} operações"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} mais: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} meses com totais não correspondentes"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} periódicos faltando no provedor"
+msgstr "{missingCount} diários faltando no fornecedor"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} periódicos faltando e {mismatchCount} meses não correspondentes"
+msgstr "{missingCount} diários faltando e {mismatchCount} meses incompatíveis"
 
 msgid "{name} deleted"
 msgstr "{name} eliminado"
@@ -220,7 +220,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} trabalhos atualizados"
+msgstr "{updatedJobCount} ordens de produção atualizadas"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} enviado — campos preenchidos a partir do documento."
@@ -232,7 +232,7 @@ msgid "{years}yr"
 msgstr "{years}ano"
 
 msgid "/month/user"
-msgstr "/mês/utilizador"
+msgstr "/mês/usuário"
 
 msgid "% of total"
 msgstr "% do total"
@@ -246,7 +246,7 @@ msgid "↩ {0} redirected from superseded {1}"
 msgstr "↩ {0} redirecionado de {1} obsoleto"
 
 msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
-msgstr "<0>Adicione uma peça de fornecedor</0> para este item para definir um fornecedor preferido."
+msgstr "<0>Adicionar um item de fornecedor</0> para este item para definir um fornecedor preferencial."
 
 msgid "0 operations"
 msgstr "0 operações"
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4h"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Mínimo 5 usuários"
 
 msgid "5-8 weeks"
 msgstr "5-8 semanas"
@@ -330,7 +330,7 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Uma migração de dados executada pela Carbon — você carrega seus próprios dados"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Um aviso de mudança rastreia uma mudança de engenharia ou fabricação controlada através de revisão e implementação."
+msgstr "Um aviso de alteração rastreia uma alteração de engenharia ou fabricação controlada através de revisão e implementação."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "Uma conta de compensação que mantém o valor das mercadorias recebidas mas ainda não faturadas; a fatura do fornecedor a limpa."
@@ -351,16 +351,16 @@ msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that 
 msgstr "Um Desconto ou Margem de Lucro definido no escopo da empresa, por percentual ou quantia fixa, que ajusta o preço de uma linha para cima ou para baixo quando a linha corresponde às condições de quantidade, data, item e cliente da regra."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "A saída de um trabalho concluído, recebida no inventário ao custo WIP real acumulado do trabalho."
+msgstr "A saída de uma ordem de produção concluída, recebida no inventário ao custo real acumulado de produto em processo."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Um consumível é um item físico usado para fazer uma peça que pode ser usada em vários trabalhos"
+msgstr "Um consumível é um item físico usado para fabricar uma peça que pode ser usado em várias ordens de produção"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Um contratante é um contato de fornecedor com habilidades particulares e horas disponíveis"
+msgstr "Um terceirizado é um contato de fornecedor com habilidades particulares e horas disponíveis"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Uma solução personalizada para atender suas necessidades"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Um cliente é uma empresa ou pessoa que compra suas peças ou serviços."
@@ -375,7 +375,7 @@ msgid "A customer's account manager changes"
 msgstr "O gerenciador de conta de um cliente muda"
 
 msgid "A customer's assignee changes"
-msgstr "O responsável de um cliente muda"
+msgstr "O designado de um cliente muda"
 
 msgid "A customer's currency changes"
 msgstr "A moeda de um cliente muda"
@@ -393,10 +393,10 @@ msgid "A customer's type changes"
 msgstr "O tipo de um cliente muda"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "Um registro datado comprovando que um medidor foi verificado em relação a um padrão rastreável; passa a menos que um sinalizador de ação necessária, ajuste ou reparo esteja marcado, e redefine a data de próximo vencimento do medidor."
+msgstr "Um registro datado que prova que um instrumento de medição foi verificado contra um padrão rastreável; é aprovado a menos que um sinalizador de ação necessária, ajuste ou reparo seja marcado, e redefine a próxima data de vencimento do instrumento."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Uma janela datada em que lançamentos se enquadram; seu status de fechamento passa de Aberto → Bloqueado → Fechado, e um período fechado fica congelado contra novos lançamentos."
+msgstr "Uma janela de tempo datada na qual os lançamentos caem; seu status muda de Aberto → Bloqueado → Fechado, e um período fechado fica congelado contra novos lançamentos."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "Um método de depreciação que cobra uma porcentagem fixa do valor contábil remanescente cada período - mais pesado no início, mais leve depois."
@@ -414,7 +414,7 @@ msgid "A formal acceptance / sign-off phase"
 msgstr "Uma fase formal de aceitação / aprovação"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "Um medidor cuja função é Mestre — o padrão de referência contra o qual outros medidores são calibrados, em vez de um usado para verificações rotineiras."
+msgstr "Um instrumento de medição cuja função é Padrão — o padrão de referência contra o qual outros instrumentos de medição são calibrados, em vez de um usado para verificações de rotina."
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "Um registro de problema rastreia problemas de qualidade e seu processo de resolução."
@@ -426,16 +426,16 @@ msgid "A job is deleted"
 msgstr "Um trabalho é excluído"
 
 msgid "A job is put on hold"
-msgstr "Um trabalho é colocado em espera"
+msgstr "Uma ordem de produção é suspensa"
 
 msgid "A job is released"
 msgstr "Um trabalho é liberado"
 
 msgid "A job operation is completed"
-msgstr "Uma operação de trabalho é concluída"
+msgstr "Uma operação da ordem é concluída"
 
 msgid "A job's assignee changes"
-msgstr "O responsável de um trabalho muda"
+msgstr "O designado de uma ordem de produção muda"
 
 msgid "A job's deadline type changes"
 msgstr "O tipo de prazo de um trabalho muda"
@@ -450,7 +450,7 @@ msgid "A job's quantity changes"
 msgstr "A quantidade de um trabalho muda"
 
 msgid "A job's scrap quantity changes"
-msgstr "A quantidade de sucata de um trabalho muda"
+msgstr "A quantidade de refugo de uma ordem de produção muda"
 
 msgid "A job's start date changes"
 msgstr "A data de início de um trabalho muda"
@@ -467,19 +467,19 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Uma lista é conectada a {0}, portanto, esta etapa é executada uma vez para cada item nela — até {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Um componente Fazer sob pedido que obtém seu próprio trabalho e rota dentro da construção do pai."
+msgstr "Um componente de Fabricação sob encomenda que recebe sua própria ordem de produção e roteiro de produção dentro da fabricação do pai."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Um componente Fazer sob pedido cujas peças são emitidas juntas para o trabalho pai — sem construção separada."
+msgstr "Um componente de Fabricação sob encomenda cujas peças são emitidas juntas para a ordem de produção do pai — sem construção separada."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Uma versão gerenciada hospedada na nuvem do Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Uma versão gerenciada com todos os recursos avançados"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Um material é um item físico usado para fazer uma peça que pode ser usada em vários trabalhos"
+msgstr "Um material é um item físico usado para fabricar uma peça que pode ser usado em várias ordens de produção"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
 msgstr "Um instrumento de medição (paquímetro, micrômetro, medidor de pino, CMM) rastreado como um registro e mantido em um cronograma de calibração recorrente."
@@ -488,10 +488,10 @@ msgid "A name is required to save a view"
 msgstr "Um nome é necessário para salvar uma visualização"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Um preço negociado fixado para um item específico — por cliente, tipo de cliente ou todos os clientes — que substitui completamente o preço base, opcionalmente com quebras de quantidade."
+msgstr "Um preço negociado fixado para um item específico — por cliente, tipo de cliente ou todos os clientes — que substitui completamente o preço base, opcionalmente com faixas de quantidade."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "Uma nova ordem de compra será criada para cada fornecedor. Alternativamente, você pode escolher uma ordem de compra de rascunho existente para o fornecedor para adicionar as operações externas."
+msgstr "Uma nova ordem de compra será criada para cada fornecedor. Alternativamente, você pode escolher um pedido de compra em rascunho existente do fornecedor para adicionar as operações externas a ele."
 
 msgid "A new revision will be created using a copy of the current revision"
 msgstr "Uma nova revisão será criada usando uma cópia da revisão atual"
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Um novo tamanho será criado usando uma cópia do tamanho atual"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Um novo cliente Stripe será criado"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Um documento sem dinheiro que liquida uma fatura em relação a uma conta de motivo: um crédito reduz o que é devido, um débito aumenta."
@@ -509,7 +509,7 @@ msgid "A non-conformance shared with a supplier over a login-free /share/scar li
 msgstr "Uma não conformidade compartilhada com um fornecedor através de um link /share/scar sem login, para que possa responder ao problema e atualizar suas tarefas fora do Carbon."
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
-msgstr "Uma sobretaxa não tributável (p. ex. despesas recuperáveis como taxas de licença) adicionada à linha e excluída da base tributária."
+msgstr "Uma sobretaxa não tributável (por ex. despesas recuperáveis como taxas de licença) adicionada à linha; excluída da base de imposto."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
 msgstr "Uma tarefa de não conformidade que corrige uma causa raiz confirmada — em oposição a uma ação preventiva ou de contenção imediata."
@@ -521,10 +521,10 @@ msgid "A part contains the information about a specific item that can be purchas
 msgstr "Uma peça contém as informações sobre um item específico que pode ser comprado ou fabricado."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "Um sinal de puxada física — um cartão impresso ou código QR vivendo com o estoque — que levanta um pedido de compra ou trabalho no momento em que é digitalizado para reabastecer uma caixa."
+msgstr "Um sinal físico de puxada — um cartão impresso ou código QR que acompanha o estoque — que gera um pedido de compra ou uma ordem de produção no momento em que é escaneado para reabastecer um compartimento."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "Um ponto em um dos próprios fluxos da Carbon que um fluxo de trabalho pode observar — um trabalho liberado, uma cotação aceita, um envio postado — em oposição a uma mudança de campo bruta; ele passa para o fluxo de trabalho os registros envolvidos por id."
+msgstr "Um ponto em um dos próprios fluxos do Carbon que um fluxo de trabalho pode monitorar — uma ordem de produção liberada, um orçamento aceito, uma remessa contabilizada — em oposição a uma mudança de campo bruta; fornece ao fluxo de trabalho os registros envolvidos por id."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
 msgstr "Um lançamento contábil postado: um cabeçalho mais linhas de débito e crédito equilibradas contra contas GL."
@@ -536,13 +536,13 @@ msgid "A pre-written description inserted into every issue that uses this workfl
 msgstr "Uma descrição pré-escrita inserida em cada problema que usa este fluxo de trabalho; os espaços reservados como {itemId} e {location} são substituídos na criação."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "Uma cotação de vendas com preço; Rascunho → Enviado → Pedido, ou termina Perdido, Expirado ou Cancelado."
+msgstr "Um orçamento de vendas com preço; Rascunho → Enviado → Pedido emitido, ou termina Perdido, Vencido ou Cancelado."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
 msgstr "Uma fatura de compra é um documento que especifica os produtos ou serviços adquiridos por um cliente e o custo correspondente."
 
 msgid "A purchase invoice is posted"
-msgstr "Uma nota fiscal de compra é postada"
+msgstr "Uma fatura de compra é contabilizada"
 
 msgid "A purchase order is created"
 msgstr "Um pedido de compra é criado"
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "Um pedido de compra é excluído"
 
 msgid "A purchase order's assignee changes"
-msgstr "O responsável de um pedido de compra muda"
+msgstr "O designado de um pedido de compra muda"
 
 msgid "A purchase order's order date changes"
 msgstr "A data do pedido de um pedido de compra muda"
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "Uma cotação é enviada"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Uma linha de cotação contém preços e prazos de entrega para uma peça específica"
+msgstr "Uma linha do orçamento contém precificação e lead times para uma peça específica"
 
 msgid "A quote's assignee changes"
-msgstr "O responsável de uma cotação muda"
+msgstr "O designado do orçamento muda"
 
 msgid "A quote's completed date changes"
 msgstr "A data de conclusão de uma cotação muda"
@@ -614,7 +614,7 @@ msgid "A quote's estimator changes"
 msgstr "O estimador de uma cotação muda"
 
 msgid "A quote's expiration date changes"
-msgstr "A data de expiração de uma cotação muda"
+msgstr "A data de validade do orçamento muda"
 
 msgid "A quote's salesperson changes"
 msgstr "O vendedor de uma cotação muda"
@@ -632,7 +632,7 @@ msgid "A receipt is posted"
 msgstr "Um recebimento é lançado"
 
 msgid "A receipt's assignee changes"
-msgstr "O responsável de um recebimento muda"
+msgstr "O designado do recebimento muda"
 
 msgid "A receipt's invoiced changes"
 msgstr "O faturado de um recebimento muda"
@@ -641,7 +641,7 @@ msgid "A receipt's location changes"
 msgstr "A localização de um recebimento muda"
 
 msgid "A receipt's posting date changes"
-msgstr "A data de lançamento de um recebimento muda"
+msgstr "A data de contabilização do recebimento muda"
 
 msgid "A receipt's source document changes"
 msgstr "O documento de origem de um recebimento muda"
@@ -656,7 +656,7 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Um conjunto reutilizável e versionado de instruções de trabalho anexadas a um processo, fornecendo a uma operação suas etapas ordenadas para registrar e verificar, além dos parâmetros em que é executada."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Uma etapa de roteamento em um job liberado, a cópia própria do job de uma operação, carregando um status que o chão de fábrica conduz de Pendente até Concluído."
+msgstr "Uma etapa de roteiro em uma ordem de produção liberada, a cópia da ordem de uma operação, carregando um status que o piso dirige de Todo até Feito."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
 msgstr "Uma fatura de vendas (você fatura um cliente) ou fatura de compra (um fornecedor o fatura), liquidada aplicando pagamentos e memorandos de crédito ou débito."
@@ -671,7 +671,7 @@ msgid "A sales invoice line contains invoice details for a particular item"
 msgstr "Uma linha de fatura de vendas contém detalhes da fatura para um item específico"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Uma ordem de venda contém informações sobre o acordo entre a empresa e um cliente específico para peças e serviços."
+msgstr "Um pedido de venda contém informações sobre o acordo entre a empresa e um cliente específico para peças e serviços."
 
 msgid "A sales order is created"
 msgstr "Um pedido de venda é criado"
@@ -683,7 +683,7 @@ msgid "A sales order line contains order details for a particular item"
 msgstr "Uma linha de pedido de venda contém detalhes do pedido para um item específico"
 
 msgid "A sales order's assignee changes"
-msgstr "O responsável de um pedido de venda muda"
+msgstr "O designado do pedido de venda muda"
 
 msgid "A sales order's completed date changes"
 msgstr "A data de conclusão de um pedido de venda muda"
@@ -707,7 +707,7 @@ msgid "A sales order's status changes"
 msgstr "O status de um pedido de venda muda"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Um pedido de cotação de vendas (RFQ) é uma consulta de cliente para precificação de um conjunto de peças e quantidades. Pode resultar em uma cotação."
+msgstr "Uma solicitação de cotação (RFQ) é uma investigação do cliente para precificação em um conjunto de peças e quantidades. Pode resultar em um orçamento."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "Um RFQ de venda (um cliente pede para você fazer uma cotação) ou um RFQ de compra (você solicita aos fornecedores); ambos alimentam o thread de oportunidade."
@@ -722,40 +722,40 @@ msgid "A service is a billable activity that is bought or performed — it is ne
 msgstr "Um serviço é uma atividade faturável que é comprada ou realizada — nunca é enviada, recebida ou armazenada"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Um conjunto de empresas sob um mesmo proprietário que compartilham configuração com escopo de grupo — o plano de contas, as moedas e as dimensões — de modo que a mesma configuração contábil abrange todas as empresas do grupo."
+msgstr "Um conjunto de empresas sob um mesmo proprietário que compartilham configuração com escopo de grupo — o plano de contas, moedas e dimensões — para que a mesma configuração contábil se estenda por todas as empresas do grupo."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Um conjunto de instruções para puxar os materiais pendentes de um trabalho do depósito e preparar de forma lateral; uma coleta move o estoque para o ponto de uso em vez de consumi-lo."
+msgstr "Um conjunto de instruções para extrair os materiais pendentes de uma ordem de produção do armazém e posicioná-los na borda de linha; uma separação move o estoque para o ponto de uso em vez de consumi-lo."
 
 msgid "A shipment is created"
-msgstr "Um envio é criado"
+msgstr "Uma remessa é criada"
 
 msgid "A shipment is deleted"
-msgstr "Um envio é excluído"
+msgstr "Uma remessa é excluída"
 
 msgid "A shipment is posted"
-msgstr "Um envio é lançado"
+msgstr "Uma remessa é contabilizada"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
 msgstr "Uma linha de remessa enviada diretamente do fornecedor ao cliente, contornando seu armazém — definida por linha, não no cabeçalho."
 
 msgid "A shipment's assignee changes"
-msgstr "O responsável de um envio muda"
+msgstr "O designado da remessa muda"
 
 msgid "A shipment's customer changes"
-msgstr "O cliente de um envio muda"
+msgstr "O cliente da remessa muda"
 
 msgid "A shipment's location changes"
-msgstr "A localização de um envio muda"
+msgstr "O local da remessa muda"
 
 msgid "A shipment's posting date changes"
-msgstr "A data de lançamento de um envio muda"
+msgstr "A data de contabilização da remessa muda"
 
 msgid "A shipment's shipping method changes"
-msgstr "O método de envio de um envio muda"
+msgstr "O método de envio da remessa muda"
 
 msgid "A shipment's status changes"
-msgstr "O status de um envio muda"
+msgstr "O status da remessa muda"
 
 msgid "A shipment's tracking number changes"
 msgstr "O número de rastreamento de uma remessa muda"
@@ -773,7 +773,7 @@ msgid "A supplier's account manager changes"
 msgstr "O gerenciador de conta de um fornecedor muda"
 
 msgid "A supplier's assignee changes"
-msgstr "O responsável de um fornecedor muda"
+msgstr "O designado do fornecedor muda"
 
 msgid "A supplier's currency changes"
 msgstr "A moeda de um fornecedor muda"
@@ -794,25 +794,25 @@ msgid "A supplier's type changes"
 msgstr "O tipo de um fornecedor muda"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "Uma sobretaxa tributável (manuseio, configuração, combustível) adicionada à linha e incluída na base tributária."
+msgstr "Uma sobretaxa tributável (manuseio, setup, combustível) adicionada à linha; é incluída na base tributária."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Um registro cronometrado de trabalho de Configuração, Mão de Obra ou Máquina registrado em uma operação de trabalho, cuja duração é acumulada no custo real da operação."
+msgstr "Um registro cronometrado de trabalho de Setup, Mão de obra ou Máquina registrado em uma operação da ordem, cuja duração é acumulada no custo real da operação."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Uma ferramenta é um item físico usado para fazer uma peça que pode ser usada em vários trabalhos"
+msgstr "Uma ferramenta é um item físico usado para fabricar uma peça que pode ser usada em múltiplas ordens de produção"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "Um utilizador regista a data de validade em cada lote ou série quando os bens são recebidos. Utilize quando os fornecedores enviam lotes com datas de validade diferentes."
+msgstr "Um usuário registra a validade em cada lote de produção ou serial quando as mercadorias são recebidas. Use quando fornecedores enviam lotes com datas de validade diferentes."
 
 msgid "abilities"
-msgstr "capacidades"
+msgstr "habilidades"
 
 msgid "Abilities"
 msgstr "Habilidades"
 
 msgid "ability"
-msgstr "capacidade"
+msgstr "habilidade"
 
 msgid "About"
 msgstr "Sobre"
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "Contabilidade"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "A contabilidade está atualmente em beta. Solicite acesso para habilitar relatórios, lançamentos contábeis, períodos contábeis, ativos fixos e muito mais."
+msgstr "Contabilidade está atualmente em beta. Solicite acesso para ativar relatórios, diários, períodos contábeis, ativos fixos e muito mais."
 
 msgid "Accounting is disabled"
 msgstr "A contabilidade está desativada"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "Períodos Contábeis"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Contabilidade: GL, AR, AP e encerramento mensal"
+msgstr "Contabilidade: Razão, Contas a receber, Contas a pagar e fechamento do mês"
 
 msgid "Accounts"
 msgstr "Contas"
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "Contas a receber para valores devidos pelos clientes."
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Contas referenciadas por padrões de lançamento ou histórico de periódicos que ainda não têm mapeamento de provedor."
+msgstr "Contas referenciadas por padrões de contabilização ou histórico de diários que ainda não têm mapeamento de provedor."
 
 msgid "Accumulated Depreciation"
 msgstr "Depreciação acumulada"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Conta de depreciação acumulada"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Depreciação acumulada na alienação"
+msgstr "Depreciação acumulada em Baixa"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Depreciação acumulada na alienação (padrão)"
+msgstr "Depreciação acumulada em Baixa (padrão)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Período de Acumulação (Semanas)"
@@ -1011,10 +1011,10 @@ msgid "Active"
 msgstr "Ativo"
 
 msgid "Active Jobs"
-msgstr "Trabalhos Ativos"
+msgstr "Ordens de produção ativas"
 
 msgid "Active Statuses"
-msgstr "Estados Ativos"
+msgstr "Status Ativos"
 
 msgid "Active Supplier Quotes"
 msgstr "Cotações de Fornecedor Ativas"
@@ -1053,7 +1053,7 @@ msgid "Add a comment..."
 msgstr "Adicione um comentário..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Adicione uma linha de preço personalizada para substituir quantidade, preço, frete, prazo de entrega e imposto"
+msgstr "Adicionar uma linha de precificação personalizada para substituir quantidade, preço, envio, lead time e imposto"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "Adicione uma seção de materiais que lista cada item na lista de materiais com sua quantidade."
@@ -1083,7 +1083,7 @@ msgid "Add Affected Item"
 msgstr "Adicionar Item Afetado"
 
 msgid "Add any notes about your decision..."
-msgstr "Adicione qualquer nota sobre sua decisão..."
+msgstr "Adicione qualquer observação sobre sua decisão..."
 
 msgid "Add Approval Requirement"
 msgstr "Adicionar Requisito de Aprovação"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "Adicionar condição"
 
 msgid "Add Contractor"
-msgstr "Adicionar Contratante"
+msgstr "Adicionar Terceirizado"
 
 msgid "Add cost center"
 msgstr "Adicionar centro de custo"
@@ -1143,10 +1143,10 @@ msgid "Add New"
 msgstr "Adicionar Novo"
 
 msgid "Add Note"
-msgstr "Adicionar Nota"
+msgstr "Adicionar Observação"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Adicione notas e documentação para este despacho de manutenção"
+msgstr "Adicionar observações e documentação para esta ordem de manutenção"
 
 msgid "Add Operation"
 msgstr "Adicionar Operação"
@@ -1206,7 +1206,7 @@ msgid "Add Selector"
 msgstr "Adicionar Seletor"
 
 msgid "Add Shipment"
-msgstr "Adicionar Envio"
+msgstr "Adicionar Remessa"
 
 msgid "Add Shipping"
 msgstr "Adicionar Envio"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Todas as {0} células correspondem"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Todas as {total} fases estão concluídas. Excelente trabalho — sua equipe está funcionando."
+msgstr "Todas as {total} fases estão concluídas. Bom trabalho — sua equipe está funcionando normalmente."
 
 msgid "All accounts"
 msgstr "Todas as contas"
@@ -1334,10 +1334,10 @@ msgid "All actions selected"
 msgstr "Todas as ações selecionadas"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Todos os recursos avançados disponíveis"
 
 msgid "All Audit Logs"
-msgstr "Todos os Registos de Auditoria"
+msgstr "Todos os logs de auditoria"
 
 msgid "All changes to auditable entities are being recorded."
 msgstr "Todas as alterações em entidades auditáveis estão sendo registradas."
@@ -1352,7 +1352,7 @@ msgid "All Documents"
 msgstr "Todos os Documentos"
 
 msgid "All item types"
-msgstr "Todos os tipos de itens"
+msgstr "Todos os tipos de item"
 
 msgid "All Items"
 msgstr "Todos os Itens"
@@ -1364,7 +1364,7 @@ msgid "All members of selected groups and selected individuals will be able to a
 msgstr "Todos os membros dos grupos selecionados e indivíduos selecionados poderão aprovar solicitações"
 
 msgid "All posting accounts are mapped"
-msgstr "Todas as contas de lançamento estão mapeadas"
+msgstr "Todas as contas de contabilização estão mapeadas"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas as linhas importadas — {inserted} inseridas, {updated} atualizadas."
@@ -1385,7 +1385,7 @@ msgid "All Types"
 msgstr "Todos os Tipos"
 
 msgid "All users"
-msgstr "Todos os utilizadores"
+msgstr "Todos os usuários"
 
 msgid "All Work Centers"
 msgstr "Todos os Centros de Trabalho"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Valor"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Montante que aumenta ativos/despesas ou diminui passivos/patrimônio/receitas nesta linha."
+msgstr "Valor que aumenta ativos/despesas ou diminui passivos/patrimônio líquido/receita nesta linha."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Montante que aumenta passivos/patrimônio/receitas ou diminui ativos/despesas nesta linha."
+msgstr "Valor que aumenta passivos/patrimônio líquido/receita ou diminui ativos/despesas nesta linha."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,7 +1422,7 @@ msgid "Amount Type"
 msgstr "Tipo de Valor"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Um balde contábil que agrupa despesas por departamento ou função para que a GL possa relatar despesas por grupo, não apenas por conta."
+msgstr "Um grupo contábil que agrupa despesas por departamento ou função para que a Razão possa relatar gasto por grupo, não apenas por conta."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
 msgstr "Um registro contábil de um elemento capitalizado que você deprecia em vez de despesado; Rascunho → Ativo → Totalmente depreciado → Alienado."
@@ -1440,7 +1440,7 @@ msgid "An automation you build on a canvas: one trigger, then steps that check c
 msgstr "Uma automação que você constrói em uma tela: um gatilho, seguido por etapas que verificam condições, procuram registros e agem — notificando alguém, criando ou atualizando um registro, ou chamando uma URL externa."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "Uma mudança de engenharia: os itens afetados cujos métodos são revisados em um rascunho e lançados juntos, substituindo as versões que substituem."
+msgstr "Uma alteração de engenharia: os itens afetados cujos métodos são revisados em rascunho e liberados juntos, que substituem as versões anteriores."
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "Uma solicitação https que o Carbon envia para um sistema seu quando um fluxo de trabalho atinge essa etapa, carregando quaisquer cabeçalhos e corpo que você configurou."
@@ -1458,7 +1458,7 @@ msgid "An issue is deleted"
 msgstr "Um problema é excluído"
 
 msgid "An issue's assignee changes"
-msgstr "O responsável de um problema muda"
+msgstr "O designado de uma requisição muda"
 
 msgid "An issue's close date changes"
 msgstr "A data de encerramento de um problema muda"
@@ -1497,16 +1497,16 @@ msgid "An item's active changes"
 msgstr "A ativação de um item muda"
 
 msgid "An item's assignee changes"
-msgstr "O responsável de um item muda"
+msgstr "O designado de um item muda"
 
 msgid "An item's default method type changes"
-msgstr "O tipo de método padrão de um item muda"
+msgstr "O tipo de suprimento padrão de um item muda"
 
 msgid "An item's name changes"
 msgstr "O nome de um item muda"
 
 msgid "An item's replenishment system changes"
-msgstr "O sistema de reabastecimento de um item muda"
+msgstr "O sistema de reposição de um item muda"
 
 msgid "An item's revision status changes"
 msgstr "O status de revisão de um item muda"
@@ -1576,7 +1576,7 @@ msgid "Anything not explicitly listed in scope above"
 msgstr "Qualquer coisa não explicitamente listada no escopo acima"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Contas a pagar"
 
 msgid "AP Aging"
 msgstr "Envelhecimento de Contas a Pagar"
@@ -1585,10 +1585,10 @@ msgid "AP Clerk"
 msgstr "Assistente de Contas a Pagar"
 
 msgid "AP Outstanding"
-msgstr "AP Pendente"
+msgstr "Contas a pagar em aberto"
 
 msgid "AP Overdue"
-msgstr "AP Vencido"
+msgstr "Contas a pagar atrasadas"
 
 msgid "API Docs"
 msgstr "Documentação da API"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Chaves de API para acesso programático aos seus dados do Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhooks e integrações"
 
 msgid "Applied"
 msgstr "Aplicado"
@@ -1652,7 +1652,7 @@ msgid "Apply payments and track aging"
 msgstr "Aplicar pagamentos e rastrear vencimento"
 
 msgid "Apply pricing rules"
-msgstr "Aplicar regras de preços"
+msgstr "Aplicar regras de precificação"
 
 msgid "Apply Rules On Top"
 msgstr "Aplicar regras na parte superior"
@@ -1709,10 +1709,10 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Contas a receber"
 
 msgid "AR / AP representation"
-msgstr "Representação AR / AP"
+msgstr "Representação de contas a receber/contas a pagar"
 
 msgid "AR Aging"
 msgstr "Envelhecimento de Contas a Receber"
@@ -1721,13 +1721,13 @@ msgid "AR Clerk"
 msgstr "Funcionário de Contas a Receber"
 
 msgid "AR Outstanding"
-msgstr "AR Pendente"
+msgstr "Contas a receber em aberto"
 
 msgid "AR Overdue"
-msgstr "AR Vencido"
+msgstr "Contas a receber atrasadas"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Contas a receber/contas a pagar"
 
 msgid "Archive"
 msgstr "Arquivo"
@@ -1750,7 +1750,7 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "Tem a certeza de que deseja ativar o processo: {name}? Ele aparecerá novamente nos menus suspensos."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Tem certeza de que deseja ativar este medidor?."
+msgstr "Tem certeza de que deseja ativar este instrumento de medição?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
@@ -1773,13 +1773,13 @@ msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Tem a certeza de que deseja concluir esta transferência de stock?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Tem a certeza de que deseja confirmar este pedido de venda? A confirmação do pedido afetará as quantidades de pedido utilizadas para calcular a oferta e a procura."
+msgstr "Tem certeza de que deseja confirmar este pedido de venda? Confirmar o pedido afetará as quantidades em pedido usadas para calcular suprimento e demanda."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "Tem a certeza de que deseja converter o RFQ para uma cotação?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Tem a certeza de que deseja criar tarefas para esta encomenda de venda? Isto criará tarefas para todas as linhas que ainda não têm tarefas."
+msgstr "Tem certeza de que deseja criar ordens de produção para este pedido de venda? Isso criará ordens de produção para todas as linhas que ainda não têm ordens de produção."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1800,31 +1800,31 @@ msgid "Are you sure you want to deactivate the process: {name}? It will no longe
 msgstr "Tem a certeza de que deseja desativar o processo: {name}? Deixará de aparecer nas listas suspensas."
 
 msgid "Are you sure you want to deactivate these users?"
-msgstr "Tem a certeza de que deseja desativar estes utilizadores?"
+msgstr "Tem certeza de que deseja desativar estes usuários?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Tem certeza de que deseja desativar este medidor?."
+msgstr "Tem certeza de que deseja desativar este instrumento de medição?."
 
 msgid "Are you sure you want to deactivate this user?"
-msgstr "Tem a certeza de que deseja desativar este utilizador?"
+msgstr "Tem certeza de que deseja desativar este usuário?"
 
 #. placeholder {0}: tool.readableIdWithRevision
 msgid "Are you sure you want to delete {0} from this operation? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar {0} desta operação? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir {0} desta operação? Isto não pode ser desfeito."
 
 #. placeholder {0}: selectedEntry.journalEntryId
 #. placeholder {0}: selectedGroup.name
 msgid "Are you sure you want to delete {0}?"
-msgstr "Tem a certeza de que deseja eliminar {0}?"
+msgstr "Tem certeza de que deseja excluir {0}?"
 
 #. placeholder {0}: getQuoteDisplayId( routeData?.quote )
 #. placeholder {0}: getQuoteDisplayId( selectedQuotation )
 #. placeholder {0}: initialValues.memoId
 msgid "Are you sure you want to delete {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir {name}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete {orderLabel}? This cannot be undone."
 msgstr "Tem certeza de que deseja excluir {orderLabel}? Isso não pode ser desfeito."
@@ -1836,211 +1836,211 @@ msgstr "Tem certeza de que deseja excluir a visualização \"{0}\"? Isto não po
 
 #. placeholder {0}: selectedCustomField?.name
 msgid "Are you sure you want to delete the {0} field?"
-msgstr "Tem a certeza de que deseja eliminar o campo {0}?"
+msgstr "Tem certeza de que deseja excluir o campo {0}?"
 
 #. placeholder {0}: parameter.label
 msgid "Are you sure you want to delete the {0} parameter? This will not update any formulas that are using this parameter."
-msgstr "Tem a certeza de que deseja eliminar o parâmetro {0}? Isto não atualizará nenhuma fórmula que esteja a utilizar este parâmetro."
+msgstr "Tem certeza de que deseja excluir o parâmetro {0}? Isso não atualizará nenhuma fórmula que esteja usando este parâmetro."
 
 msgid "Are you sure you want to delete the {key} parameter from this operation? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o parâmetro {key} desta operação? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o parâmetro {key} desta operação? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the {name} attribute from this operation? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o atributo {name} desta operação? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o atributo {name} desta operação? Isto não pode ser desfeito."
 
 #. placeholder {0}: account.name
 #. placeholder {1}: account.number ? ` (${account.number})` : ""
 msgid "Are you sure you want to delete the account: {0}{1}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a conta: {0}{1}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a conta: {0}{1}? Isto não pode ser desfeito."
 
 #. placeholder {0}: apiKey.name
 msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a chave de API: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a chave de API: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Tem certeza que deseja deletar a classe de ativo: {0}? Isso não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a classe de ativo: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "Tem certeza de que deseja excluir a ação do aviso de mudança: {0}? Isso não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a ação do aviso de alteração: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "Tem certeza de que deseja excluir a categoria de aviso de mudança: {0}? Isso não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a categoria do aviso de alteração: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o contratante: {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o terceirizado: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a peça do cliente para {0}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a peça do cliente para {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the customer portal for: {customerName}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o portal do cliente para: {customerName}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o portal do cliente para: {customerName}? Isto não pode ser desfeito."
 
 #. placeholder {0}: customerStatus.name
 msgid "Are you sure you want to delete the customer status: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o estado do cliente: {0}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir o status do cliente: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: customerType.name
 msgid "Are you sure you want to delete the customer type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de cliente: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de cliente: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o departamento: {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o departamento: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: employeeType.name
 msgid "Are you sure you want to delete the employee type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de funcionário: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de funcionário: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the failure mode: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o modo de falha: {name}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir o modo de falha: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de medidor: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de instrumento: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o grupo: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o grupo: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the holiday: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o feriado: {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o feriado: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: nonConformanceType.name
 msgid "Are you sure you want to delete the issue type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de problema: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de requisição: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: itemPostingGroup.name
 msgid "Are you sure you want to delete the item group: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o grupo de artigos: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o grupo de itens: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: line.customerPartId
 #. placeholder {0}: line.description
 #. placeholder {0}: line.itemReadableId
 msgid "Are you sure you want to delete the line: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a linha: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a linha: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the line: {itemReadableId}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a linha: {itemReadableId}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a linha: {itemReadableId}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the location: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a localização: {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o local: {name}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o cronograma de manutenção: {name}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a programação de manutenção: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a dimensão do material: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a dimensão do material: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o acabamento de material: {0}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir o acabamento: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o formulário de material: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a forma do material: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o grau de material: {0}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir o grau: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a substância material: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o material base: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de material: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de material: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o motivo sem cotação: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o motivo de sem cotação: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o parceiro: {name}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o parceiro: {name}? Isto não pode ser desfeito."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o termo de pagamento: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a condição de pagamento: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a regra de preço: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a regra de precificação: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: printerToDelete.name
 msgid "Are you sure you want to delete the printer \"{0}\"? Any assignments referencing this printer will be cleared. This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a impressora \"{0}\"? Todas as atribuições que fazem referência a esta impressora serão limpas. Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a impressora \"{0}\"? Todas as atribuições que fazem referência a esta impressora serão limpas. Isto não pode ser desfeito."
 
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a linha da fatura de compra para {0} {1}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a linha da fatura de compra para {0} {1}? Isto não pode ser desfeito."
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a linha da fatura de venda para {0} {1}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a linha da fatura de venda para {0} {1}? Isto não pode ser desfeito."
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a linha de encomenda de vendas para {0} {1}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a linha do pedido de venda para {0} {1}? Isto não pode ser desfeito."
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o motivo de sucata: {0}? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir o motivo de refugo: {0}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "Tem certeza de que deseja deletar a sequência de número de série para {itemLabel}? Isso não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir a sequência do número de série para {itemLabel}? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o turno: {name} de {locationName}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o turno: {name} do {locationName}? Isto não pode ser desfeito."
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o método de envio: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o método de envio: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de armazenamento: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de armazenamento: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a unidade de armazenamento: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a unidade de armazenamento: {0}? Isto não pode ser desfeito."
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o tipo de fornecedor: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o tipo de fornecedor: {0}? Isso não pode ser desfeito."
 
 #. placeholder {0}: unitOfMeasure.name
 msgid "Are you sure you want to delete the unit of measure: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar a unidade de medida: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir a unidade de medida: {0}? Isso não pode ser desfeito."
 
 #. placeholder {0}: selectedView.name
 msgid "Are you sure you want to delete the view \"{0}\"?"
-msgstr "Tem a certeza de que deseja eliminar a vista \"{0}\"?"
+msgstr "Tem certeza de que deseja excluir a visualização \"{0}\"?"
 
 #. placeholder {0}: webhook.name
 msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar o webhook: {0}? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir o webhook: {0}? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this approval rule? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar esta regra de aprovação? Isto não pode ser desfeito."
+msgstr "Tem certeza de que deseja excluir esta regra de aprovação? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "Tem certeza de que deseja excluir este aviso de mudança?"
+msgstr "Tem certeza de que deseja excluir este aviso de alteração?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Tem certeza de que deseja excluir este medidor?"
+msgstr "Tem certeza de que deseja excluir este instrumento de medição?"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "Tem certeza que deseja excluir este plano de inspeção?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar este plano de inspeção? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir este plano de inspeção? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Tem certeza de que deseja excluir este fluxo de trabalho de problema?"
@@ -2049,34 +2049,34 @@ msgid "Are you sure you want to delete this issue?"
 msgstr "Tem certeza de que deseja excluir este problema?"
 
 msgid "Are you sure you want to delete this kanban card? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar este cartão kanban? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir este cartão kanban? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar este despacho de manutenção? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir esta ordem de manutenção? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
-msgstr "Tem certeza de que deseja eliminar esta chave de acesso? Não poderá mais usá-la para iniciar sessão."
+msgstr "Tem certeza de que deseja excluir esta chave de acesso? Você não poderá mais usá-la para fazer login."
 
 msgid "Are you sure you want to delete this quality document?"
-msgstr "Tem a certeza de que deseja eliminar este documento de qualidade?"
+msgstr "Tem certeza de que deseja excluir este documento de qualidade?"
 
 msgid "Are you sure you want to delete this record?"
 msgstr "Tem certeza de que deseja excluir este registro?"
 
 msgid "Are you sure you want to delete this required action?"
-msgstr "Tem a certeza de que deseja eliminar esta ação obrigatória?"
+msgstr "Tem certeza de que deseja excluir esta ação necessária?"
 
 msgid "Are you sure you want to delete this risk?"
-msgstr "Tem certeza de que deseja deletar este risco?"
+msgstr "Tem certeza de que deseja excluir este risco?"
 
 msgid "Are you sure you want to delete this risk? This cannot be undone."
 msgstr "Tem certeza de que deseja excluir este risco? Isto não pode ser desfeito."
 
 msgid "Are you sure you want to delete this suggestion? This action cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar esta sugestão? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir esta sugestão? Esta ação não pode ser desfeita."
 
 msgid "Are you sure you want to delete this timecard? This cannot be undone."
-msgstr "Tem a certeza de que deseja eliminar este cartão de ponto? Esta ação não pode ser desfeita."
+msgstr "Tem certeza de que deseja excluir este cartão de ponto? Isso não pode ser desfeito."
 
 msgid "Are you sure you want to delete this workflow? Its versions and run history go with it."
 msgstr "Tem certeza de que deseja excluir este fluxo de trabalho? Suas versões e histórico de execução serão excluídos também."
@@ -2097,16 +2097,16 @@ msgstr "Tem a certeza de que deseja passar neste checkpoint? A fase {0} ainda te
 #. placeholder {0}: selectedPurchaseInvoice.invoiceId!
 #. placeholder {0}: selectedSalesInvoice.invoiceId!
 msgid "Are you sure you want to permanently delete {0}?"
-msgstr "Tem a certeza de que deseja eliminar permanentemente {0}?"
+msgstr "Tem certeza de que deseja excluir permanentemente {0}?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "Tem a certeza de que deseja eliminar permanentemente o processo do fornecedor?"
+msgstr "Tem certeza de que deseja excluir permanentemente o processo do fornecedor?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "Tem a certeza de que deseja publicar este recibo?"
 
 msgid "Are you sure you want to post this shipment?"
-msgstr "Tem a certeza de que deseja publicar este envio?"
+msgstr "Tem certeza de que deseja contabilizar esta remessa?"
 
 msgid "Are you sure you want to reject this quote?"
 msgstr "Tem a certeza de que deseja rejeitar esta cotação?"
@@ -2125,16 +2125,16 @@ msgid "Are you sure you want to remove this item from the price list? This canno
 msgstr "Tem a certeza de que deseja remover este item da lista de preços? Esta ação não pode ser desfeita."
 
 msgid "Are you sure you want to revoke the invitation for this user?"
-msgstr "Tem a certeza de que deseja revogar o convite para este utilizador?"
+msgstr "Tem certeza de que deseja revogar o convite para este usuário?"
 
 msgid "Are you sure you want to revoke the invitations for these users?"
-msgstr "Tem a certeza de que deseja revogar os convites para estes utilizadores?"
+msgstr "Tem certeza de que deseja revogar os convites para estes usuários?"
 
 msgid "Are you sure you want to send an invite to these users?"
-msgstr "Tem a certeza de que deseja enviar um convite para estes utilizadores?"
+msgstr "Tem certeza de que deseja enviar um convite para estes usuários?"
 
 msgid "Are you sure you want to send an invite to this user?"
-msgstr "Tem a certeza de que deseja enviar um convite para este utilizador?"
+msgstr "Tem certeza de que deseja enviar um convite para este usuário?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
 msgstr "Tem a certeza de que deseja anular esta fatura de compra? Esta ação reverterá todas as transações financeiras e não pode ser desfeita."
@@ -2146,7 +2146,7 @@ msgid "Are you sure you want to void this sales invoice? This action will revers
 msgstr "Tem a certeza de que deseja anular esta fatura de venda? Esta ação reverterá todas as transações financeiras e não pode ser desfeita."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Tem a certeza de que deseja anular este envio? Esta ação reverterá todas as transações de inventário e não pode ser desfeita."
+msgstr "Tem certeza de que deseja anular esta remessa? Esta ação reverterá todas as transações de inventário e não pode ser desfeita."
 
 msgid "Are you sure?"
 msgstr "Tem a certeza?"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "A partir de:"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "Como proprietário da empresa, você pode transferir a propriedade para outro funcionário. Isso lhe dará acesso total às configurações de faturamento e administrativas."
+msgstr "Como proprietário da empresa, você pode transferir a propriedade para outro funcionário. Isso lhe dará acesso total aos recursos de cobrança e configurações administrativas."
 
 msgid "Ascending"
 msgstr "Ascendente"
@@ -2221,10 +2221,10 @@ msgid "Asset Classes"
 msgstr "Classes de Ativos"
 
 msgid "Asset Cost on Disposal"
-msgstr "Custo do ativo na alienação"
+msgstr "Custo do Ativo na Baixa"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Custo do ativo na alienação (padrão)"
+msgstr "Custo do Ativo na Baixa (padrão)"
 
 msgid "Asset ID"
 msgstr "ID do Ativo"
@@ -2251,7 +2251,7 @@ msgid "Assigned to Me"
 msgstr "Atribuído a Mim"
 
 msgid "Assignee"
-msgstr "Atribuído a"
+msgstr "Designado"
 
 msgid "Assignment"
 msgstr "Atribuição"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Atribuições"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Atribui esta unidade de armazenamento a um centro de trabalho (lineside)"
+msgstr "Atribui esta unidade de armazenamento a um centro de trabalho (borda de linha)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Atribui esta unidade a um centro de trabalho para material ao lado da linha, para que os operadores o vejam na visualização de produção; herdado da unidade principal quando definido lá."
+msgstr "Atribui esta unidade a um centro de trabalho para material de borda de linha, para que os operadores a vejam na visualização de produção; herdada da unidade pai quando configurada lá."
 
 msgid "At each gate"
 msgstr "Em cada etapa"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Atributo"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Padrão de amostragem de atributos usado para calcular tamanhos de amostra de lote e números de aceitação/rejeição em inspeções de entrada."
+msgstr "Padrão de amostragem de atributo usado para calcular tamanhos de amostra de lote e números de aceitação/rejeição em inspeções de recebimento."
 
 msgid "Attributes"
 msgstr "Atributos"
@@ -2302,10 +2302,10 @@ msgid "Attributes are inherited from the procedure."
 msgstr "Os atributos são herdados do procedimento."
 
 msgid "Audit Log"
-msgstr "Registro de Auditoria"
+msgstr "Log de auditoria"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Registro de auditoria"
 
 msgid "Audit Logging"
 msgstr "Registro de Auditoria"
@@ -2320,7 +2320,7 @@ msgid "Audit logging is not enabled"
 msgstr "O registro de auditoria não está ativado"
 
 msgid "Audit Logs"
-msgstr "Registos de Auditoria"
+msgstr "Logs de auditoria"
 
 msgid "Authentication Error"
 msgstr "Erro de Autenticação"
@@ -2338,7 +2338,7 @@ msgid "Auto arrange"
 msgstr "Organizar automaticamente"
 
 msgid "Auto Release"
-msgstr "Lançamento Automático"
+msgstr "Liberação automática"
 
 msgid "Auto release must be enabled to start a job automatically"
 msgstr "A liberação automática deve estar ativada para iniciar um trabalho automaticamente"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Código QR gerado automaticamente"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Formatos de numeração automática para pedidos, trabalhos, peças e muito mais"
+msgstr "Formatos de numeração automática para pedidos, ordens de produção, peças e muito mais"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Sugerir automaticamente compras a partir da demanda e pontos de reabastecimento"
+msgstr "Sugerir automaticamente compras de demanda e pontos de ressuprimento"
 
 msgid "Automate"
 msgstr "Automatizar"
@@ -2371,13 +2371,13 @@ msgid "Automatic Cost Updates"
 msgstr "Atualizações Automáticas de Custo"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Atualizações Automáticas de Prazo de Entrega"
+msgstr "Atualizações automáticas de lead time"
 
 msgid "Automatic Updates"
 msgstr "Atualizações Automáticas"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Atualizações automáticas e backups"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Consumo automático e rateado de materiais não rastreados de um trabalho quando a saída é relatada — os materiais rastreados são emitidos manualmente."
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "Voltar para rastreabilidade"
 
 msgid "Backflush"
-msgstr "Descarga Automática"
+msgstr "Baixa automática"
 
 msgid "Backups"
 msgstr "Backups"
@@ -2438,7 +2438,7 @@ msgid "Ballooned drawings with inspection features."
 msgstr "Desenhos ampliados com recursos de inspeção."
 
 msgid "Bank - Cash"
-msgstr "Banco - Dinheiro"
+msgstr "Banco - Caixa"
 
 msgid "Bank - Foreign Currency"
 msgstr "Banco - Moeda estrangeira"
@@ -2447,7 +2447,7 @@ msgid "Bank - Local Currency"
 msgstr "Banco - Moeda local"
 
 msgid "Bank — Cash (default)"
-msgstr "Banco — Dinheiro (padrão)"
+msgstr "Banco — Caixa (padrão)"
 
 msgid "Bank — Foreign Currency (default)"
 msgstr "Banco — Moeda estrangeira (padrão)"
@@ -2468,7 +2468,7 @@ msgid "Bank and financial service charge expenses"
 msgstr "Despesas de taxas de serviços bancários e financeiros."
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "As barras mostram o fluxo semanal: &lt;0&gt;oferta&lt;/0&gt; empurra o inventário para cima, &lt;1&gt;demanda&lt;/1&gt; o puxa para baixo. A &lt;2&gt;linha&lt;/2&gt; é seu inventário disponível projetado — quando cai abaixo &lt;3&gt;do estoque de segurança&lt;/3&gt; você está em risco, e abaixo de zero é uma &lt;4&gt;falta de estoque&lt;/4&gt;."
+msgstr "Os gráficos mostram o fluxo de cada semana: <0>suprimento</0> aumenta o inventário, <1>demanda</1> o reduz. A <2>linha</2> é seu inventário disponível projetado — quando cai abaixo do <3>estoque de segurança</3> você está em risco, e abaixo de zero é uma <4>ruptura de estoque</4>."
 
 msgid "Base Currency"
 msgstr "Moeda Base"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Preço Base"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Funcionalidade ERP, MES e QMS básica"
 
 msgid "Basic Information"
 msgstr "Informações Básicas"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "Lote / Série"
 
 msgid "Batch items require a sales order"
-msgstr "Itens em lote requerem uma ordem de venda"
+msgstr "Itens em lote de produção exigem um pedido de venda"
 
 msgid "Batch number"
 msgstr "Número de lote"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "Beta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Maiores causas de sucata por motivo, item ou centro de trabalho"
+msgstr "Maiores causas de refugo por motivo, item ou centro de trabalho"
 
 msgid "Bill of Material"
 msgstr "Lista de Materiais"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "Lista de Materiais"
 
 msgid "Bill of Process"
-msgstr "Plano de Processo"
+msgstr "Lista de operações"
 
 msgid "Bill To"
 msgstr "Faturar Para"
@@ -2556,7 +2556,7 @@ msgid "Block with an error"
 msgstr "Bloquear com um erro"
 
 msgid "Block, allow override"
-msgstr "Bloquear, permitir substituição"
+msgstr "Bloquear, permitir sobrescrita"
 
 msgid "Blocked"
 msgstr "Bloqueado"
@@ -2566,7 +2566,7 @@ msgid "Blocked by {0}"
 msgstr "Bloqueado por {0}"
 
 msgid "Blocks save until resolved"
-msgstr "Bloqueia a gravação até ser resolvido"
+msgstr "Bloqueios são salvos até serem resolvidos"
 
 msgid "Body"
 msgstr "Corpo"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Migalha de pão"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Importe suas peças, BOMs, Bill of Process e custos — com as ferramentas de importação do Carbon, CSV ou ajuda de LLM."
+msgstr "Traga suas peças, BOMs, listas de operações e custeio — com as ferramentas de importação do Carbon, CSV ou ajuda de LLM."
 
 msgid "Browse library"
 msgstr "Procurar biblioteca"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Navegue pela versão publicada somente leitura. Você ainda pode reorganizar etapas para limpar o layout."
 
 msgid "Bucket"
 msgstr "Bucket"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Criar integrações e personalizações"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Criar cotações puxando dados de peça ao vivo, custo e Lista de Processos"
+msgstr "Crie orçamentos extraindo dados de peça, custo e lista de operações em tempo real"
 
 msgid "Build role-based training materials"
 msgstr "Criar materiais de treinamento baseados em funções"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Importação em Massa"
 
 msgid "Bulk Jobs"
-msgstr "Trabalhos em Lote"
+msgstr "Ordens de produção em massa"
 
 msgid "Business moment"
 msgstr "Momento de negócio"
@@ -2662,7 +2662,7 @@ msgid "Buy"
 msgstr "Comprar"
 
 msgid "Buy and Make"
-msgstr "Comprar e Fazer"
+msgstr "Compra e fabricação"
 
 msgid "Buyer"
 msgstr "Comprador"
@@ -2704,7 +2704,7 @@ msgid "Calculate from BOM"
 msgstr "Calcular a partir da BOM"
 
 msgid "Calculated finished-good expiry"
-msgstr "Expiração do produto acabado calculada"
+msgstr "Validade calculada de produto acabado"
 
 msgid "Calculation Method"
 msgstr "Método de Cálculo"
@@ -2743,10 +2743,10 @@ msgid "Called a method in Carbon — the components plus operations that produce
 msgstr "Chamada uma método em Carbon — os componentes mais as operações que produzem uma parte."
 
 msgid "Can't delete this period"
-msgstr "Não é possível deletar este período"
+msgstr "Não é possível excluir este período"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "Não é possível desativar o único intervalo ativo. Adicione outro intervalo ou alterne o status Ativo da substituição."
+msgstr "Não é possível desabilitar o único intervalo ativo. Adicione outro intervalo ou altere a sobrescrita Ativa em vez disso."
 
 msgid "Can't download this file"
 msgstr "Não é possível baixar este arquivo"
@@ -2755,10 +2755,10 @@ msgid "Cancel"
 msgstr "Cancelar"
 
 msgid "Cancel change notice"
-msgstr "Cancelar aviso de mudança"
+msgstr "Cancelar aviso de alteração"
 
 msgid "Cancel Change Notice"
-msgstr "Cancelar Aviso de Mudança"
+msgstr "Cancelar Aviso de Alteração"
 
 msgid "Cancel Job"
 msgstr "Cancelar Trabalho"
@@ -2767,7 +2767,7 @@ msgid "Cancel Order"
 msgstr "Cancelar pedido"
 
 msgid "Cancel Purchase Order"
-msgstr "Cancelar ordem de compra"
+msgstr "Cancelar Pedido de compra"
 
 msgid "Cancel Sales Order"
 msgstr "Cancelar Pedido de Venda"
@@ -2815,19 +2815,19 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "Não é possível fazer o pedido - nenhum fornecedor associado a este item"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "Não é possível postar — o envio contém entidades rastreadas expiradas."
+msgstr "Não é possível contabilizar — a remessa contém entidades rastreadas vencidas."
 
 msgid "Cannot send RFQ"
 msgstr "Não é possível enviar RFQ"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Não é possível enviar através do Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
-msgstr "Não é possível fazer upload — interação com fornecedor ainda não foi criada"
+msgstr "Não é possível enviar arquivo — interação com fornecedor ainda não foi criada"
 
 msgid "Cannot upload to parts bucket without item ID"
-msgstr "Não é possível fazer upload para o bucket de peças sem ID do item"
+msgstr "Não é possível enviar arquivo para bucket de peças sem ID do item"
 
 msgid "Caption"
 msgstr "Legenda"
@@ -2888,19 +2888,19 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Apenas Carbon · o cliente vê este texto, bloqueado."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "O nome de Carbon para lista de materiais e lista de processos (roteamento): os componentes mais as operações que fabricam uma peça."
+msgstr "O nome do Carbon para uma lista de materiais e lista de operações (roteiro): os componentes mais as operações que compõem uma peça."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "A execução de planejamento de Carbon compensa a oferta contra a demanda e explode métodos, revelando deficiências — mas não cria pedidos por si."
+msgstr "A execução de planejamento do Carbon balanceia suprimento contra demanda e explode métodos, expondo insuficiências — mas não cria ordens por si só."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Ordem de produção de Carbon — um trabalho constrói uma quantidade de um item a partir de seu método e roteamento copiados."
+msgstr "A ordem de produção do Carbon — uma ordem de produção constrói uma quantidade de um item a partir de seu próprio método copiado e roteiro."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "O aplicativo de piso de produção do Carbon onde os operadores executam operações, relatam quantidades, emitem materiais e registram tempo em relação aos trabalhos lançados em tempo real."
+msgstr "O aplicativo de chão de fábrica do Carbon onde operadores executam operações, relatam quantidades, fazem requisição de material e registram tempo contra ordens de produção liberadas em tempo real."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "O registro único do Carbon para qualquer coisa com um número de peça — Parte, Material, Ferramenta, Serviço, Consumível ou Fixture — ao qual trabalhos, métodos, pedidos e inventário apontam."
+msgstr "O registro único do Carbon para qualquer coisa com um número de peça — Peça, Material, Ferramenta, Serviço, Consumível ou Dispositivo de fixação — ao qual ordens de produção, métodos, pedidos e inventário apontam."
 
 msgid "Cards"
 msgstr "Cartões"
@@ -2948,7 +2948,7 @@ msgid "Chain"
 msgstr "Cadeia"
 
 msgid "Champion users are available for training and data validation"
-msgstr "Utilizadores-chave estão disponíveis para treinamento e validação de dados"
+msgstr "Usuários-campeões estão disponíveis para treinamento e validação de dados"
 
 msgid "Champion(s)"
 msgstr "Campeão(ões)"
@@ -2966,25 +2966,25 @@ msgid "Change Inspection Plan"
 msgstr "Alterar Plano de Inspeção"
 
 msgid "Change notice"
-msgstr "Aviso de mudança"
+msgstr "Aviso de alteração"
 
 msgid "Change Notice"
-msgstr "Aviso de Mudança"
+msgstr "Aviso de Alteração"
 
 msgid "Change Notice Actions"
-msgstr "Ações do Aviso de Mudança"
+msgstr "Ações do Aviso de Alteração"
 
 msgid "Change Notice Types"
-msgstr "Tipos de Aviso de Mudança"
+msgstr "Tipos de Aviso de Alteração"
 
 msgid "Change Notices"
-msgstr "Avisos de Mudança"
+msgstr "Avisos de Alteração"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "Os avisos de mudança não puderam ser carregados, portanto novas versões e revisões estão bloqueadas. Recarregue para tentar novamente."
+msgstr "Os avisos de alteração não puderam ser carregados, portanto novas versões e revisões estão bloqueadas. Recarregue para tentar novamente."
 
 msgid "Change order"
-msgstr "Ordem de mudança"
+msgstr "Ordem de alteração"
 
 msgid "Change status"
 msgstr "Alterar status"
@@ -3011,7 +3011,7 @@ msgid "Changing this will update the part ID"
 msgstr "Alterar isto atualizará o ID da peça"
 
 msgid "Changing type resets this item's draft edits."
-msgstr "Alterar tipo redefine as edições de rascunho deste item."
+msgstr "Mudar tipo redefine as edições de rascunho deste item."
 
 msgid "Chart of accounts"
 msgstr "Plano de contas"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Verifique o razão de itens para qualquer item com quantidade em mão negativa até o final do período — geralmente um recebimento faltante ou um lançamento fora de ordem que distorce o valor do estoque e o custo dos bens vendidos. Marque como concluído após revisado ou pule com um motivo."
+msgstr "Verifique o ledger do item para qualquer item com quantidade disponível negativa no final do período — geralmente um recebimento ausente ou uma contabilização fora de ordem que distorce o valor do inventário e o custo dos produtos vendidos. Marque como feito após revisado ou pule com um motivo."
 
 msgid "Check your email"
 msgstr "Verifique seu email"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Verificando Stripe para este cliente…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Escolher outro arquivo"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Escolha o que aparece no aviso de trabalho impresso."
+msgstr "Escolha o que aparece na ficha de acompanhamento impressa."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Escolha seu idioma preferido para a interface."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Classe (herdada)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Classifica uma operação de roteamento: operações de Processo, Montagem e Inspeção são executadas em seu próprio chão de fábrica no MES — Montagem obtém a visualização de montagem orientada e Inspeção uma verificação de qualidade — enquanto uma operação de Processamento Externo é subcontratada para um fornecedor e cria uma ordem de compra; o processo carrega o mesmo tipo e o define como padrão em novas operações."
+msgstr "Classifica uma operação de roteiro: Operações de Processo, Montagem e Inspeção são executadas no seu chão de fábrica no MES — Montagem obtém a visualização de montagem guiada e Inspeção uma verificação de qualidade — enquanto uma operação de Beneficiamento externo é terceirizada para um fornecedor e cria um pedido de compra; o processo carrega o mesmo tipo e o estabelece como padrão em novas operações."
 
 msgid "Clean and approve the migrated data"
 msgstr "Limpar e aprovar os dados migrados"
@@ -3095,13 +3095,13 @@ msgid "Clear selection"
 msgstr "Limpar seleção"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Limpe esta fatura com os créditos lançados da parte bem como dinheiro. Os créditos se aplicam diretamente — nenhum lançamento necessário."
+msgstr "Liquidar esta fatura com os créditos contabilizados da parte, bem como caixa. Os créditos se aplicam diretamente — nenhuma contabilização necessária."
 
 msgid "Clear value"
 msgstr "Limpar valor"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Conta de compensação entre recebimento de mercadorias e fatura do fornecedor; equilibra quando ambos foram lançados."
+msgstr "Conta de compensação entre recebimento de mercadorias e fatura do fornecedor; equilibra quando ambos foram contabilizados."
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "Conta de compensação para recebimento de mercadorias / correspondência de recebimento de fatura"
@@ -3116,13 +3116,13 @@ msgid "Click to rename"
 msgstr "Clique para renomear"
 
 msgid "Click to upload a PDF drawing"
-msgstr "Clique para fazer upload de um desenho em PDF"
+msgstr "Clique para enviar um desenho em PDF"
 
 msgid "Clock In"
-msgstr "Registar Entrada"
+msgstr "Apontar início"
 
 msgid "Clock Out"
-msgstr "Saída"
+msgstr "Apontar fim"
 
 msgid "Clocked in since <0/>"
 msgstr "Marcado desde <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Nuvem, ou seu ambiente auto-hospedado."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Em conformidade com CMMC"
 
 msgid "Code"
 msgstr "Código"
@@ -3188,7 +3188,7 @@ msgid "Collapse features table"
 msgstr "Recolher tabela de recursos"
 
 msgid "Collapse Labor"
-msgstr "Recolher Trabalho"
+msgstr "Recolher Mão de obra"
 
 msgid "Collapse Machine"
 msgstr "Recolher Máquina"
@@ -3227,13 +3227,13 @@ msgid "Comments"
 msgstr "Comentários"
 
 msgid "Commit a champion user for each area"
-msgstr "Designar um utilizador campeão para cada área"
+msgstr "Designar um usuário campeão para cada área"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
 msgstr "Confirmar um recibo, remessa ou fatura: as quantidades se movem, os lançamentos do diário atingem o razão, e o status se torna Lançado."
 
 msgid "Community support"
-msgstr ""
+msgstr "Suporte comunitário"
 
 msgid "Companies"
 msgstr "Empresas"
@@ -3275,7 +3275,7 @@ msgid "Complete All"
 msgstr "Completar Tudo"
 
 msgid "Complete all quantities on barcode scan"
-msgstr "Completar todas as quantidades na leitura do código de barras"
+msgstr "Concluir todas as quantidades ao escanear código de barras"
 
 msgid "Complete Job"
 msgstr "Concluir Trabalho"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Configurar contas padrão para transações de fornecedor e supridor"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Configurar contas padrão de patrimônio líquido e lucros retidos"
+msgstr "Configurar contas padrão de patrimônio líquido e lucros acumulados"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Configure padrões para o painel de qualidade."
@@ -3357,25 +3357,25 @@ msgid "Configure Item"
 msgstr "Configurar Item"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Configure notificações para quando os medidores saem de calibração."
+msgstr "Configurar notificações para quando os instrumentos de medição saem da calibração."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Configure notificações para quando trabalhos são concluídos."
+msgstr "Configurar notificações para quando as ordens de produção são concluídas."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Configure notificações para quando despachos de manutenção são criados do chão de fábrica. As notificações são roteadas com base no tipo de modo de falha."
+msgstr "Configurar notificações para quando as ordens de manutenção são criadas no chão de fábrica. As notificações são encaminhadas com base no tipo de modo de falha."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Configure notificações para quando novas sugestões são enviadas."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Configurar sites, centros de trabalho, Bill of Process, BOMs, custeio, funções"
+msgstr "Configurar sites, centros de trabalho, Lista de operações, BOMs, custeio, funções"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Configure as contas padrão usadas para vários tipos de transação em todo o seu sistema"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "Configure os meses de início para seus anos fiscais e tributários"
+msgstr "Configurar os meses iniciais para seus anos fiscais e de impostos"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "Configure quando os custos dos itens comprados devem ser atualizados a partir das transações do fornecedor."
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "Confirmar {0}"
 
 msgid "Confirm & release"
-msgstr "Confirmar e lançar"
+msgstr "Confirmar e liberar"
 
 msgid "Confirm all"
 msgstr "Confirmar tudo"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Estoque de entrada confirmado — pedidos de compra e produção (barras acima de zero)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Estoque de saída confirmado — pedidos de vendas e materiais de trabalho (barras abaixo de zero)."
+msgstr "Estoque de saída confirmado — pedidos de venda e materiais da ordem (barras abaixo de zero)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Confirma que cada lançamento de diário lançado no período tem débitos e créditos iguais. Se algum lançamento estiver fora de equilíbrio, o balancete não se equilibrará, portanto deve ser corrigido antes do fechamento do período."
+msgstr "Confirma que cada lançamento contabilizado no período tem débitos e créditos iguais. Se alguma entrada estiver desbalanceada, o saldo de verificação não fechará, portanto deve ser corrigida antes de o período poder fechar."
 
 msgid "Conflict reason"
 msgstr "Motivo do conflito"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "Contacto (opcional)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Entre em contato conosco"
 
 msgid "contacts"
 msgstr "contatos"
@@ -3559,16 +3559,16 @@ msgid "Contra-revenue GL account for discounts given on customer invoices."
 msgstr "Conta GL de contra receita para descontos concedidos em faturas de clientes."
 
 msgid "Contractor"
-msgstr "Contratante"
+msgstr "Terceirizado"
 
 msgid "Contractors"
-msgstr "Contratantes"
+msgstr "Terceirizados"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "Controlar alterações de design com revisões / ECOs"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "Controle como os operadores pegam material e rastreiam o tempo no piso da fábrica."
+msgstr "Controle como os operadores separam material e rastreiam tempo no chão de fábrica."
 
 msgid "Controller, Accountant"
 msgstr "Controlador, Contador"
@@ -3577,7 +3577,7 @@ msgid "Controls how planning handles a discontinued item: Consume First exhausts
 msgstr "Controla como o planejamento lida com um item descontinuado: Consumir Primeiro esgota o estoque existente antes de mudar para o sucessor, Preferir Novo redireciona a nova demanda para o sucessor imediatamente, Apenas Estoque mantém apenas uma reserva mínima de serviço, e Sem Estoque remove o item do planejamento inteiramente."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Controla se a lista de materiais e a lista de processos de uma revisão lançada (Produção) podem ser editadas fora de uma ordem de alteração."
+msgstr "Controla se a lista de materiais e a lista de operações de uma revisão liberada (Produção) podem ser editadas fora de uma ordem de alteração."
 
 msgid "Convention"
 msgstr "Convenção"
@@ -3604,10 +3604,10 @@ msgid "Convert Line to Job"
 msgstr "Converter Linha para Trabalho"
 
 msgid "Convert Lines to Jobs"
-msgstr "Converter Linhas em Trabalhos"
+msgstr "Converter Linhas para Ordens de produção"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Converta sugestões de MRP em pedidos de compra e tarefas."
+msgstr "Converter sugestões de MRP em pedidos de compra e ordens de produção."
 
 msgid "Convert to Quote"
 msgstr "Converter para Cotação"
@@ -3625,7 +3625,7 @@ msgid "Copy"
 msgstr "Copiar"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Copiar todos os itens e preços para outro cliente ou tipo."
+msgstr "Copiar todos os itens e precificação para outro cliente ou tipo."
 
 msgid "Copy API Key"
 msgstr "Copiar Chave de API"
@@ -3637,10 +3637,10 @@ msgid "Copy consumable number"
 msgstr "Copiar número do consumível"
 
 msgid "Copy dispatch ID"
-msgstr "Copiar ID de despacho"
+msgstr "Copiar ID da ordem de manutenção"
 
 msgid "Copy dispatch number"
-msgstr "Copiar número de despacho"
+msgstr "Copiar número da ordem de manutenção"
 
 msgid "Copy document name"
 msgstr "Copiar nome do documento"
@@ -3664,13 +3664,13 @@ msgid "Copy link"
 msgstr "Copiar ligação"
 
 msgid "Copy link to change notice"
-msgstr "Copiar link para aviso de mudança"
+msgstr "Copiar link para aviso de alteração"
 
 msgid "Copy link to consumable"
 msgstr "Copiar link para consumível"
 
 msgid "Copy link to dispatch"
-msgstr "Copiar link para despacho"
+msgstr "Copiar link para ordem de manutenção"
 
 msgid "Copy link to document"
 msgstr "Copiar link do documento"
@@ -3718,10 +3718,10 @@ msgid "Copy PIN"
 msgstr "Copiar PIN"
 
 msgid "Copy pricing to a single customer"
-msgstr "Copiar preços para um único cliente"
+msgstr "Copiar precificação para um único cliente"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Copiar preços para todos os clientes de um tipo"
+msgstr "Copiar precificação para todos os clientes de um tipo"
 
 msgid "Copy Procedure"
 msgstr "Copiar Procedimento"
@@ -3748,7 +3748,7 @@ msgid "Copy service unique identifier"
 msgstr "Copiar identificador exclusivo do serviço"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Copie o preço deste item para outro escopo."
+msgstr "Copiar a precificação deste item para outro escopo."
 
 msgid "Copy this link to share the quote with a customer"
 msgstr "Copie este link para compartilhar a cotação com um cliente"
@@ -3820,13 +3820,13 @@ msgid "Cost History"
 msgstr "Histórico de Custos"
 
 msgid "Cost of Goods Sold"
-msgstr "Custo dos Bens Vendidos"
+msgstr "Custo dos produtos vendidos"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Custo dos bens vendidos (COGS)"
+msgstr "Custo dos produtos vendidos (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Custo dos Bens Vendidos (padrão)"
+msgstr "Custo dos produtos vendidos (padrão)"
 
 msgid "Cost of Sales"
 msgstr "Custo das Vendas"
@@ -3835,7 +3835,7 @@ msgid "Costing"
 msgstr "Custeio"
 
 msgid "Costing & Posting"
-msgstr "Custeio e Lançamento"
+msgstr "Custeio e Contabilização"
 
 msgid "Costing method"
 msgstr "Método de Custeio"
@@ -3921,28 +3921,28 @@ msgid "Create & Snapshot"
 msgstr "Criar e Capturar"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "Criar um aviso de mudança para a nova revisão e abri-lo"
+msgstr "Criar um aviso de alteração para a nova revisão e abri-lo"
 
 msgid "Create a job"
 msgstr "Criar um trabalho"
 
 msgid "Create a new kanban card for scan-based replenishment."
-msgstr "Crie um novo cartão kanban para reabastecimento baseado em varredura."
+msgstr "Criar um novo cartão Kanban para reabastecimento baseado em leitura de código."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Crie uma nova ordem de manutenção para rastrear reparos de equipamentos e atividades de manutenção"
+msgstr "Criar uma nova ordem de manutenção para rastrear reparos e atividades de manutenção do equipamento"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Criar um novo trabalho de produção para atender ao pedido de venda"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Criar um novo cliente Stripe em seu lugar"
 
 msgid "Create a new version"
 msgstr "Criar uma nova versão"
 
 msgid "Create a purchase order"
-msgstr "Criar uma ordem de compra"
+msgstr "Criar um pedido de compra"
 
 msgid "Create a quote with a new quote ID"
 msgstr "Criar uma cotação com um novo ID de cotação"
@@ -3969,13 +3969,13 @@ msgid "Create audit trail entries"
 msgstr "Criar entradas de trilha de auditoria"
 
 msgid "Create Change Notice"
-msgstr "Criar Aviso de Mudança"
+msgstr "Criar Aviso de alteração"
 
 msgid "Create Issue"
 msgstr "Criar Problema"
 
 msgid "Create Jobs"
-msgstr "Criar Trabalhos"
+msgstr "Criar Ordens de produção"
 
 msgid "Create Kanban"
 msgstr "Criar Kanban"
@@ -4008,7 +4008,7 @@ msgid "Create Transfer"
 msgstr "Criar Transferência"
 
 msgid "Create User"
-msgstr "Criar Utilizador"
+msgstr "Criar Usuário"
 
 msgid "Create Version"
 msgstr "Criar Versão"
@@ -4038,10 +4038,10 @@ msgid "Created By"
 msgstr "Criado por"
 
 msgid "Created change notice action"
-msgstr "Ação de aviso de mudança criada"
+msgstr "Ação de aviso de alteração criada"
 
 msgid "Created change notice type"
-msgstr "Tipo de aviso de mudança criado"
+msgstr "Tipo de aviso de alteração criado"
 
 msgid "Created consumable"
 msgstr "Consumível criado"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Modo de falha criado"
 
 msgid "Created gauge type"
-msgstr "Tipo de medidor criado"
+msgstr "Tipo de instrumento criado"
 
 msgid "Created item group"
 msgstr "Grupo de itens criado"
@@ -4096,7 +4096,7 @@ msgid "Created material grade"
 msgstr "Grau de material criado"
 
 msgid "Created material substance"
-msgstr "Substância material criada"
+msgstr "Material base criado"
 
 msgid "Created material type"
 msgstr "Tipo de material criado"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Parte criada"
 
 msgid "Created payment term"
-msgstr "Termo de pagamento criado"
+msgstr "Condição de pagamento criada"
 
 msgid "Created process"
 msgstr "Processo criado"
@@ -4120,7 +4120,7 @@ msgid "Created required action"
 msgstr "Ação obrigatória criada"
 
 msgid "Created scrap reason"
-msgstr "Motivo de sucata criado"
+msgstr "Motivo de refugo criado"
 
 msgid "Created service"
 msgstr "Serviço criado"
@@ -4173,16 +4173,16 @@ msgid "Credit Account"
 msgstr "Conta de Crédito"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Conta de crédito quando tempo de mão de obra/máquina é absorvido em WIP"
+msgstr "Conta contábil de crédito quando mão de obra/tempo de máquina é absorvido em Produto em processo"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Conta de crédito quando a sobrecarga é absorvida em WIP"
+msgstr "Conta contábil de crédito quando custos indiretos são absorvidos em Produto em processo"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Contas de crédito usadas quando custos de fabricação são absorvidos em WIP"
+msgstr "Contas contábeis de crédito usadas quando custos de manufatura são absorvidos em Produto em processo"
 
 msgid "Credit Memo"
-msgstr "Memorando de Crédito"
+msgstr "Nota de crédito"
 
 msgid "Credits"
 msgstr "Créditos"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "Peça do Cliente"
 
 msgid "Customer Part ID"
-msgstr "ID da Peça do Cliente"
+msgstr "Referência do cliente"
 
 msgid "Customer Part Number"
 msgstr "Número de Peça do Cliente"
@@ -4356,7 +4356,7 @@ msgid "Customer Portals"
 msgstr "Portais de Cliente"
 
 msgid "Customer pricing"
-msgstr "Preços para clientes"
+msgstr "Precificação do cliente"
 
 msgid "Customer reference"
 msgstr "Referência do cliente"
@@ -4383,7 +4383,7 @@ msgid "customer statuses"
 msgstr "status dos clientes"
 
 msgid "Customer Statuses"
-msgstr "Estados do Cliente"
+msgstr "Status do cliente"
 
 msgid "customer type"
 msgstr "tipo de cliente"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Tipos de Cliente"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Baixa de Cliente (Crédito Duvidoso)"
+msgstr "Baixa contábil de cliente (Dívida incobrável)"
 
 msgid "customers"
 msgstr "clientes"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Clientes"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Personalizações, treinamento e integrações"
 
 msgid "Customize"
 msgstr "Personalizar"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Dias Vencidos"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Dias desde o pedido de uma peça até ter disponível; o planejamento compensa a demanda para trás por este período."
+msgstr "Dias desde a encomenda de uma peça até tê-la disponível; o deslocamento de planejamento move a demanda para trás por essa quantidade."
 
 msgid "Days Off"
 msgstr "Dias de Folga"
@@ -4578,7 +4578,7 @@ msgid "Debit ({0})"
 msgstr "Débito ({0})"
 
 msgid "Debit Account"
-msgstr "Conta Devedora"
+msgstr "Conta contábil de débito"
 
 msgid "Debit Memo"
 msgstr "Memorando de Débito"
@@ -4587,10 +4587,10 @@ msgid "Debits"
 msgstr "Débitos"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "Decida o que um operador vê se tentar emitir um lote ou série que já expirou."
+msgstr "Decida o que um operador vê se tentar requisitar um lote de produção ou série que já está vencido."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Decida o que acontece quando um operador pressiona Concluir no piso de produção com material ainda não colhido."
+msgstr "Decida o que acontece quando um operador pressiona Concluir no chão de fábrica com material ainda não retirado."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
 msgstr "Decida quando o material coletado para um centro de trabalho, mas não consumido, flui de volta para o armazém."
@@ -4605,7 +4605,7 @@ msgid "Default"
 msgstr "Padrão"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Conta padrão para registrar receita de vendas de faturas"
+msgstr "Conta contábil padrão para contabilização da receita de vendas de faturas"
 
 msgid "Default Accounts"
 msgstr "Contas Padrão"
@@ -4626,7 +4626,7 @@ msgid "Default accounts for tax-related transactions"
 msgstr "Contas padrão para transações relacionadas a impostos"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Contas padrão para o custo dos bens vendidos e compras indiretas"
+msgstr "Contas contábeis padrão para custo dos produtos vendidos e compras indiretas"
 
 msgid "Default Approver"
 msgstr "Aprovador Padrão"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "Destinatários CC Padrão"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "Conta padrão de GL creditada quando a alienação de um ativo imobilizado resulta em ganho."
+msgstr "Conta contábil padrão creditada quando a baixa de um ativo fixo resulta em ganho."
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "Conta padrão de GL debitada quando a alienação de um ativo imobilizado resulta em perda."
+msgstr "Conta contábil padrão debitada quando a baixa de um ativo fixo resulta em perda."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
-msgstr "Conta GL padrão usada para transações em dinheiro quando nenhuma conta bancária específica é selecionada."
+msgstr "Conta contábil padrão usada para transações em caixa quando nenhuma conta bancária específica é selecionada."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Conta GL de despesa padrão para manutenção de equipamentos e instalações."
+msgstr "Conta de despesa contábil padrão para manutenção de equipamento e instalação."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Conta GL de despesa padrão para execuções de depreciação periódica."
+msgstr "Conta de despesa contábil padrão para processamentos periódicos de depreciação."
 
 msgid "Default Method"
 msgstr "Método Padrão"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Método padrão que é pré-preenchido em novos ativos nesta classe (ainda editável por ativo)."
 
 msgid "Default method type"
-msgstr "Tipo de método padrão"
+msgstr "Tipo de suprimento padrão"
 
 msgid "Default Method Type"
-msgstr "Tipo de Método Padrão"
+msgstr "Tipo de Suprimento Padrão"
 
 msgid "Default Permissions"
 msgstr "Permissões Padrão"
@@ -4710,38 +4710,38 @@ msgid "Defaults"
 msgstr "Padrões"
 
 msgid "Deferred Tax Expense"
-msgstr "Despesa Fiscal Diferida"
+msgstr "Despesa de Imposto Diferido"
 
 msgid "Deferred Tax Expense (default)"
-msgstr "Despesa Fiscal Diferida (padrão)"
+msgstr "Despesa de Imposto Diferido (padrão)"
 
 msgid "Deferred Tax Liability"
-msgstr "Passivo Fiscal Diferido"
+msgstr "Passivo de Imposto Diferido"
 
 msgid "Deferred Tax Liability (default)"
-msgstr "Passivo Fiscal Diferido (padrão)"
+msgstr "Passivo de imposto diferido (padrão)"
 
 msgid "Define a manufacturing operation first."
 msgstr "Defina primeiro uma operação de manufatura."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Definir BOMs multi-nível e Bill of Process (métodos de fabricação)"
+msgstr "Definir BOMs multinível e Lista de operações (métodos de fabricação)"
 
 msgid "Delete"
-msgstr "Eliminar"
+msgstr "Excluir"
 
 #. placeholder {0}: view.name
 msgid "Delete {0}"
 msgstr "Excluir {0}"
 
 msgid "Delete {name}"
-msgstr "Eliminar {name}"
+msgstr "Excluir {name}"
 
 msgid "Delete {periodLabel}"
-msgstr "Deletar {periodLabel}"
+msgstr "Excluir {periodLabel}"
 
 msgid "Delete {storageUnitName}"
-msgstr "Eliminar {storageUnitName}"
+msgstr "Excluir {storageUnitName}"
 
 msgid "Delete action"
 msgstr "Excluir ação"
@@ -4750,275 +4750,275 @@ msgid "Delete Action"
 msgstr "Excluir Ação"
 
 msgid "Delete API Key"
-msgstr "Eliminar Chave de API"
+msgstr "Excluir chave de API"
 
 msgid "Delete Asset"
-msgstr "Deletar Ativo"
+msgstr "Excluir ativo"
 
 msgid "Delete Asset Class"
-msgstr "Deletar Classe de Ativo"
+msgstr "Excluir classe de ativo"
 
 msgid "Delete Assignment"
-msgstr "Eliminar Atribuição"
+msgstr "Excluir atribuição"
 
 msgid "Delete Association"
-msgstr "Eliminar Associação"
+msgstr "Excluir associação"
 
 msgid "Delete Attribute"
-msgstr "Eliminar Atributo"
+msgstr "Excluir atributo"
 
 msgid "Delete Category"
-msgstr "Eliminar Categoria"
+msgstr "Excluir categoria"
 
 msgid "Delete Change Notice"
-msgstr "Excluir Aviso de Mudança"
+msgstr "Excluir aviso de alteração"
 
 msgid "Delete Consumable"
-msgstr "Eliminar Consumível"
+msgstr "Excluir consumível"
 
 msgid "Delete Contact"
-msgstr "Eliminar Contacto"
+msgstr "Excluir contato"
 
 msgid "Delete Contractor"
-msgstr "Eliminar Contratista"
+msgstr "Excluir terceirizado"
 
 msgid "Delete Count"
-msgstr "Eliminar Contagem"
+msgstr "Excluir contagem"
 
 msgid "Delete Custom Field"
-msgstr "Eliminar Campo Personalizado"
+msgstr "Excluir campo personalizado"
 
 msgid "Delete Customer"
-msgstr "Eliminar Cliente"
+msgstr "Excluir cliente"
 
 msgid "Delete Customer Status"
-msgstr "Eliminar Status do Cliente"
+msgstr "Excluir status do cliente"
 
 msgid "Delete Customer Type"
-msgstr "Eliminar Tipo de Cliente"
+msgstr "Excluir tipo de cliente"
 
 msgid "Delete Department"
 msgstr "Excluir Departamento"
 
 msgid "Delete Dimension"
-msgstr "Deletar Dimensão"
+msgstr "Excluir dimensão"
 
 msgid "Delete Dispatch"
-msgstr "Excluir Despacho"
+msgstr "Excluir ordem de manutenção"
 
 msgid "Delete Document"
-msgstr "Eliminar Documento"
+msgstr "Excluir documento"
 
 msgid "Delete Employee Type"
-msgstr "Eliminar Tipo de Funcionário"
+msgstr "Excluir tipo de funcionário"
 
 msgid "Delete Failure Mode"
-msgstr "Eliminar Modo de Falha"
+msgstr "Excluir modo de falha"
 
 msgid "Delete file"
 msgstr "Excluir arquivo"
 
 msgid "Delete Group"
-msgstr "Eliminar Grupo"
+msgstr "Excluir grupo"
 
 msgid "Delete Holiday"
 msgstr "Excluir Feriado"
 
 msgid "Delete Inspection Plan"
-msgstr "Eliminar Plano de Inspeção"
+msgstr "Excluir plano de inspeção"
 
 msgid "Delete Issue"
-msgstr "Eliminar Problema"
+msgstr "Excluir requisição"
 
 msgid "Delete Item Group"
 msgstr "Excluir grupo de itens"
 
 msgid "Delete Journal Entry"
-msgstr "Deletar Lançamento no Diário"
+msgstr "Excluir lançamento"
 
 msgid "Delete line"
-msgstr "Deletar linha"
+msgstr "Excluir linha"
 
 msgid "Delete Line"
-msgstr "Eliminar Linha"
+msgstr "Excluir Linha"
 
 msgid "Delete Location"
-msgstr "Eliminar Localização"
+msgstr "Excluir local"
 
 msgid "Delete Material"
-msgstr "Eliminar Material"
+msgstr "Excluir material"
 
 msgid "Delete Material Dimension"
-msgstr "Eliminar Dimensão de Material"
+msgstr "Excluir dimensão de material"
 
 msgid "Delete Material Finish"
-msgstr "Eliminar Acabado de Material"
+msgstr "Excluir acabamento"
 
 msgid "Delete Material Grade"
-msgstr "Eliminar Grau de Material"
+msgstr "Excluir grau"
 
 msgid "Delete Material Shape"
-msgstr "Eliminar Forma de Material"
+msgstr "Excluir forma"
 
 msgid "Delete Material Type"
-msgstr "Eliminar Tipo de Material"
+msgstr "Excluir tipo de material"
 
 msgid "Delete Memo"
 msgstr "Excluir Memorando"
 
 msgid "Delete Part"
-msgstr "Eliminar Peça"
+msgstr "Excluir Peça"
 
 msgid "Delete Partner"
-msgstr "Eliminar Parceiro"
+msgstr "Excluir Parceiro"
 
 msgid "Delete passkey"
-msgstr "Eliminar chave de acesso"
+msgstr "Excluir chave de acesso"
 
 msgid "Delete Passkey"
-msgstr "Eliminar Chave de Acesso"
+msgstr "Excluir Chave de acesso"
 
 msgid "Delete Payment"
-msgstr "Eliminar Pagamento"
+msgstr "Excluir Pagamento"
 
 msgid "Delete Payment Term"
-msgstr "Eliminar Termo de Pagamento"
+msgstr "Excluir Condição de pagamento"
 
 msgid "Delete Period"
-msgstr "Deletar Período"
+msgstr "Excluir Período"
 
 msgid "Delete Picking List"
-msgstr "Eliminar Lista de Picking"
+msgstr "Excluir Lista de separação"
 
 msgid "Delete Portal"
-msgstr "Eliminar Portal"
+msgstr "Excluir Portal"
 
 msgid "Delete Price Break"
-msgstr "Eliminar Intervalo de Preço"
+msgstr "Excluir Faixa de preço"
 
 msgid "Delete Pricing Rule"
-msgstr "Eliminar Regra de Preço"
+msgstr "Excluir Regra de precificação"
 
 msgid "Delete Procedure"
-msgstr "Eliminar Procedimento"
+msgstr "Excluir Procedimento"
 
 msgid "Delete Process"
-msgstr "Eliminar Processo"
+msgstr "Excluir Processo"
 
 msgid "Delete Purchase Invoice"
-msgstr "Eliminar Fatura de Compra"
+msgstr "Excluir Fatura de compra"
 
 msgid "Delete Purchase Order"
-msgstr "Eliminar Ordem de Compra"
+msgstr "Excluir Pedido de compra"
 
 msgid "Delete Purchase Orders"
-msgstr "Eliminar Pedidos de Compra"
+msgstr "Excluir Pedidos de compra"
 
 msgid "Delete Question"
-msgstr "Eliminar Pergunta"
+msgstr "Excluir Pergunta"
 
 msgid "Delete Quote"
-msgstr "Eliminar Cotação"
+msgstr "Excluir Orçamento"
 
 msgid "Delete Reason"
-msgstr "Eliminar Motivo"
+msgstr "Excluir Motivo"
 
 msgid "Delete Receipt"
-msgstr "Eliminar Recebimento"
+msgstr "Excluir Recebimento"
 
 msgid "Delete receipt line"
 msgstr "Excluir linha de recebimento"
 
 msgid "Delete requirement"
-msgstr "Eliminar requisito"
+msgstr "Excluir requisito"
 
 msgid "Delete RFQ"
-msgstr "Eliminar RFQ"
+msgstr "Excluir RFQ"
 
 msgid "Delete Risk"
-msgstr "Eliminar Risco"
+msgstr "Excluir Risco"
 
 msgid "Delete row"
-msgstr "Eliminar linha"
+msgstr "Excluir linha"
 
 msgid "Delete Rule"
-msgstr "Eliminar Regra"
+msgstr "Excluir Regra"
 
 msgid "Delete Sales Invoice"
-msgstr "Eliminar Fatura de Venda"
+msgstr "Excluir Fatura de venda"
 
 msgid "Delete Sales Order"
-msgstr "Eliminar Pedido de Venda"
+msgstr "Excluir Pedido de venda"
 
 msgid "Delete Schedule"
-msgstr "Eliminar Cronograma"
+msgstr "Excluir Programação"
 
 msgid "Delete Service"
 msgstr "Excluir Serviço"
 
 msgid "Delete Shift"
-msgstr "Eliminar Turno"
+msgstr "Excluir Turno"
 
 msgid "Delete Shipment"
-msgstr "Eliminar Envio"
+msgstr "Excluir Remessa"
 
 msgid "Delete shipment line"
-msgstr "Eliminar linha de envio"
+msgstr "Excluir linha da remessa"
 
 msgid "Delete Shipping Method"
-msgstr "Eliminar Método de Envío"
+msgstr "Excluir Método de envio"
 
 msgid "Delete step"
-msgstr "Eliminar etapa"
+msgstr "Excluir etapa"
 
 msgid "Delete Step"
-msgstr "Eliminar Etapa"
+msgstr "Excluir Etapa"
 
 msgid "Delete Stock Transfer"
-msgstr "Eliminar Transferência de Estoque"
+msgstr "Excluir Transferência de estoque"
 
 msgid "Delete Storage Type"
-msgstr "Eliminar Tipo de Armazenamento"
+msgstr "Excluir Tipo de armazenamento"
 
 msgid "Delete Storage Unit"
-msgstr "Eliminar Unidade de Armazenamento"
+msgstr "Excluir Unidade de armazenamento"
 
 msgid "Delete Substance"
-msgstr "Eliminar Substância"
+msgstr "Excluir Substância"
 
 msgid "Delete Suggestion"
-msgstr "Eliminar Sugestão"
+msgstr "Excluir Sugestão"
 
 msgid "Delete supplier"
-msgstr "Eliminar fornecedor"
+msgstr "Excluir fornecedor"
 
 msgid "Delete Supplier"
-msgstr "Eliminar Fornecedor"
+msgstr "Excluir Fornecedor"
 
 msgid "Delete Supplier Quote"
-msgstr "Eliminar Cotação de Fornecedor"
+msgstr "Excluir Cotação do fornecedor"
 
 msgid "Delete Supplier Type"
-msgstr "Eliminar Tipo de Fornecedor"
+msgstr "Excluir Tipo de fornecedor"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Excluir a quebra de preço para a quantidade {0}? Isso não pode ser desfeito."
+msgstr "Excluir a faixa de preço para quantidade {0}? Isso não pode ser desfeito."
 
 msgid "Delete Timecard"
-msgstr "Eliminar Cartão de Ponto"
+msgstr "Excluir Cartão de ponto"
 
 msgid "Delete Tool"
-msgstr "Eliminar Ferramenta"
+msgstr "Excluir Ferramenta"
 
 msgid "Delete Training"
-msgstr "Eliminar Treinamento"
+msgstr "Excluir Treinamento"
 
 msgid "Delete Transfer"
 msgstr "Excluir Transferência"
 
 msgid "Delete Transfer Line"
-msgstr "Eliminar Linha de Transferência"
+msgstr "Excluir Linha de transferência"
 
 msgid "Delete Type"
 msgstr "Excluir Tipo"
@@ -5030,16 +5030,16 @@ msgid "Delete view"
 msgstr "Excluir visualização"
 
 msgid "Delete View"
-msgstr "Eliminar Visualização"
+msgstr "Excluir Visualização"
 
 msgid "Delete Warehouse Transfer"
-msgstr "Eliminar Transferência de Armazém"
+msgstr "Excluir Transferência de armazém"
 
 msgid "Delete Webhook"
-msgstr "Eliminar Webhook"
+msgstr "Excluir Webhook"
 
 msgid "Delete Workflow"
-msgstr "Deletar fluxo de trabalho"
+msgstr "Excluir Fluxo de trabalho"
 
 msgid "Delivery Date"
 msgstr "Data de Entrega"
@@ -5060,7 +5060,7 @@ msgid "Demand Forecast — Driven by"
 msgstr "Previsão de Demanda — Impulsionada por"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Previsão de demanda = demanda explodida por BOM de pedidos de vendas abertos, trabalhos ativos e projeções de produção."
+msgstr "Previsão de demanda = Demanda desdobrada da BOM a partir de pedidos de venda abertos, ordens de produção ativas e projeções de produção."
 
 msgid "Demand projection"
 msgstr "Projeção de demanda"
@@ -5126,7 +5126,7 @@ msgid "Depreciation Start Date"
 msgstr "Data de Início da Depreciação"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Derive a vida útil deste artigo da vida útil mais curta de seus componentes, ignorando o campo Dias acima."
+msgstr "Derivar a vida de prateleira deste item da menor vida de prateleira de seus componentes, ignorando o campo Dias acima."
 
 msgid "Description"
 msgstr "Descrição"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Descartar"
 
 msgid "Dispatch"
-msgstr "Despacho"
+msgstr "Ordem de manutenção"
 
 msgid "Dispatch ID"
-msgstr "ID de Despacho"
+msgstr "ID da Ordem de manutenção"
 
 msgid "Dispatch priority"
-msgstr "Prioridade de expedição"
+msgstr "Prioridade da ordem de manutenção"
 
 msgid "Dispatches"
-msgstr "Despachos"
+msgstr "Ordens de manutenção"
 
 msgid "Display Settings"
 msgstr "Configurações de Exibição"
 
 msgid "Disposal"
-msgstr "Alienação"
+msgstr "Baixa"
 
 msgid "Disposal Date"
-msgstr "Data de Alienação"
+msgstr "Data de Baixa"
 
 msgid "Dispose"
 msgstr "Alienar"
@@ -5283,7 +5283,7 @@ msgid "Dispositions"
 msgstr "Disposições"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
-msgstr "Deseja sobrescrever as permissões atuais do utilizador com as permissões padrão para este tipo de funcionário?"
+msgstr "Deseja sobrescrever as permissões atuais do usuário com as permissões padrão para este tipo de funcionário?"
 
 msgid "Doc-Backed"
 msgstr "Apoiado em documento"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Documentos"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documentos envia faturas, contas a pagar e pagamentos como documentos nativos do provedor; seus diários são registados como cobertos pelo documento. Também obtém pagamentos registados no provedor de volta para Carbon, fechando a fatura ou conta a pagar correspondente e publicando um diário GL do Carbon. Off registra-os como deliberadamente excluídos."
+msgstr "Documentos envia faturas, contas e pagamentos como documentos nativos do provedor; seus diários são registrados como cobertos pelo documento. Também extrai pagamentos registrados no provedor de volta para o Carbon, fechando a fatura ou conta correspondente e postando um lançamento contábil da Razão do Carbon. Quando desligado, registra-os como deliberadamente excluídos."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Documentos que abrir aparecerão aqui para acesso rápido."
@@ -5322,13 +5322,13 @@ msgid "Don't Cancel"
 msgstr "Não Cancelar"
 
 msgid "done"
-msgstr "concluído"
+msgstr "feito"
 
 msgid "Done"
-msgstr "Concluído"
+msgstr "Feito"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Concluído quando o dia a dia funciona sem nós na sala"
+msgstr "Feito quando o dia a dia funciona sem nós"
 
 msgid "Download"
 msgstr "Baixar"
@@ -5365,7 +5365,7 @@ msgid "Drag & drop files, or click to browse"
 msgstr "Arraste e solte arquivos, ou clique para procurar"
 
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
-msgstr "Arraste e solte um PDF de Ordem de Compra aqui, ou clique para selecionar um arquivo"
+msgstr "Arraste e solte um PDF de Pedido de Compra aqui ou clique para selecionar um arquivo"
 
 msgid "Drag handle"
 msgstr "Puxador de arrasto"
@@ -5395,10 +5395,10 @@ msgid "Drawing replaced. Balloon placements were removed; feature rows are uncha
 msgstr "Desenho substituído. Os posicionamentos de balões foram removidos; as linhas de recursos permanecem inalteradas."
 
 msgid "Drop Shipment"
-msgstr "Envio Direto"
+msgstr "Entrega Direta"
 
 msgid "Drop Shipment Statuses"
-msgstr "Estados de Envio Direto"
+msgstr "Status de Entregas Diretas"
 
 msgid "Drop whole pages or sections a customer doesn't need."
 msgstr "Remova páginas ou seções inteiras que o cliente não precisa."
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "Solte seu arquivo aqui ou clique para procurar."
 
 msgid "Drop-ship"
-msgstr "Envio Direto"
+msgstr "Entrega direta"
 
 msgid "Due"
 msgstr "Vencimento"
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Data de Vencimento do Último Trabalho"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Data de vencimento do trabalho mais antigo do lote; os trabalhos posteriores são espaçados uniformemente entre esta data e a data de vencimento do último trabalho."
+msgstr "Data de vencimento da primeira ordem de produção no lote em massa; as ordens posteriores espaçam-se uniformemente entre essa data e Data de Vencimento da Última Ordem."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Data de vencimento do trabalho final no lote; combinada com a data de vencimento do primeiro trabalho para espaçar os trabalhos uniformemente."
+msgstr "Data de vencimento da última ordem de produção no lote em massa; combinada com Data de Vencimento da Primeira Ordem para espaçar as ordens uniformemente."
 
 msgid "Due Days"
 msgstr "Dias de Vencimento"
@@ -5453,7 +5453,7 @@ msgid "Duplicate Price List"
 msgstr "Duplicar Lista de Preços"
 
 msgid "Duplicate Pricing Rule"
-msgstr "Duplicar Regra de Preço"
+msgstr "Duplicar Regra de Precificação"
 
 msgid "Duplicate To"
 msgstr "Duplicar Para"
@@ -5573,13 +5573,13 @@ msgid "Edit Category"
 msgstr "Editar Categoria"
 
 msgid "Edit Change Notice"
-msgstr "Editar Aviso de Mudança"
+msgstr "Editar Aviso de alteração"
 
 msgid "Edit Change Notice Action"
-msgstr "Editar Ação do Aviso de Mudança"
+msgstr "Editar Ação do Aviso de alteração"
 
 msgid "Edit Change Notice Type"
-msgstr "Editar Tipo de Aviso de Mudança"
+msgstr "Editar Tipo de Aviso de alteração"
 
 msgid "Edit column visibility"
 msgstr "Editar visibilidade da coluna"
@@ -5588,7 +5588,7 @@ msgid "Edit Contact"
 msgstr "Editar Contacto"
 
 msgid "Edit Contractor"
-msgstr "Editar Contratante"
+msgstr "Editar Terceirizado"
 
 msgid "Edit Cost Center"
 msgstr "Editar Centro de Custo"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "Editar Dimensão"
 
 msgid "Edit Dispatch"
-msgstr "Editar Despacho"
+msgstr "Editar Ordem de manutenção"
 
 msgid "Edit Employee"
 msgstr "Editar Funcionário"
@@ -5627,7 +5627,7 @@ msgid "Edit Employee Type"
 msgstr "Editar Tipo de Funcionário"
 
 msgid "Edit expiration date"
-msgstr "Editar data de expiração"
+msgstr "Editar data de validade"
 
 msgid "Edit Expiry"
 msgstr "Editar Validade"
@@ -5639,10 +5639,10 @@ msgid "Edit Fixed Asset"
 msgstr "Editar Ativo Fixo"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Editar Registro de Calibração de Medidor"
+msgstr "Editar Registro de calibração"
 
 msgid "Edit Gauge Type"
-msgstr "Editar Tipo de Medidor"
+msgstr "Editar Tipo de instrumento"
 
 msgid "Edit Group"
 msgstr "Editar Grupo"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Editar Localização"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Editar Despacho de Manutenção"
+msgstr "Editar Ordem de manutenção"
 
 msgid "Edit Material"
 msgstr "Editar Material"
@@ -5687,7 +5687,7 @@ msgid "Edit Material Shape"
 msgstr "Editar Forma de Material"
 
 msgid "Edit Material Substance"
-msgstr "Editar Substância Material"
+msgstr "Editar Material base"
 
 msgid "Edit Material Type"
 msgstr "Editar Tipo de Material"
@@ -5711,28 +5711,28 @@ msgid "Edit Payment"
 msgstr "Editar Pagamento"
 
 msgid "Edit Payment Term"
-msgstr "Editar Termo de Pagamento"
+msgstr "Editar Condição de pagamento"
 
 msgid "Edit permissions"
-msgstr "Permissões de edição"
+msgstr "Editar permissões"
 
 msgid "Edit Permissions"
-msgstr "Permissões de Edição"
+msgstr "Editar Permissões"
 
 msgid "Edit Picking List"
-msgstr "Editar Lista de Coleta"
+msgstr "Editar Lista de separação"
 
 msgid "Edit Portal"
 msgstr "Editar Portal"
 
 msgid "Edit Price Override"
-msgstr "Editar Substituição de Preço"
+msgstr "Editar Sobrescrita de preço"
 
 msgid "Edit Pricing"
-msgstr "Editar Preço"
+msgstr "Editar Precificação"
 
 msgid "Edit Pricing Rule"
-msgstr "Editar Regra de Preço"
+msgstr "Editar Regra de precificação"
 
 msgid "Edit Process"
 msgstr "Editar Processo"
@@ -5747,7 +5747,7 @@ msgid "Edit Production Quantity"
 msgstr "Editar Quantidade de Produção"
 
 msgid "Edit purchase order line type"
-msgstr "Editar tipo de linha de ordem de compra"
+msgstr "Editar tipo de linha de pedido de compra"
 
 msgid "Edit Question"
 msgstr "Editar Pergunta"
@@ -5927,13 +5927,13 @@ msgid "Enable digital quotes for your company. This will allow you to send digit
 msgstr "Ative cotações digitais para sua empresa. Isso permitirá que você envie cotações digitais para seus clientes e permita que eles as aceitem online."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Ativar contabilidade de competência completa com lançamentos de diário, relatórios financeiros e postagem no razão geral."
+msgstr "Ativar contabilidade de regime de competência completo com lançamentos em diários, relatórios financeiros e contabilização no livro razão."
 
 msgid "Enable in Settings"
 msgstr "Ativar nas Configurações"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "Ativar notificações quando uma RFQ é marcada como pronta para cotação."
+msgstr "Ativar notificações quando um RFQ é marcado como pronto para orçamento."
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
 msgstr "Ativar modo de estação de trabalho compartilhada para terminais MES. Os operadores se identificam via PIN antes de realizar o trabalho."
@@ -5948,7 +5948,7 @@ msgid "Enable to allow shared workstation mode."
 msgstr "Ativar para permitir modo de estação de trabalho compartilhada."
 
 msgid "Enable to automatically post transactions to the general ledger."
-msgstr "Ativar para lançar automaticamente transações no razão geral."
+msgstr "Ativar para contabilizar automaticamente as transações no livro razão."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
 msgstr "Ativar para configurar métodos de depreciação específicos de impostos em classes de ativos (por exemplo, MACRS, acelerado)."
@@ -5991,7 +5991,7 @@ msgid "Ending ({0})"
 msgstr "Fim ({0})"
 
 msgid "Enforce — edits are blocked"
-msgstr "Forçar — edições são bloqueadas"
+msgstr "Impor — edições bloqueadas"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
 msgstr "Aplicar validação e diretrizes por item em recebimentos, remessas, transferências e ajustes."
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "Inscrever"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "Insira um número de lote antes de definir a data de expiração"
+msgstr "Insira um número de lote antes de definir a data de validade"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "Digite uma quantidade entre 1 e {0}."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Inserir e aprovar faturas de fornecedores contra uma PO (correspondência de três vias)"
+msgstr "Insira e aprove faturas de fornecedores em relação a um pedido de compra (conciliação de três vias)"
 
 msgid "Enter number…"
 msgstr "Digite o número…"
@@ -6064,7 +6064,7 @@ msgid "Entity certification: Accepted"
 msgstr "Certificação da entidade: Aceita"
 
 msgid "Entity certification: Expired"
-msgstr "Certificação da entidade: Expirada"
+msgstr "Certificação de entidade: Vencida"
 
 msgid "Entity certification: Pending"
 msgstr "Certificação da entidade: Pendente"
@@ -6088,10 +6088,10 @@ msgid "Equity"
 msgstr "Patrimônio Líquido"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "Conta de patrimônio para lucros ou perdas acumulados"
+msgstr "Conta de patrimônio líquido para lucros ou perdas acumulados"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Conta de patrimônio para ajustes de conversão de moeda (CTA)"
+msgstr "Conta de patrimônio líquido para ajustes de conversão de moeda (CTA)"
 
 msgid "Error"
 msgstr "Erro"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Erro ao buscar dados do fornecedor"
 
 msgid "Error loading assigned dispatches"
-msgstr "Erro ao carregar despachos atribuídos"
+msgstr "Erro ao carregar ordens de manutenção atribuídas"
 
 msgid "Error loading assigned documents"
 msgstr "Erro ao carregar documentos atribuídos"
@@ -6139,7 +6139,7 @@ msgid "Error removing model from job"
 msgstr "Erro ao remover modelo do trabalho"
 
 msgid "Error removing model from quote line"
-msgstr "Erro ao remover modelo da linha de cotação"
+msgstr "Erro ao remover modelo da linha do orçamento"
 
 msgid "Error removing model from RFQ line"
 msgstr "Erro ao remover modelo da linha de RFQ"
@@ -6166,10 +6166,10 @@ msgid "Estimated Duration (minutes)"
 msgstr "Duração Estimada (minutos)"
 
 msgid "Estimated Scrap Quantity"
-msgstr "Quantidade de Sucata Estimada"
+msgstr "Quantidade estimada de Refugo"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Quantidade estimada de sucata aplicada a cada trabalho no lote."
+msgstr "Quantidade de refugo estimada aplicada a cada ordem de produção no lote de produção em massa."
 
 msgid "Estimated time"
 msgstr "Tempo estimado"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Cada correspondência"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Toda tarefa obrigatória deve ser Concluída ou Saltada antes que o período possa ser fechado."
+msgstr "Cada tarefa necessária deve estar Feita ou Ignorada antes que o período possa ser fechado."
 
 msgid "Every row was imported successfully."
 msgstr "Cada linha foi importada com sucesso."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeamentos existentes. Escolha uma opção de provedor diferente para remapear."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Cliente Stripe existente"
 
 msgid "Expand"
 msgstr "Expandir"
@@ -6269,7 +6269,7 @@ msgid "Expand features table"
 msgstr "Expandir tabela de recursos"
 
 msgid "Expand Labor"
-msgstr "Expandir Trabalho"
+msgstr "Expandir Mão de obra"
 
 msgid "Expand Machine"
 msgstr "Expandir Máquina"
@@ -6281,7 +6281,7 @@ msgid "Expand subtree"
 msgstr "Expandir subárvore"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Demanda futura esperada para uma peça a fabricar inserida semana a semana antes de qualquer pedido de vendas existir; o planejamento a compensa contra a oferta e explode o método para solicitar componentes antecipadamente."
+msgstr "Demanda futura esperada para uma peça de fabricação inserida semana a semana antes de qualquer pedido de venda existir; o planejamento a compensa contra o suprimento e explode o método para encomendar componentes antecipadamente."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
 msgstr "Demanda futura esperada para um item, agrupada por período, preenchida pela execução do planejamento junto com a demanda real."
@@ -6293,7 +6293,7 @@ msgid "Expected Receipt Date"
 msgstr "Data de Recebimento Esperada"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Conta de despesa para saldos de clientes baixados como incobrável na liquidação de AR"
+msgstr "Conta de despesa para saldos de clientes cancelados como incobrável na liquidação de contas a receber"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "Conta de despesas para ajustes de imposto diferido sobre depreciação"
@@ -6305,16 +6305,16 @@ msgid "Expense account for FX losses when a payment settles a foreign-currency i
 msgstr "Conta de despesa para perdas de câmbio quando um pagamento liquida uma fatura em moeda estrangeira a uma taxa menos favorável"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Conta de despesas para compras fora do inventário (serviços, suprimentos)"
+msgstr "Conta de despesa para compras não estocáveis (serviços, suprimentos)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Conta de despesas GL debitada quando o inventário é enviado/emitido contra uma venda."
+msgstr "Conta de despesa para o custo dos itens vendidos"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Lado de despesa dos movimentos de imposto diferido (emparelhado com passivo de imposto diferido)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Falha ao criar classe de ativo: {0}"
+msgstr "Lado de despesa dos movimentos de imposto diferido (emparelhado com passivo de imposto diferido)."
 
 msgid "Expenses"
 msgstr "Despesas"
@@ -6323,27 +6323,27 @@ msgid "Expert guidance"
 msgstr "Orientação especializada"
 
 msgid "Expiration date"
-msgstr "Data de expiração"
+msgstr "Data de validade"
 
 msgid "Expiration Date"
-msgstr "Data de Expiração"
+msgstr "Data de validade"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Data de Expiração (aplica-se a todos os seriais nesta linha)"
+msgstr "Data de validade (aplica-se a todos os números de série nesta linha)"
 
 msgid "Expired"
-msgstr "Expirado"
+msgstr "Vencido"
 
 #. placeholder {0}: formatDate(date)
 #. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
-msgstr "Expirado em {0}"
+msgstr "Vencido {0}"
 
 msgid "Expired batch"
-msgstr "Lote expirado"
+msgstr "Lote de produção vencido"
 
 msgid "Expired Batches"
-msgstr "Lotes Expirados"
+msgstr "Lotes de produção vencidos"
 
 msgid "Expires"
 msgstr "Expira"
@@ -6365,10 +6365,10 @@ msgid "Expiry"
 msgstr "Validade"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "A expiração começa quando o processo selecionado é concluído."
+msgstr "A validade começa quando o processo selecionado é concluído."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "A expiração começa quando o processo selecionado inicia."
+msgstr "A validade começa quando o processo selecionado é iniciado."
 
 msgid "Expiry trace"
 msgstr "Rastreamento de validade"
@@ -6401,10 +6401,10 @@ msgid "External link"
 msgstr "Link externo"
 
 msgid "External notes"
-msgstr "Notas externas"
+msgstr "Observações externas"
 
 msgid "External Notes"
-msgstr "Notas Externas"
+msgstr "Observações Externas"
 
 msgid "External Ref."
 msgstr "Ref. Externa"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "Informações extras enviadas com a solicitação, como uma chave de autorização; os valores do cabeçalho estão ocultos no histórico de execução, embora os nomes permaneçam legíveis."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "Tags extras para segmentar seus relatórios GL"
+msgstr "Etiquetas extras para segmentar seus relatórios da Razão"
 
 msgid "Fail"
-msgstr "Falhar"
+msgstr "Reprovado"
 
 msgid "Failed"
 msgstr "Falhou"
@@ -6432,7 +6432,7 @@ msgstr "Recursos com falha"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (primeiro a expirar, primeiro a sair)"
+msgstr "Falha ao criar classe de ativo: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Falha ao criar modo de falha: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Falha ao criar tipo de medidor: {0}"
+msgstr "Falha ao criar tipo de instrumento: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6500,7 +6500,7 @@ msgstr "Falha ao criar grau de material: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Falha ao criar substância material: {0}"
+msgstr "Falha ao criar material base: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6520,7 +6520,7 @@ msgstr "Falha ao criar peça: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Falha ao criar termo de pagamento: {0}"
+msgstr "Falha ao criar condição de pagamento: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6583,7 +6583,7 @@ msgid "Failed to initialize Carbon client"
 msgstr "Falha ao inicializar cliente Carbon"
 
 msgid "Failed to insert quote line"
-msgstr "Falha ao inserir linha de cotação"
+msgstr "Falha ao inserir linha do orçamento"
 
 msgid "Failed to insert supplier quote line"
 msgstr "Falha ao inserir linha de cotação do fornecedor"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Falha ao carregar dados"
 
 msgid "Failed to load inbound inspections"
-msgstr "Falha ao carregar inspeções de entrada"
+msgstr "Falha ao carregar inspeções de recebimento"
 
 msgid "Failed to load item data"
 msgstr "Falha ao carregar dados do item"
@@ -6607,13 +6607,13 @@ msgid "Failed to load item details"
 msgstr "Falha ao carregar detalhes do item"
 
 msgid "Failed to load job operations"
-msgstr "Falha ao carregar operações de trabalho"
+msgstr "Falha ao carregar operações da ordem"
 
 msgid "Failed to load jobs"
-msgstr "Falha ao carregar trabalhos"
+msgstr "Falha ao carregar ordens de produção"
 
 msgid "Failed to load purchase order lines"
-msgstr "Falha ao carregar linhas de ordem de compra"
+msgstr "Falha ao carregar linhas do pedido de compra"
 
 msgid "Failed to load purchase orders"
 msgstr "Falha ao carregar pedidos de compra"
@@ -6631,7 +6631,7 @@ msgid "Failed to load sales orders"
 msgstr "Falha ao carregar pedidos de venda"
 
 msgid "Failed to load shipment lines"
-msgstr "Falha ao carregar linhas de envio"
+msgstr "Falha ao carregar linhas da remessa"
 
 msgid "Failed to load shipments"
 msgstr "Falha ao carregar remessas"
@@ -6713,7 +6713,7 @@ msgid "Failed to update opportunity with purchase order"
 msgstr "Falha ao atualizar oportunidade com pedido de compra"
 
 msgid "Failed to update quote line"
-msgstr "Falha ao atualizar linha de cotação"
+msgstr "Falha ao atualizar linha do orçamento"
 
 msgid "Failed to update supplier quote line"
 msgstr "Falha ao atualizar linha de cotação do fornecedor"
@@ -6723,39 +6723,39 @@ msgstr "Falha ao atualizar caminho da miniatura"
 
 #. placeholder {0}: file.name
 msgid "Failed to upload {0}"
-msgstr "Falha ao carregar {0}"
+msgstr "Falha ao enviar arquivo {0}"
 
 msgid "Failed to upload certificate"
-msgstr "Falha ao fazer upload do certificado"
+msgstr "Falha ao enviar certificado"
 
 msgid "Failed to upload CSV file."
-msgstr "Falha ao carregar arquivo CSV."
+msgstr "Falha ao enviar arquivo CSV."
 
 msgid "Failed to upload file"
-msgstr "Falha ao carregar arquivo"
+msgstr "Falha ao enviar arquivo"
 
 msgid "Failed to upload file to new location"
-msgstr "Falha ao carregar arquivo para novo local"
+msgstr "Falha ao enviar arquivo para novo local"
 
 #. placeholder {0}: file.name
 #. placeholder {0}: fileUpload.name
 msgid "Failed to upload file: {0}"
-msgstr "Falha ao carregar arquivo: {0}"
+msgstr "Falha ao enviar arquivo: {0}"
 
 msgid "Failed to upload image"
-msgstr "Falha ao carregar imagem"
+msgstr "Falha ao enviar imagem"
 
 msgid "Failed to upload logo: {errorMessage}"
-msgstr "Falha ao carregar logo: {errorMessage}"
+msgstr "Falha ao enviar logotipo: {errorMessage}"
 
 msgid "Failed to upload model"
-msgstr "Falha ao carregar modelo"
+msgstr "Falha ao enviar modelo"
 
 msgid "Failed to upload PDF"
-msgstr "Falha ao carregar PDF"
+msgstr "Falha ao enviar PDF"
 
 msgid "Failed to upload thumbnail"
-msgstr "Falha ao carregar miniatura"
+msgstr "Falha ao enviar miniatura"
 
 msgid "Failure"
 msgstr "Falha"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Taxas"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Acabamento"
+msgstr "FEFO (primeiro a vencer, primeiro a sair)"
 
 msgid "Fetch"
 msgstr "Buscar"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "Finalizar"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Finalizar um mês fiscal através do ciclo de vida Aberto → Bloqueado → Fechado; um período fechado é congelado e seus saldos são capturados, reversível apenas por reabertura explícita."
+msgstr "Finalizando um mês fiscal através do ciclo de vida Aberto → Bloqueado → Fechado; um período fechado é congelado e seus saldos são capturados, reversível apenas por reabertura explícita."
 
 msgid "Financial Statements"
 msgstr "Demonstrações Financeiras"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "Finalizar com material não coletado?"
 
 msgid "Finished goods"
-msgstr "Acabamentos"
+msgstr "Produtos acabados"
 
 msgid "Finished Goods"
 msgstr "Produtos Acabados"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Fixo"
 
 msgid "Fixed asset"
-msgstr "Variância de amortização de custo fixo quando o tamanho do lote difere do padrão"
+msgstr "Ativo fixo"
 
 msgid "Fixed Asset"
 msgstr "Ativo Fixo"
@@ -6937,22 +6937,22 @@ msgid "Fixed Assets"
 msgstr "Ativos Fixos"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Ganhos e Perdas"
+msgstr "Variação de amortização de custo fixo quando o tamanho do lote difere do padrão"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
-msgstr "Fixado após os períodos contábeis terem sido lançados ou fechados. Delete todos os períodos abertos para alterá-lo."
+msgstr "Fixado após períodos contábeis serem contabilizados ou fechados. Exclua todos os períodos abertos para alterá-lo."
 
 msgid "Fixed Reorder"
 msgstr "Reabastecimento Fixo"
 
 msgid "Fixed Shelf Life"
-msgstr "Vida Útil Fixa"
+msgstr "Vida de prateleira fixa"
 
 msgid "Fixture"
-msgstr "Acessório"
+msgstr "Dispositivo de fixação"
 
 msgid "Fixture ID"
-msgstr "ID do Acessório"
+msgstr "ID do dispositivo de fixação"
 
 msgid "Flags"
 msgstr "Sinalizadores"
@@ -6962,16 +6962,16 @@ msgstr "para qualquer coisa. Eles vão trazer a pessoa certa."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Método de previsão: <0>{0}</0>. Esta linha não foi derivada de trabalhos ativos, portanto nenhuma fonte pai está disponível."
+msgstr "Método de previsão: <0>{0}</0>. Esta linha não foi derivada de ordens ativas, portanto nenhuma origem está disponível."
 
 msgid "Forgot to Clock Out?"
-msgstr "Esqueceu de Registrar a Saída?"
+msgstr "Esqueceu de apontar fim?"
 
 msgid "Format"
 msgstr "Formato"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Engenheiro de campo"
 
 msgid "Foundation"
 msgstr "Fundação"
@@ -7021,13 +7021,13 @@ msgid "From Storage Unit"
 msgstr "Unidade de Armazenamento De"
 
 msgid "Fulfillment Location"
-msgstr "Local de Cumprimento"
+msgstr "Local de expedição"
 
 msgid "Full name"
 msgstr "Nome completo"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Configuração completa e migrações"
 
 msgid "Fully Depreciated"
 msgstr "Totalmente Depreciado"
@@ -7039,58 +7039,58 @@ msgid "FX G/L"
 msgstr "FX G/L"
 
 msgid "Gain on Disposal"
-msgstr "Ganho na Alienação"
+msgstr "Ganho na baixa"
 
 msgid "Gain on Disposal (default)"
-msgstr "Ganho na Alienação (padrão)"
+msgstr "Ganho na baixa (padrão)"
 
 msgid "Gain on Disposal Account"
-msgstr "Conta de Ganho na Alienação"
+msgstr "Conta de ganho na baixa"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "Ganhos reconhecidos na alienação de ativos imobilizados"
+msgstr "Ganhos reconhecidos na baixa de ativos fixos"
 
 msgid "gauge"
-msgstr "Bitolas"
+msgstr "instrumento de medição"
 
 msgid "Gauge"
-msgstr "Medidor"
+msgstr "Instrumento de medição"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Notificações de Calibração de Medidores"
+msgstr "Notificações de calibração de instrumento de medição"
 
 msgid "Gauge ID"
-msgstr "ID do Medidor"
+msgstr "ID do instrumento de medição"
 
 msgid "Gauge not found"
-msgstr "Medidor não encontrado"
+msgstr "Instrumento de medição não encontrado"
 
 msgid "Gauge Type"
-msgstr "Tipo de Medidor"
+msgstr "Tipo de instrumento"
 
 msgid "Gauge Types"
-msgstr "Tipos de Medidor"
+msgstr "Tipos de instrumento"
 
 msgid "gauges"
-msgstr "Genealogia"
+msgstr "instrumentos de medição"
 
 msgid "Gauges"
-msgstr "Medidores"
+msgstr "Instrumentos de medição"
 
 msgid "Genealogy"
-msgstr "Razão Geral"
+msgstr "Genealogia"
 
 msgid "General"
 msgstr "Geral"
 
 msgid "General ledger"
-msgstr "Conta GL que captura diferenças de custos em operações de processamento externo."
+msgstr "livro razão"
 
 msgid "General Ledger"
-msgstr "Razão Geral"
+msgstr "Livro razão"
 
 msgid "General Ledger and month-end close"
-msgstr "Razão Geral e fechamento de mês"
+msgstr "Livro razão e encerramento do período"
 
 msgid "Generate"
 msgstr "Gerar"
@@ -7114,7 +7114,7 @@ msgid "Generate new PIN"
 msgstr "Gerar novo PIN"
 
 msgid "Generate Picking List"
-msgstr "Gerar Lista de Picking"
+msgstr "Gerar lista de separação"
 
 msgid "Generated IDs are disabled"
 msgstr "IDs gerados estão desativados"
@@ -7144,10 +7144,10 @@ msgid "Getting set up"
 msgstr "Configurando"
 
 msgid "Give it an owner and a date"
-msgstr "Atribua um proprietário e uma data"
+msgstr "Dê a ele um responsável e uma data"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Razão"
 
 msgid "GL Account"
 msgstr "Conta Contábil"
@@ -7156,13 +7156,13 @@ msgid "GL account capturing cost differences on outside-processing operations."
 msgstr "Conta GL que captura diferenças de custo em operações de processamento externo."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Conta GL que captura diferenças entre despesas gerais de fabricação aplicadas e reais."
+msgstr "Conta contábil que captura diferenças entre custos indiretos de manufatura aplicados e reais."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Conta GL que captura diferenças entre material esperado por BOM e consumido realmente."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Conta GL que captura diferenças entre o tempo de trabalho/máquina esperado e real."
+msgstr "Conta contábil que captura diferenças entre tempo de mão de obra/máquina esperado em roteiro e real."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Conta GL que captura diferenças de custos fixos quando o tamanho real do lote difere do planejado."
@@ -7171,13 +7171,13 @@ msgid "GL account credited to remove the asset's original cost when it is dispos
 msgstr "Conta GL creditada para remover o custo original do ativo quando este é alienado."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "Conta GL creditada quando uma fatura do fornecedor é lançada (saldo AP)."
+msgstr "Conta contábil creditada quando uma fatura de fornecedor é contabilizada (saldo de contas a pagar)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Conta GL creditada quando o custo de trabalho ou máquina é absorvido em um trabalho de produção."
+msgstr "Conta contábil creditada quando o custo de mão de obra ou máquina é absorvido em uma ordem de produção."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
-msgstr "Conta GL creditada quando a sobrecarga de fabricação é absorvida em um trabalho de produção."
+msgstr "Conta contábil creditada quando custos indiretos de manufatura são absorvidos em uma ordem de produção."
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
 msgstr "Conta GL debitada para limpar a depreciação acumulada quando um ativo é alienado."
@@ -7201,7 +7201,7 @@ msgid "GL account for tax accrued under reverse-charge rules where the buyer sel
 msgstr "Conta GL para impostos acumulados sob regras de cobrança reversa onde o comprador faz autoavaliação."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
-msgstr "Conta GL para diferenças de timing fiscal (p. ex., depreciação fiscal acelerada vs. depreciação contábil)."
+msgstr "Conta contábil para diferenças de timing de impostos (por exemplo, depreciação fiscal acelerada versus depreciação contábil)."
 
 msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Conta GL afetada quando as contagens físicas divergem do inventário do sistema."
@@ -7213,7 +7213,7 @@ msgid "GL account in the target company to credit for this intercompany transact
 msgstr "Conta GL na empresa alvo para crédito desta transação entre empresas."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
-msgstr "Conta GL que absorve diferenças de arredondamento de sub-centavos no lançamento."
+msgstr "Conta contábil que absorve diferenças de arredondamento de frações de centavo na contabilização."
 
 msgid "GL account that captures the difference between standard cost and actual purchase cost."
 msgstr "Conta GL que captura a diferença entre custo padrão e custo real de compra."
@@ -7222,13 +7222,13 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "Conta GL que registra o custo de aquisição original de um ativo — debitada quando adquirido e creditada pelo custo bruto total quando é alienado ou vendido."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Conta GL que mantém o valor de trabalhos em produção até que sejam registrados como produtos acabados."
+msgstr "Conta contábil que mantém o valor de ordens de produção em produção até que sejam contabilizadas em produtos acabados."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
-msgstr "Conta contábil que mantém o valor de bens manufaturados (itens de fabricação); debitada na conclusão do trabalho, creditada no envio."
+msgstr "Conta contábil que mantém o valor de bens manufaturados (itens de fabricação); debitada na conclusão da ordem de produção, creditada na remessa."
 
 msgid "GL account that holds the value of purchased stock and components (Buy items); debited on receipt, credited on issue/shipment."
-msgstr "Conta contábil que mantém o valor de estoque comprado e componentes (itens de compra); debitada no recebimento, creditada na emissão/envio."
+msgstr "Conta contábil que mantém o valor de estoque comprado e componentes (itens de compra); debitada no recebimento, creditada na requisição/remessa."
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
 msgstr "Conta GL usada quando um cliente paga antes de uma fatura ser emitida; limpa quando a fatura é registrada."
@@ -7240,34 +7240,34 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "Conta GL onde são registrados os descontos de pagamento antecipado obtidos dos fornecedores."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Conta GL contra-ativo creditada à medida que a depreciação é registrada a cada período e debitada integralmente quando o ativo é vendido ou sucateado."
+msgstr "Conta contra-ativo contábil creditada quando a depreciação é contabilizada a cada período e debitada integralmente quando o ativo é vendido ou sucateado."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Conta GL contra-ativo que acumula depreciação registrada contra ativos fixos."
+msgstr "Conta contra-ativo contábil que acumula depreciação contabilizada contra ativos fixos."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Conta GL de patrimônio (reserva CTA) que mantém diferenças FX não realizadas da retradução de saldos em moeda estrangeira no final do período; separada do ganho/perda FX realizado na DRE."
+msgstr "Conta de patrimônio líquido contábil (reserva CTA) que mantém diferenças FX não realizadas de retradução de saldos em moeda estrangeira no fechamento do período; separada de ganho/perda FX realizado na DRE."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Conta GL de patrimônio onde o lucro líquido é fechado no final do ano fiscal."
+msgstr "Conta de patrimônio líquido contábil onde a receita líquida é fechada no final do ano fiscal."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Conta GL de despesa debitada a cada período quando depreciação é registrada."
+msgstr "Conta de despesa contábil debitada a cada período quando a depreciação é contabilizada."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Conta GL de despesa debitada quando o valor contábil de um ativo é reduzido por imparidade, ou seja, quando o valor recuperável fica abaixo do valor contábil líquido."
+msgstr "Conta de despesa contábil debitada quando o valor contábil de um ativo é reduzido por impairment, ou seja, quando seu valor recuperável cai abaixo do valor contábil líquido."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Conta GL de despesa para compras fora do inventário (suprimentos, serviços)."
+msgstr "Conta de despesa contábil para compras não estocáveis (suprimentos, serviços)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Conta GL de passivo creditada para imposto sobre vendas cobrado de clientes."
+msgstr "Conta de passivo contábil creditada por impostos sobre vendas coletados de clientes."
 
 msgid "GL tie-out"
-msgstr "Reconciliação GL"
+msgstr "Reconciliação da Razão"
 
 msgid "GL Tie-Out"
-msgstr "Reconciliação GL"
+msgstr "Reconciliação da Razão"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Ative-se corretamente na primeira vez — com nossa equipe ao seu lado"
@@ -7358,7 +7358,7 @@ msgid "Guided implementation"
 msgstr "Implementação guiada"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Processar lançamentos contábeis recorrentes e reversíveis"
+msgstr "Gerenciar lançamentos diários recorrentes e de reversão"
 
 msgid "Hands-on"
 msgstr "Prático"
@@ -7400,10 +7400,10 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "Dados históricos anteriores aos que estão no Mapa de Migração de Dados"
 
 msgid "Historical Rate (equity)"
-msgstr "Taxa Histórica (Patrimônio)"
+msgstr "Taxa histórica (patrimônio líquido)"
 
 msgid "Historical Rate (Equity)"
-msgstr "Taxa Histórica (Patrimônio)"
+msgstr "Taxa histórica (Patrimônio líquido)"
 
 msgid "History"
 msgstr "Histórico"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Horas/Peça"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Como um artigo é reabastecido em geral (Comprar, Fazer ou Comprar e Fazer), definido por artigo, diferente do tipo de método por linha."
+msgstr "Como um item é reabastecido em geral (Compra, Fabricação ou Compra e fabricação), definido por item, diferentemente do tipo de suprimento por linha."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Como um artigo é reabastecido: Reposição Manual, Reposição Baseada em Demanda, Quantidade de Reposição Fixa ou Quantidade Máxima."
@@ -7454,7 +7454,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Como o custo unitário de um artigo é avaliado: Padrão, Média, FIFO ou LIFO. Definido por artigo."
 
 msgid "How items roll up for posting and reporting"
-msgstr "Como os itens são consolidados para lançamento e relatórios"
+msgstr "Como os itens se consolidam para contabilização e relatórios"
 
 msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank to use the default."
 msgstr "Quanto tempo cada fase dura, em semanas. Orienta a linha do tempo do Plano; deixe em branco para usar o padrão."
@@ -7496,10 +7496,10 @@ msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Com que frequência este medidor deve ser recalibrado; combinado com a data da última calibração para recalcular automaticamente a próxima data de calibração."
+msgstr "Com que frequência este instrumento de medição deve ser recalibrado; combinado com a Data da Última Calibração para recalcular automaticamente a Data da Próxima Calibração."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Com que frequência esta manutenção se repete — Diariamente, Semanalmente, Mensalmente, Na Contagem de Ciclo; Diariamente revela o seletor de dia da semana, os demais usam matemática de intervalo mais simples."
+msgstr "Com que frequência esta manutenção se repete — Diário, Semanal, Mensal, Na Contagem cíclica; Diário revela o seletor de dia da semana, os outros usam cálculo de intervalo mais simples."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Quão rigorosa é a data de vencimento — Hard Deadline bloqueia o agendamento, Soft Deadline permite que o planejamento avance com um aviso, No Deadline ignora completamente."
@@ -7514,7 +7514,7 @@ msgid "How the sample size is decided — Inspect All, Inspect First N, Percenta
 msgstr "Como o tamanho da amostra é decidido — Inspecionar Tudo, Inspecionar Primeiro N, Percentual do Lote ou AQL (Z1.4 / ISO 2859-1). Cada modo revela seus próprios campos de parâmetros abaixo."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Como este medidor é usado — Padrão (verificações regulares) ou Mestre (calibra outros medidores)."
+msgstr "Como este instrumento de medição é usado — Normal (verificações regulares) ou Padrão (calibra outros instrumentos de medição)."
 
 msgid "How this price was calculated"
 msgstr "Como este preço foi calculado"
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "Como ler este gráfico"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Quão urgente é este despacho — Baixo / Médio / Alto / Crítico; combinado com Prioridade e Impacto OEE para decidir o slot do cronograma."
+msgstr "Urgência desta ordem de manutenção — Baixo / Médio / Alto / Crítico; combinado com Prioridade e Impacto OEE para decidir o slot de programação."
 
 msgid "How we know we're done"
 msgstr "Como sabemos que terminamos"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "Hypercare: suporte intenso nas primeiras semanas"
 
 msgid "I (reduced)"
-msgstr "I (reduzido)"
+msgstr "I (Atenuada)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "Tenho uma base razoável para acreditar que este indivíduo é uma pessoa dos EUA conforme definido em 22 CFR 120.62"
@@ -7595,13 +7595,13 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "Se não puder esperar pela próxima chamada, os líderes de ambos os lados decidem."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "Se está bloqueando ou uma data está em risco, recebe um proprietário e é rastreado."
+msgstr "Se está bloqueando ou uma data está em risco, recebe um responsável e é rastreado."
 
 msgid "If items already exist"
 msgstr "Se os itens já existem"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "Se encomendado, nenhuma falta de estoque projetada nas próximas 48 semanas"
+msgstr "Se houver pedido emitido, nenhuma ruptura de estoque projetada nas próximas 48 semanas"
 
 msgid "If something is off track"
 msgstr "Se algo estiver fora do caminho"
@@ -7613,7 +7613,7 @@ msgid "II (normal default)"
 msgstr "II (padrão normal)"
 
 msgid "III (tightened)"
-msgstr "III (apertado)"
+msgstr "III (Severa)"
 
 msgid "Impact"
 msgstr "Impacto"
@@ -7662,7 +7662,7 @@ msgid "In Process Only"
 msgstr "Apenas em Processamento"
 
 msgid "In progress"
-msgstr "Em progresso"
+msgstr "Em andamento"
 
 msgid "In Progress"
 msgstr "Em Andamento"
@@ -7701,13 +7701,13 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Ações inativas não aparecerão nas listas de seleção"
 
 msgid "Inbound inspection"
-msgstr "Inspeção de entrada"
+msgstr "Inspeção de recebimento"
 
 msgid "Inbox"
 msgstr "Caixa de entrada"
 
 msgid "Include extra parts in shipment"
-msgstr "Incluir peças extras no envio"
+msgstr "Incluir peças extras na remessa"
 
 msgid "Include Inactive"
 msgstr "Incluir Inativos"
@@ -7716,10 +7716,10 @@ msgid "Included"
 msgstr "Incluído"
 
 msgid "Includes tax and shipping costs"
-msgstr "Inclui impostos e custos de envio"
+msgstr "Inclui impostos e fretes"
 
 msgid "Income / Balance (inherited)"
-msgstr "Renda / Saldo (herdado)"
+msgstr "Receitas / Saldo (herdado)"
 
 msgid "Income Statement"
 msgstr "Demonstração de Resultados"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Herdado do pai"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Herdado do grupo: classificação de nível superior (ativo, passivo, patrimônio, receita, despesa)."
+msgstr "Herdado do grupo: classificação de nível superior (ativo, passivo, patrimônio líquido, receita, despesa)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Herdado do grupo: onde essa conta aparece nas demonstrações financeiras."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Herdado do grupo: se essa conta fecha para lucros retidos (receita) ou continua (saldo)."
+msgstr "Herdado do grupo: se esta conta se encerra em lucros acumulados (receitas) ou se carrega para frente (saldo)."
 
 msgid "Inherited from the parent group."
 msgstr "Herdado do grupo pai."
@@ -7890,10 +7890,10 @@ msgid "Internal Delta"
 msgstr "Delta interno"
 
 msgid "Internal notes"
-msgstr "Notas internas"
+msgstr "Observações internas"
 
 msgid "Internal Notes"
-msgstr "Notas Internas"
+msgstr "Observações Internas"
 
 msgid "inv"
 msgstr "inv"
@@ -7917,10 +7917,10 @@ msgid "Inventory actions"
 msgstr "Ações de inventário"
 
 msgid "Inventory Adjustment"
-msgstr "Ajuste de Inventário"
+msgstr "Ajuste de estoque"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Ajuste de Inventário (padrão)"
+msgstr "Ajuste de estoque (padrão)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Inventário e compras, com planejamento automatizado"
@@ -7962,7 +7962,7 @@ msgid "Invite"
 msgstr "Convidar"
 
 msgid "Invite Expired"
-msgstr "Convite Expirado"
+msgstr "Convite Vencido"
 
 msgid "Invited"
 msgstr "Convidado"
@@ -8031,7 +8031,7 @@ msgid "Invoiced Amount:"
 msgstr "Valor Faturado:"
 
 msgid "Invoiced Statuses"
-msgstr "Estados Faturados"
+msgstr "Status Faturados"
 
 msgid "Invoices"
 msgstr "Faturas"
@@ -8040,7 +8040,7 @@ msgid "Invoices this memo has been applied to. Click a row to open the document.
 msgstr "Faturas às quais este memorando foi aplicado. Clique em uma linha para abrir o documento."
 
 msgid "Invoicing"
-msgstr "Faturação"
+msgstr "Faturamento"
 
 msgid "is"
 msgstr "é"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Problemas"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Ele parará de ser executado até que você publique uma versão novamente. Nada é excluído."
 
 msgid "ITAR Certifications"
 msgstr "Certificações ITAR"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Mestre de Itens e Métodos de Fabricação"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Mestre de itens, BOMs e Bill of Process"
+msgstr "Mestre de itens, BOMs e Lista de operações"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "Item deve corresponder a um tipo selecionado E um grupo selecionado"
@@ -8205,10 +8205,10 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Itens dentro desta janela recebem um crachá amarelo."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Itens: mestre de itens, BOMs, Bill of Process, alterações de engenharia, CAD"
+msgstr "Itens: mestre de itens, BOMs, Lista de operações, alterações de engenharia, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "O design do item pode mudar antes da liberação do aviso de mudança."
+msgstr "Seu design pode mudar antes do aviso de alteração ser liberado."
 
 msgid "Job"
 msgstr "Trabalho"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "Localização do Trabalho"
 
 msgid "Job make method"
-msgstr "Método de confecção"
+msgstr "Método de fabricação da ordem"
 
 msgid "Job Materials"
-msgstr "Materiais de Trabalho"
+msgstr "Materiais da ordem"
 
 msgid "Job operation"
-msgstr "Operação de trabalho"
+msgstr "Operação da ordem"
 
 msgid "Job Operation"
-msgstr "Operação de Trabalho"
+msgstr "Operação da ordem"
 
 msgid "Job Operations"
-msgstr "Operações de Trabalho"
+msgstr "Operações da ordem"
 
 msgid "Job Priority"
 msgstr "Prioridade da ordem"
@@ -8244,19 +8244,19 @@ msgid "Job readable"
 msgstr "Ordem legível"
 
 msgid "Job Traveler"
-msgstr "Aviso de Trabalho"
+msgstr "Ficha de acompanhamento"
 
 msgid "Jobs"
-msgstr "Trabalhos"
+msgstr "Ordens de produção"
 
 msgid "Jobs Assigned to Me"
-msgstr "Tarefas Atribuídas a Mim"
+msgstr "Ordens de produção designadas a mim"
 
 msgid "Jobs Required"
-msgstr "Trabalhos Necessários"
+msgstr "Ordens de produção necessárias"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Trabalhos que têm este item na sua lista de materiais"
+msgstr "Ordens de produção que têm este item em sua lista de materiais"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
@@ -8275,7 +8275,7 @@ msgid "Journal Entry"
 msgstr "Lançamento de Diário"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Os periódicos datados nesta data ou antes são tratados como bloqueados. Mesclado com a data de bloqueio informada pelo provedor quando ambas existem."
+msgstr "Diários datados nesta data ou antes são tratados como bloqueados. Mesclados com a data de bloqueio relatada pelo fornecedor quando ambos existem."
 
 msgid "Just one"
 msgstr "Apenas um"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Manter Atual"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Manter preços existentes, adicionar apenas novos itens"
+msgstr "Manter precificação existente, apenas adicionar itens novos"
 
 msgid "Keep only items where…"
 msgstr "Manter apenas itens onde…"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "Manter Aberto"
 
 msgid "Keep picking"
-msgstr "Continuar coletando"
+msgstr "Manter separação"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantém pedidos, cotações e configurações atrás de uma segunda verificação"
@@ -8369,13 +8369,13 @@ msgid "Labor time"
 msgstr "Tempo de mão de obra"
 
 msgid "Labor Time"
-msgstr "Tempo de Trabalho"
+msgstr "Tempo de mão de obra"
 
 msgid "Labor unit"
 msgstr "Unidade de mão de obra"
 
 msgid "Labor Unit"
-msgstr "Unidade de Trabalho"
+msgstr "Unidade de mão de obra"
 
 msgid "Language"
 msgstr "Idioma"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Latitude"
 
 msgid "Lead time"
-msgstr "Tempo de Entrega"
+msgstr "Lead time"
 
 msgid "Lead Time"
-msgstr "Tempo de Entrega"
+msgstr "Lead Time"
 
 msgid "Lead time (days)"
-msgstr "Tempo de entrega (dias)"
+msgstr "Lead time (dias)"
 
 msgid "Lead Time (Days)"
-msgstr "Tempo de Entrega (Dias)"
+msgstr "Lead Time (Dias)"
 
 msgid "Lead Time:"
-msgstr "Tempo de Entrega:"
+msgstr "Lead Time:"
 
 msgid "Learn"
 msgstr "Aprender"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Menos trabalho manual, menos erros"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Vamos Construir"
 
 msgid "Let's build something"
 msgstr "Vamos construir algo"
@@ -8549,16 +8549,16 @@ msgid "Lines need internal part numbers"
 msgstr "As linhas precisam de números de peça internos"
 
 msgid "Lines need prices or lead times"
-msgstr "As linhas precisam de preços ou prazos de entrega"
+msgstr "Linhas precisam de preços ou lead times"
 
 msgid "Lineside"
-msgstr "Lateral de linha"
+msgstr "Borda de linha"
 
 msgid "Link"
 msgstr "Ligação"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "Ligação (opcional) — ex. /x/settings/…"
+msgstr "Link (opcional) — p.ex. /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Vincular Problema do Jira"
@@ -8567,7 +8567,7 @@ msgid "Link Linear Issue"
 msgstr "Vincular Problema Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Vincule este cliente Carbon a um deles ou crie um cliente Stripe separado."
 
 msgid "Link to sales order line"
 msgstr "Vincular à linha do pedido de venda"
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Carregado por último, logo no cutover, para que os saldos estejam atualizados."
 
 msgid "Loading associated jobs..."
-msgstr "Carregando trabalhos associados..."
+msgstr "Carregando ordens de produção associadas..."
 
 msgid "Loading current quantity…"
 msgstr "Carregando quantidade atual…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Bloqueado"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "O bloqueio torna o período somente leitura para documentos operacionais (recebimentos, remessas, faturas) enquanto ainda permite ajustes contábeis como depreciação e alienações. Um período deve ser bloqueado antes de poder ser fechado."
+msgstr "O bloqueio torna o período somente leitura para documentos operacionais (recebimentos, remessas, faturas) enquanto ainda permite ajustes contábeis como depreciação e baixa. Um período deve ser bloqueado antes de poder ser fechado."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Registar não conformidades e impulsionar uma CAPA"
@@ -8695,16 +8695,16 @@ msgid "Looks empty here"
 msgstr "Parece vazio aqui"
 
 msgid "Loss on Disposal"
-msgstr "Perda na Alienação"
+msgstr "Perda em Baixa"
 
 msgid "Loss on Disposal (default)"
-msgstr "Perda na Alienação (padrão)"
+msgstr "Perda em Baixa (padrão)"
 
 msgid "Loss on Disposal Account"
-msgstr "Conta de Perda na Alienação"
+msgstr "Conta de Perda em Baixa"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "Perdas reconhecidas na alienação de ativos imobilizados"
+msgstr "Perdas reconhecidas em baixa de ativos fixos"
 
 msgid "Lost"
 msgstr "Perdido"
@@ -8728,7 +8728,7 @@ msgid "Lot Size:"
 msgstr "Tamanho do Lote:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Inspeção baseada em lotes de bens recebidos em relação a um plano de amostragem; as unidades postam Em Espera no recebimento e só são liberadas para Disponível assim que o lote é disposto como aceito."
+msgstr "Inspeção de bens recebidos baseada em lote em relação a um plano de amostragem; as unidades são contabilizadas em Suspenso no recebimento e só são liberadas para Disponível quando o lote é disposicionado como Aceito."
 
 msgid "Low"
 msgstr "Baixo"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "Manutenção"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Notificações de Despacho de Manutenção"
+msgstr "Notificações de Ordem de Manutenção"
 
 msgid "Maintenance Dispatches"
-msgstr "Despachos de Manutenção"
+msgstr "Ordens de Manutenção"
 
 msgid "Maintenance Expense"
 msgstr "Despesa de Manutenção"
@@ -8806,7 +8806,7 @@ msgid "Make Default"
 msgstr "Definir como Padrão"
 
 msgid "Make Inactive"
-msgstr "Desativar"
+msgstr "Inativar"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
 msgstr "Itens de fabricação não podem ser faturados diretamente. Altere o método para Coleta para continuar."
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Tomar a decisão de prosseguir ou não"
 
 msgid "Make to Order"
-msgstr "Fazer por Encomenda"
+msgstr "Fabricação sob encomenda"
 
 msgid "Make tracked entities available again"
 msgstr "Disponibilizar entidades rastreadas novamente"
@@ -8851,7 +8851,7 @@ msgid "Manage"
 msgstr "Gerenciar"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "Gerir como a vida útil é rastreada, calculada e aplicada no inventário."
+msgstr "Gerenciar como a vida de prateleira é rastreada, calculada e aplicada no inventário."
 
 msgid "Manage Ownership"
 msgstr "Gerenciar Propriedade"
@@ -8878,13 +8878,13 @@ msgid "Manufacturer Part Number"
 msgstr "Número de Peça do Fabricante"
 
 msgid "Manufacturing"
-msgstr "Fabricação"
+msgstr "Manufatura"
 
 msgid "Map accounts"
 msgstr "Mapear contas"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Mapeie contas Carbon para o plano de contas do provedor. Os periódicos lançados são enviados usando o código de conta de provedor mapeado."
+msgstr "Mapeie contas Carbon para o plano de contas do fornecedor. Diários contabilizados são enviados usando o código de conta do fornecedor mapeado."
 
 msgid "Map Extracted Invoice Lines"
 msgstr "Mapear Linhas de Fatura Extraídas"
@@ -8933,16 +8933,16 @@ msgid "Mark Dark Mode"
 msgstr "Marca Modo Escuro"
 
 msgid "Mark done"
-msgstr "Marcar como concluído"
+msgstr "Marcar como feito"
 
 msgid "Mark Done"
-msgstr "Marcar Como Concluído"
+msgstr "Marcar como Feito"
 
 msgid "Mark Light Mode"
 msgstr "Marca Modo Claro"
 
 msgid "Mark not done"
-msgstr "Marcar como não concluído"
+msgstr "Marcar como não feito"
 
 msgid "Mark scope as agreed"
 msgstr "Marcar escopo como acordado"
@@ -8951,10 +8951,10 @@ msgid "Mark Short"
 msgstr "Marcar como Falta"
 
 msgid "Mark to delete"
-msgstr "Marcar para eliminar"
+msgstr "Marcar para exclusão"
 
 msgid "Master gauge"
-msgstr "Medidor mestre"
+msgstr "Instrumento de medição padrão"
 
 msgid "Master records"
 msgstr "Registros mestres"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "Propriedades do Material"
 
 msgid "Material Review Board (MRB)"
-msgstr "Conselho de Revisão de Materiais (MRB)"
+msgstr "Comitê de análise de materiais (MRB)"
 
 msgid "Material Shape"
 msgstr "Forma de Material"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Formas de Material"
 
 msgid "Material Substance"
-msgstr "Substância Material"
+msgstr "Material base"
 
 msgid "Material Substances"
-msgstr "Substâncias Materiais"
+msgstr "Materiais base"
 
 msgid "material type"
 msgstr "Tipo de Material"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Operações de Método"
 
 msgid "Method type"
-msgstr "Tipo de Método"
+msgstr "Tipo de suprimento"
 
 msgid "Method Type"
-msgstr "Tipo de Método"
+msgstr "Tipo de suprimento"
 
 msgid "Methods"
 msgstr "Métodos"
@@ -9221,7 +9221,7 @@ msgid "Missing Operations"
 msgstr "Operações Ausentes"
 
 msgid "Missing Shipping Costs"
-msgstr "Custos de Envio Ausentes"
+msgstr "Fretes ausentes"
 
 msgid "Missing Suppliers"
 msgstr "Fornecedores Ausentes"
@@ -9248,7 +9248,7 @@ msgid "Model removed from line"
 msgstr "Modelo removido da linha"
 
 msgid "Model upload"
-msgstr "Upload do modelo"
+msgstr "Envio de modelo"
 
 msgid "Modified"
 msgstr "Modificado"
@@ -9275,7 +9275,7 @@ msgid "Monthly"
 msgstr "Mensal"
 
 msgid "Months over which this asset depreciates for tax purposes (when not using MACRS)."
-msgstr "Meses durante os quais este ativo se deprecia para fins fiscais (quando não está usando MACRS)."
+msgstr "Meses durante os quais esse ativo é depreciado para fins fiscais (quando não está usando MACRS)."
 
 msgid "More"
 msgstr "Mais"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Mover item"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Mova parte da quantidade para uma nova linha de disposição para que o MRB possa decidir cada porção separadamente (por exemplo, sucatear alguns, refazer alguns)."
+msgstr "Mover parte da quantidade para uma nova linha de disposição para que o Comitê de análise de materiais possa decidir cada parte separadamente (por exemplo, refugar parte, fazer retrabalho em parte)."
 
 msgid "Move to"
 msgstr "Mover para"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "Nome"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "Nomeie um proprietário de projeto interno com autoridade de decisão"
+msgstr "Nomeie um responsável interno do projeto com autoridade de decisão"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "Os nomes preenchem em qualquer lugar onde essas funções são referenciadas em todo o hub."
@@ -9397,7 +9397,7 @@ msgid "Net Change"
 msgstr "Alteração Líquida"
 
 msgid "Net Income"
-msgstr "Lucro Líquido"
+msgstr "Receita líquida"
 
 msgid "Never"
 msgstr "Nunca"
@@ -9430,19 +9430,19 @@ msgid "New Attribute Category"
 msgstr "Nova Categoria de Atributo"
 
 msgid "New Change Notice"
-msgstr "Novo Aviso de Mudança"
+msgstr "Novo aviso de alteração"
 
 msgid "New Change Notice Action"
-msgstr "Nova Ação de Aviso de Mudança"
+msgstr "Nova ação de aviso de alteração"
 
 msgid "New Change Notice Type"
-msgstr "Novo Tipo de Aviso de Mudança"
+msgstr "Novo tipo de aviso de alteração"
 
 msgid "New Consumable"
 msgstr "Novo Consumível"
 
 msgid "New Contractor"
-msgstr "Novo Contratante"
+msgstr "Novo terceirizado"
 
 msgid "New Cost Center"
 msgstr "Novo Centro de Custo"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "Novo Tipo de Funcionário"
 
 msgid "New expiration date"
-msgstr "Nova data de expiração"
+msgstr "Nova data de validade"
 
 msgid "New Failure Mode"
 msgstr "Novo Modo de Falha"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Novo Ativo Fixo"
 
 msgid "New Gauge"
-msgstr "Novo Indicador"
+msgstr "Novo instrumento de medição"
 
 msgid "New Gauge Calibration Record"
-msgstr "Novo Registro de Calibração de Medidor"
+msgstr "Novo registro de calibração do instrumento de medição"
 
 msgid "New Gauge Type"
-msgstr "Novo Tipo de Medidor"
+msgstr "Novo tipo de instrumento"
 
 msgid "New Group"
 msgstr "Novo Grupo"
@@ -9538,13 +9538,13 @@ msgid "New Material Finish"
 msgstr "Novo Acabamento de Material"
 
 msgid "New Material Grade"
-msgstr "Nova Classificação de Material"
+msgstr "Novo grau"
 
 msgid "New Material Shape"
 msgstr "Nova Forma de Material"
 
 msgid "New Material Substance"
-msgstr "Nova Substância Material"
+msgstr "Novo material base"
 
 msgid "New Material Type"
 msgstr "Novo Tipo de Material"
@@ -9553,7 +9553,7 @@ msgid "New Non Conformance Type"
 msgstr "Novo Tipo de Não Conformidade"
 
 msgid "New Owner"
-msgstr "Novo Proprietário"
+msgstr "Novo responsável"
 
 msgid "New Part"
 msgstr "Nova Peça"
@@ -9565,10 +9565,10 @@ msgid "New Payment"
 msgstr "Novo Pagamento"
 
 msgid "New Payment Term"
-msgstr "Novo Termo de Pagamento"
+msgstr "Nova condição de pagamento"
 
 msgid "New Picking List"
-msgstr "Nova Lista de Picking"
+msgstr "Nova lista de separação"
 
 msgid "New PIN"
 msgstr "Novo PIN"
@@ -9577,10 +9577,10 @@ msgid "New PO"
 msgstr "Novo PO"
 
 msgid "New Price Override"
-msgstr "Novo Desconto de Preço"
+msgstr "Nova sobrescrita de preço"
 
 msgid "New Pricing Rule"
-msgstr "Nova Regra de Preço"
+msgstr "Nova regra de precificação"
 
 msgid "New Procedure"
 msgstr "Novo Procedimento"
@@ -9598,7 +9598,7 @@ msgid "New Quote"
 msgstr "Nova Cotação"
 
 msgid "New Quote Line"
-msgstr "Nova Linha de Cotação"
+msgstr "Nova linha do orçamento"
 
 msgid "New Receipt"
 msgstr "Novo Recebimento"
@@ -9643,7 +9643,7 @@ msgid "New Shift"
 msgstr "Novo Turno"
 
 msgid "New Shipment"
-msgstr "Novo Envio"
+msgstr "Nova remessa"
 
 msgid "New Shipping Method"
 msgstr "Novo Método de Envio"
@@ -9724,7 +9724,7 @@ msgid "Next Sequence"
 msgstr "Próxima Sequência"
 
 msgid "Next step"
-msgstr "Próximo passo"
+msgstr "Próxima etapa"
 
 msgid "Next:"
 msgstr "Próximo:"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Nenhuma ação selecionada"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Nenhum trabalho ativo encontrado para este pedido de venda. O pedido será cancelado diretamente."
+msgstr "Nenhuma ordem de produção ativa encontrada para este pedido de venda. O pedido será cancelado diretamente."
 
 msgid "No active plan"
 msgstr "Nenhum plano ativo"
@@ -9785,7 +9785,7 @@ msgstr "Sem aplicações. O pagamento será na conta."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Nenhum log arquivado ainda. Logs com mais de {0} dias serão automaticamente arquivados e disponíveis para download aqui."
+msgstr "Nenhum registro arquivado ainda. Registros com mais de {0} dias serão automaticamente arquivados e disponíveis para baixar aqui."
 
 msgid "No attachments."
 msgstr "Sem anexos."
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Sem comentários ainda. Seja o primeiro a adicionar um comentário."
 
 msgid "No completed jobs within range"
-msgstr "Nenhum trabalho concluído no intervalo"
+msgstr "Nenhuma ordem de produção concluída dentro do intervalo"
 
 msgid "No condition may match"
 msgstr "Nenhuma condição pode corresponder"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Nenhum arquivo enviado"
 
 msgid "No Gauge Selected"
-msgstr "Nenhum Medidor Selecionado"
+msgstr "Nenhum instrumento de medição selecionado"
 
 msgid "No grouped notifications"
 msgstr "Sem notificações agrupadas"
@@ -9920,7 +9920,7 @@ msgid "No items have inventory activity here yet."
 msgstr "Nenhum item teve atividade de inventário aqui ainda."
 
 msgid "No jobs were created"
-msgstr "Nenhum trabalho foi criado"
+msgstr "Nenhuma ordem de produção foi criada"
 
 msgid "No journal lines in scope for this period"
 msgstr "Nenhuma linha de diário no escopo para este período"
@@ -9950,13 +9950,13 @@ msgid "No matches. Type to create one."
 msgstr "Nenhuma correspondência. Digite para criar uma."
 
 msgid "No matching bins"
-msgstr "Nenhuma caixa correspondente"
+msgstr "Nenhum compartimento correspondente"
 
 msgid "No new notifications"
 msgstr "Sem notificações novas"
 
 msgid "No notes"
-msgstr "Sem notas"
+msgstr "Nenhuma observação"
 
 msgid "No open invoices"
 msgstr "Nenhuma fatura aberta"
@@ -9971,7 +9971,7 @@ msgid "No operations found."
 msgstr "Nenhuma operação encontrada."
 
 msgid "No operations require picking at this location"
-msgstr "Nenhuma operação requer picking neste local"
+msgstr "Nenhuma operação requer separação neste local"
 
 msgid "No operators."
 msgstr "Nenhum operador."
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "Nenhuma opção encontrada."
 
 msgid "No other bins hold this item"
-msgstr "Nenhum outro recipiente contém este item"
+msgstr "Nenhum outro compartimento contém este item"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Nenhum outro funcionário encontrado. Adicione funcionários para ativar a transferência de propriedade."
@@ -10019,10 +10019,10 @@ msgid "No posted journals in this period for this account"
 msgstr "Nenhum diário lançado neste período para esta conta"
 
 msgid "No pricing for selected quantity"
-msgstr "Sem preço para a quantidade selecionada"
+msgstr "Nenhuma precificação para a quantidade selecionada"
 
 msgid "No pricing options found"
-msgstr "Nenhuma opção de preço encontrada"
+msgstr "Nenhuma opção de precificação encontrada"
 
 msgid "No printer configured"
 msgstr "Nenhuma impressora configurada"
@@ -10049,7 +10049,7 @@ msgid "No Quote Reasons"
 msgstr "Sem Motivos de Cotação"
 
 msgid "No receivables"
-msgstr "Sem recebíveis"
+msgstr "Sem contas a receber"
 
 msgid "No records found"
 msgstr "Nenhum registro encontrado"
@@ -10061,7 +10061,7 @@ msgid "No remaining entities to inspect."
 msgstr "Nenhuma entidade restante para inspecionar."
 
 msgid "No reports match your search."
-msgstr "Nenhum relatório corresponde à sua busca."
+msgstr "Nenhum relatório corresponde à sua pesquisa."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
 msgstr "Nenhum representante desta empresa aceitou ainda o Carbon GovCloud Rider. Um administrador desta empresa deve aceitá-lo antes que qualquer pessoa possa acessar o Carbon — a equipe da Carbon não pode aceitá-lo em seu nome."
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "Sem estoque neste local"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "Nenhuma falta de estoque prevista nas próximas 48 semanas"
+msgstr "Sem ruptura de estoque projetada nas próximas 48 semanas"
 
 msgid "No storage unit"
 msgstr "Sem unidade de armazenamento"
@@ -10160,10 +10160,10 @@ msgid "Non-conformance (issue)"
 msgstr "Não conformidade (problema)"
 
 msgid "Non-Inventory"
-msgstr "Não-Inventário"
+msgstr "Não estocável"
 
 msgid "Non-Inventory Tracking"
-msgstr "Rastreamento Não-Inventário"
+msgstr "Rastreamento de não estocável"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Conta de despesa não operacional debitada quando um ativo desta classe é vendido ou sucatado abaixo de seu valor contábil líquido."
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Não é uma tabela, mas um saldo do livro-razão geral: o custo se acumula conforme os materiais do trabalho são emitidos e é compensado quando o trabalho é recebido no estoque."
+msgstr "Não é uma tabela, mas um saldo da razão: o custo se acumula conforme os materiais da ordem são emitidos e é zerado quando a ordem é recebida em estoque."
 
 msgid "Not certified"
 msgstr "Não certificado"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Não há trabalhos suficientes para cobrir a quantidade"
+msgstr "Não há ordens de produção suficientes para cobrir a quantidade"
 
 msgid "Not reached"
 msgstr "Não atingido"
@@ -10223,13 +10223,13 @@ msgid "Not you?"
 msgstr "Não é você?"
 
 msgid "Note"
-msgstr "Nota"
+msgstr "Observação"
 
 msgid "Notes"
-msgstr "Notas"
+msgstr "Observações"
 
 msgid "Notes (optional)"
-msgstr "Notas (opcional)"
+msgstr "Observações (opcional)"
 
 msgid "Nothing"
 msgstr "Nada"
@@ -10245,7 +10245,7 @@ msgid "Nothing in the archive"
 msgstr "Nada no arquivo"
 
 msgid "Nothing yet. A step only offers values once it is configured."
-msgstr "Nada ainda. Um passo só oferece valores uma vez que está configurado."
+msgstr "Nada ainda. Uma etapa só oferece valores após ser configurada."
 
 msgid "Notification"
 msgstr "Notificação"
@@ -10326,10 +10326,10 @@ msgid "On Hand"
 msgstr "Em Mãos"
 
 msgid "On Hold"
-msgstr "Em Espera"
+msgstr "Suspenso"
 
 msgid "On Jobs"
-msgstr "Em Trabalhos"
+msgstr "Em ordens de produção"
 
 msgid "On order"
 msgstr "Em pedido"
@@ -10338,7 +10338,7 @@ msgid "On Production Demand"
 msgstr "Em Demanda de Produção"
 
 msgid "On Purchase Order"
-msgstr "Em Ordem de Compra"
+msgstr "Em pedido de compra"
 
 msgid "On Sales Order"
 msgstr "Em Pedido de Venda"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "Inventário em mão permanece"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "Valor em mão por localização ou item, com reconciliação GL"
+msgstr "Valor em estoque por local ou item, com reconciliação com a razão"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "Valor em mãos de bens manufaturados (itens de fabricação)"
@@ -10374,22 +10374,22 @@ msgid "On-time delivery"
 msgstr "Entrega no prazo"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "Uma execução de um fluxo de trabalho, registrada passo a passo com os valores que cada passo usou e produziu, agindo em todo o tempo com as permissões do proprietário do fluxo de trabalho."
+msgstr "Uma execução de um fluxo de trabalho, registrada passo a passo com os valores que cada etapa usou e produziu, agindo sempre com as permissões do proprietário do fluxo de trabalho."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Uma unidade serial ou um lote que o Carbon rastreia individualmente, levando seu próprio status e atributos, como uma data de vencimento."
+msgstr "Uma unidade serial ou um lote que Carbon acompanha individualmente, carregando seu próprio status e atributos como data de validade."
 
 msgid "One set of numbers"
 msgstr "Um conjunto de números"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Uma etapa na rota de um trabalho, nomeando um processo e um centro de trabalho e levando seus próprios tempos de configuração, trabalho e máquina e taxas."
+msgstr "Uma operação no roteiro de produção de uma ordem, nomeando um processo e um centro de trabalho, e carregando seu próprio Setup, mão de obra, tempos de máquina e taxas."
 
 msgid "One system from quote to cash"
-msgstr "Um sistema do orçamento ao pagamento"
+msgstr "Um único sistema de orçamento até caixa"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "Somente procedimentos em rascunho são editáveis. Crie uma nova versão para alterar um procedimento ativo ou arquivado."
+msgstr "Apenas os procedimentos em Rascunho são editáveis. Crie uma nova versão para alterar um procedimento Ativo ou Arquivado."
 
 msgid "Only empty, open periods can be deleted."
 msgstr "Apenas períodos vazios e abertos podem ser deletados."
@@ -10413,7 +10413,7 @@ msgid "Onshape Status"
 msgstr "Status do Onshape"
 
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
-msgstr "Oops! O link que você está tentando acessar expirou ou não é mais válido."
+msgstr "Ops! O link que você está tentando acessar expirou ou não é mais válido."
 
 msgid "Oops! The link you're trying to access is not valid."
 msgstr "Oops! O link que está tentando acessar não é válido."
@@ -10422,7 +10422,7 @@ msgid "Open"
 msgstr "Abrir"
 
 msgid "Open a change notice"
-msgstr "Abrir um aviso de mudança"
+msgstr "Abrir um aviso de alteração"
 
 msgid "Open Actions"
 msgstr "Ações Abertas"
@@ -10431,13 +10431,13 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Abrir um NCR para disposição de MRB"
 
 msgid "Open AP"
-msgstr "AP aberto"
+msgstr "Contas a pagar abertas"
 
 msgid "Open AR"
-msgstr "AR aberto"
+msgstr "Contas a receber abertas"
 
 msgid "Open Audit Log"
-msgstr "Abrir Registro de Auditoria"
+msgstr "Abrir log de auditoria"
 
 msgid "Open date"
 msgstr "Data de abertura"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Data de Abertura"
 
 msgid "Open Dispatches"
-msgstr "Despachos Abertos"
+msgstr "Ordens de manutenção abertas"
 
 msgid "Open in Carbon"
 msgstr "Abrir no Carbon"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "Aberto no aviso de mudança {ids}. Libere-o para criar novas versões ou revisões."
+msgstr "Aberto em aviso de alteração {ids}. Libere-o para criar novas versões ou revisões."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "Aberto nos avisos de mudança {ids}. Libere-os para criar novas versões ou revisões."
+msgstr "Aberto em avisos de alteração {ids}. Libere-os para criar novas versões ou revisões."
 
 msgid "Open in MES"
 msgstr "Abrir no MES"
@@ -10464,10 +10464,10 @@ msgid "Open Issues"
 msgstr "Problemas Abertos"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Demanda de trabalho aberta mais transferências pendentes deste recipiente"
+msgstr "Demanda aberta de ordem de produção mais transferências pendentes deste compartimento"
 
 msgid "Open jobs"
-msgstr "Trabalhos abertos"
+msgstr "Ordens de produção abertas"
 
 msgid "Open menu"
 msgstr "Abrir menu"
@@ -10533,13 +10533,13 @@ msgid "Operating Expenses"
 msgstr "Despesas Operacionais"
 
 msgid "Operating Income"
-msgstr "Lucro Operacional"
+msgstr "Receita operacional"
 
 msgid "Operation"
 msgstr "Operação"
 
 msgid "Operation lead time"
-msgstr "Tempo de espera da operação"
+msgstr "Lead time da operação"
 
 msgid "Operation minimum cost"
 msgstr "Custo mínimo da operação"
@@ -10593,7 +10593,7 @@ msgid "Operators can use shared workstations with PIN authentication."
 msgstr "Os operadores podem usar estações de trabalho compartilhadas com autenticação PIN."
 
 msgid "Operators start on the Scan tab"
-msgstr "Operadores começam na aba Digitalizar"
+msgstr "Operadores começam na aba Escanear"
 
 msgid "Operators start the timer themselves when they begin an operation."
 msgstr "Os operadores iniciam o temporizador quando começam uma operação."
@@ -10602,7 +10602,7 @@ msgid "Opportunity"
 msgstr "Oportunidade"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr "Otimizado para visualizações rápidas — downloads sempre servem o arquivo original enviado"
+msgstr "Otimizado para visualizações rápidas — downloads sempre servem o arquivo original carregado"
 
 msgid "Optional"
 msgstr "Opcional"
@@ -10723,43 +10723,43 @@ msgid "Overall result"
 msgstr "Resultado geral"
 
 msgid "Overdue"
-msgstr "Vencido"
+msgstr "Atrasado"
 
 msgid "Overhead Absorption"
-msgstr "Absorção de Sobrecarga"
+msgstr "Absorção de custos indiretos"
 
 msgid "Overhead Absorption (default)"
-msgstr "Absorção de Sobrecarga (padrão)"
+msgstr "Absorção de custos indiretos (padrão)"
 
 msgid "Overhead rate"
-msgstr "Taxa de sobrecarga"
+msgstr "Taxa de custos indiretos"
 
 msgid "Overhead Rate"
-msgstr "Taxa de Sobrecarga"
+msgstr "Taxa de custos indiretos"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "Taxa de Sobrecarga (Por Hora)"
+msgstr "Taxa de custos indiretos (por hora)"
 
 msgid "Overhead Variance"
-msgstr "Variação de Despesas Gerais (padrão)"
+msgstr "Variação de custos indiretos"
 
 msgid "Overhead Variance (default)"
-msgstr "Proprietário (centro de custo)"
+msgstr "Variação de custos indiretos (padrão)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "A substituição requer a permissão inventory:update e um motivo."
+msgstr "Sobrescrita requer a permissão inventory:update e um motivo."
 
 msgid "Override Price"
-msgstr "Preço de Substituição"
+msgstr "Sobrescrita de preço"
 
 msgid "Override price for a single customer"
-msgstr "Substituir preço para um único cliente"
+msgstr "Sobrescrita de preço para um único cliente"
 
 msgid "Override price for all customers of a type"
-msgstr "Substituir preço para todos os clientes de um tipo"
+msgstr "Sobrescrita de preço para todos os clientes de um tipo"
 
 msgid "Override the expiration on {label}."
-msgstr "Substituir a expiração em {label}."
+msgstr "Sobrescrita da expiração em {label}."
 
 msgid "Overtime"
 msgstr "Horas Extras"
@@ -10774,13 +10774,13 @@ msgid "Overwrite the quote method with the source method"
 msgstr "Sobrescrever o método de cotação com o método de origem"
 
 msgid "Overwrite the target manufacturing method with the quote method"
-msgstr "Sobrescrever o método de fabricação de destino com o método de cotação"
+msgstr "Sobrescrever o método de manufatura alvo com o método de orçamento"
 
 msgid "Owner"
-msgstr "Proprietário"
+msgstr "Responsável"
 
 msgid "Owner (cost center)"
-msgstr "Centro de custo principal"
+msgstr "Responsável (centro de custo)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,7 +10814,7 @@ msgid "Params"
 msgstr "Parâmetros"
 
 msgid "Parent cost center"
-msgstr "peça"
+msgstr "Centro de custo pai"
 
 msgid "Parent Cost Center"
 msgstr "Centro de Custo Pai"
@@ -10856,7 +10856,7 @@ msgid "Part ID"
 msgstr "ID da Peça"
 
 msgid "Part is configured for manufacturing"
-msgstr "Peça configurada para fabricação"
+msgstr "Peça está configurada para manufatura"
 
 msgid "Part Number"
 msgstr "Número da Peça"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Parceiros"
 
 msgid "parts"
-msgstr "Contas a Pagar"
+msgstr "peças"
 
 msgid "Parts"
 msgstr "Peças"
@@ -10919,7 +10919,7 @@ msgid "Payables (AP)"
 msgstr "Contas a Pagar (AP)"
 
 msgid "Payables (default)"
-msgstr "prazo de pagamento"
+msgstr "Contas a pagar (padrão)"
 
 msgid "Payables aging"
 msgstr "Envelhecimento de contas a pagar"
@@ -10937,22 +10937,22 @@ msgid "Payment ID"
 msgstr "ID de Pagamento"
 
 msgid "payment term"
-msgstr "prazos de pagamento"
+msgstr "condição de pagamento"
 
 msgid "Payment term"
-msgstr "Termo de pagamento"
+msgstr "Condição de pagamento"
 
 msgid "Payment Term"
-msgstr "Termo de Pagamento"
+msgstr "Condição de pagamento"
 
 msgid "payment terms"
-msgstr "pessoas"
+msgstr "condições de pagamento"
 
 msgid "Payment Terms"
 msgstr "Condições de Pagamento"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "Termos de pagamento como Net 30 ou vencimento no recebimento"
+msgstr "Condições de pagamento como Líquido 30 ou vencível no recebimento"
 
 msgid "Payments"
 msgstr "Pagamentos"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "Pendente"
 
 msgid "people"
-msgstr "Despesa de depreciação periódica para ativos fixos"
+msgstr "pessoas"
 
 msgid "People"
 msgstr "Pessoas"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "Por Unidade"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Substituição por linha da localização de atendimento do cabeçalho do pedido; usada para envios divididos e drop-ships."
+msgstr "Sobrescrita por linha do local de expedição do cabeçalho do pedido; usada para remessas divididas e entregas diretas."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "Substituição por linha da localização de entrega do cabeçalho do PO; usada para entregas divididas a múltiplos armazéns ou drop-ships."
+msgstr "Sobrescrita por linha do local de entrega do cabeçalho da OC; usada para entregas divididas a múltiplos armazéns ou entregas diretas."
 
 msgid "Percentage"
 msgstr "Percentual"
@@ -11015,10 +11015,10 @@ msgid "Period lock policy"
 msgstr "Política de bloqueio de período"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "A coleta oferece entidades rastreadas na ordem de vencimento mais próximo primeiro, então o estoque que vence mais cedo sai primeiro por padrão."
+msgstr "Despesa de depreciação periódica para ativos fixos"
 
 msgid "Permanently Delete"
-msgstr "Eliminar Permanentemente"
+msgstr "Excluir permanentemente"
 
 msgid "Permission groups for granting access in bulk"
 msgstr "Grupos de permissão para conceder acesso em massa"
@@ -11060,7 +11060,7 @@ msgid "Pick a column to sort by"
 msgstr "Escolha uma coluna para ordenar"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "Selecione um cliente ou tipo de cliente para visualizar seus preços."
+msgstr "Escolha um cliente ou tipo de cliente para visualizar seus preços."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "Escolha uma data ou deixe em branco para limpar."
@@ -11078,7 +11078,7 @@ msgid "Pick a record type…"
 msgstr "Escolha um tipo de registro…"
 
 msgid "Pick a value from an earlier step"
-msgstr "Escolha um valor de um passo anterior"
+msgstr "Escolha um valor de uma etapa anterior"
 
 msgid "Pick a variable…"
 msgstr "Escolha uma variável…"
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "Ordem de Coleta"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "Escolha o bin que precisa de estoque, depois escolha os bins de onde puxar."
+msgstr "Separe o compartimento que precisa de estoque, depois separe os compartimentos para puxar o estoque deles."
 
 msgid "Pick tracked item"
 msgstr "Selecionar item rastreado"
@@ -11102,25 +11102,25 @@ msgid "Picked quantity"
 msgstr "Quantidade colhida"
 
 msgid "Picking Lines"
-msgstr "Linhas de Picking"
+msgstr "Linhas de separação"
 
 msgid "Picking list"
 msgstr "Lista de separação"
 
 msgid "Picking List"
-msgstr "Lista de Picking"
+msgstr "Lista de separação"
 
 msgid "Picking List ID"
-msgstr "ID da Lista de Picking"
+msgstr "ID da lista de separação"
 
 msgid "Picking List Notes"
-msgstr "Notas da Lista de Coleta"
+msgstr "Observações da lista de separação"
 
 msgid "Picking Lists"
-msgstr "Listas de Picking"
+msgstr "Listas de separação"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Planejado"
+msgstr "A separação prioriza entidades rastreadas por vencimento mais próximo, então o estoque que vence em breve sai primeiro por padrão."
 
 msgid "Pieces/Hour"
 msgstr "Peças/Hora"
@@ -11215,7 +11215,7 @@ msgid "Please select an item"
 msgstr "Selecione um item"
 
 msgid "Please upload a CSV file of your data"
-msgstr "Por favor, carregue um arquivo CSV dos seus dados"
+msgstr "Por favor, envie um arquivo CSV de seus dados"
 
 msgid "PO"
 msgstr "PO"
@@ -11257,7 +11257,7 @@ msgid "Post Receipt"
 msgstr "Lançar Recebimento"
 
 msgid "Post Shipment"
-msgstr "Postar Envio"
+msgstr "Contabilizar remessa"
 
 msgid "Postal code"
 msgstr "Código postal"
@@ -11290,13 +11290,13 @@ msgid "Posted once, no corrections."
 msgstr "Lançado uma vez, sem correções."
 
 msgid "Posting"
-msgstr "Adiantamentos"
+msgstr "Contabilização"
 
 msgid "Posting date"
-msgstr "Data de postagem"
+msgstr "data de contabilização"
 
 msgid "Posting Date"
-msgstr "Data de Postagem"
+msgstr "Data de contabilização"
 
 msgid "Potential Data Loss"
 msgstr "Possível Perda de Dados"
@@ -11305,7 +11305,7 @@ msgid "Pre-filled for a new item when expiry is Fixed Duration."
 msgstr "Pré-preenchido para um novo item quando a validade é Duração Fixa."
 
 msgid "Preferred Supplier"
-msgstr "Fornecedor Preferido"
+msgstr "Fornecedor preferencial"
 
 msgid "Prefix"
 msgstr "Prefixo"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "Adiantamentos (padrão)"
 
 msgid "Prepayments (default)"
-msgstr "Ação preventiva"
+msgstr "Adiantamentos (padrão)"
 
 msgid "Present Week"
 msgstr "Semana atual"
@@ -11323,7 +11323,7 @@ msgid "Prev"
 msgstr "Anterior"
 
 msgid "Preventive action"
-msgstr "Conta principal para valoração de estoque disponível"
+msgstr "Ação preventiva"
 
 msgid "Preventive maintenance schedules for your equipment"
 msgstr "Cronogramas de manutenção preventiva para seu equipamento"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Valor anterior de {0}"
 
 msgid "Price break actions"
-msgstr "Ações de quebra de preço"
+msgstr "Ações de faixa de preço"
 
 msgid "Price Break History"
 msgstr "Histórico de Faixa de Preço"
 
 msgid "Price Breaks"
-msgstr "Quebras de Preço"
+msgstr "Faixas de preço"
 
 msgid "Price List"
 msgstr "Lista de Preços"
@@ -11372,28 +11372,28 @@ msgid "Price Lists"
 msgstr "Listas de Preços"
 
 msgid "Price override"
-msgstr "Substituição de preço"
+msgstr "Sobrescrita de preço"
 
 msgid "Prices"
 msgstr "Preços"
 
 msgid "Pricing"
-msgstr "Preços"
+msgstr "Precificação"
 
 msgid "Pricing rule"
-msgstr "Regra de preço"
+msgstr "Regra de precificação"
 
 msgid "Pricing Rule"
-msgstr "Regra de Preço"
+msgstr "Regra de precificação"
 
 msgid "Pricing Rules"
-msgstr "Regras de Preço"
+msgstr "Regras de precificação"
 
 msgid "Pricing Trace"
-msgstr "Rastreamento de Preços"
+msgstr "Rastreamento de precificação"
 
 msgid "Primary cash account for bank transactions"
-msgstr "procedimento"
+msgstr "Conta caixa primária para transações bancárias"
 
 msgid "Print"
 msgstr "Imprimir"
@@ -11403,14 +11403,14 @@ msgid "Print {0} Labels"
 msgstr "Imprimir {0} Etiquetas"
 
 msgid "Print Jobs"
-msgstr "Trabalhos de Impressão"
+msgstr "Imprimir ordens de produção"
 
 msgid "Print Label"
 msgstr "Imprimir Etiqueta"
 
 #. placeholder {0}: viewContent.contentType?.toUpperCase()
 msgid "Print Output ({0})"
-msgstr "Saída de Impressão ({0})"
+msgstr "Saída de impressão ({0})"
 
 msgid "Printer Settings"
 msgstr "Configurações de Impressora"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Procedimento"
 
 msgid "procedures"
-msgstr "processo"
+msgstr "procedimentos"
 
 msgid "Procedures"
 msgstr "Procedimentos"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Quantidade de Produção"
 
 msgid "Production variance"
-msgstr "Demanda projetada decomposta de BOMs e previsões."
+msgstr "Variação de produção"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Produção: app de chão de fábrica e agendamento"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "Projeto"
 
 msgid "Project owner"
-msgstr "Proprietário do projeto"
+msgstr "Responsável do projeto"
 
 msgid "Project Plan"
 msgstr "Plano do Projeto"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Início do projeto"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Inventário Projetado"
+msgstr "Demanda projetada expandida de BOMs e previsões."
 
 msgid "Projected inventory"
 msgstr "Disponível Projetado"
@@ -11543,14 +11543,14 @@ msgstr "Stock projetado"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Projetado a cair abaixo do estoque de segurança na semana de {0}"
+msgstr "Ruptura de estoque projetada na semana de {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "Projetado a permanecer acima do estoque de segurança"
 
 msgid "Projected to stay above safety stock"
-msgstr "Ordem de Compra"
+msgstr "Projetado para permanecer acima do estoque de segurança"
 
 msgid "Projection"
 msgstr "Projeção"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Publicado pela Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Versão publicada"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "As versões publicadas não podem ser editadas. Procure somente para leitura ou ramifique uma nova versão para fazer alterações."
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "Puxar da contabilidade"
 
 msgid "Pull from Inventory"
-msgstr "Retirar do Inventário"
+msgstr "Retirar do estoque"
 
 msgid "Pull, map, and load your data"
 msgstr "Extrair, mapear e carregar seus dados"
@@ -11653,40 +11653,40 @@ msgid "Purchase Invoices"
 msgstr "Faturas de Compra"
 
 msgid "Purchase order"
-msgstr "Variação de Preço de Compra"
+msgstr "Pedido de compra"
 
 msgid "Purchase Order"
-msgstr "Ordem de Compra"
+msgstr "Pedido de compra"
 
 msgid "Purchase Order Amount"
 msgstr "Valor do Pedido de Compra"
 
 msgid "Purchase Order approval rule"
-msgstr "Regra de aprovação de Ordem de Compra"
+msgstr "Regra de aprovação de pedido de compra"
 
 msgid "Purchase Order ID"
-msgstr "ID da Ordem de Compra"
+msgstr "ID do pedido de compra"
 
 msgid "Purchase Order Line"
-msgstr "Linha de Ordem de Compra"
+msgstr "Linha de pedido de compra"
 
 msgid "Purchase Order Location"
-msgstr "Localização da Ordem de Compra"
+msgstr "Local do pedido de compra"
 
 msgid "Purchase order removed successfully"
-msgstr "Ordem de compra removida com sucesso"
+msgstr "Pedido de compra removido com sucesso"
 
 msgid "Purchase Order Type"
-msgstr "Tipo de Ordem de Compra"
+msgstr "Tipo de pedido de compra"
 
 msgid "Purchase Orders"
 msgstr "Pedidos de Compra"
 
 msgid "Purchase Orders and Planning"
-msgstr "Ordens de Compra e Planejamento"
+msgstr "Pedidos de compra e planejamento"
 
 msgid "Purchase orders required"
-msgstr "Ordens de compra necessárias"
+msgstr "Pedidos de compra necessários"
 
 msgid "Purchase planning"
 msgstr "Planejamento de compras"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Variação de Preço de Compra (padrão)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Imposto de Compra a Pagar"
+msgstr "Variação de preço de compra (padrão)"
 
 msgid "Purchase Qty"
 msgstr "Qtd. de Compra"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "Imposto de Compra a Pagar (padrão)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "compras"
+msgstr "Imposto sobre compras a pagar (padrão)"
 
 msgid "Purchase to Order"
-msgstr "Compra por Encomenda"
+msgstr "Compra sob encomenda"
 
 msgid "Purchase Unit of Measure"
 msgstr "Unidade de Medida de Compra"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Qtd. Sucata"
 
 msgid "quality"
-msgstr "Cotação para Caixa"
+msgstr "qualidade"
 
 msgid "Quality"
 msgstr "Qualidade"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Quantidade a chegar — em pedidos de compra abertos mais em ordens de produção (fabricação)."
 
 msgid "Quantity Breaks"
-msgstr "Quebras de Quantidade"
+msgstr "Faixas de quantidade"
 
 msgid "Quantity complete"
 msgstr "Quantidade completa"
@@ -11840,16 +11840,16 @@ msgid "Quantity must be greater than 0"
 msgstr "A quantidade deve ser maior que 0"
 
 msgid "Quantity on hand"
-msgstr "Quantidade em estoque"
+msgstr "Saldo em estoque"
 
 msgid "Quantity on Hand"
-msgstr "Quantidade em Mão"
+msgstr "Saldo em estoque"
 
 msgid "Quantity on Jobs"
-msgstr "Quantidade em Trabalhos"
+msgstr "Quantidade em ordens de produção"
 
 msgid "Quantity on Purchase Order"
-msgstr "Quantidade em Ordem de Compra"
+msgstr "Quantidade no pedido de compra"
 
 msgid "Quantity on Sales Order"
 msgstr "Quantidade em Pedido de Venda"
@@ -11861,7 +11861,7 @@ msgid "Quantity per Parent"
 msgstr "Quantidade por Pai"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Quantidade fisicamente presente na unidade de armazenamento (prateleira) atribuída ao material. Fica vermelha quando está abaixo do que essa unidade precisa fornecer."
+msgstr "Quantidade fisicamente na unidade de armazenamento atribuída do material (prateleira). Fica vermelha quando está abaixo do que essa unidade precisa fornecer."
 
 msgid "Quantity Range"
 msgstr "Intervalo de Quantidade"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Tipo de Quantidade"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Níveis de preço baseados em quantidade para esta substituição; o preço unitário aplicado é a linha com a maior quantidade mínima que a linha de pedido satisfaz."
+msgstr "Níveis de precificação baseados em quantidade para esta sobrescrita; o preço unitário aplicado é a linha com a maior quantidade mínima que a linha do pedido atender."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11895,7 +11895,7 @@ msgid "Question"
 msgstr "Pergunta"
 
 msgid "Queued"
-msgstr "Enfileirado"
+msgstr "Na fila"
 
 msgid "Quote"
 msgstr "Cotação"
@@ -11907,19 +11907,19 @@ msgid "Quote Accepted By Email"
 msgstr "Email de Aceitação da Cotação"
 
 msgid "Quote expired"
-msgstr "Cotação expirada"
+msgstr "Orçamento vencido"
 
 msgid "Quote ID"
 msgstr "ID da Cotação"
 
 msgid "Quote line"
-msgstr "Linha de cotação"
+msgstr "Linha do orçamento"
 
 msgid "Quote Line"
-msgstr "Linha de Cotação"
+msgstr "Linha do orçamento"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "Linhas de cotação cuja lista de materiais inclui este item"
+msgstr "Linhas do orçamento cuja lista de materiais inclui este item"
 
 msgid "Quote Location"
 msgstr "Localização da Cotação"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Número da Cotação"
 
 msgid "Quote to cash"
-msgstr "Contas a Receber"
+msgstr "De orçamento até caixa"
 
 msgid "Quote Type"
 msgstr "Tipo de Cotação"
@@ -12006,7 +12006,7 @@ msgid "Ready"
 msgstr "Pronto"
 
 msgid "Ready for Quote"
-msgstr "Pronto para Cotação"
+msgstr "Pronto para orçamento"
 
 msgid "ready to keep or revert"
 msgstr "pronto para manter ou reverter"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "Contas a Receber (AR)"
 
 msgid "Receivables (default)"
-msgstr "Reconciliação de um pedido de compra com o que foi recebido e faturado — implícito em Carbon, através das quantidades de linha e saldo GR/IR."
+msgstr "Contas a receber (padrão)"
 
 msgid "Receivables aging"
 msgstr "Envelhecimento de contas a receber"
@@ -12145,7 +12145,7 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "A reconciliação encontrou discrepâncias com o provedor"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Período de Recuperação"
+msgstr "Reconciliação de um pedido de compra contra o que foi recebido e faturado — implícito no Carbon, através das quantidades das linhas e do saldo GR/IR."
 
 msgid "Record"
 msgstr "Gravar"
@@ -12154,7 +12154,7 @@ msgid "Record a credit or debit memo against a customer or supplier. Application
 msgstr "Registre um memorando de crédito ou débito contra um cliente ou fornecedor. As aplicações a faturas específicas são adicionadas após a criação do memorando."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Registre o dinheiro recebido de um cliente (Recebimento) ou pago a um fornecedor (Desembolso). As aplicações para faturas específicas são adicionadas após a criação do pagamento."
+msgstr "Registre caixa recebido de um cliente (Recebimento) ou pago a um fornecedor (Desembolso). Aplicações a faturas específicas são adicionadas após o pagamento ser criado."
 
 msgid "Record deleted"
 msgstr "Registro eliminado"
@@ -12166,13 +12166,13 @@ msgid "Record type"
 msgstr "Tipo de registro"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Registrado em uma calibração que o medidor precisa de reparo antes de suas leituras poderem ser confiáveis."
+msgstr "Registrado em uma calibração que o instrumento de medição precisa de reparo antes que suas leituras possam ser confiáveis."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Registrado que o acompanhamento é necessário após esta calibração; mostra este indicador na fila de ações abertas."
+msgstr "Registrado que acompanhamento é necessário após esta calibração; apresenta este instrumento de medição na fila de ações abertas."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Registrado que o indicador foi ajustado durante esta calibração; afeta como o intervalo de calibração é recalculado."
+msgstr "Registrado que o instrumento de medição foi ajustado durante esta calibração; afeta como o intervalo de calibração é recalculado."
 
 msgid "Records"
 msgstr "Registros"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "Redirecionando para página de verificação..."
 
 msgid "Reduced"
-msgstr "Reduzido"
+msgstr "Atenuada"
 
 msgid "Reference"
 msgstr "Referência"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Registrado"
 
 msgid "Registered"
-msgstr "Ponto de Reabastecimento"
+msgstr "Registrado"
 
 msgid "Registration failed"
 msgstr "Falha no registo"
@@ -12247,13 +12247,13 @@ msgid "Release"
 msgstr "Liberação"
 
 msgid "Release change notice"
-msgstr "Liberar aviso de mudança"
+msgstr "Liberar aviso de alteração"
 
 msgid "Release control"
-msgstr "Controle de lançamento"
+msgstr "Liberar controle"
 
 msgid "Release Control"
-msgstr "Controle de Lançamento"
+msgstr "Liberar Controle"
 
 msgid "Release Job"
 msgstr "Liberar Trabalho"
@@ -12335,7 +12335,7 @@ msgid "Remove sort by column"
 msgstr "Remover ordenação por coluna"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Remova este tipo de armazenamento de todas as unidades de armazenamento que o referenciam e o delete. Isto não pode ser desfeito."
+msgstr "Remova este tipo de armazenamento de todas as unidades de armazenamento que o referenciam e o exclua. Isto não pode ser desfeito."
 
 msgid "Remove tool"
 msgstr "Remover ferramenta"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "Reordenar Grupo"
 
 msgid "Reorder point"
-msgstr "Ponto de Reabastecimento"
+msgstr "Ponto de ressuprimento"
 
 msgid "Reorder Point"
-msgstr "Ponto de Reordenação"
+msgstr "Ponto de ressuprimento"
 
 msgid "Reorder Point:"
-msgstr "Ponto de Reabastecimento:"
+msgstr "Ponto de ressuprimento:"
 
 msgid "Reorder Policy"
 msgstr "Política de Reordenação"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "Quantidade de Recompra:"
 
 msgid "Reordering policy"
-msgstr "Política de reordenação"
+msgstr "Política de ressuprimento"
 
 msgid "Reordering Policy"
-msgstr "Política de Reordenação"
+msgstr "Política de ressuprimento"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Reordena apenas a sequência de despacho e o centro de trabalho — não reagenda. Altere as datas no quadro de datas."
+msgstr "Reordena apenas a sequência de despacho e centro de trabalho — não reagenda. Altere as datas no painel de datas."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Repete uma vez para cada item em {inputLabel}"
@@ -12405,7 +12405,7 @@ msgid "Replace drawing?"
 msgstr "Substituir desenho?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Substituir preços existentes pelos valores de origem"
+msgstr "Substitua a precificação existente pelos valores de origem"
 
 msgid "Replace PDF"
 msgstr "Substituir PDF"
@@ -12420,10 +12420,10 @@ msgid "Replenishment"
 msgstr "Reabastecimento"
 
 msgid "Replenishment system"
-msgstr "Sistema de reabastecimento"
+msgstr "Sistema de reposição"
 
 msgid "Replenishment System"
-msgstr "Sistema de Reabastecimento"
+msgstr "Sistema de reposição"
 
 msgid "Report"
 msgstr "Relatório"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "Ações Obrigatórias (em ordem)"
 
 msgid "Required Date"
-msgstr "Data Necessária"
+msgstr "Data de necessidade"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Obrigatório num ambiente controlado — o registo de auditoria não pode ser desativado."
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Restaurar da Lixeira"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Restaurar esta entidade para o estoque disponível no depósito e custo de onde foi sucatada."
+msgstr "Restaure esta entidade ao estoque disponível no compartimento e custo de onde foi sucateada."
 
 msgid "Restore tracked entities to available"
 msgstr "Restaurar entidades rastreadas para disponível"
@@ -12622,7 +12622,7 @@ msgid "Revenue and expenses over a period"
 msgstr "Receita e despesas em um período"
 
 msgid "Reverse all inventory adjustments"
-msgstr "Reverter todos os ajustes de inventário"
+msgstr "Reverter todos os ajustes de estoque"
 
 msgid "Reverse all journal and cost ledger entries"
 msgstr "Reverter todos os lançamentos de diário e razão de custos"
@@ -12631,7 +12631,7 @@ msgid "Reverse any item ledger entries from this invoice"
 msgstr "Reverter quaisquer entradas do razão de itens desta fatura"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Cobrança reversa"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Imposto de vendas de cobrança reversa"
@@ -12640,10 +12640,10 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "Imposto de vendas de cobrança reversa (padrão)"
 
 msgid "Reverse the related journal entries"
-msgstr "Reverter os lançamentos contábeis relacionados"
+msgstr "Reverter os lançamentos do diário relacionados"
 
 msgid "Reversed"
-msgstr "Revertido"
+msgstr "Estornado"
 
 msgid "Revert"
 msgstr "Reverter"
@@ -12658,7 +12658,7 @@ msgid "Review each item's changes, then confirm — releasing can't be undone."
 msgstr "Revise as alterações de cada item e confirme — liberar não pode ser desfeito."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Revise o balanço patrimonial e demonstração de resultado do período e confirme se os valores parecem corretos. Esta é uma aprovação manual — marque como concluído depois de tê-los revisado."
+msgstr "Revise o balanço patrimonial e a demonstração de resultados do período e confirme que os números parecem corretos. Esta é uma aprovação manual — marque como feito após tê-los revisado."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
 msgstr "Revise as correspondências sugeridas antes de aplicar. Estas são uma melhor aproximação — confirme que cada uma está correta."
@@ -12765,13 +12765,13 @@ msgid "Rounding Account (default)"
 msgstr "Conta de arredondamento (padrão)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Encaminhe todas as faturas de AP para um endereço (por exemplo, sede corporativa) em vez de compradores individuais."
+msgstr "Encaminhe todas as faturas de contas a pagar para um endereço (p.ex. sede corporativa) em vez de compradores individuais."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Encaminhe todas as faturas de AR para um endereço (por exemplo, sede corporativa) em vez de locais individuais."
+msgstr "Encaminhe todas as faturas de contas a receber para um endereço (p.ex. sede corporativa) em vez de locais individuais."
 
 msgid "Routing"
-msgstr "Roteiro"
+msgstr "Roteiro de produção"
 
 msgid "rows"
 msgstr "linhas"
@@ -12867,10 +12867,10 @@ msgid "S-4 (finest special)"
 msgstr "S-4 (mais fino especial)"
 
 msgid "Safety stock"
-msgstr "Stock de segurança"
+msgstr "Estoque de segurança"
 
 msgid "Safety Stock"
-msgstr "Stock de Segurança"
+msgstr "Estoque de segurança"
 
 #. placeholder {0}: numberFormatter.format(safetyStockValue)
 msgid "Safety stock ({0})"
@@ -12934,7 +12934,7 @@ msgid "Sales Order"
 msgstr "Pedido de Venda"
 
 msgid "Sales Order ID"
-msgstr "ID da Ordem de Venda"
+msgstr "ID do pedido de venda"
 
 msgid "Sales order line"
 msgstr "Linha de pedido de vendas"
@@ -12946,7 +12946,7 @@ msgid "Sales Order Line (job)"
 msgstr "Linha de pedido de vendas (trabalho)"
 
 msgid "Sales Order Location"
-msgstr "Localização da Ordem de Venda"
+msgstr "Local do pedido de venda"
 
 msgid "Sales Order Number"
 msgstr "Número de Pedido de Venda"
@@ -12997,19 +12997,19 @@ msgid "Saturday"
 msgstr "Sábado"
 
 msgid "Save"
-msgstr "Guardar"
+msgstr "Salvar"
 
 msgid "Save & Close"
-msgstr "Guardar e Fechar"
+msgstr "Salvar e fechar"
 
 msgid "Save and Overwrite"
-msgstr "Guardar e Sobrescrever"
+msgstr "Salvar e sobrescrever"
 
 msgid "Save applications"
-msgstr "Guardar aplicações"
+msgstr "Salvar aplicações"
 
 msgid "Save contacts"
-msgstr "Guardar contactos"
+msgstr "Salvar contatos"
 
 msgid "Save dimension settings"
 msgstr "Salvar configurações de dimensão"
@@ -13021,7 +13021,7 @@ msgid "Save view"
 msgstr "Salvar visualização"
 
 msgid "Save View"
-msgstr "Guardar Visualização"
+msgstr "Salvar visualização"
 
 msgid "Saved"
 msgstr "Salvo"
@@ -13039,34 +13039,34 @@ msgid "Saving…"
 msgstr "Salvando…"
 
 msgid "Scan"
-msgstr "Digitalizar"
+msgstr "Escanear"
 
 msgid "Scan a label or search by item ID or tracking ID."
-msgstr "Digitalize um rótulo ou pesquise por ID do item ou ID de rastreamento."
+msgstr "Escanear um rótulo ou pesquisar por ID de item ou ID de rastreamento."
 
 msgid "Scan or choose a batch number"
-msgstr "Digitalize ou escolha um número de lote"
+msgstr "Escanear ou escolher um número de lote de produção"
 
 msgid "Scan or choose a serial number"
-msgstr "Digitalize ou escolha um número de série"
+msgstr "Escanear ou escolher um número de série"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Digitalize ou insira ID da entidade rastreada, série ou lote"
+msgstr "Escanear ou inserir ID de entidade rastreada, série ou lote de produção"
 
 msgid "Scan or enter tracking number"
-msgstr "Digitalize ou insira o número de rastreamento"
+msgstr "Escanear ou inserir número de rastreamento"
 
 msgid "Scan or search..."
-msgstr "Digitalize ou pesquise..."
+msgstr "Escanear ou pesquisar..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Digitalize ou selecione uma entidade rastreada deste lote para adicioná-la como coluna de amostra e, em seguida, registre seu resultado na grade."
+msgstr "Escanear ou selecionar uma entidade rastreada deste lote para adicioná-la como coluna de amostra, depois registre seu resultado na grade."
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
-msgstr "Digitalize este código QR com a sua aplicação autenticadora (p.ex. Google Authenticator ou 1Password), depois introduza o código de 6 dígitos que apresenta."
+msgstr "Escanear este código QR com seu aplicativo autenticador (por exemplo, Google Authenticator ou 1Password), depois insira o código de 6 dígitos que ele exibe."
 
 msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
-msgstr "Digitalize isto com seu aplicativo autenticador, depois digite o código de 6 dígitos que ele exibe."
+msgstr "Escanear isto com seu aplicativo autenticador, depois insira o código de 6 dígitos que ele exibe."
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -13078,7 +13078,7 @@ msgid "Schedule"
 msgstr "Cronograma"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Agendar trabalhos contra capacidade do centro de trabalho"
+msgstr "Programar ordens de produção em relação à capacidade do centro de trabalho"
 
 msgid "Schedule Name"
 msgstr "Nome da Agenda"
@@ -13108,40 +13108,40 @@ msgid "Scopes"
 msgstr "Escopos"
 
 msgid "Scrap"
-msgstr "Sucata"
+msgstr "Refugo"
 
 msgid "Scrap / Cost of Quality"
-msgstr "Sucata / Custo de Qualidade"
+msgstr "Refugo / Custo da qualidade"
 
 msgid "Scrap Percent"
-msgstr "Percentual de Sucata"
+msgstr "Percentual de refugo"
 
 msgid "Scrap percentage"
-msgstr "Percentual de descarte"
+msgstr "percentual de refugo"
 
 msgid "Scrap Qty"
-msgstr "Qtd. Sucata"
+msgstr "Quantidade de refugo"
 
 msgid "Scrap quantity"
-msgstr "Quantidade descartada"
+msgstr "quantidade de refugo"
 
 msgid "Scrap Quantity"
-msgstr "Quantidade de Sucata"
+msgstr "Quantidade de refugo"
 
 msgid "Scrap Quantity Per Job"
-msgstr "Quantidade de Sucata Por Trabalho"
+msgstr "Quantidade de refugo por ordem de produção"
 
 msgid "scrap reason"
-msgstr "Motivo da sucata"
+msgstr "motivo de refugo"
 
 msgid "Scrap Reason"
-msgstr "Motivo da Sucata"
+msgstr "Motivo de refugo"
 
 msgid "scrap reasons"
-msgstr "Motivos da sucata"
+msgstr "motivos de refugo"
 
 msgid "Scrap Reasons"
-msgstr "Motivos de Sucata"
+msgstr "Motivos de refugo"
 
 msgid "Scrapped"
 msgstr "Sucatada"
@@ -13180,10 +13180,10 @@ msgid "Search fields..."
 msgstr "Pesquisar campos..."
 
 msgid "Search for existing or create a new one"
-msgstr "Procure por um existente ou crie um novo"
+msgstr "Pesquisar um existente ou criar um novo"
 
 msgid "Search items or bins"
-msgstr "Pesquisar itens ou recipientes"
+msgstr "Pesquisar itens ou compartimentos"
 
 msgid "Search Job"
 msgstr "Pesquisar Trabalho"
@@ -13240,13 +13240,13 @@ msgid "Security"
 msgstr "Segurança"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "Segmentos que determinam preços e condições de clientes"
+msgstr "Segmentos que determinam a precificação e os termos do cliente"
 
 msgid "Select"
 msgstr "Selecionar"
 
 msgid "Select a assignee"
-msgstr "Selecione um responsável"
+msgstr "Selecione um designado"
 
 msgid "Select a default approver"
 msgstr "Selecione um aprovador padrão"
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "Selecione um documento"
 
 msgid "Select a new owner"
-msgstr "Selecione um novo proprietário"
+msgstr "Selecione um novo responsável"
 
 msgid "Select a new parent group for this account."
 msgstr "Selecione um novo grupo pai para esta conta."
@@ -13280,7 +13280,7 @@ msgid "Select a quote"
 msgstr "Selecione uma cotação"
 
 msgid "Select a quote line"
-msgstr "Selecione uma linha de cotação"
+msgstr "Selecione uma linha do orçamento"
 
 msgid "Select a reason for why the quote was not created."
 msgstr "Selecione um motivo pelo qual a cotação não foi criada."
@@ -13307,7 +13307,7 @@ msgid "Select an action…"
 msgstr "Selecionar uma ação…"
 
 msgid "Select an assignee"
-msgstr "Selecione um responsável"
+msgstr "Selecione um designado"
 
 msgid "Select an event…"
 msgstr "Selecionar um evento…"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Selecionar campo"
 
 msgid "Select Gauge"
-msgstr "Selecionar Medidor"
+msgstr "Selecione o instrumento de medição"
 
 msgid "Select groups or individuals"
 msgstr "Selecione grupos ou indivíduos"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Selecione os grupos que devem concluir este treinamento"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Selecione as faturas que este pagamento liquida. Desconto e cancelamento estão na moeda da fatura."
+msgstr "Selecione as faturas que este pagamento liquida. Desconto e baixa contábil estão na moeda da fatura."
 
 msgid "Select value"
 msgstr "Selecionar valor"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Autogerenciado"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Auto-hospedado ou gerenciado"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Auto-integração"
 
 msgid "Self-paced"
 msgstr "Autoaprendizagem"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "Série / Lote"
 
 msgid "Serial items require a sales order"
-msgstr "Itens seriais requerem uma ordem de venda"
+msgstr "Itens de série requerem um pedido de venda"
 
 msgid "Serial Number"
 msgstr "Número de Série"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Defina uma meta"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Configure o Carbon de acordo com como sua empresa funciona: sites, peças, BOMs, Bill of Process e os fluxos que você usa."
+msgstr "Configure o Carbon de acordo com como sua empresa funciona: locais, peças, BOMs, Lista de operações e os fluxos que você usa."
 
 msgid "Set Clock Out"
-msgstr "Definir Saída"
+msgstr "Apontar fim"
 
 msgid "Set clock-out time"
 msgstr "Definir hora de saída"
@@ -13572,7 +13572,7 @@ msgid "Set Console PIN"
 msgstr "Definir PIN do Console"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Defina percentuais de margem padrão para cada categoria de custo em novas linhas de cotação"
+msgstr "Defina percentuais de margem padrão para cada categoria de custo em novas linhas do orçamento"
 
 msgid "Set demand projection values for each week"
 msgstr "Defina valores de projeção de demanda para cada semana"
@@ -13581,7 +13581,7 @@ msgid "Set due date"
 msgstr "Definir data de vencimento"
 
 msgid "Set Pricing"
-msgstr "Definir Preço"
+msgstr "Definir precificação"
 
 msgid "Set Quantity"
 msgstr "Definir Quantidade"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Mapa de Configuração"
 
 msgid "Setup time"
-msgstr "Tempo de configuração"
+msgstr "Tempo de setup"
 
 msgid "Setup Time"
-msgstr "Tempo de Configuração"
+msgstr "Tempo de setup"
 
 msgid "Setup unit"
 msgstr "Unidade de configuração"
@@ -13645,7 +13645,7 @@ msgid "Severities"
 msgstr "Severidades"
 
 msgid "Severity"
-msgstr "Gravidade"
+msgstr "Severidade"
 
 msgid "shape"
 msgstr "forma"
@@ -13681,13 +13681,13 @@ msgid "Shared Sections"
 msgstr "Seções Compartilhadas"
 
 msgid "Shelf life"
-msgstr "Vida útil"
+msgstr "Vida de prateleira"
 
 msgid "Shelf Life (Days)"
-msgstr "Vida Útil (Dias)"
+msgstr "Vida de prateleira (dias)"
 
 msgid "Shelf Life Start Process"
-msgstr "Processo de Início da Vida Útil"
+msgstr "Processo inicial da vida de prateleira"
 
 msgid "Shelf-Life"
 msgstr "Vida de Prateleira"
@@ -13723,22 +13723,22 @@ msgid "Ship-From Location"
 msgstr "Local de Envio"
 
 msgid "Shipment"
-msgstr "Envio"
+msgstr "Remessa"
 
 msgid "Shipment Date"
-msgstr "Data de Envio"
+msgstr "Data da remessa"
 
 msgid "Shipment ID"
-msgstr "ID de Envio"
+msgstr "ID da remessa"
 
 msgid "Shipment Line"
-msgstr "Linha de Envio"
+msgstr "Linha da remessa"
 
 msgid "Shipment Lines"
-msgstr "Linhas de Envio"
+msgstr "Linhas da remessa"
 
 msgid "Shipment Location"
-msgstr "Localização do Envio"
+msgstr "Local da remessa"
 
 msgid "Shipments"
 msgstr "Remessas"
@@ -13753,7 +13753,7 @@ msgid "Shipping Contact"
 msgstr "Contato de Envio"
 
 msgid "Shipping Cost"
-msgstr "Custo de Envio"
+msgstr "Frete"
 
 msgid "Shipping Customer"
 msgstr "Cliente de Envio"
@@ -13777,7 +13777,7 @@ msgid "Shipping Methods"
 msgstr "Métodos de Envio"
 
 msgid "Shipping Notes"
-msgstr "Notas de Envio"
+msgstr "Observações de envio"
 
 msgid "Shipping Supplier"
 msgstr "Fornecedor de Envio"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Mostrado ao usuário quando esta regra falha."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Entrar no Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Inicie sessão com biometria em vez de uma ligação mágica. As chaves de acesso são protegidas por Face ID, Touch ID ou o PIN do seu dispositivo."
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "Entrar com Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Entrar com Passkey"
+msgstr "Entrar com chave de acesso"
 
 msgid "Sign out"
 msgstr "Sair"
@@ -13943,7 +13943,7 @@ msgid "Skip scheduled maintenance on company holidays"
 msgstr "Ignorar manutenção programada em feriados da empresa"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
-msgstr "Ignore o estado liberado mas não iniciado - o trabalho começa imediatamente na verificação."
+msgstr "Ignore o estado liberado mas não iniciado — a ordem de produção inicia imediatamente no escaneamento."
 
 msgid "Skipped"
 msgstr "Ignorado"
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "Em breve"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "A expiração mais próxima em todos os materiais define o produto acabado."
+msgstr "A validade mais próxima em cada material define o produto acabado."
 
 msgid "Sort"
 msgstr "Ordenar"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "Dividir linha de recebimento"
 
 msgid "Split shipment line"
-msgstr "Dividir linha de envio"
+msgstr "Dividir linha da remessa"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Configurar hospedagem"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "Fator padrão"
 
 msgid "Standard Lead Time"
-msgstr "Tempo de Entrega Padrão"
+msgstr "Lead time padrão"
 
 msgid "Start"
 msgstr "Iniciar"
@@ -14133,7 +14133,7 @@ msgid "Start of Fiscal Year"
 msgstr "Início do Ano Fiscal"
 
 msgid "Start of Tax Year"
-msgstr "Início do Ano Fiscal"
+msgstr "Início do ano fiscal"
 
 msgid "Start Time"
 msgstr "Hora de Início"
@@ -14163,7 +14163,7 @@ msgid "Statistical acceptance failed, so the entire lot of {0} is considered non
 msgstr "A aceitação estatística falhou, portanto o lote inteiro de {0} é considerado não-conforme (ISO 9001:2015 §8.7) — {passes} amostra(s) aprovada(s) e {fails} falha(s)."
 
 msgid "Status"
-msgstr "Estado"
+msgstr "Status"
 
 msgid "Status call: progress, blockers, what's next"
 msgstr "Chamada de status: progresso, bloqueadores, próximos passos"
@@ -14172,7 +14172,7 @@ msgid "Status Distribution"
 msgstr "Distribuição de Status"
 
 msgid "Statuses"
-msgstr "Estados"
+msgstr "Status"
 
 msgid "Stay on this page"
 msgstr "Ficar nesta página"
@@ -14181,7 +14181,7 @@ msgid "Step"
 msgstr "Etapa"
 
 msgid "Step added"
-msgstr "Passo adicionado"
+msgstr "Etapa adicionada"
 
 msgid "Step detail is kept for 30 days. This run's steps have been removed."
 msgstr "O detalhe da etapa é mantido por 30 dias. As etapas desta execução foram removidas."
@@ -14193,13 +14193,13 @@ msgid "Step removed — pick a new value"
 msgstr "Etapa removida — selecione um novo valor"
 
 msgid "steps"
-msgstr "passos"
+msgstr "etapas"
 
 msgid "Steps"
 msgstr "Etapas"
 
 msgid "Steps are inherited from the assembly instruction."
-msgstr "Os passos são herdados da instrução de montagem."
+msgstr "As etapas são herdadas da instrução de montagem."
 
 msgid "Steps are inherited from the inspection plan."
 msgstr "As etapas são herdadas do plano de inspeção."
@@ -14214,7 +14214,7 @@ msgid "Stock Transfer Lines"
 msgstr "Linhas de Transferência de Estoque"
 
 msgid "Stock Transfer Notes"
-msgstr "Notas de Transferência de Estoque"
+msgstr "Observações de transferência de estoque"
 
 msgid "Stock Transfer Wizard"
 msgstr "Assistente de Transferência de Estoque"
@@ -14230,10 +14230,10 @@ msgid "Stocked for spares only."
 msgstr "Armazenado apenas para peças de reposição."
 
 msgid "Stockout"
-msgstr "Fora de estoque"
+msgstr "Ruptura de estoque"
 
 msgid "Stop raising purchase orders after this date"
-msgstr "Parar de criar ordens de compra após esta data"
+msgstr "Parar de criar pedidos de compra após esta data"
 
 msgid "Stop Receiving"
 msgstr "Parar Recebimento"
@@ -14287,19 +14287,19 @@ msgid "Straight line"
 msgstr "Linear"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe já tem um cliente com este e-mail"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Data de vencimento do Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "O Stripe envia a fatura para o cliente, portanto um endereço é obrigatório. Isso também será salvo no contato no Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "O Stripe não tem um cliente para este cliente do Carbon ainda. A contabilização criará um na sua conta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de saída do kanban para mostrar na tabela Kanban"
@@ -14413,13 +14413,13 @@ msgid "Supersedes"
 msgstr "Substitui"
 
 msgid "Supersession"
-msgstr "Supersessão"
+msgstr "Substituição"
 
 msgid "Supersession chain detected"
-msgstr "Cadeia de supersessão detectada"
+msgstr "Cadeia de substituição detectada"
 
 msgid "Supersession Mode"
-msgstr "Modo de Supersessão"
+msgstr "Modo de substituição"
 
 msgid "supplier"
 msgstr "Fornecedor"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Peça do Fornecedor"
 
 msgid "Supplier Part ID"
-msgstr "ID da Peça do Fornecedor"
+msgstr "Referência do fornecedor"
 
 msgid "Supplier Part Number"
 msgstr "Número da Peça do Fornecedor"
@@ -14485,7 +14485,7 @@ msgid "Supplier Payment Discounts (default)"
 msgstr "Descontos de Pagamento do Fornecedor (padrão)"
 
 msgid "Supplier Prepayments"
-msgstr "Pagamentos Antecipados a Fornecedores"
+msgstr "Adiantamentos do fornecedor"
 
 msgid "supplier process"
 msgstr "Processo do Fornecedor"
@@ -14557,10 +14557,10 @@ msgid "Suppliers"
 msgstr "Fornecedores"
 
 msgid "Supply"
-msgstr "Fornecimento"
+msgstr "Suprimento"
 
 msgid "Supply & Demand"
-msgstr "Oferta e Procura"
+msgstr "Suprimento e demanda"
 
 msgid "Support"
 msgstr "Suporte"
@@ -14588,7 +14588,7 @@ msgid "Switch to select mode"
 msgstr "Mudar para modo selecionar"
 
 msgid "Switch users over and confirm access"
-msgstr "Mudar utilizadores e confirmar acesso"
+msgstr "Alternar usuários e confirmar acesso"
 
 msgid "Switching the employee's type here doesn't change their existing permissions; the modal that follows asks whether to overwrite the current set with the new type's defaults."
 msgstr "Alterar o tipo de funcionário aqui não altera suas permissões existentes; a caixa de diálogo seguinte pergunta se deve substituir o conjunto atual pelos padrões do novo tipo."
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "Personalize este hub para o cliente. As alterações são aplicadas em tempo real para todos que o visualizam. Nunca é mostrado ao cliente aqui."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Pegue a vida útil restante mais curta entre os materiais consumidos para fazer este item. Use quando a validade do produto depender de seus ingredientes."
+msgstr "Usar a vida de prateleira restante mais curta entre os materiais consumidos para fabricar este item. Use quando a validade do produto depende de seus ingredientes."
 
 msgid "taken"
 msgstr "tomado"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "Empresa Alvo"
 
 msgid "Target customers by type."
-msgstr "Item de Destino"
+msgstr "Segmentar clientes por tipo."
 
 msgid "Target disposition row"
 msgstr "Linha de disposição de destino"
@@ -14708,31 +14708,31 @@ msgid "Tax codes, rates"
 msgstr "Códigos de imposto, taxas"
 
 msgid "Tax Depreciation"
-msgstr "Depreciação Fiscal"
+msgstr "Depreciação fiscal"
 
 msgid "Tax Depreciation Method"
-msgstr "Método de Depreciação Fiscal"
+msgstr "Método de depreciação fiscal"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Isento de imposto"
 
 msgid "Tax Exempt"
 msgstr "Isento de Impostos"
 
 msgid "Tax ID"
-msgstr "ID Fiscal"
+msgstr "Identificação fiscal"
 
 msgid "Tax Information"
-msgstr "Informações Fiscais"
+msgstr "Informações fiscais"
 
 msgid "Tax liability for reverse-charge transactions"
-msgstr "Responsabilidade Fiscal para Operações de Cobrança Reversa"
+msgstr "Passivo fiscal para transações de cobrança reversa"
 
 msgid "Tax Method"
-msgstr "Método Fiscal"
+msgstr "Método fiscal"
 
 msgid "Tax Method (default)"
-msgstr "Método Fiscal (padrão)"
+msgstr "Método fiscal (padrão)"
 
 msgid "Tax percent"
 msgstr "Porcentagem de imposto"
@@ -14741,16 +14741,16 @@ msgid "Tax Percent"
 msgstr "Percentual de Imposto"
 
 msgid "Tax Residual Value %"
-msgstr "Valor Residual Fiscal %"
+msgstr "% Valor residual fiscal"
 
 msgid "Tax Useful Life (default)"
-msgstr "Vida Útil Fiscal (padrão)"
+msgstr "Vida útil fiscal (padrão)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Vida Útil Fiscal (meses)"
+msgstr "Vida útil fiscal (meses)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Vida Útil Fiscal (Meses)"
+msgstr "Vida útil fiscal (meses)"
 
 msgid "Tax:"
 msgstr "Imposto:"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Equipa treinada"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Suporte técnico"
 
 msgid "Temperature"
 msgstr "Temperatura"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "Modelos"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "Conta de compensação temporária de alienação, debitada pelo valor contábil líquido do ativo no envio e creditada pelo valor contábil líquido no faturamento, zerando ao final do ciclo de venda."
+msgstr "Conta temporária de compensação de venda debitada pelo valor contábil líquido do ativo na remessa e creditada pelo seu valor contábil líquido no faturamento, compensando para zero ao longo do ciclo de venda."
 
 msgid "Terms and Privacy"
 msgstr "Termos e Privacidade"
@@ -14805,12 +14805,12 @@ msgstr "Esse nome já está sendo usado por outra etapa."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "A fase \"{0}\" marca-se como concluída quando todas as suas tarefas no plano do projeto estão prontas."
+msgstr "A fase \"{0}\" marca-se como concluída assim que todas as suas tarefas no plano do projeto forem concluídas."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "A fase \"{0}\" está concluída — seu ponto de verificação \"{1}\" foi ultrapassado."
+msgstr "A fase \"{0}\" está concluída — seu ponto de verificação \"{1}\" foi aprovado."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
@@ -14823,13 +14823,13 @@ msgid "The accounts Carbon posts to automatically"
 msgstr "As contas que o Carbon publica automaticamente"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "A ação que copia um método salvo (seus materiais, operações e instruções de trabalho) para uma linha de trabalho ou cotação."
+msgstr "A ação que copia um método salvo (seus materiais, operações e instruções de trabalho) para uma ordem de produção ou linha do orçamento."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "Os valores permitidos para um atributo do tipo lista; os usuários escolhem entre eles em vez de digitar livremente."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Os valores permitidos que os usuários podem selecionar ao marcar postagens com essa dimensão."
+msgstr "Os valores permitidos que os usuários podem escolher ao marcar contabilizações com esta dimensão."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
 msgstr "A quantidade de dias após o método de cálculo em que o desconto à vista está disponível"
@@ -14871,13 +14871,13 @@ msgid "The carrier that delivers goods from this supplier, when different from t
 msgstr "A transportadora que entrega mercadorias deste fornecedor, quando diferente do fornecedor em si (por exemplo, fornecedor vende, FedEx envia)."
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "A URL da página de rastreamento da transportadora com {trackingNumber} como espaço reservado — Carbon substitui o número real ao gerar links nos envios."
+msgstr "A URL da página de rastreamento da transportadora com {trackingNumber} como um espaço reservado — o Carbon substitui o número real ao gerar links nas remessas."
 
 msgid "The carriers and methods you ship orders with"
 msgstr "As transportadoras e métodos com os quais você envia pedidos"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "O desconto em dinheiro que o cliente pode aproveitar se pagar dentro da janela de desconto."
+msgstr "O desconto à vista que o cliente pode obter se pagar dentro da janela de desconto."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
 msgstr "A razão do catálogo que explica este refugo; é consolidada em relatórios de refugo indexados por motivo em vez de quantidade."
@@ -14904,16 +14904,16 @@ msgid "The category of this issue (e.g. Customer Complaint, Audit Finding, Produ
 msgstr "A categoria deste problema (por exemplo, Reclamação do Cliente, Constatação de Auditoria, Defeito de Produção); determina qual modelo de fluxo de trabalho se aplica."
 
 msgid "The category this customer belongs to (OEM, distributor, end-user, internal); drives default pricing rules and GL accounts."
-msgstr "A categoria a que este cliente pertence (OEM, distribuidor, usuário final, interno); determina as regras de preço padrão e as contas GL."
+msgstr "A categoria à qual este cliente pertence (OEM, distribuidor, usuário final, interno); determina as regras de precificação padrão e as contas contábeis."
 
 msgid "The category this supplier belongs to (raw-material, services, contract-manufacturer); drives default GL accounts and reporting groupings."
 msgstr "A categoria a que este fornecedor pertence (matéria-prima, serviços, fabricante por contrato); determina as contas GL padrão e os agrupamentos de relatórios."
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "O código impresso no cartão kanban que os operadores digitalizam para marcar o trabalho como concluído; gerado automaticamente se deixado em branco."
+msgstr "O código impresso no cartão kanban que os operadores escaneiam para marcar a ordem de produção como concluída; gerado automaticamente quando deixado em branco."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "A disponibilidade semanal esperada do contratante; o agendamento a usa como limite superior ao atribuir este contratante a operações ao longo da semana."
+msgstr "A disponibilidade semanal esperada do terceirizado; o agendamento usa isso como o limite superior ao atribuir este terceirizado a operações ao longo da semana."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "A data de validade corrigida para este lote/número de série; o estoque existente em mãos é reavaliado em relação à política de vida útil após a alteração."
@@ -14952,19 +14952,19 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "A data em que a depreciação de um ativo começa; normalmente a data de entrada em serviço."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "A data após a qual os preços desta cotação não são mais honrados; a conversão para um pedido após esta data pode exigir nova cotação."
+msgstr "A data após a qual o preço deste orçamento não é mais honrado; converter para um pedido após esta data pode exigir novo orçamento."
 
 msgid "The date the customer expects to receive the goods"
 msgstr "A data em que o cliente espera receber os bens"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "A data em que as mercadorias realmente saem do armazém; registrada no lançamento da remessa e usada para pontuação de remessa no prazo."
+msgstr "A data em que os produtos realmente saem do armazém; registrada na contabilização da remessa e usada para pontuação de envio no prazo."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
 msgstr "A data em que o item é necessário no local para cobrir a demanda projetada do período."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "A data em que este ativo é aposentado do serviço; a depreciação para nesta data e o valor contábil neto restante é registrado na conta de alienação."
+msgstr "A data em que este ativo é retirado de serviço; a depreciação cessa nesta data e o valor contábil líquido restante é contabilizado na conta de baixa."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "A data em que esta entrada é registrada no razão geral; determina o período contábil em que se enquadra."
@@ -14979,13 +14979,13 @@ msgid "The deadline to send your quote to the customer."
 msgstr "O prazo para enviar sua cotação ao cliente."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "O pedido de seleção padrão usa para oferecer entidades rastreadas: FEFO (vencimento mais antigo primeiro), FIFO (mais antigo primeiro) ou LIFO (mais novo primeiro)."
+msgstr "A ordem padrão que a separação usa para oferecer entidades rastreadas: FEFO (expiração mais próxima primeiro), FIFO (mais antigo primeiro) ou LIFO (mais novo primeiro)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "A quantidade padrão de execução quando esta peça é fabricada; os ciclos de planejamento reabastecem até múltiplos disso."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "A taxa fiscal padrão aplicada às linhas de cotação e ordem de venda deste cliente, antes de substituições por linha; a matemática fiscal específica da jurisdição é executada em cima."
+msgstr "A alíquota padrão de imposto aplicada aos orçamentos e linhas do pedido de venda deste cliente, antes de sobrescritas por linha; a matemática de imposto específica da jurisdição é executada após."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "O departamento sob o qual este se acumula para relatórios e hierarquias de contagem de cabeçalho; deixar em branco para um departamento de nível superior."
@@ -14997,7 +14997,7 @@ msgid "The employee accountable for this cost center — when purchase order app
 msgstr "O funcionário responsável por este centro de custo — quando as aprovações de pedidos de compra estão ativadas, é o aprovador para despesas registradas contra ele."
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "O fluxo comercial de ponta a ponta, desde a cotação de um cliente até a cobrança de pagamento: RFQ para cotação para ordem de venda, depois remessa, fatura e pagamento liquidado."
+msgstr "O fluxo comercial completo, desde orçar um cliente até cobrar o pagamento: RFQ para orçamento para pedido de venda, depois remessa, fatura e pagamento liquidado."
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "O endpoint que recebe uma solicitação POST com os dados atualizados quando a tabela é atualizada"
@@ -15006,7 +15006,7 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "O desenho de engenharia ao qual este plano de inspeção está vinculado; as inspeções registradas nesta peça referenciam este desenho."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "O percentual esperado da produção deste item perdido durante a fabricação; o planejamento multiplica a demanda por 1 / (1 − sucata) para compensar."
+msgstr "O percentual esperado de saída deste item perdida durante a produção; o planejamento multiplica a demanda por 1 / (1 − refugo) para compensar."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "A conta de despesas em que essa linha de despesa indireta é lançada; obrigatória porque as linhas indiretas não têm um lançamento do livro de inventário do qual derivar a conta."
@@ -15021,7 +15021,7 @@ msgid "The fixed-asset record this purchase capitalizes against; the line's rece
 msgstr "O registro de ativo fixo contra o qual essa compra é capitalizada; o recebimento da linha cria uma entrada de ativo em vez de uma entrada de inventário."
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "O registro de ativo fixo que essa venda aliena; o envio da linha contabiliza a entrada de disposição do valor líquido contábil do ativo em vez de COGS."
+msgstr "O registro de ativo fixo que esta venda baixa; a remessa da linha contabiliza o lançamento de baixa do valor contábil líquido do ativo em vez do CPV."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
 msgstr "O piso para o qual um ativo é depreciado; quando o valor contábil líquido o atinge, o ativo muda para Totalmente Depreciado."
@@ -15033,13 +15033,13 @@ msgid "The following assemblies have no operations. Please assign an operation t
 msgstr "Os seguintes conjuntos não têm operações. Atribua uma operação a cada um antes de liberar."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "Os seguintes itens de linha estão faltando preços ou prazos de entrega:"
+msgstr "Os seguintes itens de linha estão sem preços ou lead times:"
 
 msgid "The following tasks are not done yet:"
-msgstr "As seguintes tarefas ainda não foram concluídas:"
+msgstr "As seguintes tarefas ainda não estão feitas:"
 
 msgid "The forms and shapes your raw materials come in"
-msgstr "As formas e formatos em que seus materiais brutos chegam"
+msgstr "As formas e formatos em que suas matérias-primas chegam"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
 msgstr "A fração de cada lote a inspecionar; a contagem real é calculada do tamanho do lote no momento da inspeção."
@@ -15060,10 +15060,10 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "A conta de grupo a qual esta conta é agregada; determina seu tipo, classe e posicionamento no relatório."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "O custo horário da mão de obra do operador neste centro de trabalho; combinado com horas de trabalho registradas para cobrar o custo da mão de obra no WIP de um trabalho."
+msgstr "O custo horário da mão de obra do operador neste centro de trabalho; combinado com as horas de mão de obra registradas para cobrar o custo de mão de obra no produto em processo da ordem de produção."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "O custo horário de funcionamento da maquinaria neste centro de trabalho; combinado com horas de máquina registradas para cobrar o custo da máquina no WIP de um trabalho."
+msgstr "O custo horário de funcionamento da maquinaria neste centro de trabalho; combinado com as horas de máquina registradas para cobrar o custo de máquina no produto em processo da ordem de produção."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
 msgstr "O encargo de custo indireto por hora aplicado a este centro de trabalho; a diferença entre mão de obra + máquina e a taxa de cotação completa é o que as despesas gerais absorvem."
@@ -15087,13 +15087,13 @@ msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastro
 msgstr "A classificação de impacto se o risco for realizado (1 = negligenciável a 5 = catastrófico); emparelhado com Probabilidade para calcular a pontuação de risco."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "O documento de postagem de entrada que recebe mercadorias em estoque (de uma PO, transferência ou saída de trabalho) e cria entidades rastreadas."
+msgstr "O documento de contabilização de entrada que leva mercadorias ao estoque (de um pedido de compra, transferência ou saída de ordem de produção) e cria quaisquer entidades rastreadas."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "A regra de Incoterms (FOB, DAP, EXW, CIF, ...) que governa quem paga o frete, quem assume o risco e onde a transferência de título ocorre nos envios deste fornecedor."
+msgstr "A regra Incoterm (FOB, DAP, EXW, CIF, …) que governa quem paga o frete, quem assume o risco e onde ocorre a transferência de propriedade em remessas deste fornecedor."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "A regra de Incoterms (FOB, DAP, EXW, CIF, ...) que governa quem paga o frete, quem assume o risco e onde a transferência de título ocorre nos envios para este cliente."
+msgstr "A regra Incoterm (FOB, DAP, EXW, CIF, …) que governa quem paga o frete, quem assume o risco e onde ocorre a transferência de propriedade em remessas para este cliente."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
 msgstr "O custo de inventário reconhecido quando uma remessa é registrada, avaliado pelo método de custeio do item."
@@ -15108,7 +15108,7 @@ msgid "The job's position in its location's schedule queue — a fractional numb
 msgstr "A posição do trabalho em sua fila de agendamento de localização — um número fracionário que o Carbon calcula a partir da data de vencimento e do tipo de prazo, não uma classificação Baixo/Alto."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "O tipo de ajuste que essa regra aplica - desconto, sobretaxa ou substituição fixa; combinado com Tipo de Valor para calcular o delta real em cada linha."
+msgstr "O tipo de ajuste que esta regra aplica — desconto, acréscimo ou sobrescrita fixa; combinado com Tipo de Valor para calcular a alteração real em cada linha."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
 msgstr "O tipo de valor que esse atributo aceita (texto, número, data, booleano, lista); bloqueado após o atributo ter valores registrados."
@@ -15117,7 +15117,7 @@ msgid "The label and document printers your company prints to"
 msgstr "As impressoras de etiquetas e documentos para as quais sua empresa imprime"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "A data mais tardia para fazer este PO para que chegue até a data de necessidade, considerando o prazo de entrega do fornecedor."
+msgstr "A data limite para colocar este pedido de compra para que chegue até a data necessária, considerando o lead time do fornecedor."
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "A entidade legal para faturar, quando diferente do cliente que recebe as mercadorias - para arranjos de faturamento de matriz/filial ou terceiros."
@@ -15135,16 +15135,16 @@ msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approv
 msgstr "O estado do ciclo de vida deste fornecedor - Ativo, Inativo, Aprovação Pendente, etc.; apenas fornecedores Ativos aparecem nos seletores PO/cotação."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "O fuso horário local em que essa localização relata a hora; os cronogramas, cartões de tempo e horas de turno nessa localização são interpretados neste fuso independentemente da localidade do navegador do usuário."
+msgstr "O fuso horário local em que este local reporta a hora; as programações, apontamentos e horas de turno neste local são interpretados nesta zona independentemente da localidade do navegador do usuário."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "A localização para a qual este funcionário está por padrão; determina a interpretação de zona horária em seus cartões de ponto e os seletores de turno padrão em seu registro de trabalho."
+msgstr "O local padrão deste funcionário; determina a interpretação do fuso horário nos apontamentos e os seletores de turno padrão no registro da ordem de produção."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "O local do qual este pedido será atendido; os locais por linha o anulam quando definidos."
+msgstr "O local do qual este pedido será atendido; as localizações por linha sobrescrevem isso quando definidas."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "O local do qual este orçamento será atendido se for convertido em um pedido; usado pelo planejamento para projetar o fornecimento no armazém correto."
+msgstr "O local do qual este orçamento será atendido se se converter em um pedido; usado pelo planejamento para projetar o suprimento no armazém correto."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
 msgstr "O local do qual esta solicitação de cotação seria atendida se for convertida em uma cotação e depois em um pedido."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "O plano de amostragem por recurso do lote será resolvido novamente a partir do documento selecionado."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "O valor mínimo que este fornecedor cobrará por esse processo, independentemente da quantidade; os trabalhos abaixo do volume de equilíbrio ainda custam pelo menos esse valor."
+msgstr "O valor mínimo que este fornecedor cobrará por este processo, independentemente da quantidade; trabalhos abaixo do volume de equilíbrio ainda custam pelo menos isso."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "As máquinas, células e estações por onde seu trabalho passa"
@@ -15186,7 +15186,7 @@ msgid "The month your financial year begins; periods are numbered from this mont
 msgstr "O mês em que seu ano fiscal começa; os períodos são numerados a partir deste mês."
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "O mês em que seu ano fiscal começa; pode diferir do ano fiscal em algumas jurisdições."
+msgstr "O mês em que seu ano fiscal de imposto começa; pode diferir do ano fiscal em algumas jurisdições."
 
 msgid "The monthly periods you post into and close"
 msgstr "Os períodos mensais nos quais você lança e fecha"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "O modo de falha mais provável que o solicitante suspeita; o técnico confirma ou substitui ao fechar, e a diferença entre o suspeito e o real alimenta os relatórios de confiabilidade."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "O preço negociado por unidade nesta linha; o ícone de rastreamento embutido mostra qual regra de preço ou anulação o produziu."
+msgstr "O preço negociado por unidade nesta linha; o ícone de rastreamento inline mostra qual regra de precificação ou sobrescrita a produziu."
 
 msgid "The new version number of the document"
 msgstr "O novo número de versão do documento"
@@ -15207,16 +15207,16 @@ msgid "The new version number of the procedure"
 msgstr "O novo número de versão do procedimento"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "O número de dias entre colocar uma PO com o fornecedor preferido e os bens chegarem no cais; o planejamento compensa a demanda para trás por esse valor."
+msgstr "O número de dias entre colocar um pedido de compra com o fornecedor preferencial e a chegada das mercadorias no cais; o planejamento desloca a demanda para trás por essa quantidade."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "O número de dias para construir um lote deste item, medido da liberação do trabalho até a conclusão; o planejamento compensa a demanda para trás por esse valor."
+msgstr "O número de dias para construir um lote de produção deste item, medido da liberação da ordem de produção até a conclusão; o planejamento desloca a demanda para trás por essa quantidade."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
 msgstr "O número de unidades adicionais a construir para compensar o refugo esperado; o planejamento o soma com a quantidade do pedido ao reservar materiais."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "O número de horas por semana que o contratante está disponível para trabalhar."
+msgstr "O número de horas por semana que o terceirizado está disponível para trabalhar."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "O número de meses durante os quais este ativo será depreciado."
@@ -15240,7 +15240,7 @@ msgid "The outbound posting document that takes goods out of stock to a customer
 msgstr "O documento de contabilização de saída que remove bens do estoque para um cliente, contabilizando o COGS no processo."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Os fornecedores externos que realizam esse processo; cada um obtém uma linha de entradas de preço e tempo de espera no formulário de processo do fornecedor."
+msgstr "Os fornecedores externos que executam este processo; cada um recebe uma linha de entradas de preço e lead time no formulário de processo do fornecedor."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "A cadeia pai-filho de entidades rastreadas - a partir do que uma unidade foi construída e no que se tornou."
@@ -15261,10 +15261,10 @@ msgid "The per-company counter behind a document type's readable number, assembl
 msgstr "O contador por empresa por trás do número legível de um tipo de documento, montando o prefixo, o próximo valor preenchido com zeros, e o sufixo, e avançando conforme cada documento é criado."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "O resultado por item registrado no material afetado de uma não-conformidade — Pendente, Devolução ao Fornecedor, Retrabalho, Sucata ou Usar Como Está — decidido para cada lote ou serial afetado individualmente."
+msgstr "O resultado por item registrado no material afetado de uma não conformidade — Pendente, Retornar ao fornecedor, Retrabalho, Refugo ou Usar como está — decidido para cada lote ou série afetado individualmente."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "A percentagem do desconto em dinheiro. Use 0 para sem desconto."
+msgstr "O percentual do desconto à vista. Use 0 para nenhum desconto."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "O conjunto de permissões que novos funcionários deste tipo recebem automaticamente; editar aqui muda apenas o modelo para futuras contratações - os funcionários existentes mantêm o que têm a menos que sejam explicitamente atualizados em massa."
@@ -15273,7 +15273,7 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "As plantas, armazéns e locais onde seu trabalho e estoque residem"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "O pacote predefinido de tarefas e requisitos de aprovação aplicados a este problema; substitui o fluxo de trabalho padrão do tipo de problema quando definido."
+msgstr "O pacote predefinido de tarefas e requisitos de aprovação aplicados a este problema; sobrescreve o fluxo de trabalho padrão do tipo de problema quando definido."
 
 msgid "The principle:"
 msgstr "O princípio:"
@@ -15285,7 +15285,7 @@ msgid "The procedure technicians follow when this maintenance is performed; repl
 msgstr "O procedimento que os técnicos seguem quando essa manutenção é executada; substituí-lo após os cronogramas já terem sido gerados afeta apenas as instâncias futuras."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Os processos que este centro de trabalho pode executar; aparece nos seletores de processo ao agendar operações e limita quais trabalhos podem rotear através deste centro de trabalho."
+msgstr "Os processos que este centro de trabalho pode executar; aparece em seletores de processo ao agendar operações e limita quais trabalhos podem rotear por este centro de trabalho."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "O provedor não oferece alvos de dimensão. Habilite o recurso no provedor primeiro (por exemplo, categorias de rastreamento, rastreamento de classe ou campos)."
@@ -15318,7 +15318,7 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "O registro para o qual uma notificação de fluxo de trabalho aponta, nomeado como um id mais seu tipo; deixe-o vazio e a notificação será vinculada à execução do fluxo de trabalho em si."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "O registro que aplica um pagamento ou memorando a uma fatura, contendo os valores aplicados, desconto e cancelamento."
+msgstr "O registro que aplica um pagamento ou memorando a uma fatura, contendo os valores aplicado, desconto e baixa contábil."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
 msgstr "A genealogia registrada de entidades rastreadas - quais entradas foram consumidas para produzir quais saídas, recebimento até remessa."
@@ -15329,18 +15329,18 @@ msgstr "Os dados de referência dos quais tudo o mais depende. Carrega primeiro.
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will be expected again and counted as incoming supply."
-msgstr "Os {0} {1} restantes serão esperados novamente e contados como fornecimento de entrada."
+msgstr "Os {0} {1} restantes serão esperados novamente e contados como suprimento recebido."
 
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "Os {0} {1} restantes não serão mais esperados. O fornecimento em aberto e o MRP deixarão de contabilizá-lo. A quantidade encomendada e o preço permanecem inalterados."
+msgstr "Os {0} {1} restantes não serão mais esperados. O suprimento pedido e o MRP deixarão de contar. A quantidade e o preço pedidos não foram alterados."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "O corpo da solicitação enviado literalmente com um tipo de conteúdo JSON após as variáveis de fluxo de trabalho dentro dele serem substituídas, nos métodos que carregam um."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "O WIP residual que um trabalho deixou no fechamento, varrido para uma conta de variância de produção - a única variância que o Carbon registra para um trabalho."
+msgstr "O produto em processo residual que uma ordem de produção deixa ao fechar, movido para uma conta de Variação de Produção — a única variação que o Carbon contabiliza para uma ordem de produção."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "A resposta do Onshape não incluía os parâmetros necessários. Tente conectar novamente."
@@ -15352,13 +15352,13 @@ msgid "The revision number of the part"
 msgstr "O número de revisão da peça"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "A linha do pedido de venda para a qual este trabalho foi criado para fornecer, vinculando o trabalho à demanda do cliente por trás dele."
+msgstr "A linha do pedido de venda que esta ordem de produção foi criada para atender, vinculando a ordem de produção à demanda do cliente por trás."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
 msgstr "O cronograma usado para distribuir o custo deste ativo durante sua vida útil (linha reta, saldo decrescente, unidades de produção)."
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "As prateleiras e caixas onde o estoque fica fisicamente armazenado"
+msgstr "As prateleiras e compartimentos onde o estoque fica fisicamente"
 
 msgid "The shop supplies and consumables you keep on hand"
 msgstr "Os suprimentos de loja e consumíveis que você mantém à mão"
@@ -15370,7 +15370,7 @@ msgid "The size of the part"
 msgstr "O tamanho da peça"
 
 msgid "The skills and abilities you track for your people"
-msgstr "As competências e habilidades que você acompanha para sua equipe"
+msgstr "As habilidades que você rastreia para suas pessoas"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "A quantidade mínima que este fornecedor aceitará em uma linha de PO para esta peça; o planejamento a arredonda."
@@ -15388,19 +15388,19 @@ msgid "The specific PO, return, or transfer this receipt posts against; availabl
 msgstr "O PO, devolução ou transferência específica contra a qual esse recebimento é contabilizado; os IDs disponíveis dependem do tipo de documento de origem acima."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "O SO, transferência ou RMA específica contra a qual esse envio é contabilizado; os IDs disponíveis dependem do tipo de documento de origem acima."
+msgstr "O pedido de venda específico, transferência ou RMA em que esta remessa é contabilizada; os IDs disponíveis dependem do tipo de documento de origem acima."
 
 msgid "The standard dimensions your materials are stocked in"
 msgstr "As dimensões padrão em que seus materiais são armazenados"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "O fator padrão (horas, minutos, peças) operações neste centro de trabalho são medidas por padrão; overrides por operação vencem quando configurados."
+msgstr "O fator normal (horas, minutos, peças) pelo qual as operações neste centro de trabalho são medidas por padrão; as sobrescritas por operação vencem quando definidas."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
 msgstr "O fator padrão usado para medir este processo - horas, minutos, peças, pés quadrados - quando suas operações são estimadas e cotadas."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "O status desta linha de cotação - Rascunho, Sem Cotação, Completo; Sem Cotação revela o campo Motivo e exclui a linha do total da cotação."
+msgstr "O estado desta linha do orçamento — Rascunho, Sem cotação, Concluído; Sem cotação revela o campo Motivo e exclui a linha do total do orçamento."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "O grupo de demonstrações que todas as contas sob este grupo usarão."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "As configurações da etapa — essa execução antecede o registro dos valores que usou."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Os tamanhos de estoque nos quais este material é comprado e mantido; cada tamanho se torna uma variante separada selecionável em trabalhos e POs."
+msgstr "Os tamanhos de estoque que este material é adquirido e armazenado; cada tamanho se torna uma variante selecionável separada em ordens de produção e pedidos de compra."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "O compartimento de armazenamento do qual esta linha coleta; se em branco, a seleção usa a unidade de armazenamento padrão do item."
+msgstr "O compartimento de armazenamento de onde esta linha é separada; se em branco, a separação usa a unidade de armazenamento padrão do item."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "O serviço de armazenamento não respondeu a tempo. Tente novamente."
@@ -15433,13 +15433,13 @@ msgid "The supplier's own reference for this order (their SO number on their sys
 msgstr "A referência própria do fornecedor para este pedido (seu número de SO em seu sistema); registrado para auditoria e mostrado no recebimento."
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "O número da nota de embalagem ou envio do fornecedor, registrado para auditoria; não utilizado por nenhuma lógica de contabilização."
+msgstr "O número da guia de remessa ou de remessa do fornecedor, registrado para auditoria; não usado por nenhuma lógica de contabilização."
 
 msgid "The suppliers and vendors you buy from"
 msgstr "Os fornecedores e vendedores de quem você compra"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Os fornecedores que recebem esta RFQ; cada um obtém sua própria linha na RFQ com a qual responde com seu próprio preço."
+msgstr "Os fornecedores que recebem este RFQ; cada fornecedor recebe sua própria linha no RFQ para responder com sua própria precificação."
 
 msgid "The surface finishes available on your materials"
 msgstr "Os acabamentos de superfície disponíveis nos seus materiais"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "O sistema passa em todos os testes de aceitação no escopo do seu sistema configurado, com seus dados; os dados são validados; e você assina. Depois, entre em operação."
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "O thread que vincula uma RFQ de vendas, sua cotação e a ordem de venda resultante - uma junção, não um documento com seu próprio status."
+msgstr "A ligação conectando um RFQ de vendas, seu orçamento e o pedido de venda resultante — uma conexão, não um documento com seu próprio status."
 
 msgid "The timer starts automatically"
 msgstr "O temporizador inicia automaticamente"
@@ -15457,28 +15457,28 @@ msgid "The timer starts manually"
 msgstr "O temporizador inicia manualmente"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "As ferramentas e acessórios que suas operações dependem"
+msgstr "As ferramentas e dispositivos de fixação dos quais suas operações dependem"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "O total a fabricar em todos os trabalhos criados neste lote em massa; combinado com Quantidade por Trabalho para decidir quantos trabalhos criar."
+msgstr "O total a fabricar em todas as ordens de produção criadas neste lote em massa; combinado com Quantidade por Ordem para decidir quantas ordens de produção criar."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "A referência rastreável (por exemplo, padrão NIST, número de série da medida mestre) contra a qual os valores de calibração foram comparados."
+msgstr "A referência rastreável (por exemplo, padrão NIST, número de série do instrumento de medição de referência) contra o qual os valores de calibração foram comparados."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "O aviso lista cada item na lista de materiais com sua quantidade."
+msgstr "A ficha de acompanhamento lista cada item da lista de materiais com sua quantidade."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "O tipo controla quais permissões padrão o novo funcionário recebe; selecioná-lo aqui pré-preenche a matriz de permissão do modelo do tipo."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "O número típico de dias entre enviar trabalho para este fornecedor para este processo e obtê-lo de volta; o planejamento compensa a demanda por esse valor ao selecionar um fornecedor."
+msgstr "O número típico de dias entre enviar trabalho para este fornecedor para este processo e recebê-lo de volta; os deslocamentos de planejamento compensam a demanda por este tempo quando este fornecedor é escolhido."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "O identificador único nesta unidade física; uma linha por número de série, a quantidade é sempre 1."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "A unidade em que um tempo de roteamento é expresso, como Horas/Peça ou Total de Horas, informando ao Carbon se o tempo varia com a quantidade ou é fixo por execução."
+msgstr "A unidade em que o tempo de roteiro de produção é expresso, como Horas/Peça ou Horas Totais, informando ao Carbon se o tempo escala com a quantidade ou é fixo por execução."
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "O preço unitário do item no momento da compra"
@@ -15493,7 +15493,7 @@ msgid "The units of measure you buy, stock, and sell in"
 msgstr "As unidades de medida que você compra, estoca e vende"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "O sistema de depreciação fiscal dos EUA com tabelas de classe de propriedade do IRS, executado como um cronograma fiscal separado ao lado do cronograma de livros."
+msgstr "O sistema de depreciação fiscal dos EUA com tabelas de classe de propriedade do IRS, executado como um calendário fiscal separado ao lado do calendário contábil."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "Os usuários neste grupo; permissões e notificações com escopo de grupo se aplicam a cada membro, e usuários podem pertencer a vários grupos (permissões efetivas são a união)."
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "O armazém do qual os bens desta cotação serão enviados; a localização de envio do cliente é onde eles chegarão."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "As formas como o equipamento falha, para rastreamento de manutenção e qualidade"
+msgstr "As maneiras pelas quais o equipamento falha, para rastreamento de manutenção e qualidade."
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "O próprio caixote do centro de trabalho onde o material separado é preparado para a produção consumir, em oposição à sua prateleira de origem no armazém."
+msgstr "O compartimento próprio do centro de trabalho onde o material separado aguarda para ser consumido pela produção, em oposição à sua prateleira de origem no armazém."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Os horários de trabalho e calendários que orientam o agendamento"
@@ -15547,7 +15547,7 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "Estes campos personalizados estarão disponíveis apenas para entidades com as mesmas tags"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Estes documentos não foram lançados no livro-razão geral, portanto seus valores estão faltando neste período. Lance ou anule cada um — um documento sem data recebe a data do dia do lançamento quando é lançado."
+msgstr "Estes documentos não foram contabilizados no livro razão, portanto seus valores estão ausentes deste período. Contabilize ou anule cada um — um documento sem data recebe a data do dia de contabilização quando é contabilizado."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "Estes endereços de email serão automaticamente copiados em todos os emails enviados para fornecedores (cotações, pedidos de compra, etc.)."
@@ -15559,7 +15559,7 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Esses itens ainda têm material para coletar. Finalizar agora marca a lista como Parcial."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Estes trabalhos têm operações atribuídas a este centro de trabalho:"
+msgstr "Estas ordens de produção têm operações atribuídas a este centro de trabalho:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Estes lançamentos de diário ainda estão em Rascunho, portanto seus débitos e créditos não estão no livro-razão para este período. Lance cada um, ou redatē-o para um período aberto posterior."
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "Isto completa a etapa de Descoberta."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Este contato não possui endereço de e-mail"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Este terceiro não tem nada pendente — o pagamento será registrado em conta."
@@ -15602,13 +15602,13 @@ msgstr "este plano de inspeção"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr "Este convite para ingressar em {0} expirou. Você pode solicitar um novo convite a ser enviado para seu e-mail."
+msgstr "Este convite para participar de {0} expirou. Você pode solicitar que um novo convite seja enviado para seu e-mail."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Esta fatura não tem uma data de vencimento utilizável — escolha uma para Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Esta fatura será cobrada do cliente Stripe já vinculado a este cliente Carbon. Para alterar seus detalhes, edite-a no painel do Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Este é um ambiente controlado, portanto um aplicativo autenticador é obrigatório."
@@ -15638,7 +15638,7 @@ msgid "this item"
 msgstr "este item"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Este item é construído por meio de um configurador e resolve seus componentes por pedido; os trabalhos criados para ele herdam a BOM resolvida do configurador."
+msgstr "Este item é construído via um configurador e resolve seus componentes por pedido; as ordens de produção criadas para ele herdam a BOM resolvida do configurador."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
 msgstr "A lista de materiais deste item não possui entradas com shelf-life ativado, portanto nenhuma data de validade será calculada a partir da BOM."
@@ -15653,13 +15653,13 @@ msgid "This job's own required quantity for the material."
 msgstr "A quantidade própria exigida por este trabalho para o material."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Este lote expirou e não pode ser selecionado."
+msgstr "Este lote expirou e não pode ser separado."
 
 msgid "This may take a moment. Hang tight."
 msgstr "Isto pode levar um momento. Aguarde."
 
 msgid "This method version is read-only. Create a new version from the method menu to make changes."
-msgstr "Esta versão do método é somente leitura. Crie uma nova versão no menu do método para fazer alterações."
+msgstr "Esta versão do método é somente leitura. Crie uma nova versão no menu de métodos para fazer alterações."
 
 msgid "This Month"
 msgstr "Este Mês"
@@ -15671,7 +15671,7 @@ msgid "This part has {quantityOnHand} on hand at this location. No Stock means i
 msgstr "Esta peça tem {quantityOnHand} em mãos nesta localização. Sem Estoque significa que não será planejada nem consumida."
 
 msgid "This part is activated when change notice {activationLockId} is released."
-msgstr "Esta peça é ativada quando o aviso de mudança {activationLockId} é liberado."
+msgstr "Esta peça é ativada quando o aviso de alteração {activationLockId} é liberado."
 
 msgid "This part is being phased out."
 msgstr "Esta peça está sendo descontinuada."
@@ -15689,7 +15689,7 @@ msgid "This period has no journal entries posted to it and can be permanently de
 msgstr "Este período não tem lançamentos de diário nele e pode ser deletado permanentemente. Isso não pode ser desfeito."
 
 msgid "this purchase order"
-msgstr "esta ordem de compra"
+msgstr "este pedido de compra"
 
 msgid "This Quarter"
 msgstr "Este Trimestre"
@@ -15698,10 +15698,10 @@ msgid "This removes their authenticator app, so their next sign-in only needs a 
 msgstr "Isso remove seu aplicativo autenticador, portanto seu próximo login só precisa de um link mágico. Use isso quando eles tiverem perdido acesso ao seu autenticador. Afeta seu login para cada empresa a que pertencem."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "Esta revisão foi liberada (Produção). As mudanças devem normalmente passar por um aviso de mudança."
+msgstr "Esta revisão é liberada (Produção). As alterações devem normalmente fluir através de um aviso de alteração."
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "Esta revisão foi liberada (Produção). Abra um aviso de mudança para modificá-la."
+msgstr "Esta revisão é liberada (Produção). Abra um aviso de alteração para modificá-la."
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "Esta execução tem mais etapas do que mostramos aqui. Apenas os primeiros {MAX_RUN_STEPS} são listados."
@@ -15710,10 +15710,10 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Isso executa o fluxo de trabalho de verdade. Ele criará registros, enviará notificações e chamará quaisquer webhooks exatamente como uma execução ao vivo faria. Isto não pode ser desfeito."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Esta ordem de venda tem trabalhos associados. Escolha o que fazer com eles."
+msgstr "Este pedido de venda tem ordens de produção associadas. Escolha o que fazer com elas."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Esta ordem de venda tem linhas que requerem a criação de trabalhos"
+msgstr "Este pedido de venda tem linhas que requerem a criação de ordens de produção."
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15723,10 +15723,10 @@ msgid "this supplier"
 msgstr "este fornecedor"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
-msgstr "Esta ferramenta é ativada quando o aviso de mudança {activationLockId} é liberado."
+msgstr "Esta ferramenta é ativada quando o aviso de alteração {activationLockId} é liberado."
 
 msgid "This updates the theme for all users of the application"
-msgstr "Isto atualiza o tema para todos os utilizadores da aplicação"
+msgstr "Isso atualiza o tema para todos os usuários da aplicação."
 
 msgid "This user does not have two-factor authentication enabled."
 msgstr "Este usuário não tem autenticação de dois fatores ativada."
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "Esta versão não pode ser aberta"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Esta versão é publicada."
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Esta versão é publicada. Crie uma nova versão para editar."
 
 msgid "This version's definition could not be read."
 msgstr "A definição desta versão não pôde ser lida."
@@ -15760,7 +15760,7 @@ msgid "This will overwrite the existing job method"
 msgstr "Isto irá sobrescrever o método de trabalho existente"
 
 msgid "This will overwrite the existing manufacturing method and the latest versions of all subassemblies."
-msgstr "Isto irá sobrescrever o método de fabricação existente e as versões mais recentes de todos os subconjuntos."
+msgstr "Isso substituirá o método de manufatura existente e as últimas versões de todas as submontagens."
 
 msgid "This will overwrite the existing quote method"
 msgstr "Isto irá sobrescrever o método de cotação existente"
@@ -15771,7 +15771,7 @@ msgstr "Isto irá recalcular o custo unitário a partir da lista de materiais e 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "Isto removerá o link de {0} para {1}. O trabalho não aparecerá mais sob a ordem de venda e os envios não o encontrarão."
+msgstr "Isso removerá o vínculo de {0} com {1}. A ordem de produção não aparecerá mais no pedido de venda e as remessas não conseguirão encontrá-la."
 
 msgid "This will replace all method materials of other revisions with this revision."
 msgstr "Isto substituirá todos os materiais de método de outras revisões por esta revisão."
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Conciliação indisponível"
 
 msgid "Tightened"
-msgstr "Apertado"
+msgstr "Severa"
 
 msgid "Time of day"
 msgstr "Hora do dia"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "Cartão de Ponto"
 
 msgid "Timecards"
-msgstr "Cartões de Ponto"
+msgstr "Apontamentos"
 
 msgid "Timecards are disabled"
-msgstr "Cartões de ponto estão desativados"
+msgstr "Apontamentos desativados"
 
 msgid "Timecards are enabled"
-msgstr "Cartões de ponto estão ativados"
+msgstr "Apontamentos ativados"
 
 msgid "Timezone"
 msgstr "Fuso Horário"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "Alternar"
 
 msgid "Toggle Assignee"
-msgstr "Alternar Responsável"
+msgstr "Alternar Designado"
 
 msgid "Toggle break active"
 msgstr "Alternar quebra ativa"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Ferramentas"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Classificação de nível superior (ativo/passivo/patrimônio/receita/despesa); definido apenas em grupos raiz, herdado por filhos."
+msgstr "Classificação de nível superior (ativo / passivo / patrimônio líquido / receita / despesa); definir apenas em grupos raiz, herdados pelos filhos."
 
 msgid "Topic"
 msgstr "Tópico"
@@ -15976,13 +15976,13 @@ msgid "Total Quantity"
 msgstr "Quantidade Total"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Quantidade total disponível do item em todas as unidades de armazenamento neste local. Fica vermelha quando o disponível mais o que está chegando não consegue cobrir a demanda total."
+msgstr "Saldo em estoque total do item em todas as unidades de armazenamento neste local. Fica vermelho quando o saldo em estoque mais entrada não conseguem cobrir a demanda total."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Quantidade total exigida em todos os trabalhos ativos e pedidos de venda neste local — não apenas neste trabalho."
+msgstr "Quantidade total necessária em todas as ordens de produção e pedidos de venda neste local — não apenas desta ordem de produção."
 
 msgid "Total scrap quantity"
-msgstr "Quantidade total de sucata"
+msgstr "Quantidade total de refugo"
 
 msgid "Total tax"
 msgstr "Imposto total"
@@ -16021,10 +16021,10 @@ msgid "Track serial/lot numbers and fulfil sales orders."
 msgstr "Rastreie números de série/lote e cumpra pedidos de vendas."
 
 msgid "Track tax depreciation separately"
-msgstr "Rastrear depreciação fiscal separadamente"
+msgstr "Registrar depreciação fiscal separadamente"
 
 msgid "Track tax depreciation separately from book depreciation and automatically post deferred tax liability entries."
-msgstr "Rastreie a depreciação fiscal separadamente da depreciação contábil e lance automaticamente as entradas de passivo fiscal diferido."
+msgstr "Registrar depreciação fiscal separadamente da depreciação contábil e contabilizar automaticamente entradas de passivo de imposto diferido."
 
 msgid "Track transactions by segment (cost center, project, service line)"
 msgstr "Rastrear transações por segmento (centro de custo, projeto, linha de serviço)"
@@ -16045,7 +16045,7 @@ msgid "Tracked entity ID is required but none was found"
 msgstr "ID da entidade rastreada é obrigatório, mas nenhum foi encontrado"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "O material rastreado é pré-selecionado por ordem de coleta (FEFO), mesmo sem uma lista de coleta."
+msgstr "Material rastreado é pré-selecionado por ordem de separação (FEFO), mesmo sem uma lista de separação."
 
 msgid "Tracking"
 msgstr "Rastreamento"
@@ -16090,13 +16090,13 @@ msgid "Training Plan"
 msgstr "Plano de Treinamento"
 
 msgid "Training your team via the Academy and in-app guides"
-msgstr "Treinar sua equipe através da Academy e guias no aplicativo"
+msgstr "Treinamento da sua equipe via Academy e guias integrados"
 
 msgid "Trainings"
 msgstr "Treinamentos"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "As transações criarão lançamentos contábeis e atualizarão o razão geral."
+msgstr "Transações criarão entradas de diário e atualizarão o livro razão."
 
 msgid "Transfer"
 msgstr "Transferência"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "Lixo"
 
 msgid "Trial Balance"
-msgstr "Balancete de Verificação"
+msgstr "Balancete"
 
 msgid "Trigger"
 msgstr "Gatilho"
@@ -16222,10 +16222,10 @@ msgid "Under Demand-Based Reorder, planning sums demand inside this rolling wind
 msgstr "Sob Reorder Baseado em Demanda, o planejamento soma a demanda dentro desta janela móvel ao calcular uma quantidade de reabastecimento."
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "Sob Quantidade Fixa de Reorder, os pedidos de planejamento são da quantidade exata cada vez que o ponto de reorder é acionado."
+msgstr "Sob quantidade fixa de ressuprimento, a quantidade exata que o planejamento pede cada vez que o ponto de ressuprimento é acionado."
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "Sob Quantidade Máxima, os pedidos de planejamento atingem este nível de estoque disponível quando o ponto de reorder é acionado."
+msgstr "Sob política de quantidade máxima, o planejamento pede até este nível de estoque quando o ponto de ressuprimento é acionado."
 
 msgid "Undo"
 msgstr "Desfazer"
@@ -16291,16 +16291,16 @@ msgid "unknown location"
 msgstr "localização desconhecida"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Suporte funcional ilimitado"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Registros ilimitados"
 
 msgid "Unlink"
 msgstr "Desvinculação"
 
 msgid "Unlink job from sales order?"
-msgstr "Desassociar trabalho da ordem de venda?"
+msgstr "Desvincular ordem de produção do pedido de venda?"
 
 msgid "Unlock"
 msgstr "Desbloquear"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Documentos Não Lançados"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Cancelar publicação"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Cancelar publicação de {name}?"
 
 msgid "Unreceived POs"
 msgstr "POs não recebidas"
@@ -16396,7 +16396,7 @@ msgid "Update a sales order"
 msgstr "Atualizar um pedido de venda"
 
 msgid "Update a shipment"
-msgstr "Atualizar um envio"
+msgstr "Atualizar uma remessa"
 
 msgid "Update a supplier"
 msgstr "Atualizar um fornecedor"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Atualizar problema Linear"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Atualizar tempos de entrega de peças a partir de recibos de compra lançados."
+msgstr "Atualizar lead times de peças a partir de recebimentos de compra contabilizados."
 
 msgid "Update Password"
 msgstr "Atualizar Senha"
@@ -16447,7 +16447,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Atualize as informações do kanban para reabastecimento baseado em varredura."
 
 msgid "Update the purchase order quantities"
-msgstr "Atualizar as quantidades da ordem de compra"
+msgstr "Atualizar as quantidades do pedido de compra"
 
 msgid "Updated"
 msgstr "Atualizado"
@@ -16478,19 +16478,19 @@ msgid "Upgrade to unlock audit history"
 msgstr "Atualize para desbloquear histórico de auditoria"
 
 msgid "Upload"
-msgstr "Carregar"
+msgstr "Enviar arquivo"
 
 msgid "Upload a PDF first"
-msgstr "Carregue um PDF primeiro"
+msgstr "Enviar um PDF primeiro"
 
 msgid "Upload completed but no file path returned"
-msgstr "Upload concluído, mas nenhum caminho de arquivo foi retornado"
+msgstr "Envio concluído, mas nenhum caminho de arquivo foi retornado"
 
 msgid "Upload CSV"
-msgstr "Carregar CSV"
+msgstr "Enviar CSV"
 
 msgid "Upload failed. Please try again."
-msgstr "Falha no envio. Tente novamente."
+msgstr "Envio falhou. Por favor, tente novamente."
 
 msgid "Uploaded model"
 msgstr "Modelo carregado"
@@ -16582,28 +16582,28 @@ msgid "Useful Life (Months)"
 msgstr "Vida Útil (Meses)"
 
 msgid "User"
-msgstr "Utilizador"
+msgstr "Usuário"
 
 msgid "User roles"
-msgstr "Funções de utilizador"
+msgstr "Funções do usuário"
 
 msgid "users"
 msgstr "usuários"
 
 msgid "Users"
-msgstr "Utilizadores"
+msgstr "Usuários"
 
 msgid "Users and groups allowed to open or download this document; the uploader is always included."
 msgstr "Usuários e grupos autorizados a abrir ou baixar este documento; quem fez o upload sempre está incluído."
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "Usuários e grupos autorizados a renomear, substituir ou reetiquetar este documento; quem fez o upload sempre está incluído, e o acesso de edição implica o de visualização."
+msgstr "Usuários e grupos autorizados a renomear, substituir ou re-rotular este documento; quem enviar sempre é incluído, e acesso de edição implica acesso de visualização."
 
 msgid "Users can update this value for themselves"
-msgstr "Os utilizadores podem atualizar este valor para si próprios"
+msgstr "Usuários podem atualizar este valor para si mesmos"
 
 msgid "Users to Update"
-msgstr "Utilizadores a Atualizar"
+msgstr "Usuários a atualizar"
 
 msgid "Valid From"
 msgstr "Válido a partir de"
@@ -16657,19 +16657,19 @@ msgid "Variance between actual and standard BOM component consumption"
 msgstr "Variância entre consumo real e padrão de componentes da BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Variância entre horas e tarifas de roteamento reais e padrão"
+msgstr "Variação entre horas de roteiro reais e padrão, e taxas"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "Variância entre o preço de compra real e o custo padrão"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Variância entre os gastos gerais de fabricação reais e aplicados"
+msgstr "Variação entre custos indiretos de manufatura aplicados e reais"
 
 msgid "Variance from physical inventory count adjustments"
 msgstr "Variância de ajustes de contagem de inventário físico"
 
 msgid "Variance in outside processing costs"
-msgstr "Variância em custos de processamento externo"
+msgstr "Variação em custos de beneficiamento externo"
 
 msgid "Variance only"
 msgstr "Apenas variância"
@@ -16678,7 +16678,7 @@ msgid "VAT Number"
 msgstr "Número de IVA"
 
 msgid "Vendor Write-Off Income"
-msgstr "Rendimento de Cancelamento de Fornecedor"
+msgstr "Receita de Baixa de Fornecedor"
 
 msgid "Verification Error"
 msgstr "Erro de Verificação"
@@ -16703,7 +16703,7 @@ msgstr "Versão"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Versão {0} está publicada agora e será substituída."
 
 msgid "Version:"
 msgstr "Versão:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Ver"
 
 msgid "View Active Jobs"
-msgstr "Ver Tarefas Ativas"
+msgstr "Visualizar ordens de produção ativas"
 
 msgid "View Active Quotes"
 msgstr "Ver Cotações Ativas"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Visualizar Ativo"
 
 msgid "View Assigned Jobs"
-msgstr "Ver Tarefas Atribuídas"
+msgstr "Ver Ordens de Produção Atribuídas"
 
 msgid "View Attachment"
 msgstr "Ver Anexo"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Ver Mestre do Item"
 
 msgid "View Journal Entry"
-msgstr "Visualizar Entrada do Diário"
+msgstr "Ver Lançamento"
 
 msgid "View Lists"
 msgstr "Ver Listas"
 
 msgid "View maintenance dispatch"
-msgstr "Ver despacho de manutenção"
+msgstr "Ver Ordem de Manutenção"
 
 msgid "View Memo"
 msgstr "Ver Memorando"
@@ -16796,7 +16796,7 @@ msgid "View missing values"
 msgstr "Ver valores ausentes"
 
 msgid "View notes"
-msgstr "Ver notas"
+msgstr "Ver Observações"
 
 msgid "View Open"
 msgstr "Ver Abertos"
@@ -16838,7 +16838,7 @@ msgid "View Permissions"
 msgstr "Permissões de Visualização"
 
 msgid "View Picking List"
-msgstr "Ver Lista de Coleta"
+msgstr "Ver Lista de Separação"
 
 msgid "View Prints"
 msgstr "Ver Impressões"
@@ -16898,7 +16898,7 @@ msgid "Visibility"
 msgstr "Visibilidade"
 
 msgid "Visible on a user's public profile"
-msgstr "Visível no perfil público de um utilizador"
+msgstr "Visível no perfil público de um usuário"
 
 msgid "Void"
 msgstr "Anular"
@@ -16916,7 +16916,7 @@ msgid "Void Sales Invoice"
 msgstr "Anular Fatura de Venda"
 
 msgid "Void Shipment"
-msgstr "Anular Envio"
+msgstr "Anular Remessa"
 
 msgid "Voided"
 msgstr "Anulado"
@@ -16928,10 +16928,10 @@ msgid "Voiding this receipt will:"
 msgstr "Anular este recibo irá:"
 
 msgid "Voiding this shipment will:"
-msgstr "Anular este envio irá:"
+msgstr "Anular esta remessa vai:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Percorra cada área com seu campeão e alterne qualquer coisa fora do escopo. Os códigos leem Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Caminhe por cada área com seu campeão e alterne qualquer coisa fora do escopo. Os códigos lêem Módulo.Área.Número (ACC.GL.01 = Contabilidade, Livro razão, item 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Percorra seu processo atual, sistemas e dados"
@@ -16958,7 +16958,7 @@ msgid "Warn but allow"
 msgstr "Avisar mas permitir"
 
 msgid "Warn this many days before expiry"
-msgstr "Avisar com este número de dias antes do vencimento"
+msgstr "Avisar este número de dias antes do vencimento"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Avisar quando a pessoa que inspeciona um item de entrada é a mesma pessoa que o recebeu."
@@ -17104,10 +17104,10 @@ msgid "What kind of change this is: Version updates how the part is made, Revisi
 msgstr "Que tipo de mudança é esta: Versão atualiza como a peça é fabricada, Revisão revisa seus detalhes e documentos, Peça de Substituição troca um novo número de peça que supersede a antiga, e Nova Peça introduz uma peça completamente nova sem predecessor."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Que tipo de saída esta entrada registra — Produção (unidades boas), Sucata (irrecuperável) ou Retrabaho (enviado de volta para correção); revela Scrap Reason quando Sucata."
+msgstr "Que tipo de saída este lançamento registra — Produção (boas unidades), Refugo (irrecuperável) ou Retrabalho (devolvido para correção); revela Motivo de refugo quando Refugo."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Que tipo de PO é este — bens padrão, serviços, processamento externo ou acordo global; determina o layout de linha e as regras de contabilização GL."
+msgstr "Que tipo de Pedido de compra é — bens padrão, serviços, beneficiamento externo ou acordo de fornecimento contínuo; determina o layout da linha e as regras de contabilização da Razão."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
 msgstr "Que tipo de cotação é esta — cotação de fornecedor padrão, cotação com preço de acordo global ou cotação de fabricação contratual; impulsiona o layout de linha de PO quando convertido."
@@ -17122,16 +17122,16 @@ msgid "What this field held before the change. Leave blank for nothing."
 msgstr "O que este campo continha antes da alteração. Deixe em branco para nada."
 
 msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
-msgstr "O que este recebimento está atendendo — uma ordem de compra, uma devolução, uma transferência de entrada ou um recebimento manual sem pai."
+msgstr "O que este Recebimento está satisfazendo — um Pedido de compra, uma devolução, uma Transferência de entrada ou um Recebimento manual sem origem."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "O que este envio está atendendo — uma ordem de vendas, uma transferência de saída, uma devolução RMA ou um envio manual."
+msgstr "O que esta Remessa está satisfazendo — um Pedido de venda, uma Transferência de saída, uma devolução de RMA ou uma Remessa manual."
 
 msgid "What this task means"
 msgstr "O que esta tarefa significa"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Como o que esta entrada de tempo conta — Trabalho (tempo do operador), Máquina (tempo de execução) ou Configuração (tempo de mudança); cada um resume sob uma taxa diferente."
+msgstr "O que esta entrada de tempo conta como — Mão de obra (tempo do operador), Máquina (tempo de execução) ou Setup (tempo de troca); cada uma é totalizada sob uma taxa diferente."
 
 msgid "What to set up"
 msgstr "O que configurar"
@@ -17155,7 +17155,7 @@ msgid "When {name} changes"
 msgstr "Quando {name} muda"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "Quando a vida útil de um produto acabado é definida como Calculada, escolha quais entradas consumidas alimentam o cálculo."
+msgstr "Quando a vida de prateleira de um produto acabado é definida como Calculada, escolha quais entradas consumidas alimentam o cálculo."
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
 msgstr "Quando um número de série ou lote expira e o que acontece se usado depois — uma política da empresa pode Avisar, Bloquear ou BloquearComSubstituição."
@@ -17164,7 +17164,7 @@ msgid "When Carbon committed to having the goods arrive; combined with the shipp
 msgstr "Quando a Carbon se comprometeu com a chegada das mercadorias; combinado com os dias de trânsito do método de envio, isso impulsiona o cálculo retroativo da Data de envio."
 
 msgid "When expired stock is used"
-msgstr "Quando estoque expirado é utilizado"
+msgstr "Quando o estoque vencido é usado"
 
 msgid "When MRP uses the successor for new demand"
 msgstr "Quando o MRP usa o sucessor para nova demanda"
@@ -17176,7 +17176,7 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Quando ativado, os funcionários podem editar o valor deste atributo em seu próprio perfil; caso contrário, apenas os administradores podem fazê-lo."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Quando ativado, as regras de preço (descontos por volume, promoções) ainda se aplicam sobre esta substituição; quando desativado, esta substituição é o preço final."
+msgstr "Quando ativado, regras de precificação (descontos por volume, promoções) ainda se aplicam acima desta sobrescrita; quando desativado, esta sobrescrita é o preço final."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Quando ativado, escanear o código de barras de operação deste processo relata toda a quantidade aberta restante como concluída em uma ação; desabilitar quando os operadores informam regularmente parciais."
@@ -17185,7 +17185,7 @@ msgid "When on, this party's invoices skip tax calculation; the party is respons
 msgstr "Quando ativado, as faturas desta parte ignoram o cálculo de impostos; a parte é responsável por manter o certificado de isenção atual."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "Quando ativado, este override de preço se aplica aos pedidos correspondentes; quando desativado, o override é retido sem exclusão para preservar o histórico de auditoria."
+msgstr "Quando ativado, esta sobrescrita de preço se aplica aos pedidos correspondentes; desativar sem deletar preserva o histórico para auditoria."
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "Quando ativado, esta regra é acionada para cada alvo do seu tipo. As linhas de atribuição são ignoradas, mas preservadas."
@@ -17221,28 +17221,28 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Quando o cartão kanban é escaneado, o trabalho é automaticamente retirado do rascunho e liberado para o piso."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Quando o local receptor espera a chegada do estoque; impulsiona a disponibilidade do MRP no destino."
+msgstr "Quando o local de recebimento espera que o estoque chegue; determina a disponibilidade de MRP no destino."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Quando o fornecedor se comprometeu a entregar; o planejamento usa esta data para a projeção de chegada de estoque de entrada."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "Quando o preço do fornecedor deixa de ser honrado; converter esta cotação para um PO após esta data pode exigir uma nova cotação."
+msgstr "Quando o preço do fornecedor deixa de ser honrado; converter este orçamento em Pedido de compra após esta data pode precisar de uma nova cotação."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Quando este medidor vence para calibração; uma vez vencido, ele lê Fora de Calibração."
+msgstr "Quando este Instrumento de medição vence para calibração; uma vez vencido, mostra Fora de calibração."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Quando este medidor foi calibrado com sucesso pela última vez; a data de próxima calibração é recomputada a partir deste valor mais o intervalo."
+msgstr "Quando este Instrumento de medição foi calibrado pela última vez com sucesso; a data da próxima calibração é recalculada a partir deste valor mais o intervalo."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "Quando isto parecer correto, marque como acordado. Isso completa a etapa de Descoberta no seu centro de comando."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Quando esta linha específica é prometida para envio; substituição por linha da Data Prometida do cabeçalho do pedido para envios divididos."
+msgstr "Quando esta linha específica é prometida para enviar; sobrescrita por linha da Data prometida do cabeçalho do pedido para remessas divididas."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Quando este lote/série específico expira; impulsiona a seleção FEFO e a política de vida de prateleira no consumo."
+msgstr "Quando este lote/série específico vence; impulsiona a separação FEFO e a política de vida de prateleira no consumo."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Quando você se comprometeu a entregar; o planejamento trata isso como a data de vencimento da demanda para o cumprimento."
@@ -17254,19 +17254,19 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "Onde uma notificação de fluxo de trabalho é entregue — no aplicativo é sempre enviado, enquanto e-mail requer um plano Business ou Partner e Slack precisa de seu espaço de trabalho do Slack conectado."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Onde uma operação é executada; leva as taxas de trabalho e cotação, com despesas gerais a diferença entre elas."
+msgstr "Onde uma operação é executada; carrega taxas de mão de obra e cotação, com custos indiretos sendo a diferença entre elas."
 
 msgid "Where and how you make things."
 msgstr "Onde e como você fabrica as coisas."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Para onde os bens neste PO são enviados por padrão pelo fornecedor; os locais de entrega por linha no PO anulam isso para cenários de envio direto e entrega dividida."
+msgstr "Para onde os bens neste Pedido de compra são enviados por padrão; locais de entrega por linha no Pedido de compra anulam isso para cenários de entrega direta e entrega dividida."
 
 msgid "Where it lives today"
 msgstr "Onde fica hoje"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Onde o novo estoque deste item aterroriza por padrão ao receber; as seleções de armazenamento por linha em um recibo o anulam."
+msgstr "Onde o novo estoque deste Item é colocado por padrão no Recebimento; seleções de armazenamento por linha em um Recebimento anulam isso."
 
 msgid "Where stock lives and how it ships."
 msgstr "Onde o estoque fica e como é enviado."
@@ -17296,19 +17296,19 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Se o valor é interpretado como uma porcentagem do preço da linha ou como um valor fixo em moeda."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Se o Carbon acompanha cada unidade (Serial), cada lote (Batch), a quantidade (Inventory) ou nenhum rastreamento (Non-Inventory)."
+msgstr "Se Carbon segue cada unidade (Série), cada lote (Lote de produção), a quantidade (Inventário) ou sem rastreamento (Não estocável)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Se o cronômetro inicia quando o processo escolhido começa ou quando ele termina."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Se este lote/série passa na inspeção (Pass) ou falha (Fail); um Fail impede que o estoque seja recebido no inventário disponível."
+msgstr "Se este lote/série passa na inspeção (Aprovado) ou falha (Reprovado); um Reprovado impede que o estoque seja recebido no estoque disponível."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Se este processo é executado em centros de trabalho internos (Processo, Montagem ou Inspeção) ou em fornecedores externos (Processamento Externo); revela diferentes campos subsequentes, muda como as rotas de planejamento funcionam para este processo e define o tipo de operação padrão em novas operações."
+msgstr "Se este Processo é executado em centros de trabalho internos (Processo, Montagem ou Inspeção) ou em fornecedores externos (Beneficiamento externo); revela campos diferentes a jusante, muda como as rotas de planejamento funcionam para este processo e define o tipo de operação padrão nas novas operações."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "Se este trabalho bloqueia a produção (Inativo), a degrada (Impacto), fica em uma janela de tempo de inatividade planejada (Planejado) ou não tem impacto na produção (Sem Impacto); informa o agendamento e a comunicação de inatividade orientada ao cliente."
+msgstr "Se este trabalho bloqueia a produção (Parada), a degrada (Impacto), está em uma janela de tempo de parada planejada (Planejado) ou não tem impacto na produção (Sem Impacto); informa o agendamento e a comunicação de tempo de parada ao cliente."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "Se as permissões selecionadas forem Adicionadas ao que cada usuário já possui, ou Atualizadas substituindo o conjunto de permissões de cada usuário pela seleção abaixo."
@@ -17317,10 +17317,10 @@ msgid "Which document drives each inspection flow for this item."
 msgstr "Qual documento conduz cada fluxo de inspeção para este item."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Que tipo de solicitação enviar: GET lê algo, POST cria, PUT e PATCH atualizam, DELETE remove. Uma nova etapa começa em GET, e apenas POST, PUT e PATCH carregam um corpo."
+msgstr "Que tipo de solicitação enviar: GET lê algo, POST cria, PUT e PATCH atualizam, DELETE remove. Uma nova etapa começa com GET, e apenas POST, PUT e PATCH carregam um corpo."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
-msgstr "Qual evento de fabricação inicia o relógio da vida útil — por exemplo, preenchimento, selagem ou QC final."
+msgstr "Qual evento de manufatura inicia o relógio de vida de prateleira — por exemplo, preenchimento, vedação ou Controle de Qualidade final."
 
 msgid "Who Can Approve"
 msgstr "Quem Pode Aprovar"
@@ -17329,7 +17329,7 @@ msgid "Who can do what"
 msgstr "Quem pode fazer o quê"
 
 msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
-msgstr "Quem faz o quê, nos seis passos. Seu lado está destacado no topo. Faça bem e o projeto avança."
+msgstr "Quem faz o quê, através das seis etapas. Seu lado está destacado no topo. Faça sua parte bem e o projeto avança."
 
 msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
 msgstr "Quem recebe treinamento sobre o quê, em qual formato. Sua parte: proteja o tempo da sessão prática nos calendários de seus campeões com antecedência. É o que mais escapa quando as empresas ficam ocupadas."
@@ -17338,28 +17338,28 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Quem tem que aprovar cotações, pedidos e compras — e quando"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Quem deve receber notificações para despachos relacionados à manutenção?"
+msgstr "Quem deve receber notificações para ordens de manutenção?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Quem deve receber notificações para despachos relacionados a operações?"
+msgstr "Quem deve receber notificações para despachos relacionados às operações?"
 
 msgid "Who should receive notifications for other dispatches?"
 msgstr "Quem deve receber notificações para outros despachos?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Quem deve receber notificações para despachos relacionados à qualidade?"
+msgstr "Quem deve receber notificações para ordens de manutenção relacionadas à qualidade?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "Quem deve receber notificações quando uma cotação digital é aceita ou expira?"
+msgstr "Quem deve receber notificações quando um orçamento digital é aceito ou vencido?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Quem deve receber notificações quando um medidor sai da calibração?"
+msgstr "Quem deve receber notificações quando um instrumento de medição sai da calibração?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "Quem deve receber notificações quando uma nova sugestão é enviada?"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "Quem deve receber notificações quando um RFQ é marcado como pronto para cotação?"
+msgstr "Quem deve receber notificações quando um RFQ é marcado como pronto para orçamento?"
 
 msgid "Who should receive notifications when a sales job is completed?"
 msgstr "Quem deve receber notificações quando um trabalho de vendas é concluído?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "Por que isso está bloqueado?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Por que o estoque está mudando — Positivo (encontrado), Negativo (perdido/scrap) ou Definir (substituir quantidade com valor medido)."
+msgstr "Por que o estoque está mudando — Positivo (encontrado), Negativo (perdido/refugo), ou Definir (substituir a contagem por um valor medido)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Por que esta linha está sendo recusada; mostrado na cotação imprimível e registrado para relatórios de ganho-perda."
@@ -17401,10 +17401,10 @@ msgid "Window:"
 msgstr "Janela:"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Produto em processo"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Sem uma lista de coleta, os operadores pegam material da aba Digitalizar."
+msgstr "Sem uma lista de separação, operadores separam material da aba Escanear."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17445,16 +17445,16 @@ msgid "Work Centers"
 msgstr "Centros de Trabalho"
 
 msgid "Work in process (WIP)"
-msgstr "Trabalho em Andamento (WIP)"
+msgstr "Trabalho em processo (Produto em processo)"
 
 msgid "Work in progress"
 msgstr "Trabalho em andamento"
 
 msgid "Work in Progress (default)"
-msgstr "Trabalho em Progresso (padrão)"
+msgstr "Trabalho em andamento (padrão)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Trabalho em Progresso (WIP)"
+msgstr "Trabalho em andamento (Produto em processo)"
 
 msgid "Work instruction"
 msgstr "Instrução de trabalho"
@@ -17487,23 +17487,23 @@ msgid "Worst Performing Machines"
 msgstr "Máquinas com Pior Desempenho"
 
 msgid "Write-Down Account"
-msgstr "Conta de Redução de Valor"
+msgstr "Conta de desvalorização"
 
 msgid "Write-off"
-msgstr "Cancelamento"
+msgstr "Baixa contábil"
 
 msgid "Write-Off"
-msgstr "Cancelamento"
+msgstr "Baixa contábil"
 
 msgid "Write-Off Account"
-msgstr "Conta de Cancelamento"
+msgstr "Conta de baixa contábil"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "Cancelamento para {0}"
+msgstr "Baixa contábil para {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Baixa de estoque sucatado ou devolvido por rejeições de inspeção e disposições de NCR"
+msgstr "Baixa contábil de estoque refugado ou devolvido via rejeições de inspeção e disposições de NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
 msgstr "Reduzir o valor de um ativo ao longo de sua vida útil — um lote mensal que você cria, revisa como rascunho e depois contabiliza."
@@ -17560,7 +17560,7 @@ msgid "You don't have permission to edit this bill of material."
 msgstr "Você não tem permissão para editar esta lista de materiais."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Você não tem permissão para editar este fluxo de processo."
+msgstr "Você não tem permissão para editar esta lista de operações."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
 msgstr "Você conduz; nós garantimos que seja feito corretamente. Olhos especialistas na sua configuração, dados e lançamento."
@@ -17576,7 +17576,7 @@ msgid "You lead"
 msgstr "Você lidera"
 
 msgid "You name a project owner with decision authority"
-msgstr "Você nomeia um proprietário do projeto com autoridade de decisão"
+msgstr "Você nomeia um responsável pelo projeto com autoridade de decisão"
 
 msgid "You received this item"
 msgstr "Você recebeu este item"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Está ao vivo no Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Você está a uma etapa de seu espaço de trabalho."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Você está configurando o Carbon por conta própria, no seu próprio ritmo"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Você está marcado há {hoursElapsed} horas. Esqueceu de marcar a saída?"
+msgstr "Você marcou entrada há {hoursElapsed} horas. Você esqueceu de apontar fim?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Sua conta permanece segura mesmo se seu login for roubado"
@@ -17603,7 +17603,7 @@ msgid "Your books and how money flows."
 msgstr "Seus livros e como o dinheiro flui."
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "Suas mudanças vão para uma nova versão de rascunho lançada com este aviso de mudança."
+msgstr "Suas alterações entram em uma nova versão de rascunho liberada com este aviso de alteração."
 
 msgid "Your Console PIN"
 msgstr "Seu PIN do Console"
@@ -17687,7 +17687,7 @@ msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample si
 msgstr "Nível de inspeção Z1.4 (I / II / III); níveis mais altos significam tamanhos de amostra maiores para o mesmo lote."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Gravidade Z1.4 (Normal / Enrijecida / Reduzida); alterna por regra com base no histórico de aceitação de lotes recentes."
+msgstr "Z1.4 severidade (Normal / Severa / Atenuada); muda por regra baseada no histórico recente de aceitação de lotes."
 
 msgid "Zoom Box"
 msgstr "Caixa de Zoom"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -14345,7 +14345,7 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "O Stripe envia a fatura para o cliente, portanto um endereço é obrigatório. Isso também será salvo no contato no Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "O Stripe não tem um cliente para este cliente do Carbon ainda. A contabilização criará um na sua conta conectada."
+msgstr "Stripe ainda não tem um cliente para este cliente do Carbon. A Contabilização criará um na sua conta conectada."
 msgstr "Stripe já possui um cliente com este e-mail"
 
 msgid "Stripe Due Date"
@@ -14355,7 +14355,7 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "O Stripe envia a fatura por e-mail ao cliente, portanto, um endereço é necessário. Isso também será salvo no contato no Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe ainda não possui um cliente para este cliente Carbon. O envio criará um em sua conta conectada."
+msgstr "Stripe ainda não tem um cliente para este cliente do Carbon. A Contabilização criará um na sua conta conectada."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Estilo de saída do kanban para mostrar na tabela Kanban"

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -103,7 +103,7 @@ msgid "Add Sample"
 msgstr "Adicionar Amostra"
 
 msgid "Add Spare Part"
-msgstr "Adicionar Peça Sobressalente"
+msgstr "Adicionar peça de reposição"
 
 msgid "All"
 msgstr "Todos"
@@ -115,7 +115,7 @@ msgid "All rework"
 msgstr "Todos para retrabalho"
 
 msgid "All scrap"
-msgstr "Tudo sucata"
+msgstr "Todo refugo"
 
 msgid "Allocate failed units"
 msgstr "Alocar unidades com falha"
@@ -145,7 +145,7 @@ msgid "Assigned to Me"
 msgstr "Atribuído a Mim"
 
 msgid "Assignee"
-msgstr "Responsável"
+msgstr "Designado"
 
 msgid "Authentication Error"
 msgstr "Erro de Autenticação"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Limpar Pesquisa"
 
 msgid "Clock In"
-msgstr "Registrar Entrada"
+msgstr "Apontar início"
 
 msgid "Clock Out"
-msgstr "Registrar Saída"
+msgstr "Apontar fim"
 
 msgid "Clocked in since <0/>"
 msgstr "Registrado desde <0/>"
@@ -278,7 +278,7 @@ msgid "Consumed"
 msgstr "Consumido"
 
 msgid "Consumed expired"
-msgstr "Consumido expirado"
+msgstr "Consumido vencido"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Detalhes"
 
 msgid "Dispatch not found"
-msgstr "Despacho não encontrado"
+msgstr "Ordem de manutenção não encontrada"
 
 msgid "Display"
 msgstr "Exibição"
@@ -444,11 +444,11 @@ msgid "Expand features table"
 msgstr "Expandir tabela de recursos"
 
 msgid "Expired"
-msgstr "Expirado"
+msgstr "Vencido"
 
 #. placeholder {0}: formatDate(date)
 msgid "Expired {0}"
-msgstr "Expirado em {0}"
+msgstr "Vencido {0}"
 
 msgid "Expires <0/>"
 msgstr "Expira em <0/>"
@@ -485,7 +485,7 @@ msgid "Failed to upload file: {0}"
 msgstr "Falha ao enviar arquivo: {0}"
 
 msgid "Failed to upload image"
-msgstr "Falha ao enviar imagem"
+msgstr "Falha ao enviar arquivo de imagem"
 
 msgid "Feature"
 msgstr "Recurso"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Terminar Mesmo Assim"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Finalize a configuração de sua conta"
 
 msgid "Finish with material unpicked?"
 msgstr "Finalizar com material não selecionado?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Esqueceu de Registrar Saída?"
+msgstr "Esqueceu de apontar fim?"
 
 msgid "Go back to operation"
 msgstr "Voltar para operação"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Ir para integração"
 
 msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
@@ -616,13 +616,13 @@ msgid "Job Details"
 msgstr "Detalhes da Ordem"
 
 msgid "Job Traveler"
-msgstr "Folha de Processo"
+msgstr "Ficha de acompanhamento"
 
 msgid "Jobs"
-msgstr "Trabalhos"
+msgstr "Ordens de produção"
 
 msgid "Keep picking"
-msgstr "Continuar selecionando"
+msgstr "Continuar separação"
 
 msgid "Kit"
 msgstr "Kit"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Manutenção Concluída"
 
 msgid "Maintenance overdue"
-msgstr "Manutenção vencida"
+msgstr "Manutenção atrasada"
 
 msgid "Make a replacement"
 msgstr "Fazer uma substituição"
@@ -776,7 +776,7 @@ msgid "No active job at this work center"
 msgstr "Nenhum trabalho ativo neste centro de trabalho"
 
 msgid "No active maintenance dispatches"
-msgstr "Nenhum despacho de manutenção ativo"
+msgstr "Nenhuma ordem de manutenção ativa"
 
 msgid "No active operations"
 msgstr "Nenhuma operação ativa"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Nenhuma entidade rastreada disponível encontrada"
 
 msgid "No dispatches assigned to you"
-msgstr "Nenhum despacho atribuído a você"
+msgstr "Nenhuma ordem de manutenção atribuída a você"
 
 msgid "No files"
 msgstr "Nenhum arquivo"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Nenhum material"
 
 msgid "No open jobs"
-msgstr "Nenhum trabalho aberto"
+msgstr "Nenhuma ordem de produção aberta"
 
 msgid "No open units to allocate"
 msgstr "Nenhuma unidade aberta para alocar"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "Nenhuma opção encontrada."
 
 msgid "No picking lists assigned"
-msgstr "Nenhuma lista de picking atribuída"
+msgstr "Nenhuma lista de separação atribuída"
 
 msgid "No printer configured"
 msgstr "Nenhuma impressora configurada"
@@ -866,7 +866,7 @@ msgid "No serial numbers found"
 msgstr "Nenhum número de série encontrado"
 
 msgid "No spare parts added yet"
-msgstr "Nenhuma peça sobressalente adicionada ainda"
+msgstr "Nenhuma peça de reposição adicionada ainda"
 
 msgid "No stock"
 msgstr "Sem stock"
@@ -899,7 +899,7 @@ msgid "Nothing scheduled at this work center"
 msgstr "Nada agendado neste centro de trabalho"
 
 msgid "Nothing to scrap"
-msgstr "Nada para descartar"
+msgstr "Nada para refugar"
 
 msgid "OEE Impact"
 msgstr "Impacto OEE"
@@ -927,7 +927,7 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Abrir um NCR para disposição MRB"
 
 msgid "Open Jobs"
-msgstr "Trabalhos Abertos"
+msgstr "Ordens de produção abertas"
 
 msgid "Operations"
 msgstr "Operações"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "Resultado geral"
 
 msgid "Overdue PMs?"
-msgstr "PMs vencidos?"
+msgstr "Manutenções preventivas atrasadas?"
 
 msgid "Parameters"
 msgstr "Parâmetros"
@@ -969,7 +969,7 @@ msgid "Passed Inspection"
 msgstr "Aprovado na Inspeção"
 
 msgid "Passkey unlock failed"
-msgstr "Falha ao desbloquear com passkey"
+msgstr "Falha ao desbloquear com chave de acesso"
 
 msgid "Pause"
 msgstr "Pausar"
@@ -1093,7 +1093,7 @@ msgid "Remove part"
 msgstr "Remover peça"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "Reabrir a subassebleia e criar uma unidade de substituição"
+msgstr "Reabrir o subconjunto e criar uma unidade de substituição"
 
 msgid "Result"
 msgstr "Resultado"
@@ -1102,7 +1102,7 @@ msgid "Rework"
 msgstr "Retrabalho"
 
 msgid "Rework created successfully"
-msgstr "Rework criado com sucesso"
+msgstr "Retrabalho criado com sucesso"
 
 msgid "Rework quantity"
 msgstr "Quantidade de retrabalho"
@@ -1120,37 +1120,37 @@ msgid "Scan"
 msgstr "Escanear"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "Digitalizar uma entidade rastreada para adicionar a primeira coluna de amostra."
+msgstr "Escanear uma entidade rastreada para adicionar a primeira coluna de amostra."
 
 msgid "Scan or enter serial number"
 msgstr "Escanear ou inserir número de série"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Digitalizar ou inserir ID da entidade rastreada, serial ou lote"
+msgstr "Escanear ou inserir ID de entidade rastreada, número de série ou lote de produção"
 
 msgid "Scan or enter tracking number"
-msgstr "Digitalize ou insira o número de rastreamento"
+msgstr "Escanear ou inserir número de rastreamento"
 
 msgid "Scan or search serial number..."
-msgstr "Digitalize ou procure número de série..."
+msgstr "Escanear ou pesquisar número de série..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Digitalizar ou selecionar uma entidade rastreada deste lote para adicioná-la como uma coluna de amostra, depois registre seu resultado na grade."
+msgstr "Escanear ou selecionar uma entidade rastreada deste lote para adicioná-la como coluna de amostra, depois registrar seu resultado na grade."
 
 msgid "Schedule"
 msgstr "Cronograma"
 
 msgid "Scrap"
-msgstr "Sucata"
+msgstr "Refugo"
 
 msgid "Scrap {readableId}"
-msgstr "Descartar {readableId}"
+msgstr "Refugar {readableId}"
 
 msgid "Scrap material"
-msgstr "Descartar material"
+msgstr "Material refugado"
 
 msgid "Scrap quantity"
-msgstr "Quantidade de sucata"
+msgstr "Quantidade de refugo"
 
 msgid "Scrap Reason"
 msgstr "Motivo do Refugo"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Sessão bloqueada"
 
 msgid "Set Clock Out"
-msgstr "Definir Saída"
+msgstr "Definir apontar fim"
 
 msgid "Set clock-out time"
 msgstr "Definir horário de saída"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "Entrar com Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Entrar com Passkey"
+msgstr "Entrar com chave de acesso"
 
 msgid "Sign out"
 msgstr "Sair"
@@ -1300,10 +1300,10 @@ msgid "Source"
 msgstr "Origem"
 
 msgid "Spare Parts"
-msgstr "Peças Sobressalentes"
+msgstr "Peças de reposição"
 
 msgid "Spare Parts Used"
-msgstr "Peças Sobressalentes Utilizadas"
+msgstr "Peças de reposição utilizadas"
 
 msgid "Start"
 msgstr "Iniciar"
@@ -1316,7 +1316,7 @@ msgstr "Estação: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "A aceitação estatística falhou, portanto o lote inteiro de {0} é considerado não-conforme (ISO 9001:2015 §8.7) — {passes} amostra(s) aprovada(s) e {fails} falha(s). Encaminhe as unidades abaixo para sucata ou retrabalho, ou registre apenas o veredicto."
+msgstr "A aceitação estatística falhou, portanto o lote inteiro de {0} é considerado não-conforme (ISO 9001:2015 §8.7) — {passes} amostra(s) aprovada(s) e {fails} falha(s). Encaminhe as unidades abaixo para refugo ou retrabalho, ou registre apenas o veredito."
 
 msgid "Status"
 msgstr "Status"
@@ -1370,10 +1370,10 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Estes itens ainda têm material para selecionar. Finalizar agora marca a lista como Parcial."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Este lote expirou e não pode ser selecionado."
+msgstr "Este lote está vencido e não pode ser separado."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Esta peça foi feita sob encomenda. Descartá-la pode reabrir seu roteamento para fazer uma substituição."
+msgstr "Esta peça foi fabricada sob encomenda. Refugá-la pode reabrir seu roteiro de produção para fazer uma substituição."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
 msgstr "Esta peça será descartada do estoque. Seu requisito permanece aberto para que você possa emitir uma substituição."
@@ -1436,7 +1436,7 @@ msgid "Unlock"
 msgstr "Desbloquear"
 
 msgid "Unlock with passkey"
-msgstr "Desbloquear com passkey"
+msgstr "Desbloqueie com chave de acesso"
 
 msgid "Unpick"
 msgstr "Desmarcar"
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "Desmarcar {0}"
 
 msgid "Unplanned downtime"
-msgstr "Tempo de inatividade não planejado"
+msgstr "Tempo de parada não planejado"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1459,7 +1459,7 @@ msgid "Up next"
 msgstr "Próximo"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
-msgstr "Até {maxAllocatable} unidade(s) pode(m) ser alocada(s); o restante é registrado sem uma postagem."
+msgstr "Até {maxAllocatable} unidade(s) pode(m) ser alocada(s); o restante é registrado sem contabilização."
 
 msgid "Update"
 msgstr "Atualizar"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "Verificar"
 
 msgid "View maintenance dispatch"
-msgstr "Ver despacho de manutenção"
+msgstr "Visualizar ordem de manutenção"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "Enviamos um link mágico para você entrar na sua conta."
@@ -1495,7 +1495,7 @@ msgid "What is {translatedTerm}?"
 msgstr "O que é {translatedTerm}?"
 
 msgid "WIP"
-msgstr "WIP"
+msgstr "Produto em processo"
 
 msgid "Work Center"
 msgstr "Centro de Trabalho"
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Você marcou entrada às <0/>. Você pode editar a hora de saída abaixo ou confirmar que ainda está trabalhando."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Você está registrado há {hoursElapsed} horas. Esqueceu de registrar a saída?"
+msgstr "Você está apontando há {hoursElapsed} horas. Você esqueceu de apontar fim?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Sua conta ainda não faz parte de uma empresa. Conclua o onboarding no Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Sua organização requer um aplicativo autenticador. Configure-o no Carbon e retorne aqui."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -520,7 +520,6 @@ msgstr "Terminar Mesmo Assim"
 
 msgid "Finish setting up your account"
 msgstr "Finalize a configuração de sua conta"
-msgstr "Termine de configurar sua conta"
 
 msgid "Finish with material unpicked?"
 msgstr "Finalizar com material não selecionado?"
@@ -533,7 +532,6 @@ msgstr "Voltar para operação"
 
 msgid "Go to onboarding"
 msgstr "Ir para integração"
-msgstr "Ir para a integração"
 
 msgid "How many were actually picked?"
 msgstr "Quantos foram realmente apanhados?"
@@ -1516,7 +1514,6 @@ msgstr "Você está apontando há {hoursElapsed} horas. Você esqueceu de aponta
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Sua conta ainda não faz parte de uma empresa. Conclua o onboarding no Carbon ERP para continuar."
-msgstr "Sua conta ainda não faz parte de uma empresa. Complete a integração no Carbon ERP para continuar."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Sua organização requer um aplicativo autenticador. Configure-o no Carbon e retorne aqui."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -8936,7 +8936,7 @@ msgid "Map Lines Now"
 msgstr "Сопоставить строки сейчас"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Сопоставьте свой план счетов с планом счетов провайдера. Счета учета по умолчанию и счета расходов обозначены как Требуемые; проведенные журналы отправляются с использованием сопоставленного кода счета провайдера."
+msgstr "Сопоставьте ваш план счетов с планом счетов провайдера. Счета проведения по умолчанию и счета расходов отмечены как требуемые; проведенные операции отправляются, используя сопоставленный код счета провайдера."
 
 msgid "Map your current process, systems, and data"
 msgstr "Сопоставьте ваш текущий процесс, системы и данные"
@@ -11620,7 +11620,7 @@ msgid "Protect training time and attend"
 msgstr "Защитите время обучения и участвуйте"
 
 msgid "Protect your company with advanced security controls like two-factor authentication enforcement."
-msgstr "Защитите вашу компанию с помощью расширенных элементов управления безопасностью, таких как принудительное применение двухфакторной аутентификации."
+msgstr "Защитите свою организацию передовыми средствами управления безопасностью, такими как требование двухфакторной аутентификации."
 
 msgid "Protects your company's data"
 msgstr "Защищает данные вашей организации"
@@ -12499,7 +12499,7 @@ msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "Требовать 6-значный код из приложения-аутентификатора при входе."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected."
-msgstr "Требуется приложение-аутентификатор, прежде чем кто-либо сможет открыть эту компанию. Их другие компании не будут затронуты."
+msgstr "Требовать использование приложения аутентификатора, прежде чем кто-либо сможет открыть эту организацию. Их другие организации не затрагиваются."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
 msgstr "Требовать приложение аутентификатора перед тем как кто-либо сможет открыть эту организацию. Их другие организации не затронуты. Посетите страницу <0>учетных записей сотрудников</0>, чтобы увидеть статус каждого человека."
@@ -14352,17 +14352,17 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe отправляет счет-фактуру клиенту по электронной почте, поэтому требуется адрес. Он также будет сохранен в контакте в Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "В Stripe еще нет покупателя для этого покупателя Carbon. При проведении будет создан в вашей подключенной учетной записи."
+msgstr "Stripe еще не имеет покупателя для этого покупателя Carbon. Проведение создаст его на вашем подключенном счете."
 msgstr "В Stripe уже есть клиент с этой электронной почтой"
 
 msgid "Stripe Due Date"
-msgstr "Срок платежа Stripe"
+msgstr "Срок выполнения Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe отправляет счет клиенту, поэтому требуется адрес. Это также будет сохранено в контакт в Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe еще не имеет клиента для этого клиента Carbon. Отправка создаст его на вашем подключенном счете."
+msgstr "Stripe еще не имеет покупателя для этого покупателя Carbon. Проведение создаст его на вашем подключенном счете."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Стиль вывода канбана для отображения в таблице Канбана"
@@ -15672,11 +15672,11 @@ msgid "This invoice has no usable due date — choose one for Stripe."
 msgstr "Этот счет-фактура не имеет используемого срока выполнения — выберите один для Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его детали, отредактируйте его в панели инструментов Stripe."
+msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его данные, отредактируйте его в панели Stripe."
 msgstr "Этот счет не имеет пригодного срока платежа — выберите один для Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr "Этот счет будет отправлен клиенту Stripe, уже связанному с этим клиентом Carbon. Чтобы изменить его детали, отредактируйте его в панели управления Stripe."
+msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его данные, отредактируйте его в панели Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Это контролируемая среда, поэтому требуется приложение аутентификации."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -30,10 +30,10 @@ msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
 msgstr "\"{0}\" недоступно на выбранной поверхности (поверхностях). Выберите другое поле."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
-msgstr "«{storageUnitName}» содержит {childCount} прямых вложенных единиц хранения. Удаление приведет к удалению этих единиц и всего, что находится под ними. Это действие невозможно отменить."
+msgstr "\"{storageUnitName}\" содержит {childCount} прямо вложенных единиц хранения. При удалении также будут удалены они и всё находящееся под ними. Это невозможно отменить."
 
 msgid "\"{storageUnitName}\" has 1 direct nested storage unit. Deleting it will also delete that unit and anything underneath it. This cannot be undone."
-msgstr "«${storageUnitName}» имеет 1 прямую вложенную единицу хранения. Удаление её также удалит эту единицу и всё, что находится под ней. Это невозможно отменить."
+msgstr "«{storageUnitName}» имеет 1 прямую вложенную единицу хранения. Удаление её также удалит эту единицу и всё, что находится под ней. Это невозможно отменить."
 
 #. placeholder {0}: setupProgress.total
 #. placeholder {1}: setupProgress.done
@@ -43,14 +43,14 @@ msgstr "\"{taskName}\" автоматически отмечается как в
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "\"{taskName}\" выполнена — все {0} элементов её Setup Map настроены."
+msgstr "«{taskName}» готово — все {0} позиций графика наладки настроены."
 
 msgid "(excluded for this customer)"
-msgstr "(исключено для этого клиента)"
+msgstr "(исключено для этого покупателя)"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
-msgstr "{0, plural, one {Этот товар находится в 1 открытом уведомлении об изменении} other {Этот товар находится в # открытых уведомлениях об изменении}}"
+msgstr "{0, plural, one {Эта номенклатура находится в 1 открытом извещении об изменении} other {Эта номенклатура находится в # открытых извещениях об изменении}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -66,7 +66,7 @@ msgstr "{0} ячеек с разницами"
 
 #. placeholder {0}: ar.count
 msgid "{0} customers with a balance"
-msgstr "{0} клиентов с остатком"
+msgstr "{0} покупателей с остатком"
 
 #. placeholder {0}: rule.escalationDays
 msgid "{0} days"
@@ -79,11 +79,11 @@ msgstr "{0} успешно удален"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} черновых записей в журнале"
+msgstr "{0} черновых операций"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} заданий создано"
+msgstr "{0} производственных заказов создано"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -92,7 +92,7 @@ msgstr "{0} строк для сопоставления"
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
-msgstr "{0} из {1} счетов сопоставлено"
+msgstr "{0} из {1} счетов проведения отображено"
 
 #. placeholder {0}: rows.length
 msgid "{0} of {maxSlots} provider slots used"
@@ -120,7 +120,7 @@ msgstr "{0} поставщиков с остатком"
 
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
-msgstr "{0} необследованных объектов будут отпущены в статус Available. Проверенные успешные остаются Available, а проверенные отказы остаются Rejected."
+msgstr "{0} необследованные единицы будут переведены в Доступно. Пройденные образцы остаются в Доступно, отклоненные образцы остаются в Отклонено."
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -145,7 +145,7 @@ msgid "{0} values missing"
 msgstr "{0} значений отсутствует"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} деталей пропущено — у них уже есть открытые задания"
+msgstr "{alreadyPlannedItemCount} деталей пропущено — у них уже есть открытые производственные заказы"
 
 msgid "{apOverduePct}% of payables"
 msgstr "{apOverduePct}% кредиторской задолженности"
@@ -169,7 +169,7 @@ msgid "{from}–{to} of {count} operations"
 msgstr "{from}–{to} из {count} операций"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} еще: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} месяцев с несовпадающими итогами"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "{missingCount} журналов отсутствуют в системе"
+msgstr "{missingCount} операций не найдено в поставщике"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} отсутствующих журналов и {mismatchCount} месяцев с несовпадениями"
+msgstr "{missingCount} не найдено операций и {mismatchCount} несовпадающих месяцев"
 
 msgid "{name} deleted"
 msgstr "{name} удален"
@@ -199,16 +199,16 @@ msgstr "{noDemandItemCount} деталей пропущено — нечего �
 
 #. placeholder {0}: (routeData?.purchaseOrder?.revisionId ?? 0) + 1
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
-msgstr "{orderLabel} будет переоткрыта для редактирования как редакция {0}. Документ, уже отправленный поставщику, остается без изменений, пока вы не завершите и не отправите заказ заново."
+msgstr "{orderLabel} будет переоткрыт для редактирования как ревизия {0}. Отправленный поставщику документ останется неизменным, пока вы не завершите и не переотправите заказ."
 
 msgid "{remaining, plural, one {# phase left} other {# phases left}}"
 msgstr "{remaining, plural, one {# этап остался} other {# этапов осталось}}"
 
 msgid "{scopeCount} permissions"
-msgstr "{scopeCount} разрешений"
+msgstr "{scopeCount} прав доступа"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "{total} этапов, чтобы ваша компания начала работать на Carbon. Каждый заканчивается контрольной точкой."
+msgstr "{total} этапов для запуска вашей организации на Carbon. Каждый завершается контрольной точкой."
 
 msgid "{total} phases to go live"
 msgstr "{total} этапов до запуска"
@@ -220,7 +220,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} заданий обновлено"
+msgstr "{updatedJobCount} производственных заказов обновлено"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "Файл {uploadedFileName} загружен — поля заполнены из документа."
@@ -246,7 +246,7 @@ msgid "↩ {0} redirected from superseded {1}"
 msgstr "↩ {0} перенаправлено из снятых с производства {1}"
 
 msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
-msgstr "<0>Добавьте компонент поставщика</0> для этого товара, чтобы установить предпочтительного поставщика."
+msgstr "<0>Добавить поставщика деталей</0> для этой номенклатуры, чтобы установить основного поставщика."
 
 msgid "0 operations"
 msgstr "0 операций"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 день"
 
 msgid "1 draft journal entry"
-msgstr "1 черновая запись в журнале"
+msgstr "1 черновая проводка"
 
 msgid "1 job created"
 msgstr "1 задание создано"
@@ -303,13 +303,13 @@ msgid "4h"
 msgstr "4ч"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "Минимум 5 пользователей"
 
 msgid "5-8 weeks"
 msgstr "5-8 недель"
 
 msgid "52-week demand"
-msgstr "Спрос за 52 недели"
+msgstr "Потребность на 52 недели"
 
 msgid "5MB file limit"
 msgstr "Лимит файла 5МБ"
@@ -330,73 +330,73 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Миграция данных, управляемая Carbon — вы загружаете свои собственные данные"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Уведомление об изменении отслеживает контролируемое инженерное или производственное изменение через проверку и реализацию."
+msgstr "Извещение об изменении отслеживает контролируемое техническое или производственное изменение на протяжении рассмотрения и внедрения."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
-msgstr "Расчетный счет, содержащий стоимость полученных, но не выставленных счетом товаров; счет поставщика его закрывает."
+msgstr "Счет, содержащий стоимость полученных товаров, еще не выставленных счетом; счет-фактура поставщика его очищает."
 
 msgid "A company that designs and builds its own finished products end to end (here, the shop building humanoid robots) rather than making parts to another company's specification."
-msgstr "Компания, которая проектирует и производит собственные готовые изделия с начала до конца (здесь магазин, производящий гуманоидных роботов), вместо производства деталей по спецификации другой компании."
+msgstr "Организация, которая проектирует и производит свои готовые продукты полностью (здесь — цех, производящий гуманоидных роботов), а не производит детали по спецификации другой организации."
 
 msgid "A company that sits at or above selected companies in the group hierarchy and receives their intercompany cancelling entries for consolidated reporting; it is never a party to the trade itself."
-msgstr "Компания, находящаяся на уровне или выше выбранных компаний в иерархии группы и получающая их взаимокомпенсирующие записи для консолидированной отчетности; она никогда не является стороной торговли."
+msgstr "Организация, которая находится на уровне или выше выбранных организаций в иерархии группы и получает их взаимозачетные проводки для консолидированной отчетности; она никогда не является стороной сделки."
 
 msgid "A company-defined extra field attached to a core table (customer, part, order); it shows on the record's form, saves alongside the built-in fields, and is queryable through the API."
-msgstr "Дополнительное поле, определённое компанией и прикреплённое к основной таблице (клиент, товар, заказ); оно отображается в форме записи, сохраняется вместе со встроенными полями и доступно для запросов через API."
+msgstr "Определенное организацией дополнительное поле, прикрепленное к основной таблице (покупатель, деталь, заказ); оно отображается на форме записи, сохраняется вместе со встроенными полями и доступно через API."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Определённая компанией ось тегов, прикреплённая к строкам журнала, позволяющая разбивать одни и те же счета по местоположению, отделению или любой другой пользовательской оси без увеличения плана счетов."
+msgstr "Определенная организацией ось тегов, прикрепленная к строкам операций, позволяющая разделить одни и те же счета по площадке, отделу или любой пользовательской оси без увеличения плана счетов."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
-msgstr "Скидка или надбавка в масштабе компании (в процентах или фиксированной сумме), которая корректирует цену строки вверх или вниз, когда строка соответствует условиям правила по количеству, дате, товару и клиенту."
+msgstr "Определенные организацией скидка или надбавка в процентах или фиксированной сумме, которая повышает или понижает цену строки, когда строка соответствует условиям количества, даты, номенклатуры и покупателя правила."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "Выход завершенной работы, поступающий в запасы по фактической накопленной стоимости незавершенного производства."
+msgstr "Продукция завершенного производственного заказа, поступившая в запасы по фактической накопленной себестоимости незавершенного производства заказа."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Расходный материал — это физический предмет, используемый для изготовления детали, которая может использоваться в нескольких заданиях"
+msgstr "Расходный материал — это физическая номенклатура, используемая для производства детали, которая может быть использована в нескольких производственных заказах."
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Подрядчик — это контакт поставщика с особыми навыками и доступными часами"
+msgstr "Подрядчик — контактное лицо поставщика с определенными навыками и доступными часами."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Пользовательское решение для удовлетворения ваших потребностей."
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Клиент — это компания или физическое лицо, которое покупает ваши детали или услуги."
 
 msgid "A customer is created"
-msgstr "Клиент создан"
+msgstr "Покупатель создан."
 
 msgid "A customer is deleted"
-msgstr "Клиент удален"
+msgstr "Покупатель удален."
 
 msgid "A customer's account manager changes"
-msgstr "Менеджер учета клиента изменяется"
+msgstr "Изменился менеджер аккаунта покупателя."
 
 msgid "A customer's assignee changes"
-msgstr "Исполнитель клиента изменяется"
+msgstr "Изменился исполнитель покупателя."
 
 msgid "A customer's currency changes"
-msgstr "Валюта клиента изменяется"
+msgstr "Изменилась валюта покупателя."
 
 msgid "A customer's name changes"
-msgstr "Имя клиента изменяется"
+msgstr "Изменилось имя покупателя."
 
 msgid "A customer's sales contact changes"
-msgstr "Контакт по продажам клиента изменяется"
+msgstr "Изменилось контактное лицо по продажам покупателя."
 
 msgid "A customer's status changes"
-msgstr "Статус клиента изменяется"
+msgstr "Статус покупателя изменяется"
 
 msgid "A customer's type changes"
-msgstr "Тип клиента изменяется"
+msgstr "Тип покупателя изменяется"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "Датированная запись, подтверждающая проверку калибра по отслеживаемому стандарту; она проходит проверку, если не установлены флаги требует-действия, требует-регулировки или требует-ремонта, и перезагружает следующую дату поверки калибра."
+msgstr "Датированная запись проверки средства измерения по эталонному стандарту; результат — Годен, если не установлены флаги требуемого действия, корректировки или ремонта. Сбрасывает дату следующей проверки."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Датированный период, в который попадают проводки; статус его закрытия меняется с Открыто → Заблокировано → Закрыто, и закрытый период заморожен для новых проводок."
+msgstr "Датированный период, в который попадают проведения; статус закрытия переходит Открыто → Заблокировано → Закрыто, и закрытый период недоступен для новых проведений."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "Метод амортизации, который списывает фиксированный процент от оставшейся балансовой стоимости каждый период — больше в начале, меньше позже."
@@ -405,16 +405,16 @@ msgid "A depreciation method that charges an equal amount each period across the
 msgstr "Метод амортизации, который списывает равную сумму каждый период в течение срока полезного использования актива."
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
-msgstr "Твердое обязательство клиента доставить; статус выполнения разделяется между отгрузкой и счетом перед достижением Завершено."
+msgstr "Твёрдое обязательство покупателя поставить; статус выполнения разделяется между отправкой и счётом перед достижением статуса Завершено."
 
 msgid "A firm order to a supplier; status moves through receive and invoice before Completed as goods and bills arrive."
-msgstr "Твердый заказ поставщику; статус проходит через получение и счет перед Завершено по мере поступления товаров и счетов."
+msgstr "Твердый заказ поставщику; статус переходит через поступление и счет-фактуру перед Завершено по мере поступления товаров и счетов."
 
 msgid "A formal acceptance / sign-off phase"
 msgstr "Формальная фаза принятия / подписания"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "Калибр, выполняющий роль Мастер — эталонный стандарт, на который калибруются другие калибры, а не используемый для плановых проверок."
+msgstr "Средство измерения, роль которого — Эталон — эталонный стандарт, по которому калибруются другие средства измерения, а не используется при текущих проверках."
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "Запись о проблеме отслеживает проблемы качества и процесс их разрешения."
@@ -432,7 +432,7 @@ msgid "A job is released"
 msgstr "Работа выпущена"
 
 msgid "A job operation is completed"
-msgstr "Операция работы завершена"
+msgstr "Операция производственного заказа завершена"
 
 msgid "A job's assignee changes"
 msgstr "Исполнитель работы изменяется"
@@ -441,7 +441,7 @@ msgid "A job's deadline type changes"
 msgstr "Тип крайнего срока работы изменяется"
 
 msgid "A job's due date changes"
-msgstr "Дата выполнения работы изменяется"
+msgstr "Срок выполнения производственного заказа изменяется"
 
 msgid "A job's priority changes"
 msgstr "Приоритет работы изменяется"
@@ -467,40 +467,40 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Список подключен к {0}, поэтому этот шаг выполняется один раз для каждого элемента в нем — до {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Компонент \"Производство на заказ\", который получает собственное задание и маршрут в рамках построения родительского компонента."
+msgstr "Компонент производства под заказ, получающий собственный производственный заказ и маршрут при сборке родительского."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Компонент \"Производство на заказ\", части которого выпускаются вместе в родительское задание — без отдельного построения."
+msgstr "Компонент производства под заказ, детали которого списаны вместе в родительский производственный заказ — без отдельной сборки."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Управляемая облачная версия Carbon"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Управляемая версия со всеми расширенными возможностями"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Материал — это физический предмет, используемый для изготовления детали, которая может использоваться в нескольких заданиях"
+msgstr "Материал — это физический элемент, применяемый при изготовлении деталей и используемый в нескольких производственных заказах"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "Измерительный инструмент (штангенциркуль, микрометр, пробка, КММ), отслеживаемый как запись и подлежащий повторяющемуся графику поверки."
+msgstr "Средство измерения (кронциркуль, микрометр, щуп, CMM) отслеживаемое как запись и регулярно проходящее калибровку по графику."
 
 msgid "A name is required to save a view"
 msgstr "Требуется имя для сохранения представления"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Согласованная цена, установленная для конкретного товара — для клиента, типа клиента или всех клиентов — заменяющая базовую цену полностью, при необходимости с ценовыми льготами по количеству."
+msgstr "Согласованная цена, установленная для конкретной номенклатуры — по покупателю, типу покупателя или для всех покупателей — которая полностью заменяет базовую цену, опционально с шкалами количества."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
 msgstr "Для каждого поставщика будет создан новый заказ на покупку. Кроме того, вы можете выбрать существующий черновик заказа на покупку поставщика, чтобы добавить к нему внешние операции."
 
 msgid "A new revision will be created using a copy of the current revision"
-msgstr "Новая редакция будет создана с использованием копии текущей редакции"
+msgstr "Новая ревизия будет создана на основе копии текущей ревизии"
 
 msgid "A new size will be created using a copy of the current size"
 msgstr "Новый размер будет создан с использованием копии текущего размера"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Будет создана новая учетная запись покупателя Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Неденежный документ, погашающий счёт-фактуру по счёту причин: кредит уменьшает сумму задолженности, дебет её увеличивает."
@@ -512,52 +512,52 @@ msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) adde
 msgstr "Неналоговый сбор (например, возмещаемые расходы в виде сборов за разрешения), добавляемый к строке и исключенный из налоговой базы."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Задача о несоответствии, которая исправляет подтвержденную коренную причину — в отличие от превентивных или немедленных мер по содержанию."
+msgstr "Задача несоответствия, которая устраняет подтвержденную коренную причину — в отличие от предупреждающего или немедленного действия локализации."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "Задача о несоответствии, которая предотвращает повторение проблемы в другом месте — отличается от корректирующего решения и содержания."
+msgstr "Задача несоответствия, которая предотвращает повторение проблемы в других местах — отличающаяся от исправления и локализации."
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "Деталь содержит информацию о конкретном товаре, который можно приобрести или изготовить."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "Физический сигнал вытягивания — печатная карточка или QR-код, находящиеся со складом, — которые создают заказ на покупку или работу в момент сканирования для пополнения корзины."
+msgstr "Физический сигнал вытягивания — печатная карточка или QR-код, находящийся рядом с запасом — который создает заказ поставщику или производственный заказ в момент сканирования для пополнения ячейки."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "Точка в одном из собственных потоков Carbon, за которой может наблюдать рабочий процесс — выпуск работы, принятие предложения, отправка партии — в отличие от простого изменения поля; она передает рабочему процессу затронутые записи по идентификатору."
+msgstr "Точка в одном из потоков Carbon, которую может отслеживать рабочий процесс — например, запуск производственного заказа, принятие коммерческого предложения, проведение отгрузки — в отличие от простого изменения поля; она передает рабочему процессу вовлеченные записи по идентификатору."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
 msgstr "Учтенная бухгалтерская запись: заголовок плюс сбалансированные строки дебетовых и кредитовых записей по счетам ГЛ."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Проведённая кассовая операция — Поступление от клиента или Выплата поставщику — применяемая к счетам-фактурам через расчёты, переходя из Черновика → Проведено → Аннулировано."
+msgstr "Проведённая денежная операция — Поступление от покупателя или Выплата поставщику — применённая к счётам через расчёты, переходящая Черновик → Проведено → Аннулировано."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Предварительно написанное описание, вставляемое в каждую проблему, использующую этот рабочий процесс; заполнители, такие как {itemId} и {location}, заменяются при создании."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "Оценка цены продажи; Черновик → Отправлено → Заказано, или заканчивается Потеряно, Истекло или Отменено."
+msgstr "Котировка продажи с ценой; Черновик → Отправлено → Заказано, либо завершается как Проиграно, Истек срок или Отменено."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
-msgstr "Счет-фактура покупателя — это документ, в котором указаны продукты или услуги, приобретенные клиентом, и соответствующие затраты."
+msgstr "Счет-фактура полученная — это документ, который определяет товары или услуги, приобретенные покупателем, и соответствующую себестоимость."
 
 msgid "A purchase invoice is posted"
-msgstr "Счет на закупку отправлен"
+msgstr "Счет-фактура полученная проведена"
 
 msgid "A purchase order is created"
-msgstr "Заказ на закупку создан"
+msgstr "Заказ поставщику создан"
 
 msgid "A purchase order is deleted"
-msgstr "Заказ на закупку удален"
+msgstr "Заказ поставщику удален"
 
 msgid "A purchase order's assignee changes"
-msgstr "Исполнитель заказа на закупку изменяется"
+msgstr "Исполнитель заказа поставщику изменяется"
 
 msgid "A purchase order's order date changes"
-msgstr "Дата заказа на закупку изменяется"
+msgstr "Дата заказа поставщику изменяется"
 
 msgid "A purchase order's status changes"
-msgstr "Статус заказа на закупку изменяется"
+msgstr "Статус заказа поставщику изменяется"
 
 msgid "A purchase order's supplier changes"
 msgstr "Поставщик заказа на закупку изменяется"
@@ -569,13 +569,13 @@ msgid "A purchase order's supplier reference changes"
 msgstr "Ссылка поставщика заказа на закупку изменяется"
 
 msgid "A purchase order's tags changes"
-msgstr "Теги заказа на закупку изменяются"
+msgstr "Теги заказа поставщику изменяются"
 
 msgid "A purchase order's type changes"
-msgstr "Тип заказа на закупку изменяется"
+msgstr "Тип заказа поставщику изменяется"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Проблема качества — зарегистрированное отклонение или дефект с настраиваемым рабочим процессом расследования и корректирующих действий."
+msgstr "Проблема качества — зафиксированное отклонение или дефект с настраиваемым рабочим процессом расследования и выполнения задач."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
 msgstr "Количество одинаковых единиц разделяет отслеживаемый объект и номер партии — один объект, много единиц."
@@ -596,25 +596,25 @@ msgid "A quote is sent"
 msgstr "Предложение отправлено"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Строка предложения содержит цены и сроки доставки для конкретной детали"
+msgstr "Строка предложения содержит ценообразование и сроки поставки для конкретной детали"
 
 msgid "A quote's assignee changes"
-msgstr "Назначенный ответственный за предложение меняется"
+msgstr "Исполнитель коммерческого предложения изменяется"
 
 msgid "A quote's completed date changes"
 msgstr "Дата завершения предложения меняется"
 
 msgid "A quote's customer changes"
-msgstr "Клиент предложения меняется"
+msgstr "Покупатель коммерческого предложения изменяется"
 
 msgid "A quote's due date changes"
-msgstr "Срок предложения меняется"
+msgstr "Срок выполнения коммерческого предложения изменяется"
 
 msgid "A quote's estimator changes"
 msgstr "Калькулятор предложения меняется"
 
 msgid "A quote's expiration date changes"
-msgstr "Дата истечения предложения меняется"
+msgstr "Дата истечения срока коммерческого предложения изменяется"
 
 msgid "A quote's salesperson changes"
 msgstr "Продавец предложения меняется"
@@ -632,7 +632,7 @@ msgid "A receipt is posted"
 msgstr "Квитанция опубликована"
 
 msgid "A receipt's assignee changes"
-msgstr "Назначенный ответственный за квитанцию меняется"
+msgstr "Исполнитель поступления изменяется"
 
 msgid "A receipt's invoiced changes"
 msgstr "Статус выставления счета квитанции меняется"
@@ -641,10 +641,10 @@ msgid "A receipt's location changes"
 msgstr "Местоположение квитанции меняется"
 
 msgid "A receipt's posting date changes"
-msgstr "Дата опубликования квитанции меняется"
+msgstr "Дата проведения поступления изменилась"
 
 msgid "A receipt's source document changes"
-msgstr "Исходный документ квитанции меняется"
+msgstr "Документ-основание поступления изменился"
 
 msgid "A receipt's status changes"
 msgstr "Статус квитанции меняется"
@@ -656,64 +656,64 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Многократно используемый, версионируемый набор рабочих инструкций, прикрепленный к процессу, предоставляющий операции упорядоченные шаги для записи и проверки, а также параметры, с которыми она работает."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Этап маршрута на выпущенном заказе, собственная копия операции заказа, имеющая статус, который цех изменяет от \"К выполнению\" до \"Выполнено\"."
+msgstr "Шаг маршрута для запущенного производственного заказа — собственная копия операции заказа, которая получает статус, управляемый цехом от «Ожидание» до «Готово»."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Счёт-фактура продажи (вы выставляете счет клиенту) или счёт-фактура покупки (поставщик выставляет счет вам), погашаемый путём применения платежей и кредит-нот или дебет-нот."
+msgstr "Счет-фактура выданный (вы выставляете счет покупателю) или счет-фактура полученный (поставщик выставляет вам счет), расчеты по которому производятся путем применения платежей и кредит- или дебет-нот."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
-msgstr "Счет-фактура продажи — это документ, в котором указаны продукты или услуги, проданные клиенту, и соответствующая стоимость."
+msgstr "Счет-фактура выданный — это документ, который указывает продукты или услуги, проданные покупателю, и соответствующую себестоимость."
 
 msgid "A sales invoice is posted"
-msgstr "Счет-фактура продажи опубликован"
+msgstr "Счет-фактура выданный проведен"
 
 msgid "A sales invoice line contains invoice details for a particular item"
-msgstr "Строка счета-фактуры содержит детали счета-фактуры для конкретного товара"
+msgstr "Строка счёта-фактуры выданного содержит детали счёта для конкретной номенклатуры"
 
 msgid "A sales order contains information about the agreement between the company and a specific customer for parts and services."
-msgstr "Заказ на продажу содержит информацию об соглашении между компанией и конкретным клиентом по деталям и услугам."
+msgstr "Заказ покупателя содержит информацию о соглашении между организацией и конкретным покупателем на детали и услуги."
 
 msgid "A sales order is created"
-msgstr "Заказ на продажу создан"
+msgstr "Заказ покупателя создан"
 
 msgid "A sales order is deleted"
-msgstr "Заказ на продажу удален"
+msgstr "Заказ покупателя удален"
 
 msgid "A sales order line contains order details for a particular item"
-msgstr "Строка заказа на продажу содержит детали заказа для конкретного товара"
+msgstr "Строка заказа покупателя содержит детали заказа для конкретной номенклатуры"
 
 msgid "A sales order's assignee changes"
-msgstr "Назначенный ответственный за заказ на продажу меняется"
+msgstr "Исполнитель заказа покупателя изменился"
 
 msgid "A sales order's completed date changes"
-msgstr "Дата завершения заказа на продажу меняется"
+msgstr "Дата завершения заказа покупателя изменилась"
 
 msgid "A sales order's customer changes"
-msgstr "Клиент заказа на продажу меняется"
+msgstr "Покупатель заказа покупателя изменился"
 
 msgid "A sales order's customer reference changes"
-msgstr "Ссылка клиента заказа на продажу меняется"
+msgstr "Ссылка на покупателя заказа покупателя изменилась"
 
 msgid "A sales order's location changes"
-msgstr "Местоположение заказа на продажу меняется"
+msgstr "Площадка заказа покупателя изменилась"
 
 msgid "A sales order's order date changes"
-msgstr "Дата заказа на продажу меняется"
+msgstr "Дата заказа покупателя изменилась"
 
 msgid "A sales order's salesperson changes"
-msgstr "Продавец заказа на продажу меняется"
+msgstr "Продавец заказа покупателя изменился"
 
 msgid "A sales order's status changes"
-msgstr "Статус заказа на продажу меняется"
+msgstr "Статус заказа покупателя изменился"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Запрос коммерческого предложения (RFQ) — это запрос клиента на получение цены за набор деталей и количества. Это может привести к получению коммерческого предложения."
+msgstr "Запрос цен — это запрос покупателя на ценообразование по набору деталей и количеств. Может привести к коммерческому предложению."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
-msgstr "Запрос коммерческого предложения продажи (клиент просит вас сделать предложение) или запрос коммерческого предложения закупки (вы просите поставщиков); оба питают цепочку возможностей."
+msgstr "Запрос цен от продаж (покупатель просит расчет) или запрос цен для закупок (вы просите поставщиков); оба подпитывают поток сделок."
 
 msgid "A scoped secret sent on the carbon-key request header that authenticates programmatic calls to Carbon, carrying its own permissions and rate limit rather than a user session's."
-msgstr "Ограниченный секрет, отправляемый в заголовке запроса carbon-key, который аутентифицирует программные вызовы к Carbon, несущий собственные разрешения и ограничение по частоте вместо сеанса пользователя."
+msgstr "Секретный ключ, отправляемый в заголовке запроса carbon-key, который аутентифицирует программные вызовы к Carbon, несущий свои собственные права доступа и лимит количества запросов вместо сессии пользователя."
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
 msgstr "Отдельный график для налоговой отчетности, когда налоговые правила требуют метода, отличного от бухгалтерской амортизации."
@@ -722,43 +722,43 @@ msgid "A service is a billable activity that is bought or performed — it is ne
 msgstr "Услуга — это платная деятельность, которая покупается или выполняется — она никогда не отправляется, не принимается и не хранится на складе"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "Набор компаний под одним владельцем, которые совместно используют конфигурацию уровня группы — план счетов, валюты и аналитики — так что одна и та же настройка учёта распространяется на каждую компанию в группе."
+msgstr "Набор организаций под одним владельцем, которые используют конфигурацию уровня группы — план счетов, валюты и измерения — так чтобы одна и та же установка бухгалтерии охватывала каждую организацию в группе."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Набор инструкций по извлечению невыданных материалов работы со склада и подготовке их у линии; перемещение перемещает товар в место использования, а не потребляет его."
+msgstr "Набор инструкций для вывоза неудовлетворенных материалов производственного заказа из склада и их размещения в прилинейном запасе; отбор перемещает запас в точку использования, а не потребляет его."
 
 msgid "A shipment is created"
-msgstr "Отправка создана"
+msgstr "Отгрузка создана"
 
 msgid "A shipment is deleted"
-msgstr "Отправка удалена"
+msgstr "Отгрузка удалена"
 
 msgid "A shipment is posted"
-msgstr "Отправка опубликована"
+msgstr "Отгрузка проведена"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "Строка отгрузки, отправленная прямо от поставщика к клиенту, минуя ваш склад — устанавливается для каждой строки, а не в заголовке."
+msgstr "Строка отгрузки, отправляемая прямо от поставщика к покупателю, минуя ваш склад — устанавливается за строку, а не на заголовок."
 
 msgid "A shipment's assignee changes"
-msgstr "Назначенный ответственный за отправку меняется"
+msgstr "Исполнитель отгрузки изменился"
 
 msgid "A shipment's customer changes"
-msgstr "Клиент отправки меняется"
+msgstr "Покупатель отгрузки изменился"
 
 msgid "A shipment's location changes"
-msgstr "Местоположение отправки меняется"
+msgstr "Площадка отгрузки изменилась"
 
 msgid "A shipment's posting date changes"
-msgstr "Дата опубликования отправки меняется"
+msgstr "Дата проведения отгрузки изменилась"
 
 msgid "A shipment's shipping method changes"
-msgstr "Способ доставки отправки меняется"
+msgstr "Способ доставки отгрузки изменился"
 
 msgid "A shipment's status changes"
-msgstr "Статус отправки меняется"
+msgstr "Статус отгрузки изменился"
 
 msgid "A shipment's tracking number changes"
-msgstr "Номер отслеживания отправки изменяется"
+msgstr "Номер отслеживания отгрузки изменился"
 
 msgid "A step needs a name."
 msgstr "Шаг должен иметь имя."
@@ -773,7 +773,7 @@ msgid "A supplier's account manager changes"
 msgstr "Менеджер счета поставщика изменяется"
 
 msgid "A supplier's assignee changes"
-msgstr "Ответственное лицо поставщика изменяется"
+msgstr "Исполнитель поставщика изменился"
 
 msgid "A supplier's currency changes"
 msgstr "Валюта поставщика изменяется"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "Налоговый сбор (погрузка, наладка, топливо), добавляемый к строке и включаемый в налоговую базу."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Синхронизированная запись работ по наладке, труду или машинному времени, зафиксированная для операции задания, продолжительность которой суммируется в фактическую стоимость операции."
+msgstr "Фиксированная по времени запись работы «Наладка», «Труд» или «Станок», зарегистрированная для операции заказа, чья продолжительность суммируется в фактическую себестоимость операции."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Инструмент — это физический предмет, используемый для изготовления детали, которая может использоваться в нескольких заданиях"
+msgstr "Инструмент — это физический предмет, используемый для производства детали, который можно использовать на нескольких производственных заказах"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "Пользователь записывает дату истечения срока для каждой партии или серийного номера при получении товара. Используйте, когда поставщики отправляют партии с разными датами истечения срока."
+msgstr "Пользователь записывает срок годности для каждой серии при получении товара. Используется, когда поставщики отправляют партии с разными датами окончания срока годности."
 
 msgid "abilities"
-msgstr "возможности"
+msgstr "навыки"
 
 msgid "Abilities"
-msgstr "Способности"
+msgstr "Навыки"
 
 msgid "ability"
-msgstr "возможность"
+msgstr "навык"
 
 msgid "About"
 msgstr "О программе"
@@ -867,10 +867,10 @@ msgid "Account for small rounding differences in transactions"
 msgstr "Учет небольших различий при округлении в транзакциях."
 
 msgid "Account for the cost of fixed assets when disposed"
-msgstr "Учет стоимости основных средств при их ликвидации."
+msgstr "Учесть себестоимость основного средства при его выбытии"
 
 msgid "Account for the purchase cost of fixed assets"
-msgstr "Учет первоначальной стоимости основных средств."
+msgstr "Учесть себестоимость приобретения основного средства"
 
 msgid "Account manager"
 msgstr "Менеджер счета"
@@ -885,7 +885,7 @@ msgid "Account Number"
 msgstr "Номер счета"
 
 msgid "Account Settings"
-msgstr "Параметры учетной записи"
+msgstr "Настройки учёта"
 
 msgid "Account Type"
 msgstr "Тип счета"
@@ -900,13 +900,13 @@ msgid "Accounting"
 msgstr "Бухгалтерия"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "Учет находится в стадии бета-тестирования. Запросите доступ для включения отчетности, журналов проводок, учетных периодов, основных средств и многого другого."
+msgstr "Бухгалтерия сейчас находится на этапе бета-тестирования. Запросите доступ для включения отчетов, операций, учетных периодов, основных средств и многого другого."
 
 msgid "Accounting is disabled"
 msgstr "Бухгалтерский учет отключен"
 
 msgid "Accounting is disabled for this company."
-msgstr "Учет отключен для этой компании."
+msgstr "Бухгалтерия отключена для этой организации."
 
 msgid "Accounting is enabled"
 msgstr "Бухгалтерский учет включен"
@@ -915,16 +915,16 @@ msgid "Accounting period"
 msgstr "Учетный период"
 
 msgid "Accounting Periods"
-msgstr "Периоды бухгалтерского учета"
+msgstr "Учетные периоды"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Бухгалтерия: ГЛ, АР, АП и закрытие месяца"
+msgstr "Бухгалтерия: Главная книга, Дебиторская задолженность, Кредиторская задолженность и закрытие месяца"
 
 msgid "Accounts"
 msgstr "Учетные записи"
 
 msgid "Accounts for recording differences between actual and standard costs"
-msgstr "Счета для учета разниц между фактическими и стандартными затратами"
+msgstr "Счета для учета разниц между фактической и нормативной себестоимостью"
 
 msgid "Accounts Payable"
 msgstr "Кредиторская задолженность"
@@ -936,10 +936,10 @@ msgid "Accounts Receivable"
 msgstr "Дебиторская задолженность"
 
 msgid "Accounts receivable for amounts owed by customers"
-msgstr "Дебиторская задолженность клиентов за задолженные суммы."
+msgstr "Дебиторская задолженность за суммы, причитающиеся от покупателей"
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Счета, на которые ссылаются стандартные значения проводок или история журналов, которые еще не имеют сопоставления с системой."
+msgstr "Счета, на которые ссылаются стандарты проведения или история операций, но которые пока не имеют сопоставления провайдера."
 
 msgid "Accumulated Depreciation"
 msgstr "Накопленная амортизация"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Счет накопленной амортизации"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Накопленная амортизация при ликвидации"
+msgstr "Накопленная амортизация при выбытии"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Накопленная амортизация при ликвидации (по умолчанию)"
+msgstr "Накопленная амортизация при выбытии (по умолчанию)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Период накопления (недели)"
@@ -972,7 +972,7 @@ msgid "Acknowledged itar"
 msgstr "Подтвержденный itar"
 
 msgid "Acquisition Cost"
-msgstr "Первоначальная стоимость"
+msgstr "Стоимость приобретения"
 
 msgid "Acquisition Date"
 msgstr "Дата приобретения"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "Активно"
 
 msgid "Active Jobs"
-msgstr "Активные задания"
+msgstr "Активные производственные заказы"
 
 msgid "Active Statuses"
 msgstr "Активные статусы"
@@ -1026,7 +1026,7 @@ msgid "Actual"
 msgstr "Фактическое"
 
 msgid "Actual Cost"
-msgstr "Фактическая стоимость"
+msgstr "Фактическая себестоимость"
 
 msgid "Actual End"
 msgstr "Фактическое окончание"
@@ -1053,13 +1053,13 @@ msgid "Add a comment..."
 msgstr "Добавить комментарий..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Добавьте пользовательскую строку ценообразования для переопределения количества, цены, доставки, времени выполнения заказа и налога"
+msgstr "Добавить пользовательскую строку ценообразования для переопределения количества, цены, доставки, срока поставки и налога"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
 msgstr "Добавить раздел материалов, в котором указывается каждый элемент спецификации материалов с его количеством."
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Добавьте принтер в параметры печати, чтобы печатать этикетки напрямую."
+msgstr "Добавьте принтер в настройки печати для прямой печати этикеток."
 
 msgid "Add a requirement"
 msgstr "Добавить требование"
@@ -1068,7 +1068,7 @@ msgid "Add a row"
 msgstr "Добавить строку"
 
 msgid "Add a step"
-msgstr "Добавить этап"
+msgstr "Добавить шаг"
 
 msgid "Add Account"
 msgstr "Добавить счет"
@@ -1083,7 +1083,7 @@ msgid "Add Affected Item"
 msgstr "Добавить затронутый элемент"
 
 msgid "Add any notes about your decision..."
-msgstr "Добавьте любые заметки о вашем решении..."
+msgstr "Добавьте примечания о вашем решении..."
 
 msgid "Add Approval Requirement"
 msgstr "Добавить требование утверждения"
@@ -1095,13 +1095,13 @@ msgid "Add Calibration Record"
 msgstr "Добавить запись калибровки"
 
 msgid "Add Child Storage Unit"
-msgstr "Добавить дочернее хранилище"
+msgstr "Добавить дочернюю единицу хранения"
 
 msgid "Add clause"
 msgstr "Добавить условие"
 
 msgid "Add Company"
-msgstr "Добавить компанию"
+msgstr "Добавить организацию"
 
 msgid "Add condition"
 msgstr "Добавить условие"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Добавить примечание"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Добавьте заметки и документацию для этого наряда на техническое обслуживание"
+msgstr "Добавьте примечания и документацию для этой заявки на техобслуживание"
 
 msgid "Add Operation"
 msgstr "Добавить операцию"
@@ -1170,13 +1170,13 @@ msgid "Add parts"
 msgstr "Добавить детали"
 
 msgid "Add Passkey"
-msgstr "Добавить Passkey"
+msgstr "Добавить ключ доступа"
 
 msgid "Add path"
 msgstr "Добавить путь"
 
 msgid "Add Permissions"
-msgstr "Добавить разрешения"
+msgstr "Добавить права доступа"
 
 msgid "Add Printer"
 msgstr "Добавить принтер"
@@ -1206,7 +1206,7 @@ msgid "Add Selector"
 msgstr "Добавить селектор"
 
 msgid "Add Shipment"
-msgstr "Добавить отправку"
+msgstr "Добавить отгрузку"
 
 msgid "Add Shipping"
 msgstr "Добавить доставку"
@@ -1249,13 +1249,13 @@ msgid "Add-On"
 msgstr "Дополнительно"
 
 msgid "Add-On Cost"
-msgstr "Дополнительная стоимость"
+msgstr "Дополнительная себестоимость"
 
 msgid "Added"
 msgstr "Добавлено"
 
 msgid "Added for this customer"
-msgstr "Добавлено для этого клиента"
+msgstr "Добавлено для этого покупателя"
 
 msgid "Adding demo records"
 msgstr "Добавление демо-записей"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "Все действия выбраны"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Все расширенные функции доступны"
 
 msgid "All Audit Logs"
 msgstr "Все журналы аудита"
@@ -1346,13 +1346,13 @@ msgid "All Companies"
 msgstr "Все компании"
 
 msgid "All Customers"
-msgstr "Все клиенты"
+msgstr "Все покупатели"
 
 msgid "All Documents"
 msgstr "Все документы"
 
 msgid "All item types"
-msgstr "Все типы товаров"
+msgstr "Все типы номенклатуры"
 
 msgid "All Items"
 msgstr "Все элементы"
@@ -1361,16 +1361,16 @@ msgid "All Locations"
 msgstr "Все местоположения"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
-msgstr "Все члены выбранных групп и выбранные лица смогут одобрять запросы"
+msgstr "Все члены выбранных групп и выбранные лица смогут утвердить запросы"
 
 msgid "All posting accounts are mapped"
-msgstr "Все счета проводок сопоставлены"
+msgstr "Все счета для проведения сопоставлены"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Все строки импортированы — {inserted} вставлено, {updated} обновлено."
 
 msgid "All slotted dimension values are mapped"
-msgstr "Все значения размерности слотов отображены"
+msgstr "Все значения измерений сопоставлены"
 
 msgid "All Suppliers"
 msgstr "Все поставщики"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Сумма"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Сумма, которая увеличивает активы/расходы или уменьшает пассивы/собственный капитал/доходы на этой строке."
+msgstr "Сумма, которая увеличивает активы/расходы или уменьшает обязательства/собственный капитал/выручку на этой строке."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Сумма, которая увеличивает пассивы/собственный капитал/доходы или уменьшает активы/расходы на этой строке."
+msgstr "Сумма, которая увеличивает обязательства/собственный капитал/выручку или уменьшает активы/расходы на этой строке."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,25 +1422,25 @@ msgid "Amount Type"
 msgstr "Тип суммы"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Учетный контейнер, который группирует расходы по отделам или функциям, чтобы GL мог отчитываться о расходах по группам, а не только по счетам."
+msgstr "Группировка расходов по отделам или функциям, чтобы главная книга могла отчитываться по группам, а не только по счетам."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Учетная запись капитализированного элемента, который вы амортизируете вместо того, чтобы расходовать; Черновик → Активный → Полностью амортизирован → Ликвидирован."
+msgstr "Учётная запись для капитализированного элемента, который вы амортизируете, а не расходуете; Черновик → Активный → Полностью амортизировано → Выбыло."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Оповещение о том, что что-то требует внимания человека, разошедшееся из события carbon/notify в приложенный почтовый ящик плюс дополнительные email и Slack, отключаемое по теме на пользователя."
 
 msgid "An approval requirement on a non-conformance whose reviewers (seeded Engineering and Quality) must sign off before the issue can close."
-msgstr "Требование одобрения несоответствия, проверяющие которого (заполняемые Engineering и Quality) должны подписать перед тем, как проблема может закрыться."
+msgstr "Требование утверждения на несоответствии, которое должны утвердить рецензенты (предзагруженные Инженерия и Качество) перед закрытием проблемы."
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "Первоначальная стоимость активов минус накопленная амортизация — его текущая балансовая стоимость и сумма, по которой он ликвидируется."
+msgstr "Стоимость приобретения основного средства за вычетом накопленной амортизации — его остаточная стоимость в учете и сумма, по которой оно выбывает."
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "Автоматизация, которую вы создаете на холсте: один триггер, затем шаги, которые проверяют условия, ищут записи и действуют — уведомляя кого-то, создавая или обновляя запись или вызывая внешний URL."
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "Инженерное изменение: затронутые элементы, методы которых пересмотрены в черновике и выпущены вместе, заменяя версии, которые они заменяют."
+msgstr "Конструкторское изменение: затронутая номенклатура, методы которой пересмотрены в черновике и совместно выпущены, вытесняя версии, которые они заменяют."
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "HTTPS-запрос, который Carbon отправляет в вашу систему, когда рабочий процесс достигает этого шага, с любыми заголовками и телом, которые вы настроили."
@@ -1458,7 +1458,7 @@ msgid "An issue is deleted"
 msgstr "Проблема удалена"
 
 msgid "An issue's assignee changes"
-msgstr "Ответственное лицо проблемы изменяется"
+msgstr "Исполнитель списания изменился"
 
 msgid "An issue's close date changes"
 msgstr "Дата закрытия проблемы изменяется"
@@ -1497,19 +1497,19 @@ msgid "An item's active changes"
 msgstr "Статус активности элемента изменяется"
 
 msgid "An item's assignee changes"
-msgstr "Назначение элемента изменяется"
+msgstr "Исполнитель номенклатуры изменился"
 
 msgid "An item's default method type changes"
-msgstr "Тип метода по умолчанию элемента изменяется"
+msgstr "Способ обеспечения номенклатуры по умолчанию изменился"
 
 msgid "An item's name changes"
 msgstr "Имя элемента изменяется"
 
 msgid "An item's replenishment system changes"
-msgstr "Система пополнения элемента изменяется"
+msgstr "Способ пополнения номенклатуры изменился"
 
 msgid "An item's revision status changes"
-msgstr "Статус редакции элемента изменяется"
+msgstr "Статус ревизии номенклатуры изменился"
 
 msgid "An item's tracking type changes"
 msgstr "Тип отслеживания элемента изменяется"
@@ -1518,7 +1518,7 @@ msgid "An item's unit of measure changes"
 msgstr "Единица измерения элемента изменяется"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Операция, выполняемая внешним поставщиком вместо внутреннего рабочего центра, охватываемая заказом на закупку с привлечением подрядчика."
+msgstr "Операция, выполняемая внешним поставщиком вместо изготовления на собственном рабочем центре, предусмотренная заказом поставщику на субподряд."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Положение операции в очереди её рабочего центра — порядок, в котором площадка берёт работу — устанавливается переупорядочением карточек на доске Рабочих центров без изменения дат."
@@ -1561,22 +1561,22 @@ msgid "Annotation updated"
 msgstr "Аннотация обновлена"
 
 msgid "Another cost center this one rolls up into, letting you nest a sub-department under its parent for hierarchical cost reporting."
-msgstr "Другой центр затрат, в который это согласовывается, позволяя вам вложить центр затрат на подчиненном уровне под его родителем для иерархического отчета о затратах."
+msgstr "Другой центр затрат, в который этот центр входит, позволяя вложить подразделение в его родительский элемент для иерархической отчётности затрат."
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "Другая единица хранения, внутри которой эта вложена (например, корзина в стойке); должна находиться в том же месте."
+msgstr "Другая единица хранения, в которую вложена данная единица (например, ячейка внутри стеллажа); должна находиться на одной площадке."
 
 msgid "Any item group"
 msgstr "Любая группа товаров"
 
 msgid "Any item type"
-msgstr "Любой тип товара"
+msgstr "Любой тип номенклатуры"
 
 msgid "Anything not explicitly listed in scope above"
 msgstr "Все, что не указано явно в области действия выше"
 
 msgid "AP"
-msgstr "КЗ"
+msgstr "Кредиторская задолженность"
 
 msgid "AP Aging"
 msgstr "Анализ возраста кредиторской задолженности"
@@ -1585,7 +1585,7 @@ msgid "AP Clerk"
 msgstr "Специалист по учету кредиторской задолженности"
 
 msgid "AP Outstanding"
-msgstr "Задолженность перед поставщиками"
+msgstr "Неоплаченная кредиторская задолженность"
 
 msgid "AP Overdue"
 msgstr "Просроченные кредиторские задолженности"
@@ -1597,19 +1597,19 @@ msgid "API Documentation"
 msgstr "Документация API"
 
 msgid "API key"
-msgstr "Ключ API"
+msgstr "API-ключ"
 
 msgid "API Key"
-msgstr "API ключ"
+msgstr "API-ключ"
 
 msgid "API Keys"
-msgstr "API ключи"
+msgstr "API-ключи"
 
 msgid "API keys for programmatic access to your Carbon data."
-msgstr "API ключи для программного доступа к вашим данным Carbon."
+msgstr "API-ключи для программного доступа к вашим данным Carbon."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, вебхуки и интеграции"
 
 msgid "Applied"
 msgstr "Применено"
@@ -1634,7 +1634,7 @@ msgid "Applies to all work centers"
 msgstr "Применяется ко всем рабочим центрам"
 
 msgid "Applies to features without their own rule, and to the lot when this plan drives an inspection."
-msgstr "Применяется к функциям без собственного правила и к партии, когда этот план инициирует проверку."
+msgstr "Применяется к функциям без собственного правила и к партии, когда этот план инициирует контроль."
 
 msgid "Apply"
 msgstr "Применить"
@@ -1664,10 +1664,10 @@ msgid "Apply To"
 msgstr "Применить к"
 
 msgid "Apply to invoice"
-msgstr "Применить к счету"
+msgstr "Применить к счет-фактуре"
 
 msgid "Apply to invoices"
-msgstr "Применить к счетам"
+msgstr "Применить к счет-фактурам"
 
 msgid "Applying"
 msgstr "Применение"
@@ -1679,10 +1679,10 @@ msgid "Approaching {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB cap."
 msgstr "Приближение к лимиту {PO_EMAIL_ATTACHMENT_LIMIT_MB} МБ."
 
 msgid "Approval Date"
-msgstr "Дата одобрения"
+msgstr "Дата утверждения"
 
 msgid "Approval is required at or above this amount, up to the next rule's minimum"
-msgstr "Одобрение требуется при этой сумме или выше, вплоть до минимума следующего правила"
+msgstr "Утверждение требуется для сумм, равных этой сумме или выше, вплоть до минимума следующего правила"
 
 msgid "Approval requirements"
 msgstr "Требования утверждения"
@@ -1697,7 +1697,7 @@ msgid "Approvals"
 msgstr "Утверждения"
 
 msgid "Approve"
-msgstr "Одобрить"
+msgstr "Утвердить"
 
 msgid "Approved By"
 msgstr "Одобрено"
@@ -1706,19 +1706,19 @@ msgid "AQL"
 msgstr "AQL"
 
 msgid "AQL (Z1.4 / ISO 2859-1)"
-msgstr "АПК (Z1.4 / ISO 2859-1)"
+msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "ДЗ"
+msgstr "Дебиторская задолженность"
 
 msgid "AR / AP representation"
-msgstr "Представление ДЗ/КЗ"
+msgstr "Представление дебиторской и кредиторской задолженности"
 
 msgid "AR Aging"
 msgstr "Анализ возраста дебиторской задолженности"
 
 msgid "AR Clerk"
-msgstr "Специалист по расчетам с дебиторами"
+msgstr "Менеджер дебиторской задолженности"
 
 msgid "AR Outstanding"
 msgstr "Дебиторская задолженность"
@@ -1727,7 +1727,7 @@ msgid "AR Overdue"
 msgstr "Просроченная дебиторская задолженность"
 
 msgid "AR/AP"
-msgstr "ДЗ/КЗ"
+msgstr "Дебиторская и кредиторская задолженность"
 
 msgid "Archive"
 msgstr "Архив"
@@ -1750,11 +1750,11 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "Вы уверены, что хотите активировать процесс: {name}? Он снова появится в раскрывающихся списках."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Вы уверены, что хотите активировать этот прибор?."
+msgstr "Вы уверены, что хотите активировать это средство измерения?"
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "Вы уверены, что хотите отменить {0}? Он будет закрыт и доступен только для чтения, пока вы его не откроете."
+msgstr "Вы уверены, что хотите отменить {0}? Он будет закрыт и доступен только для чтения, пока вы его не откроете заново."
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
@@ -1764,22 +1764,22 @@ msgid "Are you sure you want to cancel {orderLabel}? This will close the order."
 msgstr "Вы уверены, что хотите отменить {orderLabel}? Это закроет заказ."
 
 msgid "Are you sure you want to cancel this job? It will no longer be available on the shop floor."
-msgstr "Вы уверены, что хотите отменить эту работу? Она больше не будет доступна на производственном участке."
+msgstr "Вы уверены, что хотите отменить этот производственный заказ? Он больше не будет доступен в цехе."
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
-msgstr "Вы уверены, что хотите изменить свойство {propertyName}? Поскольку вы используете сгенерированные ID материалов, это изменит ID детали этой детали и все связанные редакции."
+msgstr "Вы уверены, что хотите изменить свойство {propertyName}? Так как вы используете сгенерированные идентификаторы материалов, это изменит идентификатор детали этой детали и всех связанных ревизий."
 
 msgid "Are you sure you want to complete this stock transfer?"
 msgstr "Вы уверены, что хотите завершить этот перевод запасов?"
 
 msgid "Are you sure you want to confirm this sales order? Confirming the order will affect on order quantities used to calculate supply and demand."
-msgstr "Вы уверены, что хотите подтвердить этот заказ? Подтверждение заказа повлияет на количества заказов, используемые для расчета предложения и спроса."
+msgstr "Вы уверены, что хотите подтвердить этот заказ покупателя? Подтверждение заказа повлияет на количества заказанного товара, используемые при расчете обеспечения и потребности."
 
 msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "Вы уверены, что хотите преобразовать RFQ в предложение?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Вы уверены, что хотите создать задания для этого заказа? Это создаст задания для всех строк, у которых еще нет заданий."
+msgstr "Вы уверены, что хотите создать производственные заказы для этого заказа покупателя? Это создаст производственные заказы для всех строк, которые еще не имеют производственных заказов."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Вы уверены, что хотите деактивировать этих пользователей?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Вы уверены, что хотите деактивировать этот прибор?."
+msgstr "Вы уверены, что хотите деактивировать это средство измерения?"
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Вы уверены, что хотите деактивировать этого пользователя?"
@@ -1855,37 +1855,37 @@ msgstr "Вы уверены, что хотите удалить счет: {0}{1}
 
 #. placeholder {0}: apiKey.name
 msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить API ключ: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить API-ключ: {0}? Это невозможно отменить."
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить класс активов: {0}? Это невозможно отменить."
+msgstr "Вы уверены, что хотите удалить класс основных средств: {0}? Это невозможно отменить."
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить действие уведомления об изменении: {0}? Это невозможно отменить."
+msgstr "Вы уверены, что хотите удалить действие извещения об изменении: {0}? Это невозможно отменить."
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить категорию уведомления об изменении: {0}? Это невозможно отменить."
+msgstr "Вы уверены, что хотите удалить категорию извещения об изменении: {0}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить подрядчика: {name}? Это действие невозможно отменить."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить деталь клиента для {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить деталь покупателя для {0}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete the customer portal for: {customerName}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить портал клиента для: {customerName}? Это действие невозможно отменить."
 
 #. placeholder {0}: customerStatus.name
 msgid "Are you sure you want to delete the customer status: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить статус клиента: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить статус покупателя: {0}? Это невозможно отменить."
 
 #. placeholder {0}: customerType.name
 msgid "Are you sure you want to delete the customer type: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить тип клиента: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить тип покупателя: {0}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete the department: {name}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить отдел: {name}? Это действие невозможно отменить."
@@ -1899,7 +1899,7 @@ msgstr "Вы уверены, что хотите удалить режим от�
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить тип датчика: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить тип средства измерения: {0}? Это невозможно отменить."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1929,15 +1929,15 @@ msgid "Are you sure you want to delete the location: {name}? This cannot be undo
 msgstr "Вы уверены, что хотите удалить местоположение: {name}? Это действие невозможно отменить."
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить график обслуживания: {name}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить график техобслуживания: {name}? Это невозможно отменить."
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить размер материала: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить измерение материала: {0}? Это невозможно отменить."
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить отделку материала: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить обработку поверхности: {0}? Это невозможно отменить."
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
@@ -1945,11 +1945,11 @@ msgstr "Вы уверены, что хотите удалить форму ма�
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить класс материала: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить марку: {0}? Это невозможно отменить."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить материальное вещество: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить основной материал: {0}? Это невозможно отменить."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "Вы уверены, что хотите удалить тип мате�
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить причину отсутствия предложения: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить причину отказа от предложения: {0}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить партнера: {name}? Это действие невозможно отменить."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить условие платежа: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить условия оплаты: {0}? Это невозможно отменить."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1977,24 +1977,24 @@ msgstr "Вы уверены, что хотите удалить принтер \
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить строку счета-фактуры покупателя для {0} {1}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить строку счёта-фактуры полученного на {0} {1}? Это невозможно отменить."
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить строку счета-фактуры для {0} {1}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить строку счёта-фактуры выданного на {0} {1}? Это невозможно отменить."
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
 msgid "Are you sure you want to delete the sales order line for {0} {1}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить строку заказа продажи для {0} {1}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить строку заказа покупателя для {0} {1}? Это невозможно отменить."
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить причину брака: {0}? Это действие невозможно отменить."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить последовательность серийных номеров для {itemLabel}? Это невозможно отменить."
+msgstr "Вы уверены, что хотите удалить нумерацию серийного номера для {itemLabel}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить смену: {name} из {locationName}? Это действие невозможно отменить."
@@ -2009,7 +2009,7 @@ msgstr "Вы уверены, что хотите удалить тип хран�
 
 #. placeholder {0}: storageUnit.name
 msgid "Are you sure you want to delete the storage unit: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить хранилище: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить единицу хранения: {0}? Это невозможно отменить."
 
 #. placeholder {0}: supplierType.name
 msgid "Are you sure you want to delete the supplier type: {0}? This cannot be undone."
@@ -2025,22 +2025,22 @@ msgstr "Вы уверены, что хотите удалить представ
 
 #. placeholder {0}: webhook.name
 msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить webhook: {0}? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить вебхук: {0}? Это невозможно отменить."
 
 msgid "Are you sure you want to delete this approval rule? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить это правило утверждения? Это действие невозможно отменить."
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "Вы уверены, что хотите удалить это уведомление об изменении?"
+msgstr "Вы уверены, что хотите удалить это извещение об изменении?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Вы уверены, что хотите удалить этот манометр?"
+msgstr "Вы уверены, что хотите удалить это средство измерения?"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "Вы уверены, что хотите удалить этот план контроля?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить этот план проверки? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить этот план контроля? Это невозможно отменить."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Вы уверены, что хотите удалить этот рабочий процесс проблемы?"
@@ -2052,10 +2052,10 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Вы уверены, что хотите удалить эту карточку канбана? Это действие невозможно отменить."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить эту заявку на техническое обслуживание? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите удалить эту заявку на техобслуживание? Это невозможно отменить."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
-msgstr "Вы уверены, что хотите удалить этот Passkey? Вы больше не сможете использовать его для входа."
+msgstr "Вы уверены, что хотите удалить этот ключ доступа? Вы больше не сможете использовать его для входа."
 
 msgid "Are you sure you want to delete this quality document?"
 msgstr "Вы уверены, что хотите удалить этот документ качества?"
@@ -2106,23 +2106,23 @@ msgid "Are you sure you want to post this receipt?"
 msgstr "Вы уверены, что хотите провести этот приходный ордер?"
 
 msgid "Are you sure you want to post this shipment?"
-msgstr "Вы уверены, что хотите отправить эту партию?"
+msgstr "Вы уверены, что хотите провести эту отгрузку?"
 
 msgid "Are you sure you want to reject this quote?"
 msgstr "Вы уверены, что хотите отклонить это предложение?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "Вы уверены, что хотите выпустить эту работу? Она станет доступна для цеха и будет управлять закупками и производством."
+msgstr "Вы уверены, что хотите запустить в работу этот производственный заказ? Он станет доступен цеху и начнет управлять закупками и производством."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить {0} как поставщика для этого товара? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите убрать {0} в качестве поставщика для этой номенклатуры? Это невозможно отменить."
 
 msgid "Are you sure you want to remove {supplierName} as a supplier for this item? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить {supplierName} как поставщика для этого товара? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите убрать {supplierName} в качестве поставщика для этой номенклатуры? Это невозможно отменить."
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "Вы уверены, что хотите удалить этот товар из прайс-листа? Это действие невозможно отменить."
+msgstr "Вы уверены, что хотите убрать эту номенклатуру из прайс-листа? Это невозможно отменить."
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "Вы уверены, что хотите отозвать приглашение для этого пользователя?"
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Вы уверены, что хотите отправить приглашение этому пользователю?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Вы уверены, что хотите аннулировать этот счет-фактуру покупки? Это действие отменит все финансовые операции и не может быть отменено."
+msgstr "Вы уверены, что хотите аннулировать этот счет-фактуру полученный? Это действие отменит все финансовые операции и не может быть отменено."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
 msgstr "Вы уверены, что хотите аннулировать этот чек? Это действие отменит все операции с инвентарем и не может быть отменено."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Вы уверены, что хотите аннулировать этот счет-фактуру продажи? Это действие отменит все финансовые операции и не может быть отменено."
+msgstr "Вы уверены, что хотите аннулировать этот счет-фактуру выданный? Это действие отменит все финансовые операции и не может быть отменено."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Вы уверены, что хотите аннулировать эту отправку? Это действие отменит все операции с инвентарем и не может быть отменено."
+msgstr "Вы уверены, что хотите аннулировать эту отгрузку? Это действие отменит все операции с запасами и не может быть отменено."
 
 msgid "Are you sure?"
 msgstr "Вы уверены?"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "По состоянию на:"
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "Как владелец компании, вы можете передать право собственности другому сотруднику. Это даст им полный доступ к биллингу и административным параметрам."
+msgstr "Как владелец организации, вы можете передать ответственность другому сотруднику. Это даст ему полный доступ к параметрам выставления счётов и администрирования."
 
 msgid "Ascending"
 msgstr "По возрастанию"
@@ -2173,7 +2173,7 @@ msgstr "По возрастанию"
 #. placeholder {0}: copy.moduleLabel
 #. placeholder {1}: copy.noun
 msgid "Ask an admin with {0} permission to add the first {1}."
-msgstr "Попросите администратора с разрешением {0} добавить первый {1}."
+msgstr "Попросите администратора с правом доступа {0} добавить первую {1}."
 
 msgid "Assemblies"
 msgstr "Сборки"
@@ -2200,31 +2200,31 @@ msgid "Asset account for advance payments made to suppliers before goods or serv
 msgstr "Счет активов для авансовых платежей поставщикам до получения товаров или услуг"
 
 msgid "Asset Acquisition Cost"
-msgstr "Первоначальная стоимость активов"
+msgstr "Стоимость приобретения основного средства"
 
 msgid "Asset Acquisition Cost (default)"
-msgstr "Первоначальная стоимость активов (по умолчанию)"
+msgstr "Стоимость приобретения основного средства (по умолчанию)"
 
 msgid "asset class"
-msgstr "класс активов"
+msgstr "класс основных средств"
 
 msgid "Asset class"
-msgstr "Класс активов"
+msgstr "Класс основных средств"
 
 msgid "Asset Class"
-msgstr "Класс активов"
+msgstr "Класс основных средств"
 
 msgid "asset classes"
-msgstr "классы активов"
+msgstr "классы основных средств"
 
 msgid "Asset Classes"
-msgstr "Классы активов"
+msgstr "Классы основных средств"
 
 msgid "Asset Cost on Disposal"
-msgstr "Стоимость активов при ликвидации"
+msgstr "Себестоимость основного средства при выбытии"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Стоимость активов при ликвидации (по умолчанию)"
+msgstr "Себестоимость активов при выбытии (по умолчанию)"
 
 msgid "Asset ID"
 msgstr "ID активов"
@@ -2233,7 +2233,7 @@ msgid "Assets"
 msgstr "Активы"
 
 msgid "Assets, liabilities and equity as of a date"
-msgstr "Активы, обязательства и капитал на дату"
+msgstr "Активы, обязательства и собственный капитал на определенную дату"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
 msgstr "Назначьте принтеры местоположениям. Доставка, получение и рабочие центры наследуют значение по умолчанию для местоположения, если не переопределено."
@@ -2251,7 +2251,7 @@ msgid "Assigned to Me"
 msgstr "Назначено мне"
 
 msgid "Assignee"
-msgstr "Назначенный"
+msgstr "Исполнитель"
 
 msgid "Assignment"
 msgstr "Назначение"
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Назначения"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Назначает этот блок хранения рабочему центру (линейная сторона)"
+msgstr "Назначает данную единицу хранения рабочему центру (прилинейный запас)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Назначает эту единицу рабочему центру для материалов на краю линии, чтобы операторы видели ее в представлении производства; наследуется от родительского устройства при установке там."
+msgstr "Назначает данную единицу рабочему центру для прилинейного запаса материала, чтобы операторы видели его в представлении производства; наследуется от родительской единицы, если установлено там."
 
 msgid "At each gate"
 msgstr "На каждом этапе"
@@ -2293,7 +2293,7 @@ msgid "Attribute"
 msgstr "Атрибут"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Стандарт выборочного контроля атрибутов, используемый для расчета размеров выборки партии и чисел приемки/отклонения при входящих проверках."
+msgstr "Стандарт выборочного контроля по атрибутам, используемый для вычисления объемов выборки партии и количеств принятия/отклонения при входном контроле."
 
 msgid "Attributes"
 msgstr "Атрибуты"
@@ -2305,7 +2305,7 @@ msgid "Audit Log"
 msgstr "Журнал аудита"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Журнал аудита"
 
 msgid "Audit Logging"
 msgstr "Аудит логирования"
@@ -2338,10 +2338,10 @@ msgid "Auto arrange"
 msgstr "Автоматическое расположение"
 
 msgid "Auto Release"
-msgstr "Автоматический выпуск"
+msgstr "Автоматический запуск в работу"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "Автоматический выпуск должен быть включен для автоматического запуска задания"
+msgstr "Автоматический запуск в работу должен быть включён для автоматического запуска производственного заказа"
 
 msgid "Auto Start Job"
 msgstr "Автоматический запуск задания"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "Автоматически созданный QR-код"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Форматы автонумерации для заказов, работ, деталей и многого другого"
+msgstr "Форматы автонумерации для заказов, производственных заказов, деталей и прочего"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "Автоматически предлагать покупки на основе спроса и точек переупорядочения"
+msgstr "Автоматическое предложение закупок на основе потребности и точки заказа"
 
 msgid "Automate"
 msgstr "Автоматизация"
@@ -2368,22 +2368,22 @@ msgid "Automate your business processes with event-driven workflows that trigger
 msgstr "Автоматизируйте бизнес-процессы с помощью рабочих процессов, управляемых событиями, которые инициируют действия при возникновении событий в Carbon."
 
 msgid "Automatic Cost Updates"
-msgstr "Автоматические обновления стоимости"
+msgstr "Автоматическое обновление себестоимости"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Автоматические обновления времени поставки"
+msgstr "Автоматическое обновление сроков поставки"
 
 msgid "Automatic Updates"
 msgstr "Автоматические обновления"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Автоматическое обновление и резервное копирование"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Автоматическое пропорциональное потребление материалов задания, не отслеживаемых при отчетности о выходе — отслеживаемые материалы выпускаются вручную."
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "Автоматически отпустить задание при сканировании канбана"
+msgstr "Автоматически запустить в работу производственный заказ при сканировании канбана"
 
 msgid "Automatically start the job when the kanban is scanned"
 msgstr "Автоматически запустить задание при сканировании канбана"
@@ -2414,19 +2414,19 @@ msgid "Back"
 msgstr "Назад"
 
 msgid "Back to traceability"
-msgstr "Вернуться к отслеживанию"
+msgstr "Вернуться к прослеживаемости"
 
 msgid "Backflush"
-msgstr "Обратный отвод"
+msgstr "Ретроградное списание"
 
 msgid "Backups"
 msgstr "Резервные копии"
 
 msgid "Balance"
-msgstr "Баланс"
+msgstr "Остаток"
 
 msgid "Balance Sheet"
-msgstr "Баланс"
+msgstr "Бухгалтерский баланс"
 
 msgid "Balanced"
 msgstr "Сбалансировано"
@@ -2435,7 +2435,7 @@ msgid "Balloon"
 msgstr "Выноска"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "Аннотированные чертежи с элементами проверки."
+msgstr "Детализированные чертежи с функциями контроля."
 
 msgid "Bank - Cash"
 msgstr "Банк - Денежные средства"
@@ -2456,7 +2456,7 @@ msgid "Bank — Local Currency (default)"
 msgstr "Банк — Местная валюта (по умолчанию)"
 
 msgid "Bank / Cash Account"
-msgstr "Банковский / Кассовый счет"
+msgstr "Банк / Счет денежных средств"
 
 msgid "Bank account denominated in a foreign currency"
 msgstr "Банковский счет в иностранной валюте."
@@ -2465,10 +2465,10 @@ msgid "Bank account denominated in the local currency"
 msgstr "Банковский счет в местной валюте."
 
 msgid "Bank and financial service charge expenses"
-msgstr "Расходы на комиссии банков и финансовых услуг."
+msgstr "Расходы банка и сервисного сбора финансовых услуг"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Столбцы показывают еженедельные потоки: &lt;0&gt;предложение&lt;/0&gt; толкает запасы вверх, &lt;1&gt;спрос&lt;/1&gt; тянет их вниз. &lt;2&gt;Линия&lt;/2&gt; — это прогнозируемый доступный запас — когда он падает ниже &lt;3&gt;страховой запас&lt;/3&gt; вы рискуете, а ниже нуля — это &lt;4&gt;нехватка запасов&lt;/4&gt;."
+msgstr "Столбцы показывают поток каждой недели: <0>обеспечение</0> увеличивает запасы, <1>потребность</1> снижает их. <2>Строка</2> — это ваши прогнозируемые запасы на складе — когда она падает ниже <3>страхового запаса</3>, вы в зоне риска, а ниже нуля — <4>дефицит</4>."
 
 msgid "Base Currency"
 msgstr "Базовая валюта"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Базовая цена"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Базовая функциональность ERP, MES и QMS"
 
 msgid "Basic Information"
 msgstr "Основная информация"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "Партия / Серийный номер"
 
 msgid "Batch items require a sales order"
-msgstr "Товары партии требуют заказ на продажу"
+msgstr "Позиции, производимые сериями, требуют заказ покупателя"
 
 msgid "Batch number"
 msgstr "Номер партии"
@@ -2523,7 +2523,7 @@ msgid "Beta"
 msgstr "Бета"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Основные причины брака по причине, товару или производственному участку"
+msgstr "Основные причины брака по типу, номенклатуре или рабочему центру"
 
 msgid "Bill of Material"
 msgstr "Спецификация материалов"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "Спецификация материалов"
 
 msgid "Bill of Process"
-msgstr "Спецификация процесса"
+msgstr "Перечень операций"
 
 msgid "Bill To"
 msgstr "Счет для"
@@ -2581,13 +2581,13 @@ msgid "BOM synced successfully"
 msgstr "BOM успешно синхронизирован"
 
 msgid "BOMs"
-msgstr "Спецификации"
+msgstr "BOM"
 
 msgid "Bonus Depreciation %"
 msgstr "Бонусная амортизация %"
 
 msgid "Book a call to discuss guided implementation"
-msgstr "Забронировать звонок для обсуждения управляемой реализации"
+msgstr "Забронируйте звонок для обсуждения управляемого внедрения"
 
 msgid "Book a call with Carbon"
 msgstr "Забронировать звонок с Carbon"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Навигационная цепочка"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Импортируйте ваши детали, спецификации материалов, технологические процессы и расчеты стоимости — с помощью инструментов импорта Carbon, CSV или помощи LLM."
+msgstr "Импортируйте ваши детали, BOM, перечень операций и калькуляцию — используя инструменты импорта Carbon, CSV или помощь LLM."
 
 msgid "Browse library"
 msgstr "Обзор библиотеки"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Просмотрите опубликованную версию в режиме только для чтения. Вы все еще можете переставлять шаги для очистки макета."
 
 msgid "Bucket"
 msgstr "Хранилище"
@@ -2635,13 +2635,13 @@ msgid "Build integrations and customizations"
 msgstr "Создавайте интеграции и настройки"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Создавайте предложения, используя актуальные данные о деталях, стоимости и Технологическом процессе"
+msgstr "Создавайте коммерческие предложения, используя данные о деталях, себестоимости и перечне операций в реальном времени"
 
 msgid "Build role-based training materials"
-msgstr "Создавайте учебные материалы на основе ролей"
+msgstr "Создавайте материалы обучения на основе ролей"
 
 msgid "Build tailored, role-based training materials"
-msgstr "Создавайте адаптированные учебные материалы на основе ролей"
+msgstr "Создавайте адаптированные материалы обучения на основе ролей"
 
 msgid "Built and costed as its own method"
 msgstr "Построен и рассчитан как собственный метод"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Массовый импорт"
 
 msgid "Bulk Jobs"
-msgstr "Массовые задания"
+msgstr "Массовые производственные заказы"
 
 msgid "Business moment"
 msgstr "Бизнес-момент"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "Покупка"
 
 msgid "Buy and Make"
-msgstr "Покупать и производить"
+msgstr "Закупка и производство"
 
 msgid "Buyer"
-msgstr "Покупатель"
+msgstr "Закупщик"
 
 msgid "Buyer, Planner"
-msgstr "Покупатель, Планировщик"
+msgstr "Закупщик, планировщик"
 
 msgid "by {byUser}"
 msgstr "от {byUser}"
@@ -2683,7 +2683,7 @@ msgid "By Document Date"
 msgstr "По дате документа"
 
 msgid "By Due Date"
-msgstr "По дате платежа"
+msgstr "По сроку выполнения"
 
 msgid "By field"
 msgstr "По полю"
@@ -2710,7 +2710,7 @@ msgid "Calculation Method"
 msgstr "Метод расчета"
 
 msgid "Calibration"
-msgstr "Поверка"
+msgstr "Калибровка"
 
 msgid "Calibration Attempts"
 msgstr "Попытки калибровки"
@@ -2749,16 +2749,16 @@ msgid "Can't disable the only active break. Add another break or toggle the over
 msgstr "Невозможно отключить единственный активный разрыв. Добавьте еще один разрыв или переключите активность переопределения."
 
 msgid "Can't download this file"
-msgstr "Не удается загрузить этот файл"
+msgstr "Невозможно скачать этот файл"
 
 msgid "Cancel"
 msgstr "Отмена"
 
 msgid "Cancel change notice"
-msgstr "Отменить уведомление об изменении"
+msgstr "Отмена извещения об изменении"
 
 msgid "Cancel Change Notice"
-msgstr "Отменить уведомление об изменении"
+msgstr "Отмена Извещения об изменении"
 
 msgid "Cancel Job"
 msgstr "Отменить задание"
@@ -2767,10 +2767,10 @@ msgid "Cancel Order"
 msgstr "Отменить заказ"
 
 msgid "Cancel Purchase Order"
-msgstr "Отменить заказ на покупку"
+msgstr "Отмена Заказа поставщику"
 
 msgid "Cancel Sales Order"
-msgstr "Отмена заказа на продажу"
+msgstr "Отмена Заказа покупателя"
 
 msgid "Cancel SO"
 msgstr "Отменить ПП"
@@ -2815,13 +2815,13 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "Невозможно разместить заказ - с этим товаром не связан поставщик"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "Невозможно отправить — отправка содержит истекшие отслеживаемые объекты."
+msgstr "Невозможно провести — отгрузка содержит сущности, срок действия которых истек."
 
 msgid "Cannot send RFQ"
 msgstr "Невозможно отправить РФП"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Невозможно отправить через Stripe"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Невозможно загрузить — взаимодействие с поставщиком еще не создано"
@@ -2854,7 +2854,7 @@ msgid "Carbon column"
 msgstr "Столбец Carbon"
 
 msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
-msgstr "Carbon настроена в соответствии с тем, как работает ваша компания, ваши данные загружены, и ваша команда уверенно её использует. Когда это произойдёт, вы будете готовы к запуску."
+msgstr "Carbon настроена так, как работает ваша организация, данные загружены, и ваша команда уверенно ею пользуется. Когда это так, вы готовы к запуску."
 
 msgid "Carbon leads"
 msgstr "Carbon ведёт"
@@ -2876,31 +2876,31 @@ msgstr "Значение Carbon"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon будет использовать ИИ для подбора счета поставщика для каждого из ваших {0} неотображенных счетов. Предложения — это отправная точка — вы можете проверить их перед сохранением."
+msgstr "Carbon будет использовать ИИ для определения счета провайдера для каждого из {0} несопоставленных счетов. Предложения — это отправная точка — вы можете проверить их перед сохранением."
 
 msgid "Carbon-only"
 msgstr "Только для Carbon"
 
 msgid "Carbon-only · fill in real targets for this customer. They see the values, locked."
-msgstr "Только для Carbon · заполните реальные целевые показатели для этого клиента. Они видят значения, заблокированные."
+msgstr "Carbon-only · заполните реальные цели для этого покупателя. Покупатель видит значения, заблокировано."
 
 msgid "Carbon-only · the customer sees this text, locked."
-msgstr "Carbon-only · клиент видит этот текст, заблокирован."
+msgstr "Carbon-only · покупатель видит этот текст, заблокировано."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Имя Carbon для спецификации материалов и спецификации процесса (маршрутизация): компоненты плюс операции, которые производят деталь."
+msgstr "Название Carbon для спецификации материалов и Перечня операций (маршрут): компоненты плюс операции, которые производят деталь."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Прогон планирования Carbon балансирует предложение против спроса и расширяет методы, выявляя дефициты — но сам не создает заказы."
+msgstr "Цикл планирования Carbon сопоставляет обеспечение с потребностью, развертывает методы и выявляет недостатки — но сам не создает заказы."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
 msgstr "Производственный заказ Carbon — одна работа строит количество одного товара из его скопированного метода и маршрутизации."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "Приложение Carbon для цеха, где операторы выполняют операции, сообщают количества, выдают материалы и регистрируют время по выпущенным работам в реальном времени."
+msgstr "Приложение Carbon для цеха, где операторы выполняют операции, сообщают количества, выдают материалы и регистрируют время по запущенным производственным заказам в реальном времени."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Единая запись Carbon для чего-либо с номером детали — Деталь, Материал, Инструмент, Услуга, Расходник или Приспособление — на которые указывают работы, методы, заказы и инвентарь."
+msgstr "Единая запись Carbon для всего, что имеет номер детали — Деталь, Материал, Инструмент, Услуга, Расходный материал или Приспособление — на которую ссылаются производственные заказы, методы, заказы и запасы."
 
 msgid "Cards"
 msgstr "Карточки"
@@ -2912,7 +2912,7 @@ msgid "Carrier Account"
 msgstr "Счет перевозчика"
 
 msgid "Cash & Banking"
-msgstr "Наличные и Банковские операции"
+msgstr "Денежные средства и Банк"
 
 msgid "Categories that classify how stock is stored"
 msgstr "Категории, которые классифицируют способ хранения запасов"
@@ -2966,31 +2966,31 @@ msgid "Change Inspection Plan"
 msgstr "Изменить план контроля"
 
 msgid "Change notice"
-msgstr "Уведомление об изменении"
+msgstr "Извещение об изменении"
 
 msgid "Change Notice"
-msgstr "Уведомление об изменении"
+msgstr "Извещение об изменении"
 
 msgid "Change Notice Actions"
-msgstr "Действия уведомлений об изменении"
+msgstr "Действия Извещения об изменении"
 
 msgid "Change Notice Types"
-msgstr "Типы уведомлений об изменении"
+msgstr "Типы Извещения об изменении"
 
 msgid "Change Notices"
-msgstr "Уведомления об изменении"
+msgstr "Извещения об изменении"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "Уведомления об изменении не удалось загрузить, поэтому новые версии и редакции заблокированы. Перезагрузите страницу, чтобы попробовать еще раз."
+msgstr "Извещения об изменении не удалось загрузить, поэтому новые версии и ревизии заблокированы. Перезагрузите, чтобы повторить попытку."
 
 msgid "Change order"
-msgstr "Изменение заказа"
+msgstr "Приказ об изменении"
 
 msgid "Change status"
 msgstr "Изменить статус"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "Измените тип элемента (например, Деталь, Материал, Инструмент и т. д.)"
+msgstr "Измените тип номенклатуры (например, Деталь, Материал, Инструмент и т. д.)"
 
 msgid "Change type"
 msgstr "Тип изменения"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Чат"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Проверьте реестр товаров на наличие товаров с отрицательным количеством в наличии на конец периода — обычно это отсутствующая квитанция или неправильно размещенная проводка, которая искажает стоимость запасов и себестоимость продаж. Отметьте как выполненное после проверки или пропустите с указанием причины."
+msgstr "Проверьте реестр номенклатуры на наличие номенклатур с отрицательным количеством на складе на конец периода — обычно это недостающее поступление или неправильно проведённая операция, которая искажает стоимость запасов и себестоимость продаж. Отметьте как выполненное после проверки или пропустите с указанием причины."
 
 msgid "Check your email"
 msgstr "Проверьте вашу почту"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Проверка Stripe для этого покупателя…"
 
 msgid "Checkpoint ·"
 msgstr "Контрольная точка ·"
@@ -3041,7 +3041,7 @@ msgid "Choose a batch number"
 msgstr "Выберите номер партии"
 
 msgid "Choose a company"
-msgstr "Выберите компанию"
+msgstr "Выберите организацию"
 
 msgid "Choose a row on the left to see where its stock can come from."
 msgstr "Выберите строку слева, чтобы увидеть, откуда может поступить её запас."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Класс (унаследованный)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Классифицирует операцию маршрута: операции Process, Assembly и Inspection выполняются на собственном производстве в MES — Assembly получает управляемое представление сборки, а Inspection выполняет проверку качества — в то время как операция Outside Processing субподряжается поставщику и создает заказ на покупку; процесс имеет тот же тип и использует его по умолчанию для новых операций."
+msgstr "Классификация типа операции маршрута: операции типов Процесс, Сборка и Контроль выполняются на вашем цехе в MES — тип Сборка предоставляет направляемое представление, тип Контроль — проверку качества, — в то время как операции типа Кооперация передаются на субподряд поставщику и создают Заказ поставщику; тип операции сохраняется и применяется по умолчанию для новых операций."
 
 msgid "Clean and approve the migrated data"
 msgstr "Очистить и утвердить перенесенные данные"
@@ -3095,16 +3095,16 @@ msgid "Clear selection"
 msgstr "Очистить выделение"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Погасите этот счет с помощью опубликованных кредитов стороны, а также наличных средств. Кредиты применяются напрямую — публикация не требуется."
+msgstr "Погасите этот счет-фактуру кредитами и денежными средствами стороны. Кредиты применяются напрямую — проведение не требуется."
 
 msgid "Clear value"
 msgstr "Очистить значение"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "Транзитный счет между поступлением товаров и счетом поставщика; уравновешивается, когда оба были выполнены."
+msgstr "Сальдовый счёт между поступлением товаров и счётом-фактурой от поставщика; сальдирует, когда оба проведены."
 
 msgid "Clearing account for goods received / invoice received matching"
-msgstr "Счет взаимного зачета для поступления товаров / сопоставления поступления счета"
+msgstr "Сальдовый счёт для сопоставления поступлено товаров / получено счётов-фактур"
 
 msgid "Clearing demo data"
 msgstr "Удаление демо-данных"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "Нажмите, чтобы загрузить чертеж PDF"
 
 msgid "Clock In"
-msgstr "Начало смены"
+msgstr "Начало работы"
 
 msgid "Clock Out"
-msgstr "Выход"
+msgstr "Окончание работы"
 
 msgid "Clocked in since <0/>"
 msgstr "Работаю с <0/>"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Облако или ваша собственная размещённая среда."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "Соответствует CMMC"
 
 msgid "Code"
 msgstr "Код"
@@ -3182,7 +3182,7 @@ msgid "Collapse all"
 msgstr "Свернуть все"
 
 msgid "Collapse Costs"
-msgstr "Свернуть затраты"
+msgstr "Свернуть себестоимость"
 
 msgid "Collapse features table"
 msgstr "Свернуть таблицу функций"
@@ -3191,7 +3191,7 @@ msgid "Collapse Labor"
 msgstr "Свернуть Труд"
 
 msgid "Collapse Machine"
-msgstr "Свернуть машину"
+msgstr "Свернуть станок"
 
 msgid "Collapse Setup"
 msgstr "Свернуть настройку"
@@ -3230,28 +3230,28 @@ msgid "Commit a champion user for each area"
 msgstr "Назначьте пользователя-чемпиона для каждой области"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Фиксирование квитанции, отправки или счета: количества движутся, записи журнала попадают в бухгалтерскую книгу, и статус становится Выполнено."
+msgstr "Проведение поступления, отгрузки или счета-фактуры: количества перемещаются, записи проводки попадают в главную книгу, и статус становится Проведено."
 
 msgid "Community support"
-msgstr ""
+msgstr "Поддержка сообщества"
 
 msgid "Companies"
 msgstr "Компании"
 
 msgid "Company"
-msgstr "Компания"
+msgstr "Организация"
 
 msgid "Company group"
-msgstr "Группа компаний"
+msgstr "Группа организаций"
 
 msgid "Company identity, documents, and system defaults."
-msgstr "Идентификация компании, документы и системные параметры по умолчанию."
+msgstr "Идентификация организации, документы и системные значения по умолчанию."
 
 msgid "Company Name"
-msgstr "Название компании"
+msgstr "Название организации"
 
 msgid "Company policy asks for a different person to inspect inbound items than the one who received them."
-msgstr "Политика компании требует, чтобы входящие товары проверял другой сотрудник, а не тот, кто их получил."
+msgstr "Политика организации требует, чтобы входящую номенклатуру проверял другой сотрудник, чем тот, кто её получил."
 
 msgid "Company-wide — includes all locations"
 msgstr "Во всей компании — включает все местоположения"
@@ -3312,7 +3312,7 @@ msgid "Computed At"
 msgstr "Вычислено в"
 
 msgid "Condensed P&L with margins and key subtotals"
-msgstr "Сокращенный П&У с прибыльностью и ключевыми итогами"
+msgstr "Сокращенный отчет о прибылях и убытках с маржами и ключевыми промежуточными итогами"
 
 msgid "Conditions"
 msgstr "Условия"
@@ -3339,7 +3339,7 @@ msgid "Configure Carbon"
 msgstr "Настроить Carbon"
 
 msgid "Configure default accounts for cash and bank transactions"
-msgstr "Настроить счета по умолчанию для операций с наличными и банком"
+msgstr "Установить счета учета по умолчанию для операций с денежными средствами и банком"
 
 msgid "Configure default accounts for inventory management"
 msgstr "Настроить счета по умолчанию для управления запасами"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Настроить счета по умолчанию для операций с продавцом и поставщиком"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Настроить счета капитала и накопленной прибыли по умолчанию"
+msgstr "Установить счета учета по умолчанию для собственного капитала и нераспределенной прибыли"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Настройте значения по умолчанию для панели качества."
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "Настроить элемент"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Настройте уведомления для случаев, когда датчики выходят из калибровки."
+msgstr "Настроить уведомления на случай выхода средств измерения за пределы калибровки."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "Настройте уведомления для завершенных заданий."
+msgstr "Настроить уведомления на случай завершения производственных заказов."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Настройте уведомления для случаев, когда наряды на техническое обслуживание создаются с производственного участка. Уведомления маршрутизируются на основе типа режима отказа."
+msgstr "Настроить уведомления на случай создания заявок на техобслуживание на цехе. Уведомления маршрутизируются на основе типа режима отказа."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Настройте уведомления для новых предложений."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Настройте сайты, рабочие центры, Bill of Process, BOMs, калькуляцию, роли"
+msgstr "Настроить объекты, рабочие центры, перечень операций, BOM, калькуляцию, роли"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Настройте учетные записи по умолчанию, используемые для различных типов транзакций в вашей системе"
@@ -3378,7 +3378,7 @@ msgid "Configure the start months for your fiscal and tax years"
 msgstr "Настройте месяцы начала вашего финансового и налогового годов"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
-msgstr "Настройте, когда стоимость приобретенных товаров должна обновляться на основе операций поставщика."
+msgstr "Установить, когда себестоимость закупленной номенклатуры должна обновляться из транзакций поставщика."
 
 msgid "Configure who should receive notifications when a supplier submits a quote."
 msgstr "Настройте, кто должен получать уведомления при отправке поставщиком предложения."
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "Подтвердить {0}"
 
 msgid "Confirm & release"
-msgstr "Подтвердить и выпустить"
+msgstr "Подтвердить и запустить в работу"
 
 msgid "Confirm all"
 msgstr "Подтвердить все"
@@ -3424,7 +3424,7 @@ msgid "Confirm disconnect"
 msgstr "Подтвердить отключение"
 
 msgid "Confirm how your company runs and lock the scope."
-msgstr "Подтвердите, как работает ваша компания, и зафиксируйте область охвата."
+msgstr "Подтвердить, как работает ваша организация, и зафиксировать объем."
 
 msgid "Confirm ID Change"
 msgstr "Подтвердить изменение ID"
@@ -3448,10 +3448,10 @@ msgid "Confirmed incoming stock — purchase & production orders (bars above zer
 msgstr "Подтвержденный входящий запас — заказы на покупку и производство (столбцы выше нуля)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Подтвержденный исходящий запас — заказы на продажу и материалы работ (столбцы ниже нуля)."
+msgstr "Подтвержденный исходящий запас — заказы покупателей и материалы заказа (столбцы ниже нуля)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Проверяет, что каждая опубликованная запись в журнале за период имеет равные дебеты и кредиты. Если какая-либо запись не сбалансирована, пробный баланс не совпадёт, поэтому её необходимо исправить перед закрытием периода."
+msgstr "Подтверждает, что каждая проводка, проведенная в периоде, имеет равные дебет и кредит. Если какая-либо запись неуравновешена, сверка дебета и кредита не совпадет, поэтому она должна быть исправлена до закрытия периода."
 
 msgid "Conflict reason"
 msgstr "Причина конфликта"
@@ -3472,7 +3472,7 @@ msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "Подключите обработчик Otherwise к узлу для запуска, когда ни одно условие не совпадает."
 
 msgid "Connect the outside tools your company already runs on"
-msgstr "Подключите внешние инструменты, которые уже использует ваша компания"
+msgstr "Подключить внешние инструменты, которые уже использует ваша организация"
 
 msgid "Connected to"
 msgstr "Подключено к"
@@ -3493,7 +3493,7 @@ msgid "Console Operator"
 msgstr "Оператор консоли"
 
 msgid "consumable"
-msgstr "расходное"
+msgstr "расходный материал"
 
 msgid "Consumable"
 msgstr "Расходный материал"
@@ -3505,7 +3505,7 @@ msgid "Consumable ID"
 msgstr "ID расходного материала"
 
 msgid "consumables"
-msgstr "расходные"
+msgstr "расходные материалы"
 
 msgid "Consumables"
 msgstr "Расходные материалы"
@@ -3517,22 +3517,22 @@ msgid "Consuming material from inventory into a job, which writes a Consumption 
 msgstr "Потребление материалов из запасов для работы, в результате чего в реестр товаров записывается запись потребления."
 
 msgid "contact"
-msgstr "контакт"
+msgstr "контактное лицо"
 
 msgid "Contact"
-msgstr "Контакт"
+msgstr "Контактное лицо"
 
 msgid "Contact (optional)"
-msgstr "Контакт (опционально)"
+msgstr "Контактное лицо (необязательно)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Свяжитесь с нами"
 
 msgid "contacts"
-msgstr "контакты"
+msgstr "контактные лица"
 
 msgid "Contacts"
-msgstr "Контакты"
+msgstr "Контактные лица"
 
 msgid "Contained"
 msgstr "Локализовано"
@@ -3541,7 +3541,7 @@ msgid "Containment"
 msgstr "Локализация"
 
 msgid "Containment action"
-msgstr "Действие по сдерживанию"
+msgstr "Действие по локализации"
 
 msgid "Content"
 msgstr "Содержание"
@@ -3550,13 +3550,13 @@ msgid "Context"
 msgstr "Контекст"
 
 msgid "Contra-asset account for total depreciation of fixed assets"
-msgstr "Счет-контра активов для полного износа основных средств"
+msgstr "Контрактивный счет учета на общую амортизацию основных средств"
 
 msgid "Contra-revenue account for discounts given on sales"
 msgstr "Счет-контра доходов для предоставленных скидок на продажи"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
-msgstr "Счет GL контра-дохода для скидок, предоставленных на счетах-фактурах клиентов."
+msgstr "Счет учета, противоположный выручке, для скидок, предоставленных по счетам-фактурам покупателей."
 
 msgid "Contractor"
 msgstr "Подрядчик"
@@ -3565,19 +3565,19 @@ msgid "Contractors"
 msgstr "Подрядчики"
 
 msgid "Control design changes with revisions / ECOs"
-msgstr "Контролировать изменения конструкции с помощью редакций / ECO"
+msgstr "Управление изменениями конструкции с помощью ревизий и ECO"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "Контролировать, как операторы подбирают материал и отслеживают время на производственном полу."
+msgstr "Управление тем, как операторы отбирают материал и отслеживают время на цехе."
 
 msgid "Controller, Accountant"
 msgstr "Контроллер, Бухгалтер"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "Контролирует, как планирование обрабатывает снятый с производства товар: «Сначала потребить» исчерпывает имеющийся запас перед переходом на преемника, «Предпочесть новый» немедленно перенаправляет новый спрос на преемника, «Только запас» сохраняет только минимальный резерв для обслуживания, а «Без запаса» полностью исключает товар из планирования."
+msgstr "Управляет тем, как планирование обрабатывает снятую с производства номенклатуру: режим «Сначала израсходовать» исчерпывает имеющийся запас перед переходом на преемника, режим «Предпочесть новое» сразу перенаправляет новую потребность на преемника, режим «Только запас» сохраняет только минимальный резервный запас, а режим «Нет запаса» полностью исключает номенклатуру из планирования."
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Контролирует, может ли спецификация и технологическая документация выпущенной (производственной) редакции редактироваться вне приказа об изменении."
+msgstr "Управляет, можно ли редактировать спецификацию материалов и перечень операций выпущенной (Производство) ревизии вне приказа об изменении."
 
 msgid "Convention"
 msgstr "Соглашение"
@@ -3586,10 +3586,10 @@ msgid "Conversion"
 msgstr "Конверсия"
 
 msgid "Conversion factor"
-msgstr "Коэффициент преобразования"
+msgstr "коэффициент пересчета"
 
 msgid "Conversion Factor"
-msgstr "Коэффициент конверсии"
+msgstr "Коэффициент пересчета"
 
 msgid "Conversion:"
 msgstr "Конверсия:"
@@ -3598,16 +3598,16 @@ msgid "Convert"
 msgstr "Преобразовать"
 
 msgid "Convert a quote to a sales order with no re-keying"
-msgstr "Преобразовать предложение в заказ на продажу без повторного ввода данных"
+msgstr "Преобразовать коммерческое предложение в заказ покупателя без повторного ввода данных"
 
 msgid "Convert Line to Job"
 msgstr "Преобразовать строку в задание"
 
 msgid "Convert Lines to Jobs"
-msgstr "Преобразовать строки в задания"
+msgstr "Преобразовать строки в производственные заказы"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "Преобразуйте предложения MRP в заказы на покупку и задания."
+msgstr "Преобразовывать предложения MRP в заказы поставщику и производственные заказы."
 
 msgid "Convert to Quote"
 msgstr "Преобразовать в предложение"
@@ -3625,22 +3625,22 @@ msgid "Copy"
 msgstr "Копировать"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "Скопируйте все товары и цены другому клиенту или типу."
+msgstr "Скопировать всю номенклатуру и ценообразование для другого покупателя или типа."
 
 msgid "Copy API Key"
-msgstr "Копировать API ключ"
+msgstr "Скопировать API-ключ"
 
 msgid "Copy company unique identifier"
-msgstr "Скопировать уникальный идентификатор компании"
+msgstr "Скопировать уникальный идентификатор организации"
 
 msgid "Copy consumable number"
 msgstr "Скопировать номер расходного материала"
 
 msgid "Copy dispatch ID"
-msgstr "Скопировать ID диспетчеризации"
+msgstr "Скопировать ID заявки на техобслуживание"
 
 msgid "Copy dispatch number"
-msgstr "Копировать номер наряда"
+msgstr "Скопировать номер заявки на техобслуживание"
 
 msgid "Copy document name"
 msgstr "Копировать имя документа"
@@ -3664,13 +3664,13 @@ msgid "Copy link"
 msgstr "Копировать ссылку"
 
 msgid "Copy link to change notice"
-msgstr "Скопировать ссылку на уведомление об изменении"
+msgstr "Скопировать ссылку на извещение об изменении"
 
 msgid "Copy link to consumable"
 msgstr "Скопировать ссылку на расходный материал"
 
 msgid "Copy link to dispatch"
-msgstr "Скопировать ссылку на наряд"
+msgstr "Скопировать ссылку на заявку на техобслуживание"
 
 msgid "Copy link to document"
 msgstr "Скопировать ссылку на документ"
@@ -3718,10 +3718,10 @@ msgid "Copy PIN"
 msgstr "Копировать PIN"
 
 msgid "Copy pricing to a single customer"
-msgstr "Копировать цены для одного клиента"
+msgstr "Скопировать ценообразование для одного покупателя"
 
 msgid "Copy pricing to all customers of a type"
-msgstr "Копировать цены для всех клиентов этого типа"
+msgstr "Скопировать ценообразование для всех покупателей определённого типа"
 
 msgid "Copy Procedure"
 msgstr "Копировать процедуру"
@@ -3748,10 +3748,10 @@ msgid "Copy service unique identifier"
 msgstr "Копировать уникальный идентификатор услуги"
 
 msgid "Copy this item's pricing to another scope."
-msgstr "Скопируйте цены этого товара в другую область."
+msgstr "Скопировать ценообразование этой номенклатуры в другую область."
 
 msgid "Copy this link to share the quote with a customer"
-msgstr "Скопируйте эту ссылку, чтобы поделиться предложением с клиентом"
+msgstr "Скопировать эту ссылку, чтобы поделиться коммерческим предложением с покупателем"
 
 msgid "Copy this link to share the quote with a supplier"
 msgstr "Скопируйте эту ссылку, чтобы поделиться предложением с поставщиком"
@@ -3817,7 +3817,7 @@ msgid "Cost Centers"
 msgstr "Центры затрат"
 
 msgid "Cost History"
-msgstr "История стоимости"
+msgstr "История себестоимости"
 
 msgid "Cost of Goods Sold"
 msgstr "Себестоимость реализованной продукции"
@@ -3832,16 +3832,16 @@ msgid "Cost of Sales"
 msgstr "Себестоимость продаж"
 
 msgid "Costing"
-msgstr "Расчет стоимости"
+msgstr "Калькуляция"
 
 msgid "Costing & Posting"
-msgstr "Калькуляция и проводка"
+msgstr "Калькуляция и проведение"
 
 msgid "Costing method"
 msgstr "Метод калькуляции"
 
 msgid "Costing Method"
-msgstr "Метод расчета стоимости"
+msgstr "Метод калькуляции"
 
 msgid "Could not analyze cropped region"
 msgstr "Не удалось проанализировать обрезанный регион"
@@ -3873,7 +3873,7 @@ msgid "Couldn't load related documents. Refresh before creating a new one to avo
 msgstr "Не удалось загрузить связанные документы. Обновите страницу перед созданием нового, чтобы избежать дублирования."
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
-msgstr "Не удалось загрузить цели размерности провайдера — проверьте соединение и перезагрузите страницу."
+msgstr "Не удалось загрузить целевые значения измерений поставщика — проверьте соединение и перезагрузите."
 
 msgid "Couldn't reschedule the job. Please try again."
 msgstr "Не удалось перепланировать задание. Пожалуйста, попробуйте еще раз."
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "Создать и снимок"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "Создать уведомление об изменении для новой редакции и открыть его"
+msgstr "Создать извещение об изменении для новой ревизии и открыть его"
 
 msgid "Create a job"
 msgstr "Создать задание"
@@ -3930,25 +3930,25 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Создайте новую карточку канбана для пополнения на основе сканирования."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Создайте новую заявку на техническое обслуживание для отслеживания ремонта оборудования и работ по техническому обслуживанию"
+msgstr "Создать новую заявку на техобслуживание для отслеживания ремонта оборудования и мероприятий по техническому обслуживанию"
 
 msgid "Create a new production job to fulfill the sales order"
-msgstr "Создайте новое производственное задание для выполнения заказа"
+msgstr "Создать новый производственный заказ для выполнения заказа покупателя"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Вместо этого создать нового покупателя Stripe"
 
 msgid "Create a new version"
 msgstr "Создать новую версию"
 
 msgid "Create a purchase order"
-msgstr "Создать заказ на закупку"
+msgstr "Создать заказ поставщику"
 
 msgid "Create a quote with a new quote ID"
 msgstr "Создать предложение с новым ID предложения"
 
 msgid "Create a sales order"
-msgstr "Создать заказ на продажу"
+msgstr "Создать заказ покупателя"
 
 msgid "Create Account"
 msgstr "Создать учетную запись"
@@ -3963,28 +3963,28 @@ msgid "Create an issue"
 msgstr "Создать проблему"
 
 msgid "Create and approve purchase orders"
-msgstr "Создавать и утверждать заказы на покупку"
+msgstr "Создавать и утверждать заказы поставщикам"
 
 msgid "Create audit trail entries"
 msgstr "Создать записи в журнале аудита"
 
 msgid "Create Change Notice"
-msgstr "Создать уведомление об изменении"
+msgstr "Создать извещение об изменении"
 
 msgid "Create Issue"
 msgstr "Создать проблему"
 
 msgid "Create Jobs"
-msgstr "Создать задания"
+msgstr "Создать производственные заказы"
 
 msgid "Create Kanban"
-msgstr "Создать Kanban"
+msgstr "Создать канбан"
 
 msgid "Create new rule"
 msgstr "Создать новое правило"
 
 msgid "Create PO Revision"
-msgstr "Создать редакцию заказа на покупку"
+msgstr "Создать ревизию PO"
 
 msgid "Create Production Event"
 msgstr "Создать производственное событие"
@@ -3996,10 +3996,10 @@ msgid "Create Projection"
 msgstr "Создать проекцию"
 
 msgid "Create Quote Revision"
-msgstr "Создать редакцию предложения"
+msgstr "Создать ревизию коммерческого предложения"
 
 msgid "Create Revision"
-msgstr "Создать редакцию"
+msgstr "Создать ревизию"
 
 msgid "Create Rule"
 msgstr "Создать правило"
@@ -4023,7 +4023,7 @@ msgid "Created account"
 msgstr "Счет создан"
 
 msgid "Created asset class"
-msgstr "Класс активов создан"
+msgstr "Создан класс основных средств"
 
 msgid "Created at"
 msgstr "Дата создания"
@@ -4038,10 +4038,10 @@ msgid "Created By"
 msgstr "Создано"
 
 msgid "Created change notice action"
-msgstr "Создано действие уведомления об изменении"
+msgstr "Создано действие извещения об изменении"
 
 msgid "Created change notice type"
-msgstr "Создан тип уведомления об изменении"
+msgstr "Создан тип извещения об изменении"
 
 msgid "Created consumable"
 msgstr "Расходный материал создан"
@@ -4053,14 +4053,14 @@ msgid "Created customer portal"
 msgstr "Портал клиента создан"
 
 msgid "Created customer status"
-msgstr "Статус клиента создан"
+msgstr "Создан статус покупателя"
 
 msgid "Created customer type"
-msgstr "Тип клиента создан"
+msgstr "Создан тип покупателя"
 
 #. placeholder {0}: createdCustomer?.name ?? t`Customer`
 msgid "Created customer: {0}"
-msgstr "Создан клиент: {0}"
+msgstr "Создан покупатель: {0}"
 
 msgid "Created department"
 msgstr "Отдел создан"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Режим отказа создан"
 
 msgid "Created gauge type"
-msgstr "Тип датчика создан"
+msgstr "Создан тип средства измерения"
 
 msgid "Created item group"
 msgstr "Группа товаров создана"
@@ -4078,7 +4078,7 @@ msgid "Created location"
 msgstr "Местоположение создано"
 
 msgid "Created maintenance schedule"
-msgstr "Расписание обслуживания создано"
+msgstr "Создан график техобслуживания"
 
 msgid "Created material"
 msgstr "Материал создан"
@@ -4087,7 +4087,7 @@ msgid "Created material dimension"
 msgstr "Материальное измерение создано"
 
 msgid "Created material finish"
-msgstr "Материал отделки создан"
+msgstr "Создана обработка поверхности"
 
 msgid "Created material form"
 msgstr "Форма материала создана"
@@ -4096,13 +4096,13 @@ msgid "Created material grade"
 msgstr "Создана марка материала"
 
 msgid "Created material substance"
-msgstr "Создано вещество материала"
+msgstr "Создан основной материал"
 
 msgid "Created material type"
 msgstr "Тип материала создан"
 
 msgid "Created no quote reason"
-msgstr "Причина отсутствия предложения создана"
+msgstr "Создана причина отказа от предложения"
 
 msgid "Created non conformance type"
 msgstr "Создан тип несоответствия"
@@ -4129,7 +4129,7 @@ msgid "Created shipping method"
 msgstr "Способ доставки создан"
 
 msgid "Created stock transfer line"
-msgstr "Создана строка передачи запасов"
+msgstr "Создана строка перемещения запасов"
 
 msgid "Created storage type"
 msgstr "Тип хранилища создан"
@@ -4145,7 +4145,7 @@ msgid "Created unit of measure"
 msgstr "Единица измерения создана"
 
 msgid "Created webhook"
-msgstr "Webhook создан"
+msgstr "Создан вебхук"
 
 msgid "Created work center"
 msgstr "Рабочий центр создан"
@@ -4173,13 +4173,13 @@ msgid "Credit Account"
 msgstr "Счет кредита"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "Счет кредита при поглощении времени труда/машины в WIP"
+msgstr "Счет кредита при поглощении затрат труда/машинного времени в незавершенное производство"
 
 msgid "Credit account when overhead is absorbed into WIP"
 msgstr "Кредитовый счет при поглощении накладных расходов в незавершенное производство"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Кредитовые счета, используемые при поглощении производственных затрат в незавершенное производство"
+msgstr "Счета кредита, используемые когда производственные затраты поглощаются незавершенным производством"
 
 msgid "Credit Memo"
 msgstr "Кредит-нота"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "Код валюты"
 
 msgid "Currency Translation"
-msgstr "Трансляция валюты"
+msgstr "Пересчет валют"
 
 msgid "Currency Translation (default)"
-msgstr "Трансляция валюты (по умолчанию)"
+msgstr "Пересчет валют (по умолчанию)"
 
 msgid "current"
 msgstr "текущий"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "Текущее"
 
 msgid "Current Net Book Value:"
-msgstr "Текущая чистая балансовая стоимость:"
+msgstr "Текущая остаточная стоимость:"
 
 msgid "Current Password"
 msgstr "Текущий пароль"
@@ -4269,7 +4269,7 @@ msgid "Custom Fields"
 msgstr "Пользовательские поля"
 
 msgid "Custom fields are not available for items yet."
-msgstr "Пользовательские поля пока недоступны для элементов."
+msgstr "Пользовательские поля пока недоступны для номенклатуры."
 
 msgid "Custom SOW · we manage"
 msgstr "Пользовательское SOW · мы управляем"
@@ -4278,76 +4278,76 @@ msgid "Custom…"
 msgstr "Пользовательский…"
 
 msgid "customer"
-msgstr "клиент"
+msgstr "покупатель"
 
 msgid "Customer"
-msgstr "Клиент"
+msgstr "Покупатель"
 
 msgid "Customer Accounts"
-msgstr "Учетные записи клиентов"
+msgstr "Счета покупателя"
 
 msgid "Customer contact"
-msgstr "Контакт клиента"
+msgstr "Контактное лицо покупателя"
 
 msgid "Customer Contact"
-msgstr "Контакт клиента"
+msgstr "Контактное лицо покупателя"
 
 msgid "Customer contacts"
-msgstr "Контакты клиента"
+msgstr "Контактные лица покупателя"
 
 msgid "Customer Details"
-msgstr "Детали клиента"
+msgstr "Сведения о покупателе"
 
 msgid "Customer engineering contact"
-msgstr "Инженерный контакт клиента"
+msgstr "Инженерное контактное лицо покупателя"
 
 msgid "Customer follows it alone"
-msgstr "Клиент следует ему самостоятельно"
+msgstr "Покупатель следит за ним самостоятельно"
 
 msgid "Customer ID"
-msgstr "ID клиента"
+msgstr "ID покупателя"
 
 msgid "Customer ID cannot be changed after creation"
-msgstr "ID клиента не может быть изменен после создания"
+msgstr "ID покупателя нельзя изменить после создания"
 
 msgid "Customer Invoice Number"
-msgstr "Номер счета клиента"
+msgstr "Номер счета-фактуры покупателя"
 
 msgid "Customer location"
-msgstr "Местоположение клиента"
+msgstr "Площадка покупателя"
 
 msgid "Customer Location"
-msgstr "Местоположение клиента"
+msgstr "Площадка покупателя"
 
 msgid "Customer Overview"
-msgstr "Обзор клиента"
+msgstr "Обзор покупателя"
 
 msgid "Customer Part"
-msgstr "Деталь клиента"
+msgstr "Деталь покупателя"
 
 msgid "Customer Part ID"
-msgstr "ID детали клиента"
+msgstr "Артикул покупателя"
 
 msgid "Customer Part Number"
-msgstr "Номер детали клиента"
+msgstr "Номер детали покупателя"
 
 msgid "Customer Part Revision"
-msgstr "Редакция детали клиента"
+msgstr "Ревизия детали покупателя"
 
 msgid "Customer Parts"
-msgstr "Детали клиента"
+msgstr "Детали покупателя"
 
 msgid "Customer Payment Discounts"
-msgstr "Скидки на платежи клиентов"
+msgstr "Скидки при оплате покупателя"
 
 msgid "Customer Payment Discounts (default)"
-msgstr "Скидки на платежи клиентов (по умолчанию)"
+msgstr "Скидки при оплате покупателя (по умолчанию)"
 
 msgid "Customer PO"
-msgstr "Заказ клиента"
+msgstr "PO покупателя"
 
 msgid "Customer PO Number"
-msgstr "Номер заказа клиента"
+msgstr "Номер PO покупателя"
 
 msgid "Customer Portal"
 msgstr "Портал клиента"
@@ -4356,58 +4356,58 @@ msgid "Customer Portals"
 msgstr "Портальные системы клиентов"
 
 msgid "Customer pricing"
-msgstr "Цены для клиентов"
+msgstr "Ценообразование покупателя"
 
 msgid "Customer reference"
-msgstr "Ссылка клиента"
+msgstr "Справка о покупателе"
 
 msgid "Customer Reference"
-msgstr "Ссылка на клиента"
+msgstr "Справка о покупателе"
 
 msgid "Customer Revision"
-msgstr "Редакция клиента"
+msgstr "Ревизия покупателя"
 
 msgid "Customer RFQ"
-msgstr "RFQ клиента"
+msgstr "Запрос цен покупателя"
 
 msgid "Customer Scope"
-msgstr "Область применения клиента"
+msgstr "Область покупателя"
 
 msgid "customer status"
-msgstr "статус клиента"
+msgstr "статус покупателя"
 
 msgid "Customer Status"
-msgstr "Статус клиента"
+msgstr "Статус покупателя"
 
 msgid "customer statuses"
-msgstr "статусы клиентов"
+msgstr "статусы покупателя"
 
 msgid "Customer Statuses"
-msgstr "Статусы клиентов"
+msgstr "Статусы покупателя"
 
 msgid "customer type"
-msgstr "тип клиента"
+msgstr "тип покупателя"
 
 msgid "Customer Type"
-msgstr "Тип клиента"
+msgstr "Тип покупателя"
 
 msgid "customer types"
-msgstr "типы клиентов"
+msgstr "типы покупателя"
 
 msgid "Customer Types"
-msgstr "Типы клиентов"
+msgstr "Типы покупателя"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Списание задолженности клиента (безнадежный долг)"
+msgstr "Списание покупателя (Безнадежная задолженность)"
 
 msgid "customers"
-msgstr "клиенты"
+msgstr "покупатели"
 
 msgid "Customers"
-msgstr "Клиенты"
+msgstr "Покупатели"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Настройки, обучение и интеграции"
 
 msgid "Customize"
 msgstr "Настроить"
@@ -4425,13 +4425,13 @@ msgid "Cutover checklist"
 msgstr "Контрольный список переключения"
 
 msgid "Cutover step"
-msgstr "Этап переключения"
+msgstr "Шаг перехода"
 
 msgid "Cutover support"
 msgstr "Поддержка при переходе"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "Инвентаризация и корректировка с журналом аудита"
+msgstr "Циклический пересчет и корректировка с аудитом"
 
 msgid "Daily"
 msgstr "Ежедневно"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Дни до оплаты"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Дни от заказа детали до её наличия; планирование смещает спрос назад на эту величину."
+msgstr "Дни от заказа детали до ее доступности; смещение планирования сдвигает потребность назад на эту величину."
 
 msgid "Days Off"
 msgstr "Выходные дни"
@@ -4590,7 +4590,7 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "Решите, что видит оператор при попытке выдать партию или серийный номер, срок действия которого уже истек."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Решите, что произойдет, когда оператор нажмет кнопку 'Завершить' на производстве с неподобранным материалом."
+msgstr "Решите, что происходит, когда оператор нажимает «Завершить» на цехе с еще не отобранным материалом."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
 msgstr "Решение о том, когда материал, отобранный в рабочий центр, но не использованный, поступает обратно на склад."
@@ -4599,13 +4599,13 @@ msgid "Decimal Places"
 msgstr "Десятичные разряды"
 
 msgid "Declining balance"
-msgstr "Ускоренная амортизация"
+msgstr "Уменьшаемый остаток"
 
 msgid "Default"
 msgstr "По умолчанию"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Счет по умолчанию для отражения выручки от продаж по счетам"
+msgstr "Счет по умолчанию для проведения выручки от счетов-фактур продажи"
 
 msgid "Default Accounts"
 msgstr "Счета по умолчанию"
@@ -4614,7 +4614,7 @@ msgid "Default accounts for business expenses"
 msgstr "Счета по умолчанию для деловых расходов"
 
 msgid "Default accounts for customer transactions and receivables"
-msgstr "Счета по умолчанию для операций с клиентами и дебиторской задолженности"
+msgstr "Счета по умолчанию для операций покупателей и дебиторской задолженности"
 
 msgid "Default accounts for long-term assets and depreciation"
 msgstr "Счета по умолчанию для долгосрочных активов и амортизации"
@@ -4626,7 +4626,7 @@ msgid "Default accounts for tax-related transactions"
 msgstr "Счета по умолчанию для налоговых операций"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Счета по умолчанию для стоимости проданных товаров и косвенных покупок"
+msgstr "Счета по умолчанию для себестоимости продаж и косвенных закупок"
 
 msgid "Default Approver"
 msgstr "Утверждающий по умолчанию"
@@ -4647,19 +4647,19 @@ msgid "Default CC Recipients"
 msgstr "Получатели CC по умолчанию"
 
 msgid "Default GL account credited when a fixed-asset disposal results in a gain."
-msgstr "Счёт ГЛ по умолчанию, зачисляемый при реализации основного средства с прибылью."
+msgstr "Счет учета по умолчанию, кредитуемый при выбытии основного средства, приносящем прибыль."
 
 msgid "Default GL account debited when a fixed-asset disposal results in a loss."
-msgstr "Счёт ГЛ по умолчанию, дебетуемый при реализации основного средства с убытком."
+msgstr "Счет учета по умолчанию, дебетуемый при выбытии основного средства, приносящем убыток."
 
 msgid "Default GL account used for cash transactions when no specific bank account is selected."
-msgstr "Счет GL по умолчанию, используемый для операций с наличными деньгами, когда не выбран конкретный банковский счет."
+msgstr "Счет учета по умолчанию, используемый для операций с денежными средствами, если не выбран конкретный банковский счет."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Счет GL по умолчанию для расходов на обслуживание оборудования и объектов."
+msgstr "Счет расходов главной книги по умолчанию для оборудования и техобслуживания объектов."
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Счет GL по умолчанию для расходов на периодические прогоны амортизации."
+msgstr "Счет расходов главной книги по умолчанию для периодических начислений амортизации."
 
 msgid "Default Method"
 msgstr "Метод по умолчанию"
@@ -4668,22 +4668,22 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Метод по умолчанию, который предварительно заполняется для новых активов в этом классе (по-прежнему редактируемый для каждого активa)."
 
 msgid "Default method type"
-msgstr "Тип метода по умолчанию"
+msgstr "способ обеспечения по умолчанию"
 
 msgid "Default Method Type"
-msgstr "Тип метода по умолчанию"
+msgstr "Способ обеспечения по умолчанию"
 
 msgid "Default Permissions"
-msgstr "Разрешения по умолчанию"
+msgstr "Права доступа по умолчанию"
 
 msgid "Default Priority"
 msgstr "Приоритет по умолчанию"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "Счет GL по умолчанию, который кредитуется при проведении счета-фактуры продажи."
+msgstr "Счет выручки главной книги по умолчанию, на который зачисляется при проведении счета-фактуры продажи."
 
 msgid "Default Sampling"
-msgstr "Выборка по умолчанию"
+msgstr "Выборочный контроль по умолчанию"
 
 msgid "Default shelf-life duration (days)"
 msgstr "Продолжительность срока годности по умолчанию (дни)"
@@ -4692,10 +4692,10 @@ msgid "Default Source"
 msgstr "Источник по умолчанию"
 
 msgid "Default Storage Unit"
-msgstr "Хранилище по умолчанию"
+msgstr "Единица хранения по умолчанию"
 
 msgid "Default tax depreciation method for new assets in this class."
-msgstr "Метод налогового вычета по умолчанию для новых активов в этом классе."
+msgstr "Метод налоговой амортизации по умолчанию для новых основных средств в этом классе."
 
 msgid "Default tax-book life for new assets in this class."
 msgstr "Стандартный налоговый срок полезного использования для новых активов в этом классе."
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "Сначала определите производственную операцию."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Определите многоуровневые спецификации материалов и Лист процесса (методы производства)"
+msgstr "Определите многоуровневые BOM и перечни операций (методы производства)"
 
 msgid "Delete"
 msgstr "Удалить"
@@ -4750,13 +4750,13 @@ msgid "Delete Action"
 msgstr "Удалить действие"
 
 msgid "Delete API Key"
-msgstr "Удалить API ключ"
+msgstr "Удалить API-ключ"
 
 msgid "Delete Asset"
 msgstr "Удалить актив"
 
 msgid "Delete Asset Class"
-msgstr "Удалить класс активов"
+msgstr "Удалить класс основных средств"
 
 msgid "Delete Assignment"
 msgstr "Удалить назначение"
@@ -4771,13 +4771,13 @@ msgid "Delete Category"
 msgstr "Удалить категорию"
 
 msgid "Delete Change Notice"
-msgstr "Удалить уведомление об изменении"
+msgstr "Удалить извещение об изменении"
 
 msgid "Delete Consumable"
 msgstr "Удалить расходный материал"
 
 msgid "Delete Contact"
-msgstr "Удалить контакт"
+msgstr "Удалить контактное лицо"
 
 msgid "Delete Contractor"
 msgstr "Удалить подрядчика"
@@ -4789,22 +4789,22 @@ msgid "Delete Custom Field"
 msgstr "Удалить пользовательское поле"
 
 msgid "Delete Customer"
-msgstr "Удалить клиента"
+msgstr "Удалить покупателя"
 
 msgid "Delete Customer Status"
-msgstr "Удалить статус клиента"
+msgstr "Удалить статус покупателя"
 
 msgid "Delete Customer Type"
-msgstr "Удалить тип клиента"
+msgstr "Удалить тип покупателя"
 
 msgid "Delete Department"
 msgstr "Удалить отдел"
 
 msgid "Delete Dimension"
-msgstr "Удалить размерность"
+msgstr "Удалить измерение"
 
 msgid "Delete Dispatch"
-msgstr "Удалить диспетчеризацию"
+msgstr "Удалить заявку на техобслуживание"
 
 msgid "Delete Document"
 msgstr "Удалить документ"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Удалить праздник"
 
 msgid "Delete Inspection Plan"
-msgstr "Удалить план проверки"
+msgstr "Удалить план контроля"
 
 msgid "Delete Issue"
 msgstr "Удалить проблему"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "Удалить группу позиций"
 
 msgid "Delete Journal Entry"
-msgstr "Удалить запись журнала"
+msgstr "Удалить проводку"
 
 msgid "Delete line"
 msgstr "Удалить строку"
@@ -4849,10 +4849,10 @@ msgid "Delete Material"
 msgstr "Удалить материал"
 
 msgid "Delete Material Dimension"
-msgstr "Удалить размер материала"
+msgstr "Удалить измерение материала"
 
 msgid "Delete Material Finish"
-msgstr "Удалить отделку материала"
+msgstr "Удалить обработку поверхности"
 
 msgid "Delete Material Grade"
 msgstr "Удалить марку материала"
@@ -4873,31 +4873,31 @@ msgid "Delete Partner"
 msgstr "Удалить партнера"
 
 msgid "Delete passkey"
-msgstr "Удалить Passkey"
+msgstr "Удалить ключ доступа"
 
 msgid "Delete Passkey"
-msgstr "Удалить Passkey"
+msgstr "Удалить ключ доступа"
 
 msgid "Delete Payment"
 msgstr "Удалить платеж"
 
 msgid "Delete Payment Term"
-msgstr "Удалить условие платежа"
+msgstr "Удалить условие оплаты"
 
 msgid "Delete Period"
 msgstr "Удалить период"
 
 msgid "Delete Picking List"
-msgstr "Удалить список комплектации"
+msgstr "Удалить лист отбора"
 
 msgid "Delete Portal"
 msgstr "Удалить портал"
 
 msgid "Delete Price Break"
-msgstr "Удалить ценовой разрыв"
+msgstr "Удалить ценовую шкалу"
 
 msgid "Delete Pricing Rule"
-msgstr "Удалить правило цены"
+msgstr "Удалить правило ценообразования"
 
 msgid "Delete Procedure"
 msgstr "Удалить процедуру"
@@ -4906,13 +4906,13 @@ msgid "Delete Process"
 msgstr "Удалить процесс"
 
 msgid "Delete Purchase Invoice"
-msgstr "Удалить счет-фактуру покупателя"
+msgstr "Удалить счет-фактуру полученную"
 
 msgid "Delete Purchase Order"
-msgstr "Удалить заказ на покупку"
+msgstr "Удалить заказ поставщику"
 
 msgid "Delete Purchase Orders"
-msgstr "Удалить заказы на покупку"
+msgstr "Удалить заказы поставщику"
 
 msgid "Delete Question"
 msgstr "Удалить вопрос"
@@ -4945,10 +4945,10 @@ msgid "Delete Rule"
 msgstr "Удалить правило"
 
 msgid "Delete Sales Invoice"
-msgstr "Удалить счет-фактуру продажи"
+msgstr "Удалить счет-фактуру выданную"
 
 msgid "Delete Sales Order"
-msgstr "Удалить заказ продажи"
+msgstr "Удалить заказ покупателя"
 
 msgid "Delete Schedule"
 msgstr "Удалить расписание"
@@ -4960,10 +4960,10 @@ msgid "Delete Shift"
 msgstr "Удалить смену"
 
 msgid "Delete Shipment"
-msgstr "Удалить отправку"
+msgstr "Удалить отгрузку"
 
 msgid "Delete shipment line"
-msgstr "Удалить строку отправки"
+msgstr "Удалить строку отгрузки"
 
 msgid "Delete Shipping Method"
 msgstr "Удалить способ доставки"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "Удалить тип хранилища"
 
 msgid "Delete Storage Unit"
-msgstr "Удалить хранилище"
+msgstr "Удалить единицу хранения"
 
 msgid "Delete Substance"
 msgstr "Удалить вещество"
@@ -5003,7 +5003,7 @@ msgstr "Удалить тип поставщика"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "Удалить ценовой порог для количества {0}? Это действие нельзя отменить."
+msgstr "Удалить ценовую шкалу для количества {0}? Это не может быть отменено."
 
 msgid "Delete Timecard"
 msgstr "Удалить табель учета рабочего времени"
@@ -5018,7 +5018,7 @@ msgid "Delete Transfer"
 msgstr "Удалить передачу"
 
 msgid "Delete Transfer Line"
-msgstr "Удалить строку передачи"
+msgstr "Удалить строку перемещения"
 
 msgid "Delete Type"
 msgstr "Удалить тип"
@@ -5036,37 +5036,37 @@ msgid "Delete Warehouse Transfer"
 msgstr "Удалить передачу между складами"
 
 msgid "Delete Webhook"
-msgstr "Удалить Webhook"
+msgstr "Удалить вебхук"
 
 msgid "Delete Workflow"
 msgstr "Удалить рабочий процесс"
 
 msgid "Delivery Date"
-msgstr "Дата доставки"
+msgstr "Дата поставки"
 
 msgid "Delivery Location"
 msgstr "Место доставки"
 
 msgid "Demand"
-msgstr "Спрос"
+msgstr "Потребность"
 
 msgid "Demand forecast"
-msgstr "Прогноз спроса"
+msgstr "прогноз потребности"
 
 msgid "Demand Forecast"
-msgstr "Прогноз спроса"
+msgstr "Прогноз потребности"
 
 msgid "Demand Forecast — Driven by"
-msgstr "Прогноз спроса — Обусловлено"
+msgstr "Прогноз потребности — Определяется"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Прогноз спроса = спрос, разложенный по BOM, из открытых заказов на продажу, активных работ и прогнозов производства."
+msgstr "Прогноз потребности = Спрос, разложенный по BOM, из открытых заказов покупателей, текущих производственных заказов и прогнозов производства."
 
 msgid "Demand projection"
-msgstr "Прогноз спроса"
+msgstr "Проекция потребности"
 
 msgid "Demand Projections"
-msgstr "Прогнозы спроса"
+msgstr "Проекции потребности"
 
 msgid "Demand-Based"
 msgstr "На основе спроса"
@@ -5081,7 +5081,7 @@ msgid "Demo data applied"
 msgstr "Демо-данные применены"
 
 msgid "Demo data was applied to this company. Keep it, or revert to put back exactly what was here before."
-msgstr "Демо-данные применены к этой компании. Сохраните их или восстановите, чтобы вернуть ровно то, что было раньше."
+msgstr "Демоданные применены к этой организации. Сохраните их или отмените, чтобы восстановить то, что было раньше."
 
 msgid "department"
 msgstr "отдел"
@@ -5126,7 +5126,7 @@ msgid "Depreciation Start Date"
 msgstr "Дата начала амортизации"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "Выведите срок хранения этого товара из кратчайшего срока хранения его компонентов, игнорируя поле «Дни» выше."
+msgstr "Рассчитать срок хранения этой номенклатуры на основе кратчайшего срока хранения её компонентов, игнорируя поле «Дни» выше."
 
 msgid "Description"
 msgstr "Описание"
@@ -5174,19 +5174,19 @@ msgid "dimension"
 msgstr "измерение"
 
 msgid "Dimension"
-msgstr "Размер"
+msgstr "Измерение"
 
 msgid "Dimension slots"
-msgstr "Слоты размерности"
+msgstr "Слоты измерений"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Значения размерности в опубликованных журналах, которые еще не имеют отображения провайдера."
+msgstr "Значения измерений для проведенных операций, которые еще не имеют сопоставления провайдера."
 
 msgid "dimensions"
 msgstr "измерения"
 
 msgid "Dimensions"
-msgstr "Размеры"
+msgstr "Измерения"
 
 msgid "Direct"
 msgstr "Прямой"
@@ -5238,7 +5238,7 @@ msgid "Discounts earned for early payment to suppliers"
 msgstr "Скидки, полученные за досрочную оплату поставщикам"
 
 msgid "Discounts given to customers for early payment"
-msgstr "Скидки, предоставленные клиентам за досрочную оплату"
+msgstr "Скидки, предоставленные покупателям за раннюю оплату"
 
 msgid "Discovery"
 msgstr "Обнаружение"
@@ -5247,19 +5247,19 @@ msgid "Dismiss"
 msgstr "Отклонить"
 
 msgid "Dispatch"
-msgstr "Диспетчеризация"
+msgstr "Заявка на техобслуживание"
 
 msgid "Dispatch ID"
-msgstr "ID диспетчеризации"
+msgstr "ID заявки на техобслуживание"
 
 msgid "Dispatch priority"
-msgstr "Приоритет отправки"
+msgstr "Приоритет заявки на техобслуживание"
 
 msgid "Dispatches"
-msgstr "Отправки"
+msgstr "Заявки на техобслуживание"
 
 msgid "Display Settings"
-msgstr "Параметры отображения"
+msgstr "Настройки отображения"
 
 msgid "Disposal"
 msgstr "Выбытие"
@@ -5283,7 +5283,7 @@ msgid "Dispositions"
 msgstr "Решения"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
-msgstr "Вы хотите перезаписать текущие разрешения пользователя разрешениями по умолчанию для этого типа сотрудника?"
+msgstr "Вы хотите заменить текущие права доступа пользователя правами доступа по умолчанию для этого типа сотрудника?"
 
 msgid "Doc-Backed"
 msgstr "Обеспечено документом"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Документы"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documents отправляет счета-фактуры, счета и платежи в виде родных документов поставщика; их журналы записываются как покрытые документом. Он также получает платежи, записанные в поставщик, обратно в Carbon, закрывая соответствующую счет-фактуру или счет и публикуя журнал GL Carbon. Off записывает их как намеренно исключенные."
+msgstr "Документы отправляют счета-фактуры, счета и платежи как документы нативного провайдера; их журналы записываются как охваченные документом. Он также извлекает платежи, записанные в провайдере, обратно в Carbon, закрывая соответствующие счета-фактуры или счета и проводя журнал главной книги компании. Отключение записывает их как намеренно исключенные."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Открытые вами документы появятся здесь для быстрого доступа."
@@ -5328,20 +5328,20 @@ msgid "Done"
 msgstr "Готово"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Завершено, когда повседневные операции работают без нашего участия"
+msgstr "Готово, когда ежедневные операции работают без нас в офисе"
 
 msgid "Download"
 msgstr "Скачать"
 
 #. placeholder {0}: errors.length
 msgid "Download {0} row(s) to fix"
-msgstr "Загрузить {0} строк(и) для исправления"
+msgstr "Скачать {0} строку(и) для исправления"
 
 msgid "Download CSV"
-msgstr "Загрузить CSV"
+msgstr "Скачать CSV"
 
 msgid "Download Labels"
-msgstr "Загрузить этикетки"
+msgstr "Скачать этикетки"
 
 msgid "Download Link"
 msgstr "Ссылка для скачивания"
@@ -5359,13 +5359,13 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "Черновик доступен для редактирования; Активный используется и требует новой версии для изменения; Архивный — выведен из обращения."
 
 msgid "Draft Journal Entries"
-msgstr "Черновые записи в журнале"
+msgstr "Черновые операции"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "Перетащите файлы или нажмите для обзора"
 
 msgid "Drag and drop a Purchase Order PDF here, or click to select a file"
-msgstr "Перетащите PDF-файл заказа на покупку сюда или нажмите, чтобы выбрать файл"
+msgstr "Перетащите PDF-файл заказа поставщику сюда или нажмите, чтобы выбрать файл"
 
 msgid "Drag handle"
 msgstr "Ручка перетаскивания"
@@ -5395,19 +5395,19 @@ msgid "Drawing replaced. Balloon placements were removed; feature rows are uncha
 msgstr "Рисунок заменён. Размещение выносок удалено; строки функций не изменены."
 
 msgid "Drop Shipment"
-msgstr "Прямая поставка"
+msgstr "Прямая отгрузка"
 
 msgid "Drop Shipment Statuses"
-msgstr "Статусы прямой доставки"
+msgstr "Статусы прямой отгрузки"
 
 msgid "Drop whole pages or sections a customer doesn't need."
-msgstr "Удалите целые страницы или разделы, которые клиенту не нужны."
+msgstr "Исключите целые страницы или разделы, которые покупателю не нужны."
 
 msgid "Drop your file here, or click to browse."
 msgstr "Перетащите файл сюда или нажмите для обзора."
 
 msgid "Drop-ship"
-msgstr "Прямая доставка"
+msgstr "Прямая поставка"
 
 msgid "Due"
 msgstr "Срок"
@@ -5417,25 +5417,25 @@ msgid "Due {0}"
 msgstr "Срок {0}"
 
 msgid "Due date"
-msgstr "Дата срока"
+msgstr "срок выполнения"
 
 msgid "Due Date"
-msgstr "Дата платежа"
+msgstr "Срок выполнения"
 
 msgid "Due Date (job)"
-msgstr "Дата срока (задание)"
+msgstr "Срок выполнения (производственный заказ)"
 
 msgid "Due Date of First Job"
-msgstr "Дата выполнения первого задания"
+msgstr "Срок выполнения первого производственного заказа"
 
 msgid "Due Date of Last Job"
-msgstr "Дата выполнения последнего задания"
+msgstr "Срок выполнения последнего производственного заказа"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Дата платежа самой ранней работы в пакетной партии; более поздние работы равномерно распределяются между этой датой и датой платежа последней работы."
+msgstr "Срок выполнения самого раннего производственного заказа в групповом производстве; последующие заказы распределяются равномерно между этой датой и сроком выполнения последнего производственного заказа."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Дата платежа последней работы в пакетной партии; объединяется с датой платежа первой работы для равномерного распределения работ."
+msgstr "Срок выполнения последнего производственного заказа в групповом производстве; используется вместе со сроком выполнения первого производственного заказа для равномерного распределения заказов."
 
 msgid "Due Days"
 msgstr "Дни платежа"
@@ -5453,7 +5453,7 @@ msgid "Duplicate Price List"
 msgstr "Дублировать прайс-лист"
 
 msgid "Duplicate Pricing Rule"
-msgstr "Дублировать правило цены"
+msgstr "Дублировать правило ценообразования"
 
 msgid "Duplicate To"
 msgstr "Дублировать в"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "например 48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "например Acme Manufacturing"
+msgstr "например, Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "например Detroit"
@@ -5519,10 +5519,10 @@ msgid "e.g. Zebra 2x1"
 msgstr "например Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Неиспользованный материал каждой операции возвращается сразу после завершения операции."
+msgstr "Неиспользованный материал каждой операции возвращается, как только операция завершена."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
-msgstr "Каждая физическая единица получает свою собственную отслеживаемую сущность и уникальный номер — одна сущность, одна единица."
+msgstr "Каждая физическая единица получает свой отслеживаемый объект и уникальный номер — один объект, одна единица."
 
 msgid "Each, lb, ft…"
 msgstr "Каждый, фунт, фут…"
@@ -5537,325 +5537,325 @@ msgid "Economic Operators Registration and Identification number; required for g
 msgstr "Номер регистрации и идентификации экономических операторов; требуется для товаров, пересекающих таможенные границы в ЕС/Великобритании."
 
 msgid "Edit"
-msgstr "Редактировать"
+msgstr "Изменить"
 
 msgid "Edit <0>Issue</0> Workflow"
-msgstr "Редактировать Рабочий процесс <0>Проблема</0>"
+msgstr "Изменить рабочий процесс <0>списания в производство</0>"
 
 msgid "Edit Account"
-msgstr "Редактировать счет"
+msgstr "Изменить счет"
 
 msgid "Edit Action"
-msgstr "Редактировать действие"
+msgstr "Изменить действие"
 
 msgid "Edit API Key"
-msgstr "Редактировать API ключ"
+msgstr "Изменить API-ключ"
 
 msgid "Edit Approval Rule"
-msgstr "Редактировать правило утверждения"
+msgstr "Изменить правило утверждения"
 
 msgid "Edit Asset"
 msgstr "Изменить актив"
 
 msgid "Edit Asset Class"
-msgstr "Редактировать класс активов"
+msgstr "Изменить класс основных средств"
 
 msgid "Edit Assignment"
-msgstr "Редактировать назначение"
+msgstr "Изменить назначение"
 
 msgid "Edit Attribute"
-msgstr "Редактировать атрибут"
+msgstr "Изменить атрибут"
 
 msgid "Edit Attribute Category"
-msgstr "Редактировать категорию атрибута"
+msgstr "Изменить категорию атрибутов"
 
 msgid "Edit Category"
-msgstr "Редактировать категорию"
+msgstr "Изменить категорию"
 
 msgid "Edit Change Notice"
-msgstr "Редактировать уведомление об изменении"
+msgstr "Изменить извещение об изменении"
 
 msgid "Edit Change Notice Action"
-msgstr "Редактировать действие уведомления об изменении"
+msgstr "Изменить действие извещения об изменении"
 
 msgid "Edit Change Notice Type"
-msgstr "Редактировать тип уведомления об изменении"
+msgstr "Изменить тип извещения об изменении"
 
 msgid "Edit column visibility"
 msgstr "Изменить видимость столбцов"
 
 msgid "Edit Contact"
-msgstr "Редактировать контакт"
+msgstr "Изменить контактное лицо"
 
 msgid "Edit Contractor"
-msgstr "Редактировать подрядчика"
+msgstr "Изменить подрядчика"
 
 msgid "Edit Cost Center"
 msgstr "Изменить центр затрат"
 
 msgid "Edit Count"
-msgstr "Редактировать подсчет"
+msgstr "Изменить счет"
 
 msgid "Edit Currency"
-msgstr "Редактировать валюту"
+msgstr "Изменить валюту"
 
 msgid "Edit Custom Field"
-msgstr "Редактировать пользовательское поле"
+msgstr "Изменить пользовательское поле"
 
 msgid "Edit Customer Part"
-msgstr "Редактировать деталь клиента"
+msgstr "Изменить деталь покупателя"
 
 msgid "Edit Customer Status"
-msgstr "Редактировать статус клиента"
+msgstr "Изменить статус покупателя"
 
 msgid "Edit Customer Type"
-msgstr "Редактировать тип клиента"
+msgstr "Изменить тип покупателя"
 
 msgid "Edit Department"
-msgstr "Редактировать отдел"
+msgstr "Изменить отдел"
 
 msgid "Edit Dimension"
-msgstr "Редактировать измерение"
+msgstr "Изменить измерение"
 
 msgid "Edit Dispatch"
-msgstr "Редактировать диспетчеризацию"
+msgstr "Изменить заявку на техобслуживание"
 
 msgid "Edit Employee"
-msgstr "Редактировать сотрудника"
+msgstr "Изменить сотрудника"
 
 msgid "Edit Employee Type"
-msgstr "Редактировать тип сотрудника"
+msgstr "Изменить тип сотрудника"
 
 msgid "Edit expiration date"
-msgstr "Изменить дату истечения"
+msgstr "Изменить дату истечения срока"
 
 msgid "Edit Expiry"
-msgstr "Редактировать срок годности"
+msgstr "Изменить срок годности"
 
 msgid "Edit Failure Mode"
-msgstr "Редактировать режим отказа"
+msgstr "Изменить вид отказа"
 
 msgid "Edit Fixed Asset"
-msgstr "Редактировать основное средство"
+msgstr "Изменить основное средство"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Редактировать запись калибровки датчика"
+msgstr "Изменить запись о калибровке средства измерения"
 
 msgid "Edit Gauge Type"
-msgstr "Редактировать тип датчика"
+msgstr "Изменить тип средства измерения"
 
 msgid "Edit Group"
-msgstr "Редактировать группу"
+msgstr "Изменить группу"
 
 msgid "Edit Holiday"
-msgstr "Редактировать праздник"
+msgstr "Изменить праздник"
 
 msgid "Edit Inspection Plan"
-msgstr "Отредактировать план контроля"
+msgstr "Изменить план контроля"
 
 msgid "Edit Item Group"
-msgstr "Редактировать группу товаров"
+msgstr "Изменить группу номенклатуры"
 
 msgid "Edit Journal Entry"
-msgstr "Изменить запись журнала"
+msgstr "Изменить проводку"
 
 msgid "Edit Kanban"
-msgstr "Редактировать Kanban"
+msgstr "Изменить канбан"
 
 msgid "Edit Line"
-msgstr "Редактировать строку"
+msgstr "Изменить строку"
 
 msgid "Edit Location"
-msgstr "Редактировать местоположение"
+msgstr "Изменить площадку"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Редактировать заявку на техническое обслуживание"
+msgstr "Изменить заявку на техобслуживание"
 
 msgid "Edit Material"
-msgstr "Редактировать материал"
+msgstr "Изменить материал"
 
 msgid "Edit Material Dimension"
-msgstr "Редактировать размер материала"
+msgstr "Изменить измерение материала"
 
 msgid "Edit Material Finish"
-msgstr "Редактировать отделку материала"
+msgstr "Изменить обработку поверхности"
 
 msgid "Edit Material Grade"
-msgstr "Редактировать марку материала"
+msgstr "Изменить марку"
 
 msgid "Edit Material Shape"
-msgstr "Редактировать форму материала"
+msgstr "Изменить форму"
 
 msgid "Edit Material Substance"
-msgstr "Редактировать материальное вещество"
+msgstr "Изменить основной материал"
 
 msgid "Edit Material Type"
-msgstr "Редактировать тип материала"
+msgstr "Изменить тип материала"
 
 msgid "Edit Memo"
-msgstr "Редактировать Memo"
+msgstr "Изменить заметку"
 
 msgid "Edit Non Conformance Type"
-msgstr "Редактировать тип несоответствия"
+msgstr "Изменить тип несоответствия"
 
 msgid "Edit Part"
-msgstr "Редактировать деталь"
+msgstr "Изменить деталь"
 
 msgid "Edit Partner"
-msgstr "Редактировать партнера"
+msgstr "Изменить партнера"
 
 msgid "Edit Passkey"
-msgstr "Редактировать Passkey"
+msgstr "Изменить Ключ доступа"
 
 msgid "Edit Payment"
-msgstr "Редактировать платеж"
+msgstr "Изменить Платеж"
 
 msgid "Edit Payment Term"
-msgstr "Редактировать условие платежа"
+msgstr "Изменить Условия оплаты"
 
 msgid "Edit permissions"
-msgstr "Права редактирования"
+msgstr "Изменить права доступа"
 
 msgid "Edit Permissions"
-msgstr "Разрешения на редактирование"
+msgstr "Изменить Права доступа"
 
 msgid "Edit Picking List"
-msgstr "Редактировать список комплектации"
+msgstr "Изменить Лист отбора"
 
 msgid "Edit Portal"
-msgstr "Редактировать портал"
+msgstr "Изменить Портал"
 
 msgid "Edit Price Override"
-msgstr "Редактировать переопределение цены"
+msgstr "Изменить Переопределение цены"
 
 msgid "Edit Pricing"
-msgstr "Редактировать цены"
+msgstr "Изменить Ценообразование"
 
 msgid "Edit Pricing Rule"
-msgstr "Редактировать правило цены"
+msgstr "Изменить Правило ценообразования"
 
 msgid "Edit Process"
-msgstr "Редактировать процесс"
+msgstr "Изменить Процесс"
 
 msgid "Edit Production Event"
-msgstr "Редактировать производственное событие"
+msgstr "Изменить Производственное событие"
 
 msgid "Edit Production Projection"
-msgstr "Редактировать производственную проекцию"
+msgstr "Изменить Прогноз производства"
 
 msgid "Edit Production Quantity"
-msgstr "Редактировать производственное количество"
+msgstr "Изменить Производственное количество"
 
 msgid "Edit purchase order line type"
-msgstr "Редактировать тип строки заказа покупателя"
+msgstr "Изменить тип строки заказа поставщику"
 
 msgid "Edit Question"
-msgstr "Редактировать вопрос"
+msgstr "Изменить Вопрос"
 
 msgid "Edit Reason"
-msgstr "Редактировать причину"
+msgstr "Изменить Причину"
 
 msgid "Edit Receipt"
-msgstr "Редактировать квитанцию"
+msgstr "Изменить Поступление"
 
 msgid "Edit Revision"
-msgstr "Редактировать ревизию"
+msgstr "Изменить Ревизию"
 
 msgid "Edit rule"
-msgstr "Редактировать правило"
+msgstr "Изменить правило"
 
 msgid "Edit Rule"
-msgstr "Редактировать правило"
+msgstr "Изменить Правило"
 
 msgid "Edit Schedule"
-msgstr "Редактировать расписание"
+msgstr "Изменить График"
 
 msgid "Edit Scheduled Maintenance"
-msgstr "Редактировать плановое обслуживание"
+msgstr "Изменить Запланированное техобслуживание"
 
 msgid "Edit Sequence"
-msgstr "Редактировать последовательность"
+msgstr "Изменить Нумерацию"
 
 msgid "Edit Serial Number"
-msgstr "Редактировать серийный номер"
+msgstr "Изменить Серийный номер"
 
 msgid "Edit Service"
-msgstr "Редактировать услугу"
+msgstr "Изменить Услугу"
 
 msgid "Edit Shift"
-msgstr "Редактировать смену"
+msgstr "Изменить Смену"
 
 msgid "Edit Shipment"
-msgstr "Редактировать отправку"
+msgstr "Изменить Отгрузку"
 
 msgid "Edit Shipping"
-msgstr "Редактировать доставку"
+msgstr "Изменить Доставку"
 
 msgid "Edit Shipping Method"
-msgstr "Редактировать способ доставки"
+msgstr "Изменить Способ доставки"
 
 msgid "Edit Size"
-msgstr "Редактировать размер"
+msgstr "Изменить Размер"
 
 msgid "Edit Step"
-msgstr "Редактировать шаг"
+msgstr "Изменить Шаг"
 
 msgid "Edit Stock Transfer"
-msgstr "Редактировать передачу запасов"
+msgstr "Изменить Перемещение запаса"
 
 msgid "Edit Storage Type"
-msgstr "Редактировать тип хранилища"
+msgstr "Изменить Тип хранилища"
 
 msgid "Edit Storage Unit"
-msgstr "Редактировать хранилище"
+msgstr "Изменить Единицу хранения"
 
 msgid "Edit Substance"
-msgstr "Редактировать вещество"
+msgstr "Изменить Вещество"
 
 msgid "Edit Supplier"
-msgstr "Редактировать поставщика"
+msgstr "Изменить Поставщика"
 
 msgid "Edit Supplier Part"
-msgstr "Редактировать поставщика детали"
+msgstr "Изменить Деталь поставщика"
 
 msgid "Edit supplier process"
-msgstr "Редактировать процесс поставщика"
+msgstr "Изменить процесс поставщика"
 
 msgid "Edit Supplier Type"
-msgstr "Редактировать тип поставщика"
+msgstr "Изменить Тип поставщика"
 
 msgid "Edit the rule to remove the \"Applies to all\" flag"
-msgstr "Отредактируйте правило, чтобы удалить флаг \"Применяется ко всем\""
+msgstr "Измените правило, чтобы удалить флаг «Применяется ко всем»"
 
 msgid "Edit Timecard"
-msgstr "Редактировать табель учета рабочего времени"
+msgstr "Изменить табель"
 
 msgid "Edit Tool"
-msgstr "Редактировать инструмент"
+msgstr "Изменить инструмент"
 
 msgid "Edit Training"
-msgstr "Редактировать обучение"
+msgstr "Изменить обучение"
 
 msgid "Edit Transfer"
-msgstr "Редактировать передачу"
+msgstr "Изменить перемещение"
 
 msgid "Edit Transfer Line"
-msgstr "Редактировать строку передачи"
+msgstr "Изменить строку перемещения"
 
 msgid "Edit Type"
-msgstr "Редактировать тип"
+msgstr "Изменить тип"
 
 msgid "Edit Unit of Measure"
-msgstr "Редактировать единицу измерения"
+msgstr "Изменить единицу измерения"
 
 msgid "Edit View"
-msgstr "Редактировать представление"
+msgstr "Изменить представление"
 
 msgid "Edit Webhook"
-msgstr "Редактировать Webhook"
+msgstr "Изменить вебхук"
 
 msgid "Edit Work Center"
-msgstr "Редактировать рабочий центр"
+msgstr "Изменить рабочий центр"
 
 msgid "Eliminated"
 msgstr "Исключено"
@@ -5876,7 +5876,7 @@ msgid "Email Address"
 msgstr "Адрес электронной почты"
 
 msgid "Email notifications are not included in your company's current plan; email preferences will apply if they are enabled."
-msgstr "Уведомления по электронной почте не включены в текущий план вашей компании; параметры электронной почты будут применены, если они включены."
+msgstr "Уведомления по электронной почте не включены в текущий план вашей организации; настройки электронной почты будут применяться, если они включены."
 
 msgid "Email notifications not configured"
 msgstr "Уведомления по электронной почте не настроены"
@@ -5924,13 +5924,13 @@ msgid "Enable audit logging in settings to start tracking changes to your data."
 msgstr "Включите аудит в настройках, чтобы начать отслеживать изменения ваших данных."
 
 msgid "Enable digital quotes for your company. This will allow you to send digital quotes to your customers, and allow them to accept them online."
-msgstr "Включите цифровые предложения для вашей компании. Это позволит вам отправлять цифровые предложения вашим клиентам и позволит им принимать их онлайн."
+msgstr "Включить цифровые коммерческие предложения для вашей организации. Это позволит вам отправлять цифровые коммерческие предложения вашим покупателям и позволит им принимать их онлайн."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Включите полный учет по методу начисления с записями в журнале, финансовыми отчетами и проводками в главную книгу."
+msgstr "Включить полный учет по методу начислений с проводками, финансовыми отчетами и проведением через главную книгу."
 
 msgid "Enable in Settings"
-msgstr "Включить в параметрах"
+msgstr "Включить в настройках"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
 msgstr "Включить уведомления, когда запрос коммерческого предложения отмечен как готовый к цитированию."
@@ -5939,7 +5939,7 @@ msgid "Enable shared workstation mode for MES terminals. Operators identify them
 msgstr "Включите режим общей рабочей станции для терминалов MES. Операторы идентифицируют себя по PIN-коду перед выполнением работы."
 
 msgid "Enable this rule to automatically require approval for matching documents"
-msgstr "Включите это правило, чтобы автоматически требовать одобрение для соответствующих документов"
+msgstr "Включите это правило, чтобы автоматически требовать утверждение для совпадающих документов."
 
 msgid "Enable timecard tracking for work shifts."
 msgstr "Включить отслеживание табелей учета рабочего времени для смен."
@@ -5951,7 +5951,7 @@ msgid "Enable to automatically post transactions to the general ledger."
 msgstr "Включите, чтобы автоматически отправлять транзакции в главную книгу."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
-msgstr "Включите, чтобы настроить методы налоговой амортизации для классов активов (например, MACRS, ускоренная)."
+msgstr "Включите, чтобы настроить налоговые методы амортизации для классов основных средств (например, MACRS, ускоренная)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
 msgstr "Включите для создания идентификаторов и описаний для сырья."
@@ -5963,7 +5963,7 @@ msgid "Enable to start tracking work shifts."
 msgstr "Включите для начала отслеживания рабочих смен."
 
 msgid "Enable to use metric units for material dimensions."
-msgstr "Включите использование метрических единиц для размеров материалов."
+msgstr "Включить использование метрических единиц для размеров материалов."
 
 msgid "Enabled"
 msgstr "Включено"
@@ -5991,10 +5991,10 @@ msgid "Ending ({0})"
 msgstr "Конец ({0})"
 
 msgid "Enforce — edits are blocked"
-msgstr "Принудить — редактирование заблокировано"
+msgstr "Применять — правки заблокированы"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
-msgstr "Обеспечьте валидацию и рекомендации для каждого товара в квитанциях, отправках, передачах и корректировках."
+msgstr "Применить обязательную проверку и указания для каждого элемента в поступлениях, отгрузках, перемещениях и корректировках."
 
 msgid "Engagement tier"
 msgstr "Уровень взаимодействия"
@@ -6003,26 +6003,26 @@ msgid "Engineering"
 msgstr "Инженерия"
 
 msgid "Engineering changes and CAD"
-msgstr "Инженерные изменения и САПР"
+msgstr "Конструкторские изменения и CAD"
 
 msgid "Engineering Changes and CAD"
-msgstr "Инженерные изменения и САПР"
+msgstr "Конструкторские изменения и CAD"
 
 msgid "Engineering Contact"
-msgstr "Контакт инженера"
+msgstr "Контактное лицо инженерии"
 
 msgid "Enroll"
 msgstr "Зарегистрировать"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "Введите номер партии перед установкой даты истечения"
+msgstr "Введите номер серии перед установкой даты истечения срока"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "Введите количество от 1 до {0}."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Ввести и утвердить счета поставщиков по сравнению с ПО (трёхсторонняя сверка)"
+msgstr "Введите и утвердите счета от поставщиков по заказу на покупку (трехстороннее сопоставление)"
 
 msgid "Enter number…"
 msgstr "Введите число…"
@@ -6064,7 +6064,7 @@ msgid "Entity certification: Accepted"
 msgstr "Сертификация организации: Принята"
 
 msgid "Entity certification: Expired"
-msgstr "Сертификация организации: Истекла"
+msgstr "Сертификация сущности: истек срок"
 
 msgid "Entity certification: Pending"
 msgstr "Сертификация организации: Ожидание"
@@ -6091,7 +6091,7 @@ msgid "Equity account for accumulated profits or losses"
 msgstr "Счет собственного капитала для накопленной прибыли или убытков"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Счет собственного капитала для корректировок курсовых разниц (CTA)"
+msgstr "Счет собственного капитала для корректировок пересчета валют (CTA)"
 
 msgid "Error"
 msgstr "Ошибка"
@@ -6103,13 +6103,13 @@ msgid "Error downloading file"
 msgstr "Ошибка при загрузке файла"
 
 msgid "Error fetching customer data"
-msgstr "Ошибка при получении данных клиента"
+msgstr "Ошибка получения данных покупателя"
 
 msgid "Error fetching supplier data"
 msgstr "Ошибка при получении данных поставщика"
 
 msgid "Error loading assigned dispatches"
-msgstr "Ошибка при загрузке назначенных заданий"
+msgstr "Ошибка загрузки назначенных заявок на техобслуживание"
 
 msgid "Error loading assigned documents"
 msgstr "Ошибка при загрузке назначенных документов"
@@ -6145,10 +6145,10 @@ msgid "Error removing model from RFQ line"
 msgstr "Ошибка при удалении модели из строки RFQ"
 
 msgid "Error removing model from sales invoice line"
-msgstr "Ошибка при удалении модели из строки счета-фактуры"
+msgstr "Ошибка при удалении модели из строки счета-фактуры продажи"
 
 msgid "Error removing model from sales order line"
-msgstr "Ошибка при удалении модели из строки заказа на продажу"
+msgstr "Ошибка при удалении модели из строки заказа покупателя"
 
 msgid "Escalate to the project leads"
 msgstr "Передайте проблему руководителям проекта"
@@ -6169,7 +6169,7 @@ msgid "Estimated Scrap Quantity"
 msgstr "Предполагаемое количество брака"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Предполагаемое количество отходов, применяемое к каждой работе в пакетной партии."
+msgstr "Предполагаемое количество брака применяется к каждому производственному заказу в пакетной обработке."
 
 msgid "Estimated time"
 msgstr "Примерное время"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Каждое совпадение"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Каждая требуемая задача должна быть завершена или пропущена перед закрытием периода."
+msgstr "Каждая требуемая задача должна быть Готово или Пропущено перед закрытием периода."
 
 msgid "Every row was imported successfully."
 msgstr "Каждая строка была успешно импортирована."
@@ -6211,22 +6211,22 @@ msgid "Everything else"
 msgstr "Все остальное"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "Все остальное охватывает людей, импорт, интеграции и API — все, что не входит в ваши рабочие процессы."
+msgstr "Все остальное охватывает людей, импорты, интеграции и API — что угодно, что не является одним из ваших рабочих процессов."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Превышает {PO_EMAIL_ATTACHMENT_LIMIT_MB} МБ всего — удалите некоторые вложения для отправки."
 
 msgid "Exchange rate"
-msgstr "Курс обмена"
+msgstr "Валютный курс"
 
 msgid "Exchange Rate"
-msgstr "Курс обмена"
+msgstr "Валютный курс"
 
 msgid "Exchange rate updated at"
-msgstr "Курс обмена обновлен в"
+msgstr "Валютный курс обновлен в"
 
 msgid "Exchange Rates"
-msgstr "Курсы обмена"
+msgstr "Валютные курсы"
 
 msgid "Exchanging the authorization code for an access token failed. Try connecting again."
 msgstr "Не удалось обменять код авторизации на токен доступа. Повторите попытку подключения."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Существующие отображения. Выберите другой вариант провайдера для переотображения."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Существующий покупатель Stripe"
 
 msgid "Expand"
 msgstr "Развернуть"
@@ -6263,7 +6263,7 @@ msgid "Expand all"
 msgstr "Развернуть все"
 
 msgid "Expand Costs"
-msgstr "Развернуть затраты"
+msgstr "Развернуть Себестоимость"
 
 msgid "Expand features table"
 msgstr "Развернуть таблицу функций"
@@ -6272,7 +6272,7 @@ msgid "Expand Labor"
 msgstr "Развернуть Труд"
 
 msgid "Expand Machine"
-msgstr "Развернуть машину"
+msgstr "Развернуть Станок"
 
 msgid "Expand Setup"
 msgstr "Развернуть Setup"
@@ -6281,10 +6281,10 @@ msgid "Expand subtree"
 msgstr "Развернуть поддерево"
 
 msgid "Expected future demand for a make part entered week by week before any sales order exists; planning nets it against supply and explodes the method to order components ahead."
-msgstr "Ожидаемый будущий спрос на производимый товар, вводимый неделя за неделей до того, как появится какой-либо заказ продажи; планирование сопоставляет его с предложением и разворачивает метод для упреждающего заказа компонентов."
+msgstr "Ожидаемая будущая потребность для производимой номенклатуры, вводимая еженедельно до создания заказа покупателя; планирование согласует её с обеспечением и разворачивает метод для заказа компонентов заранее."
 
 msgid "Expected future demand for an item, bucketed by period, populated by the planning run alongside actual demand."
-msgstr "Ожидаемый будущий спрос на товар, сгруппированный по периодам, заполняемый при запуске планирования наряду с фактическим спросом."
+msgstr "Ожидаемая будущая потребность для номенклатуры, разбитая по периодам и заполняемая результатом планирования наряду с фактической потребностью."
 
 msgid "Expected Receipt"
 msgstr "Ожидаемое получение"
@@ -6293,28 +6293,28 @@ msgid "Expected Receipt Date"
 msgstr "Ожидаемая дата получения"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Счет расходов для остатков клиентов, списанных как невзыскиваемые при расчете по дебиторской задолженности"
+msgstr "Счет расходов для остатков покупателей, списанных как безнадежные при урегулировании дебиторской задолженности"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
 msgstr "Счет расходов для корректировок отложенного налога на амортизацию"
 
 msgid "Expense account for equipment and facility maintenance"
-msgstr "Счет расходов на содержание оборудования и объектов"
+msgstr "Счет расходов для техобслуживания оборудования и объектов"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
-msgstr "Счет расходов для убытков от валютных операций, когда платеж погашает счет в иностранной валюте по менее выгодному курсу"
+msgstr "Счет расходов для убытков по валютным операциям при расчете платежом счета-фактуры в иностранной валюте по менее благоприятному курсу"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Счет расходов на закупки не из запасов (услуги, расходники)"
+msgstr "Счет расходов для покупок нескладских товаров (услуги, расходные материалы)"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Счет расходов, дебетуемый при отгрузке/выпуске товаров по продаже."
+msgstr "Счет расходов для себестоимости реализованной номенклатуры"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Сторона расходов в отношении отложенного налогового движения (в паре с отложенным налоговым обязательством)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Не удалось создать класс активов: {0}"
+msgstr "Сторона расходов движений отложенного налога (связано с обязательством по отложенному налогу)."
 
 msgid "Expenses"
 msgstr "Расходы"
@@ -6323,27 +6323,27 @@ msgid "Expert guidance"
 msgstr "Экспертное руководство"
 
 msgid "Expiration date"
-msgstr "Дата истечения"
+msgstr "Дата истечения срока"
 
 msgid "Expiration Date"
-msgstr "Дата истечения"
+msgstr "Дата истечения срока"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "Дата истечения (применяется ко всем серийным номерам в этой строке)"
+msgstr "Дата истечения срока (применяется ко всем серийным номерам на этой строке)"
 
 msgid "Expired"
-msgstr "Истекло"
+msgstr "Истек срок"
 
 #. placeholder {0}: formatDate(date)
 #. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
-msgstr "Истекла {0}"
+msgstr "Истек срок {0}"
 
 msgid "Expired batch"
 msgstr "Истекший срок партии"
 
 msgid "Expired Batches"
-msgstr "Истекшие партии"
+msgstr "Серии с истекшим сроком"
 
 msgid "Expires"
 msgstr "Истекает"
@@ -6362,19 +6362,19 @@ msgid "Expiring first"
 msgstr "Истекающие первыми"
 
 msgid "Expiry"
-msgstr "Срок действия"
+msgstr "Срок годности"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "Срок действия начинается после завершения выбранного процесса."
+msgstr "Срок годности начинается по завершении выбранного процесса."
 
 msgid "Expiry begins when the selected process starts."
-msgstr "Срок действия начинается при запуске выбранного процесса."
+msgstr "Срок годности начинается при запуске выбранного процесса."
 
 msgid "Expiry trace"
 msgstr "Трассировка срока годности"
 
 msgid "Export"
-msgstr "Экспорт"
+msgstr "Экспортировать"
 
 msgid "Export CSV"
 msgstr "Экспортировать CSV"
@@ -6401,7 +6401,7 @@ msgid "External link"
 msgstr "Внешняя ссылка"
 
 msgid "External notes"
-msgstr "Внешние заметки"
+msgstr "Внешние примечания"
 
 msgid "External Notes"
 msgstr "Внешние примечания"
@@ -6422,7 +6422,7 @@ msgid "Extra tags for slicing your GL reporting"
 msgstr "Дополнительные теги для разбора отчетности главной книги"
 
 msgid "Fail"
-msgstr "Не пройти"
+msgstr "Не годен"
 
 msgid "Failed"
 msgstr "Неудачно"
@@ -6432,7 +6432,7 @@ msgstr "Отказавшие элементы"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (первый истекший - первый выходит)"
+msgstr "Ошибка при создании класса основных средств: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6448,15 +6448,15 @@ msgstr "Не удалось создать портал клиента: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer status: {0}"
-msgstr "Не удалось создать статус клиента: {0}"
+msgstr "Ошибка при создании статуса покупателя: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer type: {0}"
-msgstr "Не удалось создать тип клиента: {0}"
+msgstr "Ошибка при создании типа покупателя: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create customer: {0}"
-msgstr "Не удалось создать клиента: {0}"
+msgstr "Ошибка при создании покупателя: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create department: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Не удалось создать режим отказа: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Ошибка при создании типа датчика: {0}"
+msgstr "Ошибка при создании типа средства измерения: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6480,15 +6480,15 @@ msgstr "Не удалось создать местоположение: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "Не удалось создать график обслуживания: {0}"
+msgstr "Ошибка при создании графика техобслуживания: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
-msgstr "Не удалось создать размер материала: {0}"
+msgstr "Ошибка при создании измерения материала: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "Не удалось создать отделку материала: {0}"
+msgstr "Ошибка при создании обработки поверхности: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
@@ -6500,7 +6500,7 @@ msgstr "Не удалось создать марку материала: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Ошибка при создании материального вещества: {0}"
+msgstr "Ошибка при создании основного материала: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6512,7 +6512,7 @@ msgstr "Ошибка при создании материала: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Не удалось создать причину отсутствия предложения: {0}"
+msgstr "Ошибка при создании причины отказа от предложения: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "Не удалось создать деталь: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Не удалось создать условие платежа: {0}"
+msgstr "Ошибка при создании условий оплаты: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6536,7 +6536,7 @@ msgstr "Не удалось создать способ доставки: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "Не удалось создать строку передачи запасов: {0}"
+msgstr "Ошибка при создании строки перемещения запаса: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6552,7 +6552,7 @@ msgstr "Не удалось создать инструмент: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create webhook: {0}"
-msgstr "Не удалось создать webhook: {0}"
+msgstr "Ошибка при создании вебхука: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create work center: {0}"
@@ -6562,10 +6562,10 @@ msgid "Failed to delete file from old location"
 msgstr "Не удалось удалить файл из старого местоположения"
 
 msgid "Failed to download file for moving"
-msgstr "Не удалось загрузить файл для перемещения"
+msgstr "Ошибка при скачивании файла для перемещения"
 
 msgid "Failed to fetch item costs"
-msgstr "Не удалось получить стоимость товаров"
+msgstr "Ошибка при получении себестоимости номенклатуры"
 
 msgid "Failed to fetch place details"
 msgstr "Не удалось получить детали места"
@@ -6592,13 +6592,13 @@ msgid "Failed to load configuration parameters"
 msgstr "Не удалось загрузить параметры конфигурации"
 
 msgid "Failed to load customer part details"
-msgstr "Не удалось загрузить детали детали клиента"
+msgstr "Ошибка при загрузке сведений о номенклатуре покупателя"
 
 msgid "Failed to load data"
 msgstr "Не удалось загрузить данные"
 
 msgid "Failed to load inbound inspections"
-msgstr "Не удалось загрузить входящие проверки"
+msgstr "Ошибка при загрузке входных контролей"
 
 msgid "Failed to load item data"
 msgstr "Не удалось загрузить данные элемента"
@@ -6607,16 +6607,16 @@ msgid "Failed to load item details"
 msgstr "Не удалось загрузить детали товара"
 
 msgid "Failed to load job operations"
-msgstr "Не удалось загрузить операции задания"
+msgstr "Ошибка при загрузке операций заказа"
 
 msgid "Failed to load jobs"
-msgstr "Не удалось загрузить задания"
+msgstr "Не удалось загрузить производственные заказы"
 
 msgid "Failed to load purchase order lines"
-msgstr "Не удалось загрузить строки заказа на покупку"
+msgstr "Не удалось загрузить строки заказов поставщикам"
 
 msgid "Failed to load purchase orders"
-msgstr "Не удалось загрузить заказы на покупку"
+msgstr "Не удалось загрузить заказы поставщикам"
 
 msgid "Failed to load receipt lines"
 msgstr "Не удалось загрузить строки квитанции"
@@ -6625,16 +6625,16 @@ msgid "Failed to load receipts"
 msgstr "Не удалось загрузить квитанции"
 
 msgid "Failed to load sales order lines"
-msgstr "Не удалось загрузить строки заказа продажи"
+msgstr "Не удалось загрузить строки заказов покупателей"
 
 msgid "Failed to load sales orders"
-msgstr "Не удалось загрузить заказы на продажу"
+msgstr "Не удалось загрузить заказы покупателей"
 
 msgid "Failed to load shipment lines"
-msgstr "Не удалось загрузить строки отправки"
+msgstr "Не удалось загрузить строки отгрузок"
 
 msgid "Failed to load shipments"
-msgstr "Не удалось загрузить отправки"
+msgstr "Не удалось загрузить отгрузки"
 
 msgid "Failed to load supplier part details"
 msgstr "Не удалось загрузить детали поставщика"
@@ -6650,16 +6650,16 @@ msgid "Failed to regenerate thumbnail"
 msgstr "Не удалось повторно создать миниатюру"
 
 msgid "Failed to register passkey"
-msgstr "Не удалось зарегистрировать Passkey"
+msgstr "Не удалось зарегистрировать ключ доступа"
 
 msgid "Failed to remove image: {errorMessage}"
-msgstr "Не удалось удалить изображение: {errorMessage}"
+msgstr "Ошибка при удалении изображения: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
 msgstr "Не удалось удалить миниатюру модели"
 
 msgid "Failed to remove purchase order"
-msgstr "Не удалось удалить заказ на покупку"
+msgstr "Не удалось удалить заказ поставщику"
 
 msgid "Failed to remove thumbnail"
 msgstr "Не удалось удалить миниатюру"
@@ -6707,10 +6707,10 @@ msgid "Failed to update count"
 msgstr "Ошибка обновления подсчета"
 
 msgid "Failed to update item cost"
-msgstr "Не удалось обновить стоимость товара"
+msgstr "Не удалось обновить себестоимость номенклатуры"
 
 msgid "Failed to update opportunity with purchase order"
-msgstr "Не удалось обновить возможность с заказом на покупку"
+msgstr "Не удалось обновить сделку заказом поставщику"
 
 msgid "Failed to update quote line"
 msgstr "Не удалось обновить строку предложения"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Сборы"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Отделка"
+msgstr "FEFO (первым истекает - первым отпускается)"
 
 msgid "Fetch"
 msgstr "Получить"
@@ -6841,16 +6841,16 @@ msgid "Files attached here ride along on every purchase order email sent to this
 msgstr "Файлы, прикрепленные здесь, отправляются вместе с каждым письмом заказа на покупку, отправленным этому поставщику (в дополнение к общекорпоративным значениям по умолчанию)."
 
 msgid "Fill this company with a realistic industry story so every screen has something in it. You can put back what was here before."
-msgstr "Заполните эту компанию реалистичной историей отрасли, чтобы на каждом экране было что-нибудь. Вы можете вернуть то, что было раньше."
+msgstr "Заполните организацию реалистичной историей отрасли, чтобы каждый экран содержал данные. Вы можете восстановить то, что было здесь раньше."
 
 msgid "Filter"
-msgstr "Фильтр"
+msgstr "Фильтровать"
 
 msgid "Finalize"
 msgstr "Завершить"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "Финализация налогового месяца через цикл жизни Открыто → Заблокировано → Закрыто; закрытый период заморожен и его остатки снимаются, обратимо только явным повторным открытием."
+msgstr "Завершение финансового месяца через цикл Открыто → Заблокировано → Закрыто; закрытый период заморожен, его остатки сохранены снимками и обратимы только явным открытием заново."
 
 msgid "Financial Statements"
 msgstr "Финансовые отчеты"
@@ -6871,7 +6871,7 @@ msgid "Finish with material unpicked?"
 msgstr "Завершить с непобранным материалом?"
 
 msgid "Finished goods"
-msgstr "Отделки"
+msgstr "Готовая продукция"
 
 msgid "Finished Goods"
 msgstr "Готовая продукция"
@@ -6910,7 +6910,7 @@ msgid "Fiscal Year"
 msgstr "Финансовый год"
 
 msgid "Fiscal Year Settings"
-msgstr "Параметры финансового года"
+msgstr "Настройки финансового года"
 
 msgid "Fiscal Year to Date"
 msgstr "Финансовый год на сегодняшний день"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "Фиксированный"
 
 msgid "Fixed asset"
-msgstr "Отклонение амортизации постоянных затрат, когда размер партии отличается от нормы"
+msgstr "Основное средство"
 
 msgid "Fixed Asset"
 msgstr "Основное средство"
@@ -6937,7 +6937,7 @@ msgid "Fixed Assets"
 msgstr "Основные средства"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Прибыли и Убытки"
+msgstr "Отклонение амортизации постоянных затрат при различии размера серии от нормального"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "Зафиксирован после размещения или закрытия учетных периодов. Удалите все открытые периоды, чтобы его изменить."
@@ -6946,7 +6946,7 @@ msgid "Fixed Reorder"
 msgstr "Фиксированный заказ"
 
 msgid "Fixed Shelf Life"
-msgstr "Фиксированный срок годности"
+msgstr "Фиксированный срок хранения"
 
 msgid "Fixture"
 msgstr "Приспособление"
@@ -6962,16 +6962,16 @@ msgstr "для чего угодно. Они привлекут нужного �
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Метод прогнозирования: <0>{0}</0>. Эта строка не была получена из активных заданий, поэтому родительские источники недоступны."
+msgstr "Метод прогноза: <0>{0}</0>. Эта строка не была получена из активных производственных заказов, поэтому нет доступных источников."
 
 msgid "Forgot to Clock Out?"
-msgstr "Забыли отметить уход?"
+msgstr "Забыли завершить окончание работы?"
 
 msgid "Format"
 msgstr "Формат"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Инженер на месте"
 
 msgid "Foundation"
 msgstr "Основа"
@@ -6983,10 +6983,10 @@ msgid "Freeze the old system, no new transactions"
 msgstr "Заморозить старую систему, новых транзакций нет"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "Фрахт, выставляемый клиенту за эту строку, отдельно от цены за единицу строки."
+msgstr "Стоимость доставки, выставленная покупателю по этой строке, отдельно от цены за единицу данной строки."
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
-msgstr "Фрахт, взимаемый этим поставщиком за эту строку, когда он перечисляет доставку отдельно, а не включает её в цену за единицу."
+msgstr "Стоимость доставки, указанная этим поставщиком по этой строке, когда поставщик выделяет доставку отдельно вместо включения в цену за единицу."
 
 msgid "Frequencies"
 msgstr "Частоты"
@@ -7009,7 +7009,7 @@ msgid "From <0/>"
 msgstr "От <0/>"
 
 msgid "From customer"
-msgstr "От клиента"
+msgstr "От покупателя"
 
 msgid "From Location"
 msgstr "Из местоположения"
@@ -7018,16 +7018,16 @@ msgid "from on-account credit"
 msgstr "со счета авансовых платежей"
 
 msgid "From Storage Unit"
-msgstr "Из хранилища"
+msgstr "Из единицы хранения"
 
 msgid "Fulfillment Location"
-msgstr "Местоположение исполнения"
+msgstr "Площадка отгрузки"
 
 msgid "Full name"
 msgstr "Полное имя"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Полная наладка и миграции"
 
 msgid "Fully Depreciated"
 msgstr "Полностью амортизирован"
@@ -7051,40 +7051,40 @@ msgid "Gains recognized on disposal of fixed assets"
 msgstr "Прибыль, признаваемая при выбытии основных средств"
 
 msgid "gauge"
-msgstr "Калибры"
+msgstr "средство измерения"
 
 msgid "Gauge"
-msgstr "Манометр"
+msgstr "Средство измерения"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Уведомления о калибровке датчиков"
+msgstr "Уведомления о калибровке средств измерения"
 
 msgid "Gauge ID"
-msgstr "ID датчика"
+msgstr "ID средства измерения"
 
 msgid "Gauge not found"
-msgstr "Датчик не найден"
+msgstr "Средство измерения не найдено"
 
 msgid "Gauge Type"
-msgstr "Тип датчика"
+msgstr "Тип средства измерения"
 
 msgid "Gauge Types"
-msgstr "Типы датчиков"
+msgstr "Типы средств измерения"
 
 msgid "gauges"
-msgstr "Генеалогия"
+msgstr "средства измерения"
 
 msgid "Gauges"
-msgstr "Датчики"
+msgstr "Средства измерения"
 
 msgid "Genealogy"
-msgstr "Главная Бухгалтерская Книга"
+msgstr "Генеалогия"
 
 msgid "General"
 msgstr "Общие"
 
 msgid "General ledger"
-msgstr "Счет для фиксации разницы в стоимости при внешней переработке."
+msgstr "Главная книга"
 
 msgid "General Ledger"
 msgstr "Главная книга"
@@ -7099,7 +7099,7 @@ msgid "Generate a new 4-digit PIN. Share it with the operator so they can pin in
 msgstr "Создайте новый 4-значный PIN-код. Поделитесь им с оператором, чтобы он мог войти на терминалы MES."
 
 msgid "Generate and send customer invoices"
-msgstr "Создавать и отправлять счета клиентам"
+msgstr "Создать и отправить счета-фактуры покупателям"
 
 msgid "Generate fiscal year"
 msgstr "Генерировать финансовый год"
@@ -7114,7 +7114,7 @@ msgid "Generate new PIN"
 msgstr "Создать новый PIN"
 
 msgid "Generate Picking List"
-msgstr "Создать список комплектации"
+msgstr "Создать лист отбора"
 
 msgid "Generated IDs are disabled"
 msgstr "Сгенерированные ID отключены"
@@ -7144,37 +7144,37 @@ msgid "Getting set up"
 msgstr "Начало работы"
 
 msgid "Give it an owner and a date"
-msgstr "Назначьте владельца и дату"
+msgstr "Назначьте ответственного и дату"
 
 msgid "GL"
-msgstr "ГЛ"
+msgstr "Главная книга"
 
 msgid "GL Account"
 msgstr "Счет ГЛ"
 
 msgid "GL account capturing cost differences on outside-processing operations."
-msgstr "Счет для фиксации разницы затрат по операциям внешней обработки."
+msgstr "Счет учета, фиксирующий различия в себестоимости по операциям внешней обработки."
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "Счет для фиксации разницы между плановыми и фактическими производственными издержками."
+msgstr "Счет учета, отражающий разницу между запланированными и фактическими накладными расходами производства."
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
 msgstr "Счет для фиксации разницы между материалом, указанным в BOM, и фактически использованным."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Счет для фиксации разницы между плановым и фактическим временем на операции/машину."
+msgstr "Счет учета, отражающий разницу между плановым временем маршрута и фактическим временем труда/работы машины."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
 msgstr "Счет для фиксации разницы постоянных затрат при расхождении фактического размера партии с плановым."
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "Счет, на который зачисляется сумма для удаления первоначальной стоимости актива при его списании."
+msgstr "Счет учета, по которому кредитуется списание первоначальной стоимости основного средства при его выбытии."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "Счет, на который зачисляется сумма при регистрации счета-фактуры поставщика (остаток по счетам к оплате)."
+msgstr "Счет учета, по которому кредитуется счет-фактура поставщика при проведении (остаток кредиторской задолженности)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "Счет, на который зачисляется сумма при включении затрат на труд или машину в производственный заказ."
+msgstr "Счет учета, по которому кредитуется стоимость труда или работы станка при включении в производственный заказ."
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "Счет главной книги, кредитуемый при поглощении производственных накладных расходов в производственный заказ."
@@ -7183,13 +7183,13 @@ msgid "GL account debited to clear accumulated depreciation when an asset is dis
 msgstr "Счет, по которому дебетуется сумма для списания накопленной амортизации при утилизации актива."
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
-msgstr "Счет, по которому дебетуется сумма при регистрации счета-фактуры клиента; сторнируется при оплате клиентом."
+msgstr "Счет учета, по которому дебетуется счет-фактура покупателя при проведении; погашается при оплате покупателем."
 
 msgid "GL account debited when a fixed asset is acquired (purchase or capitalized cost)."
-msgstr "Счет, по которому дебетуется сумма при приобретении основного актива (покупка или капитализированные затраты)."
+msgstr "Счет учета, по которому дебетуется приобретение основного средства (покупка или капитализированная себестоимость)."
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "Счет для банковских комиссий и аналогичных сборов."
+msgstr "Счет учета для банковских сервисных сборов и аналогичных комиссий."
 
 msgid "GL account for interest income or expense."
 msgstr "Счет для процентных доходов или расходов."
@@ -7198,7 +7198,7 @@ msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "Счет для налога на приобретение, уплаченного поставщикам (или подлежащего возврату)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "Счет для налогов, начисленных по правилам обратного взимания, когда покупатель самостоятельно определяет налог."
+msgstr "Счет учета налога, начисленного по правилам обратного начисления, когда покупатель самостоятельно определяет налоговое обязательство."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "Счет для различий в сроках налогообложения (например, ускоренная налоговая амортизация против бухгалтерской амортизации)."
@@ -7207,67 +7207,67 @@ msgid "GL account hit when physical counts differ from system inventory."
 msgstr "Счет, по которому отражаются расхождения между результатами физической инвентаризации и системными данными о запасах."
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "Счет для дебета в исходной компании при проведении межкомпанийной операции."
+msgstr "Счет учета в организации-отправителе для дебета в межкомпанийной операции."
 
 msgid "GL account in the target company to credit for this intercompany transaction."
-msgstr "Счет для кредита в целевой компании при проведении межкомпанийной операции."
+msgstr "Счет учета в организации-получателе для кредита в межкомпанийной операции."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
 msgstr "Счет, на который отражаются копеечные разницы округления при проведении операций."
 
 msgid "GL account that captures the difference between standard cost and actual purchase cost."
-msgstr "Счет GL, который фиксирует разницу между стандартной стоимостью и фактической стоимостью покупки."
+msgstr "Счет учета, отражающий разницу между нормативной себестоимостью и фактической стоимостью приобретения."
 
 msgid "GL account that carries an asset's original acquisition cost — debited when acquired and credited at full gross cost when it is disposed or sold."
-msgstr "Счет ГК, на котором учитывается первоначальная стоимость приобретения актива (покупка или капитализированные затраты) — дебетуется при приобретении и кредитуется на полную первоначальную стоимость при выбытии или продаже актива."
+msgstr "Счет учета первоначальной стоимости приобретения основного средства — дебетуется при приобретении и кредитуется в полном размере при выбытии или продаже."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "Счет GL, который хранит стоимость работ в производстве, пока они не будут зачислены на готовую продукцию."
+msgstr "Счет учета, отражающий стоимость производственных заказов до их переноса в готовую продукцию."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
-msgstr "Счёт главной книги, который содержит стоимость произведённых товаров (Товары на производство); дебетуется при завершении работы, кредитуется при отправке."
+msgstr "Счет учета, отражающий стоимость готовой продукции (товары производства); дебетуется при завершении производственного заказа, кредитуется при отгрузке."
 
 msgid "GL account that holds the value of purchased stock and components (Buy items); debited on receipt, credited on issue/shipment."
-msgstr "Счёт главной книги, который содержит стоимость приобретённого запаса и компонентов (Покупные товары); дебетуется при получении, кредитуется при выпуске/отправке."
+msgstr "Счет учета, отражающий стоимость закупленных товаров и компонентов (товары закупки); дебетуется при поступлении, кредитуется при отпуске в производство или отгрузке."
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
-msgstr "Счет GL, который используется, когда клиент платит до выдачи счета; очищается при проведении счета."
+msgstr "Счет учета, используемый, когда покупатель платит до выпуска счета-фактуры; погашается при проведении счета-фактуры."
 
 msgid "GL account where early-payment discounts given to customers are recorded."
-msgstr "Счет GL, на котором фиксируются скидки на досрочную оплату, предоставленные клиентам."
+msgstr "Счет учета для скидок за досрочную оплату, предоставленных покупателям."
 
 msgid "GL account where early-payment discounts taken from suppliers are recorded."
 msgstr "Счет GL, на котором фиксируются скидки на досрочную оплату, полученные от поставщиков."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Счет GL контра-активов, который кредитуется по мере проведения амортизации в каждом периоде и дебетуется в полном объеме при продаже или списании актива."
+msgstr "Контрактивный счет учета основных средств, который кредитуется по мере начисления амортизации в каждом периоде и полностью дебетуется при продаже или списании основного средства."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Счет GL контра-активов, который накапливает амортизацию, записанную против основных средств."
+msgstr "Контрактивный счет учета основных средств, на котором накапливается амортизация, начисленная на основные средства."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Счет GL капитала (резерв CTA), который держит нереализованные разницы по валютам в результате пересчета остатков в иностранной валюте на конец периода; отдельно от реализованной валютной прибыли/убытка в П&У."
+msgstr "Счет учета собственного капитала (резерв пересчета иностранной валюты), который содержит нереализованные курсовые разницы от пересчета остатков в иностранной валюте на конец периода; отличается от реализованной прибыли/убытка от курсовых разниц в Отчете о прибылях и убытках."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Счет GL капитала, на котором чистая прибыль закрывается в конце финансового года."
+msgstr "Счет учета собственного капитала, на который закрывается чистый доход в конце финансового года."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Счет GL расходов, который дебетуется в каждом периоде при проведении амортизации."
+msgstr "Счет учета расходов, по которому производится дебет в каждом периоде при начислении амортизации."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Счет GL расходов, который дебетуется, когда балансовая стоимость актива уменьшается из-за обесценения, то есть когда возмещаемая стоимость становится ниже чистой балансовой стоимости."
+msgstr "Счет учета расходов, по которому производится дебет при снижении балансовой стоимости основного средства вследствие обесценения, то есть когда возможная сумма возмещения падает ниже остаточной стоимости."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Счет GL расходов для покупок, не входящих в запасы (расходные материалы, услуги)."
+msgstr "Счет учета расходов для покупок нескладских товаров (материалы, услуги)."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Счет GL обязательств, кредитуемый по налогу с продаж, собранному у клиентов."
+msgstr "Счет учета обязательств, по которому кредитуется налог с продаж, собранный у покупателей."
 
 msgid "GL tie-out"
-msgstr "Сверка ГЛ"
+msgstr "Выверка главной книги"
 
 msgid "GL Tie-Out"
-msgstr "Сверка ГЛ"
+msgstr "Выверка главной книги"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "Запустите систему с первой попытки — с нашей командой рядом с вами"
@@ -7310,7 +7310,7 @@ msgid "Good morning, {0}"
 msgstr "Доброе утро, {0}"
 
 msgid "Google Places API key not configured"
-msgstr "Ключ API Google Places не настроен"
+msgstr "Google Places API key не настроен"
 
 msgid "GR/IR (goods received, not invoiced)"
 msgstr "GR/IR (товары поступили, не выставлены счета)"
@@ -7355,10 +7355,10 @@ msgid "Guided"
 msgstr "Управляемый"
 
 msgid "Guided implementation"
-msgstr "Управляемая реализация"
+msgstr "Управляемое внедрение"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Обработка повторяющихся и сторнирующих записей в журнале"
+msgstr "Обработка повторяющихся и сторнирующих операций"
 
 msgid "Hands-on"
 msgstr "Практический"
@@ -7367,7 +7367,7 @@ msgid "Hands-on, fast-response support for the first 3–4 weeks"
 msgstr "Практическая поддержка с быстрым ответом в течение первых 3–4 недель"
 
 msgid "Hard to see true cost or margin on a job"
-msgstr "Сложно увидеть истинную стоимость или маржу по заказу"
+msgstr "Сложно увидеть истинную себестоимость или маржу производственного заказа"
 
 msgid "Has conflict"
 msgstr "Имеет конфликт"
@@ -7385,7 +7385,7 @@ msgid "Hide raw"
 msgstr "Скрыть исходное"
 
 msgid "Hide system quantities until the review step"
-msgstr "Скрыть системные количества до этапа проверки"
+msgstr "Скрывать системные количества до шага рассмотрения"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Скрывать, закреплять и переупорядочивать столбцы"
@@ -7400,16 +7400,16 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "Исторические данные старше, чем указано на карте миграции данных"
 
 msgid "Historical Rate (equity)"
-msgstr "Исторический курс (Капитал)"
+msgstr "Исторический курс (собственный капитал)"
 
 msgid "Historical Rate (Equity)"
-msgstr "Исторический курс (Капитал)"
+msgstr "Исторический курс (Собственный капитал)"
 
 msgid "History"
 msgstr "История"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Удержать журнал как предупреждение для исправления."
+msgstr "Удержать операцию как предупреждение для исправления."
 
 msgid "Holiday"
 msgstr "Праздник"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Часов/Деталь"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Как товар пополняется в целом (Купить, Производить или Купить и Производить), установка по товарам, в отличие от типа метода для каждой строки."
+msgstr "Как номенклатура пополняется в целом (Закупка, Производство или Закупка и производство), устанавливается на номенклатуру, в отличие от способа обеспечения по строкам."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Как товар пополняется: Ручной Переказ, Переказ на Основе Спроса, Фиксированное Количество Переказа или Максимальное Количество."
@@ -7451,10 +7451,10 @@ msgid "How an item is sourced when added to a method or BOM line."
 msgstr "Как товар поступает при добавлении в строку метода или BOM."
 
 msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
-msgstr "Как оценивается стоимость товара за единицу: Стандартная, Средняя, FIFO или LIFO. Установка по товарам."
+msgstr "Как оценивается себестоимость за единицу номенклатуры: стандартный, средний, ФИФО или LIFO. Устанавливается на номенклатуру."
 
 msgid "How items roll up for posting and reporting"
-msgstr "Как элементы объединяются для учета и отчетности"
+msgstr "Как номенклатура агрегируется для проведения и отчетности"
 
 msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank to use the default."
 msgstr "Как долго работает каждый этап, в неделях. Определяет временную шкалу плана; оставьте пустым, чтобы использовать значение по умолчанию."
@@ -7475,10 +7475,10 @@ msgid "How many days after the calculation date the full amount is due."
 msgstr "Сколько дней после даты расчета полная сумма становится подлежащей уплате."
 
 msgid "How many days from invoice date this customer is given to pay; drives the default due date on customer invoices."
-msgstr "Сколько дней от даты счета этому клиенту дается на оплату; определяет дату платежа по умолчанию на счетах-фактурах клиентов."
+msgstr "Количество дней с даты счета-фактуры, которое дается покупателю на оплату; определяет срок выполнения по умолчанию на счетах-фактурах покупателей."
 
 msgid "How many days from invoice date this supplier expects payment; drives the default due date on bills."
-msgstr "Сколько дней от даты счета этот поставщик ожидает оплату; определяет дату платежа по умолчанию на счетах."
+msgstr "Количество дней с даты счета-фактуры, которое ожидает поставщик на оплату; определяет срок выполнения по умолчанию на счетах-фактурах поставщиков."
 
 msgid "How many fractional digits to keep when rounding amounts in this currency."
 msgstr "Сколько дробных цифр сохранять при округлении сумм в этой валюте."
@@ -7496,25 +7496,25 @@ msgid "How many were actually picked?"
 msgstr "Сколько было фактически подобрано?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Как часто этот манометр должен быть перекалиброван; в сочетании с датой последней калибровки для автоматического пересчета даты следующей калибровки."
+msgstr "Как часто это средство измерения должно перекалиброваться; в сочетании с датой последней калибровки для автоматического пересчета даты следующей калибровки."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Как часто это обслуживание повторяется — Ежедневно, Еженедельно, Ежемесячно, При Счете Цикла; Ежедневно показывает селектор дня недели, остальные используют более простую интервальную математику."
+msgstr "Как часто это техобслуживание повторяется — Ежедневно, Еженедельно, Ежемесячно, На циклический пересчет; выбор «Ежедневно» показывает селектор дня недели, остальные используют более простую математику интервалов."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
-msgstr "Как строг срок — Жесткий срок блокирует планирование, Мягкий срок позволяет планированию двигаться с предупреждением, Без срока полностью игнорирует."
+msgstr "Насколько строг срок выполнения — жесткий срок блокирует планирование после него, мягкий срок позволяет планированию сдвинуться с предупреждением, отсутствие срока полностью его игнорирует."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "Способ получения материала (изготовление, закупка или списание из запасов) и складская единица, из которой он берётся."
+msgstr "Как материал пополняется (производство, закупка или со склада) и единица хранения, из которой он изымается."
 
 msgid "How the resolved price was calculated."
 msgstr "Как была рассчитана окончательная цена."
 
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
-msgstr "Как решается размер выборки — Проверить все, Проверить первые N, Процент партии или AQL (Z1.4 / ISO 2859-1). Каждый режим раскрывает свои собственные поля параметров ниже."
+msgstr "Как определяется объем выборки — проверить все, проверить первые N, процент партии или AQL (Z1.4 / ISO 2859-1). Каждый режим показывает свои собственные поля параметров ниже."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Как используется этот калибр — Стандартный (плановые проверки) или Мастер (калибрует другие калибры)."
+msgstr "Как используется это средство измерения — Нормальный (регулярные проверки) или Эталон (калибрует другие средства измерения)."
 
 msgid "How this price was calculated"
 msgstr "Как была рассчитана эта цена"
@@ -7526,10 +7526,10 @@ msgid "How to read this chart"
 msgstr "Как читать эту таблицу"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Насколько срочно это отправка — Низко / Средне / Высоко / Критично; в сочетании с Приоритетом и Влиянием OEE для решения временного интервала."
+msgstr "Насколько срочна эта заявка на техобслуживание — Низкий / Средний / Высокий / Критический; в сочетании с приоритетом и влиянием OEE для определения слота графика."
 
 msgid "How we know we're done"
-msgstr "Как мы узнаем, что закончили"
+msgstr "Как мы узнаем, что готово"
 
 msgid "How we stay aligned and how issues get resolved. Your part: show up to the weekly call and raise blockers early, before they become delays."
 msgstr "Как мы остаемся согласованными и как решаются проблемы. Ваша роль: участвуйте в еженедельном звонке и поднимайте блокирующие проблемы рано, прежде чем они станут задержками."
@@ -7541,10 +7541,10 @@ msgid "How We Work Together"
 msgstr "Как мы работаем вместе"
 
 msgid "How your company's process maps to Carbon"
-msgstr "Как процессы вашей компании соответствуют Carbon"
+msgstr "Как процесс вашей организации отображается на Carbon"
 
 msgid "How your quotes, orders, and invoices look when they go out"
-msgstr "Как выглядят ваши предложения, заказы и счета при отправке"
+msgstr "Как выглядят ваши коммерческие предложения, заказы и счета-фактуры при отправке"
 
 msgid "How your team is organized into departments"
 msgstr "Как ваша команда организована по отделам"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "Гиперуход: интенсивная поддержка в первые недели"
 
 msgid "I (reduced)"
-msgstr "I (сокращено)"
+msgstr "I (ослабленный)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "У меня есть разумные основания полагать, что это лицо является лицом США, как определено в 22 CFR 120.62"
@@ -7595,7 +7595,7 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "Если это не может ждать до следующего звонка, решение принимают руководители с обеих сторон."
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "Если это блокирует работу или дата под угрозой, это получает владельца и отслеживается."
+msgstr "Если это блокирует или есть риск по дате, ему назначается ответственный и он отслеживается."
 
 msgid "If items already exist"
 msgstr "Если элементы уже существуют"
@@ -7613,10 +7613,10 @@ msgid "II (normal default)"
 msgstr "II (обычно по умолчанию)"
 
 msgid "III (tightened)"
-msgstr "III (ужесточено)"
+msgstr "III (усиленный)"
 
 msgid "Impact"
-msgstr "Воздействие"
+msgstr "Влияние"
 
 msgid "Imperial"
 msgstr "Имперская"
@@ -7631,10 +7631,10 @@ msgid "Implementation Lead"
 msgstr "Руководитель внедрения"
 
 msgid "Import {label} CSV"
-msgstr "Импорт {label} CSV"
+msgstr "Импортировать {label} CSV"
 
 msgid "Import results"
-msgstr "Результаты импорта"
+msgstr "Импортировать результаты"
 
 msgid "Import your BOM"
 msgstr "Импортируйте вашу BOM"
@@ -7644,16 +7644,16 @@ msgid "in {0}"
 msgstr "через {0}"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "В Onshape измените разрешения этого приложения OAuth, добавив «Application can write to your documents», затем подключитесь снова."
+msgstr "В Onshape отредактируйте разрешения этого приложения OAuth, чтобы включить «Application can write to your documents», затем подключитесь снова."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Чтобы преобразовать это РЗП в предложение, все строки должны иметь внутренний номер детали."
 
 msgid "In order to convert this RFQ to a quote, it must be associated with a customer."
-msgstr "Чтобы преобразовать этот запрос предложения в предложение, он должен быть связан с клиентом."
+msgstr "Чтобы преобразовать этот запрос цен в коммерческое предложение, он должен быть связан с покупателем."
 
 msgid "In order to convert this RFQ to a quote, it must have a customer."
-msgstr "Чтобы преобразовать этот запрос предложения в предложение, он должен быть связан с клиентом."
+msgstr "Чтобы преобразовать этот запрос цен в коммерческое предложение, у него должен быть покупатель."
 
 msgid "In order to send this RFQ to suppliers, you must first add suppliers to the RFQ."
 msgstr "Чтобы отправить этот запрос коммерческих предложений поставщикам, необходимо сначала добавить поставщиков в запрос."
@@ -7662,10 +7662,10 @@ msgid "In Process Only"
 msgstr "Только в процессе"
 
 msgid "In progress"
-msgstr "В процессе"
+msgstr "В работе"
 
 msgid "In Progress"
-msgstr "В процессе"
+msgstr "В работе"
 
 msgid "in scope"
 msgstr "в области"
@@ -7701,13 +7701,13 @@ msgid "Inactive actions will not appear in selection lists"
 msgstr "Неактивные действия не будут отображаться в списках выбора"
 
 msgid "Inbound inspection"
-msgstr "Входящая проверка"
+msgstr "Входной контроль"
 
 msgid "Inbox"
 msgstr "Входящие"
 
 msgid "Include extra parts in shipment"
-msgstr "Включить дополнительные детали в отправку"
+msgstr "Включить дополнительные детали в отгрузку"
 
 msgid "Include Inactive"
 msgstr "Включить неактивные"
@@ -7719,16 +7719,16 @@ msgid "Includes tax and shipping costs"
 msgstr "Включает налоги и стоимость доставки"
 
 msgid "Income / Balance (inherited)"
-msgstr "Доход / Баланс (унаследованный)"
+msgstr "Доходы / Остаток (унаследованные)"
 
 msgid "Income Statement"
 msgstr "Отчет о прибылях и убытках"
 
 msgid "Income Tax"
-msgstr "Налог на прибыль"
+msgstr "Налог на доход"
 
 msgid "Income/Balance"
-msgstr "Доход/Баланс"
+msgstr "Доходы/Остаток"
 
 msgid "incoming"
 msgstr "входящий"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Унаследовано от родителя"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Унаследовано из группы: классификация верхнего уровня (активы, пассивы, капитал, доходы, расходы)."
+msgstr "Унаследовано из группы: классификация верхнего уровня (актив, пассив, собственный капитал, выручка, расход)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Унаследовано из группы: где этот счет отображается в финансовых отчетах."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Унаследовано из группы: закрывается ли этот счет на прибыль (доход) или переносится (баланс)."
+msgstr "Унаследовано из группы: закрывается ли эта учетная запись на нераспределенную прибыль (доходы) или переносится вперед (остаток)."
 
 msgid "Inherited from the parent group."
 msgstr "Унаследовано от родительской группы."
@@ -7803,13 +7803,13 @@ msgid "Inspect Item"
 msgstr "Проверить товар"
 
 msgid "Inspection"
-msgstr "Проверка"
+msgstr "Контроль"
 
 msgid "Inspection document"
-msgstr "Документ проверки"
+msgstr "Документ контроля"
 
 msgid "Inspection Level"
-msgstr "Уровень проверки"
+msgstr "Уровень контроля"
 
 msgid "Inspection Plan"
 msgstr "План контроля"
@@ -7821,19 +7821,19 @@ msgid "Inspection Plans"
 msgstr "Планы контроля"
 
 msgid "Inspection Status"
-msgstr "Статус проверки"
+msgstr "Статус контроля"
 
 msgid "Inspections"
-msgstr "Проверки"
+msgstr "Контроли"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "Проверки, несоответствия и CAPA"
+msgstr "Контроли, несоответствия и CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "Проверки, несоответствия, CAPA"
+msgstr "Контроли, несоответствия, CAPA"
 
 msgid "Inspections: Require Different Inspector"
-msgstr "Проверки: Требуется другой инспектор"
+msgstr "Контроли: требуется другой инспектор"
 
 msgid "Install"
 msgstr "Установить"
@@ -7863,16 +7863,16 @@ msgid "Intercompany"
 msgstr "Межкомпанийные операции"
 
 msgid "Intercompany Balances"
-msgstr "Сальдо межфирменного сектора"
+msgstr "Межорганизационные остатки"
 
 msgid "Intercompany company"
-msgstr "Компания между компаниями"
+msgstr "Связанная организация"
 
 msgid "Intercompany Transactions"
 msgstr "Межфирменные операции"
 
 msgid "Intercompany transactions involving this company that are still Unmatched should be matched and eliminated, so consolidated results don't double-count activity between entities."
-msgstr "Межкомпанейские операции с участием этой компании, которые всё ещё не согласованы, должны быть согласованы и исключены, чтобы консолидированные результаты не учитывали операции между компаниями дважды."
+msgstr "Межорганизационные операции с участием этой организации, которые еще не сопоставлены, должны быть сопоставлены и исключены, чтобы консолидированные результаты не считали активность между организациями дважды."
 
 msgid "Interest"
 msgstr "Проценты"
@@ -7890,7 +7890,7 @@ msgid "Internal Delta"
 msgstr "Внутренняя разница"
 
 msgid "Internal notes"
-msgstr "Внутренние заметки"
+msgstr "Внутренние примечания"
 
 msgid "Internal Notes"
 msgstr "Внутренние примечания"
@@ -7920,7 +7920,7 @@ msgid "Inventory Adjustment"
 msgstr "Корректировка запасов"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Корректировка инвентаря (по умолчанию)"
+msgstr "Корректировка запасов (по умолчанию)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Инвентаризация и закупки с автоматизированным планированием"
@@ -7962,82 +7962,82 @@ msgid "Invite"
 msgstr "Пригласить"
 
 msgid "Invite Expired"
-msgstr "Приглашение истекло"
+msgstr "Истек срок приглашения"
 
 msgid "Invited"
 msgstr "Приглашено"
 
 msgid "Invoice"
-msgstr "Счет"
+msgstr "Счет-фактура"
 
 msgid "Invoice Contact"
-msgstr "Контакт счета"
+msgstr "Контактное лицо счета-фактуры"
 
 msgid "Invoice customer"
-msgstr "Счет клиента"
+msgstr "Покупатель счета-фактуры"
 
 msgid "Invoice Customer"
-msgstr "Клиент счета"
+msgstr "Покупатель счета-фактуры"
 
 msgid "Invoice customer contact"
-msgstr "Контакт клиента счета"
+msgstr "Контактное лицо покупателя счета-фактуры"
 
 msgid "Invoice Customer Contact"
-msgstr "Контакт клиента счета"
+msgstr "Контактное лицо покупателя счета-фактуры"
 
 msgid "Invoice customer location"
-msgstr "Расположение клиента счета"
+msgstr "Площадка покупателя счета-фактуры"
 
 msgid "Invoice Customer Location"
-msgstr "Местоположение клиента счета"
+msgstr "Площадка покупателя счета-фактуры"
 
 msgid "Invoice ID"
-msgstr "ID счета"
+msgstr "Счет-фактура ID"
 
 msgid "Invoice Location"
-msgstr "Местоположение счета"
+msgstr "Площадка счета-фактуры"
 
 msgid "Invoice Number"
-msgstr "Номер счета"
+msgstr "Номер счета-фактуры"
 
 msgid "Invoice settlement"
-msgstr "Погашение счёта"
+msgstr "Расчет по счету-фактуре"
 
 msgid "Invoice supplier"
-msgstr "Счет поставщика"
+msgstr "Поставщик счета-фактуры"
 
 msgid "Invoice Supplier"
-msgstr "Поставщик счета"
+msgstr "Поставщик счета-фактуры"
 
 msgid "Invoice supplier contact"
-msgstr "Контакт поставщика счета"
+msgstr "Контактное лицо поставщика счета-фактуры"
 
 msgid "Invoice Supplier Contact"
-msgstr "Контакт поставщика счета"
+msgstr "Контактное лицо поставщика счета-фактуры"
 
 msgid "Invoice supplier location"
-msgstr "Расположение поставщика счета"
+msgstr "Площадка поставщика счета-фактуры"
 
 msgid "Invoice Supplier Location"
-msgstr "Местоположение поставщика счета"
+msgstr "Площадка поставщика счета-фактуры"
 
 msgid "Invoice Total"
-msgstr "Итого по счету"
+msgstr "Итого счета-фактуры"
 
 msgid "Invoiced"
-msgstr "Счетировано"
+msgstr "Выставлен счет"
 
 msgid "Invoiced Amount:"
-msgstr "Сумма счета:"
+msgstr "Выставленная сумма счета-фактуры:"
 
 msgid "Invoiced Statuses"
-msgstr "Статусы счетов"
+msgstr "Статусы выставленного счета"
 
 msgid "Invoices"
-msgstr "Счета"
+msgstr "Счета-фактуры"
 
 msgid "Invoices this memo has been applied to. Click a row to open the document."
-msgstr "Счета, к которым применена эта справка. Нажмите на строку, чтобы открыть документ."
+msgstr "Счета-фактуры, к которым применена данная заметка. Нажмите на строку, чтобы открыть документ."
 
 msgid "Invoicing"
 msgstr "Выставление счетов"
@@ -8052,10 +8052,10 @@ msgid "Is console operator"
 msgstr "Является оператором консоли"
 
 msgid "Is customer org group"
-msgstr "Является группой организаций клиентов"
+msgstr "Группа организаций покупателя"
 
 msgid "Is customer type group"
-msgstr "Является группой типов клиентов"
+msgstr "Группа типа покупателя"
 
 msgid "Is employee type group"
 msgstr "Является группой типов сотрудников"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "Рабочие процессы проблем"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "Рабочие процессы проблем определили предустановленные значения для проблемы. Например, у вас может быть рабочий процесс 8D или рабочий процесс сдерживания."
+msgstr "Рабочие процессы для несоответствий определяют предустановленные значения. Например, у вас может быть рабочий процесс 8D или рабочий процесс локализации."
 
 msgid "Issued"
 msgstr "Выдано"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Проблемы"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Он перестанет работать, пока вы не опубликуете версию снова. Ничего не удаляется."
 
 msgid "ITAR Certifications"
 msgstr "Сертификации ITAR"
@@ -8139,7 +8139,7 @@ msgid "Item / Location"
 msgstr "Товар / Местоположение"
 
 msgid "Item filters"
-msgstr "Фильтры товаров"
+msgstr "Фильтры номенклатуры"
 
 msgid "item group"
 msgstr "группа товаров"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Мастер элементов и методы производства"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Мастер элементов, спецификации и технологический процесс"
+msgstr "Номенклатура, BOM и Перечень операций"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "Товар должен соответствовать выбранному типу И выбранной группе"
@@ -8184,13 +8184,13 @@ msgid "Item Scope"
 msgstr "Область применения товара"
 
 msgid "Item Type"
-msgstr "Тип товара"
+msgstr "Тип номенклатуры"
 
 msgid "Item Type (optional)"
-msgstr "Тип товара (опционально)"
+msgstr "Тип номенклатуры (опционально)"
 
 msgid "Item types"
-msgstr "Типы товаров"
+msgstr "Типы номенклатуры"
 
 msgid "items"
 msgstr "элементы"
@@ -8205,10 +8205,10 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Товары в этом диапазоне получают жёлтый значок."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Товары: справочник товаров, спецификации, технологические процессы, инженерные изменения, САПР"
+msgstr "Номенклатура: управление номенклатурой, BOM, Перечень операций, Конструкторское изменение, CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "Конструкция может измениться до выпуска уведомления об изменении."
+msgstr "Его конструкция может измениться до выпуска Извещения об изменении."
 
 msgid "Job"
 msgstr "Задание"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "Местоположение задания"
 
 msgid "Job make method"
-msgstr "Способ изготовления работы"
+msgstr "Метод производства заказа"
 
 msgid "Job Materials"
-msgstr "Материалы задания"
+msgstr "Материалы заказа"
 
 msgid "Job operation"
-msgstr "Операция задания"
+msgstr "Операция заказа"
 
 msgid "Job Operation"
-msgstr "Операция задания"
+msgstr "Операция заказа"
 
 msgid "Job Operations"
-msgstr "Операции задания"
+msgstr "Операции заказа"
 
 msgid "Job Priority"
 msgstr "Приоритет работы"
@@ -8247,35 +8247,35 @@ msgid "Job Traveler"
 msgstr "Маршрутный лист работы"
 
 msgid "Jobs"
-msgstr "Работы"
+msgstr "Производственные заказы"
 
 msgid "Jobs Assigned to Me"
-msgstr "Задания, назначенные мне"
+msgstr "Производственные заказы, назначенные мне"
 
 msgid "Jobs Required"
-msgstr "Требуются работы"
+msgstr "Необходимые производственные заказы"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Работы, содержащие этот товар в спецификации материалов"
+msgstr "Производственные заказы, у которых эта номенклатура указана в спецификации"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Присоединиться к {0}"
 
 msgid "Journal"
-msgstr "Журнал"
+msgstr "Операция"
 
 msgid "Journal Entries"
-msgstr "Записи в журнале"
+msgstr "Операции"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "Записи в журнале, датированные в этом периоде и всё ещё находящиеся в статусе «Черновик», должны быть опубликованы или переделированы на более поздний открытый период. Черновые записи не являются частью главной книги, поэтому их дебеты и кредиты будут отсутствовать в закрытии."
+msgstr "Проводки, датированные в этом периоде и находящиеся в статусе Черновик, должны быть проведены или переддатированы в более поздний открытый период. Проводки в статусе Черновик не являются частью операции, поэтому их дебеты и кредиты будут отсутствовать при закрытии."
 
 msgid "Journal Entry"
-msgstr "Запись в журнале"
+msgstr "Проводка"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Журналы с датой в указанный день или раньше считаются заблокированными. Объединяются с датой блокировки, сообщаемой системой, когда обе существуют."
+msgstr "Операции, датированные в эту дату или ранее, считаются заблокированными. Объединены с датой блокировки, указанной поставщиком, если обе существуют."
 
 msgid "Just one"
 msgstr "Только один"
@@ -8287,7 +8287,7 @@ msgid "Kanban for {kanbanName}"
 msgstr "Канбан для {kanbanName}"
 
 msgid "Kanban Output"
-msgstr "Вывод Kanban"
+msgstr "Выпуск Канбана"
 
 msgid "Kanbans"
 msgstr "Канбаны"
@@ -8299,7 +8299,7 @@ msgid "Keep Current"
 msgstr "Сохранить текущие"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "Сохранить существующие цены, добавить только новые товары"
+msgstr "Сохранить существующее ценообразование, добавить только новую номенклатуру"
 
 msgid "Keep only items where…"
 msgstr "Оставить только элементы где…"
@@ -8311,10 +8311,10 @@ msgid "Keep Open"
 msgstr "Оставить открытым"
 
 msgid "Keep picking"
-msgstr "Продолжить комплектацию"
+msgstr "Сохранить отбор"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
-msgstr "Защищает заказы, предложения и параметры вторым уровнем проверки"
+msgstr "Требует дополнительную проверку для заказов, коммерческих предложений и настроек"
 
 msgid "Key"
 msgstr "Ключ"
@@ -8345,19 +8345,19 @@ msgid "Labor"
 msgstr "Труд"
 
 msgid "Labor & Machine Absorption"
-msgstr "Поглощение труда и машины"
+msgstr "Поглощение трудозатрат и времени станка"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "Поглощение труда и машины (по умолчанию)"
+msgstr "Поглощение трудозатрат и времени станка (по умолчанию)"
 
 msgid "Labor & Machine Variance"
-msgstr "Отклонение труда и машины"
+msgstr "Отклонение трудозатрат и времени станка"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "Отклонение труда и машины (по умолчанию)"
+msgstr "Отклонение трудозатрат и времени станка (по умолчанию)"
 
 msgid "Labor rate"
-msgstr "Тариф на работу"
+msgstr "Ставка трудозатрат"
 
 msgid "Labor Rate"
 msgstr "Ставка оплаты труда"
@@ -8366,13 +8366,13 @@ msgid "Labor Rate (Hourly)"
 msgstr "Почасовая ставка труда"
 
 msgid "Labor time"
-msgstr "Время работы"
+msgstr "Трудозатраты"
 
 msgid "Labor Time"
-msgstr "Время труда"
+msgstr "Трудозатраты"
 
 msgid "Labor unit"
-msgstr "Единица работы"
+msgstr "Единица труда"
 
 msgid "Labor Unit"
 msgstr "Единица труда"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Широта"
 
 msgid "Lead time"
-msgstr "Время поставки"
+msgstr "Срок поставки"
 
 msgid "Lead Time"
-msgstr "Время поставки"
+msgstr "Срок поставки"
 
 msgid "Lead time (days)"
-msgstr "Время доставки (дни)"
+msgstr "Срок поставки (дни)"
 
 msgid "Lead Time (Days)"
-msgstr "Время выполнения (дни)"
+msgstr "Срок поставки (Дни)"
 
 msgid "Lead Time:"
-msgstr "Время доставки:"
+msgstr "Срок поставки:"
 
 msgid "Learn"
 msgstr "Узнать"
@@ -8459,7 +8459,7 @@ msgid "Leave blank for built-in"
 msgstr "Оставьте пустым для встроенного"
 
 msgid "Leave blank to use the next revision automatically"
-msgstr "Оставьте пусто для использования следующей редакции автоматически"
+msgstr "Оставить пусто, чтобы использовать следующую ревизию автоматически"
 
 msgid "Leave empty for exact match"
 msgstr "Оставьте пустым для точного совпадения"
@@ -8486,13 +8486,13 @@ msgid "Less manual work, fewer errors"
 msgstr "Меньше ручной работы, меньше ошибок"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Начнём производство"
 
 msgid "Let's build something"
 msgstr "Давайте создадим что-то"
 
 msgid "Let's set up your new company"
-msgstr "Давайте настроим вашу новую компанию"
+msgstr "Создадим вашу новую организацию"
 
 msgid "Let's setup your account"
 msgstr "Давайте настроим вашу учетную запись"
@@ -8504,7 +8504,7 @@ msgid "Liability account for deferred taxes from accelerated depreciation"
 msgstr "Счет обязательств по отложенным налогам от ускоренной амортизации"
 
 msgid "Liability account for sales tax collected from customers"
-msgstr "Счет обязательств по налогу с продаж, собранному у клиентов"
+msgstr "Счет обязательств по налогу на продажи, собранному от покупателей"
 
 msgid "Liability account for tax paid on purchases"
 msgstr "Счет обязательств по налогам, уплаченным при покупках"
@@ -8552,7 +8552,7 @@ msgid "Lines need prices or lead times"
 msgstr "Строки требуют цены или сроки поставки"
 
 msgid "Lineside"
-msgstr "У линии"
+msgstr "Прилинейный запас"
 
 msgid "Link"
 msgstr "Ссылка"
@@ -8567,10 +8567,10 @@ msgid "Link Linear Issue"
 msgstr "Связать проблему Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Свяжите этого покупателя Carbon с одним из них или создайте отдельного покупателя Stripe."
 
 msgid "Link to sales order line"
-msgstr "Связать со строкой заказа на продажу"
+msgstr "Ссылка на строку заказа покупателя"
 
 #. placeholder {0}: r.linkedSum
 #. placeholder {1}: r.quantity
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Загружается в последнюю очередь, прямо при переходе, поэтому остатки актуальны."
 
 msgid "Loading associated jobs..."
-msgstr "Загрузка связанных заданий..."
+msgstr "Загрузка связанных производственных заказов..."
 
 msgid "Loading current quantity…"
 msgstr "Загрузка текущего количества…"
@@ -8661,7 +8661,7 @@ msgid "Locked"
 msgstr "Заблокирован"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "Блокировка делает период доступным только для чтения для операционных документов (приёмки, отгрузки, счета-фактуры), при этом по-прежнему позволяя учётные корректировки, такие как амортизация и выбытие. Период должен быть заблокирован перед его закрытием."
+msgstr "Блокировка делает период доступным только для чтения для операционных документов (Поступления, Отгрузки, счета-фактуры), но при этом разрешает бухгалтерские корректировки, такие как Амортизация и Выбытие. Период должен быть заблокирован перед тем, как его можно закрыть."
 
 msgid "Log nonconformances and drive a CAPA"
 msgstr "Регистрируйте несоответствия и инициируйте CAPA"
@@ -8707,7 +8707,7 @@ msgid "Losses recognized on disposal of fixed assets"
 msgstr "Убытки, признаваемые при выбытии основных средств"
 
 msgid "Lost"
-msgstr "Потеряно"
+msgstr "Проиграно"
 
 msgid "Lot"
 msgstr "Партия"
@@ -8728,22 +8728,22 @@ msgid "Lot Size:"
 msgstr "Размер партии:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Партионная проверка полученных товаров по плану выборки; единицы размещаются как На удержании при получении и выпускаются в Доступно только после того, как партия dispositionируется как принята."
+msgstr "Контроль на основе партии полученных товаров в соответствии с планом выборочного контроля; единицы переводятся в статус Приостановлено при поступлении и переходят в статус Доступно только после того, как партия получит статус Принято."
 
 msgid "Low"
 msgstr "Низкий"
 
 msgid "Machine"
-msgstr "Машина"
+msgstr "Станок"
 
 msgid "Machine rate"
-msgstr "Тариф оборудования"
+msgstr "Ставка станка"
 
 msgid "Machine Rate"
-msgstr "Ставка машины"
+msgstr "Ставка станка"
 
 msgid "Machine Rate (Hourly)"
-msgstr "Ставка машины (в час)"
+msgstr "Ставка станка (почасовая)"
 
 msgid "Machine time"
 msgstr "Машинное время"
@@ -8752,10 +8752,10 @@ msgid "Machine Time"
 msgstr "Время машины"
 
 msgid "Machine unit"
-msgstr "Единица оборудования"
+msgstr "Единица станка"
 
 msgid "Machine Unit"
-msgstr "Единица машины"
+msgstr "Единица станка"
 
 msgid "Machines, cells, stations"
 msgstr "Машины, ячейки, станции"
@@ -8776,25 +8776,25 @@ msgid "Maintain a single part and item master"
 msgstr "Ведите единый реестр деталей и товаров"
 
 msgid "Maintenance"
-msgstr "Техническое обслуживание"
+msgstr "Техобслуживание"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Уведомления о диспетчеризации обслуживания"
+msgstr "Уведомления о заявках на техобслуживание"
 
 msgid "Maintenance Dispatches"
-msgstr "Наряды на техническое обслуживание"
+msgstr "Заявки на техобслуживание"
 
 msgid "Maintenance Expense"
-msgstr "Расходы на техническое обслуживание"
+msgstr "Расходы на техобслуживание"
 
 msgid "Maintenance Expense (default)"
-msgstr "Расходы на техническое обслуживание (по умолчанию)"
+msgstr "Расходы на техобслуживание (по умолчанию)"
 
 msgid "Maintenance Schedules"
-msgstr "Графики обслуживания"
+msgstr "Графики техобслуживания"
 
 msgid "Maintenance Type"
-msgstr "Тип обслуживания"
+msgstr "Тип техобслуживания"
 
 msgid "Make"
 msgstr "Производить"
@@ -8819,11 +8819,11 @@ msgstr "Произвести платеж"
 
 #. placeholder {0}: selectedInvoices.length
 msgid "Make Payment · {0} invoices"
-msgstr "Произвести платеж · {0} счетов"
+msgstr "Произвести платеж · {0} счета-фактур"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make revision {0} default?"
-msgstr "Сделать редакцию {0} по умолчанию?"
+msgstr "Сделать ревизию {0} по умолчанию?"
 
 #. placeholder {0}: selectedRevision.revision
 msgid "Make size {0} default?"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Принять решение о запуске / отказе от запуска"
 
 msgid "Make to Order"
-msgstr "Изготовление на заказ"
+msgstr "Производство под заказ"
 
 msgid "Make tracked entities available again"
 msgstr "Сделать отслеживаемые объекты доступными снова"
@@ -8851,7 +8851,7 @@ msgid "Manage"
 msgstr "Управление"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "Управляйте отслеживанием, расчетом и применением сроков годности по всему инвентарю."
+msgstr "Управление отслеживанием, вычислением и применением срока хранения в запасах."
 
 msgid "Manage Ownership"
 msgstr "Управление правами собственности"
@@ -8884,10 +8884,10 @@ msgid "Map accounts"
 msgstr "Сопоставить счета"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Сопоставьте счета Carbon с планом счетов системы. Проводимые журналы отправляются, используя сопоставленный код счета системы."
+msgstr "Сопоставьте счета Carbon с планом счетов поставщика. Проведенные операции отправляются с использованием сопоставленного кода счета поставщика."
 
 msgid "Map Extracted Invoice Lines"
-msgstr "Сопоставить извлеченные строки счета"
+msgstr "Сопоставить извлеченные строки счета-фактуры"
 
 msgid "Map Extracted Lines"
 msgstr "Сопоставить извлеченные строки"
@@ -8933,16 +8933,16 @@ msgid "Mark Dark Mode"
 msgstr "Логотип в тёмном режиме"
 
 msgid "Mark done"
-msgstr "Отметить выполненным"
+msgstr "Отметить как готово"
 
 msgid "Mark Done"
-msgstr "Отметить как выполнено"
+msgstr "Отметить как готово"
 
 msgid "Mark Light Mode"
 msgstr "Логотип в светлом режиме"
 
 msgid "Mark not done"
-msgstr "Отметить как невыполненное"
+msgstr "Отметить как не готово"
 
 msgid "Mark scope as agreed"
 msgstr "Отметить область как согласованную"
@@ -8951,10 +8951,10 @@ msgid "Mark Short"
 msgstr "Отметить как недостача"
 
 msgid "Mark to delete"
-msgstr "Отметить для удаления"
+msgstr "Отметить к удалению"
 
 msgid "Master gauge"
-msgstr "Мастер-калибр"
+msgstr "Эталонное средство измерения"
 
 msgid "Master records"
 msgstr "Основные записи"
@@ -8999,19 +8999,19 @@ msgid "Material"
 msgstr "Материал"
 
 msgid "Material Dimension"
-msgstr "Размер материала"
+msgstr "Измерение материала"
 
 msgid "Material Dimensions"
-msgstr "Размеры материалов"
+msgstr "Измерения материала"
 
 msgid "Material dimensions use metric units."
-msgstr "Размеры материалов используют метрические единицы."
+msgstr "Измерения материала используют метрические единицы."
 
 msgid "Material Finish"
-msgstr "Отделка материала"
+msgstr "Обработка поверхности"
 
 msgid "Material Finishes"
-msgstr "Отделки материалов"
+msgstr "Обработки поверхности"
 
 msgid "Material Form"
 msgstr "Форма материала"
@@ -9035,7 +9035,7 @@ msgid "Material Properties"
 msgstr "Свойства материалов"
 
 msgid "Material Review Board (MRB)"
-msgstr "Комиссия по проверке материалов (МРБ)"
+msgstr "Комиссия по браку"
 
 msgid "Material Shape"
 msgstr "Форма материала"
@@ -9044,10 +9044,10 @@ msgid "Material Shapes"
 msgstr "Формы материалов"
 
 msgid "Material Substance"
-msgstr "Материальное вещество"
+msgstr "Основной материал"
 
 msgid "Material Substances"
-msgstr "Материальные вещества"
+msgstr "Основные материалы"
 
 msgid "material type"
 msgstr "Тип материала"
@@ -9110,7 +9110,7 @@ msgid "Mean Time To Repair"
 msgstr "Среднее время на ремонт"
 
 msgid "Measurement Standard"
-msgstr "Стандарт измерения"
+msgstr "Эталон измерений"
 
 msgid "Media Size"
 msgstr "Размер носителя"
@@ -9155,10 +9155,10 @@ msgid "Method Operations"
 msgstr "Операции метода"
 
 msgid "Method type"
-msgstr "Тип метода"
+msgstr "способ обеспечения"
 
 msgid "Method Type"
-msgstr "Тип метода"
+msgstr "Способ обеспечения"
 
 msgid "Methods"
 msgstr "Методы"
@@ -9188,10 +9188,10 @@ msgid "Minimum Amount"
 msgstr "Минимальная сумма"
 
 msgid "Minimum Cost"
-msgstr "Минимальная стоимость"
+msgstr "Минимальная себестоимость"
 
 msgid "Minimum Order Quantity"
-msgstr "Минимальное количество заказа"
+msgstr "Минимальный объем заказа"
 
 msgid "Minimum Order:"
 msgstr "Минимальный заказ:"
@@ -9221,7 +9221,7 @@ msgid "Missing Operations"
 msgstr "Отсутствуют операции"
 
 msgid "Missing Shipping Costs"
-msgstr "Отсутствуют расходы на доставку"
+msgstr "Отсутствующие стоимости доставки"
 
 msgid "Missing Suppliers"
 msgstr "Отсутствуют поставщики"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Переместить элемент"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "Переместите часть количества в новую строку диспозиции, чтобы MRB мог решить для каждой части отдельно (например, утилизировать часть, переработать часть)."
+msgstr "Переместить часть количества в новую строку решения, чтобы MRB мог решить каждую часть отдельно (например, отправить на брак, отправить на доработку)."
 
 msgid "Move to"
 msgstr "Переместить в"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "Имя"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "Назначьте внутреннего владельца проекта с правом принятия решений"
+msgstr "Назначьте внутреннего ответственного за проект с правом решения"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "Имена заполняются везде, где эти роли упоминаются в хабе."
@@ -9388,10 +9388,10 @@ msgid "Negative Adjustment"
 msgstr "Отрицательная корректировка"
 
 msgid "Net book value"
-msgstr "Чистая балансовая стоимость"
+msgstr "остаточная стоимость"
 
 msgid "Net Book Value"
-msgstr "Чистая балансовая стоимость"
+msgstr "Остаточная стоимость"
 
 msgid "Net Change"
 msgstr "Чистое изменение"
@@ -9412,13 +9412,13 @@ msgid "New Account"
 msgstr "Новый счет"
 
 msgid "New API Key"
-msgstr "Новый API ключ"
+msgstr "Новый API-ключ"
 
 msgid "New Approval Rule"
 msgstr "Новое правило утверждения"
 
 msgid "New Asset Class"
-msgstr "Новый класс активов"
+msgstr "Новый класс основных средств"
 
 msgid "New Assignment"
 msgstr "Новое назначение"
@@ -9430,13 +9430,13 @@ msgid "New Attribute Category"
 msgstr "Новая категория атрибутов"
 
 msgid "New Change Notice"
-msgstr "Новое уведомление об изменении"
+msgstr "Новое извещение об изменении"
 
 msgid "New Change Notice Action"
-msgstr "Новое действие уведомления об изменении"
+msgstr "Новое действие извещения об изменении"
 
 msgid "New Change Notice Type"
-msgstr "Новый тип уведомления об изменении"
+msgstr "Новый тип извещения об изменении"
 
 msgid "New Consumable"
 msgstr "Новый расходный материал"
@@ -9454,10 +9454,10 @@ msgid "New Custom Field"
 msgstr "Новое пользовательское поле"
 
 msgid "New Customer"
-msgstr "Новый клиент"
+msgstr "Новый покупатель"
 
 msgid "New Customer Part"
-msgstr "Новая деталь клиента"
+msgstr "Новая деталь покупателя"
 
 msgid "New Department"
 msgstr "Новый отдел"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "Новый тип сотрудника"
 
 msgid "New expiration date"
-msgstr "Новая дата истечения"
+msgstr "Новая дата истечения срока"
 
 msgid "New Failure Mode"
 msgstr "Новый режим отказа"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "Новое основное средство"
 
 msgid "New Gauge"
-msgstr "Новый датчик"
+msgstr "Новое средство измерения"
 
 msgid "New Gauge Calibration Record"
-msgstr "Новая запись калибровки датчика"
+msgstr "Новая запись о калибровке средства измерения"
 
 msgid "New Gauge Type"
-msgstr "Новый тип датчика"
+msgstr "Новый тип средства измерения"
 
 msgid "New Group"
 msgstr "Новая группа"
@@ -9505,7 +9505,7 @@ msgid "New Inventory Count"
 msgstr "Новый подсчет инвентаря"
 
 msgid "New Invoice"
-msgstr "Новый счет"
+msgstr "Новая счет-фактура"
 
 msgid "New Issue"
 msgstr "Новая проблема"
@@ -9514,7 +9514,7 @@ msgid "New Item Group"
 msgstr "Новая группа товаров"
 
 msgid "New Kanban"
-msgstr "Новый Kanban"
+msgstr "Новый канбан"
 
 msgid "New Line"
 msgstr "Новая строка"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "Новое местоположение"
 
 msgid "New Maintenance Dispatch"
-msgstr "Новая заявка на техническое обслуживание"
+msgstr "Новая заявка на техобслуживание"
 
 msgid "New Material"
 msgstr "Новый материал"
@@ -9535,7 +9535,7 @@ msgid "New Material Dimension"
 msgstr "Новое измерение материала"
 
 msgid "New Material Finish"
-msgstr "Новая отделка материала"
+msgstr "Новая обработка поверхности"
 
 msgid "New Material Grade"
 msgstr "Новая марка материала"
@@ -9544,7 +9544,7 @@ msgid "New Material Shape"
 msgstr "Новая форма материала"
 
 msgid "New Material Substance"
-msgstr "Новое вещество материала"
+msgstr "Новый основной материал"
 
 msgid "New Material Type"
 msgstr "Новый тип материала"
@@ -9553,7 +9553,7 @@ msgid "New Non Conformance Type"
 msgstr "Новый тип несоответствия"
 
 msgid "New Owner"
-msgstr "Новый владелец"
+msgstr "Новый ответственный"
 
 msgid "New Part"
 msgstr "Новая деталь"
@@ -9565,10 +9565,10 @@ msgid "New Payment"
 msgstr "Новый платеж"
 
 msgid "New Payment Term"
-msgstr "Новый платежный срок"
+msgstr "Новые условия оплаты"
 
 msgid "New Picking List"
-msgstr "Новый список комплектации"
+msgstr "Новый лист отбора"
 
 msgid "New PIN"
 msgstr "Новый PIN"
@@ -9580,7 +9580,7 @@ msgid "New Price Override"
 msgstr "Новое переопределение цены"
 
 msgid "New Pricing Rule"
-msgstr "Новое правило цены"
+msgstr "Новое правило ценообразования"
 
 msgid "New Procedure"
 msgstr "Новая процедура"
@@ -9607,7 +9607,7 @@ msgid "New record created"
 msgstr "Создана новая запись"
 
 msgid "New Revision"
-msgstr "Новая редакция"
+msgstr "Новая ревизия"
 
 msgid "New RFQ"
 msgstr "Новый RFQ"
@@ -9619,19 +9619,19 @@ msgid "New Rule"
 msgstr "Новое правило"
 
 msgid "New Sales Invoice"
-msgstr "Новый счет-фактура продажи"
+msgstr "Новая счет-фактура выданная"
 
 msgid "New Sales Invoice Line"
-msgstr "Новая строка счета продажи"
+msgstr "Новая строка счета-фактуры выданного"
 
 msgid "New Sales Order"
-msgstr "Новый заказ на продажу"
+msgstr "Новый заказ покупателя"
 
 msgid "New Sales Order Line"
-msgstr "Новая строка заказа продажи"
+msgstr "Новая строка заказа покупателя"
 
 msgid "New Scheduled Maintenance"
-msgstr "Новое плановое обслуживание"
+msgstr "Новое плановое техобслуживание"
 
 msgid "New Serial Number"
 msgstr "Новый серийный номер"
@@ -9643,7 +9643,7 @@ msgid "New Shift"
 msgstr "Новая смена"
 
 msgid "New Shipment"
-msgstr "Новая отправка"
+msgstr "Новая отгрузка"
 
 msgid "New Shipping Method"
 msgstr "Новый способ доставки"
@@ -9655,7 +9655,7 @@ msgid "New Storage Type"
 msgstr "Новый тип хранилища"
 
 msgid "New Storage Unit"
-msgstr "Новое хранилище"
+msgstr "Новая единица хранения"
 
 msgid "New Supplier"
 msgstr "Новый поставщик"
@@ -9676,7 +9676,7 @@ msgid "New Transfer"
 msgstr "Новый трансфер"
 
 msgid "New Transfer Line"
-msgstr "Новая строка передачи"
+msgstr "Новая Строка перемещения"
 
 msgid "New Unit of Measure"
 msgstr "Новая единица измерения"
@@ -9688,7 +9688,7 @@ msgid "New Warehouse Transfer"
 msgstr "Новый трансфер склада"
 
 msgid "New Webhook"
-msgstr "Новый Webhook"
+msgstr "Новый Вебхук"
 
 msgid "New Work Center"
 msgstr "Новый рабочий центр"
@@ -9715,13 +9715,13 @@ msgid "Next Due"
 msgstr "Следующий срок"
 
 msgid "Next Due Date"
-msgstr "Следующая дата платежа"
+msgstr "Следующий Срок выполнения"
 
 msgid "Next page"
 msgstr "Следующая страница"
 
 msgid "Next Sequence"
-msgstr "Следующая последовательность"
+msgstr "Следующая Нумерация"
 
 msgid "Next step"
 msgstr "Следующий шаг"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Действия не выбраны"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Для этого заказа не найдено активных работ. Заказ будет отменен напрямую."
+msgstr "Не найдены текущие производственные заказы для этого заказа покупателя. Заказ будет отменен непосредственно."
 
 msgid "No active plan"
 msgstr "Нет активного плана"
@@ -9785,7 +9785,7 @@ msgstr "Нет приложений. Платеж будет на счет."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Нет архивированных логов. Логи старше {0} дней будут автоматически архивированы и доступны для скачивания здесь."
+msgstr "Нет архивированных логов. Логи старше {0} дней будут автоматически архивированы и будут доступны для скачивания здесь."
 
 msgid "No attachments."
 msgstr "Нет вложений."
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "Нет комментариев. Будьте первым, кто добавит комментарий."
 
 msgid "No completed jobs within range"
-msgstr "Нет завершенных работ в диапазоне"
+msgstr "Нет завершенных производственных заказов в диапазоне"
 
 msgid "No condition may match"
 msgstr "Ни одно условие не должно совпадать"
@@ -9827,7 +9827,7 @@ msgid "No conversion is required"
 msgstr "Преобразование не требуется"
 
 msgid "No cost history found"
-msgstr "История стоимости не найдена"
+msgstr "История себестоимости не найдена"
 
 msgid "No Data"
 msgstr "Нет данных"
@@ -9842,10 +9842,10 @@ msgid "No default attachments yet."
 msgstr "Пока нет вложений по умолчанию."
 
 msgid "No dimension slots configured"
-msgstr "Нет настроенных слотов размерности"
+msgstr "Слоты измерений не настроены"
 
 msgid "No dimension values mapped yet"
-msgstr "Значения размерности еще не отображены"
+msgstr "Значения измерений еще не сопоставлены"
 
 msgid "No draft make method for this item yet."
 msgstr "Пока нет чернового метода производства для этого элемента."
@@ -9869,16 +9869,16 @@ msgid "No events found."
 msgstr "События не найдены."
 
 msgid "No extra cutover steps yet. Add anything specific to this customer."
-msgstr "Нет дополнительных этапов перехода. Добавьте что-нибудь специфичное для этого клиента."
+msgstr "Нет дополнительных переходных шагов. Добавьте что-либо специфичное для этого покупателя."
 
 msgid "No extra data sets yet. Add anything specific to this customer."
-msgstr "Нет дополнительных наборов данных. Добавьте что-нибудь специфичное для этого клиента."
+msgstr "Нет дополнительных наборов данных. Добавьте что-либо специфичное для этого покупателя."
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "Нет дополнительных требований. Добавьте что-нибудь специфичное для этого клиента."
+msgstr "Нет дополнительных требований. Добавьте что-либо специфичное для этого покупателя."
 
 msgid "No extra setup items yet. Add anything specific to this customer."
-msgstr "Нет дополнительных элементов настройки. Добавьте что-нибудь специфичное для этого клиента."
+msgstr "Нет дополнительных элементов настройки. Добавьте что-либо специфичное для этого покупателя."
 
 msgid "No failure path — the run stops here and is marked failed"
 msgstr "Нет пути отказа — выполнение останавливается здесь и отмечается как неудачное"
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Файлы не загружены"
 
 msgid "No Gauge Selected"
-msgstr "Датчик не выбран"
+msgstr "Средство измерения не выбрано"
 
 msgid "No grouped notifications"
 msgstr "Нет сгруппированных уведомлений"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Здесь еще нет активности с товарами."
 
 msgid "No jobs were created"
-msgstr "Никаких заданий не было создано"
+msgstr "Производственные заказы не были созданы"
 
 msgid "No journal lines in scope for this period"
-msgstr "Нет строк журнала в пределах этого периода"
+msgstr "Нет строк операций в этом периоде"
 
 msgid "No lines to map"
 msgstr "Нет строк для сопоставления"
@@ -9956,22 +9956,22 @@ msgid "No new notifications"
 msgstr "Нет новых уведомлений"
 
 msgid "No notes"
-msgstr "Нет заметок"
+msgstr "Нет примечаний"
 
 msgid "No open invoices"
-msgstr "Нет открытых счетов"
+msgstr "Нет открытых счетов-фактур"
 
 msgid "No open orders for this item are available to link."
 msgstr "Нет открытых заказов для этого товара, доступных для связи."
 
 msgid "No open sales order lines"
-msgstr "Нет открытых строк заказа продажи"
+msgstr "Нет открытых строк заказов покупателя"
 
 msgid "No operations found."
 msgstr "Операции не найдены."
 
 msgid "No operations require picking at this location"
-msgstr "На этом месте нет операций, требующих комплектации"
+msgstr "Ни одна операция не требует отбора на этой площадке"
 
 msgid "No operators."
 msgstr "Нет операторов."
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "Нет доступных вариантов."
 
 msgid "No other bins hold this item"
-msgstr "Нет других контейнеров с этим товаром"
+msgstr "Ни одна другая ячейка не содержит эту номенклатуру"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Других сотрудников не найдено. Добавьте сотрудников, чтобы включить передачу прав собственности."
@@ -10016,13 +10016,13 @@ msgid "No planning data"
 msgstr "Нет данных планирования"
 
 msgid "No posted journals in this period for this account"
-msgstr "Нет проведенных журналов в этом периоде для этого счета"
+msgstr "Нет проведенных операций в этом периоде по этому счету"
 
 msgid "No pricing for selected quantity"
-msgstr "Нет цен для выбранного количества"
+msgstr "Нет ценообразования для выбранного количества"
 
 msgid "No pricing options found"
-msgstr "Нет доступных вариантов цен"
+msgstr "Варианты ценообразования не найдены"
 
 msgid "No printer configured"
 msgstr "Принтер не настроен"
@@ -10040,13 +10040,13 @@ msgid "No purchases in this period"
 msgstr "Нет покупок в этом периоде"
 
 msgid "No Quote"
-msgstr "Нет предложения"
+msgstr "Отказ от предложения"
 
 msgid "No Quote Reason"
-msgstr "Причина отсутствия предложения"
+msgstr "Причина отказа от предложения"
 
 msgid "No Quote Reasons"
-msgstr "Причины отсутствия предложения"
+msgstr "Причины отказа от предложения"
 
 msgid "No receivables"
 msgstr "Нет дебиторской задолженности"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "Никакие отчеты не соответствуют вашему поиску."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "Ни один представитель этой компании ещё не принял Carbon GovCloud Rider. Администратор этой компании должен принять его, прежде чем кто-либо получит доступ к Carbon — сотрудники Carbon не могут принять его от вашего имени."
+msgstr "Ни один представитель этой организации еще не принял Carbon GovCloud Rider. Администратор этой организации должен принять его перед тем, как кто-либо сможет получить доступ к Carbon — персонал Carbon не может принять его от вас."
 
 msgid "No results"
 msgstr "Нет результатов"
@@ -10145,7 +10145,7 @@ msgid "Nom"
 msgstr "Номин"
 
 msgid "Nominal Cost"
-msgstr "Номинальная стоимость"
+msgstr "Номинальная себестоимость"
 
 msgid "Non conformance"
 msgstr "Несоответствие"
@@ -10160,10 +10160,10 @@ msgid "Non-conformance (issue)"
 msgstr "Несоответствие (проблема)"
 
 msgid "Non-Inventory"
-msgstr "Не в наличии"
+msgstr "Нескладской"
 
 msgid "Non-Inventory Tracking"
-msgstr "Отслеживание вне инвентаря"
+msgstr "Отслеживание нескладского"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Счёт прочих расходов, дебетуемый при продаже или списании актива данного класса по цене ниже его остаточной стоимости."
@@ -10172,7 +10172,7 @@ msgid "Non-operating income account credited when an asset in this class is sold
 msgstr "Счёт прочих доходов, зачисляемый при продаже актива данного класса по цене выше его остаточной стоимости."
 
 msgid "Non-Taxable Add-On Cost"
-msgstr "Не облагаемая налогом дополнительная стоимость"
+msgstr "Не подлежащая налогообложению добавочная себестоимость"
 
 msgid "Non-working days that scheduling and capacity respect"
 msgstr "Нерабочие дни, которые учитываются при планировании и расчете мощности"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Обычный"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Не таблица, а баланс главной книги: стоимость накапливается по мере выдачи материалов задания и очищается при поступлении задания на склад."
+msgstr "Это не таблица, а остаток главной книги: себестоимость накапливается по мере выдачи материалов производственного заказа и очищается при получении заказа на запас."
 
 msgid "Not certified"
 msgstr "Не сертифицировано"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Недостаточно заданий для покрытия количества"
+msgstr "Недостаточно производственных заказов для покрытия количества"
 
 msgid "Not reached"
 msgstr "Не достигнуто"
@@ -10299,7 +10299,7 @@ msgid "Off — handled outside the sync"
 msgstr "Отключено — обработано вне синхронизации"
 
 msgid "Off — released revisions stay editable"
-msgstr "Выключено — выпущенные версии остаются редактируемыми"
+msgstr "Отключено — выпущенные ревизии остаются редактируемыми"
 
 msgid "OK"
 msgstr "ОК"
@@ -10326,25 +10326,25 @@ msgid "On Hand"
 msgstr "На складе"
 
 msgid "On Hold"
-msgstr "На удержании"
+msgstr "Приостановлено"
 
 msgid "On Jobs"
-msgstr "На заказах"
+msgstr "На производственных заказах"
 
 msgid "On order"
 msgstr "Заказано"
 
 msgid "On Production Demand"
-msgstr "На производственном спросе"
+msgstr "На производственную потребность"
 
 msgid "On Purchase Order"
-msgstr "На заказе покупки"
+msgstr "На заказе поставщику"
 
 msgid "On Sales Order"
-msgstr "На заказе продажи"
+msgstr "На заказе покупателя"
 
 msgid "On Storage Unit"
-msgstr "На складском отделении"
+msgstr "На единице хранения"
 
 msgid "On this operation"
 msgstr "На эту операцию"
@@ -10374,10 +10374,10 @@ msgid "On-time delivery"
 msgstr "Своевременная доставка"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "Один запуск рабочего процесса, записанный пошагово с значениями, которые каждый шаг использовал и создал, действуя с разрешениями владельца рабочего процесса."
+msgstr "Одно выполнение рабочего процесса, записанное пошагово со значениями, использованными и созданными каждым шагом, выполняющееся с правами доступа владельца рабочего процесса."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Одна серийная единица или одна партия, которую Carbon отслеживает индивидуально, имея собственный статус и атрибуты, такие как дата истечения."
+msgstr "Одна серийная единица или одна серия, которую Carbon отслеживает отдельно, со своим статусом и атрибутами, такими как срок годности."
 
 msgid "One set of numbers"
 msgstr "Один набор цифр"
@@ -10386,7 +10386,7 @@ msgid "One step in a job's routing, naming a process and a work center and carry
 msgstr "Один шаг в маршрутизации задания, определяющий процесс и рабочий центр, и несущий собственное время настройки, труда и машины, а также ставки."
 
 msgid "One system from quote to cash"
-msgstr "Одна система от предложения до оплаты"
+msgstr "Единая система от коммерческого предложения до денежных средств"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
 msgstr "Редактировать можно только процедуры в статусе «Черновик». Создайте новую версию, чтобы изменить активную или архивную процедуру."
@@ -10422,13 +10422,13 @@ msgid "Open"
 msgstr "Открыть"
 
 msgid "Open a change notice"
-msgstr "Открыть уведомление об изменении"
+msgstr "Открыть Извещение об изменении"
 
 msgid "Open Actions"
 msgstr "Открытые действия"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "Открыть NCR для диспозиции MRB"
+msgstr "Открыть NCR для решения о браке"
 
 msgid "Open AP"
 msgstr "Открытые кредиторские задолженности"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Дата открытия"
 
 msgid "Open Dispatches"
-msgstr "Открытые наряды"
+msgstr "Открыть Заявки на техобслуживание"
 
 msgid "Open in Carbon"
 msgstr "Открыть в Carbon"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "Открыто в уведомлении об изменении {ids}. Выпустите его, чтобы создать новые версии или редакции."
+msgstr "Открыть в Извещении об изменении {ids}. Запустите его в работу, чтобы создать новые версии или ревизии."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "Открыто в уведомлениях об изменении {ids}. Выпустите их, чтобы создать новые версии или редакции."
+msgstr "Открыть в Извещениях об изменении {ids}. Запустите их в работу, чтобы создать новые версии или ревизии."
 
 msgid "Open in MES"
 msgstr "Открыть в MES"
@@ -10464,25 +10464,25 @@ msgid "Open Issues"
 msgstr "Открытые проблемы"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Открытый спрос на работы плюс незавершенные передачи из этого контейнера"
+msgstr "Открытая потребность производственного заказа плюс неурегулированные перемещения из этой ячейки"
 
 msgid "Open jobs"
-msgstr "Открытые заказы"
+msgstr "Открытые производственные заказы"
 
 msgid "Open menu"
 msgstr "Открыть меню"
 
 msgid "Open payables by supplier and age"
-msgstr "Открытые счета к оплате по поставщикам и срокам"
+msgstr "Открытая кредиторская задолженность по поставщикам и срокам"
 
 msgid "Open Purchase Invoices"
-msgstr "Открытые счета-фактуры"
+msgstr "Открытые счета-фактуры полученные"
 
 msgid "Open purchase orders"
-msgstr "Открытые заказы на покупку"
+msgstr "Открытые заказы поставщикам"
 
 msgid "Open Purchase Orders"
-msgstr "Открытые заказы на покупку"
+msgstr "Открытые Заказы поставщикам"
 
 msgid "Open Quotes"
 msgstr "Открытые предложения"
@@ -10491,16 +10491,16 @@ msgid "Open Reactive"
 msgstr "Открытые реактивные"
 
 msgid "Open receivables by customer and age"
-msgstr "Открытые счета к получению по клиентам и срокам"
+msgstr "Открытая дебиторская задолженность по покупателям и срокам"
 
 msgid "Open RFQs"
 msgstr "Открытые РФП"
 
 msgid "Open sales orders"
-msgstr "Открытые заказы на продажу"
+msgstr "Открытые заказы покупателей"
 
 msgid "Open Sales Orders"
-msgstr "Открытые заказы на продажу"
+msgstr "Открытые Заказы покупателей"
 
 msgid "Open Scheduled"
 msgstr "Открытые запланированные"
@@ -10527,7 +10527,7 @@ msgid "Opening an operation starts its timer, so time is tracked from the moment
 msgstr "Открытие операции запускает её таймер, поэтому время отсчитывается с момента начала работы."
 
 msgid "Opening balance of depreciation already booked before this asset was added to Carbon (use 0 for new acquisitions)."
-msgstr "Начальный баланс амортизации, уже учтенный до добавления этого актива в Carbon (используйте 0 для новых приобретений)."
+msgstr "Начальный остаток амортизации, уже учтенный до добавления этого актива в Carbon (используйте 0 для новых приобретений)."
 
 msgid "Operating Expenses"
 msgstr "Операционные расходы"
@@ -10539,10 +10539,10 @@ msgid "Operation"
 msgstr "Операция"
 
 msgid "Operation lead time"
-msgstr "Время выполнения операции"
+msgstr "Срок поставки операции"
 
 msgid "Operation minimum cost"
-msgstr "Минимальная стоимость операции"
+msgstr "Минимальная себестоимость операции"
 
 msgid "Operation order"
 msgstr "Порядок операций"
@@ -10563,13 +10563,13 @@ msgid "Operation Type"
 msgstr "Тип операции"
 
 msgid "Operation unit cost"
-msgstr "Стоимость единицы операции"
+msgstr "Себестоимость операции за единицу"
 
 msgid "Operations"
 msgstr "Операции"
 
 msgid "Operations / steps"
-msgstr "Операции / этапы"
+msgstr "Операции / шаги"
 
 msgid "Operations Type"
 msgstr "Тип операций"
@@ -10599,10 +10599,10 @@ msgid "Operators start the timer themselves when they begin an operation."
 msgstr "Операторы запускают таймер сами, когда они начинают операцию."
 
 msgid "Opportunity"
-msgstr "Возможность"
+msgstr "Сделка"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
-msgstr "Оптимизировано для быстрого предпросмотра — загрузки всегда предоставляют исходный загруженный файл"
+msgstr "Оптимизировано для быстрого предпросмотра — при скачивании всегда передается исходный загруженный файл"
 
 msgid "Optional"
 msgstr "Опционально"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "Дополнительный контекст для этого правила"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "Дополнительный фиксированный курс, используемый при пересчете балансов собственного капитала в соответствии с МСФО 21 (вместо периодического курса)."
+msgstr "Дополнительный фиксированный курс, используемый при пересчете остатков собственного капитала в соответствии с МСА 21 (вместо курса периода)."
 
 msgid "Optional pages & sections"
 msgstr "Дополнительные страницы и разделы"
@@ -10690,7 +10690,7 @@ msgid "Other Income"
 msgstr "Прочие доходы"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "Счет прочих доходов для прибыли от валютных операций при расчете по иностранной валюте по более выгодному курсу"
+msgstr "Счет прочих доходов для обменной прибыли, когда платеж погашает счет-фактуру в иностранной валюте по более выгодному курсу"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
 msgstr "Счет прочих доходов для остатков поставщиков, погашенных без полной оплаты при расчете по кредиторской задолженности"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Выход"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "Выпуск никогда не превышает срок действия своих сырьевых материалов. Возвращается к фиксированной продолжительности, когда ни один входной материал не имеет даты истечения."
+msgstr "Готовая продукция никогда не превышает срок действия сырья. Применяется фиксированная длительность, когда ни один исходный материал не имеет срока годности."
 
 msgid "Outside operation"
 msgstr "Отклонение косвенных затрат"
@@ -10726,10 +10726,10 @@ msgid "Overdue"
 msgstr "Просрочено"
 
 msgid "Overhead Absorption"
-msgstr "Абсорбция накладных расходов"
+msgstr "Распределение накладных расходов"
 
 msgid "Overhead Absorption (default)"
-msgstr "Абсорбция накладных расходов (по умолчанию)"
+msgstr "Распределение накладных расходов (по умолчанию)"
 
 msgid "Overhead rate"
 msgstr "Ставка накладных расходов"
@@ -10741,22 +10741,22 @@ msgid "Overhead Rate (Hourly)"
 msgstr "Ставка накладных расходов (в час)"
 
 msgid "Overhead Variance"
-msgstr "Отклонение косвенных затрат (по умолчанию)"
+msgstr "Отклонение накладных расходов"
 
 msgid "Overhead Variance (default)"
-msgstr "Владелец (центр затрат)"
+msgstr "Отклонение накладных расходов (по умолчанию)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "Переопределение требует разрешения inventory:update и причину."
+msgstr "Для переопределения требуется право доступа inventory:update и причина."
 
 msgid "Override Price"
 msgstr "Цена переопределения"
 
 msgid "Override price for a single customer"
-msgstr "Переопределить цену для одного клиента"
+msgstr "Переопределить цену для одного покупателя"
 
 msgid "Override price for all customers of a type"
-msgstr "Переопределить цену для всех клиентов этого типа"
+msgstr "Переопределить цену для всех покупателей такого типа"
 
 msgid "Override the expiration on {label}."
 msgstr "Переопределить срок действия для {label}."
@@ -10768,7 +10768,7 @@ msgid "Overwrite Existing"
 msgstr "Перезаписать существующие"
 
 msgid "Overwrite Permissions"
-msgstr "Перезаписать разрешения"
+msgstr "Перезаписать права доступа"
 
 msgid "Overwrite the quote method with the source method"
 msgstr "Перезаписать метод предложения исходным методом"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "Перезаписать целевой производственный метод методом предложения"
 
 msgid "Owner"
-msgstr "Владелец"
+msgstr "Ответственный"
 
 msgid "Owner (cost center)"
-msgstr "Главный центр затрат"
+msgstr "Ответственный (Центр затрат)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,7 +10814,7 @@ msgid "Params"
 msgstr "Параметры"
 
 msgid "Parent cost center"
-msgstr "деталь"
+msgstr "Родительский Центр затрат"
 
 msgid "Parent Cost Center"
 msgstr "Родительский центр затрат"
@@ -10829,10 +10829,10 @@ msgid "Parent Item"
 msgstr "Родительский товар"
 
 msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
-msgstr "Родительские товары. (Если вы щёлкнете на один из родительских товаров ниже, вы увидите этот товар в качестве компонента в спецификации материалов.)"
+msgstr "Номенклатура-родители. (Если вы откроете одну из деталей-родителей ниже, вы увидите эту номенклатуру как компонент в спецификации материалов.)"
 
 msgid "Parent Storage Unit"
-msgstr "Родительское хранилище"
+msgstr "Родительская Единица хранения"
 
 msgid "Pareto by Type"
 msgstr "Парето по типам"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Припарковать как ошибку"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Припаркуйте журнал с предупреждением до отображения значения"
+msgstr "Отложить операцию с предупреждением до сопоставления значения"
 
 msgid "part"
 msgstr "детали"
@@ -10862,7 +10862,7 @@ msgid "Part Number"
 msgstr "Номер детали"
 
 msgid "Part Supersession"
-msgstr "Замена детали"
+msgstr "Замещение деталей"
 
 msgid "Partial"
 msgstr "Частично"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Партнеры"
 
 msgid "parts"
-msgstr "Кредиторская задолженность"
+msgstr "детали"
 
 msgid "Parts"
 msgstr "Детали"
@@ -10895,10 +10895,10 @@ msgid "Passed"
 msgstr "Пройдено"
 
 msgid "Passkey name"
-msgstr "Имя Passkey"
+msgstr "Имя ключа доступа"
 
 msgid "Passkey unlock failed"
-msgstr "Не удалось разблокировать Passkey"
+msgstr "Не удалось разблокировать ключ доступа"
 
 msgid "Passkeys"
 msgstr "Ключи доступа"
@@ -10919,7 +10919,7 @@ msgid "Payables (AP)"
 msgstr "Кредиторская задолженность (КЗ)"
 
 msgid "Payables (default)"
-msgstr "условие платежа"
+msgstr "Кредиторская задолженность (по умолчанию)"
 
 msgid "Payables aging"
 msgstr "Старение кредиторской задолженности"
@@ -10937,19 +10937,19 @@ msgid "Payment ID"
 msgstr "ID платежа"
 
 msgid "payment term"
-msgstr "условия платежа"
+msgstr "условия оплаты"
 
 msgid "Payment term"
-msgstr "Условие платежа"
+msgstr "Условия оплаты"
 
 msgid "Payment Term"
-msgstr "Условие платежа"
+msgstr "Условия оплаты"
 
 msgid "payment terms"
-msgstr "люди"
+msgstr "условия оплаты"
 
 msgid "Payment Terms"
-msgstr "Условия платежа"
+msgstr "Условия оплаты"
 
 msgid "Payment terms like Net 30 or due on receipt"
 msgstr "Условия оплаты, такие как Net 30 или оплата при получении"
@@ -10958,7 +10958,7 @@ msgid "Payments"
 msgstr "Платежи"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "Платежи и кредиты, применённые к этому счёту. Нажмите на строку, чтобы открыть исходный документ."
+msgstr "Платежи и кредиты, применные к этому счету-фактуре. Нажмите на строку, чтобы открыть документ-основание."
 
 msgid "PDF"
 msgstr "PDF"
@@ -10982,16 +10982,16 @@ msgid "Pending"
 msgstr "Ожидание"
 
 msgid "people"
-msgstr "Периодические расходы на амортизацию основных средств"
+msgstr "сотрудники"
 
 msgid "People"
-msgstr "Люди"
+msgstr "Сотрудники"
 
 msgid "Per Unit"
 msgstr "За единицу"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Переопределение по строкам местоположения выполнения заголовка заказа; используется для разделенных поставок и дроп-шипов."
+msgstr "Переопределение на уровне строки площадки отгрузки из заголовка заказа; используется для разделённых отгрузок и прямых поставок."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
 msgstr "Переопределение по строкам местоположения доставки заголовка ПО; используется для разделенных доставок на несколько складов или дроп-шипов."
@@ -11015,16 +11015,16 @@ msgid "Period lock policy"
 msgstr "Политика блокировки периода"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Комплектация предлагает отслеживаемые сущности в порядке самого раннего истечения сначала, поэтому запас, истекающий в первую очередь, по умолчанию выходит первым."
+msgstr "Периодический расход амортизации основных средств"
 
 msgid "Permanently Delete"
 msgstr "Окончательно удалить"
 
 msgid "Permission groups for granting access in bulk"
-msgstr "Группы разрешений для массового предоставления доступа"
+msgstr "Группы прав доступа для массового предоставления доступа"
 
 msgid "Permissions"
-msgstr "Разрешения"
+msgstr "Права доступа"
 
 msgid "Person"
 msgstr "Человек"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Длительность этапов"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Снятие товара с производства в пользу товара-преемника, так что планирование перенаправляет спрос на старый товар — умноженный на коэффициент пересчета — на новый."
+msgstr "Снятие номенклатуры с производства в пользу детали-преемника, поэтому планирование перенаправляет потребность старой номенклатуры — умноженную на коэффициент пересчета — на новую."
 
 msgid "Phone"
 msgstr "Телефон"
@@ -11054,13 +11054,13 @@ msgid "Pick"
 msgstr "Выбрать"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "Выберите размерность Carbon и цель провайдера, на которую она отправляется. Автоматическое создание добавляет отсутствующие параметры провайдера по имени во время отправки."
+msgstr "Выберите измерение Carbon и целевого провайдера, на которого оно проводится. Автоматическое создание добавляет отсутствующие параметры провайдера по имени во время отправки."
 
 msgid "Pick a column to sort by"
 msgstr "Выберите столбец для сортировки"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "Выберите клиента или тип клиента для просмотра их цен."
+msgstr "Выберите покупателя или тип покупателя, чтобы просмотреть их ценообразование."
 
 msgid "Pick a date or leave blank to clear it."
 msgstr "Выберите дату или оставьте пустым, чтобы очистить."
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "Порядок комплектации"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "Выберите контейнер, который нуждается в запасе, затем выберите контейнеры, из которых его извлечь."
+msgstr "Выберите ячейку, которой нужен запас, затем выберите ячейки, из которых его извлечь."
 
 msgid "Pick tracked item"
 msgstr "Выбрать отслеживаемый товар"
@@ -11102,25 +11102,25 @@ msgid "Picked quantity"
 msgstr "Выбранное количество"
 
 msgid "Picking Lines"
-msgstr "Строки комплектации"
+msgstr "Строки отбора"
 
 msgid "Picking list"
-msgstr "Список подбора"
+msgstr "лист отбора"
 
 msgid "Picking List"
-msgstr "Список комплектации"
+msgstr "Лист отбора"
 
 msgid "Picking List ID"
-msgstr "ID списка комплектации"
+msgstr "ID листа отбора"
 
 msgid "Picking List Notes"
-msgstr "Заметки списка комплектации"
+msgstr "Примечания листа отбора"
 
 msgid "Picking Lists"
-msgstr "Списки комплектации"
+msgstr "Листы отбора"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Запланировано"
+msgstr "Отбор предлагает отслеживаемые товары в первую очередь с наиболее ранним сроком истечения, поэтому запас с ближайшим сроком истечения уходит первым по умолчанию."
 
 msgid "Pieces/Hour"
 msgstr "Штук/час"
@@ -11164,10 +11164,10 @@ msgid "Planned Order"
 msgstr "Плановый заказ"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "Плановый заказ = предложение MRP для покрытия прогнозируемого спроса на основе политики переупорядочения товара (или добавлено вручную)."
+msgstr "Запланированный заказ = предложение MRP для покрытия прогнозируемой потребности на основе политики переоформления номенклатуры (или добавленный вручную)."
 
 msgid "Planned purchase order"
-msgstr "Запланированный заказ на закупку"
+msgstr "Запланированный заказ поставщику"
 
 msgid "Planned Start"
 msgstr "Запланированное начало"
@@ -11182,7 +11182,7 @@ msgid "Planning rounds suggested replenishment up to a whole multiple of this nu
 msgstr "Циклы планирования предложили пополнение до целого кратного этому числу."
 
 msgid "Planning's lower bound on a suggested replenishment quantity; distinct from a supplier's MOQ, which lives on the supplier-part record."
-msgstr "Нижний предел планирования на предлагаемый объем пополнения; отличается от MOQ поставщика, который находится на записи поставщик-часть."
+msgstr "Нижняя граница планирования предлагаемого количества пополнения; отличается от минимального количества заказа поставщика, которое находится в карточке поставщик-номенклатура."
 
 msgid "Planning's upper bound on a single suggested replenishment; quantities above this are split into multiple orders."
 msgstr "Верхний предел планирования на одно предлагаемое пополнение; количества выше этого разделяются на несколько заказов."
@@ -11248,16 +11248,16 @@ msgid "Post Comment"
 msgstr "Опубликовать комментарий"
 
 msgid "Post Invoice"
-msgstr "Отправить счет"
+msgstr "Провести счет-фактуру"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "Публикуйте записи журнала с правильными кодами счета и описания"
+msgstr "Проводите операции журнала с правильными кодами счетов и описания"
 
 msgid "Post Receipt"
 msgstr "Отправить квитанцию"
 
 msgid "Post Shipment"
-msgstr "Отправить отправку"
+msgstr "Провести отгрузку"
 
 msgid "Postal code"
 msgstr "Почтовый индекс"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Опубликовано"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Опубликованные журналы с этими типами источников всегда синхронизируются. Ежедневная сводка группирует журналы дня в одну запись поставщика для каждого счета."
+msgstr "Проведенные операции с этими типами источников всегда синхронизируются. Ежедневное резюме группирует операции одного дня в одну запись поставщика по счету."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Опубликовано один раз, исправлено {corrections} раз(а)."
@@ -11290,31 +11290,31 @@ msgid "Posted once, no corrections."
 msgstr "Опубликовано один раз, без исправлений."
 
 msgid "Posting"
-msgstr "Авансовые платежи"
+msgstr "Проведение"
 
 msgid "Posting date"
-msgstr "Дата публикации"
+msgstr "Дата проведения"
 
 msgid "Posting Date"
-msgstr "Дата публикации"
+msgstr "Дата проведения"
 
 msgid "Potential Data Loss"
 msgstr "Потенциальная потеря данных"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "Предварительно заполняется для нового товара, когда срок действия установлен как Фиксированная продолжительность."
+msgstr "Предзаполнено для новой номенклатуры, если срок годности установлен на фиксированную продолжительность."
 
 msgid "Preferred Supplier"
-msgstr "Предпочитаемый поставщик"
+msgstr "Основной поставщик"
 
 msgid "Prefix"
 msgstr "Префикс"
 
 msgid "Prepayments"
-msgstr "Авансовые платежи (по умолчанию)"
+msgstr "Предоплаты"
 
 msgid "Prepayments (default)"
-msgstr "Предупредительное действие"
+msgstr "Предоплаты (по умолчанию)"
 
 msgid "Present Week"
 msgstr "Текущая неделя"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "Пред"
 
 msgid "Preventive action"
-msgstr "Основной счет для оценки имеющегося запаса"
+msgstr "Предупреждающее действие"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "Графики профилактического обслуживания вашего оборудования"
+msgstr "Графики предупреждающего техобслуживания вашего оборудования"
 
 msgid "Preview"
 msgstr "Предпросмотр"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Предыдущее значение {0}"
 
 msgid "Price break actions"
-msgstr "Действия ценовой скидки"
+msgstr "Действия ценовой шкалы"
 
 msgid "Price Break History"
-msgstr "История разбиения цены"
+msgstr "История ценовой шкалы"
 
 msgid "Price Breaks"
-msgstr "Ценовые диапазоны"
+msgstr "Ценовые шкалы"
 
 msgid "Price List"
 msgstr "Прайс-лист"
@@ -11384,16 +11384,16 @@ msgid "Pricing rule"
 msgstr "Правило ценообразования"
 
 msgid "Pricing Rule"
-msgstr "Правило цены"
+msgstr "Правило ценообразования"
 
 msgid "Pricing Rules"
-msgstr "Правила цен"
+msgstr "Правила ценообразования"
 
 msgid "Pricing Trace"
-msgstr "Трассировка цен"
+msgstr "Трассировка ценообразования"
 
 msgid "Primary cash account for bank transactions"
-msgstr "процедура"
+msgstr "Основной счет денежных средств для банковских операций"
 
 msgid "Print"
 msgstr "Печать"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "Печать {0} этикеток"
 
 msgid "Print Jobs"
-msgstr "Задания печати"
+msgstr "Печать производственных заказов"
 
 msgid "Print Label"
 msgstr "Печать этикетки"
@@ -11413,7 +11413,7 @@ msgid "Print Output ({0})"
 msgstr "Вывод печати ({0})"
 
 msgid "Printer Settings"
-msgstr "Параметры принтера"
+msgstr "Настройки принтера"
 
 msgid "Printer URL"
 msgstr "URL принтера"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Процедура"
 
 msgid "procedures"
-msgstr "процесс"
+msgstr "процедуры"
 
 msgid "Procedures"
 msgstr "Процедуры"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Производственное количество"
 
 msgid "Production variance"
-msgstr "Прогнозируемый спрос, разложенный из ведомостей материалов и прогнозов."
+msgstr "Отклонение производства"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Производство: приложение для цеха и планирование"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "Проект"
 
 msgid "Project owner"
-msgstr "Владелец проекта"
+msgstr "Ответственный проекта"
 
 msgid "Project Plan"
 msgstr "План проекта"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Начало проекта"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Прогнозируемый запас"
+msgstr "Прогнозируемая потребность, разобранная из BOM и прогнозов."
 
 msgid "Projected inventory"
 msgstr "Прогнозируемое наличие"
@@ -11543,14 +11543,14 @@ msgstr "Прогнозируемый запас"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "Прогнозируется падение ниже страховочного запаса на неделю {0}"
+msgstr "Прогнозируемый дефицит на неделе {0}"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "Прогнозируется, что останется выше страховочного запаса"
 
 msgid "Projected to stay above safety stock"
-msgstr "Заказ на покупку"
+msgstr "По прогнозам, останется выше страхового запаса"
 
 msgid "Projection"
 msgstr "Прогноз"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "Прогнозы"
 
 msgid "Promised Date"
-msgstr "Обещанная дата"
+msgstr "Подтвержденная дата"
 
 msgid "Properties"
 msgstr "Свойства"
@@ -11571,7 +11571,7 @@ msgid "Proposed matches where the Carbon account number equals the provider acco
 msgstr "Предложенные совпадения, где номер счета Carbon точно совпадает с кодом счета системы."
 
 msgid "Proposed matches where the Carbon dimension value's name equals a provider option name exactly."
-msgstr "Предложенные совпадения, где имя значения размерности Carbon точно соответствует имени параметра провайдера."
+msgstr "Предложенные совпадения, где название значения измерения Carbon точно совпадает с названием варианта поставщика."
 
 msgid "Protect the go-live date"
 msgstr "Защитите дату запуска"
@@ -11580,7 +11580,7 @@ msgid "Protect training time and attend"
 msgstr "Защитите время обучения и участвуйте"
 
 msgid "Protects your company's data"
-msgstr "Защищает данные вашей компании"
+msgstr "Защищает данные вашей организации"
 
 msgid "Provide process knowledge and inputs"
 msgstr "Предоставить знания о процессе и входные данные"
@@ -11611,7 +11611,7 @@ msgid "Published by Carbon"
 msgstr "Опубликовано Carbon"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Опубликованная версия"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "Опубликованные версии нельзя редактировать. Просмотрите их в режиме только для чтения или создайте ветвь новой версии для внесения изменений."
@@ -11623,10 +11623,10 @@ msgid "Pull From"
 msgstr "Извлечь из"
 
 msgid "Pull from accounting"
-msgstr "Получить из учета"
+msgstr "Из бухгалтерии"
 
 msgid "Pull from Inventory"
-msgstr "Извлечение из инвентаря"
+msgstr "Со склада"
 
 msgid "Pull, map, and load your data"
 msgstr "Извлеките, сопоставьте и загрузите ваши данные"
@@ -11638,55 +11638,55 @@ msgid "Purchase History"
 msgstr "История покупок"
 
 msgid "Purchase invoice"
-msgstr "Счет-фактура закупки"
+msgstr "Счет-фактура полученный"
 
 msgid "Purchase Invoice"
-msgstr "Счет-фактура"
+msgstr "Счет-фактура полученный"
 
 msgid "Purchase Invoice Amount"
-msgstr "Сумма счета покупателя"
+msgstr "Сумма счета-фактуры полученного"
 
 msgid "Purchase Invoice Line"
-msgstr "Строка счета-фактуры покупки"
+msgstr "Строка счета-фактуры полученного"
 
 msgid "Purchase Invoices"
-msgstr "Счета-фактуры покупателя"
+msgstr "Счета-фактуры полученные"
 
 msgid "Purchase order"
-msgstr "Отклонение цены покупки"
+msgstr "Заказ поставщику"
 
 msgid "Purchase Order"
-msgstr "Заказ на покупку"
+msgstr "Заказ поставщику"
 
 msgid "Purchase Order Amount"
-msgstr "Сумма заказа на покупку"
+msgstr "Сумма заказа поставщику"
 
 msgid "Purchase Order approval rule"
-msgstr "Правило утверждения заказа на покупку"
+msgstr "Правило утверждения заказа поставщику"
 
 msgid "Purchase Order ID"
-msgstr "Номер заказа на покупку"
+msgstr "ID Заказа поставщику"
 
 msgid "Purchase Order Line"
-msgstr "Строка заказа на покупку"
+msgstr "Строка Заказа поставщику"
 
 msgid "Purchase Order Location"
-msgstr "Местоположение заказа на покупку"
+msgstr "Площадка Заказа поставщику"
 
 msgid "Purchase order removed successfully"
-msgstr "Заказ на покупку успешно удален"
+msgstr "Заказ поставщику успешно удален"
 
 msgid "Purchase Order Type"
-msgstr "Тип заказа на покупку"
+msgstr "Тип Заказа поставщику"
 
 msgid "Purchase Orders"
-msgstr "Заказы на покупку"
+msgstr "Заказы поставщику"
 
 msgid "Purchase Orders and Planning"
-msgstr "Заказы на покупку и планирование"
+msgstr "Заказы поставщику и Планирование"
 
 msgid "Purchase orders required"
-msgstr "Требуются заказы на покупку"
+msgstr "Требуются заказы поставщику"
 
 msgid "Purchase planning"
 msgstr "Планирование закупок"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Отклонение цены покупки (по умолчанию)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Налог на покупку подлежащий уплате"
+msgstr "Отклонение цены закупки (по умолчанию)"
 
 msgid "Purchase Qty"
 msgstr "Кол-во покупки"
@@ -11707,10 +11707,10 @@ msgid "Purchase Tax Payable"
 msgstr "Налог на покупку подлежащий уплате (по умолчанию)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "закупки"
+msgstr "Налог к оплате (по умолчанию)"
 
 msgid "Purchase to Order"
-msgstr "Покупка по заказу"
+msgstr "Закупка под заказ"
 
 msgid "Purchase Unit of Measure"
 msgstr "Единица измерения покупки"
@@ -11737,13 +11737,13 @@ msgid "Purchasing and auto-planning"
 msgstr "Закупки и автоматическое планирование"
 
 msgid "Purchasing contact"
-msgstr "Контакт закупок"
+msgstr "контактное лицо закупок"
 
 msgid "Purchasing Contact"
-msgstr "Контакт по закупкам"
+msgstr "Контактное лицо закупок"
 
 msgid "Purchasing Invoices"
-msgstr "Счета на покупку"
+msgstr "Счета-фактуры закупок"
 
 msgid "Purchasing Unit of Measure"
 msgstr "Единица измерения закупки"
@@ -11758,10 +11758,10 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Отправляйте изменения записей во внешние системы в момент их возникновения."
 
 msgid "Push the journal without the dimension"
-msgstr "Отправить журнал без размерности"
+msgstr "Провести операцию без измерения"
 
 msgid "Push to accounting"
-msgstr "Отправить в учет"
+msgstr "Отправить в бухгалтерию"
 
 msgid "Putting your data back"
 msgstr "Восстановление ваших данных"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Кол-во брака"
 
 msgid "quality"
-msgstr "От предложения к платежу"
+msgstr "качество"
 
 msgid "Quality"
 msgstr "Качество"
@@ -11810,7 +11810,7 @@ msgid "Quality Type"
 msgstr "Тип качества"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "Качество: проверки, несоответствия, CAPA"
+msgstr "Качество: контроль, несоответствие, CAPA"
 
 msgid "Quantities"
 msgstr "Количества"
@@ -11819,10 +11819,10 @@ msgid "Quantity"
 msgstr "Количество"
 
 msgid "Quantity arriving — on open purchase orders plus on production (make) orders."
-msgstr "Ожидаемое поступление — по открытым заказам на закупку и производственным заказам (изготовление)."
+msgstr "Поступающее количество — из открытых заказов поставщику и производственных заказов."
 
 msgid "Quantity Breaks"
-msgstr "Разрывы количества"
+msgstr "Шкала количества"
 
 msgid "Quantity complete"
 msgstr "Полное количество"
@@ -11831,7 +11831,7 @@ msgid "Quantity Completed"
 msgstr "Завершено количество"
 
 msgid "Quantity in transit to the storage unit via open stock transfers."
-msgstr "Количество в пути к складской единице по открытым перемещениям запасов."
+msgstr "Количество в пути в единицу хранения через открытые перемещения запасов."
 
 msgid "Quantity is derived from completed serials/batches in MES and cannot be edited."
 msgstr "Количество определяется на основе завершенных серийных номеров/партий в MES и не может быть отредактировано."
@@ -11840,28 +11840,28 @@ msgid "Quantity must be greater than 0"
 msgstr "Количество должно быть больше 0"
 
 msgid "Quantity on hand"
-msgstr "Количество в наличии"
+msgstr "остаток на складе"
 
 msgid "Quantity on Hand"
-msgstr "Количество в наличии"
+msgstr "Остаток на складе"
 
 msgid "Quantity on Jobs"
-msgstr "Количество в заказах"
+msgstr "Количество в производственных заказах"
 
 msgid "Quantity on Purchase Order"
-msgstr "Количество в заказе на покупку"
+msgstr "Количество в заказе поставщику"
 
 msgid "Quantity on Sales Order"
-msgstr "Количество в заказе на продажу"
+msgstr "Количество в заказе покупателя"
 
 msgid "Quantity Per Job"
 msgstr "Количество на задание"
 
 msgid "Quantity per Parent"
-msgstr "Количество на родителя"
+msgstr "Количество на изделие"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Количество, физически находящееся в назначенной материалу складской единице (полке). Становится красным, когда оно ниже того, что эта единица должна обеспечить."
+msgstr "Количество товара, находящееся физически в выделенной единице хранения (полке). Становится красным, когда оно ниже необходимого количества для обеспечения."
 
 msgid "Quantity Range"
 msgstr "Диапазон количества"
@@ -11882,7 +11882,7 @@ msgid "Quantity Type"
 msgstr "Тип количества"
 
 msgid "Quantity-based pricing tiers for this override; the unit price applied is the row with the largest minimum quantity that the order line satisfies."
-msgstr "Ярусы цен на основе количества для этого переопределения; применяемая цена за единицу - это строка с наибольшим минимальным количеством, которое удовлетворяет строке заказа."
+msgstr "Уровни ценообразования на основе количества для этого переопределения; применяемая цена за единицу — это строка с наибольшим минимальным количеством, которое удовлетворяет строке заказа."
 
 #. placeholder {0}: numberFormatter.format(forecastQuantity)
 msgid "Quantity: {0}"
@@ -11907,7 +11907,7 @@ msgid "Quote Accepted By Email"
 msgstr "Письмо принято по электронной почте"
 
 msgid "Quote expired"
-msgstr "Предложение истекло"
+msgstr "Коммерческое предложение истекло"
 
 msgid "Quote ID"
 msgstr "ID предложения"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Номер предложения"
 
 msgid "Quote to cash"
-msgstr "Дебиторская задолженность"
+msgstr "От коммерческого предложения к продаже"
 
 msgid "Quote Type"
 msgstr "Тип предложения"
@@ -11949,7 +11949,7 @@ msgid "Quotes"
 msgstr "Предложения"
 
 msgid "Quoting and sales orders"
-msgstr "Котировки и заказы на продажу"
+msgstr "Коммерческие предложения и заказы покупателей"
 
 msgid "Quoting, Orders, Configure-to-Order"
 msgstr "Предложения, Заказы, Конфигурирование на заказ"
@@ -11994,10 +11994,10 @@ msgid "Readable"
 msgstr "Читаемо"
 
 msgid "Readable ID"
-msgstr "Читаемый ID"
+msgstr "Читаемый идентификатор"
 
 msgid "Readable id with revision"
-msgstr "Читаемый идентификатор с редакцией"
+msgstr "читаемый идентификатор с ревизией"
 
 msgid "Reading the document..."
 msgstr "Чтение документа..."
@@ -12042,7 +12042,7 @@ msgid "Reasons"
 msgstr "Причины"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "Переназначить конкретные отслеживаемые объекты из этой строки в другую строку диспозиции."
+msgstr "Переназначить отслеживаемые сущности из этой строки в другую строку решения."
 
 msgid "Recalculate"
 msgstr "Пересчитать"
@@ -12066,7 +12066,7 @@ msgid "Receipt Lines"
 msgstr "Строки квитанции"
 
 msgid "Receipt Promised Date"
-msgstr "Обещанная дата получения"
+msgstr "Подтвержденная дата поступления"
 
 msgid "Receipt Requested Date"
 msgstr "Запрошенная дата получения"
@@ -12075,7 +12075,7 @@ msgid "Receipts"
 msgstr "Квитанции"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Приёмки, отгрузки, счета-фактуры продаж, счета-фактуры покупок, платежи и кредит/дебет-ноты, которые всё ещё находятся в статусе «Черновик» или «Ожидание», должны быть опубликованы или аннулированы — как документы, датированные в этом периоде, так и неотдатированные документы, которые получат дату при публикации. До их публикации их суммы не находятся в главной книге, поэтому период был бы недостаточно представлен."
+msgstr "Поступления, отгрузки, счета-фактуры выданные, счета-фактуры полученные, платежи и кредит-ноты/дебет-ноты, которые остаются в статусе Черновик или В ожидании, должны быть проведены или аннулированы — как документы, датированные в этом периоде, так и недатированные документы, которые получат дату при проведении в этом периоде. Пока они не проведены, их суммы не включены в главную книгу, поэтому период будет занижен."
 
 msgid "Receivables"
 msgstr "Дебиторская задолженность (по умолчанию)"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "Дебиторская задолженность (ДЗ)"
 
 msgid "Receivables (default)"
-msgstr "Сверка заказа на покупку с полученным и выставленным счетом — неявно в Carbon через количество строк и остаток GR/IR."
+msgstr "Дебиторская задолженность (по умолчанию)"
 
 msgid "Receivables aging"
 msgstr "Старение дебиторской задолженности"
@@ -12104,7 +12104,7 @@ msgstr "Получить платеж"
 
 #. placeholder {0}: selectedInvoices.length
 msgid "Receive Payment · {0} invoices"
-msgstr "Получить платеж · {0} счетов"
+msgstr "Получить платеж · {0} счетов-фактур"
 
 msgid "Receive to Inventory"
 msgstr "Получить в инвентарь"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "Полученное кол-во"
 
 msgid "Receiving Location"
-msgstr "Место получения"
+msgstr "Площадка приемки"
 
 msgid "Recent"
 msgstr "Недавние"
@@ -12145,34 +12145,34 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "Сверка обнаружила расхождения с поставщиком"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Период восстановления"
+msgstr "Сверка заказа поставщику с полученными товарами и выставленными счетами — выполняется автоматически в Carbon на основе количеств в строках и остатка GR/IR."
 
 msgid "Record"
 msgstr "Записать"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "Запишите кредит-ноту или дебет-ноту для клиента или поставщика. Применение к конкретным счетам добавляется после создания ноты."
+msgstr "Зарегистрируйте кредит-ноту или дебет-ноту для покупателя или поставщика. Применения к конкретным счетам-фактурам добавляются после создания документа."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Записывайте денежные средства, полученные от клиента (Поступление) или выплаченные поставщику (Выплата). Применение к конкретным счетам добавляется после создания платежа."
+msgstr "Зарегистрируйте денежные средства, полученные от покупателя (Поступление) или выплаченные поставщику (Выплата). Применения к конкретным счетам-фактурам добавляются после создания платежа."
 
 msgid "Record deleted"
 msgstr "Запись удалена"
 
 msgid "Record inspections tied to a part and a job"
-msgstr "Записывать проверки, связанные с деталью и заказом"
+msgstr "Зарегистрировать контроль, связанный с деталью и производственным заказом"
 
 msgid "Record type"
 msgstr "Тип записи"
 
 msgid "Recorded on a calibration that the gauge needs repair before its readings can be trusted."
-msgstr "Записано при калибровке, что калибр нужно отремонтировать перед тем, как можно доверять его показаниям."
+msgstr "Зафиксировано при калибровке, что средство измерения нуждается в ремонте перед использованием его показаний."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Записано, что необходимо последующее наблюдение после этой калибровки; отображает этот датчик в очереди открытых действий."
+msgstr "Зафиксировано, что требуется последующее действие после этой калибровки; выводит это средство измерения в очередь открытых действий."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Записано, что датчик был отрегулирован во время этой калибровки; влияет на пересчет интервала калибровки."
+msgstr "Зафиксировано, что средство измерения было отрегулировано при этой калибровке; влияет на пересчет интервала калибровки."
 
 msgid "Records"
 msgstr "Записи"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "Перенаправление на страницу проверки..."
 
 msgid "Reduced"
-msgstr "Сокращено"
+msgstr "Ослабленный"
 
 msgid "Reference"
 msgstr "Ссылка"
@@ -12193,7 +12193,7 @@ msgid "Refresh"
 msgstr "Обновить"
 
 msgid "Refresh exchange rate"
-msgstr "Обновить курс обмена"
+msgstr "Обновить валютный курс"
 
 msgid "Regenerate thumbnail from the 3D model"
 msgstr "Восстановить миниатюру из 3D модели"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Зарегистрирован"
 
 msgid "Registered"
-msgstr "Точка переза́каза"
+msgstr "Зарегистрировано"
 
 msgid "Registration failed"
 msgstr "Регистрация не удалась"
@@ -12244,19 +12244,19 @@ msgid "Relative timeline · dates to be confirmed"
 msgstr "Относительная шкала времени · даты будут подтверждены"
 
 msgid "Release"
-msgstr "Выпуск"
+msgstr "Запустить в работу"
 
 msgid "Release change notice"
-msgstr "Выпустить уведомление об изменении"
+msgstr "Запустить в работу извещение об изменении"
 
 msgid "Release control"
-msgstr "Контроль выпуска"
+msgstr "Управление запуском"
 
 msgid "Release Control"
-msgstr "Контроль выпуска"
+msgstr "Управление запуском в работу"
 
 msgid "Release Job"
-msgstr "Выпустить задание"
+msgstr "Запустить производственный заказ в работу"
 
 msgid "Released"
 msgstr "Выпущено"
@@ -12265,10 +12265,10 @@ msgid "Released date"
 msgstr "Дата выпуска"
 
 msgid "Released revision"
-msgstr "Выпущенная версия"
+msgstr "Выпущенная ревизия"
 
 msgid "Released revision is locked"
-msgstr "Выпущенная версия заблокирована"
+msgstr "Выпущенная ревизия заблокирована"
 
 msgid "Remaining"
 msgstr "Остаток"
@@ -12280,68 +12280,68 @@ msgid "Remember this PIN. You will need it to exit console mode on MES terminals
 msgstr "Запомните этот PIN-код. Он потребуется вам для выхода из режима консоли на терминалах MES."
 
 msgid "Remove"
-msgstr "Удалить"
+msgstr "Убрать"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "Удалить {0}"
+msgstr "Убрать {0}"
 
 msgid "Remove {label}"
-msgstr "Удалить {label}"
+msgstr "Убрать {label}"
 
 msgid "Remove authenticator app"
-msgstr "Удалить приложение-аутентификатор"
+msgstr "Удалить приложение аутентификации"
 
 msgid "Remove clause"
-msgstr "Удалить условие"
+msgstr "Убрать условие"
 
 msgid "Remove condition"
-msgstr "Удалить условие"
+msgstr "Убрать условие"
 
 msgid "Remove filter"
-msgstr "Удалить фильтр"
+msgstr "Убрать фильтр"
 
 msgid "Remove Filters"
-msgstr "Удалить фильтры"
+msgstr "Убрать фильтры"
 
 msgid "Remove from Price List"
-msgstr "Удалить из прайс-листа"
+msgstr "Убрать из прайс-листа"
 
 msgid "Remove line"
-msgstr "Удалить строку"
+msgstr "Убрать строку"
 
 msgid "Remove order"
-msgstr "Удалить заказ"
+msgstr "Убрать заказ"
 
 msgid "Remove pair"
-msgstr "Удалить пару"
+msgstr "Убрать пару"
 
 msgid "Remove part"
-msgstr "Удалить деталь"
+msgstr "Убрать деталь"
 
 msgid "Remove path"
-msgstr "Удалить путь"
+msgstr "Убрать путь"
 
 msgid "Remove row"
-msgstr "Удалить строку"
+msgstr "Убрать строку"
 
 msgid "Remove slide"
-msgstr "Удалить слайд"
+msgstr "Убрать слайд"
 
 msgid "Remove slot"
-msgstr "Удалить слот"
+msgstr "Убрать слот"
 
 msgid "Remove sort by column"
-msgstr "Удалить сортировку по столбцу"
+msgstr "Убрать сортировку по столбцу"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
-msgstr "Удалите этот тип хранилища из всех ссылающихся на него единиц хранения и удалите его. Это невозможно отменить."
+msgstr "Удалите этот тип хранения из всех ссылающихся единиц хранения и удалите его. Это невозможно отменить."
 
 msgid "Remove tool"
-msgstr "Удалить инструмент"
+msgstr "Убрать инструмент"
 
 msgid "Remove two-factor authentication"
-msgstr "Удалить двухфакторную аутентификацию"
+msgstr "Убрать двухфакторную аутентификацию"
 
 msgid "Removed"
 msgstr "Удалено"
@@ -12357,7 +12357,7 @@ msgid "Rendering label preview..."
 msgstr "Отрисовка предпросмотра этикетки..."
 
 msgid "Reopen"
-msgstr "Переоткрыть"
+msgstr "Открыть заново"
 
 msgid "Reorder"
 msgstr "Переупорядочить"
@@ -12369,10 +12369,10 @@ msgid "Reorder point"
 msgstr "Точка переза́каза"
 
 msgid "Reorder Point"
-msgstr "Точка переупорядочения"
+msgstr "Точка заказа"
 
 msgid "Reorder Point:"
-msgstr "Точка переупорядочивания:"
+msgstr "Точка заказа:"
 
 msgid "Reorder Policy"
 msgstr "Политика переупорядочения"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "Количество переупорядочивания:"
 
 msgid "Reordering policy"
-msgstr "Политика переопорядочения"
+msgstr "Политика пополнения"
 
 msgid "Reordering Policy"
-msgstr "Политика переупорядочения"
+msgstr "Политика пополнения"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Перераспределяет только последовательность диспетчеризации и рабочий центр — не перепланирует. Изменяйте даты на доске дат."
+msgstr "Переупорядочивает только последовательность заявок и рабочий центр — не переплан. Измените даты на доске Даты."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "Повторяется один раз для каждого элемента в {inputLabel}"
@@ -12405,25 +12405,25 @@ msgid "Replace drawing?"
 msgstr "Заменить чертёж?"
 
 msgid "Replace existing pricing with source values"
-msgstr "Заменить существующие цены на значения источника"
+msgstr "Заменить существующее ценообразование значениями источника"
 
 msgid "Replace PDF"
 msgstr "Заменить PDF"
 
 msgid "Replace this company's data with a demo dataset — snapshotted first, so you can revert."
-msgstr "Замените данные этой компании набором демо-данных — сначала создан снимок, чтобы вы могли восстановить исходные данные."
+msgstr "Заменить данные этой организации демонаборами данных — сначала сделав снимок, чтобы вы могли отменить."
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "Замена PDF удаляет все размещения выносок в этом документе. Строки функций и их значения остаются; вы можете снова разместить выноски на новом чертеже."
+msgstr "Замена PDF удаляет все размещения выносок на этом документе. Строки элементов и их значения остаются; вы можете разместить выноски снова на новом чертеже."
 
 msgid "Replenishment"
 msgstr "Пополнение"
 
 msgid "Replenishment system"
-msgstr "Система пополнения"
+msgstr "Способ пополнения"
 
 msgid "Replenishment System"
-msgstr "Система пополнения"
+msgstr "Способ пополнения"
 
 msgid "Report"
 msgstr "Отчет"
@@ -12447,25 +12447,25 @@ msgid "Request access"
 msgstr "Запросить доступ"
 
 msgid "Request Approval"
-msgstr "Запросить одобрение"
+msgstr "Запросить утверждение"
 
 msgid "Requested Date"
-msgstr "Запрашиваемая дата"
+msgstr "Запрошенная дата"
 
 msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "Требовать 6-значный код из приложения-аутентификатора при входе."
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
-msgstr "Требуется приложение аутентификации перед доступом к этой компании. Другие компании пользователей не затронуты. Посетите <0>страницу учетных записей сотрудников</0>, чтобы увидеть статус каждого человека."
+msgstr "Требовать приложение аутентификатора перед тем как кто-либо сможет открыть эту организацию. Их другие организации не затронуты. Посетите страницу <0>учетных записей сотрудников</0>, чтобы увидеть статус каждого человека."
 
 msgid "Require approval before suppliers can be set to Active"
-msgstr "Требуется одобрение перед тем, как поставщики смогут быть установлены в статус Активный"
+msgstr "Требовать утверждение перед установкой статуса «Активный» для поставщиков"
 
 msgid "Require approval for purchase orders based on amount thresholds"
-msgstr "Требовать утверждение для заказов на покупку на основе пороговых значений сумм"
+msgstr "Требовать утверждение для заказов поставщику на основе пороговых значений суммы"
 
 msgid "Require approval for quality documents in your workflow"
-msgstr "Требуется одобрение для документов качества в вашем рабочем процессе"
+msgstr "Требовать утверждение для документов качества в вашем рабочем процессе"
 
 msgid "Require two-factor authentication"
 msgstr "Требовать двухфакторную аутентификацию"
@@ -12486,7 +12486,7 @@ msgid "Required Actions (in order)"
 msgstr "Требуемые действия (по порядку)"
 
 msgid "Required Date"
-msgstr "Требуемая дата"
+msgstr "Дата потребности"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Требуется в контролируемой среде — ведение журнала аудита невозможно отключить."
@@ -12507,7 +12507,7 @@ msgid "Requires Action"
 msgstr "Требует действия"
 
 msgid "Requires Adjustment"
-msgstr "Требует регулировки"
+msgstr "Требует корректировки"
 
 msgid "Requires Repair"
 msgstr "Требует ремонта"
@@ -12541,13 +12541,13 @@ msgid "Reset view"
 msgstr "Сбросить вид"
 
 msgid "Residual value"
-msgstr "Остаточная стоимость"
+msgstr "Ликвидационная стоимость"
 
 msgid "Residual Value %"
-msgstr "Остаточная стоимость %"
+msgstr "Ликвидационная стоимость %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "Разрешите эти проблемы перед завершением NCR: каждая строка должна иметь статус, отличный от «Ожидание», и количество связанных сущностей должно совпадать с количеством строки."
+msgstr "Решите эти вопросы перед завершением NCR: каждая строка должна иметь решение, которое не является Ожидающим, и количества связанных сущностей должны совпадать с количеством строки."
 
 msgid "Resolved Price"
 msgstr "Разрешённая цена"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Восстановить из корзины"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Восстановить эту сущность в доступный запас на складе и стоимость, из которых она была списана."
+msgstr "Восстановить эту сущность в доступный запас по ячейке и себестоимости, откуда она была выбракована."
 
 msgid "Restore tracked entities to available"
 msgstr "Восстановить отслеживаемые объекты в доступные"
@@ -12589,7 +12589,7 @@ msgid "Retained Earnings (default)"
 msgstr "Нераспределенная прибыль (по умолчанию)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
-msgstr "Вывод основного средства из эксплуатации путём списания или продажи, с отражением прибыли или убытка относительно чистой балансовой стоимости и переводом статуса в «Ликвидирован»."
+msgstr "Вывод активов из эксплуатации путем выбраковки или продажи, учет любой прибыли или убытка против остаточной стоимости и установка статуса на Выбыло."
 
 msgid "Retry"
 msgstr "Повторить"
@@ -12619,19 +12619,19 @@ msgid "Revenue"
 msgstr "Выручка"
 
 msgid "Revenue and expenses over a period"
-msgstr "Доход и расходы за период"
+msgstr "Выручка и расходы за период"
 
 msgid "Reverse all inventory adjustments"
 msgstr "Отменить все корректировки запасов"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "Обратить все записи журнала и реестра затрат"
+msgstr "Развернуть все операции и записи реестра затрат"
 
 msgid "Reverse any item ledger entries from this invoice"
-msgstr "Отменить все записи реестра товаров из этого счета"
+msgstr "Отменить любые записи журнала номенклатуры из этой счет-фактуры"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Обратное начисление"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Налог на продажи с обратным взиманием"
@@ -12640,7 +12640,7 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "Налог на продажи с обратным взиманием (по умолчанию)"
 
 msgid "Reverse the related journal entries"
-msgstr "Отменить связанные записи в журнале"
+msgstr "Отменить связанные записи операций"
 
 msgid "Reversed"
 msgstr "Сторнировано"
@@ -12652,32 +12652,32 @@ msgid "Reverting"
 msgstr "Восстановление"
 
 msgid "Review"
-msgstr "Обзор"
+msgstr "Рассмотрение"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "Просмотрите изменения каждого элемента, затем подтвердите — выпуск нельзя отменить."
+msgstr "Рассмотреть изменения каждой номенклатуры, затем подтвердить — выпуск нельзя отменить."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Проверьте балансовый лист и отчёт о прибылях и убытках за период и подтвердите, что цифры выглядят правильно. Это ручное утверждение — отметьте как завершённое после их проверки."
+msgstr "Рассмотреть бухгалтерский баланс и отчет о прибылях и убытках периода и подтвердить, что цифры выглядят правильно. Это ручное утверждение — отметьте как готово как только вы их рассмотрели."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "Проверьте предложенные совпадения перед применением. Это лучшее предположение — подтвердите, что каждое из них верно."
+msgstr "Рассмотреть предложенные совпадения перед применением. Это лучшее предположение — подтвердите каждое правильно."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Просмотрите предупреждения ниже, а затем опубликуйте подсчет для применения корректировок."
+msgstr "Рассмотреть предупреждения ниже, затем провести подсчет чтобы применить корректировки."
 
 msgid "Revision"
-msgstr "Редакция"
+msgstr "Ревизия"
 
 #. placeholder {0}: revision.revision
 msgid "Revision {0}"
-msgstr "Версия {0}"
+msgstr "Ревизия {0}"
 
 msgid "Revision status"
-msgstr "Статус редакции"
+msgstr "Статус ревизии"
 
 msgid "Revisions"
-msgstr "Версии"
+msgstr "Ревизии"
 
 msgid "Revoke"
 msgstr "Отозвать"
@@ -12689,19 +12689,19 @@ msgid "Revoke Invites"
 msgstr "Отозвать приглашения"
 
 msgid "Rework"
-msgstr "Переделка"
+msgstr "Доработка"
 
 msgid "RFQ"
 msgstr "РФП"
 
 msgid "RFQ (request for quote)"
-msgstr "РКП (запрос коммерческого предложения)"
+msgstr "Запрос цен"
 
 msgid "RFQ Date"
 msgstr "Дата РФП"
 
 msgid "RFQ has no customer"
-msgstr "РФЗ не имеет клиента"
+msgstr "Запрос цен не имеет покупателя"
 
 msgid "RFQ has no suppliers"
 msgstr "РФЗ не имеет поставщиков"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "РФЗ"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Передайте размерности Carbon вместе с отправленными журналами. Каждый слот отображает одну размерность Carbon в одну цель аналитики провайдера; приведенное ниже отображение значений связывает отдельные значения размерности с параметрами провайдера."
+msgstr "Переносить измерения Carbon на проводимые операции. Каждый слот связывает одно измерение Carbon с одной целью аналитики провайдера; сопоставление значений ниже связывает отдельные значения измерений с опциями провайдера."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12753,7 +12753,7 @@ msgid "Roles and Responsibilities"
 msgstr "Роли и ответственность"
 
 msgid "Roles that set default permissions for new employees"
-msgstr "Роли, которые устанавливают разрешения по умолчанию для новых сотрудников"
+msgstr "Роли, устанавливающие права доступа по умолчанию для новых сотрудников"
 
 msgid "Room to grow without bolting on more tools"
 msgstr "Место для роста без добавления новых инструментов"
@@ -12765,10 +12765,10 @@ msgid "Rounding Account (default)"
 msgstr "Счет округления (по умолчанию)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Маршрутизируйте все счета-фактуры AP на один адрес (например, корпоративный офис) вместо отдельных закупщиков."
+msgstr "Маршрутизируйте все счета-фактуры кредиторской задолженности на один адрес (например, корпоративный офис) вместо отдельных покупателей."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Маршрутизируйте все счета-фактуры AR на один адрес (например, корпоративный офис) вместо отдельных местоположений."
+msgstr "Маршрутизируйте все счета-фактуры дебиторской задолженности на один адрес (например, корпоративный офис) вместо отдельных площадок."
 
 msgid "Routing"
 msgstr "Маршрут операций"
@@ -12780,7 +12780,7 @@ msgid "Rule"
 msgstr "Правило"
 
 msgid "Rule applies to every customer."
-msgstr "Правило применяется ко всем клиентам."
+msgstr "Правило применяется к каждому покупателю."
 
 msgid "Rule applies to every item."
 msgstr "Правило применяется ко всем товарам."
@@ -12792,7 +12792,7 @@ msgid "Rules"
 msgstr "Правила"
 
 msgid "Rules that adjust prices automatically by quantity or customer"
-msgstr "Правила, которые автоматически корректируют цены в зависимости от количества или клиента"
+msgstr "Правила, которые автоматически корректируют цены по количеству или покупателю"
 
 msgid "Rules that decide where each item gets stored"
 msgstr "Правила, определяющие, где хранится каждый товар"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Запустить контрольный список приемки до успешного завершения"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Управляйте цехом с планшетов: учитывайте рабочее время, отслеживайте прогресс, просматривайте инструкции"
+msgstr "Управляйте цехом на планшетах: фиксируйте труд, сообщайте о прогрессе, смотрите инструкции"
 
 msgid "Run this workflow now?"
 msgstr "Запустить этот рабочий процесс сейчас?"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "Выполняется"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "Инвентарь, обновляемый после еженедельного спроса и предложения — строка."
+msgstr "Текущие запасы после еженедельного обеспечения и потребности — строка."
 
 msgid "Running Total"
 msgstr "Итоговая сумма"
@@ -12895,13 +12895,13 @@ msgid "Sales & Quoting"
 msgstr "Продажи и котирование"
 
 msgid "Sales & Revenue"
-msgstr "Продажи и доход"
+msgstr "Продажи и выручка"
 
 msgid "Sales contact"
-msgstr "Контакт по продажам"
+msgstr "контактное лицо по продажам"
 
 msgid "Sales Contact"
-msgstr "Контакт по продажам"
+msgstr "Контактное лицо по продажам"
 
 msgid "Sales Discounts"
 msgstr "Скидки на продажи"
@@ -12913,46 +12913,46 @@ msgid "Sales Funnel"
 msgstr "Воронка продаж"
 
 msgid "Sales invoice"
-msgstr "Счет-фактура продажи"
+msgstr "счет-фактура выданный"
 
 msgid "Sales Invoice"
-msgstr "Счет-фактура продажи"
+msgstr "Счет-фактура выданный"
 
 msgid "Sales Invoice Line"
-msgstr "Строка счета продажи"
+msgstr "Строка счета-фактуры выданного"
 
 msgid "Sales Invoices"
-msgstr "Счета-фактуры продажи"
+msgstr "Счета-фактуры выданные"
 
 msgid "Sales Job Notifications"
 msgstr "Уведомления о продажах"
 
 msgid "Sales order"
-msgstr "Заказ на продажу"
+msgstr "заказ покупателя"
 
 msgid "Sales Order"
-msgstr "Заказ на продажу"
+msgstr "Заказ покупателя"
 
 msgid "Sales Order ID"
-msgstr "Номер заказа на продажу"
+msgstr "ID заказа покупателя"
 
 msgid "Sales order line"
-msgstr "Строка заказа продажи"
+msgstr "строка заказа покупателя"
 
 msgid "Sales Order Line"
-msgstr "Строка заказа продажи"
+msgstr "Строка заказа покупателя"
 
 msgid "Sales Order Line (job)"
-msgstr "Строка заказа продажи (работа)"
+msgstr "Строка заказа покупателя (производственный заказ)"
 
 msgid "Sales Order Location"
-msgstr "Местоположение заказа на продажу"
+msgstr "Площадка заказа покупателя"
 
 msgid "Sales Order Number"
-msgstr "Номер заказа продажи"
+msgstr "Номер заказа покупателя"
 
 msgid "Sales Orders"
-msgstr "Заказы на продажу"
+msgstr "Заказы покупателей"
 
 msgid "Sales Person"
 msgstr "Менеджер по продажам"
@@ -12982,16 +12982,16 @@ msgid "Sample"
 msgstr "Образец"
 
 msgid "Sample Size"
-msgstr "Размер выборки"
+msgstr "Объем выборки"
 
 msgid "Sampling"
-msgstr "Выборка"
+msgstr "Выборочный контроль"
 
 msgid "Sampling — Feature {featureLabel}"
-msgstr "Выборка — Функция {featureLabel}"
+msgstr "Выборочный контроль — функция {featureLabel}"
 
 msgid "Sampling Standard"
-msgstr "Стандарт выборки"
+msgstr "Стандарт выборочного контроля"
 
 msgid "Saturday"
 msgstr "Суббота"
@@ -13009,10 +13009,10 @@ msgid "Save applications"
 msgstr "Сохранить применения"
 
 msgid "Save contacts"
-msgstr "Сохранить контакты"
+msgstr "Сохранить контактные лица"
 
 msgid "Save dimension settings"
-msgstr "Сохранить настройки размерности"
+msgstr "Сохранить настройки измерений"
 
 msgid "Save Method"
 msgstr "Сохранить метод"
@@ -13042,31 +13042,31 @@ msgid "Scan"
 msgstr "Сканировать"
 
 msgid "Scan a label or search by item ID or tracking ID."
-msgstr "Отсканируйте этикетку или выполните поиск по ID товара или ID отслеживания."
+msgstr "Отсканируйте этикетку или выполните поиск по ID номенклатуры или ID отслеживания."
 
 msgid "Scan or choose a batch number"
-msgstr "Отсканируйте или выберите номер партии"
+msgstr "Отсканируйте или выберите номер серии"
 
 msgid "Scan or choose a serial number"
 msgstr "Отсканируйте или выберите серийный номер"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Отсканируйте или введите ID отслеживаемого объекта, серийный номер или партию"
+msgstr "Отсканируйте или введите ID отслеживаемого объекта, серийный номер или серию"
 
 msgid "Scan or enter tracking number"
 msgstr "Отсканируйте или введите номер отслеживания"
 
 msgid "Scan or search..."
-msgstr "Сканировать или искать..."
+msgstr "Отсканировать или выполнить поиск..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Отсканируйте или выберите отслеживаемую сущность из этой партии, чтобы добавить её в качестве столбца образца, затем запишите её результат в сетку."
+msgstr "Отсканируйте или выберите отслеживаемый объект из этой партии, чтобы добавить его как столбец образца, затем зарегистрируйте его результат в таблице."
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
-msgstr "Сканируйте этот QR-код с помощью приложения-аутентификатора (например, Google Authenticator или 1Password), а затем введите отображаемый 6-значный код."
+msgstr "Отсканируйте этот QR код с помощью приложения аутентификации (например, Google Authenticator или 1Password), затем введите 6-значный код, который оно показывает."
 
 msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
-msgstr "Отсканируйте это в приложении аутентификации, а затем введите 6-значный код, который оно показывает."
+msgstr "Отсканируйте это с помощью приложения аутентификации, затем введите 6-значный код, который оно показывает."
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -13078,16 +13078,16 @@ msgid "Schedule"
 msgstr "График"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "Планировать работы с учетом пропускной способности рабочего центра"
+msgstr "Составьте график производственных заказов в зависимости от пропускной способности рабочего центра"
 
 msgid "Schedule Name"
 msgstr "Имя расписания"
 
 msgid "Scheduled Maintenance"
-msgstr "Плановое обслуживание"
+msgstr "Запланированное техобслуживание"
 
 msgid "Scheduled Maintenances"
-msgstr "Запланированное техническое обслуживание"
+msgstr "Запланированные техобслуживания"
 
 msgid "Schedules"
 msgstr "Расписания"
@@ -13165,10 +13165,10 @@ msgid "Search by linear issue title..."
 msgstr "Поиск по названию задачи Linear..."
 
 msgid "Search customers and types..."
-msgstr "Поиск клиентов и типов..."
+msgstr "Поиск покупателей и типов..."
 
 msgid "Search customers or types..."
-msgstr "Поиск клиентов или типов..."
+msgstr "Поиск покупателей или типов..."
 
 msgid "Search employees..."
 msgstr "Поиск сотрудников..."
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "Поиск существующей или создание новой"
 
 msgid "Search items or bins"
-msgstr "Поиск товаров или контейнеров"
+msgstr "Поиск номенклатуры или ячеек"
 
 msgid "Search Job"
 msgstr "Поиск задания"
@@ -13240,7 +13240,7 @@ msgid "Security"
 msgstr "Безопасность"
 
 msgid "Segments that drive customer pricing and terms"
-msgstr "Сегменты, которые определяют цены и условия для клиентов"
+msgstr "Сегменты, которые определяют ценообразование и условия для покупателей"
 
 msgid "Select"
 msgstr "Выбрать"
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "Выберите документ"
 
 msgid "Select a new owner"
-msgstr "Выберите нового владельца"
+msgstr "Выбрать нового ответственного"
 
 msgid "Select a new parent group for this account."
 msgstr "Выберите новую родительскую группу для этого счёта."
@@ -13331,25 +13331,25 @@ msgid "Select an option"
 msgstr "Выберите опцию"
 
 msgid "Select at least one line to convert"
-msgstr "Выберите хотя бы одну строку для конвертации"
+msgstr "Выберите хотя бы одну строку для преобразования"
 
 msgid "Select Contact"
-msgstr "Выберите контакт"
+msgstr "Выбрать контактное лицо"
 
 msgid "Select Customer Status"
-msgstr "Выберите статус клиента"
+msgstr "Выбрать статус покупателя"
 
 msgid "Select Customer Type"
-msgstr "Выберите тип клиента"
+msgstr "Выбрать тип покупателя"
 
 msgid "Select customer types"
-msgstr "Выберите типы клиентов"
+msgstr "Выбрать типы покупателей"
 
 msgid "Select customers"
-msgstr "Выберите клиентов"
+msgstr "Выбрать покупателей"
 
 msgid "Select dimension"
-msgstr "Выбрать размерность"
+msgstr "Выбрать измерение"
 
 msgid "Select Employee"
 msgstr "Выберите сотрудника"
@@ -13361,22 +13361,22 @@ msgid "Select field"
 msgstr "Выберите поле"
 
 msgid "Select Gauge"
-msgstr "Выбрать датчик"
+msgstr "Выбрать средство измерения"
 
 msgid "Select groups or individuals"
 msgstr "Выберите группы или отдельных лиц"
 
 msgid "Select invoice"
-msgstr "Выберите счет"
+msgstr "Выбрать счет-фактуру"
 
 msgid "Select invoices from a single counterparty"
 msgstr "Выберите счета-фактуры от одного контрагента"
 
 msgid "Select invoices in a single currency"
-msgstr "Выберите счета в одной валюте"
+msgstr "Выберите счета-фактуры в одной валюте"
 
 msgid "Select Item Type"
-msgstr "Выберите тип элемента"
+msgstr "Выбрать тип номенклатуры"
 
 msgid "Select items"
 msgstr "Выберите товары"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Выберите группы, которые должны пройти это обучение"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Выберите счета, которые погашает этот платеж. Скидка и списание указаны в валюте счета."
+msgstr "Выберите счета-фактуры, которые погашает этот платеж. Скидка и списание указаны в валюте счета-фактуры."
 
 msgid "Select value"
 msgstr "Выберите значение"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Самоуправляемый"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Локальная установка или облачная"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Самостоятельное внедрение"
 
 msgid "Self-paced"
 msgstr "Самостоятельно"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "Отправляется каждому получателю, у которого включены email-уведомления."
 
 msgid "Sequences"
-msgstr "Последовательности"
+msgstr "Нумерация"
 
 msgid "Serial"
 msgstr "Серийный"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "Серийный номер / Партия"
 
 msgid "Serial items require a sales order"
-msgstr "Товары с серийным номером требуют заказ на продажу"
+msgstr "Для серийных номенклатур требуется заказ покупателя"
 
 msgid "Serial Number"
 msgstr "Серийный номер"
@@ -13536,10 +13536,10 @@ msgid "Service"
 msgstr "Обслуживание"
 
 msgid "Service Charges"
-msgstr "Сборы за услуги"
+msgstr "Сервисные сборы"
 
 msgid "Service Charges (default)"
-msgstr "Сборы за услуги (по умолчанию)"
+msgstr "Сервисные сборы (по умолчанию)"
 
 msgid "Service Details"
 msgstr "Сведения об услуге"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Установить цель"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Настройте Carbon в соответствии с тем, как работает ваша компания: сайты, детали, спецификации материалов, технологический процесс и используемые вами потоки."
+msgstr "Настройте Carbon в соответствии с тем, как работает ваша организация: участки, детали, BOM, Перечень операций и используемые вами процессы."
 
 msgid "Set Clock Out"
-msgstr "Установить время выхода"
+msgstr "Установить окончание работы"
 
 msgid "Set clock-out time"
 msgstr "Установить время выхода"
@@ -13572,16 +13572,16 @@ msgid "Set Console PIN"
 msgstr "Установить PIN консоли"
 
 msgid "Set default markup percentages for each cost category on new quote lines"
-msgstr "Установите процентные надбавки по умолчанию для каждой категории затрат в новых строках предложения"
+msgstr "Установить процентные наценки по умолчанию для каждой категории затрат в новых строках предложения"
 
 msgid "Set demand projection values for each week"
-msgstr "Установите значения прогноза спроса для каждой недели"
+msgstr "Установить значения прогноза потребности на каждую неделю"
 
 msgid "Set due date"
-msgstr "Установить срок"
+msgstr "Установить срок выполнения"
 
 msgid "Set Pricing"
-msgstr "Установить цену"
+msgstr "Установить ценообразование"
 
 msgid "Set Quantity"
 msgstr "Установить количество"
@@ -13596,10 +13596,10 @@ msgid "Set up two-factor authentication"
 msgstr "Установить двухфакторную аутентификацию"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "Настройте свою компанию с помощью пошагового плана внедрения, охватывающего настройку, данные, обучение и запуск в производство."
+msgstr "Настройте вашу организацию с помощью пошагового плана внедрения, охватывающего наладку, данные, обучение и запуск."
 
 msgid "Set up your own data with import tools and LLM help"
-msgstr "Настройте свои данные с помощью инструментов импорта и LLM"
+msgstr "Настройте свои данные с помощью инструментов импорта и помощи LLM"
 
 msgid "Set up your resources and settings"
 msgstr "Настройте ваши ресурсы и параметры"
@@ -13612,7 +13612,7 @@ msgid "Set your default location in profile settings to pick a storage unit."
 msgstr "Установите местоположение по умолчанию в настройках профиля, чтобы выбрать единицу хранения."
 
 msgid "Settings"
-msgstr "Параметры"
+msgstr "Настройки"
 
 msgid "Setup"
 msgstr "Настройка"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Карта настройки"
 
 msgid "Setup time"
-msgstr "Время настройки"
+msgstr "время наладки"
 
 msgid "Setup Time"
-msgstr "Время подготовки"
+msgstr "Время наладки"
 
 msgid "Setup unit"
 msgstr "Единица настройки"
@@ -13663,7 +13663,7 @@ msgid "Share"
 msgstr "Поделиться"
 
 msgid "Share a branded portal link so customers can track their orders and documents."
-msgstr "Поделитесь ссылкой на фирменный портал, чтобы клиенты могли отслеживать свои заказы и документы."
+msgstr "Поделитесь брендированной ссылкой на портал, чтобы покупатели могли отслеживать свои заказы и документы."
 
 msgid "Share Link"
 msgstr "Поделиться ссылкой"
@@ -13681,13 +13681,13 @@ msgid "Shared Sections"
 msgstr "Общие разделы"
 
 msgid "Shelf life"
-msgstr "Срок годности"
+msgstr "срок хранения"
 
 msgid "Shelf Life (Days)"
-msgstr "Срок годности (дни)"
+msgstr "Срок хранения (дни)"
 
 msgid "Shelf Life Start Process"
-msgstr "Процесс начала срока годности"
+msgstr "Процесс запуска срока хранения"
 
 msgid "Shelf-Life"
 msgstr "Срок годности"
@@ -13717,31 +13717,31 @@ msgid "Ship some, stock some"
 msgstr "Отправить часть, оставить часть на складе"
 
 msgid "Ship to Customer"
-msgstr "Отправить клиенту"
+msgstr "Отправить Покупателю"
 
 msgid "Ship-From Location"
 msgstr "Место отправки"
 
 msgid "Shipment"
-msgstr "Отправка"
+msgstr "Отгрузка"
 
 msgid "Shipment Date"
-msgstr "Дата отправки"
+msgstr "Дата отгрузки"
 
 msgid "Shipment ID"
-msgstr "ID отправки"
+msgstr "ID отгрузки"
 
 msgid "Shipment Line"
-msgstr "Строка отправки"
+msgstr "Строка отгрузки"
 
 msgid "Shipment Lines"
-msgstr "Строки отправки"
+msgstr "Строки отгрузки"
 
 msgid "Shipment Location"
-msgstr "Местоположение отправки"
+msgstr "Площадка отгрузки"
 
 msgid "Shipments"
-msgstr "Отправки"
+msgstr "Отгрузки"
 
 msgid "Shipped Qty"
 msgstr "Отправленное кол-во"
@@ -13750,13 +13750,13 @@ msgid "Shipping"
 msgstr "Доставка"
 
 msgid "Shipping Contact"
-msgstr "Контакт доставки"
+msgstr "Контактное лицо отгрузки"
 
 msgid "Shipping Cost"
 msgstr "Стоимость доставки"
 
 msgid "Shipping Customer"
-msgstr "Клиент доставки"
+msgstr "Покупатель доставки"
 
 msgid "Shipping Location"
 msgstr "Место доставки"
@@ -13774,7 +13774,7 @@ msgid "shipping methods"
 msgstr "способы доставки"
 
 msgid "Shipping Methods"
-msgstr "Методы доставки"
+msgstr "Способы доставки"
 
 msgid "Shipping Notes"
 msgstr "Примечания к доставке"
@@ -13816,13 +13816,13 @@ msgid "Shortcuts"
 msgstr "Сочетания клавиш"
 
 msgid "Show a readable Customer ID column on the customer list, customer forms, and dropdowns. Customers are still identified internally either way."
-msgstr "Показывать столбец с читаемым ID клиента в списке клиентов, формах клиентов и раскрывающихся списках. Клиенты по-прежнему идентифицируются внутри системы в любом случае."
+msgstr "Показывать столбец с читаемым ID Покупателя в списке покупателей, формах и выпадающих списках. Покупатели по-прежнему идентифицируются внутренне одинаково."
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Показать читаемый столбец ID поставщика в списке поставщиков, формах поставщиков и раскрывающихся списках. Поставщики по-прежнему идентифицируются внутри системы в любом случае."
 
 msgid "Show Customer IDs"
-msgstr "Показать ID клиентов"
+msgstr "Показывать ID Покупателей"
 
 msgid "Show Durations"
 msgstr "Показать длительность"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "Показано первые 500 строк"
 
 msgid "Showing the newest 200 journals"
-msgstr "Показываются последние 200 журналов"
+msgstr "Отображение 200 новейших операций"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Показано топ 1000 групп по сумме"
@@ -13868,10 +13868,10 @@ msgid "Shown as a faint background behind every page of generated PDFs"
 msgstr "Отображается как бледный фон на каждой странице сгенерированных PDF-файлов"
 
 msgid "Shown to the user when this rule fails."
-msgstr "Показывается пользователю при ошибке этого правила."
+msgstr "Показано пользователю при ошибке этого правила."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Войти в Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Войдите с использованием биометрии вместо волшебной ссылки. Ключи доступа защищены Face ID, Touch ID или PIN-кодом вашего устройства."
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "Войти через Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Войти с помощью Passkey"
+msgstr "Вход с Ключом доступа"
 
 msgid "Sign out"
 msgstr "Выход"
@@ -13898,7 +13898,7 @@ msgid "Sign out instead"
 msgstr "Вместо этого выйти"
 
 msgid "Sign-off review before moving to the next step"
-msgstr "Утверждение перед переходом к следующему этапу"
+msgstr "Подтверждение рассмотрения перед переходом к следующему шагу"
 
 msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
 msgstr "Утверждения, которые должны быть записаны перед закрытием этой проблемы; в дополнение к тем, которые требуются рабочим процессом."
@@ -13919,7 +13919,7 @@ msgid "Sites & locations"
 msgstr "Объекты и местоположения"
 
 msgid "Sites, locations, work centers, users, suppliers, and your company settings — the foundation everything else builds on. Start from ready-made templates."
-msgstr "Сайты, местоположения, рабочие центры, пользователи, поставщики и параметры вашей компании — основа, на которой строится всё остальное. Начните с готовых шаблонов."
+msgstr "Площадки, местоположения, рабочие центры, пользователи, поставщики и настройки вашей организации — основа всего остального. Начните с готовых шаблонов."
 
 msgid "Size"
 msgstr "Размер"
@@ -13940,7 +13940,7 @@ msgid "Skip raw-material dates set at receipt. Only inputs with their own shelf-
 msgstr "Пропустить даты сырья, установленные при получении. Учитываются только входы с собственной политикой срока хранения."
 
 msgid "Skip scheduled maintenance on company holidays"
-msgstr "Пропускать запланированное техническое обслуживание в праздничные дни компании"
+msgstr "Пропустить плановое техобслуживание в праздничные дни организации"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Пропустить состояние «выпущено, но не начато» — задание начинается сразу при сканировании."
@@ -13958,7 +13958,7 @@ msgid "Slice expenses by location, cost center, or any dimension"
 msgstr "Разбить расходы по местоположению, центру затрат или любому измерению"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Разделить доход по клиенту, типу клиента или любому измерению"
+msgstr "Разделить выручку по покупателям, типам покупателей или любому измерению"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Дымовое тестирование основных ежедневных процессов от начала до конца"
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "Инженер решений"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "Некоторые строки, извлеченные из PDF, не удалось автоматически сопоставить с элементами вашего инвентаря. Проверьте и сопоставьте каждую строку ниже."
+msgstr "Некоторые строки, извлеченные из PDF, не удалось автоматически сопоставить с вашими номенклатурными позициями. Проверьте и сопоставьте каждую строку ниже."
 
 msgid "Something went wrong. Please try again."
 msgstr "Что-то пошло не так. Пожалуйста, попробуйте еще раз."
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "Скоро"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "Самый ранний срок истечения среди всех материалов определяет готовый продукт."
+msgstr "Самый ранний срок годности среди всех материалов определяет готовый продукт."
 
 msgid "Sort"
 msgstr "Сортировка"
@@ -14000,19 +14000,19 @@ msgid "Source Analysis"
 msgstr "Анализ источников"
 
 msgid "Source Company"
-msgstr "Исходная компания"
+msgstr "Исходная Организация"
 
 msgid "Source document"
-msgstr "Исходный документ"
+msgstr "Документ-основание"
 
 msgid "Source Document"
-msgstr "Исходный документ"
+msgstr "Документ-основание"
 
 msgid "Source Document ID"
-msgstr "ID исходного документа"
+msgstr "ID документа-основания"
 
 msgid "Source document readable"
-msgstr "Читаемый исходный документ"
+msgstr "Читаемый документ-основание"
 
 msgid "Source Item"
 msgstr "Исходный элемент"
@@ -14042,22 +14042,22 @@ msgid "Spare Part Consumption"
 msgstr "Потребление запасных частей"
 
 msgid "Spare Part Cost"
-msgstr "Стоимость запасных частей"
+msgstr "Себестоимость запасной части"
 
 msgid "Spec"
 msgstr "Тех. условия"
 
 msgid "Specific Customer"
-msgstr "Конкретный клиент"
+msgstr "Конкретный Покупатель"
 
 msgid "Specific Customers"
-msgstr "Конкретные клиенты"
+msgstr "Конкретные Покупатели"
 
 msgid "Specific Items"
 msgstr "Конкретные товары"
 
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
-msgstr "Расходы по поставщику, товару или категории — ваши основные драйверы затрат"
+msgstr "Расходы по поставщикам, номенклатуре или категориям — ваши основные факторы затрат"
 
 msgid "Split"
 msgstr "Разделить"
@@ -14072,10 +14072,10 @@ msgid "Split receipt line"
 msgstr "Разделить строку приемки"
 
 msgid "Split shipment line"
-msgstr "Разделить строку отправки"
+msgstr "Разделить строку отгрузки"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Развернуть хостинг"
@@ -14087,16 +14087,16 @@ msgid "Standard"
 msgstr "Стандартный"
 
 msgid "Standard cloud Carbon fits how your company runs"
-msgstr "Стандартное облачное решение Carbon соответствует тому, как работает ваша компания"
+msgstr "Стандартное облако Carbon соответствует тому, как работает ваша организация"
 
 msgid "Standard Cost Variances"
-msgstr "Отклонения стандартной стоимости"
+msgstr "Отклонения нормативной себестоимости"
 
 msgid "Standard factor"
 msgstr "Стандартный коэффициент"
 
 msgid "Standard Lead Time"
-msgstr "Стандартное время доставки"
+msgstr "Стандартный срок поставки"
 
 msgid "Start"
 msgstr "Начать"
@@ -14187,7 +14187,7 @@ msgid "Step detail is kept for 30 days. This run's steps have been removed."
 msgstr "Подробная информация шага хранится 30 дней. Шаги этого запуска удалены."
 
 msgid "Step Records"
-msgstr "Записи этапов"
+msgstr "Записи шагов"
 
 msgid "Step removed — pick a new value"
 msgstr "Шаг удален — выберите новое значение"
@@ -14199,10 +14199,10 @@ msgid "Steps"
 msgstr "Шаги"
 
 msgid "Steps are inherited from the assembly instruction."
-msgstr "Этапы наследуются из инструкции по сборке."
+msgstr "Шаги наследуются из инструкции сборки."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "Этапы наследуются из плана контроля."
+msgstr "Шаги наследуются из плана контроля."
 
 msgid "Stock movement corrected"
 msgstr "Движение запаса исправлено"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "ID передачи запасов"
 
 msgid "Stock Transfer Lines"
-msgstr "Строки передачи запасов"
+msgstr "Строки перемещения запасов"
 
 msgid "Stock Transfer Notes"
 msgstr "Примечания к передаче запасов"
@@ -14230,10 +14230,10 @@ msgid "Stocked for spares only."
 msgstr "Хранится только для запасных частей."
 
 msgid "Stockout"
-msgstr "Отсутствие запасов"
+msgstr "Дефицит"
 
 msgid "Stop raising purchase orders after this date"
-msgstr "Прекратить создание заказов на покупку после этой даты"
+msgstr "Прекратить создание заказов поставщику после этой даты"
 
 msgid "Stop Receiving"
 msgstr "Остановить получение"
@@ -14260,7 +14260,7 @@ msgid "storage unit"
 msgstr "единица хранения"
 
 msgid "Storage unit"
-msgstr "Единица хранилища"
+msgstr "Единица хранения"
 
 msgid "Storage Unit"
 msgstr "Единица хранения"
@@ -14275,31 +14275,31 @@ msgid "Storage Units"
 msgstr "Единицы хранения"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "Сохраняйте фиксированное количество дней для этого товара. Дата начала истечения устанавливается для каждой партии или серийного номера при его создании (или при запуске процесса триггера, если установлено)."
+msgstr "Хранить фиксированное количество дней для этой номенклатуры. Дата начала срока годности устанавливается для каждой серии или серийного номера при его создании (или когда запускается процесс триггера, если установлен)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "Сохраняйте фиксированное количество дней для этого товара. Дата начала истечения устанавливается для каждой партии или серийного номера при получении или создании (или при запуске процесса триггера, если установлено)."
+msgstr "Хранить фиксированное количество дней для этой номенклатуры. Дата начала срока годности устанавливается для каждой серии или серийного номера при его получении или создании (или когда запускается процесс триггера, если установлен)."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Сохраняйте фиксированное количество дней для этого товара. Дата начала срока действия устанавливается для каждой партии или серийного номера при получении."
+msgstr "Хранить фиксированное количество дней для этой номенклатуры. Дата начала срока годности устанавливается для каждой серии или серийного номера при его получении."
 
 msgid "Straight line"
-msgstr "Линейный"
+msgstr "Линейный метод"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "У Stripe уже есть покупатель с этим адресом электронной почты"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Срок выполнения Stripe"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe отправляет счет-фактуру клиенту по электронной почте, поэтому требуется адрес. Он также будет сохранен в контакте в Carbon."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "В Stripe еще нет покупателя для этого покупателя Carbon. При проведении будет создан в вашей подключенной учетной записи."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Стиль вывода канбана для отображения в таблице Канбана"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "Отправить на утверждение"
 
 msgid "Submit Inspection"
-msgstr "Отправить проверку"
+msgstr "Отправить контроль"
 
 msgid "Submitted By"
 msgstr "Отправлено"
@@ -14368,10 +14368,10 @@ msgid "Successfully copied quote"
 msgstr "Предложение успешно скопировано"
 
 msgid "Successfully created a new revision"
-msgstr "Успешно создана новая редакция"
+msgstr "Ревизия успешно создана"
 
 msgid "Successor effectivity"
-msgstr "Эффективность преемника"
+msgstr "Дата вступления в силу преемника"
 
 msgid "Successor Effectivity Date"
 msgstr "Дата вступления преемника в силу"
@@ -14413,13 +14413,13 @@ msgid "Supersedes"
 msgstr "Заменяет"
 
 msgid "Supersession"
-msgstr "Замена"
+msgstr "Замещение"
 
 msgid "Supersession chain detected"
-msgstr "Обнаружена цепь замены"
+msgstr "Обнаружена цепь замещений"
 
 msgid "Supersession Mode"
-msgstr "Режим замены"
+msgstr "Режим замещения"
 
 msgid "supplier"
 msgstr "Поставщик"
@@ -14434,10 +14434,10 @@ msgid "Supplier added and selected"
 msgstr "Поставщик добавлен и выбран"
 
 msgid "Supplier contact"
-msgstr "Контакт поставщика"
+msgstr "Контактное лицо поставщика"
 
 msgid "Supplier Contact"
-msgstr "Контакт поставщика"
+msgstr "Контактное лицо поставщика"
 
 msgid "Supplier ID"
 msgstr "ID поставщика"
@@ -14449,7 +14449,7 @@ msgid "Supplier interaction"
 msgstr "Взаимодействие поставщика"
 
 msgid "Supplier Invoice Number"
-msgstr "Номер счета поставщика"
+msgstr "Номер счета-фактуры поставщика"
 
 msgid "Supplier location"
 msgstr "Место расположения поставщика"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Поставщик Детали"
 
 msgid "Supplier Part ID"
-msgstr "ID поставщика детали"
+msgstr "Артикул поставщика"
 
 msgid "Supplier Part Number"
 msgstr "Номер детали поставщика"
@@ -14485,7 +14485,7 @@ msgid "Supplier Payment Discounts (default)"
 msgstr "Скидки по платежам поставщика (по умолчанию)"
 
 msgid "Supplier Prepayments"
-msgstr "Авансовые платежи поставщикам"
+msgstr "Предоплаты поставщику"
 
 msgid "supplier process"
 msgstr "Процесс поставщика"
@@ -14557,10 +14557,10 @@ msgid "Suppliers"
 msgstr "Поставщики"
 
 msgid "Supply"
-msgstr "Поставка"
+msgstr "Обеспечение"
 
 msgid "Supply & Demand"
-msgstr "Предложение и спрос"
+msgstr "Обеспечение и потребность"
 
 msgid "Support"
 msgstr "Поддержка"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "Переключить"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "Отключите модуль, чтобы удалить его везде: Requirements, Data, Training, Scope."
+msgstr "Отключите модуль, чтобы удалить его везде: Требования, Данные, Обучение, Область охвата."
 
 msgid "Switch to pan mode"
 msgstr "Переключиться в режим панорамы"
@@ -14591,7 +14591,7 @@ msgid "Switch users over and confirm access"
 msgstr "Переключите пользователей и подтвердите доступ"
 
 msgid "Switching the employee's type here doesn't change their existing permissions; the modal that follows asks whether to overwrite the current set with the new type's defaults."
-msgstr "Изменение типа сотрудника здесь не изменяет их существующие разрешения; следующее диалоговое окно спрашивает, следует ли перезаписать текущий набор значениями по умолчанию нового типа."
+msgstr "Изменение типа сотрудника здесь не изменяет его существующие права доступа; модальное окно, которое следует, спрашивает, следует ли перезаписать текущий набор значениями по умолчанию для нового типа."
 
 msgid "Sync"
 msgstr "Синхронизация"
@@ -14627,10 +14627,10 @@ msgid "Tags"
 msgstr "Теги"
 
 msgid "Tailor this hub for the customer. Changes apply live for everyone viewing it. Never shown to the customer here."
-msgstr "Настройте этот центр для клиента. Изменения применяются в реальном времени для всех, кто его просматривает. Никогда не показывается клиенту здесь."
+msgstr "Настройте этот центр для покупателя. Изменения применяются в реальном времени для всех, кто его просматривает. Никогда не показывается покупателю здесь."
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "Возьмите самый короткий оставшийся срок годности среди материалов, использованных для изготовления этого товара. Используйте, когда срок годности продукта зависит от его ингредиентов."
+msgstr "Возьмите кратчайший оставшийся срок хранения из всей используемой номенклатуры для производства этой номенклатуры. Используйте, когда срок годности продукта зависит от его компонентов."
 
 msgid "taken"
 msgstr "взято"
@@ -14645,13 +14645,13 @@ msgid "Target an item group."
 msgstr "Выберите группу товаров."
 
 msgid "Target Company"
-msgstr "Целевая компания"
+msgstr "Целевая организация"
 
 msgid "Target customers by type."
-msgstr "Целевой элемент"
+msgstr "Выберите покупателей по типу."
 
 msgid "Target disposition row"
-msgstr "Целевая строка диспозиции"
+msgstr "Целевая строка решения"
 
 msgid "Target go-live"
 msgstr "Целевая дата запуска"
@@ -14666,7 +14666,7 @@ msgid "Target number of open issues shown as a reference line on the Issue Trend
 msgstr "Целевое количество открытых проблем, отображаемое в виде справочной линии на диаграмме тренда проблем."
 
 msgid "Target one or more customers."
-msgstr "Выберите одного или нескольких клиентов."
+msgstr "Выберите одного или нескольких покупателей."
 
 msgid "Target one or more items."
 msgstr "Целевая версия"
@@ -14696,7 +14696,7 @@ msgid "Tax"
 msgstr "Налог"
 
 msgid "Tax & Additional Costs"
-msgstr "Налог и дополнительные расходы"
+msgstr "Налоги и дополнительные расходы"
 
 msgid "Tax & Shipping"
 msgstr "Налог и доставка"
@@ -14714,10 +14714,10 @@ msgid "Tax Depreciation Method"
 msgstr "Метод налоговой амортизации"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "Не облагается налогом"
 
 msgid "Tax Exempt"
-msgstr "Налоговое освобождение"
+msgstr "Не облагается налогом"
 
 msgid "Tax ID"
 msgstr "Налоговый ID"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Команда обучена"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Техническая поддержка"
 
 msgid "Temperature"
 msgstr "Температура"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "Шаблоны"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "Временный клиринговый счет выбытия, дебетуемый на сумму чистой балансовой стоимости актива при отгрузке и кредитуемый на сумму чистой балансовой стоимости при выставлении счета — обнуляется по завершении цикла продажи."
+msgstr "Временный счет для учета выбытия, дебетуемый на остаточную стоимость активов при отгрузке и кредитуемый на остаточную стоимость при выставлении счетов, нетто равно нулю в течение цикла продажи."
 
 msgid "Terms and Privacy"
 msgstr "Условия и конфиденциальность"
@@ -14805,31 +14805,31 @@ msgstr "Это имя уже используется другим шагом."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "Фаза \"{0}\" автоматически отмечается как завершённая, когда все её задачи в плане проекта выполнены."
+msgstr "Фаза «{0}» помечается как завершенная, когда все её задачи в плане проекта выполнены."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "Фаза \"{0}\" завершена — её контрольная точка \"{1}\" пройдена."
+msgstr "Фаза «{0}» завершена — её контрольная точка «{1}» пройдена."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
 msgstr "Фазы {0} до запуска, каждая заканчивается контрольной точкой. Отмечайте каждую задачу по мере её выполнения."
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "Учетное измерение, которое классифицирует элементы для отчетности и анализа."
+msgstr "Измерение бухгалтерии, которое категоризирует номенклатуру для отчетности и анализа."
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "Счета, на которые Carbon автоматически проводит операции"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "Действие, которое копирует сохраненный метод (его материалы, операции и инструкции по работе) на строку заказа или предложения."
+msgstr "Действие копирования сохраненного метода (его материалы, операции и рабочие инструкции) на производственный заказ или строку предложения."
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
 msgstr "Разрешенные значения для атрибута типа списка; пользователи выбирают из них вместо свободного ввода текста."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Допустимые значения, которые пользователи могут выбирать при добавлении тегов к проводкам по этому измерению."
+msgstr "Допустимые значения, которые пользователи могут выбирать при пометке проведений этим измерением."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
 msgstr "Количество дней после метода расчета, в течение которых доступна скидка за наличный расчет"
@@ -14844,10 +14844,10 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "Авторизация была отклонена в Onshape. Повторите попытку подключения."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Книга всех проведенных строк журнала, суммированные по счетам — записывается только при включенной учетной политике компании."
+msgstr "Журнал всех проведенных операций, сгруппированных по счетам — ведется только когда в организации включена бухгалтерия."
 
 msgid "The buckets you track costs against"
-msgstr "Корзины, по которым вы отслеживаете затраты"
+msgstr "Бюджеты, по которым вы отслеживаете затраты"
 
 msgid "The capital assets you own and depreciate"
 msgstr "Основные средства, которыми вы владеете и амортизируете"
@@ -14856,7 +14856,7 @@ msgid "The Carbon user currently responsible for working this record, set per re
 msgstr "Пользователь Carbon, в настоящее время отвечающий за работу с этой записью, установлен для каждой записи и независим от полей владения, таких как Менеджер аккаунта или Продавец."
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
-msgstr "Пользователь Carbon, ответственный за взаимоотношения с клиентом; электронные письма и напоминания об этом клиенте направляются им."
+msgstr "Пользователь Carbon, отвечающий за отношения с этим покупателем; электронные письма и напоминания о этом покупателе направляются ему."
 
 msgid "The Carbon user responsible for this supplier relationship; emails and reminders about this supplier route to them."
 msgstr "Пользователь Carbon, ответственный за взаимоотношения с поставщиком; электронные письма и напоминания об этом поставщике направляются им."
@@ -14865,22 +14865,22 @@ msgid "The Carbon user who owns this RFQ; supplier responses and reminders route
 msgstr "Пользователь Carbon, который владеет этой RFQ; ответы поставщика и напоминания направляются им."
 
 msgid "The carrier and service a shipment goes out on, supplying the tracking-URL template that turns a tracking number into a link and the account freight charges post to."
-msgstr "Перевозчик и услуга, по которой отправляется отправка, предоставляя шаблон URL отслеживания, который превращает номер отслеживания в ссылку и счет, на котором размещаются сборы за доставку."
+msgstr "Перевозчик и сервис, через которые отправляется отгрузка, предоставляя шаблон URL отслеживания, который преобразует номер отслеживания в ссылку, и счет, на который проводятся почтовые сборы."
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
 msgstr "Перевозчик, который доставляет товары от этого поставщика, когда отличается от самого поставщика (например, поставщик продает, FedEx доставляет)."
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "URL страницы отслеживания перевозчика с {trackingNumber} в качестве заполнителя — Carbon заменяет фактический номер при создании ссылок на отправки."
+msgstr "URL страницы отслеживания перевозчика с {trackingNumber} в качестве заполнителя — Carbon подставляет фактический номер при создании ссылок на отгрузках."
 
 msgid "The carriers and methods you ship orders with"
 msgstr "Перевозчики и методы доставки ваших заказов"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "Скидка при оплате, которую клиент может получить, если платит в течение периода скидки."
+msgstr "Скидка за наличный расчет, которую клиент может получить при оплате в течение периода скидки."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "Причина из каталога, объясняющая этот отход; накапливается в отчеты об отходах по причине, а не по количеству."
+msgstr "Причина из каталога, объясняющая этот брак; включается в отчеты по браку, организованные по причине, а не по количеству."
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "Каталог, на котором вы работаете. Загружается после загрузки основы."
@@ -14901,16 +14901,16 @@ msgid "The category of risk (operational, strategic, financial, compliance, etc.
 msgstr "Категория риска (операционный, стратегический, финансовый, соответствие и т. д.); определяет, в какие отчеты включается риск."
 
 msgid "The category of this issue (e.g. Customer Complaint, Audit Finding, Production Defect); drives which workflow template applies."
-msgstr "Категория этой проблемы (например, жалоба клиента, вывод аудита, дефект производства); определяет, какой шаблон рабочего процесса применяется."
+msgstr "Категория этой заявки (например, жалоба покупателя, результат аудита, производственный дефект); определяет, какой шаблон рабочего процесса применяется."
 
 msgid "The category this customer belongs to (OEM, distributor, end-user, internal); drives default pricing rules and GL accounts."
-msgstr "Категория, к которой принадлежит этот клиент (OEM, дистрибьютор, конечный пользователь, внутренний); определяет правила цен по умолчанию и счета GL."
+msgstr "Категория, к которой принадлежит этот покупатель (OEM, дистрибьютор, конечный пользователь, внутренний); определяет правила ценообразования по умолчанию и счета учета."
 
 msgid "The category this supplier belongs to (raw-material, services, contract-manufacturer); drives default GL accounts and reporting groupings."
 msgstr "Категория, к которой принадлежит этот поставщик (сырье, услуги, контрактный производитель); определяет счета GL по умолчанию и группировки отчетов."
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "Код, напечатанный на карточке канбан, который операторы сканируют, чтобы отметить работу как завершенную; генерируется автоматически, если оставлено пусто."
+msgstr "Код, напечатанный на карточке канбан, который операторы сканируют, чтобы отметить производственный заказ завершенным; автоматически генерируется, если оставить пустым."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
 msgstr "Ожидаемая еженедельная доступность подрядчика; планирование использует это как верхний предел при назначении подрядчика операциям в течение недели."
@@ -14922,25 +14922,25 @@ msgid "The currencies you trade in and their rates"
 msgstr "Валюты, в которых вы торгуете, и их курсы"
 
 msgid "The customer record this portal account links to; only contacts already on that customer can be selected as the account holder below."
-msgstr "Запись клиента, к которой привязана эта учетная запись портала; только контакты, уже связанные с этим клиентом, можно выбрать в качестве владельца учетной записи ниже."
+msgstr "Запись покупателя, к которой привязана эта учетная запись портала; в качестве владельца учетной записи ниже можно выбрать только контактных лиц этого покупателя."
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "Клиент, которому доставляются товары, если он отличается от счета-фактуры клиента (например, счет на головной офис, доставка в филиал)."
+msgstr "Покупатель, которому доставляются товары, если отличается от покупателя, которому выставляется счет (например, счет в штаб-квартиру, отгрузка в филиал)."
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
-msgstr "Клиент, для которого этот ссылка портала предоставлена; только контакты на этом клиенте могут войти через ссылку."
+msgstr "Покупатель, для которого предоставлена эта ссылка на портал; через ссылку могут входить только контактные лица этого покупателя."
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "Собственная ссылка клиента для этого документа — обычно его номер RFQ или PO в его системе; отображается в печатном выводе и переносится в любой документ, в который он преобразуется."
+msgstr "Собственный номер ссылки покупателя на этот документ — обычно номер их запроса цен или заказа в их системе; отображается в печатном выводе и передается в любой документ, в который преобразуется этот документ."
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
-msgstr "Тег версии клиента для его идентификатора детали, если он отличается от нашего; закреплен на уровне перекрестной ссылки, а не на нашей версии."
+msgstr "Тег ревизии покупателя для их ID детали, когда он отличается от нашего; зафиксирован на уровне перекрестной ссылки, а не на нашей ревизии."
 
 msgid "The customers who go live fastest own these well. The full ours/yours split is below."
-msgstr "Клиенты, которые быстрее всего запускаются, хорошо владеют этим. Полное разделение наше/ваше показано ниже."
+msgstr "Покупатели, которые быстрее других внедрили систему, хорошо владеют этим. Полный раздел наши/ваши находится ниже."
 
 msgid "The customers you sell and ship to"
-msgstr "Клиенты, которым вы продаете и отправляете товары"
+msgstr "Покупатели, которым вы продаете и отправляете товары"
 
 msgid "The dashed threshold you don't want inventory to fall below."
 msgstr "Пунктирный порог, ниже которого вы не хотите, чтобы опускался инвентарь."
@@ -14952,40 +14952,40 @@ msgid "The date depreciation begins for this asset; usually the in-service date.
 msgstr "Дата начала амортизации данного основного средства; обычно дата ввода в эксплуатацию."
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "Дата, после которой цены в этом предложении больше не действуют; преобразование заказа после этой даты может потребовать переквотирования."
+msgstr "Дата, после которой цены из этого предложения больше не действительны; преобразование в заказ после этой даты может потребовать повторного расчета цены."
 
 msgid "The date the customer expects to receive the goods"
-msgstr "Дата, когда клиент ожидает получить товары"
+msgstr "Дата, когда покупатель ожидает получить товары"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "Дата, когда товары фактически покидают склад; регистрируется при учете отправки и используется для оценки доставки вовремя."
+msgstr "Дата фактического отправления товаров со склада; записывается в проведении отгрузки и используется для оценки доставки в срок."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
-msgstr "Дата, когда товар должен быть доставлен на объект для покрытия прогнозируемого спроса за период."
+msgstr "Дата, когда номенклатура требуется на месте для покрытия прогнозируемого спроса периода."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "Дата, когда основное средство выбывает; амортизация прекращается на эту дату, а оставшаяся чистая балансовая стоимость учитывается на счете выбытия."
+msgstr "Дата, когда этот актив выводится из эксплуатации; амортизация останавливается в эту дату и оставшаяся остаточная стоимость записывается на счет выбытия."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
-msgstr "Дата, когда эта проводка попадает в главную книгу; определяет отчетный период, к которому она относится."
+msgstr "Дата, когда эта запись попадает в главную книгу; определяет учетный период, в который она попадает."
 
 msgid "The date this intercompany transaction hits both companies' ledgers."
 msgstr "Дата, когда эта внутригрупповая операция записывается в главные книги обеих компаний."
 
 msgid "The date you received this RFQ from the customer. Defaults to today."
-msgstr "Дата получения этого запроса на коммерческое предложение от клиента. По умолчанию — сегодняшняя дата."
+msgstr "Дата получения этого запроса цен от покупателя. По умолчанию установлена сегодня."
 
 msgid "The deadline to send your quote to the customer."
-msgstr "Крайний срок отправки коммерческого предложения клиенту."
+msgstr "Крайний срок для отправки вашего коммерческого предложения покупателю."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "Заказ комплектации по умолчанию используется для предложения отслеживаемых сущностей: FEFO (самый ранний срок истечения в первую очередь), FIFO (самый старый в первую очередь) или LIFO (самый новый в первую очередь)."
+msgstr "Порядок отбора по умолчанию для предложения отслеживаемых сущностей: FEFO (самое раннее истечение в первую очередь), ФИФО (самое старое в первую очередь) или LIFO (самое новое в первую очередь)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "Количество прогона по умолчанию при изготовлении этой детали; циклы планирования дополняют пополнение на кратные этому."
 
 msgid "The default tax rate applied to this customer's quote and sales-order lines, before per-line overrides; jurisdiction-specific tax math runs on top."
-msgstr "Стандартная налоговая ставка, применяемая к строкам предложения и заказа на продажу этого клиента, до переопределений по строкам; поверх нее выполняется математика налогообложения, специфичная для юрисдикции."
+msgstr "Налоговая ставка по умолчанию, применяемая к строкам коммерческого предложения и заказа покупателя, до переопределений по строкам; поверх этого применяется математика налогообложения, специфичная для юрисдикции."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
 msgstr "Отдел, под который это накапливается для отчетности и иерархий подсчета; оставить пусто для отдела верхнего уровня."
@@ -14994,10 +14994,10 @@ msgid "The eight-disciplines quality method, modeled with the nonconformance wor
 msgstr "Метод качества восьми дисциплин, моделируемый с помощью задач рабочего процесса несоответствия, а не жестко закодированный."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "Сотрудник, отвечающий за этот центр затрат. Когда включены утверждения заказов на закупку, он является утверждающим расходов, поступающих по счету."
+msgstr "Сотрудник, ответственный за этот центр затрат — когда утверждения заказов поставщику включены, они являются утверждающим лицом для расходов, проведенных по нему."
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
-msgstr "Сквозной коммерческий процесс от предложения клиенту до получения платежа: запрос предложения, предложение, заказ на продажу, отгрузка, счет и полученный платеж."
+msgstr "Полный коммерческий цикл от предложения покупателю до получения платежа: запрос цен, коммерческое предложение, заказ покупателя, затем отгрузка, счет-фактура и полученный платеж."
 
 msgid "The endpoint that receives a POST request with the updated data when the table is updated"
 msgstr "Конечная точка, которая получает POST-запрос с обновленными данными при обновлении таблицы"
@@ -15006,7 +15006,7 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "Техническая схема, к которой привязан данный план контроля; проверки, записанные для этой детали, ссылаются на эту схему."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "Ожидаемый процент выпуска этого товара, потерянный во время производства; планирование умножает спрос на 1 / (1 − отход) для компенсации."
+msgstr "Ожидаемый процент выпуска этой номенклатуры, потерянного во время производства; планирование умножает потребность на 1 / (1 − брак) для компенсации."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Счет расходов, на который относится эта строка косвенных расходов; требуется, так как косвенные строки не имеют записи в книге товаров, из которой можно вывести счет."
@@ -15021,13 +15021,13 @@ msgid "The fixed-asset record this purchase capitalizes against; the line's rece
 msgstr "Запись основного средства, на которую эта покупка капитализируется; квитанция по строке создает запись об активе, а не запись об инвентаре."
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
-msgstr "Запись основного средства, которую эта продажа отчуждает; доставка по строке учитывает запись об отчислении чистой балансовой стоимости актива вместо себестоимости реализованной продукции."
+msgstr "Запись основного средства, которое продается в этой транзакции; отгрузка строки проводит запись выбытия по остаточной стоимости активов вместо COGS."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "Нижняя граница, до которой амортизируется основное средство. Когда чистая балансовая стоимость ее достигает, основное средство переходит в статус «Полностью амортизировано»."
+msgstr "Нижний предел, до которого амортизируется актив; когда остаточная стоимость его достигает, актив переходит в статус « Полностью амортизировано »."
 
 msgid "The floor and the office read the same inventory and cost figures."
-msgstr "Цех и офис видят одинаковые показатели инвентаря и стоимости."
+msgstr "Цеха и офис видят одинаковые цифры по запасам и затратам."
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
 msgstr "Следующие сборки не имеют операций. Пожалуйста, назначьте операцию для каждой перед выпуском."
@@ -15036,16 +15036,16 @@ msgid "The following line items are missing prices or lead times:"
 msgstr "Следующие позиции отсутствуют цены или сроки поставки:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Следующие задачи еще не выполнены:"
+msgstr "Следующие задачи еще не готовы:"
 
 msgid "The forms and shapes your raw materials come in"
 msgstr "Формы и виды, в которых поступают ваши сырьевые материалы"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "Доля каждой партии для проверки; фактический подсчет вычисляется из размера партии во время проверки."
+msgstr "Доля каждой партии для проверки; фактическое количество рассчитывается на основе размера партии при проведении контроля."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "Разница между ценой заказа на закупку и счетом поставщика, учитываемая на счете отклонения при проводке счета."
+msgstr "Разница между ценой в заказе поставщику и счетом поставщика, проведенная на счет отклонений при проведении счета-фактуры."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "Счет GL, на который учитываются взносы за этого перевозчика (расходы на доставку, доставку внутри/наружу)."
@@ -15060,43 +15060,43 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "Групповой счет, на который свертывается этот счет, определяет его тип, класс и расположение в отчете."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "Почасовая стоимость труда оператора на этом рабочем центре; объединяется с зарегистрированными рабочими часами для отнесения затрат на труд на незавершенное производство задания."
+msgstr "Почасовая стоимость труда оператора в этом рабочем центре; в сочетании с зафиксированными часами труда для учета затрат на труд в незавершенное производство производственного заказа."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "Почасовая стоимость работы механизмов на этом рабочем центре; объединяется с зарегистрированными часами работы механизмов для отнесения затрат на механизмы на незавершенное производство задания."
+msgstr "Почасовая стоимость работы оборудования в этом рабочем центре; в сочетании с зафиксированными часами работы оборудования для учета затрат на оборудование в незавершенное производство производственного заказа."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "Почасовая нагрузка косвенных затрат, применяемая к этому рабочему центру; разница между трудом + машиной и полной ставкой котировки - это то, что поглощает накладные расходы."
+msgstr "Почасовая косвенная стоимость, применяемая к этому рабочему центру; разница между трудом и оборудованием и полной ставкой расчета затрат компенсируется накладными расходами."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "HTTPS-адрес, на который шаг вебхука рабочего процесса отправляет данные — простой http, перенаправления и хосты, разрешающие в приватные или link-local адреса, отклоняются, и вызов прекращается через десять секунд."
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "Понятный номер документа (например J000001 или ECO-000001), сгенерированный из последовательности и сохранённый в записи, отличный от его внутреннего ID."
+msgstr "Удобочитаемый номер документа (например J000001 или ECO-000001), созданный из правила нумерации и сохраненный в записи, отличный от его внутреннего идентификатора."
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "Идентификатор, который клиент использует для этой детали на их заказах; Carbon разрешает его на наш внутренний идентификатор детали при импорте заказа."
+msgstr "Идентификатор, который покупатель использует для этой детали в своих заказах; Carbon преобразует его во внутренний ID детали при импорте заказа."
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
-msgstr "Идентификатор, который поставщик использует для этой детали в своих предложениях и счетах-фактурах; Carbon разрешает его на наш внутренний идентификатор детали."
+msgstr "Идентификатор, который поставщик использует для этой детали в своих коммерческих предложениях и счетах-фактурах; Carbon преобразует его во внутренний ID детали."
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
-msgstr "Немедленная задача несоответствия, которая изолирует затронутые запасы или работу до выявления первопричины."
+msgstr "Немедленная задача несоответствия, которая изолирует затронутый запас или работу до выявления коренной причины."
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
-msgstr "Оценка воздействия при реализации риска (1 = незначительно до 5 = катастрофически); в паре с Вероятностью для расчета оценки риска."
+msgstr "Рейтинг влияния, если риск будет реализован (1 = незначительный до 5 = катастрофический); в сочетании с вероятностью для вычисления оценки риска."
 
 msgid "The inbound posting document that takes goods into stock (from a PO, transfer, or job output) and creates any tracked entities."
-msgstr "Входящий документ учета, который принимает товары на склад (из заказа на закупку, передачи или выхода работы) и создает отслеживаемые сущности."
+msgstr "Входящий документ проведения, который принимает товары на запас (из заказа поставщику, перемещения или выпуска производственного заказа) и создает любые отслеживаемые объекты."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "Правило Incoterms (FOB, DAP, EXW, CIF, ...), которое регулирует, кто оплачивает доставку, кто несет риск и где происходит передача права собственности при доставке от этого поставщика."
+msgstr "Правило Инкотермс (FOB, DAP, EXW, CIF, …), которое определяет, кто платит за доставку, кто несет риск и где происходит передача права собственности при отгрузке этого поставщика."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "Правило Incoterms (FOB, DAP, EXW, CIF, ...), которое регулирует, кто оплачивает доставку, кто несет риск и где происходит передача права собственности при доставке этому клиенту."
+msgstr "Правило Инкотермс (FOB, DAP, EXW, CIF, …), которое определяет, кто платит за доставку, кто несет риск и где происходит передача права собственности при отгрузке этому покупателю."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Стоимость инвентаря, признаваемая при учете отгрузки, оценивается методом учета стоимости товара."
+msgstr "Стоимость запасов, признаваемая при проведении отгрузки, оцениваемая по методу калькуляции номенклатуры."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "Класс периода восстановления IRS для этого основного средства в соответствии с MACRS (3, 5, 7, 10, 15, 20, 27,5, 39 лет)."
@@ -15105,34 +15105,34 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "Работа, операция которой охватывает эту строку внешней обработки; квитанция по строке закрывает операцию для этой работы."
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "Позиция работы в очереди графика её местоположения — дробное число, которое Carbon вычисляет из даты срока и типа срока, а не оценка Low/High."
+msgstr "Положение производственного заказа в очереди графика его площадки — дробное число, которое Carbon вычисляет из срока выполнения и типа крайнего срока, а не рейтинг «Низкий/Высокий»."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
 msgstr "Тип корректировки, которую применяет это правило — скидка, доплата или фиксированное переопределение; в сочетании с типом суммы для расчета фактической дельты в каждой строке."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "Тип значения, которое принимает этот атрибут (текст, число, дата, логическое значение, список); заблокирован после того, как атрибут содержит записанные значения."
+msgstr "Вид значения, которое принимает это пользовательское поле (текст, число, дата, логическое значение, список); заблокировано после записи каких-либо значений."
 
 msgid "The label and document printers your company prints to"
-msgstr "Принтеры этикеток и документов, на которые печатает ваша компания"
+msgstr "Принтеры этикеток и документов, на которые печатает ваша организация"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "Последняя дата размещения этого заказа, чтобы он прибыл к требуемой дате, учитывая время доставки поставщика."
+msgstr "Самая поздняя дата размещения этого заказа поставщику, чтобы он прибыл к нужной дате, с учетом срока поставки поставщика."
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
-msgstr "Юридическое лицо для выставления счета, если оно отличается от клиента, получающего товары - для соглашений о выставлении счета по материнским/дочерним или третьим сторонам."
+msgstr "Организация для выставления счета, если отличается от покупателя, получающего товары — для взаимоотношений между головной компанией/дочерней компанией или третьей стороной."
 
 msgid "The legal entity to bill, when different from the supplier who delivers the goods — for parent / subsidiary or factoring arrangements."
 msgstr "Юридическое лицо для выставления счета, если оно отличается от поставщика, поставляющего товары - для соглашений о материнской компании/дочерней компании или факторинге."
 
 msgid "The lifecycle stages you track customers through"
-msgstr "Этапы жизненного цикла, через которые вы отслеживаете клиентов"
+msgstr "Этапы жизненного цикла, через которые вы отслеживаете покупателей"
 
 msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.; only Active customers appear in sales-order selectors."
-msgstr "Состояние жизненного цикла этого клиента - Активный, Перспективный, Неактивный и т. д.; только активные клиенты отображаются в селекторах заказов на продажу."
+msgstr "Состояние жизненного цикла этого покупателя — Активный, Потенциальный, Неактивный и т. д.; только активные покупатели появляются в селекторах заказов."
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "Состояние жизненного цикла этого поставщика - Активный, Неактивный, Ожидание одобрения и т. д.; только активные поставщики отображаются в селекторах ПО/предложений."
+msgstr "Состояние жизненного цикла этого поставщика — Активный, Неактивный, В ожидании утверждения и т. д.; только активные поставщики появляются в селекторах заказов поставщикам и коммерческих предложений."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
 msgstr "Местный часовой пояс, в котором это местоположение сообщает время; расписания, табели учета рабочего времени и часы смены в этом месте интерпретируются в этом часовом поясе независимо от локали браузера пользователя."
@@ -15144,7 +15144,7 @@ msgid "The location this order will fulfill from; per-line locations override th
 msgstr "Местоположение, из которого будет выполнен этот заказ; местоположения по строке переопределяют его при установке."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "Местоположение, из которого будет выполнено это предложение, если оно преобразуется в заказ; используется при планировании для прогнозирования предложения на правильном складе."
+msgstr "Площадка, с которой будет исполнено это коммерческое предложение, если оно преобразуется в заказ; используется планированием для проецирования обеспечения на правильном складе."
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
 msgstr "Местоположение, из которого будет выполнено этоРЗП, если оно преобразуется в предложение, а затем в заказ."
@@ -15159,16 +15159,16 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "Идентификатор партии для этого запаса; одна строка на партию, количество - это количество на руках для этой партии."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "Партия будет отмечена как принята. {fails} образец(ов) с дефектом(и) записан(ы) для ваших записей."
+msgstr "Партия будет отмечена как пройдено. Зафиксировано {fails} ошибка(и) образца в ваших записях."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Партия все еще будет отклонена, но NCR не может быть создана до тех пор, пока не будет настроен хотя бы один тип проблемы."
 
 msgid "The lot's per-feature sampling plan will be re-resolved from the selected document."
-msgstr "План выборочной проверки партии по элементам будет переопределен из выбранного документа."
+msgstr "План выборочного контроля партии по каждому признаку будет переопределен из выбранного документа."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "Минимальная сумма, которую этот поставщик взимает за этот процесс, независимо от количества; работы ниже объема безубыточности все еще стоят как минимум эту сумму."
+msgstr "Минимальная сумма, которую этот поставщик будет взимать за этот процесс, независимо от количества; производственные заказы ниже точки безубыточности все равно стоят как минимум столько же."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Машины, ячейки и станции, через которые проходит ваша работа"
@@ -15195,7 +15195,7 @@ msgid "The most likely failure mode the requester suspects; the technician confi
 msgstr "Наиболее вероятный режим отказа, который подозревает запросчик; техник подтверждает или заменяет это при закрытии, и разница между подозреваемым и фактическим питает отчеты надежности."
 
 msgid "The negotiated price per unit on this line; the inline trace icon shows which pricing rule or override produced it."
-msgstr "Согласованная цена за единицу на этой строке; встроенный значок трассировки показывает, какое правило цены или переопределение его произвело."
+msgstr "Согласованная цена за единицу на этой строке; значок встроенной трассировки показывает, какое правило ценообразования или переопределение его создало."
 
 msgid "The new version number of the document"
 msgstr "Новый номер версии документа"
@@ -15207,13 +15207,13 @@ msgid "The new version number of the procedure"
 msgstr "Новый номер версии процедуры"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Количество дней между размещением заказа у предпочтительного поставщика и прибытием товара на причал; планирование компенсирует спрос на эту сумму в обратном направлении."
+msgstr "Количество дней между размещением заказа у основного поставщика и прибытием товара на склад; планирование смещает спрос назад на столько же дней."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Количество дней для сборки одной партии этого товара, измеренное от выпуска задания до завершения; планирование компенсирует спрос на эту сумму в обратном направлении."
+msgstr "Количество дней для производства одной серии этой номенклатуры, измеренное от запуска производственного заказа до завершения; планирование смещает спрос назад на столько же дней."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "Количество дополнительных единиц для сборки в целях компенсации ожидаемых отходов; при резервировании материалов планирование суммирует это с количеством заказа."
+msgstr "Количество дополнительных единиц для производства, чтобы компенсировать ожидаемый брак; планирование суммирует это с количеством заказа при резервировании материалов."
 
 msgid "The number of hours per week the contractor is available to work."
 msgstr "Количество часов в неделю, в течение которых подрядчик доступен для работы."
@@ -15225,22 +15225,22 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "Уровень наличного запаса, который запускает новый заказ на пополнение в соответствии с политиками на основе количества."
 
 msgid "The operations and steps your parts move through"
-msgstr "Операции и этапы, через которые проходят ваши детали"
+msgstr "Операции и шаги, через которые переходят ваши детали"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
 msgstr "Упорядоченный список задач, которые должны выполнять проблемы, использующие этот рабочий процесс; порядок здесь - это порядок, в котором они отображаются в проблеме."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "Упорядоченная последовательность операций, которые выполняет задание, скопированная из расчета процессов метода."
+msgstr "Упорядоченная последовательность операций, через которые проходит производственный заказ, скопированная из перечня операций метода."
 
 msgid "The original model file is no longer available"
 msgstr "Исходный файл модели больше недоступен"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "Документ исходящего учета, который выводит товары со склада к клиенту, осуществляя учет себестоимости проданных товаров."
+msgstr "Исходящий документ проведения, который выводит товары из запаса покупателю, проводя COGS по пути."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Внешние поставщики, выполняющие этот процесс; каждый получает строку входных данных по цене и времени выполнения в форме процесса поставщика."
+msgstr "Внешние поставщики, которые выполняют этот процесс; каждый получает строку входных данных по ценообразованию и сроку поставки в форме процесса поставщика."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "Цепь родитель-потомок отслеживаемых объектов — из чего была построена единица и чем она стала."
@@ -15249,25 +15249,25 @@ msgid "The part is manufactured as its own job when the parent that needs it is 
 msgstr "Деталь производится как собственное задание, когда производится родитель, который ее нужен."
 
 msgid "The part is taken from existing stock when its parent is built — no new job or purchase order."
-msgstr "Деталь берется из существующего запаса при построении ее родителя — нет нового задания или заказа на покупку."
+msgstr "Деталь берется из существующего запаса при производстве ее родительского элемента — без создания нового производственного заказа или заказа поставщику."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Люди со стороны Carbon, которые будут управлять вашей реализацией, и как их найти."
+msgstr "Люди со стороны Carbon, которые будут проводить ваше внедрение, и как их найти."
 
 msgid "The people on your team and their access to Carbon"
-msgstr "Люди в вашей команде и их доступ к Carbon"
+msgstr "Люди в вашей бригаде и их доступ к Carbon"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
 msgstr "Счётчик на уровне компании, формирующий читаемый номер документа путём объединения префикса, дополняемого нулями числового значения и суффикса, и увеличивающийся при создании каждого документа."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "Исход для каждого элемента, записанный для затронутого материала несоответствия — В ожидании, Вернуть поставщику, Переработка, Брак или Использовать как есть — решается для каждой затронутой партии или серии отдельно."
+msgstr "Результат по номенклатуре, записанный на затронутом материале несоответствия — В ожидании, Вернуть поставщику, Доработка, Брак или Использовать как есть — решается для каждой затронутой партии или серии отдельно."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "Процент скидки за наличный расчет. Используйте 0 для отсутствия скидки."
+msgstr "Процент скидки при оплате наличными. Используйте 0, если скидки нет."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
-msgstr "Набор разрешений, которые новые сотрудники этого типа получают автоматически; редактирование здесь изменяет шаблон только для будущих найма — существующие сотрудники сохраняют то, что у них есть, если только они явно не обновлены массово."
+msgstr "Набор прав доступа, который автоматически получают новые сотрудники этого типа; редактирование здесь изменяет шаблон только для будущих сотрудников — существующие сотрудники сохраняют свои права, пока их явно не обновить массово."
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Заводы, склады и объекты, где находятся ваша работа и запасы"
@@ -15282,16 +15282,16 @@ msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certa
 msgstr "Оценка вероятности возникновения риска (1 = редко до 5 = почти наверняка); в паре с Серьезностью для расчета оценки риска."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "Процедура, которой следуют техники при выполнении этого обслуживания; замена ее после того, как расписания уже были созданы, влияет только на будущие экземпляры."
+msgstr "Процедура, которую следуют техники при выполнении этого техобслуживания; замена после того, как графики уже созданы, влияет только на будущие экземпляры."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Процессы, которые может выполнять этот рабочий центр; отображается в селекторах процессов при планировании операций и ограничивает, какие задания могут маршрутизироваться через этот рабочий центр."
+msgstr "Процессы, которые может выполнять этот рабочий центр; отображается в программах выбора процессов при планировании операций и ограничивает, какие производственные заказы могут проходить через этот рабочий центр."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
-msgstr "Провайдер не предлагает цели размерности. Сначала включите функцию в провайдере (например, категории отслеживания, отслеживание класса или поля)."
+msgstr "Поставщик не предлагает целевые показатели по измерениям. Сначала включите функцию у поставщика (например, категории отслеживания, отслеживание класса или поля)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "Точки разрыва количества, по которым эта строка оценивается; каждый столбец имеет собственную цену за единицу для переговоров между покупателем и поставщиком и для преобразования в нижние документы."
+msgstr "Точки разрыва по количеству, при которых рассчитывается цена этой строки; каждый столбец содержит свою цену за единицу для переговоров между закупщиком и поставщиком и для преобразования в последующие документы."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "Количество товара, которое будет переупорядочено при сканировании для пополнения запасов."
@@ -15303,7 +15303,7 @@ msgid "The quote has been created"
 msgstr "Предложение было создано"
 
 msgid "The quote will be copied with a revision suffix"
-msgstr "Предложение будет скопировано с суффиксом редакции"
+msgstr "Коммерческое предложение будет скопировано с суффиксом ревизии."
 
 msgid "The raw stock and material master you buy and consume"
 msgstr "Сырьё и материалы, которые вы покупаете и используете"
@@ -15318,10 +15318,10 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "Запись, на которую указывает уведомление рабочего процесса, названная как id и её тип; оставьте пустым, и уведомление будет указывать на сам прогон рабочего процесса."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "Запись, которая применяет платёж или памятку к счёту-фактуре, содержащая применённые, дисконтные и списанные суммы."
+msgstr "Запись, которая применяет платеж или памятку к счет-фактуре, содержащая применяемые суммы, скидки и списания."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
-msgstr "Записанная генеалогия отслеживаемых объектов — какие входные данные были использованы для получения каких выходных данных, от приемки до доставки."
+msgstr "Записанная генеалогия отслеживаемых объектов — какие входные данные были израсходованы для производства каких выходных данных, от поступления через отгрузку."
 
 msgid "The reference data everything else hangs off. Loads first."
 msgstr "Справочные данные, на которые опирается всё остальное. Загружаются первыми."
@@ -15329,12 +15329,12 @@ msgstr "Справочные данные, на которые опираетс�
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will be expected again and counted as incoming supply."
-msgstr "Оставшиеся {0} {1} будут ожидаться вновь и учитываться как входящие поставки."
+msgstr "Оставшиеся {0} {1} будут ожидаться снова и учитываться как входящее обеспечение."
 
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "Оставшиеся {0} {1} больше не будут ожидаться. Входящие поставки и MRP прекратят их учет. Заказанное количество и цены остаются неизменными."
+msgstr "Оставшиеся {0} {1} больше не будут ожидаться. Заказанное обеспечение и MRP перестанут их считать. Заказанное количество и ценообразование остаются без изменений."
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "Тело запроса, отправляемое дословно с типом содержимого JSON после замены переменных рабочего процесса внутри него, в методах, которые его несут."
@@ -15349,16 +15349,16 @@ msgid "The result will not appear on the Runs page."
 msgstr "Результат не появится на странице Запусков."
 
 msgid "The revision number of the part"
-msgstr "Номер редакции детали"
+msgstr "Номер ревизии детали."
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "Строка заказа на продажу, для которой была создана эта работа, связывая работу с потребностью клиента за ней."
+msgstr "Строка заказа покупателя, для которой был создан этот производственный заказ, связывая заказ с находящимся за ним спросом покупателя."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "Метод амортизации, используемый для распределения стоимости этого актива в течение его полезного срока действия (прямолинейный, убывающий баланс, единицы производства)."
+msgstr "График, используемый для распределения стоимости этого актива на протяжении его срока полезного использования (линейный метод, уменьшаемый остаток, единицы выпуска)."
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "Полки и контейнеры, где физически находится запас"
+msgstr "Полки и ячейки, где физически располагается запас."
 
 msgid "The shop supplies and consumables you keep on hand"
 msgstr "Расходные материалы и товары, которые вы держите под рукой"
@@ -15370,28 +15370,28 @@ msgid "The size of the part"
 msgstr "Размер детали"
 
 msgid "The skills and abilities you track for your people"
-msgstr "Навыки и способности, которые вы отслеживаете для своей команды"
+msgstr "Навыки и способности, которые вы отслеживаете для своих сотрудников."
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "Минимальное количество, которое этот поставщик примет на строке ПО для этой детали; планирование округляет к нему."
+msgstr "Наименьшее количество, которое этот поставщик примет по строке заказа для этой детали; планирование округляет до этого количества."
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
-msgstr "Конкретный контакт на выбранном клиенте, который будет владеть этой учетной записью портала; его электронная почта становится идентификатором входа."
+msgstr "Конкретное контактное лицо у выбранного покупателя, которое будет владеть этой учетной записью портала; их электронная почта становится идентификатором для входа."
 
 msgid "The specific contact on the selected supplier who will own this portal account; their email becomes the sign-in identifier."
-msgstr "Конкретный контакт на выбранном поставщике, который будет владеть этой учетной записью портала; его электронная почта становится идентификатором входа."
+msgstr "Конкретное контактное лицо у выбранного поставщика, которое будет владеть этой учетной записью портала; их электронная почта становится идентификатором для входа."
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "Конкретная операция в задании выше, которую покупает эта строка ПО; только операции, отмеченные как внешняя обработка, можно выбрать."
+msgstr "Конкретная операция над производственным заказом, которую эта строка заказа закупает; доступны только операции, помеченные как субподряд."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "Конкретное ПО, возврат или передача, по которому учитывается этот приемный документ; доступные идентификаторы зависят от типа исходного документа выше."
+msgstr "Конкретный заказ покупателя, возврат или перемещение, на который это поступление проводится; доступные ID зависят от типа документа-основания выше."
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "Конкретное SO, передача или RMA, по которому учитывается эта доставка; доступные идентификаторы зависят от типа исходного документа выше."
+msgstr "Конкретный заказ покупателя, перемещение или RMA, на который эта отгрузка проводится; доступные ID зависят от типа документа-основания выше."
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "Стандартные размеры, в которых хранится ваш материал"
+msgstr "Стандартные измерения, в которых хранятся ваши материалы."
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
 msgstr "Стандартный коэффициент (часы, минуты, детали), по которому измеряются операции на этом рабочем центре по умолчанию; переопределения по операции вступают в силу при установке."
@@ -15400,19 +15400,19 @@ msgid "The standard factor used to measure this process — hours, minutes, piec
 msgstr "Стандартный коэффициент, используемый для измерения этого процесса — часы, минуты, детали, квадратные футы — когда его операции оцениваются и определяются."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "Состояние этой строки котировки — Черновик, Без котировки, Завершено; Без котировки раскрывает поле Причина и исключает строку из итога котировки."
+msgstr "Состояние этой строки предложения — Черновик, Отказ от предложения, Завершено; Отказ от предложения раскрывает поле Причина и исключает строку из итога предложения."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Группа отчетов, которую будут использовать все учетные записи в этой группе."
 
 msgid "The step's settings — this run predates recording the values it used."
-msgstr "Параметры шага — этот прогон предшествует записи значений, которые он использовал."
+msgstr "Настройки этого шага — этот запуск предшествует записи использованных им значений."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Размеры запасов, в которых приобретается и хранится этот материал; каждый размер становится отдельным выбираемым вариантом на задания и ПО."
+msgstr "Размеры запасов, в которых приобретается и хранится этот материал; каждый размер становится отдельным выбираемым вариантом в производственных заказах и заказах на поставку."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "Ячейка хранения, из которой эта строка выбирает; если пусто, выбор использует единицу хранения по умолчанию для товара."
+msgstr "Ячейка хранения, из которой собирается эта строка; если пусто, отбор использует единицу хранения по умолчанию для номенклатуры."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "Сервис хранилища не ответил вовремя. Пожалуйста, попробуйте еще раз."
@@ -15424,22 +15424,22 @@ msgid "The supplier planning suggests first when this item needs to be bought; o
 msgstr "Поставщик, который планирование предлагает в первую очередь, когда этот товар необходимо купить; другие поставщики остаются доступными в раскрывающемся списке на каждой строке ПО."
 
 msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
-msgstr "Запись поставщика, к которой привязана эта учетная запись портала; только контакты, уже связанные с этим поставщиком, можно выбрать в качестве владельца учетной записи ниже."
+msgstr "Запись поставщика, на которую связана эта учетная запись портала; только контактные лица, уже связанные с этим поставщиком, могут быть выбраны в качестве владельца учетной записи ниже."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
-msgstr "Собственный номер котировки/предложения поставщика; записан для отслеживаемости на ПО, которое преобразуется из этого предложения."
+msgstr "Собственный номер коммерческого предложения/предложения поставщика; записывается для прослеживаемости в заказе на поставку, который преобразуется из этого предложения."
 
 msgid "The supplier's own reference for this order (their SO number on their system); recorded for audit and surfaced on the receipt."
 msgstr "Собственная ссылка поставщика на этот заказ (их номер SO в их системе); записана для аудита и отображена в квитанции."
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "Номер упаковочного или отправочного списка поставщика, записанный для аудита; не используется никакой логикой учета."
+msgstr "Номер упаковочного листа или отгрузки поставщика, записываемый для аудита; не используется никакой логикой проведения."
 
 msgid "The suppliers and vendors you buy from"
 msgstr "Поставщики и продавцы, у которых вы покупаете"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
-msgstr "Поставщики, получающие этот RFQ; каждый получает собственную строку RFQ, на которую они отвечают своей собственной ценой."
+msgstr "Поставщики, получающие этот запрос цен; каждый получает свою строку в запросе цен, на которую они отвечают со своим ценообразованием."
 
 msgid "The surface finishes available on your materials"
 msgstr "Доступные поверхностные покрытия ваших материалов"
@@ -15448,7 +15448,7 @@ msgid "The system passes every in-scope acceptance test in your configured syste
 msgstr "Система проходит все тесты приемки в области охвата в вашей настроенной системе с вашими данными; данные проверяются; и вы подписываете акт. Затем переход в боевую эксплуатацию."
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "Цепочка, которая связывает RFQ продаж, его предложение и результирующий заказ на продажу — соединение, а не документ со своим статусом."
+msgstr "Цепь, связывающая запрос цен продаж, его коммерческое предложение и результирующий заказ покупателя — соединение, а не документ со своим собственным статусом."
 
 msgid "The timer starts automatically"
 msgstr "Таймер запускается автоматически"
@@ -15460,19 +15460,19 @@ msgid "The tooling and fixtures your operations rely on"
 msgstr "Инструменты и приспособления, на которые полагаются ваши операции"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Общее количество для производства на всех заданиях, созданных в этом массовом пакете; в сочетании с количеством на задание для определения количества заданий для создания."
+msgstr "Общее количество для производства по всем производственным заказам, созданным в этой групповой партии; в сочетании с Количество на производственный заказ решает, сколько производственных заказов создать."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "Отслеживаемая ссылка (например, стандарт NIST, серийный номер эталонного датчика), по которой сравнивались значения калибровки."
+msgstr "Прослеживаемый эталон (например, стандарт NIST, серийный номер эталонного средства измерения), с которым сравнивались значения калибровки."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
 msgstr "Маршрутный лист содержит каждый элемент спецификации материалов с его количеством."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
-msgstr "Тип управляет тем, какие разрешения по умолчанию получает новый сотрудник; выбор его здесь предварительно заполняет матрицу разрешений из шаблона типа."
+msgstr "Тип управляет тем, какие права доступа по умолчанию получает новый сотрудник; выбор его здесь предварительно заполняет матрицу разрешений из шаблона типа."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Типичное количество дней между отправкой работы этому поставщику для этого процесса и получением ее обратно; планирование компенсирует спрос на эту сумму при выборе поставщика."
+msgstr "Типичное количество дней между отправкой работы этому поставщику для этого процесса и получением её обратно; планирование смещает спрос на столько же дней при выборе поставщика."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "Уникальный идентификатор на этом физическом устройстве; одна строка на серийный номер, количество всегда 1."
@@ -15496,7 +15496,7 @@ msgid "The US tax depreciation system with IRS property-class tables, run as a s
 msgstr "Американская система налоговой амортизации с таблицами категорий имущества IRS, работающая как отдельный налоговый график вместе с графиком книг."
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
-msgstr "Пользователи в этой группе; разрешения и уведомления, определяемые группой, применяются к каждому члену, и пользователи могут принадлежать к нескольким группам (эффективные разрешения — это объединение)."
+msgstr "Пользователи в этой группе; права доступа и уведомления уровня группы применяются к каждому члену, и пользователи могут принадлежать к нескольким группам (эффективные права доступа — объединение)."
 
 msgid "The version of the new document"
 msgstr "Версия нового документа"
@@ -15511,16 +15511,16 @@ msgid "The version stamp for this procedure; new versions create a copy that sup
 msgstr "Отметка версии для этой процедуры; новые версии создают копию, которая заменяет предыдущую без ее удаления."
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "Склад, с которого будут отправлены товары этого заказа; местоположение доставки клиента - это место их прибытия."
+msgstr "Склад, с которого будут отгружены товары по этому заказу; площадка доставки покупателя — это место, где они прибудут."
 
 msgid "The warehouse goods on this quote will ship from; the customer's Shipping Location is where they'll arrive."
-msgstr "Склад, с которого будут отправлены товары этого предложения; местоположение доставки клиента - это место их прибытия."
+msgstr "Склад, с которого будут отгружены товары по этому коммерческому предложению; площадка доставки покупателя — это место, где они прибудут."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "Способы отказа оборудования для отслеживания обслуживания и качества"
+msgstr "Способы отказа оборудования для отслеживания техобслуживания и качества"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Собственный контейнер рабочего центра, где подобранный материал подготавливается для производства к использованию, в отличие от его полки-источника на складе."
+msgstr "Собственная ячейка рабочего центра, где отобранный материал подготавливается для производства, в отличие от исходной полки его склада."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Рабочие часы и календари, которые управляют планированием"
@@ -15547,46 +15547,46 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "Эти пользовательские поля будут доступны только для сущностей с одинаковыми тегами"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Эти документы не опубликованы в главной книге, поэтому их суммы отсутствуют в этом периоде. Опубликуйте или аннулируйте каждый — неотдатированный документ получает дату публикации при его публикации."
+msgstr "Эти документы не проведены в главную книгу, поэтому их суммы отсутствуют в этом периоде. Проведите или аннулируйте каждый из них — документ без даты получит дату проведения при проведении."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "Эти адреса электронной почты будут автоматически добавлены в копию на все письма, отправляемые поставщикам (предложения, заказы на покупку и т. д.)."
 
 msgid "These email addresses will be automatically CC'd on all quote emails sent to customers."
-msgstr "Эти адреса электронной почты будут автоматически добавлены в копию на все письма с предложениями, отправляемые клиентам."
+msgstr "Эти адреса электронной почты будут автоматически скопированы во все письма коммерческих предложений, отправляемые покупателям."
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
 msgstr "У этих товаров все еще есть материал для комплектации. Завершение сейчас отметит список как Частичный."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Эти задания имеют операции, назначенные этому рабочему центру:"
+msgstr "Эти производственные заказы имеют операции, назначенные этому рабочему центру:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Эти записи в журнале всё ещё находятся в статусе «Черновик», поэтому их дебеты и кредиты не находятся в главной книге за этот период. Опубликуйте каждую или переделируйте её на более поздний открытый период."
+msgstr "Эти операции по-прежнему находятся в режиме Черновик, поэтому их дебеты и кредиты не включены в главную книгу для этого периода. Проведите каждый из них или переведите его в более поздний открытый период."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "В этом экземпляре Carbon отсутствуют учётные данные OAuth для Onshape. Попросите администратора настроить их."
 
 msgid "This change notice is being implemented, so its changes are locked. Reopen it to edit."
-msgstr "Это уведомление об изменении реализуется, поэтому его изменения заблокированы. Откройте его повторно, чтобы отредактировать."
+msgstr "Это извещение об изменении внедряется, поэтому его изменения заблокированы. Откройте его заново для редактирования."
 
 msgid "This change notice is closed, so its changes are read-only."
-msgstr "Это уведомление об изменении закрыто, поэтому его изменения доступны только для чтения."
+msgstr "Это извещение об изменении закрыто, поэтому его изменения доступны только для чтения."
 
 msgid "This completes the Discovery step."
-msgstr "Это завершает этап Discovery."
+msgstr "Этим завершается этап обнаружения."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Это контактное лицо не имеет адреса электронной почты"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Эта контрагент не имеет задолженности — платеж будет записан на счет."
 
 msgid "This download link is invalid or has been tampered with."
-msgstr "Эта ссылка для скачивания недействительна или была изменена."
+msgstr "Эта ссылка для скачивания недействительна или была подделана."
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "Этот файл больше не доступен, или у вас нет разрешения на его загрузку."
+msgstr "Этот файл больше недоступен, или у вас нет права доступа для его скачивания."
 
 msgid "This Fiscal Year"
 msgstr "Этот финансовый год"
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Эта информация будет видна всем пользователям, поэтому будьте осторожны с тем, что вы делитесь."
 
 msgid "this inspection plan"
-msgstr "этот план проверки"
+msgstr "этот план контроля"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr "Это приглашение присоединиться к {0} истекло. Вы можете запросить новое приглашение, которое будет отправлено на вашу электронную почту."
+msgstr "Это приглашение присоединиться к {0} истекло. Вы можете запросить отправку нового приглашения на вашу электронную почту."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Этот счет-фактура не имеет используемого срока выполнения — выберите один для Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его детали, отредактируйте его в панели инструментов Stripe."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Это контролируемая среда, поэтому требуется приложение аутентификации."
@@ -15638,22 +15638,22 @@ msgid "this item"
 msgstr "этот товар"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Этот элемент строится через конфигуратор и разрешает его компоненты в зависимости от заказа; задания, созданные для него, наследуют разрешенный BOM конфигуратора."
+msgstr "Эта номенклатура собирается через конфигуратор и разрешает свои компоненты для каждого заказа; производственные заказы, созданные для нее, наследуют разрешенный BOM конфигуратора."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "У этого товара в спецификации материалов нет входов с включенной политикой срока хранения, поэтому срок годности не будет рассчитан на основе спецификации."
+msgstr "Спецификация этой номенклатуры не имеет входов с включенным сроком хранения, поэтому срок годности не будет рассчитан из BOM."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "Эта работа будет получена в инвентарь. Она больше не будет доступна на производственном полу."
+msgstr "Этот производственный заказ будет получен в запасы. Он больше не будет доступен в цехе."
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "Эта работа больше не будет доступна на производственном участке."
+msgstr "Этот производственный заказ больше не будет доступен в цехе."
 
 msgid "This job's own required quantity for the material."
 msgstr "Собственное требуемое количество материала для этого задания."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Эта партия истекла и не может быть выбрана."
+msgstr "Эта партия с истекшим сроком и не может быть отобрана."
 
 msgid "This may take a moment. Hang tight."
 msgstr "Это может занять некоторое время. Не волнуйтесь."
@@ -15665,13 +15665,13 @@ msgid "This Month"
 msgstr "Этот месяц"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "Эта страница вашего Implementation Hub находится в разработке. Начните с командного центра, пока мы её завершаем."
+msgstr "Эта страница вашего центра внедрения разрабатывается. Начните с командного центра, пока мы его завершаем."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "Эта деталь имеет {quantityOnHand} на складе в этом месте. Режим \"No Stock\" означает, что она не будет ни планироваться, ни использоваться."
 
 msgid "This part is activated when change notice {activationLockId} is released."
-msgstr "Эта деталь будет активирована после выпуска уведомления об изменении {activationLockId}."
+msgstr "Эта деталь активизируется при запуске извещения об изменении {activationLockId}."
 
 msgid "This part is being phased out."
 msgstr "Эта деталь снимается с производства."
@@ -15680,28 +15680,28 @@ msgid "This part is obsolete (No Stock)."
 msgstr "Эта деталь снята с производства (нет в наличии)."
 
 msgid "This part is superseded and set to Stock Only — it's replenished to its spares reserve floor, independent of demand."
-msgstr "Эта деталь снята с производства и установлена в режим «Только запас» — она пополняется до минимального уровня резервного запаса независимо от спроса."
+msgstr "Эта деталь снята с производства и установлена в режим Только на запас — она пополняется до уровня резерва запасных частей, независимо от потребности."
 
 msgid "This path only decides what runs next"
 msgstr "Этот путь решает только, что будет запущено дальше"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "В этот период не размещены записи журнала, и он может быть окончательно удален. Это действие нельзя отменить."
+msgstr "Этот период не имеет проведенных операций и может быть безвозвратно удален. Это невозможно отменить."
 
 msgid "this purchase order"
-msgstr "этот заказ на покупку"
+msgstr "этот заказ поставщику"
 
 msgid "This Quarter"
 msgstr "Этот квартал"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "Это удаляет их приложение аутентификации, поэтому при следующем входе потребуется только магическая ссылка. Используйте это, когда они потеряли доступ к своему аутентификатору. Это влияет на их вход во все компании, к которым они принадлежат."
+msgstr "Это удаляет их приложение аутентификатора, поэтому их следующий вход требует только волшебной ссылки. Используйте это, когда они потеряли доступ к своему аутентификатору. Это влияет на их вход для каждой организации, которой они принадлежат."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "Эта редакция выпущена (Производство). Изменения должны нормально проходить через уведомление об изменении."
+msgstr "Эта ревизия запущена (Производство). Изменения должны нормально проходить через извещение об изменении."
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "Эта редакция выпущена (Производство). Откройте уведомление об изменении, чтобы изменить его."
+msgstr "Эта ревизия запущена (Производство). Откройте извещение об изменении для его изменения."
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "Этот прогон имеет больше шагов, чем мы показываем здесь. Показаны только первые {MAX_RUN_STEPS}."
@@ -15710,20 +15710,20 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Это запускает рабочий процесс по-настоящему. Он создаст записи, отправит уведомления и вызовет любые вебхуки точно так же, как это делал бы реальный прогон. Это нельзя отменить."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Этот заказ на продажу имеет связанные работы. Выберите, что с ними делать."
+msgstr "Этот заказ покупателя имеет связанные производственные заказы. Выберите, что с ними делать."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Этот заказ на продажу содержит строки, для которых необходимо создать задания"
+msgstr "Этот заказ покупателя имеет строки, требующие создания производственных заказов"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
-msgstr "Этот тип хранилища в настоящее время используется {usageCount} хранилищем{0}."
+msgstr "Этот тип хранения в настоящее время используется {usageCount} единиц хранения{0}."
 
 msgid "this supplier"
 msgstr "этот поставщик"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
-msgstr "Этот инструмент будет активирован после выпуска уведомления об изменении {activationLockId}."
+msgstr "Этот инструмент активизируется при запуске извещения об изменении {activationLockId}."
 
 msgid "This updates the theme for all users of the application"
 msgstr "Это обновляет тему для всех пользователей приложения"
@@ -15735,20 +15735,20 @@ msgid "This usually takes a few seconds. You can leave the page — it keeps run
 msgstr "Обычно это занимает несколько секунд. Вы можете оставить страницу — она продолжит работу."
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
-msgstr "Эта версия принадлежит открытому <0>уведомлению об изменении</0>. Отредактируйте его там."
+msgstr "Эта версия принадлежит открытому <0>извещению об изменении</0>. Отредактируйте его там."
 
 #. placeholder {0}: lock.readableId
 msgid "This version belongs to change notice <0>{0}</0>. Edit it there."
-msgstr "Эта версия принадлежит уведомлению об изменении <0>{0}</0>. Отредактируйте его там."
+msgstr "Эта версия принадлежит <0>извещению об изменении {0}</0>. Отредактируйте его там."
 
 msgid "This version cannot be opened"
 msgstr "Эта версия не может быть открыта"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Эта версия опубликована"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Эта версия опубликована. Создайте новую версию для редактирования."
 
 msgid "This version's definition could not be read."
 msgstr "Определение этой версии не удалось прочитать."
@@ -15771,22 +15771,22 @@ msgstr "Это пересчитает себестоимость единицы 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
 msgid "This will remove {0}'s link to {1}. The job will no longer appear under the sales order and shipments won't find it."
-msgstr "Это удалит связь {0} с {1}. Задание больше не будет отображаться в заказе на продажу, и отправки его не найдут."
+msgstr "Это удалит ссылку {0} на {1}. Производственный заказ больше не будет отображаться под заказом покупателя, и отгрузки его не найдут."
 
 msgid "This will replace all method materials of other revisions with this revision."
-msgstr "Это заменит все материалы методов других редакций на эту редакцию."
+msgstr "Это заменит все материалы метода других ревизий этой ревизией."
 
 msgid "This will replace all method materials of other sizes with this size."
 msgstr "Это заменит все материалы методов других размеров на этот размер."
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "Это установит текущую версию способа изготовления на активную, сделав её доступной только для чтения."
+msgstr "Это установит текущую версию метода производства в активный, сделав его доступным только для чтения."
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "Это спишет оставшуюся чистую балансовую стоимость актива."
 
 msgid "Three-way match"
-msgstr "Трёхсторонняя сверка"
+msgstr "Трехстороннее сопоставление"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15814,7 +15814,7 @@ msgid "Thursday"
 msgstr "Четверг"
 
 msgid "Tie shipments through to an invoice with no re-keying"
-msgstr "Связать отправки с счетом без повторного ввода данных"
+msgstr "Связать отгрузки со счетом-фактурой без повторного ввода данных"
 
 msgid "Tie-out"
 msgstr "Согласование"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Сверка недоступна"
 
 msgid "Tightened"
-msgstr "Ужесточенный"
+msgstr "Усиленный"
 
 msgid "Time of day"
 msgstr "Время суток"
@@ -15862,16 +15862,16 @@ msgid "To reactivate, use the row menu and choose Send Invite. The employee beco
 msgstr "Чтобы переактивировать, используйте меню строки и выберите Отправить приглашение. Сотрудник становится активным после принятия приглашения."
 
 msgid "To Receive"
-msgstr "К получению"
+msgstr "Ожидает приемки"
 
 msgid "To Ship"
-msgstr "К отправке"
+msgstr "К отгрузке"
 
 msgid "To Ship and Receive"
-msgstr "К отправке и получению"
+msgstr "К отгрузке и приемке"
 
 msgid "To Storage Unit"
-msgstr "На хранилище"
+msgstr "В единицу хранения"
 
 msgid "To supplier"
 msgstr "Поставщику"
@@ -15886,7 +15886,7 @@ msgid "Toggle"
 msgstr "Переключить"
 
 msgid "Toggle Assignee"
-msgstr "Переключить назначенного"
+msgstr "Переключить исполнителя"
 
 msgid "Toggle break active"
 msgstr "Переключить активность разбиения"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Инструменты"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Классификация верхнего уровня (активы/пассивы/собственный капитал/доходы/расходы); устанавливается только в корневых группах, наследуется дочерними."
+msgstr "Верхнеуровневая классификация (активы/обязательства/собственный капитал/выручка/расходы); устанавливается только в корневых группах, наследуется подчиненными"
 
 msgid "Topic"
 msgstr "Тема"
@@ -15955,13 +15955,13 @@ msgid "Total Amount"
 msgstr "Общая сумма"
 
 msgid "Total capitalized cost of the asset (purchase price plus freight, install, and other costs that become part of book value)."
-msgstr "Общая капитализированная стоимость актива (цена покупки плюс доставка, установка и другие затраты, которые становятся частью чистой балансовой стоимости)."
+msgstr "Итоговая капитализированная стоимость актива (цена покупки плюс доставка, установка и другие затраты, которые становятся частью балансовой стоимости)."
 
 msgid "Total discount"
 msgstr "Общая скидка"
 
 msgid "Total expected production units for units-of-production depreciation; cost is spread per unit produced."
-msgstr "Всего ожидаемые производственные единицы для амортизации производственных единиц; стоимость распределяется на произведенную единицу."
+msgstr "Итоговое ожидаемое количество производимых единиц для амортизации по единицам производства; стоимость распределяется на производимую единицу."
 
 msgid "Total Hours"
 msgstr "Всего часов"
@@ -15976,10 +15976,10 @@ msgid "Total Quantity"
 msgstr "Общее количество"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "Общее наличное количество позиции по всем складским единицам в этом местоположении. Становится красным, когда наличие плюс поступления не покрывают общий спрос."
+msgstr "Итоговый остаток на складе для номенклатуры по всем единицам хранения в этой площадке. Становится красным, когда остаток на складе плюс входящий не может покрыть общий спрос."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Общее требуемое количество по всем активным заданиям и заказам на продажу в этом местоположении — не только по этому заданию."
+msgstr "Общее количество, требуемое для всех активных производственных заказов и заказов покупателей на этой площадке — не только для этого производственного заказа"
 
 msgid "Total scrap quantity"
 msgstr "Общее количество брака"
@@ -16000,25 +16000,25 @@ msgid "Totals"
 msgstr "Итоги"
 
 msgid "Traceability"
-msgstr "Отслеживаемость"
+msgstr "Прослеживаемость"
 
 msgid "Track"
 msgstr "Отслеживание"
 
 msgid "Track changes to key business entities including invoices, orders, customers, suppliers, and more."
-msgstr "Отслеживайте изменения ключевых бизнес-сущностей, включая счета-фактуры, заказы, клиентов, поставщиков и многое другое."
+msgstr "Отслеживать изменения ключевых бизнес-сущностей, включая счета-фактуры, заказы, покупателей, поставщиков и многое другое."
 
 msgid "Track every change to your orders, invoices, customers, and more."
-msgstr "Отслеживайте каждое изменение ваших заказов, счетов, клиентов и многого другого."
+msgstr "Отслеживать каждое изменение ваших заказов, счетов-фактур, покупателей и многого другого."
 
 msgid "Track every change to your orders, invoices, customers, suppliers, and more."
-msgstr "Отслеживайте каждое изменение ваших заказов, счетов, клиентов, поставщиков и многого другого."
+msgstr "Отслеживать каждое изменение ваших заказов, счетов-фактур, покупателей, поставщиков и многого другого."
 
 msgid "Track real-time inventory by location and bin"
 msgstr "Отслеживайте инвентарь в реальном времени по местоположению и ячейке"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
-msgstr "Отслеживайте серийные номера и номера партий, выполняйте заказы на продажу."
+msgstr "Отслеживайте серийные номера/партии и выполняйте заказы покупателей"
 
 msgid "Track tax depreciation separately"
 msgstr "Отслеживать налоговую амортизацию отдельно"
@@ -16036,16 +16036,16 @@ msgid "Tracked Entities"
 msgstr "Отслеживаемые сущности"
 
 msgid "Tracked entity"
-msgstr "Отслеживаемая сущность"
+msgstr "Отслеживаемый объект"
 
 msgid "Tracked Entity"
-msgstr "Отслеживаемая сущность"
+msgstr "Отслеживаемый объект"
 
 msgid "Tracked entity ID is required but none was found"
-msgstr "ID отслеживаемой сущности требуется, но ничего не найдено"
+msgstr "Требуется идентификатор отслеживаемого объекта, но ничего не найдено"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "Отслеживаемый материал предварительно выбирается по порядку выборки (FEFO), даже без листа подбора."
+msgstr "Отслеживаемый материал предварительно выбирается в порядке отбора (FEFO), даже без листа отбора"
 
 msgid "Tracking"
 msgstr "Отслеживание"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "Обучение"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "Транзакции создадут записи в журнале и обновят главную книгу."
+msgstr "Операции создадут записи и обновят Главную книгу"
 
 msgid "Transfer"
 msgstr "Передача"
@@ -16111,13 +16111,13 @@ msgid "Transfer ID"
 msgstr "ID передачи"
 
 msgid "Transfer Lines"
-msgstr "Строки передачи"
+msgstr "Строки перемещения"
 
 msgid "Transfer Ownership"
 msgstr "Передать право собственности"
 
 msgid "Transfer ownership of this company to another user"
-msgstr "Передайте право собственности на эту компанию другому пользователю"
+msgstr "Передайте право собственности на эту организацию другому пользователю"
 
 msgid "Transfer To"
 msgstr "Передать в"
@@ -16126,7 +16126,7 @@ msgid "Trash"
 msgstr "Корзина"
 
 msgid "Trial Balance"
-msgstr "Пробный баланс"
+msgstr "Сальдовая ведомость"
 
 msgid "Trigger"
 msgstr "Триггер"
@@ -16180,7 +16180,7 @@ msgid "Type an email and press Enter to add an external recipient"
 msgstr "Введите адрес электронной почты и нажмите Enter, чтобы добавить внешнего получателя"
 
 msgid "Type of Permission Update"
-msgstr "Тип обновления разрешений"
+msgstr "Тип обновления прав доступа"
 
 msgid "Type to search across your workspace"
 msgstr "Введите текст для поиска в вашем рабочем пространстве"
@@ -16219,13 +16219,13 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Неучтённые строки остаются неизменными при отправке — они не обнуляются."
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "При переупорядочении на основе спроса планирование суммирует спрос в пределах этого скользящего окна при расчете количества пополнения."
+msgstr "При переупорядочении на основе потребности планирование суммирует потребность в этом скользящем окне при расчете количества пополнения"
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "При фиксированном количестве переупорядочения плановые заказы выполняются в точном количестве каждый раз при срабатывании точки переупорядочения."
+msgstr "При политике фиксированного количества пополнения планирование заказывает точное количество каждый раз, когда срабатывает точка заказа"
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "При политике максимального количества плановые заказы выполняются до этого уровня наличного запаса при срабатывании точки переупорядочения."
+msgstr "При политике максимального количества планирование заказывает до этого уровня остатка на складе, когда срабатывает точка заказа"
 
 msgid "Undo"
 msgstr "Отменить"
@@ -16240,7 +16240,7 @@ msgid "Unit"
 msgstr "Единица"
 
 msgid "Unit Cost"
-msgstr "Стоимость единицы"
+msgstr "Себестоимость за единицу"
 
 msgid "unit of measure"
 msgstr "единица измерения"
@@ -16270,7 +16270,7 @@ msgid "Units"
 msgstr "Единицы"
 
 msgid "Units of base currency per one unit of this currency; used to translate amounts on posting."
-msgstr "Единицы базовой валюты за одну единицу этой валюты; используется для преобразования сумм при проводке."
+msgstr "Единицы базовой валюты за одну единицу этой валюты; используется для преобразования сумм при проведении"
 
 msgid "units of measure"
 msgstr "единицы измерения"
@@ -16279,7 +16279,7 @@ msgid "Units of measure"
 msgstr "Единицы измерения"
 
 msgid "Units reported as unrecoverable at an operation, with a reason — the alternative to rework."
-msgstr "Единицы, указанные как невозвратные при операции с причиной — альтернатива переработке."
+msgstr "Единицы, объявленные неремонтируемыми на операции с указанием причины — альтернатива доработке"
 
 msgid "Unknown"
 msgstr "Неизвестно"
@@ -16291,28 +16291,28 @@ msgid "unknown location"
 msgstr "неизвестное местоположение"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Неограниченная функциональная поддержка"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Неограниченное количество записей"
 
 msgid "Unlink"
 msgstr "Отменить связь"
 
 msgid "Unlink job from sales order?"
-msgstr "Отменить связь задания с заказом на продажу?"
+msgstr "Отсоединить производственный заказ от заказа покупателя?"
 
 msgid "Unlock"
 msgstr "Разблокировать"
 
 msgid "Unlock with passkey"
-msgstr "Разблокировка с помощью Passkey"
+msgstr "Разблокировать с помощью ключа доступа"
 
 msgid "Unmapped accounts"
 msgstr "Несопоставленные счета"
 
 msgid "Unmapped dimension values"
-msgstr "Неотображенные значения размерности"
+msgstr "Неотображенные значения измерений"
 
 msgid "Unmapped Extracted Lines"
 msgstr "Неотображённые извлечённые строки"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Неопубликованные документы"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Отменить публикацию"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Отменить публикацию {name}?"
 
 msgid "Unreceived POs"
 msgstr "Неполученные ПО"
@@ -16360,7 +16360,7 @@ msgid "Unshipped orders"
 msgstr "Невыполненные заказы"
 
 msgid "Unsupported source document type: {sourceDocument}"
-msgstr "Неподдерживаемый тип исходного документа: {sourceDocument}"
+msgstr "Неподдерживаемый тип документа-основания: {sourceDocument}"
 
 msgid "Untitled Diagram"
 msgstr "Безымянная диаграмма"
@@ -16378,13 +16378,13 @@ msgid "Update"
 msgstr "Обновить"
 
 msgid "Update a customer"
-msgstr "Обновить клиента"
+msgstr "Обновить покупателя"
 
 msgid "Update a job"
 msgstr "Обновить работу"
 
 msgid "Update a purchase order"
-msgstr "Обновить заказ на покупку"
+msgstr "Обновить Заказ поставщику"
 
 msgid "Update a quote"
 msgstr "Обновить предложение"
@@ -16393,7 +16393,7 @@ msgid "Update a receipt"
 msgstr "Обновить приходную накладную"
 
 msgid "Update a sales order"
-msgstr "Обновить заказ на продажу"
+msgstr "Обновить Заказ покупателя"
 
 msgid "Update a shipment"
 msgstr "Обновить отгрузку"
@@ -16408,7 +16408,7 @@ msgid "Update an item"
 msgstr "Обновить товар"
 
 msgid "Update costs on"
-msgstr "Обновлять стоимость на"
+msgstr "Обновить Себестоимость на"
 
 msgid "Update Inventory"
 msgstr "Обновить инвентарь"
@@ -16417,7 +16417,7 @@ msgid "Update Jira issue"
 msgstr "Обновить задачу Jira"
 
 msgid "Update Kanban"
-msgstr "Обновить Kanban"
+msgstr "Обновить Канбан"
 
 msgid "Update Linear issue"
 msgstr "Обновить задачу Linear"
@@ -16429,7 +16429,7 @@ msgid "Update Password"
 msgstr "Обновить пароль"
 
 msgid "Update Permissions"
-msgstr "Обновить разрешения"
+msgstr "Обновить Права доступа"
 
 msgid "Update Projection"
 msgstr "Обновить прогноз"
@@ -16441,13 +16441,13 @@ msgid "Update Rule"
 msgstr "Обновить правило"
 
 msgid "Update source document quantities"
-msgstr "Обновить количества исходного документа"
+msgstr "Обновить количества в документе-основании"
 
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Обновите информацию канбана для пополнения на основе сканирования."
 
 msgid "Update the purchase order quantities"
-msgstr "Обновить количества в заказе на покупку"
+msgstr "Обновить количества Заказа поставщику"
 
 msgid "Updated"
 msgstr "Обновлено"
@@ -16528,7 +16528,7 @@ msgid "Usage/Day (90d)"
 msgstr "Использование/День (90д)"
 
 msgid "Use ... to get the next consumable ID"
-msgstr "Используйте ... для получения следующего ID расходника"
+msgstr "Используйте ... для получения следующего ID Расходного материала"
 
 msgid "Use ... to get the next material ID"
 msgstr "Используйте ... для получения следующего ID материала"
@@ -16549,13 +16549,13 @@ msgid "Use a different email"
 msgstr "Использовать другой адрес электронной почты"
 
 msgid "Use metric system for default material dimensions."
-msgstr "Используйте метрическую систему для размеров материалов по умолчанию."
+msgstr "Используйте метрическую систему для измерений материала по умолчанию."
 
 msgid "Used In"
 msgstr "Используется в"
 
 msgid "Used in the navigation and on documents like sales orders"
-msgstr "Используется в навигации и в документах, таких как заказы на продажу"
+msgstr "Используется в навигации и в документах, таких как Заказы покупателя"
 
 msgid "Used in the navigation in dark mode"
 msgstr "Используется в навигации в темном режиме"
@@ -16573,13 +16573,13 @@ msgid "Used when a cell is empty or doesn't match an option above. Clear it to l
 msgstr "Используется, когда ячейка пуста или не соответствует ни одному из вариантов выше. Очистите ее, чтобы оставить эти строки пустыми."
 
 msgid "Useful Life (default)"
-msgstr "Полезное использование (по умолчанию)"
+msgstr "Срок полезного использования (по умолчанию)"
 
 msgid "Useful Life (months)"
-msgstr "Полезное использование (месяцы)"
+msgstr "Срок полезного использования (месяцы)"
 
 msgid "Useful Life (Months)"
-msgstr "Полезное использование (Месяцы)"
+msgstr "Срок полезного использования (месяцы)"
 
 msgid "User"
 msgstr "Пользователь"
@@ -16594,10 +16594,10 @@ msgid "Users"
 msgstr "Пользователи"
 
 msgid "Users and groups allowed to open or download this document; the uploader is always included."
-msgstr "Пользователи и группы, которым разрешено открывать или скачивать этот документ; загрузивший всегда включён."
+msgstr "Пользователи и группы, имеющие право на открытие или скачивание этого документа; загрузивший документ пользователь всегда включен."
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "Пользователи и группы, которым разрешено переименовывать, заменять или менять метки у этого документа; загрузивший всегда включён, а доступ на редактирование подразумевает доступ на просмотр."
+msgstr "Пользователи и группы, которым разрешено переименовывать, заменять или переименовать метку этого документа; загрузивший всегда включен, и доступ Изменить подразумевает доступ Просмотр."
 
 msgid "Users can update this value for themselves"
 msgstr "Пользователи могут обновлять это значение для себя"
@@ -16615,7 +16615,7 @@ msgid "Valid To"
 msgstr "Действительно до"
 
 msgid "Validate a sample and approve the migrated data"
-msgstr "Проверьте образец и одобрите перенесенные данные"
+msgstr "Проверить образец и Утвердить перенесенные данные"
 
 msgid "validated"
 msgstr "проверено"
@@ -16636,13 +16636,13 @@ msgid "Value source by surface"
 msgstr "Источник значения по поверхности"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
-msgstr "Номер регистрации налога на добавленную стоимость; требуется в счетах ЕС для поставок с обратным взиманием налога или с нулевой ставкой."
+msgstr "Номер регистрации для целей налога на добавленную стоимость; требуется в счетах-фактурах ЕС для обратного взимания налога или нулевых ставок."
 
 msgid "Values"
 msgstr "Значения"
 
 msgid "Values apply today's unit costs to historical quantities."
-msgstr "Значения применяют текущие цены за единицу к историческим количествам."
+msgstr "Значения применяют сегодняшние себестоимость на единицу к историческим количествам."
 
 msgid "Values in this run have been summarised. Full detail is kept for 7 days."
 msgstr "Значения в этом запуске были сведены. Полные детали хранятся 7 дней."
@@ -16651,31 +16651,31 @@ msgid "Variables"
 msgstr "Переменные"
 
 msgid "Variance"
-msgstr "Расхождение"
+msgstr "Отклонение"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Расхождение между фактическим и стандартным потреблением компонентов спецификации"
+msgstr "Отклонение между фактическим и нормальным потреблением компонентов BOM"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Расхождение между фактическими и стандартными часами маршрутизации и ставками"
+msgstr "Отклонение между фактическими и нормальными часами маршрута и ставками"
 
 msgid "Variance between actual purchase price and standard cost"
-msgstr "Расхождение между фактической ценой покупки и стандартной стоимостью"
+msgstr "Отклонение между фактической ценой покупки и Нормативной себестоимостью"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Расхождение между применяемыми и фактическими производственными накладными расходами"
+msgstr "Отклонение между применёнными и фактическими производственными накладными расходами"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "Расхождение от корректировок счета физического инвентаря"
+msgstr "Отклонение от Корректировки физического подсчета запасов"
 
 msgid "Variance in outside processing costs"
-msgstr "Расхождение в затратах на внешнюю обработку"
+msgstr "Отклонение в затратах на кооперацию"
 
 msgid "Variance only"
 msgstr "Только отклонения"
 
 msgid "VAT Number"
-msgstr "Номер НДС"
+msgstr "ИНН"
 
 msgid "Vendor Write-Off Income"
 msgstr "Доход от списания задолженности перед поставщиком"
@@ -16703,7 +16703,7 @@ msgstr "Версия"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Версия {0} опубликована сейчас и будет заменена."
 
 msgid "Version:"
 msgstr "Версия:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Просмотр"
 
 msgid "View Active Jobs"
-msgstr "Просмотр активных заданий"
+msgstr "Просмотр Активных Производственных заказов"
 
 msgid "View Active Quotes"
 msgstr "Просмотреть активные предложения"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Просмотр актива"
 
 msgid "View Assigned Jobs"
-msgstr "Просмотр назначенных заданий"
+msgstr "Просмотр Назначенных Производственных заказов"
 
 msgid "View Attachment"
 msgstr "Просмотреть вложение"
@@ -16748,7 +16748,7 @@ msgid "View Certificate"
 msgstr "Просмотр сертификата"
 
 msgid "View Contact"
-msgstr "Просмотр контакта"
+msgstr "Просмотр контактного лица"
 
 msgid "View Contained Issues"
 msgstr "Просмотреть содержащиеся проблемы"
@@ -16760,7 +16760,7 @@ msgid "View Custom Fields"
 msgstr "Просмотр пользовательских полей"
 
 msgid "View Customers"
-msgstr "Просмотр клиентов"
+msgstr "Просмотр Покупателей"
 
 msgid "View Employees"
 msgstr "Просмотр сотрудников"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Просмотр основных данных товара"
 
 msgid "View Journal Entry"
-msgstr "Просмотр записи в журнале"
+msgstr "Просмотр Проводки"
 
 msgid "View Lists"
 msgstr "Просмотр списков"
 
 msgid "View maintenance dispatch"
-msgstr "Просмотр заказа на техническое обслуживание"
+msgstr "Просмотр Заявки на техобслуживание"
 
 msgid "View Memo"
 msgstr "Просмотр Memo"
@@ -16796,7 +16796,7 @@ msgid "View missing values"
 msgstr "Просмотреть отсутствующие значения"
 
 msgid "View notes"
-msgstr "Просмотр заметок"
+msgstr "Просмотр Примечаний"
 
 msgid "View Open"
 msgstr "Просмотреть открытые"
@@ -16805,7 +16805,7 @@ msgid "View Open Actions"
 msgstr "Просмотреть открытые действия"
 
 msgid "View Open Invoices"
-msgstr "Просмотреть открытые счета"
+msgstr "Просмотр открытых счетов-фактур"
 
 msgid "View Open Issues"
 msgstr "Просмотреть открытые проблемы"
@@ -16832,13 +16832,13 @@ msgid "View Period"
 msgstr "Просмотр периода"
 
 msgid "View permissions"
-msgstr "Права просмотра"
+msgstr "Просмотр прав доступа"
 
 msgid "View Permissions"
-msgstr "Разрешения на просмотр"
+msgstr "Просмотр Прав доступа"
 
 msgid "View Picking List"
-msgstr "Просмотр списка комплектации"
+msgstr "Просмотр Листа отбора"
 
 msgid "View Prints"
 msgstr "Просмотр печатей"
@@ -16847,7 +16847,7 @@ msgid "View Production Events"
 msgstr "Просмотр событий производства"
 
 msgid "View Purchase Invoice"
-msgstr "Просмотреть счет-фактуру покупки"
+msgstr "Просмотр счета-фактуры полученного"
 
 msgid "View Reactive"
 msgstr "Просмотреть реактивные"
@@ -16865,7 +16865,7 @@ msgid "View Scheduled"
 msgstr "Просмотреть запланированные"
 
 msgid "View Shipment"
-msgstr "Просмотр отправки"
+msgstr "Просмотр Отгрузки"
 
 msgid "View Status"
 msgstr "Просмотр статуса"
@@ -16886,7 +16886,7 @@ msgid "View tie-out"
 msgstr "Просмотр согласования"
 
 msgid "View Traceability Graph"
-msgstr "Просмотр графика отслеживания"
+msgstr "Просмотр графика прослеживаемости"
 
 msgid "View Transfer"
 msgstr "Просмотр передачи"
@@ -16904,34 +16904,34 @@ msgid "Void"
 msgstr "Аннулировать"
 
 msgid "Void Invoice"
-msgstr "Аннулировать счет"
+msgstr "Аннулировать счет-фактуру"
 
 msgid "Void Purchase Invoice"
-msgstr "Аннулировать счет-фактуру покупки"
+msgstr "Аннулировать счет-фактуру полученную"
 
 msgid "Void Receipt"
 msgstr "Аннулировать квитанцию"
 
 msgid "Void Sales Invoice"
-msgstr "Аннулировать счет-фактуру продажи"
+msgstr "Аннулировать счет-фактуру выданную"
 
 msgid "Void Shipment"
-msgstr "Аннулировать отправку"
+msgstr "Аннулировать отгрузку"
 
 msgid "Voided"
 msgstr "Аннулировано"
 
 msgid "Voiding this purchase invoice will:"
-msgstr "Аннулирование этого счета-фактуры покупки приведет к:"
+msgstr "Аннулирование этой счет-фактуры полученной приведет к:"
 
 msgid "Voiding this receipt will:"
 msgstr "Аннулирование этого чека приведет к:"
 
 msgid "Voiding this shipment will:"
-msgstr "Отмена этой отправки приведет к:"
+msgstr "Аннулирование этой отгрузки приведет к:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Пройдите каждую область со своим чемпионом и отключите все, что выходит за рамки. Коды читаются как Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Проведите обзор каждой области вместе с вашим лидером и отключите всё, что выходит за границы проекта. Коды читаются как Модуль.Область.Номер (ACC.GL.01 = Бухгалтерия, Главная книга, элемент 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Пройдитесь по вашему текущему процессу, системам и данным"
@@ -16952,13 +16952,13 @@ msgid "Warn"
 msgstr "Предупреждение"
 
 msgid "Warn — edits succeed with a warning"
-msgstr "Предупреждение — редактирование выполнено с предупреждением"
+msgstr "Предупредить — изменения выполняются с предупреждением"
 
 msgid "Warn but allow"
 msgstr "Предупредить, но разрешить"
 
 msgid "Warn this many days before expiry"
-msgstr "Предупредить за столько дней до истечения срока"
+msgstr "Предупредить за столько дней до срока годности"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
 msgstr "Предупреждать, когда лицо, проверяющее входящий товар, является тем же лицом, которое его получило."
@@ -16973,7 +16973,7 @@ msgid "Watch full video"
 msgstr "Смотреть полное видео"
 
 msgid "We auto-matched each column. Review the values below before continuing."
-msgstr "Мы автоматически сопоставили каждый столбец. Проверьте приведенные ниже значения перед продолжением."
+msgstr "Мы автоматически сопоставили каждый столбец. Рассмотрите значения ниже перед продолжением."
 
 msgid "We triage and fix issues fast while your team settles in"
 msgstr "Мы быстро разбираемся с проблемами и их решаем, пока ваша команда адаптируется"
@@ -16991,16 +16991,16 @@ msgid "Webhook"
 msgstr "Вебхук"
 
 msgid "Webhook Body"
-msgstr "Тело Webhook"
+msgstr "Тело вебхука"
 
 msgid "Webhook Documentation"
 msgstr "Документация по вебхукам"
 
 msgid "Webhook Headers"
-msgstr "Заголовки Webhook"
+msgstr "Заголовки вебхука"
 
 msgid "Webhook Method"
-msgstr "Метод Webhook"
+msgstr "Метод вебхука"
 
 msgid "Webhook URL"
 msgstr "URL вебхука"
@@ -17039,7 +17039,7 @@ msgid "Weekly"
 msgstr "Еженедельно"
 
 msgid "Weekly demand"
-msgstr "Еженедельный спрос"
+msgstr "Еженедельная потребность"
 
 #. placeholder {0}: Math.round(startWeek) + 1
 #. placeholder {1}: Math.round(endWeek)
@@ -17068,7 +17068,7 @@ msgid "Weighted Average"
 msgstr "Средневзвешенное значение"
 
 msgid "Weighted average cost over last year calculated when the invoice is posted"
-msgstr "Средневзвешенная стоимость за последний год, рассчитанная при проводке счета"
+msgstr "Взвешенная средняя себестоимость за последний год рассчитывается при проведении счета-фактуры"
 
 msgid "Welcome to Carbon"
 msgstr "Добро пожаловать в Carbon"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Что повлияло на инвентаризацию вверх или вниз, по любому измерению"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Что происходит, когда журнал датирован в закрытом периоде."
+msgstr "Что происходит, когда операция датирована в заблокированный период."
 
 msgid "What is {translatedTerm}?"
 msgstr "Что такое {translatedTerm}?"
@@ -17101,37 +17101,37 @@ msgid "What it is"
 msgstr "Что это такое"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "Какой это вид изменения: Версия обновляет способ производства детали, Редакция пересматривает её детали и документы, Замена детали вводит новый номер детали, заменяющий старый, а Новая деталь представляет совершенно новую деталь без предшественника."
+msgstr "Вид изменения: Версия обновляет способ изготовления детали, Ревизия пересматривает её характеристики и документы, Замена детали заменяет номер детали на новый, вытесняющий старый, и Новая деталь вводит совершенно новую деталь без предшественника."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Какой тип выхода записывает эта запись — Производство (хорошие единицы), Отходы (невозвратные) или Переработка (отправлено на исправление); показывает Причину отходов при отходах."
+msgstr "Что фиксирует эта запись о выпуске — Производство (готовые единицы), Брак (неисправимый) или Доработка (отправлено на исправление); показывает Причину брака при выборе Брак."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Какой это тип ПО — стандартные товары, услуги, внешняя обработка или бланкетное соглашение; определяет макет строки и правила проводки ГЛ."
+msgstr "Тип этого Заказа поставщику — стандартные товары, услуги, внешняя обработка или рамочное соглашение; определяет макет строки и правила проведения Главной книги."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
 msgstr "Какой это тип предложения — стандартное предложение поставщика, предложение по цене бланкетного соглашения или предложение контрактного производства; определяет макет строки ПО при преобразовании."
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
-msgstr "Из какого источника эта измерение извлекает допустимые значения (пользовательский список или существующий объект, например клиент, местоположение, сотрудник)."
+msgstr "Источник, из которого это Измерение получает допустимые значения (пользовательский список или существующая сущность, такая как Покупатель, Площадка, Сотрудник)."
 
 msgid "What the due-date countdown starts from (invoice date, end of month, etc.)."
-msgstr "Откуда начинается обратный отсчет до сроку платежа (дата счета, конец месяца и т. д.)."
+msgstr "От чего начинается отсчет срока (дата счета-фактуры, конец месяца и т. д.)."
 
 msgid "What this field held before the change. Leave blank for nothing."
 msgstr "Что содержало это поле до изменения. Оставьте пусто, если ничего нет."
 
 msgid "What this receipt is fulfilling — a purchase order, a return, an inbound transfer, or a manual receipt with no parent."
-msgstr "Что этот счет выполняет — заказ на покупку, возврат, входящий трансфер или ручный счет без родителя."
+msgstr "Что исполняет это Поступление — Заказ поставщику, возврат, входящее Перемещение или ручное Поступление без родителя."
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "Что эта отправка выполняет — заказ на продажу, исходящий трансфер, возврат RMA или ручную отправку."
+msgstr "Что исполняет эта Отгрузка — Заказ покупателя, исходящее Перемещение, возврат RMA или ручная Отгрузка."
 
 msgid "What this task means"
 msgstr "Что означает эта задача"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Что засчитывает эта запись времени — Работа (время оператора), Машина (время выполнения) или Установка (время переналадки); каждая резюмируется по другой ставке."
+msgstr "Что считает эта запись времени — Труд (время оператора), Станок (время обработки) или Наладка (время переналадки); каждое значение накапливается с другой ставкой."
 
 msgid "What to set up"
 msgstr "Что настроить"
@@ -17158,13 +17158,13 @@ msgid "When a finished product's shelf life is set to Calculated, pick which con
 msgstr "Когда срок хранения готового продукта установлен на Рассчитанный, выберите, какие потребленные входные данные питают расчет."
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
-msgstr "Когда серийный номер или партия истекает и что происходит, если она используется после — политика компании может предупредить, заблокировать или заблокировать с переопределением."
+msgstr "Когда истекает срок годности серии или производственной серии и что происходит при использовании после — политика организации может предупредить, заблокировать или заблокировать с переопределением."
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
 msgstr "Когда Carbon обязалась доставить товары; в сочетании с днями доставки способа доставки, это определяет обратный расчет даты отправки."
 
 msgid "When expired stock is used"
-msgstr "Когда используется истекший товар"
+msgstr "Когда используется Запас с истекшим сроком"
 
 msgid "When MRP uses the successor for new demand"
 msgstr "Когда MRP использует преемника для новых потребностей"
@@ -17173,16 +17173,16 @@ msgid "When on, attributes in this category show up on a person's public profile
 msgstr "Когда включено, атрибуты в этой категории отображаются в открытом профиле человека; в противном случае они видны только администраторам."
 
 msgid "When on, employees can edit this attribute's value on their own profile; otherwise only admins can."
-msgstr "Когда включено, сотрудники могут редактировать значение этого атрибута в своем профиле; в противном случае это могут делать только администраторы."
+msgstr "Если включено, сотрудники могут изменять значение этого атрибута в своем профиле; в противном случае это могут делать только администраторы."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Когда включено, правила цены (скидки по объемам, акции) по-прежнему применяются сверх этого переопределения; когда отключено, это переопределение — финальная цена."
+msgstr "Если включено, Правила ценообразования (объемные скидки, акции) по-прежнему применяются поверх этого Переопределения; если отключено, это Переопределение — финальная Цена."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Когда включено, сканирование операционного штрих-кода этого процесса сообщает всю оставшуюся открытую количество как завершенную в одном действии; отключите, если операторы регулярно сообщают о частичных."
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
-msgstr "Если включено, счета этой стороны пропускают расчет налога; сторона отвечает за актуальность сертификата об освобождении."
+msgstr "Если включено, счета-фактуры этой стороны пропускают расчет налога; сторона несет ответственность за актуальность свидетельства об освобождении от налога."
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
 msgstr "Если включено, это переопределение цены применяется к совпадающим заказам; если отключено, переопределение сохраняется без удаления для сохранения истории аудита."
@@ -17194,25 +17194,25 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "Когда ожидается ответ поставщиков; поставщики видят эту дату на портале RFQ, и Carbon перестает принимать поздние ответы после нее (настраивается)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "Когда покупатель запросил товары; поставщик может обещать что-то другое на обещанную дату и снова записать что-то другое на дату доставки."
+msgstr "Когда закупщик запросил товары; поставщик может обещать что-либо другое в подтвержденную дату и провести что-либо другое в дату поставки."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "Когда покупатель нуждается в товарах этой строки на причале; планирование использует эту дату для доступности запасов и планирования внешней обработки."
+msgstr "Когда закупщику нужны товары этой строки на причале; планирование использует эту дату для проверки наличия запаса и планирования кооперации."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "Когда клиент запросил доставку; заказ обязывает обещанную дату, которая может отличаться."
+msgstr "Когда покупатель запросил доставку; заказ подтверждает подтвержденную дату, которая может отличаться."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Когда клиент хочет получить товары; предложение обещает эту дату, если клиент принимает."
+msgstr "Когда покупатель попросил получить товары; коммерческое предложение подтверждает эту дату, если покупатель принимает."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Когда клиент хочет получить товары."
+msgstr "Когда покупатель попросил получить товары."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
-msgstr "Когда клиент отправил эту RFQ; отсчет ответа начинается с этой даты."
+msgstr "Когда покупатель подал этот Запрос цен; отсчет времени ответа начинается с этой даты."
 
 msgid "When the customer's request stops being current; past this date the RFQ is auto-closed and won't accept quote responses unless re-opened."
-msgstr "Когда запрос клиента перестает быть актуальным; после этой даты RFQ автоматически закрывается и не принимает ответы на предложения, если не переоткрыта."
+msgstr "Когда запрос цен покупателя перестает быть актуальным; после этой даты запрос цен автоматически закрывается и не принимает ответы на коммерческие предложения, если не переоткрыты."
 
 msgid "When the goods actually arrived; recorded on the receipt and used for supplier on-time-delivery scoring."
 msgstr "Когда товары действительно прибыли; записано в квитанцию и используется для оценки доставки поставщика вовремя."
@@ -17221,28 +17221,28 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Когда карточка канбана сканируется, задание автоматически удаляется из черновика и выпускается на пол."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Когда место получения ожидает прибытия запасов; определяет доступность MRP в пункте назначения."
+msgstr "Когда Площадка приемки ожидает прибытия Запаса; определяет доступность MRP в пункте назначения."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Когда поставщик обязался доставить; планирование использует эту дату для прогноза прибытия входящего запаса."
 
 msgid "When the supplier's pricing stops being honored; converting this quote to a PO after this date may need re-quoting."
-msgstr "Когда цены поставщика перестают быть соблюдаемыми; преобразование этого предложения в PO после этой даты может потребовать переквотации."
+msgstr "Когда ценообразование поставщика перестает действовать; преобразование этого Коммерческого предложения в Заказ поставщику после этой даты может потребовать переквотирования."
 
 msgid "When this gauge becomes due for calibration; once past due it reads Out-of-Calibration."
-msgstr "Когда этот калибр подлежит калибровке; после истечения срока он показывает выходит из калибра."
+msgstr "Когда это Средство измерения подлежит Калибровке; после истечения срока оно показывает « Вне калибровки »."
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "Когда этот ориентир был в последний раз успешно откалиброван; дата следующей кальибровки пересчитывается из этого значения плюс интервал."
+msgstr "Когда это средство измерения последний раз успешно калибровалось; дата следующей калибровки пересчитывается из этого значения плюс интервал."
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
-msgstr "Когда это будет выглядеть правильно, отметьте как согласованное. Это завершит этап Discovery в вашем командном центре."
+msgstr "Если это выглядит правильно, отметьте как согласовано. Это завершает этап обнаружения на вашем командном центре."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Когда эта конкретная строка обещана отправке; переопределение каждой строки обещанной даты заголовка заказа для разделенных отправок."
+msgstr "Когда обещана отгрузка этой конкретной строки; переопределение на уровне строки подтвержденной даты заголовка заказа для разделенных отгрузок."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Когда эти конкретные партия/серийный номер истекает; определяет выбор FEFO и политику срока хранения при потреблении."
+msgstr "Когда эта конкретная партия/серийный номер истекает; определяет отбор FEFO и политику сроков годности при потреблении."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Когда вы обязались доставить; планирование рассматривает это как дату требования спроса для выполнения."
@@ -17260,7 +17260,7 @@ msgid "Where and how you make things."
 msgstr "Где и как вы производите товары."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Куда товары на этом PO отправляются по умолчанию поставщиком; местоположения доставки по строкам на PO переопределяют это для сценариев drop-ship и разделенной доставки."
+msgstr "Куда по умолчанию отправляются товары на этом РП; места доставки на уровне строки РП переопределяют это для сценариев прямой поставки и разделенной доставки."
 
 msgid "Where it lives today"
 msgstr "Где это находится сегодня"
@@ -17275,16 +17275,16 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "Где затронутые элементы используются по всей системе. Информационно — ничто здесь не блокирует выпуск."
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "Откуда произошла эта запись (ручной ввод, контировка из продаж/покупок, повторяющийся шаблон и т. д.)."
+msgstr "Откуда произошла эта запись (ручной ввод, проведение из продаж/закупок, повторяющийся шаблон и т. д.)."
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
-msgstr "Откуда был поднят этот вопрос — внутренняя КК, жалоба клиента, аудит поставщика и т. д.; используется для отчетности, не блокирует рабочий процесс."
+msgstr "Откуда был поднят этот вопрос — внутренний контроль качества, жалоба покупателя, аудит поставщика и т. д.; используется для отчетов, не ограничивает рабочий процесс."
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
 msgstr "Где товары этой строки попадают в инвентарь при получении; если пусто, квитанции используют единицу хранения по умолчанию товара."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "Откуда возникла эта заявка на техническое обслуживание — сообщено оператором, запланировано, триггер мониторинга состояния, инспекция после работы; определяет распределение источников в отчетах о техническом обслуживании."
+msgstr "Откуда пришел этот запрос на техобслуживание — сообщено оператором, запланировано, триггер мониторинга состояния, контроль после работы; определяет разбор источников в отчетах по техобслуживанию."
 
 msgid "Where you are today"
 msgstr "Где вы находитесь сегодня"
@@ -17296,64 +17296,64 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Интерпретируется ли сумма как процент от цены строки или как фиксированная сумма в валюте."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Отслеживает ли Carbon каждую единицу (Serial), каждую партию (Batch), количество (Inventory) или без отслеживания (Non-Inventory)."
+msgstr "Отслеживает ли Carbon каждую единицу (Серийный номер), каждую серию (Серия), количество (Запасы) или без отслеживания (Нескладской)."
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Запускается ли отсчёт времени в начале выбранного процесса или при его завершении."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Проходит ли эта партия/серийный номер проверку (Pass) или не проходит (Fail); Fail блокирует приём запасов в доступные складские остатки."
+msgstr "Проходит ли эта партия/серийный номер контроль (Годен) или не проходит (Не годен); Не годен блокирует запас от поступления в доступные запасы."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Определяет, выполняется ли этот процесс на внутренних рабочих центрах (Process, Assembly или Inspection) или у внешних поставщиков (Outside Processing); раскрывает различные нижестоящие поля, изменяет способ работы планирования маршрутов для этого процесса и устанавливает тип операции по умолчанию для новых операций."
+msgstr "Выполняется ли этот процесс на внутренних рабочих центрах (Процесс, Сборка или Контроль) или у внешних поставщиков (Кооперация); раскрывает различные нижестоящие поля, изменяет способ работы маршрутов планирования для этого процесса и устанавливает тип операции по умолчанию для новых операций."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
 msgstr "Блокирует ли эта работа производство (Вниз), его деградирует (Воздействие), находится в окне планового простоя (Плановое) или не оказывает влияния на производство (Без воздействия); информирует планирование и общение об простое, обращенное к клиентам."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
-msgstr "Если выбранные разрешения Добавляются к тому, что каждый пользователь уже имеет, или Обновляются путем замены набора разрешений каждого пользователя на выбранные ниже."
+msgstr "Добавить выбранные права доступа поверх того, что уже имеет каждый пользователь, или Обновить, заменив набор прав доступа каждого пользователя полностью выбором ниже."
 
 msgid "Which document drives each inspection flow for this item."
 msgstr "Какой документ определяет каждый процесс контроля для этого элемента."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Какой тип запроса отправить: GET читает, POST создаёт, PUT и PATCH обновляют, DELETE удаляет. Новый шаг начинается с GET, и только POST, PUT и PATCH несут тело запроса."
+msgstr "Какой вид запроса отправить: GET читает что-то, POST создает, PUT и PATCH обновляют, DELETE удаляет. Новый шаг начинается с GET, и только POST, PUT и PATCH содержат тело."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "Какое производственное событие запускает часы срока хранения — например, заполнение, уплотнение или окончательный контроль качества."
 
 msgid "Who Can Approve"
-msgstr "Кто может одобрить"
+msgstr "Кто может утвердить"
 
 msgid "Who can do what"
 msgstr "Кто может делать что"
 
 msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
-msgstr "Кто что делает на всех шести этапах. Ваша часть выделена вверху. Хорошо выполняйте свою работу, и проект будет двигаться вперед."
+msgstr "Кто что делает во всех шести шагах. Ваша сторона выделена вверху. Выполняйте это хорошо, и проект движется."
 
 msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
 msgstr "Кто получает обучение, по каким темам и в каком формате. Ваша задача: зарезервируйте время практических занятий в календарях ваших ключевых сотрудников заранее. Это то, что чаще всего откладывается, когда компании становятся загруженными."
 
 msgid "Who has to approve quotes, orders, and purchases — and when"
-msgstr "Кто должен одобрять предложения, заказы и покупки — и когда"
+msgstr "Кто должен утвердить коммерческие предложения, заказы и закупки — и когда"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Кто должен получать уведомления о диспетчеризации, связанной с техническим обслуживанием?"
+msgstr "Кто должен получать уведомления о заявках на техобслуживание?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Кто должен получать уведомления о диспетчеризации, связанной с операциями?"
+msgstr "Кто должен получать уведомления о заявках на техобслуживание, связанных с операциями?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "Кто должен получать уведомления о других отправках?"
+msgstr "Кто должен получать уведомления о других заявках на техобслуживание?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Кто должен получать уведомления о диспетчеризации, связанной с качеством?"
+msgstr "Кто должен получать уведомления о заявках на техобслуживание, связанных с качеством?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "Кто должен получать уведомления, когда цифровое предложение принято или истекло?"
+msgstr "Кто должен получать уведомления, когда цифровое коммерческое предложение принято или истек срок?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Кто должен получать уведомления, когда датчик выходит из калибровки?"
+msgstr "Кто должен получать уведомления, когда средство измерения выходит за пределы калибровки?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "Кто должен получать уведомления при отправке нового предложения?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "Почему это заблокировано?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Почему запас меняется — Положительный (найден), Отрицательный (потеря/отходы) или Установить (заменить количество измеренным значением)."
+msgstr "Почему изменяется запас — Положительное (найдено), Отрицательное (потеряно/брак) или Установить (заменить количество измеренным значением)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Почему эта строка отклоняется; отображается в печатаемом предложении и записывается для отчетов по победам и потерям."
@@ -17401,10 +17401,10 @@ msgid "Window:"
 msgstr "Окно:"
 
 msgid "WIP"
-msgstr "НЗП"
+msgstr "Незавершенное производство"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Без листа подбора операторы подбирают материал со вкладки Сканирование."
+msgstr "Без листа отбора операторы отбирают материал со вкладки Сканирование."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17439,7 +17439,7 @@ msgid "work centers"
 msgstr "рабочие центры"
 
 msgid "Work centers"
-msgstr "Производственные центры"
+msgstr "Рабочие центры"
 
 msgid "Work Centers"
 msgstr "Рабочие центры"
@@ -17454,7 +17454,7 @@ msgid "Work in Progress (default)"
 msgstr "Незавершенное производство (по умолчанию)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Незавершенное производство (WIP)"
+msgstr "Незавершенное производство (НЗП)"
 
 msgid "Work instruction"
 msgstr "Рабочая инструкция"
@@ -17484,10 +17484,10 @@ msgid "Working sessions on configuration and data"
 msgstr "Рабочие сессии по конфигурации и данным"
 
 msgid "Worst Performing Machines"
-msgstr "Машины с наихудшей производительностью"
+msgstr "Худшие станки"
 
 msgid "Write-Down Account"
-msgstr "Счет уменьшения стоимости"
+msgstr "Счет уценки"
 
 msgid "Write-off"
 msgstr "Списание"
@@ -17503,10 +17503,10 @@ msgid "Write-off for {0}"
 msgstr "Списание для {0}"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Списание запасов, забракованных или возвращённых через отклонения проверки и решения NCR"
+msgstr "Списание запаса, забракованного или возвращенного через отказ при контроле и решения NCR"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "Снижение стоимости актива в течение его полезного использования — ежемесячный пакет, который вы создаете, проверяете как черновик, затем контируете."
+msgstr "Уменьшение стоимости актива в течение его жизни — ежемесячная серия, которую вы создаете, рассматриваете как черновик, затем проводите."
 
 msgid "Year"
 msgstr "Год"
@@ -17533,7 +17533,7 @@ msgid "You"
 msgstr "Вы"
 
 msgid "You belong to more than one company. Pick where to work."
-msgstr "Вы принадлежите более чем одной компании. Выберите, где работать."
+msgstr "Вы принадлежите более чем одной организации. Выберите, где работать."
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "Вы можете изменить стиль интерфейса в любое время через настройку темы"
@@ -17542,7 +17542,7 @@ msgid "You can only see this key once. Store it safely."
 msgstr "Вы можете увидеть этот ключ только один раз. Сохраните его в безопасном месте."
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Вы начали работу в <0/>. Вы можете отредактировать время выхода ниже или подтвердить, что вы еще работаете."
+msgstr "Вы отметились в <0/>. Вы можете отредактировать время отметки окончания работы ниже или подтвердить, что вы все еще работаете."
 
 #. placeholder {0}: leftoverQuantity === 1 ? "part" : "parts"
 #. placeholder {1}: job.quantity
@@ -17554,29 +17554,29 @@ msgid ""
 msgstr "Вы завершили {leftoverQuantity} больше {0}, чем заказанное количество {1}. Что вы хотите сделать с дополнительными деталями?"
 
 msgid "You do not have permission to edit workflows"
-msgstr "У вас нет разрешения на редактирование рабочих процессов"
+msgstr "У вас нет права доступа для изменения рабочих процессов"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "У вас нет разрешения на редактирование этой ведомости материалов."
+msgstr "У вас нет права доступа для изменения этой спецификации материалов."
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "У вас нет разрешения на редактирование этой технологической карты."
+msgstr "У вас нет права доступа для изменения этого перечня операций."
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "Вы управляете процессом; мы следим, чтобы всё было сделано правильно. Опытный взгляд на вашу настройку, данные и запуск."
+msgstr "Вы его ведете; мы следим за тем, чтобы это было сделано правильно. Опытный взгляд на вашу наладку, данные и запуск в производство."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
 msgstr "У вас есть {0} строк, извлеченных из PDF, которые не сопоставлены ни с одним товаром в инвентаре."
 
 msgid "You haven't created any contacts yet."
-msgstr "Вы еще не создали ни одного контакта."
+msgstr "Вы еще не создали ни одного контактного лица."
 
 msgid "You lead"
 msgstr "Вы ведете"
 
 msgid "You name a project owner with decision authority"
-msgstr "Вы назначаете владельца проекта с правом принятия решений"
+msgstr "Вы назначаете ответственного проекта с правом принятия решений"
 
 msgid "You received this item"
 msgstr "Вы получили этот товар"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Вы работаете на Carbon"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Вы на один шаг от вашего рабочего пространства."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Вы самостоятельно настраиваете Carbon в удобном для вас темпе"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Вы отметились на работу {hoursElapsed} часов назад. Вы забыли отметиться на выход?"
+msgstr "Вы в работе уже {hoursElapsed} часов. Вы забыли об окончании работы?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Ваша учетная запись остается в безопасности, даже если ваше имя входа украдено"
@@ -17603,13 +17603,13 @@ msgid "Your books and how money flows."
 msgstr "Ваши книги и движение денежных средств."
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "Ваши изменения переходят в новую черновую версию, выпущенную с этим уведомлением об изменении."
+msgstr "Ваши изменения переходят в новую версию черновика, которая будет выпущена с этим извещением об изменении."
 
 msgid "Your Console PIN"
 msgstr "Ваш PIN консоли"
 
 msgid "Your customer list"
-msgstr "Ваш список клиентов"
+msgstr "Ваш список покупателей"
 
 msgid "Your customer-facing price lists"
 msgstr "Ваши ценовые списки для клиентов"
@@ -17630,7 +17630,7 @@ msgid "your Implementation Lead"
 msgstr "ваш руководитель внедрения"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "Ваше приглашение недействительно или уже было принято. Пожалуйста, свяжитесь со службой поддержки, если вы считаете, что это ошибка."
+msgstr "Ваше приглашение недействительно или уже принято. Пожалуйста, свяжитесь со службой поддержки, если вы считаете, что это ошибка."
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "Ваша задача здесь: проверьте реальный образец каждой строки, затем отметьте её как проверенную. Данные фундамента загружаются первыми, затем основные записи, затем открытые транзакции при переходе."
@@ -17639,7 +17639,7 @@ msgid "Your legal name, addresses, branding, and document defaults"
 msgstr "Ваше юридическое имя, адреса, брендинг и стандартные параметры документов"
 
 msgid "Your main point of contact"
-msgstr "Ваша основная точка контакта"
+msgstr "Ваше основное контактное лицо"
 
 msgid "Your Name"
 msgstr "Ваше имя"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "себя"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Уровень контроля Z1.4 (I / II / III); более высокие уровни означают больший размер выборки для одной партии."
+msgstr "Z1.4 уровень контроля (I / II / III); более высокие уровни означают больший объем выборки для одной партии."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Серьезность Z1.4 (Нормальная / Ужесточенная / Сокращенная); переключается по правилу на основе недавней истории приемки партии."
+msgstr "Z1.4 серьезность (Нормальный / Усиленный / Ослабленный); переключается по правилу на основе недавней истории приемки партии."
 
 msgid "Zoom Box"
 msgstr "Масштабирование"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -170,7 +170,6 @@ msgstr "{from}–{to} из {count} операций"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "{hiddenCount} еще: {hiddenNames}"
-msgstr "{hiddenCount} ещё: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -362,7 +361,6 @@ msgstr "Подрядчик — контактное лицо поставщик�
 
 msgid "A custom solution to meet your needs"
 msgstr "Пользовательское решение для удовлетворения ваших потребностей."
-msgstr "Пользовательское решение в соответствии с вашими потребностями"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Клиент — это компания или физическое лицо, которое покупает ваши детали или услуги."
@@ -479,7 +477,6 @@ msgstr "Управляемая облачная версия Carbon"
 
 msgid "A managed version with all the advanced features"
 msgstr "Управляемая версия со всеми расширенными возможностями"
-msgstr "Управляемая версия со всеми дополнительными функциями"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
 msgstr "Материал — это физический элемент, применяемый при изготовлении деталей и используемый в нескольких производственных заказах"
@@ -504,7 +501,6 @@ msgstr "Новый размер будет создан с использова�
 
 msgid "A new Stripe customer will be created"
 msgstr "Будет создана новая учетная запись покупателя Stripe"
-msgstr "Будет создан новый клиент Stripe"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Неденежный документ, погашающий счёт-фактуру по счёту причин: кредит уменьшает сумму задолженности, дебет её увеличивает."
@@ -2313,7 +2309,6 @@ msgstr "Журнал аудита"
 
 msgid "Audit logging"
 msgstr "Журнал аудита"
-msgstr "Логирование аудита"
 
 msgid "Audit Logging"
 msgstr "Аудит логирования"
@@ -2386,7 +2381,6 @@ msgstr "Автоматические обновления"
 
 msgid "Automatic updates and backups"
 msgstr "Автоматическое обновление и резервное копирование"
-msgstr "Автоматические обновления и резервные копии"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Автоматическое пропорциональное потребление материалов задания, не отслеживаемых при отчетности о выходе — отслеживаемые материалы выпускаются вручную."
@@ -2627,7 +2621,6 @@ msgstr "Обзор библиотеки"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Просмотрите опубликованную версию в режиме только для чтения. Вы все еще можете переставлять шаги для очистки макета."
-msgstr "Просмотрите опубликованную версию в режиме только для чтения. Вы все равно можете переупорядочить шаги для чистоты макета."
 
 msgid "Bucket"
 msgstr "Хранилище"
@@ -3043,7 +3036,6 @@ msgstr "Проверьте вашу почту"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Проверка Stripe для этого покупателя…"
-msgstr "Проверка Stripe для этого клиента…"
 
 msgid "Checkpoint ·"
 msgstr "Контрольная точка ·"
@@ -3185,7 +3177,6 @@ msgstr "Облако или ваша собственная размещённа
 
 msgid "CMMC compliant"
 msgstr "Соответствует CMMC"
-msgstr "Соответствие CMMC"
 
 msgid "Code"
 msgstr "Код"
@@ -3955,7 +3946,6 @@ msgstr "Создать новый производственный заказ д
 
 msgid "Create a new Stripe customer instead"
 msgstr "Вместо этого создать нового покупателя Stripe"
-msgstr "Создайте нового клиента Stripe вместо этого"
 
 msgid "Create a new version"
 msgstr "Создать новую версию"
@@ -6273,7 +6263,6 @@ msgstr "Существующие отображения. Выберите дру
 
 msgid "Existing Stripe customer"
 msgstr "Существующий покупатель Stripe"
-msgstr "Существующий клиент Stripe"
 
 msgid "Expand"
 msgstr "Развернуть"
@@ -6995,7 +6984,6 @@ msgstr "Формат"
 
 msgid "Forward deployed engineer"
 msgstr "Инженер на месте"
-msgstr "Развернутый инженер"
 
 msgid "Foundation"
 msgstr "Основа"
@@ -7052,7 +7040,6 @@ msgstr "Полное имя"
 
 msgid "Full setup and migrations"
 msgstr "Полная наладка и миграции"
-msgstr "Полная настройка и миграции"
 
 msgid "Fully Depreciated"
 msgstr "Полностью амортизирован"
@@ -8150,7 +8137,6 @@ msgstr "Проблемы"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Он перестанет работать, пока вы не опубликуете версию снова. Ничего не удаляется."
-msgstr "Он будет остановлен до тех пор, пока вы снова не опубликуете версию. Ничего не удаляется."
 
 msgid "ITAR Certifications"
 msgstr "Сертификации ITAR"
@@ -8522,7 +8508,6 @@ msgstr "Меньше ручной работы, меньше ошибок"
 
 msgid "Let's Build"
 msgstr "Начнём производство"
-msgstr "Давайте начнём"
 
 msgid "Let's build something"
 msgstr "Давайте создадим что-то"
@@ -8604,7 +8589,6 @@ msgstr "Связать проблему Linear"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "Свяжите этого покупателя Carbon с одним из них или создайте отдельного покупателя Stripe."
-msgstr "Свяжите этого клиента Carbon с одним из них или создайте отдельного клиента Stripe."
 
 msgid "Link to sales order line"
 msgstr "Ссылка на строку заказа покупателя"
@@ -13499,7 +13483,6 @@ msgstr "Локальная установка или облачная"
 
 msgid "Self-onboarding"
 msgstr "Самостоятельное внедрение"
-msgstr "Размещается самостоятельно или управляется"
 
 msgid "Self-onboarding"
 msgstr "Самостоятельное подключение"
@@ -14353,7 +14336,6 @@ msgstr "Stripe отправляет счет-фактуру клиенту по 
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe еще не имеет покупателя для этого покупателя Carbon. Проведение создаст его на вашем подключенном счете."
-msgstr "В Stripe уже есть клиент с этой электронной почтой"
 
 msgid "Stripe Due Date"
 msgstr "Срок выполнения Stripe"
@@ -15641,7 +15623,6 @@ msgstr "Этим завершается этап обнаружения."
 
 msgid "This contact has no email address"
 msgstr "Это контактное лицо не имеет адреса электронной почты"
-msgstr "Этот контакт не имеет адреса электронной почты"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Эта контрагент не имеет задолженности — платеж будет записан на счет."
@@ -15673,7 +15654,6 @@ msgstr "Этот счет-фактура не имеет используемо�
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его данные, отредактируйте его в панели Stripe."
-msgstr "Этот счет не имеет пригодного срока платежа — выберите один для Stripe."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Этот счет-фактура будет выставлен покупателю Stripe, уже связанному с этим покупателем Carbon. Чтобы изменить его данные, отредактируйте его в панели Stripe."
@@ -16772,7 +16752,6 @@ msgstr "Версия"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "Версия {0} опубликована сейчас и будет заменена."
-msgstr "Версия {0} опубликована и будет заменена."
 
 msgid "Version:"
 msgstr "Версия:"
@@ -17658,7 +17637,6 @@ msgstr "Вы работаете на Carbon"
 
 msgid "You're one step away from your workspace."
 msgstr "Вы на один шаг от вашего рабочего пространства."
-msgstr "Вы в одном шаге от вашего рабочего пространства."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Вы самостоятельно настраиваете Carbon в удобном для вас темпе"

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -520,7 +520,6 @@ msgstr "Завершить в любом случае"
 
 msgid "Finish setting up your account"
 msgstr "Завершите настройку вашего аккаунта"
-msgstr "Завершить настройку учетной записи"
 
 msgid "Finish with material unpicked?"
 msgstr "Завершить с неподобранным материалом?"
@@ -533,7 +532,6 @@ msgstr "Вернуться к операции"
 
 msgid "Go to onboarding"
 msgstr "Перейти к первоначальной настройке"
-msgstr "Перейти к адаптации"
 
 msgid "How many were actually picked?"
 msgstr "Сколько было фактически собрано?"
@@ -1516,7 +1514,6 @@ msgstr "Вы проработали {hoursElapsed} часов. Вы забыли
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Ваша учетная запись еще не входит ни в одну Организацию. Завершите подготовку к работе в Carbon ERP, чтобы продолжить."
-msgstr "Ваша учетная запись еще не связана с компанией. Завершите адаптацию в Carbon ERP, чтобы продолжить."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ваша организация требует приложения аутентификатора. Настройте его в Carbon, а затем вернитесь сюда."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Списано"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} прошедших единиц будут завершены."
+msgstr "{completions} пройденных единиц будут завершены."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} записанных отказов будут НЕ завершены — разрешите их из меню действий."
@@ -94,7 +94,7 @@ msgid "Add & Issue"
 msgstr "Добавить и выдать"
 
 msgid "Add a printer in the printing settings to print labels directly."
-msgstr "Добавьте принтер в параметры печати, чтобы печатать этикетки напрямую."
+msgstr "Добавьте принтер в настройки печати, чтобы печатать наклейки непосредственно."
 
 msgid "Add Inventory"
 msgstr "Добавить запас"
@@ -112,7 +112,7 @@ msgid "All clear"
 msgstr "Все в порядке"
 
 msgid "All rework"
-msgstr "Все переработки"
+msgstr "Все доработки"
 
 msgid "All scrap"
 msgstr "Весь брак"
@@ -210,16 +210,16 @@ msgid "Clear"
 msgstr "Очистить"
 
 msgid "Clear Filters"
-msgstr "Сбросить фильтры"
+msgstr "Очистить фильтры"
 
 msgid "Clear Search"
 msgstr "Очистить поиск"
 
 msgid "Clock In"
-msgstr "Отметить приход"
+msgstr "Начало работы"
 
 msgid "Clock Out"
-msgstr "Отметить уход"
+msgstr "Окончание работы"
 
 msgid "Clocked in since <0/>"
 msgstr "Отметился в системе с <0/>"
@@ -251,7 +251,7 @@ msgid "Columns"
 msgstr "Столбцы"
 
 msgid "Company"
-msgstr "Компания"
+msgstr "Организация"
 
 msgid "Complete"
 msgstr "Завершить"
@@ -260,7 +260,7 @@ msgid "Complete All"
 msgstr "Завершить все"
 
 msgid "Complete passed"
-msgstr "Завершить прошедшие"
+msgstr "Завершить пройденные"
 
 msgid "Completed"
 msgstr "Завершено"
@@ -278,11 +278,11 @@ msgid "Consumed"
 msgstr "Использовано"
 
 msgid "Consumed expired"
-msgstr "Потреблено истекшее"
+msgstr "Израсходовано - истек срок"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
-msgstr "Стоимость незапланированного обслуживания за последние {0} дней"
+msgstr "Себестоимость внепланового техобслуживания за последние {0} дней"
 
 #. placeholder {0}: search.trim() === "" ? (createLabel ?? label) : search
 #. placeholder {0}: search.trim() === "" ? label : search
@@ -296,13 +296,13 @@ msgid "Create Quality Issue"
 msgstr "Создать проблему качества"
 
 msgid "Create Rework"
-msgstr "Создать переделку"
+msgstr "Создать доработку"
 
 msgid "Current work"
 msgstr "Текущая работа"
 
 msgid "Customer"
-msgstr "Заказчик"
+msgstr "Покупатель"
 
 msgid "Dark Mode"
 msgstr "Тёмная тема"
@@ -317,7 +317,7 @@ msgid "Default"
 msgstr "По умолчанию"
 
 msgid "Default Storage Unit"
-msgstr "Хранилище по умолчанию"
+msgstr "Единица хранения по умолчанию"
 
 msgid "Delete"
 msgstr "Удалить"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Детали"
 
 msgid "Dispatch not found"
-msgstr "Наряд не найден"
+msgstr "Заявка на техобслуживание не найдена"
 
 msgid "Display"
 msgstr "Отображение"
@@ -353,20 +353,20 @@ msgid "Down"
 msgstr "Простой"
 
 msgid "Down for maintenance"
-msgstr "На техническом обслуживании"
+msgstr "На техобслуживание"
 
 #. placeholder {0}: workCenter.blockingDispatchReadableId
 msgid "Down for maintenance · {0}"
-msgstr "На техническом обслуживании · {0}"
+msgstr "На техобслуживание · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "На плановом техническом обслуживании"
+msgstr "На плановое техобслуживание"
 
 msgid "Download"
 msgstr "Скачать"
 
 msgid "Download Labels"
-msgstr "Загрузить этикетки"
+msgstr "Скачать наклейки"
 
 msgid "Draft"
 msgstr "Черновик"
@@ -398,22 +398,22 @@ msgid "Due today?"
 msgstr "Срок сегодня?"
 
 msgid "Duplicate batch number"
-msgstr "Дублирующийся номер партии"
+msgstr "Дублированный номер серии"
 
 msgid "Duplicate serial number"
-msgstr "Дублирующийся серийный номер"
+msgstr "Дублированный серийный номер"
 
 msgid "Duration"
 msgstr "Длительность"
 
 msgid "Edit"
-msgstr "Редактировать"
+msgstr "Изменить"
 
 msgid "Elapsed"
 msgstr "Прошедшее время"
 
 msgid "Email Address"
-msgstr "Электронная почта"
+msgstr "Адрес электронной почты"
 
 msgid "Empty work centers"
 msgstr "Пустые рабочие центры"
@@ -438,17 +438,17 @@ msgid "Estimated"
 msgstr "План"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "Каждый блок имеет вердикт: {passes} прошли и {fails} не прошли. Партия закрывается с маршрутизацией каждого блока к его собственному результату."
+msgstr "Каждая единица имеет результат: {passes} пройдено и {fails} отклонено. Партия закрывается с распределением каждой единицы по её результату."
 
 msgid "Expand features table"
 msgstr "Развернуть таблицу функций"
 
 msgid "Expired"
-msgstr "Истекло"
+msgstr "Истек срок"
 
 #. placeholder {0}: formatDate(date)
 msgid "Expired {0}"
-msgstr "Истекла {0}"
+msgstr "Истек {0}"
 
 msgid "Expires <0/>"
 msgstr "Истекает <0/>"
@@ -500,13 +500,13 @@ msgid "Files"
 msgstr "Файлы"
 
 msgid "Files related to the job and the opportunity line."
-msgstr "Файлы, связанные с заданием и позицией заказа."
+msgstr "Файлы, связанные с производственным заказом и позицией сделки."
 
 msgid "Filter"
-msgstr "Фильтр"
+msgstr "Фильтровать"
 
 msgid "Filter by location"
-msgstr "Фильтр по расположению"
+msgstr "Фильтровать по площадке"
 
 msgid "Finish"
 msgstr "Завершить"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Завершить в любом случае"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Завершите настройку вашего аккаунта"
 
 msgid "Finish with material unpicked?"
 msgstr "Завершить с неподобранным материалом?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Забыли отметить уход?"
+msgstr "Забыли отметить окончание работы?"
 
 msgid "Go back to operation"
 msgstr "Вернуться к операции"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Перейти к первоначальной настройке"
 
 msgid "How many were actually picked?"
 msgstr "Сколько было фактически собрано?"
@@ -619,10 +619,10 @@ msgid "Job Traveler"
 msgstr "Маршрутный лист"
 
 msgid "Jobs"
-msgstr "Работы"
+msgstr "Производственные заказы"
 
 msgid "Keep picking"
-msgstr "Продолжить сбор"
+msgstr "Продолжить отбор"
 
 msgid "Kit"
 msgstr "Комплект"
@@ -691,16 +691,16 @@ msgid "Machine"
 msgstr "Станок"
 
 msgid "Machine down for maintenance now?"
-msgstr "Машина на обслуживании сейчас?"
+msgstr "Станок на техобслуживание сейчас?"
 
 msgid "Maintenance"
-msgstr "Обслуживание"
+msgstr "Техобслуживание"
 
 msgid "Maintenance Completed"
-msgstr "Обслуживание завершено"
+msgstr "Техобслуживание завершено"
 
 msgid "Maintenance overdue"
-msgstr "Обслуживание просрочено"
+msgstr "Техобслуживание просрочено"
 
 msgid "Make a replacement"
 msgstr "Создать замену"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "Добавить номенклатуру на склад вручную"
 
 msgid "Manually remove items from inventory"
-msgstr "Списать номенклатуру со склада вручную"
+msgstr "Вручную убрать позиции из запасов"
 
 msgid "Mark Short"
 msgstr "Отметить как недостача"
@@ -776,7 +776,7 @@ msgid "No active job at this work center"
 msgstr "Нет активной работы на этом рабочем центре"
 
 msgid "No active maintenance dispatches"
-msgstr "Нет активных нарядов на обслуживание"
+msgstr "Нет активных заявок на техобслуживание"
 
 msgid "No active operations"
 msgstr "Нет активных операций"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Не найдено доступных отслеживаемых объектов"
 
 msgid "No dispatches assigned to you"
-msgstr "Нет нарядов, назначенных вам"
+msgstr "Вам не назначены никакие заявки на техобслуживание"
 
 msgid "No files"
 msgstr "Нет файлов"
@@ -809,7 +809,7 @@ msgid "No issue types configured"
 msgstr "Типы проблем не настроены"
 
 msgid "No maintenance scheduled for today"
-msgstr "На сегодня обслуживание не запланировано"
+msgstr "На сегодня техобслуживание не запланировано"
 
 msgid "No matches. Type to create one."
 msgstr "Совпадений не найдено. Введите текст для создания."
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Нет материалов"
 
 msgid "No open jobs"
-msgstr "Нет открытых заданий"
+msgstr "Нет открытых производственных заказов"
 
 msgid "No open units to allocate"
 msgstr "Нет открытых единиц для распределения"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "Варианты не найдены."
 
 msgid "No picking lists assigned"
-msgstr "Нет назначенных списков комплектации"
+msgstr "Листы отбора не назначены"
 
 msgid "No printer configured"
 msgstr "Принтер не настроен"
@@ -899,7 +899,7 @@ msgid "Nothing scheduled at this work center"
 msgstr "Ничего не запланировано на этом рабочем центре"
 
 msgid "Nothing to scrap"
-msgstr "Нечего списывать"
+msgstr "Нечего браковать"
 
 msgid "OEE Impact"
 msgstr "Влияние на OEE"
@@ -927,7 +927,7 @@ msgid "Open an NCR for MRB disposition"
 msgstr "Открыть NCR для решения MRB"
 
 msgid "Open Jobs"
-msgstr "Открытые задания"
+msgstr "Открытые производственные заказы"
 
 msgid "Operations"
 msgstr "Операции"
@@ -963,16 +963,16 @@ msgid "Partial"
 msgstr "Частичный"
 
 msgid "Partial Disposition"
-msgstr "Частичное распределение"
+msgstr "Частичное решение"
 
 msgid "Passed Inspection"
 msgstr "Контроль пройден"
 
 msgid "Passkey unlock failed"
-msgstr "Ошибка разблокировки по пропуску"
+msgstr "Не удалось разблокировать ключ доступа"
 
 msgid "Pause"
-msgstr "Пауза"
+msgstr "Приостановить"
 
 msgid "Pick"
 msgstr "Выбрать"
@@ -993,7 +993,7 @@ msgid "Picked up Column {0} at position: {1} of {2}"
 msgstr "Столбец {0} взят с позиции: {1} из {2}"
 
 msgid "Picking"
-msgstr "Комплектация"
+msgstr "Отбор"
 
 msgid "Pin Out"
 msgstr "Выход по PIN"
@@ -1014,13 +1014,13 @@ msgid "Prev"
 msgstr "Назад"
 
 msgid "Preventive"
-msgstr "Профилактическое"
+msgstr "Предупреждающее"
 
 msgid "Print"
 msgstr "Печать"
 
 msgid "Printer Settings"
-msgstr "Параметры принтера"
+msgstr "Настройки принтера"
 
 msgid "Priority"
 msgstr "Приоритет"
@@ -1056,7 +1056,7 @@ msgid "Queue empty"
 msgstr "Очередь пуста"
 
 msgid "Reason for rework"
-msgstr "Причина переделки"
+msgstr "Причина доработки"
 
 msgid "Recent"
 msgstr "Недавние"
@@ -1081,37 +1081,37 @@ msgid "Reject Lot"
 msgstr "Отклонить партию"
 
 msgid "Remove"
-msgstr "Удалить"
+msgstr "Убрать"
 
 msgid "Remove filter"
-msgstr "Удалить фильтр"
+msgstr "Убрать фильтр"
 
 msgid "Remove Inventory"
-msgstr "Списать запас"
+msgstr "Убрать запасы"
 
 msgid "Remove part"
-msgstr "Удалить деталь"
+msgstr "Убрать деталь"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "Снова открыть узел и создать сменный агрегат"
+msgstr "Открыть заново узел и создать единицу для замены"
 
 msgid "Result"
 msgstr "Результат"
 
 msgid "Rework"
-msgstr "Переделка"
+msgstr "Доработка"
 
 msgid "Rework created successfully"
-msgstr "Переработка успешно создана"
+msgstr "Доработка успешно создана"
 
 msgid "Rework quantity"
-msgstr "Количество переработки"
+msgstr "Количество для доработки"
 
 msgid "Running"
 msgstr "Работает"
 
 msgid "Sales Order"
-msgstr "Заказ на продажу"
+msgstr "Заказ покупателя"
 
 msgid "Save"
 msgstr "Сохранить"
@@ -1123,19 +1123,19 @@ msgid "Scan a tracked entity to add the first sample column."
 msgstr "Отсканируйте отслеживаемый объект, чтобы добавить первый столбец образца."
 
 msgid "Scan or enter serial number"
-msgstr "Сканируйте или введите серийный номер"
+msgstr "Отсканируйте или введите серийный номер"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Отсканируйте или введите ID отслеживаемого объекта, серийный номер или партию"
+msgstr "Отсканируйте или введите ID отслеживаемого объекта, серийный номер или серию"
 
 msgid "Scan or enter tracking number"
 msgstr "Отсканируйте или введите номер отслеживания"
 
 msgid "Scan or search serial number..."
-msgstr "Сканируйте или ищите серийный номер..."
+msgstr "Отсканируйте или найдите серийный номер..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "Отсканируйте или выберите отслеживаемый объект из этой партии, чтобы добавить его в качестве столбца образца, затем запишите его результат в сетку."
+msgstr "Отсканируйте или выберите отслеживаемый объект из этой партии для добавления его как столбца образца, затем запишите его результат в сетку."
 
 msgid "Schedule"
 msgstr "Расписание"
@@ -1144,10 +1144,10 @@ msgid "Scrap"
 msgstr "Брак"
 
 msgid "Scrap {readableId}"
-msgstr "Списать {readableId}"
+msgstr "Браковать {readableId}"
 
 msgid "Scrap material"
-msgstr "Списать материал"
+msgstr "Браковка материала"
 
 msgid "Scrap quantity"
 msgstr "Количество брака"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Сеанс заблокирован"
 
 msgid "Set Clock Out"
-msgstr "Установить время ухода"
+msgstr "Установить окончание работы"
 
 msgid "Set clock-out time"
 msgstr "Установить время ухода"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "Войти через Outlook"
 
 msgid "Sign in with Passkey"
-msgstr "Войти с помощью Passkey"
+msgstr "Войти с ключом доступа"
 
 msgid "Sign out"
 msgstr "Выход"
@@ -1316,7 +1316,7 @@ msgstr "Станция: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "Статистическая приемка не пройдена, поэтому вся партия из {0} считается несоответствующей (ISO 9001:2015 §8.7) — {passes} прошедших образцов и {fails} отказов. Направьте единицы ниже в брак или переработку, или только зафиксируйте результат."
+msgstr "Статистическая приемка не пройдена, поэтому вся партия из {0} считается несоответствующей требованиям (ISO 9001:2015 §8.7) — {passes} образцов из выборки прошли проверку и {fails} образцов не прошли. Направьте единицы ниже в брак или доработку, либо только запишите решение."
 
 msgid "Status"
 msgstr "Статус"
@@ -1361,19 +1361,19 @@ msgid "The lot will still be dispositioned, but an NCR cannot be created until a
 msgstr "Партия все еще будет распределена, но NCR не может быть создана до тех пор, пока не будет настроен хотя бы один тип проблемы."
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "Для этого материала нет доступных или использованных отслеживаемых компонентов."
+msgstr "Для этого материала нет доступных или израсходованных отслеживаемых деталей."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "В спецификации есть материалы с серийным или партионным учётом, которые не были полностью выданы. Завершение без выдачи может привести к некорректным записям прослеживаемости."
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
-msgstr "Эти позиции содержат материал для подбора. Завершение отметит список как Неполный."
+msgstr "Эти позиции еще содержат материал для отбора. Завершение сейчас отметит список как частичный."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Эта партия истекла и не может быть выбрана."
+msgstr "Эта партия истекла и не может быть отобрана."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "Эта часть была изготовлена на заказ. Её списание может снова открыть маршрут для создания замены."
+msgstr "Эта деталь была произведена на заказ. Списание может открыть заново ее маршрут для создания замены."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
 msgstr "Эта часть будет списана со склада. Её требование остается открытым, чтобы вы могли выдать замену."
@@ -1436,7 +1436,7 @@ msgid "Unlock"
 msgstr "Разблокировать"
 
 msgid "Unlock with passkey"
-msgstr "Разблокировать с помощью пропуска"
+msgstr "Разблокируйте ключом доступа"
 
 msgid "Unpick"
 msgstr "Отменить выбор"
@@ -1450,7 +1450,7 @@ msgstr "Незапланированное время простоя"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr "Элементы незапланированного обслуживания за последние {0} дней"
+msgstr "Незапланированные элементы техобслуживания за последние {0} дней"
 
 msgid "Unsaved changes"
 msgstr "Несохранённые изменения"
@@ -1459,7 +1459,7 @@ msgid "Up next"
 msgstr "Следующее"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
-msgstr "До {maxAllocatable} единиц могут быть распределены; остальное записывается без проводки."
+msgstr "Можно распределить до {maxAllocatable} единиц(ы); остальное записывается без проведения."
 
 msgid "Update"
 msgstr "Обновить"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "Подтвердить"
 
 msgid "View maintenance dispatch"
-msgstr "Просмотреть наряд на обслуживание"
+msgstr "Просмотреть заявку на техобслуживание"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "Мы отправили вам ссылку для входа в ваш аккаунт."
@@ -1495,7 +1495,7 @@ msgid "What is {translatedTerm}?"
 msgstr "Что такое {translatedTerm}?"
 
 msgid "WIP"
-msgstr "НЗП"
+msgstr "Незавершенное производство"
 
 msgid "Work Center"
 msgstr "Рабочий центр"
@@ -1507,13 +1507,13 @@ msgid "Yes"
 msgstr "Да"
 
 msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowledge that you're still working."
-msgstr "Вы отметились в системе в <0/>. Вы можете отредактировать время выхода ниже или подтвердить, что вы еще работаете."
+msgstr "Вы начали работу в <0/>. Ниже вы можете изменить время окончания работы или подтвердить, что вы все еще работаете."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Вы на смене уже {hoursElapsed} часов. Вы забыли отметить уход?"
+msgstr "Вы проработали {hoursElapsed} часов. Вы забыли завершить работу?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Ваша учетная запись еще не входит ни в одну Организацию. Завершите подготовку к работе в Carbon ERP, чтобы продолжить."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Ваша организация требует приложения аутентификатора. Настройте его в Carbon, а затем вернитесь сюда."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -27,7 +27,7 @@ msgstr ", {years}yr"
 
 #. placeholder {0}: fieldDef?.label ?? condition.field
 msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
-msgstr "\"{0}\" seçilen yüzeylerde mevcut değil. Başka bir alan seçin."
+msgstr "\"{0}\" seçili yüzey(ler)de kullanılabilir değildir. Başka bir alan seçin."
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\" {childCount} adet doğrudan iç içe geçmiş depolama birimine sahip. Bunu silmek, onları ve altlarındaki her şeyi de silecektir. Bu geri alınamaz."
@@ -43,7 +43,7 @@ msgstr "\"{taskName}\" {0} Setup Map öğesi \"Yapılandırıldı\" olarak işar
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "\"{taskName}\" tamamlandı — tüm {0} Setup Haritası öğesi yapılandırıldı."
+msgstr "\"{taskName}\" bitti — tüm {0} Kurulum Haritası öğesi yapılandırıldı."
 
 msgid "(excluded for this customer)"
 msgstr "(bu müşteri için hariç tutulmuş)"
@@ -79,11 +79,11 @@ msgstr "{0} başarıyla silindi"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} taslak muhasebe kaydı"
+msgstr "{0} taslak muhasebe fişi"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} iş oluşturuldu"
+msgstr "{0} iş emri oluşturuldu"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -92,7 +92,7 @@ msgstr "{0} satır eşlenecek"
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
-msgstr "{0} / {1} deftere nakil hesapları eşlendi"
+msgstr "{0}/{1} muhasebeleştirme hesabı eşleştirildi"
 
 #. placeholder {0}: rows.length
 msgid "{0} of {maxSlots} provider slots used"
@@ -112,7 +112,7 @@ msgstr "{0} Süreçler"
 
 #. placeholder {0}: result.credentialName ?? "Passkey"
 msgid "{0} registered"
-msgstr "{0} kayıtlı"
+msgstr "{0} kaydedildi"
 
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
@@ -145,16 +145,16 @@ msgid "{0} values missing"
 msgstr "{0} değeri eksik"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} parça atlandı — zaten açık işleri var"
+msgstr "{alreadyPlannedItemCount} parça atlandı — bunların zaten açık iş emirleri var"
 
 msgid "{apOverduePct}% of payables"
-msgstr "{apOverduePct}% borç"
+msgstr "{apOverduePct}% borçlar"
 
 msgid "{arOverduePct}% of receivables"
 msgstr "{arOverduePct}% alacakların"
 
 msgid "{chainLabel}. Consider pointing this part directly at the final successor."
-msgstr "{chainLabel}. Bu parçayı doğrudan son halefine yönlendirmeyi düşünün."
+msgstr "{chainLabel}. Bu parçayı doğrudan nihai ardıla yönlendirmeyi düşünün."
 
 msgid "{count, plural, one {# course} other {# courses}}"
 msgstr "{count, plural, one {# kurs} other {# kurs}}"
@@ -166,10 +166,10 @@ msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}–{to} / {count} işlem"
+msgstr "{from}–{to} /{count} operasyon"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "{hiddenCount} daha: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -186,10 +186,10 @@ msgid "{mismatchCount} months with mismatched totals"
 msgstr "{mismatchCount} ay tutarları uyuşmazlığı"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "sağlayıcıda eksik {missingCount} yevmiye"
+msgstr "{missingCount} muhasebe fişi sağlayıcıda eksik"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} eksik yevmiye ve {mismatchCount} tutarları uyuşmazlığı olan ay"
+msgstr "{missingCount} eksik muhasebe fişi ve {mismatchCount} uyumsuz ay"
 
 msgid "{name} deleted"
 msgstr "{name} silindi"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} iş güncellendi"
+msgstr "{updatedJobCount} iş emri güncellendi"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
 msgstr "{uploadedFileName} yüklendi — alanlar belgeden dolduruldu."
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "{variances, plural, one {# satır beklenen miktardan farklı} other {# satırlar beklenen miktardan farklı}}"
+msgstr "{variances, plural, one {# satır beklenen miktardan farklıdır} other {# satır beklenen miktardan farklıdır}}"
 
 msgid "{years}yr"
 msgstr "{years}yr"
@@ -249,7 +249,7 @@ msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
 msgstr "<0>Bu ürün için bir tedarikçi parçası ekleyin</0> tercih edilen tedarikçi ayarlamak için."
 
 msgid "0 operations"
-msgstr "0 işlem"
+msgstr "0 operasyon"
 
 msgid "0-4 weeks"
 msgstr "0-4 hafta"
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4s"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "5 kullanıcı minimum"
 
 msgid "5-8 weeks"
 msgstr "5-8 hafta"
@@ -330,7 +330,7 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Bir Carbon tarafından yönetilen veri taşıması — kendi verilerinizi yüklersiniz"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "Bir değişiklik bildirisi, gözden geçirme ve uygulamadan geçen kontrollü bir mühendislik veya üretim değişikliğini izler."
+msgstr "Değişiklik bildirimi, kontrollü bir mühendislik veya üretim değişikliğini inceleme ve uygulama aşamalarından takip eder."
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "Alınan ancak henüz faturalanmayan malların değerini tutan bir takas hesabı; tedarikçi faturası bunu temizler."
@@ -345,22 +345,22 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "Temel bir tabloya (müşteri, parça, sipariş) eklenen şirket tarafından tanımlı ek bir alan; kaydın formunda görünür, yerleşik alanlarla birlikte kaydedilir ve API üzerinden sorgulanabilir."
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "Muhasebe satırlarına eklenen şirket tarafından tanımlı bir etiket ekseni; aynı hesaplar konum, bölüm veya herhangi bir özel eksen tarafından dilimlenebilir ve hesap planı çoğaltılmadan yönetilebilir."
+msgstr "Muhasebe fiş satırlarına eklenen şirket tarafından tanımlanan etiket ekseni, aynı hesapların lokasyon, departman veya herhangi bir özel eksen ile dilimlenebilmesini sağlayan, hesap planını çoğaltmayan yapı."
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
-msgstr "Satırın miktar, tarih, ürün ve müşteri koşulları kurala uyduğunda satır fiyatını yukarı veya aşağı ayarlayan, yüzde veya sabit tutar olarak şirket kapsamında bir İndirim veya Marj."
+msgstr "Şirket kapsamında tanımlanan, yüzde veya sabit tutar olarak, satırın miktar, tarih, stok kartı ve müşteri koşullarıyla eşleştiğinde satır fiyatını yukarı veya aşağı ayarlayan bir İskonto veya Kâr marjı."
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "Tamamlanan bir işin çıktısı, işin gerçek birikmiş WIP maliyetine göre envantere alınır."
+msgstr "Tamamlanan iş emrinin çıktısı, iş emrinin gerçek birikmiş yarı mamul maliyeti üzerinden envantere alınan."
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Sarflama, birden fazla işte kullanılabilecek bir parça yapmak için kullanılan fiziksel bir malzemedir"
+msgstr "Sarf malzemesi, bir parçayı yapmak için kullanılan ve birden fazla iş emrinde kullanılabilen fiziksel bir stok kartıdır."
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "Bir yüklenici, belirli yeteneklere ve müsait saatlere sahip bir tedarikçi iletişimidir."
+msgstr "Taşeron, belirli yetkinliklere ve kullanılabilir saatlere sahip bir tedarikçi ilgili kişisidir."
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "Sizin ihtiyaçlarınızı karşılamak için özel bir çözüm"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Bir müşteri, parçalarınızı veya hizmetlerinizi satın alan bir işletme veya kişidir."
@@ -384,7 +384,7 @@ msgid "A customer's name changes"
 msgstr "Bir müşterinin adı değiştirildi"
 
 msgid "A customer's sales contact changes"
-msgstr "Bir müşterinin satış temsilcisi değiştirildi"
+msgstr "Müşterinin satış ilgili kişisi değişiyor"
 
 msgid "A customer's status changes"
 msgstr "Bir müşterinin durumu değiştirildi"
@@ -393,16 +393,16 @@ msgid "A customer's type changes"
 msgstr "Bir müşterinin türü değiştirildi"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "Bir göstergenin izlenebilir bir standarda karşı kontrol edildiğini kanıtlayan tarihli bir kayıt; işlem gerekli, ayarlama gerekli veya onarım gerekli bayrağı işaretlenmediği sürece geçer ve göstergenin sonraki kontrol tarihini sıfırlar."
+msgstr "Ölçüm aletinin izlenebilir bir standarda karşı kontrol edildiğini kanıtlayan tarihli kayıt; eylem, ayarlama veya onarım gerektiren bayrak işaretlenmediği sürece uygun bulunur ve ölçüm aletinin bir sonraki kontrol tarihini sıfırlar."
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "Girişlerin düştüğü tarihli bir dönem; kapatma durumu Açık → Kilitli → Kapalı şeklinde ilerler ve kapalı bir dönem yeni girişlere karşı donmuş durumda kalır."
+msgstr "Muhasebeleştirmelerin girdiği tarihli pencere; kapatma durumu Açık → Kilitli → Kapatıldı şeklinde ilerler ve kapatılan dönem yeni muhasebeleştirmelere karşı kilitlenir."
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
 msgstr "Kalan defter değerinin her dönem sabit bir yüzdesini şarj eden bir amortisman yöntemi — başında daha ağır, sonra daha hafif."
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
-msgstr "Varlığın faydalı ömrü boyunca her dönem eşit bir tutarı şarj eden bir amortisman yöntemi."
+msgstr "Varlığın faydalı ömrü boyunca her dönem eşit tutar kadar yükleyen bir amortisman yöntemi."
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
 msgstr "Müşterinin teslim etme konusunda kesin bir taahhüdü; yerine getirme durumu Tamamlanan statüsüne ulaşmadan önce gönderim ve fatura arasında bölünür."
@@ -414,7 +414,7 @@ msgid "A formal acceptance / sign-off phase"
 msgstr "Resmi bir kabul / imza aşaması"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "Rolü Ana Gösterge olan bir gösterge — rutin kontroller için kullanılan değil, diğer göstergelerin kalibre edildiği referans standarttır."
+msgstr "Mastar rolü taşıyan bir ölçüm aleti — diğer ölçüm aletlerinin kalibrasyonunun yapıldığı referans standart, rutin kontroller için kullanılan değil."
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "Bir sorun kaydı kalite sorunlarını ve çözüm süreçlerini izler."
@@ -426,13 +426,13 @@ msgid "A job is deleted"
 msgstr "Bir iş silindi"
 
 msgid "A job is put on hold"
-msgstr "Bir iş beklemeye alındı"
+msgstr "İş emri askıya alındı"
 
 msgid "A job is released"
 msgstr "Bir iş serbest bırakıldı"
 
 msgid "A job operation is completed"
-msgstr "Bir iş operasyonu tamamlandı"
+msgstr "İş emri operasyonu tamamlandı"
 
 msgid "A job's assignee changes"
 msgstr "Bir işin atanan kişi değiştirildi"
@@ -450,10 +450,10 @@ msgid "A job's quantity changes"
 msgstr "Bir işin miktarı değiştirildi"
 
 msgid "A job's scrap quantity changes"
-msgstr "Bir işin atık miktarı değiştirildi"
+msgstr "İş emrinin fire miktarı değişiyor"
 
 msgid "A job's start date changes"
-msgstr "Bir işin başlama tarihi değiştirildi"
+msgstr "İş emrinin başlangıç tarihi değişiyor"
 
 msgid "A job's status changes"
 msgstr "Bir işin durumu değiştirildi"
@@ -467,28 +467,28 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "Bir liste {0} öğesine bağlandı, bu nedenle bu adım içindeki her öğe için bir kez çalışır — en fazla {MAX_LIST_ITEMS}."
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "Kendi işini ve yönlendirmesini ana kısmının içinde alan bir Sipariş üzere Üretim bileşeni."
+msgstr "Siparişe göre üretim bileşeni, ana ürünün yapısı içinde kendi iş emri ve rotasını alan."
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "Parçaları ebeveyn işine birlikte verilen bir Sipariş üzere Üretim bileşeni — ayrı yapı yok."
+msgstr "Siparişe göre üretim bileşeni, parçaları ana iş emrine birlikte verilen — ayrı yapı yoktur."
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbon'ın yönetilen bulut barındırılan sürümü"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "Tüm gelişmiş özelliklerle yönetilen sürüm"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Bir malzeme, birden fazla işte kullanılabilecek bir parça yapmak için kullanılan fiziksel bir öğedir"
+msgstr "Malzeme, bir parçayı yapmak için kullanılan ve birden fazla iş emrinde kullanılabilen fiziksel bir stok kartıdır."
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "Bir kayıt olarak izlenen ve yinelenen bir kalibrasyon programına tabi tutulan bir ölçüm aracı (kumpas, mikrometre, pim göstergesi, CMM)."
+msgstr "Ölçüm aleti (kumpas, mikrometre, pin ölçüm aleti, CMM) bir kayıt olarak izlenen ve yinelenen bir kalibrasyon çizelgesine tabi tutulan."
 
 msgid "A name is required to save a view"
 msgstr "Bir görünüm kaydetmek için bir isim gereklidir"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "Belirli bir ürün için sabitlenen müzakere edilen bir fiyat — müşteri, müşteri türü veya tüm müşteriler tarafından — temel fiyatı tamamen değiştirir, isteğe bağlı olarak miktar seviyeleriyle."
+msgstr "Belirli bir müşteri, müşteri türü veya tüm müşteriler için sabitlenmiş ve temel fiyatın yerini tamamıyla alan, isteğe bağlı olarak miktar kademesileri ile birlikte gelen müzakere edilmiş fiyat."
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
 msgstr "Her tedarikçi için yeni bir satın alma siparişi oluşturulacaktır. Alternatif olarak, tedarikçinin dış operasyonları eklemesi için mevcut taslak bir satın alma siparişi seçebilirsiniz."
@@ -500,7 +500,7 @@ msgid "A new size will be created using a copy of the current size"
 msgstr "Yeni bir boyut, mevcut boyutun bir kopyası kullanılarak oluşturulacaktır"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "Yeni bir Stripe müşterisi oluşturulacak"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "Bir faturayı bir sebep hesabına karşı ödeyen nakitsiz bir belge: alacak, borçlu olunan tutarı azaltır, borç artırır."
@@ -512,37 +512,37 @@ msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) adde
 msgstr "Vergilendirilmeyen bir ek ücret (örneğin izin ücretleri gibi geri alınabilir giderler) satıra eklenir ve vergi matrahından hariç tutulur."
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "Onaylanan kök nedeni düzelten bir uygunsuzluk görevi — önleyici veya anında kapatma eyleminin aksine."
+msgstr "Teyit edilmiş bir kök neden düzelten uygunsuzluk görevi — önleyici veya acil çevreleme eyleminin aksine."
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "Problemin başka yerde yeniden oluşmasını önleyen bir uygunsuzluk görevi — düzeltici düzeltme ve kapatmadan farklıdır."
+msgstr "Sorununun başka yerlerde tekrarlanmasını durduran uygunsuzluk görevi — düzeltici onarım ve çevrelemeden farklı."
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "Bir parça, satın alınabilir veya üretilebilir belirli bir öğe hakkındaki bilgileri içerir."
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "Stokla yaşayan fiziksel bir çekme sinyali — basılı bir kart veya QR kodu — bir bin'i doldurmak için tarandığı anda bir satın alma siparişi veya iş oluşturur."
+msgstr "Stoğun yanında yaşayan basılı kart veya QR kodu olan, göz doldurmak için taranması anında satın alma siparişi veya iş emri oluşturan fiziksel çekme sinyali."
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
 msgstr "Carbon'un kendi akışlarından birinde, bir iş akışı tarafından izlenebilir — bir iş serbest bırakıldı, bir teklif kabul edildi, bir sevkiyat nakledildi — ham alan değişimine karşın; iş akışına söz konusu kayıtları id'ye göre teslim eder."
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "Deftere geçirilen muhasebe girişi: GL hesaplarına karşı dengeli debit ve kredi satırları artı başlık."
+msgstr "Muhasebeleştirilmiş muhasebe girdisi: başlık artı muhasebe hesaplarına karşı dengeli borç ve alacak satırları."
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
-msgstr "Deftere kaydedilmiş bir nakit işlemi — bir müşteriden alınan Makbuz veya bir tedarikçiye yapılan Ödeme — faturaları anlaşmalar aracılığıyla uygulanan, Taslak → Deftere Kaydedildi → İptal edildi şeklinde ilerler."
+msgstr "Muhasebeleştirilmiş nakit işlemi — bir müşteriden alınan Nakit ya da bir tedarikçiye yapılan Tediye — ödemeler ve kredi veya borç dekontları uygulanarak, Taslak → Muhasebeleştirildi → Hükümsüz arasında hareket ediyor."
 
 msgid "A pre-written description inserted into every issue that uses this workflow; placeholders like {itemId} and {location} are substituted at creation."
 msgstr "Bu iş akışını kullanan her sorun içine eklenen önceden yazılmış bir açıklama; {itemId} ve {location} gibi yer tutucu değerleri oluşturma sırasında değiştirilir."
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "Fiyatlandırılmış bir satış teklifi; Taslak → Gönderilen → Sipariş Edildi veya Kayıp, Süresi Geçmiş veya İptal ile sonlanır."
+msgstr "Fiyatlandırılmış satış teklifi; Taslak → Gönderilen → Sipariş edildi, ya da Kaybedildi, Süresi doldu veya İptal edildi ile sonlanır."
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
-msgstr "Bir satın alma faturası, bir müşterinin satın aldığı ürünleri veya hizmetleri ve bunlara karşılık gelen maliyeti belirten bir belgedir."
+msgstr "Alış faturası, bir müşteri tarafından satın alınan ürün veya hizmetleri ve bunlara karşılık gelen maliyeti belirten belgedir."
 
 msgid "A purchase invoice is posted"
-msgstr "Bir satın alma faturası nakledildi"
+msgstr "Alış faturası muhasebeleştirildi"
 
 msgid "A purchase order is created"
 msgstr "Bir satın alma siparişi oluşturuldu"
@@ -575,10 +575,10 @@ msgid "A purchase order's type changes"
 msgstr "Bir satın alma siparişinin türü değiştirildi"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "Bir kalite sorunu — kaydedilmiş bir sapma veya kusur ve araştırma ve iyileştirme görevlerinin yapılandırılabilir iş akışı."
+msgstr "Kalite sorunu — araştırma ve eylem görevlerinin yapılandırılabilir iş akışı ile kaydedilen sapma veya hata."
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
-msgstr "Bir dizi aynı birim izlenen bir varlığı ve toplu numarasını paylaşır — bir varlık, birçok birim."
+msgstr "Aynı birimlerin bir miktarı bir izlenen varlık ve parti numarasını paylaşır — bir varlık, birçok adet."
 
 msgid "A quote is a set of prices for specific parts and quantities."
 msgstr "Teklif, belirli parçalar ve miktarlar için bir fiyat kümesidir."
@@ -596,7 +596,7 @@ msgid "A quote is sent"
 msgstr "Bir teklif gönderildi"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "Bir fiyat teklifi satırı, belirli bir parça için fiyatlandırma ve teslim süreleri içerir"
+msgstr "Teklif satırı belirli bir parça için fiyatlandırma ve tedarik sürelerini içerir"
 
 msgid "A quote's assignee changes"
 msgstr "Teklifin atanmış kişisi değişti"
@@ -641,7 +641,7 @@ msgid "A receipt's location changes"
 msgstr "Makbuzun konumu değişti"
 
 msgid "A receipt's posting date changes"
-msgstr "Makbuzun kayıt tarihi değişti"
+msgstr "Mal kabul muhasebeleştirme tarihi değişir"
 
 msgid "A receipt's source document changes"
 msgstr "Makbuzun kaynak belgesi değişti"
@@ -656,10 +656,10 @@ msgid "A reusable, versioned set of work instructions attached to a process, giv
 msgstr "Bir işleme bağlı, yeniden kullanılabilir, sürümlendirilmiş bir iş talimatları seti; bir operasyona kaydedilecek ve kontrol edilecek sıralı adımlar ile çalıştığı parametreleri sağlar."
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "Yayınlanan bir işin yönlendirme adımı, işin kendi operasyon kopyası, durumu zemin tarafından Yapılacak'tan Tamamlandı'ya kadar yönetilir."
+msgstr "Serbest bırakıldı iş emrindeki rota adımı — iş emrinin kendi operasyon kopyası — zeminin Yapılacak'tan Bitti'ye kadar yönlendirdiği bir durum taşır."
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "Bir satış faturası (müşteriye fatura kesme) veya satın alma faturası (tedarikçi size fatura kesiyor), ödemeler ve alacak veya borç muhasebe defteri belgeleri uygulanarak ödenmiş."
+msgstr "Satış faturası (müşteriye fatura kesiyorsunuz) veya alış faturası (tedarikçi sizi faturalandırıyor), ödemeler ve kredi veya borç dekontları uygulanarak ödenir."
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
 msgstr "Satış faturası, bir müşteriye satılan ürünleri veya hizmetleri ve bunlara karşılık gelen maliyeti belirten bir belgedir."
@@ -707,7 +707,7 @@ msgid "A sales order's status changes"
 msgstr "Satış siparişinin durumu değişti"
 
 msgid "A sales request for quote (RFQ) is a customer inquiry for pricing on a set of parts and quantities. It may result in a quote."
-msgstr "Teklif talebi (RFQ), bir dizi parça ve miktar için müşterinin fiyat teklifi talebidir. Bir teklifle sonuçlanabilir."
+msgstr "Satış teklif talebi (RFQ), bir dizi parça ve miktar üzerinde fiyatlandırma için müşteri soruşturmasıdır. Bir teklif ile sonuçlanabilir."
 
 msgid "A sales RFQ (a customer asks you to quote) or a purchasing RFQ (you ask suppliers); both feed the opportunity thread."
 msgstr "Bir satış RFQ (müşteri sizi alıntı yapmak için ister) veya satın alma RFQ (siz tedarikçileri istersiniz); her ikisi de fırsat ipliğini besler."
@@ -725,7 +725,7 @@ msgid "A set of companies under one owner that share group-scoped configuration 
 msgstr "Tek bir sahip altında, grup kapsamlı yapılandırmayı — hesap planı, para birimleri ve boyutlar — paylaşan, böylece aynı muhasebe kurulumunun gruptaki her şirketi kapsadığı şirketler kümesi."
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "Bir işin bekleyen malzemeleri depodan çekmek ve üretime hazırlamak için bir dizi talimat; bir çekme stoku tüketmek yerine kullanım noktasına taşır."
+msgstr "Bir iş emrinin ihtiyaç duyulan malzemeleri depodan çekmek ve onları hat yanına hazırlamak için bir dizi talimat; bir toplama işi stoğu tüketmek yerine kullanım noktasına hareket ettirir."
 
 msgid "A shipment is created"
 msgstr "Bir sevkiyat oluşturuldu"
@@ -737,7 +737,7 @@ msgid "A shipment is posted"
 msgstr "Bir sevkiyat kaydedildi"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "Deponuzu atlayarak doğrudan tedarikçiden müşteriye gönderilen bir gönderim satırı — satır başına ayarlanır, başlıkta değil."
+msgstr "Tedarikçiden doğrudan müşteriye gönderilen ve deponuzu atlayan sevkiyat satırı — satır başına ayarlanır, başlıkta değil."
 
 msgid "A shipment's assignee changes"
 msgstr "Sevkiyatın atanmış kişisi değişti"
@@ -749,7 +749,7 @@ msgid "A shipment's location changes"
 msgstr "Sevkiyatın konumu değişti"
 
 msgid "A shipment's posting date changes"
-msgstr "Sevkiyatın kayıt tarihi değişti"
+msgstr "Sevkiyatın muhasebeleştirme tarihi değişir"
 
 msgid "A shipment's shipping method changes"
 msgstr "Sevkiyatın kargo yöntemi değişti"
@@ -797,22 +797,22 @@ msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into
 msgstr "Vergilendirilecek bir ek ücret (işçilik, kurulum, yakıt) satıra eklenir ve vergi matrahına dahil edilir."
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "Bir iş operasyonuna karşı kaydedilen Kurulum, İşçilik veya Makine çalışmasının zamanlanmış kaydı; süresi operasyonun gerçek maliyetine toplanır."
+msgstr "Bir iş emri operasyonuna karşı kaydedilen Hazırlık, İşçilik veya Makine çalışmasının zamanlı kaydı, süresi operasyonun gerçek maliyetinde toplanır."
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "Bir takım, birden fazla işte kullanılabilecek bir parça yapmak için kullanılan fiziksel bir öğedir"
+msgstr "Takım, birden fazla iş emri arasında kullanılabilen bir parça yapmak için kullanılan fiziksel bir öğedir"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
 msgstr "Kullanıcı, mallar alındığında her parti veya seri için son kullanma tarihini kaydeder. Tedarikçiler farklı son kullanma tarihlerine sahip partiler gönderdiğinde kullanılır."
 
 msgid "abilities"
-msgstr "yetenekler"
+msgstr "yetkinlikler"
 
 msgid "Abilities"
-msgstr "Yetenekler"
+msgstr "Yetkinlikler"
 
 msgid "ability"
-msgstr "yetenek"
+msgstr "yetkinlik"
 
 msgid "About"
 msgstr "Hakkında"
@@ -842,7 +842,7 @@ msgid "Acceptance"
 msgstr "Kabul"
 
 msgid "Acceptance passed"
-msgstr "Kabul edildi"
+msgstr "Kabul geçti"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
@@ -867,10 +867,10 @@ msgid "Account for small rounding differences in transactions"
 msgstr "İşlemlerdeki küçük yuvarlama farkları hesaplayın."
 
 msgid "Account for the cost of fixed assets when disposed"
-msgstr "Sabit varlıkları elden çıkarırken maliyetleri hesaplayın."
+msgstr "Elden çıkarıldığında sabit kıymetlerin maliyetini hesaba kat"
 
 msgid "Account for the purchase cost of fixed assets"
-msgstr "Sabit varlıkların satın alma maliyetini hesaplayın."
+msgstr "Sabit kıymetlerin satın alma maliyetini hesaba kat"
 
 msgid "Account manager"
 msgstr "Hesap yöneticisi"
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "Muhasebe"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "Muhasebe şu anda beta aşamasındadır. Raporlama, günlük girişler, muhasebe dönemleri, sabit varlıklar ve daha fazlasını etkinleştirmek için erişim isteyin."
+msgstr "Muhasebe şu anda beta aşamasındadır. Raporlama, muhasebe fişi, muhasebe dönemleri, sabit kıymetler ve daha fazlasını etkinleştirmek için erişim isteyin."
 
 msgid "Accounting is disabled"
 msgstr "Muhasebe devre dışı"
@@ -918,7 +918,7 @@ msgid "Accounting Periods"
 msgstr "Muhasebe Dönemleri"
 
 msgid "Accounting: GL, AR, AP, and month-end close"
-msgstr "Muhasebe: GL, AR, AP ve ay sonu kapanışı"
+msgstr "Muhasebe: Büyük defter, Alacak hesapları, Borç hesapları ve ay sonu kapanışı"
 
 msgid "Accounts"
 msgstr "Hesaplar"
@@ -927,7 +927,7 @@ msgid "Accounts for recording differences between actual and standard costs"
 msgstr "Fiili ve standart maliyetler arasındaki farklılıkları kaydetmek için kullanılan hesaplar"
 
 msgid "Accounts Payable"
-msgstr "Ödenecek hesaplar"
+msgstr "Borç hesapları"
 
 msgid "Accounts payable for amounts owed to suppliers"
 msgstr "Tedarikçilere borçlu olunan tutarlar için ödenecek hesaplar."
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "Müşteriler tarafından borçlu olunan tutarlar için alacak hesapları."
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "Deftere nakil varsayılanları veya yevmiye geçmişi tarafından referans verilen ancak henüz sağlayıcı haritalaması olmayan hesaplar."
+msgstr "Muhasebeleştirme varsayılanları veya muhasebe fişi geçmişi tarafından referans gösterilen ancak henüz sağlayıcı eşlemesi olmayan hesaplar."
 
 msgid "Accumulated Depreciation"
 msgstr "Birikmiş amortisman"
@@ -954,10 +954,10 @@ msgid "Accumulated Depreciation Account"
 msgstr "Birikmiş amortisman hesabı"
 
 msgid "Accumulated Depreciation on Disposal"
-msgstr "Bertaraf sırasında birikmiş amortisman"
+msgstr "Elden Çıkarma Sırasında Birikmiş Amortisman"
 
 msgid "Accumulated Depreciation on Disposal (default)"
-msgstr "Bertaraf sırasında birikmiş amortisman (varsayılan)"
+msgstr "Elden Çıkarma Sırasında Birikmiş Amortisman (varsayılan)"
 
 msgid "Accumulation Period (Weeks)"
 msgstr "Biriktirme Süresi (Hafta)"
@@ -972,7 +972,7 @@ msgid "Acknowledged itar"
 msgstr "İTAR kabul edildi"
 
 msgid "Acquisition Cost"
-msgstr "Satın alma maliyeti"
+msgstr "Edinme maliyeti"
 
 msgid "Acquisition Date"
 msgstr "Satın alma tarihi"
@@ -1011,7 +1011,7 @@ msgid "Active"
 msgstr "Aktif"
 
 msgid "Active Jobs"
-msgstr "Aktif İşler"
+msgstr "Aktif İş emirleri"
 
 msgid "Active Statuses"
 msgstr "Aktif Durumlar"
@@ -1053,16 +1053,16 @@ msgid "Add a comment..."
 msgstr "Bir yorum ekle..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "Miktar, fiyat, kargo, teslim süresi ve vergiyi geçersiz kılmak için özel bir fiyatlandırma satırı ekleyin"
+msgstr "Miktarı, fiyatı, nakliyeyi, tedarik süresini ve vergiyi geçersiz kılmak için özel bir fiyatlandırma satırı ekleyin"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
-msgstr "Malzeme listesindeki her parçayı ve miktarını gösteren bir malzeme bölümü ekleyin."
+msgstr "Ürün ağacısındaki her stok kartını miktarı ile listeleyen bir bölüm ekleyin"
 
 msgid "Add a printer in the printing settings to print labels directly."
 msgstr "Etiketleri doğrudan yazdırmak için yazdırma ayarlarında bir yazıcı ekleyin."
 
 msgid "Add a requirement"
-msgstr "Bir gereksinim ekle"
+msgstr "Gereklilik ekle"
 
 msgid "Add a row"
 msgstr "Bir satır ekle"
@@ -1077,7 +1077,7 @@ msgid "Add Actions"
 msgstr "Eylemler Ekle"
 
 msgid "Add Adjustment"
-msgstr "Ayarlama ekle"
+msgstr "Düzeltme Ekle"
 
 msgid "Add Affected Item"
 msgstr "Etkilenen Öğe Ekle"
@@ -1086,7 +1086,7 @@ msgid "Add any notes about your decision..."
 msgstr "Kararınızla ilgili herhangi bir not ekleyin..."
 
 msgid "Add Approval Requirement"
-msgstr "Onay Gereksinimi Ekle"
+msgstr "Onay Gereklilik Ekle"
 
 msgid "Add Authenticator App"
 msgstr "Kimlik Doğrulayıcı Uygulaması Ekle"
@@ -1095,7 +1095,7 @@ msgid "Add Calibration Record"
 msgstr "Kalibrasyon Kaydı Ekle"
 
 msgid "Add Child Storage Unit"
-msgstr "Alt Depo Birimi Ekle"
+msgstr "Alt Depolama Birimi Ekle"
 
 msgid "Add clause"
 msgstr "Madde ekle"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "Koşul ekle"
 
 msgid "Add Contractor"
-msgstr "Yüklenici Ekle"
+msgstr "Taşeron Ekle"
 
 msgid "Add cost center"
 msgstr "Maliyet Merkezi Ekle"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "Not Ekle"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "Bu bakım sevkiyatı için notlar ve dokümantasyon ekleyin"
+msgstr "Bu bakım emri için notlar ve belgeler ekleyin"
 
 msgid "Add Operation"
 msgstr "İşlem Ekle"
@@ -1191,7 +1191,7 @@ msgid "Add Receipt"
 msgstr "Makbuz Ekle"
 
 msgid "Add Requirement"
-msgstr "Gereksinim Ekle"
+msgstr "Gereklilik Ekle"
 
 msgid "Add Risk"
 msgstr "Risk Ekle"
@@ -1279,7 +1279,7 @@ msgid "Address line2"
 msgstr "Adres satırı 2"
 
 msgid "Adjustment Type"
-msgstr "Ayarlama Türü"
+msgstr "Düzeltme Türü"
 
 msgid "Admin"
 msgstr "Yönetici"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "Tüm {0} hücre uyumluyor"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "Tüm {total} aşama tamamlandı. Harika iş — ekibiniz çalışmaya başladı."
+msgstr "Tüm {total} aşama bitti. Harika iş — ekibiniz çalışıyor."
 
 msgid "All accounts"
 msgstr "Tüm hesaplar"
@@ -1334,10 +1334,10 @@ msgid "All actions selected"
 msgstr "Tüm eylemler seçildi"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "Tüm gelişmiş özellikler kullanılabilir"
 
 msgid "All Audit Logs"
-msgstr "Tüm Denetim Kayıtları"
+msgstr "Tüm Denetim Günlükleri"
 
 msgid "All changes to auditable entities are being recorded."
 msgstr "Denetlenebilir varlıklardaki tüm değişiklikler kaydediliyor."
@@ -1352,7 +1352,7 @@ msgid "All Documents"
 msgstr "Tüm Belgeler"
 
 msgid "All item types"
-msgstr "Tüm öğe türleri"
+msgstr "Tüm stok kartı türleri"
 
 msgid "All Items"
 msgstr "Tüm Öğeler"
@@ -1364,7 +1364,7 @@ msgid "All members of selected groups and selected individuals will be able to a
 msgstr "Seçilen gruplardaki ve bireylerdeki tüm üyeler talepleri onaylayabilecektir"
 
 msgid "All posting accounts are mapped"
-msgstr "Tüm deftere nakil hesapları haritalanmış"
+msgstr "Tüm muhasebeleştirme hesapları eşlendi"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "{inserted} eklendi, {updated} güncellendi — tüm satırlar içe aktarıldı."
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "Tutar"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "Bu satırda varlıkları/giderleri artıran veya yükümlülükleri/özkaynakları/gelirleri azaltan tutar."
+msgstr "Bu satırda varlıkları/giderleri artıran veya yükümlülükleri/özkaynağı/hasılatı azaltan tutar."
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "Bu satırda yükümlülükleri/özkaynakları/gelirleri artıran veya varlıkları/giderleri azaltan tutar."
+msgstr "Bu satırda yükümlülükleri/özkaynağı/hasılatı artıran veya varlıkları/giderleri azaltan tutar."
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,10 +1422,10 @@ msgid "Amount Type"
 msgstr "Tutar Türü"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "Departman veya işlev tarafından harcamaları gruplandıran bir muhasebe kovası, böylece GL harcamaları hesap tarafından değil grup tarafından raporlayabilir."
+msgstr "Giderleri departman veya işlev tarafından gruplandıran ve Büyük Defteri harcamaları hesap yerine grup tarafından rapor etmesine izin veren bir muhasebe kategorisi."
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "Harcama yerine amorti ettiğiniz kapitalize edilmiş bir öğe için bir muhasebe kaydı; Taslak → Etkin → Tamamen amorti edilmiş → İmha edilmiş."
+msgstr "Gider yerine amortisman yaptığınız kapitalize edilmiş bir madde için bir muhasebe kaydı; Taslak → Aktif → Amortismanı tamamlanmış → Elden çıkarıldı."
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
 msgstr "Bir carbon/notify etkinliğinden uygulama içi gelen kutusu ve isteğe bağlı e-posta ve Slack'e dağıtılan bir uyarı; konu başına ve kullanıcı başına sessize alınabilir."
@@ -1434,7 +1434,7 @@ msgid "An approval requirement on a non-conformance whose reviewers (seeded Engi
 msgstr "Sorun kapanmadan önce gözden geçirenler (Mühendislik ve Kalite) onay vermelidir uygunsuzluk üzerinde bir onay gerekliliği."
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "Bir varlığın satın alma maliyeti eksi birikmiş amortisman — kitaplarda halen değeri olan ve imha edildiği tutar."
+msgstr "Bir varlığın edinme maliyeti eksi birikmiş amortisman — defterler üzerinde hala ne kadar değerli olduğu ve elden çıkarıldığı rakam."
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "Bir kanvas üzerinde oluşturduğunuz bir otomasyon: bir tetikleyici, ardından koşulları kontrol eden, kayıtları arayan ve hareket eden adımlar — birini bilgilendiren, bir kaydı oluşturan veya güncelleyen veya dış bir URL çağırma."
@@ -1500,25 +1500,25 @@ msgid "An item's assignee changes"
 msgstr "Bir öğenin atanmış kişisi değişir"
 
 msgid "An item's default method type changes"
-msgstr "Bir öğenin varsayılan yöntem türü değişir"
+msgstr "Bir stok kartının varsayılan tedarik şekli değişir"
 
 msgid "An item's name changes"
 msgstr "Bir öğenin adı değişir"
 
 msgid "An item's replenishment system changes"
-msgstr "Bir öğenin yeniden sağlanma sistemi değişir"
+msgstr "Bir stok kartının ikmal yöntemi değişir"
 
 msgid "An item's revision status changes"
 msgstr "Bir öğenin revizyon durumu değişir"
 
 msgid "An item's tracking type changes"
-msgstr "Bir öğenin takip türü değişir"
+msgstr "Bir stok kartının izleme türü değişir"
 
 msgid "An item's unit of measure changes"
 msgstr "Bir öğenin ölçü birimi değişir"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "Bir iç çalışma merkezi yerine harici bir sağlayıcı tarafından gerçekleştirilen ve bir alt yüklenici satın alma siparişiyle kapsanan işlem."
+msgstr "Bir iç merkez yerine harici bir taşeron tarafından yapılan, taşeron satın alma siparişi kapsamında olan bir operasyon."
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
 msgstr "Bir işin iş merkezinin kuyruğundaki konumu — işinin çekildiği sıra — İş Merkezleri panosundaki kartları herhangi bir tarihi değiştirmeden yeniden sıralayarak ayarlanan."
@@ -1564,31 +1564,31 @@ msgid "Another cost center this one rolls up into, letting you nest a sub-depart
 msgstr "Bu toplandığı başka bir maliyet merkezi, hiyerarşik maliyet raporlaması için bir alt maliyet merkezini ana kütesinin altında iç içe geçirmenizi sağlar."
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "Bu iç içe geçen başka bir depolama birimi (ör. bir raftaki bin); aynı konumda olmalıdır."
+msgstr "Bu depolama biriminin yerleştirildiği başka bir depolama birimi (örneğin, bir raf içinde bir göz); aynı lokasyonda olması gerekir."
 
 msgid "Any item group"
 msgstr "Herhangi bir ürün grubu"
 
 msgid "Any item type"
-msgstr "Herhangi bir ürün tipi"
+msgstr "Herhangi bir stok kartı türü"
 
 msgid "Anything not explicitly listed in scope above"
 msgstr "Yukarıda açıkça kapsamda listelenmemiş herhangi bir şey"
 
 msgid "AP"
-msgstr "AP"
+msgstr "Borç hesapları"
 
 msgid "AP Aging"
-msgstr "AP Yaşlandırma"
+msgstr "Borç Hesapları Yaşlandırması"
 
 msgid "AP Clerk"
-msgstr "AP Muhasebesi Görevlisi"
+msgstr "Borç Hesapları Memuru"
 
 msgid "AP Outstanding"
-msgstr "AP Ödenmemiş"
+msgstr "Ödenmemiş Borç Hesapları"
 
 msgid "AP Overdue"
-msgstr "AP Vadesi Geçmiş"
+msgstr "Gecikmiş Borç Hesapları"
 
 msgid "API Docs"
 msgstr "API Belgeleri"
@@ -1609,7 +1609,7 @@ msgid "API keys for programmatic access to your Carbon data."
 msgstr "Carbon verilerinize programatik erişim için API anahtarları."
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API, webhook'lar ve entegrasyonlar"
 
 msgid "Applied"
 msgstr "Uygulandı"
@@ -1643,7 +1643,7 @@ msgid "Apply a demo template"
 msgstr "Demo şablonu uygula"
 
 msgid "Apply available credits"
-msgstr "Mevcut kredileri uygula"
+msgstr "Kullanılabilir kredileri uygula"
 
 msgid "Apply credits"
 msgstr "Kredileri uygula"
@@ -1685,10 +1685,10 @@ msgid "Approval is required at or above this amount, up to the next rule's minim
 msgstr "Onay, bu tutar veya daha yüksek bir tutarda ve sonraki kuralın minimumuna kadar gereklidir"
 
 msgid "Approval requirements"
-msgstr "Onay gereksinimleri"
+msgstr "Onay gereklilikleri"
 
 msgid "Approval Requirements"
-msgstr "Onay Gereksinimleri"
+msgstr "Onay Gereklilikleri"
 
 msgid "Approval Rules"
 msgstr "Onay Kuralları"
@@ -1709,25 +1709,25 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "Alacak hesapları"
 
 msgid "AR / AP representation"
-msgstr "AR / AP gösterimi"
+msgstr "Alacak hesapları / Borç hesapları temsili"
 
 msgid "AR Aging"
-msgstr "AR Yaşlandırma"
+msgstr "Alacak Hesapları Yaşlandırması"
 
 msgid "AR Clerk"
-msgstr "AR Görevlisi"
+msgstr "Alacak Hesapları Memuru"
 
 msgid "AR Outstanding"
-msgstr "AR Ödenmemiş"
+msgstr "Ödenmemiş Alacak Hesapları"
 
 msgid "AR Overdue"
-msgstr "AR Vadesi Geçmiş"
+msgstr "Gecikmiş Alacak Hesapları"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "Alacak hesapları/Borç hesapları"
 
 msgid "Archive"
 msgstr "Arşiv"
@@ -1750,7 +1750,7 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "İş akışını etkinleştirmek istediğinizden emin misiniz: {name}? Tekrar açılır menülerde görünecektir."
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "Bu kalibratörü etkinleştirmek istediğinizden emin misiniz?."
+msgstr "Bu ölçüm aletini etkinleştirmek istediğinizden emin misiniz?."
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
@@ -1779,7 +1779,7 @@ msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "RFQ'yu teklife dönüştürmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "Bu satış emri için iş oluşturmak istediğinizden emin misiniz? Bu, zaten işleri olmayan tüm satırlar için işler oluşturacaktır."
+msgstr "Bu satış siparişi için iş emirleri oluşturmak istediğinizden emin misiniz? Bu, zaten iş emirleri olmayan tüm satırlar için iş emirleri oluşturacaktır."
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1787,11 +1787,11 @@ msgstr "{0}'yi devre dışı bırakmak istediğinizden emin misiniz?"
 
 #. placeholder {0}: selectedCategory?.name
 msgid "Are you sure you want to deactivate the {0} attribute category?"
-msgstr "Bu {0} nitelik kategorisini devre dışı bırakmak istediğinizden emin misiniz?"
+msgstr "{0} öznitelik kategorisini devre dışı bırakmak istediğinizden emin misiniz?"
 
 #. placeholder {0}: selectedAttribute?.name
 msgid "Are you sure you want to deactivate the {0} attribute?"
-msgstr "{0} özelliğini devre dışı bırakmak istediğinizden emin misiniz?"
+msgstr "{0} özniteliğini devre dışı bırakmak istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to deactivate the {label} configuration rule?"
 msgstr "{label} yapılandırma kuralını devre dışı bırakmak istediğinizden emin misiniz?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "Bu kullanıcıları devre dışı bırakmak istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "Bu ölçüm cihazını devre dışı bırakmak istediğinizden emin misiniz?."
+msgstr "Bu ölçüm aletini devre dışı bırakmak istediğinizden emin misiniz?."
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "Bu kullanıcıyı devre dışı bırakmak istediğinizden emin misiniz?"
@@ -1846,7 +1846,7 @@ msgid "Are you sure you want to delete the {key} parameter from this operation? 
 msgstr "Bu işlemden {key} parametresini silmek istediğinizden emin misiniz? Bu geri alınamaz."
 
 msgid "Are you sure you want to delete the {name} attribute from this operation? This cannot be undone."
-msgstr "Bu işlemden {name} özelliğini silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "Bu operasyondan {name} özniteliğini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: account.name
 #. placeholder {1}: account.number ? ` (${account.number})` : ""
@@ -1870,7 +1870,7 @@ msgid "Are you sure you want to delete the change notice category: {0}? This can
 msgstr "{0} değişiklik bildirisi kategorisini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "Yükleniciyi silmek istediğinizden emin misiniz: {name}? Bu geri alınamaz."
+msgstr "{name} taşeronunu silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1899,7 +1899,7 @@ msgstr "Hata modu '{name}' silmek istediğinizden emin misiniz? Bu geri alınama
 
 #. placeholder {0}: gaugeType.name
 msgid "Are you sure you want to delete the gauge type: {0}? This cannot be undone."
-msgstr "Eminsiz misiniz, ölçü tipi {0}'ı silmek? Bu geri alınamaz."
+msgstr "{0} ölçüm aleti türünü silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: group.name
 msgid "Are you sure you want to delete the group: {0}? This cannot be undone."
@@ -1937,7 +1937,7 @@ msgstr "Malzeme boyutunu silmek istediğinizden emin misiniz: {0}? Bu geri alın
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
-msgstr "Malzeme bitişini silmek istediğinizden emin misiniz: {0}? Bu geri alınamaz."
+msgstr "{0} yüzey işlemini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
@@ -1945,11 +1945,11 @@ msgstr "Malzeme formu '{0}' silmek istediğinizden emin misiniz? Bu geri alınam
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "Malzeme sınıfını silmek istediğinizden emin misiniz: {0}? Bu geri alınamaz."
+msgstr "{0} malzeme kalitesini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "Malzeme özüntesini silmek istediğinizden emin misiniz: {0}? Bu geri alınamaz."
+msgstr "{0} ana malzemeyi silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
@@ -1957,14 +1957,14 @@ msgstr "Malzeme türünü silmek istediğinizden emin misiniz: {0}? Bu geri alı
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "Eminsiyon nedeni '{0}' silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "{0} teklif yok nedenini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "Ortak: {name}'i silmek istediğinizden emin misiniz? Bu geri alınamaz."
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "Ödeme vadesini silmek istediğinizden emin misiniz: {0}? Bu geri alınamaz."
+msgstr "{0} ödeme koşulunu silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1977,12 +1977,12 @@ msgstr "Yazıcı \"{0}\" cihazını silmek istediğinizden emin misiniz? Bu yaz�
 #. placeholder {0}: purchaseInvoiceLine.quantity ?? 0
 #. placeholder {1}: purchaseInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the purchase invoice line for {0} {1}? This cannot be undone."
-msgstr "Ürün faturası satırını {0} {1} için silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "{0} {1} alış faturası satırını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: salesInvoiceLine.quantity ?? 0
 #. placeholder {1}: salesInvoiceLine.description ?? ""
 msgid "Are you sure you want to delete the sales invoice line for {0} {1}? This cannot be undone."
-msgstr "Ürün için {0} {1} satırını silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "{0} {1} satış faturası satırını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: salesOrderLine.saleQuantity ?? 0
 #. placeholder {1}: salesOrderLine.description ?? ""
@@ -1991,17 +1991,17 @@ msgstr "Satır siparişi için {0} {1} satırını silmek istediğinizden emin m
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "Atık nedeni: {0}'ı silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "{0} fire nedenini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "Seri numarası dizisini {itemLabel} için silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "{itemLabel} öğesi için seri numarası numaralandırmasını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "Vardığınız vardiyayı silmek istediğinizden emin misiniz: {name} adlı vardiya, {locationName}'dan mı? Bu işlem geri alınamaz."
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "Kargo yöntemini silmek istediğinizden emin misiniz: {0}? Bu geri alınamaz."
+msgstr "{0} sevkiyat yöntemini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
@@ -2034,13 +2034,13 @@ msgid "Are you sure you want to delete this change notice?"
 msgstr "Bu değişiklik bildirisini silmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "Bu kalibratörü silmek istediğinizden emin misiniz?"
+msgstr "Bu ölçüm aletini silmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to delete this inspection plan?"
-msgstr "Bu muayene planını silmek istediğinizden emin misiniz?"
+msgstr "Bu kontrol planını silmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to delete this inspection plan? This cannot be undone."
-msgstr "Bu muayene planını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
+msgstr "Bu kontrol planını silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete this issue workflow?"
 msgstr "Bu iş akışını silmek istediğinizden emin misiniz?"
@@ -2052,7 +2052,7 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "Bu kanban kartını silmek istediğinizden emin misiniz? Bu geri alınamaz."
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "Bu bakım sevkini silmek istediğinizden emin misiniz? Bu geri alınamaz."
+msgstr "Bu bakım emrini silmek istediğinizden emin misiniz? Bu işlem geri alınamaz."
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
 msgstr "Bu geçiş anahtarını silmek istediğinizden emin misiniz? Artık oturum açmak için kullanamazsınız."
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "{0} öğesini kalıcı olarak silmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "Tedarikçi sürecini kalıcı olarak silmek istediğinizden emin misiniz?"
+msgstr "Tedarikçi prosesini kalıcı olarak silmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "Bu makbuzu yayınlamak istediğinizden emin misiniz?"
@@ -2112,7 +2112,7 @@ msgid "Are you sure you want to reject this quote?"
 msgstr "Bu teklifi reddetmek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "Bu işi yayınlamak istediğinizden emin misiniz? Atölye zemininde kullanılabilir hale gelecek ve satın alma ile üretimi tetikleyecektir."
+msgstr "Bu iş emrini serbest bırakmak istediğinizden emin misiniz? Atölyede kullanılabilir hale gelecek ve satın almayı ve üretimi yönlendirecektir."
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
@@ -2137,16 +2137,16 @@ msgid "Are you sure you want to send an invite to this user?"
 msgstr "Bu kullanıcıya daveti göndermek istediğinizden emin misiniz?"
 
 msgid "Are you sure you want to void this purchase invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Bu satın alma faturasını geçersiz kılmak istediğinizden emin misiniz? Bu işlem tüm finansal işlemleri tersine çevirecek ve geri alınamaz."
+msgstr "Bu alış faturasını hükümsüz kılmak istediğinizden emin misiniz? Bu işlem tüm mali işlemleri tersine çevirecek ve geri alınamaz."
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Bu fişi geçersiz kılmak istediğinizden emin misiniz? Bu işlem tüm envanter işlemlerini tersine çevirecek ve geri alınamaz."
+msgstr "Bu mal kabulünü hükümsüz kılmak istediğinizden emin misiniz? Bu işlem tüm envanter işlemlerini tersine çevirecek ve geri alınamaz."
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
-msgstr "Bu satış faturasını geçersiz kılmak istediğinizden emin misiniz? Bu işlem tüm finansal işlemleri tersine çevirecek ve geri alınamaz."
+msgstr "Bu satış faturasını hükümsüz kılmak istediğinizden emin misiniz? Bu işlem tüm mali işlemleri tersine çevirecek ve geri alınamaz."
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "Bu sevkiyatı geçersiz kılmak istediğinizden emin misiniz? Bu işlem tüm envanter işlemlerini tersine çevirecek ve geri alınamaz."
+msgstr "Bu sevkiyatı hükümsüz kılmak istediğinizden emin misiniz? Bu işlem tüm envanter işlemlerini tersine çevirecek ve geri alınamaz."
 
 msgid "Are you sure?"
 msgstr "Emin misiniz?"
@@ -2173,7 +2173,7 @@ msgstr "Artan"
 #. placeholder {0}: copy.moduleLabel
 #. placeholder {1}: copy.noun
 msgid "Ask an admin with {0} permission to add the first {1}."
-msgstr "{0} izni olan bir yöneticiye ilk {1}i eklemesini isteyin."
+msgstr "{0} izni olan bir yöneticiden ilk {1} eklemesini isteyiniz."
 
 msgid "Assemblies"
 msgstr "Montajlar"
@@ -2200,10 +2200,10 @@ msgid "Asset account for advance payments made to suppliers before goods or serv
 msgstr "Mallar veya hizmetler alınmadan önce tedarikçilere yapılan ön ödemeler için varlık hesabı"
 
 msgid "Asset Acquisition Cost"
-msgstr "Varlık satın alma maliyeti"
+msgstr "Varlık Edinme Maliyeti"
 
 msgid "Asset Acquisition Cost (default)"
-msgstr "Varlık satın alma maliyeti (varsayılan)"
+msgstr "Varlık Edinme Maliyeti (varsayılan)"
 
 msgid "asset class"
 msgstr "varlık sınıfı"
@@ -2221,10 +2221,10 @@ msgid "Asset Classes"
 msgstr "Varlık Sınıfları"
 
 msgid "Asset Cost on Disposal"
-msgstr "Varlık maliyeti bertarafa sırasında"
+msgstr "Elden Çıkarma Sırasında Varlık Maliyeti"
 
 msgid "Asset Cost on Disposal (default)"
-msgstr "Varlık maliyeti bertarafa sırasında (varsayılan)"
+msgstr "Elden Çıkarma Sırasında Varlık Maliyeti (varsayılan)"
 
 msgid "Asset ID"
 msgstr "Varlık Kimliği"
@@ -2233,7 +2233,7 @@ msgid "Assets"
 msgstr "Varlıklar"
 
 msgid "Assets, liabilities and equity as of a date"
-msgstr "Bir tarih itibariyle aktif, pasif ve öz kaynak"
+msgstr "Bir tarih itibariyle varlıklar, yükümlülükler ve özkaynak"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
 msgstr "Yazıcıları konumlara atayın. Sevkiyat, kabul ve iş merkezleri, geçersiz kılınmadıkça konum varsayılanını miras alır."
@@ -2260,10 +2260,10 @@ msgid "Assignments"
 msgstr "Atamalar"
 
 msgid "Assigns this storage unit to a work center (lineside)"
-msgstr "Bu depolama birimini bir iş merkezine atar (hat boyunca)"
+msgstr "Bu depolama birimini bir iş merkezine atar (hat yanı)"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "Bu birimi lineside malzemeleri için bir çalışma merkezine atar, böylece operatörler bunu üretim görünümünde görebilir; orada ayarlandığında ana birimden miras alınır."
+msgstr "Bu birimi hat yanı malzemesi için bir iş merkezine atar; böylece operatörler bunu üretim görünümünde görürler; orada ayarlandığında ana birimden devralınır."
 
 msgid "At each gate"
 msgstr "Her kapıda"
@@ -2293,19 +2293,19 @@ msgid "Attribute"
 msgstr "Öznitelik"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "Gelen muayenelerde parti örnek boyutlarını ve kabul/red sayılarını hesaplamak için kullanılan niteliksel örnekleme standardı."
+msgstr "Lot örneklem büyüklükleri ve girdi kontrolünde kabul/ret sayılarını hesaplamak için kullanılan öznitelik örnekleme standardı."
 
 msgid "Attributes"
 msgstr "Öznitelikler"
 
 msgid "Attributes are inherited from the procedure."
-msgstr "Nitelikler prosedürden miras alınır."
+msgstr "Öznitelikler prosedürden devralınır."
 
 msgid "Audit Log"
-msgstr "Denetim Kaydı"
+msgstr "Denetim günlüğü"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "Denetim günlüğü tutma"
 
 msgid "Audit Logging"
 msgstr "Denetim Kaydı Tutma"
@@ -2320,7 +2320,7 @@ msgid "Audit logging is not enabled"
 msgstr "Denetim günlükleme etkinleştirilmemiş"
 
 msgid "Audit Logs"
-msgstr "Denetim Kayıtları"
+msgstr "Denetim günlükleri"
 
 msgid "Authentication Error"
 msgstr "Kimlik Doğrulama Hatası"
@@ -2353,7 +2353,7 @@ msgid "Auto-generated QR Code"
 msgstr "Otomatik oluşturulan QR kodu"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "Siparişler, işler, parçalar ve daha fazlası için otomatik numaralandırma formatları"
+msgstr "Siparisler, iş emirleri, parçalar ve daha fazlası için otomatik numaralandırma biçimleri"
 
 msgid "Auto-suggest purchases from demand and reorder points"
 msgstr "Talep ve yeniden sipariş noktalarından otomatik satın alma önerileri"
@@ -2371,13 +2371,13 @@ msgid "Automatic Cost Updates"
 msgstr "Otomatik Maliyet Güncellemeleri"
 
 msgid "Automatic Lead Time Updates"
-msgstr "Otomatik Süre Güncellemeleri"
+msgstr "Otomatik Tedarik Süresi Güncellemeleri"
 
 msgid "Automatic Updates"
 msgstr "Otomatik Güncellemeler"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "Otomatik güncellemeler ve yedeklemeler"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
 msgstr "Çıktı raporlandığında bir işin izlenmeyen malzemelerin otomatik, orantılı tüketimi — izlenen malzeme el ile verilir."
@@ -2389,13 +2389,13 @@ msgid "Automatically start the job when the kanban is scanned"
 msgstr "Kanban taranıp iş otomatik olarak başlatılır"
 
 msgid "available"
-msgstr "mevcut"
+msgstr "kullanılabilir"
 
 msgid "Available"
-msgstr "Mevcut"
+msgstr "Kullanılabilir"
 
 msgid "Available Actions (click to add)"
-msgstr "Mevcut işlemler (eklemek için tıklayın)"
+msgstr "Kullanılabilir Eylemler (eklemek için tıklayın)"
 
 #. placeholder {0}: port.label
 msgid "Available after {0}"
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "İzlenebilirliğe geri dön"
 
 msgid "Backflush"
-msgstr "Geri Akış"
+msgstr "Geriye dönük tüketim"
 
 msgid "Backups"
 msgstr "Yedeklemeler"
@@ -2435,40 +2435,40 @@ msgid "Balloon"
 msgstr "Balon"
 
 msgid "Ballooned drawings with inspection features."
-msgstr "İnceleme özellikleriyle balona alınmış çizimler."
+msgstr "Muayene özellikleriyle ayrıntılı çizimler."
 
 msgid "Bank - Cash"
 msgstr "Banka - Nakit"
 
 msgid "Bank - Foreign Currency"
-msgstr "Banka - Dış ticaret"
+msgstr "Banka - Yabancı Para Birimi"
 
 msgid "Bank - Local Currency"
-msgstr "Banka - Yerel para"
+msgstr "Banka - Yerel Para Birimi"
 
 msgid "Bank — Cash (default)"
 msgstr "Banka — Nakit (varsayılan)"
 
 msgid "Bank — Foreign Currency (default)"
-msgstr "Banka — Dış ticaret (varsayılan)"
+msgstr "Banka — Yabancı Para Birimi (varsayılan)"
 
 msgid "Bank — Local Currency (default)"
-msgstr "Banka — Yerel para (varsayılan)"
+msgstr "Banka — Yerel Para Birimi (varsayılan)"
 
 msgid "Bank / Cash Account"
 msgstr "Banka / Nakit Hesabı"
 
 msgid "Bank account denominated in a foreign currency"
-msgstr "Yabancı para cinsinden ifade edilen banka hesabı."
+msgstr "Yabancı para biriminde yapılandırılmış banka hesabı"
 
 msgid "Bank account denominated in the local currency"
-msgstr "Yerel para cinsinden ifade edilen banka hesabı."
+msgstr "Yerel para biriminde yapılandırılmış banka hesabı"
 
 msgid "Bank and financial service charge expenses"
-msgstr "Banka ve finansal hizmet ücreti giderleri."
+msgstr "Banka ve mali hizmet bedeli giderleri"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "Çubuklar her haftanın akışını gösterir: &lt;0&gt;arz&lt;/0&gt; envanteri yukarı ittirir, &lt;1&gt;talep&lt;/1&gt; onu aşağı çeker. &lt;2&gt;Çizgi&lt;/2&gt; öngörülen mevcut envanter — &lt;3&gt;emniyet stoğunun&lt;/3&gt; altına düştüğünde riskte olursunuz, sıfırın altında &lt;4&gt;stok tükenmesi&lt;/4&gt; vardır."
+msgstr "Çubuklar her haftanın akışını gösterir: <0>arz</0> envanteri yukarı iter, <1>talep</1> onu aşağı çeker. <2>Satır</2> tahmini eldeki envanterdir — <3>emniyet stoku</3> altına düştüğünde risk altındasın ve sıfırın altı bir <4>stoksuzluk</4>."
 
 msgid "Base Currency"
 msgstr "Temel Para Birimi"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "Temel Fiyat"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "Temel ERP, MES ve QMS işlevselliği"
 
 msgid "Basic Information"
 msgstr "Temel Bilgiler"
@@ -2514,28 +2514,28 @@ msgstr "Başlangıç"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Being phased out — successor: <0>{0}</0>"
-msgstr "Aşamalı olarak kaldırılıyor — halef: <0>{0}</0>"
+msgstr "Kademeli olarak kullanımdan kaldırılıyor — ardıl: <0>{0}</0>"
 
 msgid "Below safety stock"
-msgstr "Emniyet stoğunun altında"
+msgstr "Emniyet stokunun altında"
 
 msgid "Beta"
 msgstr "Beta"
 
 msgid "Biggest causes of scrap by reason, item, or work center"
-msgstr "Nedene, ürüne veya iş merkezine göre ıskartanın en büyük nedenleri"
+msgstr "Fire'in nedene, stok kartına veya iş merkezine göre en büyük nedenleri"
 
 msgid "Bill of Material"
 msgstr "Malzeme Listesi"
 
 msgid "Bill of materials"
-msgstr "Malzeme listesi"
+msgstr "Ürün ağacı"
 
 msgid "Bill of Materials"
-msgstr "Malzeme Listesi"
+msgstr "Ürün ağacı"
 
 msgid "Bill of Process"
-msgstr "İş Akışı"
+msgstr "Operasyon listesi"
 
 msgid "Bill To"
 msgstr "Fatura Adresi"
@@ -2581,7 +2581,7 @@ msgid "BOM synced successfully"
 msgstr "BOM başarıyla senkronize edildi"
 
 msgid "BOMs"
-msgstr "Ürün Yapıları"
+msgstr "BOM'lar"
 
 msgid "Bonus Depreciation %"
 msgstr "Bonus amortisman %"
@@ -2608,13 +2608,13 @@ msgid "Breadcrumb"
 msgstr "Sayfa Yolu"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "Parçalarınızı, BOM'larınızı, İşlem Faturasını ve maliyetlendirmeyi getirin — Carbon'ın içe aktarma araçları, CSV veya LLM yardımı ile."
+msgstr "Parçalarınızı, BOM'ları, Operasyon listesini ve maliyetlendirmeyi getirin — Carbon'ın içe aktarma araçları, CSV veya LLM yardımıyla."
 
 msgid "Browse library"
 msgstr "Kütüphaneyi göz at"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "Yayınlanan sürümü salt okunur şekilde inceleyin. Düzeni düzenlemek için adımları yine de yeniden düzenleyebilirsiniz."
 
 msgid "Bucket"
 msgstr "Kova"
@@ -2635,7 +2635,7 @@ msgid "Build integrations and customizations"
 msgstr "Entegrasyonlar ve özelleştirmeler oluşturun"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "Canlı parça, maliyet ve İşlem Faturası verilerini çekerek teklifler oluşturun"
+msgstr "Canlı parça, maliyet ve Operasyon listesi verilerini çekerek teklifler oluşturun"
 
 msgid "Build role-based training materials"
 msgstr "Rol tabanlı eğitim materyalleri oluşturun"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "Toplu İçe Aktarma"
 
 msgid "Bulk Jobs"
-msgstr "Toplu İşler"
+msgstr "Toplu İş Emirleri"
 
 msgid "Business moment"
 msgstr "İş anı"
@@ -2662,13 +2662,13 @@ msgid "Buy"
 msgstr "Satın Al"
 
 msgid "Buy and Make"
-msgstr "Satın Al ve Üret"
+msgstr "Satın alma ve üretim"
 
 msgid "Buyer"
-msgstr "Satın Alan"
+msgstr "Satın almacı"
 
 msgid "Buyer, Planner"
-msgstr "Alıcı, Planlayıcı"
+msgstr "Satın almacı, Planlayıcı"
 
 msgid "by {byUser}"
 msgstr "by {byUser}"
@@ -2683,7 +2683,7 @@ msgid "By Document Date"
 msgstr "Belge Tarihine Göre"
 
 msgid "By Due Date"
-msgstr "Vade Tarihine Göre"
+msgstr "Son Tarih'e Göre"
 
 msgid "By field"
 msgstr "Alana göre"
@@ -2740,7 +2740,7 @@ msgid "Call an outside URL"
 msgstr "Harici bir URL çağır"
 
 msgid "Called a method in Carbon — the components plus operations that produce a part."
-msgstr "Carbon'da çağrılan bir yöntem — bir parça üreten bileşenler ve işlemler."
+msgstr "Carbon'da bir yöntem olarak adlandırılır — bir parçayı oluşturan bileşenler artı operasyonlar."
 
 msgid "Can't delete this period"
 msgstr "Bu dönem silinemez"
@@ -2815,13 +2815,13 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "Sipariş verilemiyor - bu ürünle ilişkili tedarikçi yok"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "Gönderilemiyor — gönderi süresi dolmuş takip edilen varlıklar içeriyor."
+msgstr "Muhasebeleştirilemiyor — sevkiyat süresi dolmuş izlenen varlıkları içeriyor."
 
 msgid "Cannot send RFQ"
 msgstr "RFQ gönderilemiyor"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "Stripe aracılığıyla gönderilemez"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "Yüklenemiyor — tedarikçi etkileşimi henüz oluşturulmadı"
@@ -2876,7 +2876,7 @@ msgstr "Carbon Değeri"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon, {0} eşleştirilmemiş hesabınızın her biri için bir sağlayıcı hesabını tahmin etmek için Yapay Zeka kullanacaktır. Öneriler başlangıç noktasıdır — herhangi bir şey kaydedilmeden önce bunları gözden geçirebilirsiniz."
+msgstr "Carbon, {0} eşleştirilmemiş hesaplarınızın her biri için bir sağlayıcı hesabını tahmin etmek için yapay zeka kullanacaktır. Öneriler bir başlangıç noktasıdır — her şey kaydedilmeden önce bunları gözden geçirebilirsiniz."
 
 msgid "Carbon-only"
 msgstr "Yalnızca Carbon"
@@ -2888,28 +2888,28 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "Carbon-only · müşteri bu metni görür, kilitli."
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Malzeme listesi ve işlem listesi (yönlendirme) için Carbon'un adı: bir parça üreten bileşenler ve işlemler."
+msgstr "Carbon'ın ürün ağacı ve operasyon listesi (rota) için adı: bir parçayı yapan bileşenler artı operasyonlar."
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
 msgstr "Carbon'un planlama çalışması arz ve talep tarafından net ve açılı yöntemler, eksikleri ortaya çıkarır — ancak kendi başına siparişler oluşturmaz."
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Carbon'ın üretim emri — bir iş, kopyalanmış yöntemi ve yönlendirmesinden bir öğenin miktarını oluşturur."
+msgstr "Carbon'ın üretim emri — bir iş emri, kopyalanan yöntem ve rotasından bir stok kartının miktarını oluşturur."
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "Operatörlerin işlemleri çalıştırdığı, miktarları rapor ettiği, malzeme verdiği ve yayınlanan işlere karşı gerçek zamanlı olarak zaman kaydettiği Carbon'un atölye uygulaması."
+msgstr "Carbon'ın operatörlerin operasyonları çalıştırdığı, miktarları rapor ettiği, malzemeyi çıkış yaptığı ve serbest bırakılmış iş emirlerine karşı zamanı gerçek zamanlı olarak kaydettiği atölye uygulaması."
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Karbon'un parça numarası olan herhangi bir şey için tek kaydı — Parça, Malzeme, Araç, Hizmet, Tüketim Malzemeleri veya Montaj Parçası — işlerin, yöntemlerin, siparişlerin ve envantering tümü işaret eder."
+msgstr "Carbon'ın bir parça numarası olan her şey için — Parça, Malzeme, Takım, Hizmet, Sarf malzemesi veya Bağlama aparatı — iş emirleri, yöntemler, siparişler ve envanterin işaret ettiği tek stok kartı."
 
 msgid "Cards"
 msgstr "Kartlar"
 
 msgid "Carrier"
-msgstr "Taşıyıcı"
+msgstr "Nakliyeci"
 
 msgid "Carrier Account"
-msgstr "Taşıyıcı Hesap"
+msgstr "Nakliyeci Hesabı"
 
 msgid "Cash & Banking"
 msgstr "Nakit ve Bankacılık"
@@ -2963,7 +2963,7 @@ msgid "Change Document"
 msgstr "Belgeyi Değiştir"
 
 msgid "Change Inspection Plan"
-msgstr "Muayene Planını Değiştir"
+msgstr "Kontrol Planını Değiştir"
 
 msgid "Change notice"
 msgstr "Değişiklik bildirisi"
@@ -2990,7 +2990,7 @@ msgid "Change status"
 msgstr "Durum değiştir"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "Ürün türünü değiştirin (örneğin Parça, Malzeme, Alet vb.)"
+msgstr "Stok kartı türünü değiştir (örn. Parça, Malzeme, Takım, vb.)"
 
 msgid "Change type"
 msgstr "Türü değiştir"
@@ -3014,7 +3014,7 @@ msgid "Changing type resets this item's draft edits."
 msgstr "Türü değiştirmek bu öğenin taslak düzenlemelerini sıfırlar."
 
 msgid "Chart of accounts"
-msgstr "Muhasebe planı"
+msgstr "Hesap planı"
 
 msgid "Chart of Accounts"
 msgstr "Hesap Planı"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "Sohbet"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "Dönem sonunda negatif el altında miktarı olan herhangi bir madde için madde defterini kontrol edin — genellikle eksik bir makbuz veya envanter değerini ve satılan mal maliyetini bozacak düzensiz bir posting vardır. Gözden geçirildikten sonra tamamlandı olarak işaretleyin veya nedenli olarak atlayın."
+msgstr "Dönem sonu itibariyle negatif eldeki miktarı olan herhangi bir stok kartı için stok kartı defterini kontrol edin — genellikle eksik bir mal kabul veya envanter değerini ve satılan malın maliyetini bozan sıra dışı bir muhasebeleştirme. İncelendikten sonra bitti olarak işaretleyin veya bir gerekçeyle atlayın."
 
 msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "Bu müşteri için Stripe kontrol ediliyor…"
 
 msgid "Checkpoint ·"
 msgstr "Kontrol Noktası ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "Başka bir dosya seç"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "Basılı iş talimatında neyin görüneceğini seçin."
+msgstr "Yazdırılan İş takip kartında neyin görüneceğini seçin."
 
 msgid "Choose your preferred language for the interface."
 msgstr "Arayüz için tercih ettiğiniz dili seçin."
@@ -3071,7 +3071,7 @@ msgid "Class (inherited)"
 msgstr "Sınıf (Devralınan)"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "Bir rota işlemini sınıflandırır: Proses, Montaj ve Muayene işlemleri MES'te kendi atölyenizde çalışır — Montaj kılavuzlu montaj görünümü ve Muayene kalite kontrolü alır — Dış İşleme işlemi ise bir tedarikçiye yaptırılır ve satın alma siparişi oluşturur; işlem aynı türü taşır ve yeni işlemlerde bunu varsayılan olarak ayarlar."
+msgstr "Bir rota operasyonunu sınıflandırır: Proses, Montaj ve Muayene operasyonları MES'te kendi atölyenizde çalışır — Montaj rehberli montaj görünümü alırken Muayene bir kalite kontrolü alır — Fason işlem operasyonu bir tedarikçiye taşerona verilir ve bir satın alma siparişi oluşturur; proses aynı türü taşır ve yeni operasyonlarda varsayılan olarak ayarlanır."
 
 msgid "Clean and approve the migrated data"
 msgstr "Geçirilen verileri temizleyin ve onaylayın"
@@ -3080,7 +3080,7 @@ msgid "Clear"
 msgstr "Temizle"
 
 msgid "Clear due date"
-msgstr "Vade tarihini temizle"
+msgstr "Son tarihi temizle"
 
 msgid "Clear Filters"
 msgstr "Filtreleri Temizle"
@@ -3095,7 +3095,7 @@ msgid "Clear selection"
 msgstr "Seçimi temizle"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "Bu faturayı tarafın deftere nakledilmiş kredileri ve nakit ile kapatın. Krediler doğrudan uygulanır — deftere nakil gerekmez."
+msgstr "Bu faturayı tarafın muhasebeleştirilmiş alacakları ve nakit ile kapatın. Alacaklar doğrudan uygulanır — muhasebeleştirme gerekmez."
 
 msgid "Clear value"
 msgstr "Değeri temizle"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "PDF çizimi yüklemek için tıklayın"
 
 msgid "Clock In"
-msgstr "Giriş Saati"
+msgstr "İş başlangıcı"
 
 msgid "Clock Out"
-msgstr "Çıkış Saati"
+msgstr "İş bitişi"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/> tarihinden beri saatlenmiş"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "Bulut veya kendi barındırılan ortamınız."
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "CMMC uyumlu"
 
 msgid "Code"
 msgstr "Kod"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "Her alan için bir şampiyon kullanıcı atayın"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "Bir makbuzu, sevkiyatı veya faturayı taahhüt etme: miktarlar hareket eder, günlük girişleri deftere vurur ve durum Gönderilen olur."
+msgstr "Bir mal kabulü, sevkiyat veya faturayı kaydetme: miktarlar hareket eder, muhasebe fişleri muhasebe defterine vurur ve durum Muhasebeleştirildi olur."
 
 msgid "Community support"
-msgstr ""
+msgstr "Topluluk desteği"
 
 msgid "Companies"
 msgstr "Şirketler"
@@ -3312,7 +3312,7 @@ msgid "Computed At"
 msgstr "Hesaplama Tarihi"
 
 msgid "Condensed P&L with margins and key subtotals"
-msgstr "Marjlar ve kilit alt toplamlarla sıkıştırılmış P&L"
+msgstr "Kenar boşluklarına ve anahtar ara toplamlarına sahip Sıkıştırılmış Kâr ve Zarar"
 
 msgid "Conditions"
 msgstr "Koşullar"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "Satıcı ve tedarikçi işlemleri için varsayılan hesapları yapılandırın"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "Varsayılan öz sermaye ve birikmiş karlar hesaplarını yapılandırın"
+msgstr "Varsayılan Özkaynak ve Dağıtılmamış kârlar hesaplarını yapılandırın"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "Kalite panosu için varsayılan ayarları yapılandırın."
@@ -3357,31 +3357,31 @@ msgid "Configure Item"
 msgstr "Öğe Yapılandır"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "Kalıbrasyon dışı kaldığında bildirimleri yapılandırın."
+msgstr "Ölçüm aletleri kalibrasyon dışına çıktığında bildirim yapılandırın."
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "İşler tamamlandığında bildirimleri yapılandırın."
+msgstr "İş emirleri tamamlandığında bildirim yapılandırın."
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "Bakım sevkiyatları atölye zemininden oluşturulduğunda bildirimleri yapılandırın. Bildirimler arıza modu türüne göre yönlendirilir."
+msgstr "Bakım emirleri atölyeden oluşturulduğunda bildirim yapılandırın. Bildirimler arıza modu türüne göre yönlendirilir."
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "Yeni öneriler gönderildiğinde bildirimleri yapılandırın."
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "Siteleri, iş merkezlerini, Proses Faturasını, BOM'ları, maliyetlendirmeyi, rolleri yapılandırın"
+msgstr "Tesisleri, İş merkezlerini, Operasyon listesini, BOM'ları, Maliyetlendirmeyi, Rolleri yapılandırın"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "Sisteminizdeki çeşitli işlem türleri için kullanılan varsayılan hesapları yapılandırın"
 
 msgid "Configure the start months for your fiscal and tax years"
-msgstr "Mali ve muhasebe yıllarınız için başlangıç aylarını yapılandırın"
+msgstr "Mali ve vergi yıllarının başlangıç aylarını yapılandırın"
 
 msgid "Configure when purchased item costs should be updated from supplier transactions."
 msgstr "Satın alınan ürün maliyetlerinin tedarikçi işlemlerinden ne zaman güncelleneceğini yapılandırın."
 
 msgid "Configure who should receive notifications when a supplier submits a quote."
-msgstr "Bir tedarikçi teklif sunduğunda kimin bildirim alacağını yapılandırın."
+msgstr "Bir tedarikçi teklif gönderdiğinde bildirimleri kimin alması gerektiğini yapılandırın."
 
 msgid "Configure-to-order"
 msgstr "Siparişe göre yapılandır"
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "Onayla {0}"
 
 msgid "Confirm & release"
-msgstr "Onayla ve yayınla"
+msgstr "Teyit et ve Serbest bırak"
 
 msgid "Confirm all"
 msgstr "Tümünü onayla"
@@ -3445,13 +3445,13 @@ msgid "Confirm Skip"
 msgstr "Atlamayı Onayla"
 
 msgid "Confirmed incoming stock — purchase & production orders (bars above zero)."
-msgstr "Onaylanan gelen stok — satın alma ve üretim siparişleri (sıfırın üzerindeki çubuklar)."
+msgstr "Teyit edildi gelen stok — Satın alma ve Üretim siparişleri (sıfırın üzerindeki çubuklar)."
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "Onaylanan giden stok — satış siparişleri ve iş malzemeleri (sıfırın altındaki çubuklar)."
+msgstr "Teyit edildi giden stok — Satış siparişleri ve İş emri malzemeleri (sıfırın altındaki çubuklar)."
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "Dönem içinde deftere geçen her muhasebe kaydının eşit borç ve alacak tutarlarına sahip olduğunu doğrular. Herhangi bir kayıt dengeli değilse, deneme dengesi uyuşmayacak, bu nedenle dönem kapatılmadan önce düzeltilmesi gerekir."
+msgstr "Dönemdeki her muhasebeleştirilmiş muhasebe fişinin eşit borç ve alacağa sahip olduğunu doğrular. Herhangi bir giriş dengesi kaybetmişse mizan tutmayacak, bu nedenle dönem kapanmadan önce düzeltilmesi gerekir."
 
 msgid "Conflict reason"
 msgstr "Çatışma nedeni"
@@ -3466,7 +3466,7 @@ msgid "Connect Linear issue"
 msgstr "Linear sorununu bağla"
 
 msgid "Connect Slack under Settings → Integrations first."
-msgstr "Slack'i önce Ayarlar → İntegrasyonlar altında bağlayın."
+msgstr "Önce Ayarlar → Entegrasyonlar altında Slack'i bağlayın."
 
 msgid "Connect the Otherwise handle to a node to run when no condition matches."
 msgstr "Hiçbir koşul eşleşmediğinde çalıştırılacak bir düğüme Aksi takdirde işlecini bağlayın."
@@ -3493,22 +3493,22 @@ msgid "Console Operator"
 msgstr "Konsol Operatörü"
 
 msgid "consumable"
-msgstr "tüketilir"
+msgstr "sarf malzemesi"
 
 msgid "Consumable"
-msgstr "Sarflama"
+msgstr "Sarf malzemesi"
 
 msgid "Consumable Details"
-msgstr "Sarflama Detayları"
+msgstr "Sarf malzemesi Ayrıntıları"
 
 msgid "Consumable ID"
-msgstr "Tüketilebilir Ürün Kodu"
+msgstr "Sarf malzemesi ID"
 
 msgid "consumables"
-msgstr "tüketilirler"
+msgstr "sarf malzemeleri"
 
 msgid "Consumables"
-msgstr "Sarflar"
+msgstr "Sarf malzemeleri"
 
 msgid "Consumed"
 msgstr "Tüketildi"
@@ -3517,31 +3517,31 @@ msgid "Consuming material from inventory into a job, which writes a Consumption 
 msgstr "Envanterdeki malzemeyi bir işe tüketmek, bu da madde defterine bir Tüketim girişi yazar."
 
 msgid "contact"
-msgstr "iletişim"
+msgstr "ilgili kişi"
 
 msgid "Contact"
-msgstr "İletişim"
+msgstr "İlgili kişi"
 
 msgid "Contact (optional)"
-msgstr "İletişim (isteğe bağlı)"
+msgstr "İlgili kişi (İsteğe bağlı)"
 
 msgid "Contact us"
-msgstr ""
+msgstr "Bize ulaşın"
 
 msgid "contacts"
-msgstr "kişiler"
+msgstr "İlgili kişiler"
 
 msgid "Contacts"
-msgstr "Kişiler"
+msgstr "İlgili Kişiler"
 
 msgid "Contained"
 msgstr "İçlenmiş"
 
 msgid "Containment"
-msgstr "İzolasyon"
+msgstr "Çevreleme"
 
 msgid "Containment action"
-msgstr "Kapsama Eylemi"
+msgstr "Çevreleme işlemi"
 
 msgid "Content"
 msgstr "İçerik"
@@ -3553,16 +3553,16 @@ msgid "Contra-asset account for total depreciation of fixed assets"
 msgstr "Sabit kıymetlerin toplam amortismanı için karşı hesap"
 
 msgid "Contra-revenue account for discounts given on sales"
-msgstr "Satışlarda verilen indirimler için contra-gelir hesabı"
+msgstr "Satışlarda verilen iskontolar için kontra-gelir hesabı"
 
 msgid "Contra-revenue GL account for discounts given on customer invoices."
-msgstr "Müşteri faturalarında verilen indirimler için contra-gelir GL hesabı."
+msgstr "Müşteri faturalarında verilen iskontolar için kontra-gelir muhasebe hesabı."
 
 msgid "Contractor"
-msgstr "Yüklenici"
+msgstr "Taşeron"
 
 msgid "Contractors"
-msgstr "Yükleniciler"
+msgstr "Taşeronlar"
 
 msgid "Control design changes with revisions / ECOs"
 msgstr "Tasarım değişikliklerini revizyonlar / ECO'lar ile kontrol edin"
@@ -3577,7 +3577,7 @@ msgid "Controls how planning handles a discontinued item: Consume First exhausts
 msgstr "Planlamanın kullanımdan kaldırılan bir öğeyi nasıl işlediğini kontrol eder: Önce Tüket mevcut stoğu tüketir ve ardından halefi kullanmaya geçer, Yeni Tercih et yeni talebi hemen halefi yönlendirir, Yalnızca Stok minimum bir hizmet rezervi tutar ve Stok Yok öğeyi planlama işleminden tamamen çıkarır.\""
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "Yayınlanan (Üretim) revizyonunun malzeme listesi ve işlem listesinin bir değişiklik emri dışında düzenlenip düzenlenmeyeceğini kontrol eder."
+msgstr "Serbest bırakılan (Üretim) revizyonun ürün ağacı ve operasyon listesinin bir değişiklik emri dışında düzenlenmesine izin verip vermediğini kontrol eder."
 
 msgid "Convention"
 msgstr "Sözleşme"
@@ -3586,10 +3586,10 @@ msgid "Conversion"
 msgstr "Dönüşüm"
 
 msgid "Conversion factor"
-msgstr "Dönüştürme faktörü"
+msgstr "Çevrim katsayısı"
 
 msgid "Conversion Factor"
-msgstr "Dönüşüm Faktörü"
+msgstr "Çevrim Katsayısı"
 
 msgid "Conversion:"
 msgstr "Dönüşüm:"
@@ -3604,13 +3604,13 @@ msgid "Convert Line to Job"
 msgstr "Satırı İşe Dönüştür"
 
 msgid "Convert Lines to Jobs"
-msgstr "Satırları İşlere Dönüştür"
+msgstr "Satırları İş emirlerine Dönüştür"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "MRP önerilerini satın alma siparişlerine ve işlere dönüştürün."
+msgstr "MRP önerilerini satın alma siparişlerine ve iş emirlerine dönüştür."
 
 msgid "Convert to Quote"
-msgstr "Teklif Oluştur"
+msgstr "Teklife Dönüştür"
 
 msgid "Converting…"
 msgstr "Dönüştürülüyor…"
@@ -3634,13 +3634,13 @@ msgid "Copy company unique identifier"
 msgstr "Şirket benzersiz tanımlayıcısını kopyala"
 
 msgid "Copy consumable number"
-msgstr "Tüketilebilir numarasını kopyala"
+msgstr "Sarf malzemesi numarasını kopyala"
 
 msgid "Copy dispatch ID"
-msgstr "Devreye alma kimlik numarasını kopyala"
+msgstr "Bakım emri ID'sini kopyala"
 
 msgid "Copy dispatch number"
-msgstr "İş emri numarasını kopyala"
+msgstr "Bakım emri numarasını kopyala"
 
 msgid "Copy document name"
 msgstr "Belge adını kopyala"
@@ -3667,10 +3667,10 @@ msgid "Copy link to change notice"
 msgstr "Değişiklik bildirisi bağlantısını kopyala"
 
 msgid "Copy link to consumable"
-msgstr "Tüketilebilir bağlantısını kopyala"
+msgstr "Sarf malzemeye bağlantı kopyala"
 
 msgid "Copy link to dispatch"
-msgstr "Görev bağlantısını kopyala"
+msgstr "Bakım emirine bağlantı kopyala"
 
 msgid "Copy link to document"
 msgstr "Belge bağlantısını kopyala"
@@ -3796,7 +3796,7 @@ msgid "Corrections"
 msgstr "Düzeltmeler"
 
 msgid "Corrective action"
-msgstr "Düzeltici Eylem"
+msgstr "Düzeltici faaliyet"
 
 msgid "cost center"
 msgstr "maliyet merkezi"
@@ -3820,13 +3820,13 @@ msgid "Cost History"
 msgstr "Maliyet Geçmişi"
 
 msgid "Cost of Goods Sold"
-msgstr "Satılan Malların Maliyeti"
+msgstr "Satılan malın maliyeti"
 
 msgid "Cost of goods sold (COGS)"
-msgstr "Satılan Malların Maliyeti (COGS)"
+msgstr "Satılan malın maliyeti (COGS)"
 
 msgid "Cost of Goods Sold (default)"
-msgstr "Satılan Malların Maliyeti (varsayılan)"
+msgstr "Satılan malın maliyeti (varsayılan)"
 
 msgid "Cost of Sales"
 msgstr "Satışların Maliyeti"
@@ -3835,7 +3835,7 @@ msgid "Costing"
 msgstr "Maliyetlendirme"
 
 msgid "Costing & Posting"
-msgstr "Maliyetlendirme ve Kayıt"
+msgstr "Maliyetlendirme ve Muhasebeleştirme"
 
 msgid "Costing method"
 msgstr "Maliyetlendirme Yöntemi"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "Belgeler yüklenemedi"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "İlgili belgeler yüklenemedi. Yeni bir tane oluşturmadan önce yenileyerek tekrarları önleyin."
+msgstr "İlgili belgeler yüklenemedi. Yinelemelerden kaçınmak için yeni bir tane oluşturmadan önce yenileyin."
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "Sağlayıcının boyut hedefleri yüklenemedi — bağlantıyı kontrol edin ve sayfayı yeniden yükleyin."
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "Tarama tabanlı ikmal için yeni bir kanban kartı oluştur."
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "Ekipman onarımlarını ve bakım faaliyetlerini izlemek için yeni bir bakım sevkıyatı oluşturun"
+msgstr "Ekipman onarımlarını ve bakım faaliyetlerini izlemek için yeni bir bakım emri oluşturun"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "Satış siparişini yerine getirmek için yeni bir üretim işi oluşturun"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "Bunun yerine yeni bir Stripe müşterisi oluşturun"
 
 msgid "Create a new version"
 msgstr "Yeni bir sürüm oluşturun"
@@ -3975,7 +3975,7 @@ msgid "Create Issue"
 msgstr "Sorun Oluştur"
 
 msgid "Create Jobs"
-msgstr "İş Oluştur"
+msgstr "İş emirleri oluştur"
 
 msgid "Create Kanban"
 msgstr "Kanban Oluştur"
@@ -3987,7 +3987,7 @@ msgid "Create PO Revision"
 msgstr "PO Revizyonu Oluştur"
 
 msgid "Create Production Event"
-msgstr "Üretim Etkinliği Oluştur"
+msgstr "Üretim olayı oluştur"
 
 msgid "Create Production Quantity"
 msgstr "Üretim Miktarı Oluştur"
@@ -4044,7 +4044,7 @@ msgid "Created change notice type"
 msgstr "Oluşturulan değişiklik bildirisi türü"
 
 msgid "Created consumable"
-msgstr "Tüketilebilir malzeme oluşturuldu"
+msgstr "Sarf malzemesi oluşturuldu"
 
 msgid "Created cost center"
 msgstr "Oluşturulan Maliyet Merkezi"
@@ -4069,7 +4069,7 @@ msgid "Created failure mode"
 msgstr "Başarısız mod oluşturuldu"
 
 msgid "Created gauge type"
-msgstr "Jeneratör tipi oluşturuldu"
+msgstr "Ölçüm aleti türü oluşturuldu"
 
 msgid "Created item group"
 msgstr "Oluşturulan ürün grubu"
@@ -4087,22 +4087,22 @@ msgid "Created material dimension"
 msgstr "Oluşturulan malzeme boyutu"
 
 msgid "Created material finish"
-msgstr "Oluşturulan malzeme bitişi"
+msgstr "Yüzey işlemi oluşturuldu"
 
 msgid "Created material form"
 msgstr "Oluşturulan malzeme formu"
 
 msgid "Created material grade"
-msgstr "Oluşturulan malzeme sınıfı"
+msgstr "Malzeme kalitesi oluşturuldu"
 
 msgid "Created material substance"
-msgstr "Malzeme özü oluşturuldu"
+msgstr "Ana malzeme oluşturuldu"
 
 msgid "Created material type"
 msgstr "Malzeme tipi oluşturuldu"
 
 msgid "Created no quote reason"
-msgstr "Boş teklif nedeni oluşturuldu"
+msgstr "Teklif yok nedeni oluşturuldu"
 
 msgid "Created non conformance type"
 msgstr "Uygunsuzluk türü oluşturuldu"
@@ -4111,7 +4111,7 @@ msgid "Created part"
 msgstr "Oluşturulan parça"
 
 msgid "Created payment term"
-msgstr "Oluşturulan ödeme vadesi"
+msgstr "Ödeme koşulu oluşturuldu"
 
 msgid "Created process"
 msgstr "Oluşturulan süreç"
@@ -4120,13 +4120,13 @@ msgid "Created required action"
 msgstr "Gerekli eylem oluşturuldu"
 
 msgid "Created scrap reason"
-msgstr "Üretim sebebi oluşturuldu"
+msgstr "Fire nedeni oluşturuldu"
 
 msgid "Created service"
 msgstr "Hizmet oluşturuldu"
 
 msgid "Created shipping method"
-msgstr "Gönderi yöntemi oluşturuldu"
+msgstr "Sevkiyat yöntemi oluşturuldu"
 
 msgid "Created stock transfer line"
 msgstr "Stok transfer satırı oluşturuldu"
@@ -4142,7 +4142,7 @@ msgid "Created tool"
 msgstr "Oluşturulan araç"
 
 msgid "Created unit of measure"
-msgstr "Birim oluşturuldu"
+msgstr "Ölçü birimi oluşturuldu"
 
 msgid "Created webhook"
 msgstr "Webhook başarıyla oluşturuldu"
@@ -4173,16 +4173,16 @@ msgid "Credit Account"
 msgstr "Kredi Hesabı"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "İşçilik/makine zamanı WIP'de emildiğinde kredi hesabı"
+msgstr "İşçilik/makine süresi WIP'e soğurulduğunda alacak hesabı"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "Genel giderler devam eden işlere emildiğinde kredi hesabı"
+msgstr "Genel üretim giderleri WIP'e soğurulduğunda alacak hesabı"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "Üretim maliyetleri devam eden işlere emildiğinde kullanılan kredi hesapları"
+msgstr "Üretim maliyetleri WIP'e soğurulduğunda kullanılan alacak hesapları"
 
 msgid "Credit Memo"
-msgstr "Alacak Notu"
+msgstr "Alacak dekontu"
 
 msgid "Credits"
 msgstr "Krediler"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "Para birimi kodu"
 
 msgid "Currency Translation"
-msgstr "Para Birimi Çevirisi"
+msgstr "Kur çevrimi"
 
 msgid "Currency Translation (default)"
-msgstr "Para Birimi Çevirisi (varsayılan)"
+msgstr "Kur çevrimi (varsayılan)"
 
 msgid "current"
 msgstr "geçerli"
@@ -4251,7 +4251,7 @@ msgid "Custom {label}"
 msgstr "Özel {label}"
 
 msgid "Custom attributes you track against your people"
-msgstr "İnsanlarınıza karşı izlediğiniz özel öznitelikler"
+msgstr "Personellerinize karşı izlediğiniz özel öznitelikler"
 
 msgid "Custom development beyond what's listed"
 msgstr "Listelenenin ötesinde özel geliştirme"
@@ -4287,19 +4287,19 @@ msgid "Customer Accounts"
 msgstr "Müşteri Hesapları"
 
 msgid "Customer contact"
-msgstr "Müşteri iletişim"
+msgstr "Müşteri ilgili kişisi"
 
 msgid "Customer Contact"
-msgstr "Müşteri İletişim Bilgisi"
+msgstr "Müşteri İlgili Kişi"
 
 msgid "Customer contacts"
-msgstr "Müşteri kişileri"
+msgstr "Müşteri ilgili kişileri"
 
 msgid "Customer Details"
 msgstr "Müşteri Detayları"
 
 msgid "Customer engineering contact"
-msgstr "Müşteri mühendislik iletişim"
+msgstr "Müşteri mühendislik ilgili kişi"
 
 msgid "Customer follows it alone"
 msgstr "Müşteri bunu tek başına takip eder"
@@ -4326,7 +4326,7 @@ msgid "Customer Part"
 msgstr "Müşteri Parçası"
 
 msgid "Customer Part ID"
-msgstr "Müşteri Parça Kimliği"
+msgstr "Müşteri parça numarası"
 
 msgid "Customer Part Number"
 msgstr "Müşteri Parça Numarası"
@@ -4338,10 +4338,10 @@ msgid "Customer Parts"
 msgstr "Müşteri Parçaları"
 
 msgid "Customer Payment Discounts"
-msgstr "Müşteri Ödeme İndirimleri"
+msgstr "Müşteri Ödeme İskontoları"
 
 msgid "Customer Payment Discounts (default)"
-msgstr "Müşteri Ödeme İndirimleri (varsayılan)"
+msgstr "Müşteri Ödeme İskontoları (varsayılan)"
 
 msgid "Customer PO"
 msgstr "Müşteri Sipariş Numarası"
@@ -4398,7 +4398,7 @@ msgid "Customer Types"
 msgstr "Müşteri Tipleri"
 
 msgid "Customer Write-Off (Bad Debt)"
-msgstr "Müşteri Silme (Şüpheli Alacak)"
+msgstr "Müşteri Kayıttan Düşme (Şüpheli Alacak)"
 
 msgid "customers"
 msgstr "müşteriler"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "Müşteriler"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "Özelleştirmeler, eğitim ve entegrasyonlar"
 
 msgid "Customize"
 msgstr "Özelleştir"
@@ -4431,7 +4431,7 @@ msgid "Cutover support"
 msgstr "Geçiş desteği"
 
 msgid "Cycle count and adjust with an audit trail"
-msgstr "Dönem sayımı yapın ve denetim izlemesiyle ayarlayın"
+msgstr "Periyodik sayım yapın ve denetim izi ile ayarlayın"
 
 msgid "Daily"
 msgstr "Günlük"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "Vade Tarihi"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "Bir parça sipariş etmekten elde edilebilir olana kadar geçen günler; planlama talebi bu kadar geriye kaydırır."
+msgstr "Bir parça sipariş etmekten itibaren kullanılabilir olana kadar olan günler; planlama kaydırması talebi bu kadar geriye kaydırır."
 
 msgid "Days Off"
 msgstr "İzin Günleri"
@@ -4534,7 +4534,7 @@ msgid "Days Remaining"
 msgstr "Kalan Günler"
 
 msgid "Deactivate"
-msgstr "Etkisizleştir"
+msgstr "Devre dışı bırak"
 
 #. placeholder {0}: workCenter.name
 msgid "Deactivate {0}"
@@ -4587,10 +4587,10 @@ msgid "Debits"
 msgstr "Borçlar"
 
 msgid "Decide what an operator sees if they try to issue a batch or serial that's already expired."
-msgstr "Operatörün zaten süresi dolmuş bir parti veya seri çıkarmaya çalışması durumunda ne göreceğini belirleyin."
+msgstr "Bir operatör süresi dolan bir partiye veya seri numarasına çıkış yapmaya çalışırsa ne göreceğini belirleyin."
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "Bir operatör, malzeme henüz seçilmemiş olarak üretim alanında Bitir'e bastığında ne olacağını belirleyin."
+msgstr "Bir operatör atölyede henüz çıkış yapılmamış malzeme varken Bitir'e bastığında ne olacağını belirleyin."
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
 msgstr "Bir iş merkezine alınan ancak tüketilmeyen malzemenin depoya geri akışının ne zaman gerçekleşeceğine karar verin."
@@ -4605,7 +4605,7 @@ msgid "Default"
 msgstr "Varsayılan"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "Faturalardan satış gelirini kaydetmek için varsayılan hesap"
+msgstr "Faturalardan satış hasılatını muhasebeleştirmek için varsayılan hesap"
 
 msgid "Default Accounts"
 msgstr "Varsayılan Hesaplar"
@@ -4626,7 +4626,7 @@ msgid "Default accounts for tax-related transactions"
 msgstr "Vergi ile ilgili işlemler için varsayılan hesaplar"
 
 msgid "Default accounts for the cost of goods sold and indirect purchases"
-msgstr "Satılan malların maliyeti ve dolaylı satın almalar için varsayılan hesaplar"
+msgstr "Satılan malın maliyeti ve dolaylı satın almalar için varsayılan hesaplar"
 
 msgid "Default Approver"
 msgstr "Varsayılan Onaylayıcı"
@@ -4635,10 +4635,10 @@ msgid "Default Attachments"
 msgstr "Varsayılan Ekler"
 
 msgid "Default cash account for transactions in non-base currencies."
-msgstr "Temel olmayan para birimleri cinsinden işlemler için varsayılan kasa hesabı."
+msgstr "Temel olmayan para birimlerinde işlemler için varsayılan nakit hesabı"
 
 msgid "Default cash account for transactions in your base currency."
-msgstr "Temel para biriminizde işlemler için varsayılan kasa hesabı."
+msgstr "Temel para biriminizde işlemler için varsayılan nakit hesabı"
 
 msgid "Default cc"
 msgstr "Varsayılan cc"
@@ -4656,10 +4656,10 @@ msgid "Default GL account used for cash transactions when no specific bank accou
 msgstr "Belirli bir banka hesabı seçilmediğinde nakit işlemler için kullanılan varsayılan GL hesabı."
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "Ekipman ve tesis bakım için varsayılan GL gider hesabı."
+msgstr "Ekipman ve tesis bakımı için varsayılan muhasebe gideri hesabı"
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "Periyodik amortisman çalıştırmaları için varsayılan GL gider hesabı."
+msgstr "Periyodik amortisman çalışmaları için varsayılan muhasebe gideri hesabı"
 
 msgid "Default Method"
 msgstr "Varsayılan Yöntem"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "Bu sınıftaki yeni varlıklar için önceden doldurulan varsayılan yöntem (varlık başına düzenlenebilir hale gelir)."
 
 msgid "Default method type"
-msgstr "Varsayılan yöntem türü"
+msgstr "Varsayılan tedarik şekli"
 
 msgid "Default Method Type"
-msgstr "Varsayılan Yöntem Türü"
+msgstr "Varsayılan Tedarik Şekli"
 
 msgid "Default Permissions"
 msgstr "Varsayılan İzinler"
@@ -4680,7 +4680,7 @@ msgid "Default Priority"
 msgstr "Varsayılan Öncelik"
 
 msgid "Default revenue GL account credited when a sales invoice posts."
-msgstr "Bir satış faturası nakledildiğinde alacaklandırılan varsayılan gelir GL hesabı."
+msgstr "Satış faturası muhasebeleştirildiğinde alacaklandırılan varsayılan hasılat muhasebe hesabı"
 
 msgid "Default Sampling"
 msgstr "Varsayılan Örnekleme"
@@ -4704,7 +4704,7 @@ msgid "Default Unit"
 msgstr "Varsayılan Birim"
 
 msgid "Default useful life that pre-fills on new assets in this class."
-msgstr "Bu sınıftaki yeni varlıklar üzerinde önceden doldurulan varsayılan faydalı yaşam."
+msgstr "Bu sınıftaki yeni varlıklara önceden doldurulan varsayılan faydalı ömür"
 
 msgid "Defaults"
 msgstr "Varsayılanlar"
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "Önce bir üretim işlemini tanımlayın."
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "Çok seviyeli BOM'ları ve Bill of Process'i (üretim yöntemlerini) tanımlayın"
+msgstr "Çok seviyeli BOM'lar ve Operasyon listesi (üretim yöntemleri) tanımlayın"
 
 msgid "Delete"
 msgstr "Sil"
@@ -4741,7 +4741,7 @@ msgid "Delete {periodLabel}"
 msgstr "{periodLabel} öğesini sil"
 
 msgid "Delete {storageUnitName}"
-msgstr "Delete {storageUnitName}"
+msgstr "{storageUnitName} sil"
 
 msgid "Delete action"
 msgstr "Eylemi sil"
@@ -4774,13 +4774,13 @@ msgid "Delete Change Notice"
 msgstr "Değişiklik Bildirisini Sil"
 
 msgid "Delete Consumable"
-msgstr "Tüketilebilir Malı Sil"
+msgstr "Sarf malzemesini sil"
 
 msgid "Delete Contact"
-msgstr "İletişim Bilgisini Sil"
+msgstr "İlgili kişiyi sil"
 
 msgid "Delete Contractor"
-msgstr "Yükleniciyi Sil"
+msgstr "Taşeronu sil"
 
 msgid "Delete Count"
 msgstr "Sayımı Sil"
@@ -4804,7 +4804,7 @@ msgid "Delete Dimension"
 msgstr "Boyutu Sil"
 
 msgid "Delete Dispatch"
-msgstr "Görevlendirmeyi Sil"
+msgstr "Bakım emrini sil"
 
 msgid "Delete Document"
 msgstr "Belgeyi Sil"
@@ -4825,7 +4825,7 @@ msgid "Delete Holiday"
 msgstr "Tatili Sil"
 
 msgid "Delete Inspection Plan"
-msgstr "Muayene Planını Sil"
+msgstr "Kontrol planını sil"
 
 msgid "Delete Issue"
 msgstr "Sorunu Sil"
@@ -4852,13 +4852,13 @@ msgid "Delete Material Dimension"
 msgstr "Malzeme Boyutunu Sil"
 
 msgid "Delete Material Finish"
-msgstr "Malzeme Bitirişini Sil"
+msgstr "Yüzey işlemini sil"
 
 msgid "Delete Material Grade"
-msgstr "Malzeme Derecesini Sil"
+msgstr "Malzeme kalitesini sil"
 
 msgid "Delete Material Shape"
-msgstr "Malzeme Şeklini Sil"
+msgstr "Şekli Sil"
 
 msgid "Delete Material Type"
 msgstr "Malzeme Türünü Sil"
@@ -4882,19 +4882,19 @@ msgid "Delete Payment"
 msgstr "Ödemeyi Sil"
 
 msgid "Delete Payment Term"
-msgstr "Ödeme Şartını Sil"
+msgstr "Ödeme Koşulunu Sil"
 
 msgid "Delete Period"
 msgstr "Dönemi Sil"
 
 msgid "Delete Picking List"
-msgstr "Seçim Listesini Sil"
+msgstr "Toplama Listesini Sil"
 
 msgid "Delete Portal"
 msgstr "Portalı Sil"
 
 msgid "Delete Price Break"
-msgstr "Fiyat Farkını Sil"
+msgstr "Fiyat Kademesini Sil"
 
 msgid "Delete Pricing Rule"
 msgstr "Fiyatlandırma Kuralını Sil"
@@ -4906,7 +4906,7 @@ msgid "Delete Process"
 msgstr "İşlemi Sil"
 
 msgid "Delete Purchase Invoice"
-msgstr "Satın Alma Faturasını Sil"
+msgstr "Alış Faturasını Sil"
 
 msgid "Delete Purchase Order"
 msgstr "Satın Alma Siparişini Sil"
@@ -4930,7 +4930,7 @@ msgid "Delete receipt line"
 msgstr "Fiş hattını sil"
 
 msgid "Delete requirement"
-msgstr "Gereksinimi sil"
+msgstr "Gerekliliği Sil"
 
 msgid "Delete RFQ"
 msgstr "RFQ'yu Sil"
@@ -4966,7 +4966,7 @@ msgid "Delete shipment line"
 msgstr "Sevkiyat satırını sil"
 
 msgid "Delete Shipping Method"
-msgstr "Kargo Yöntemini Sil"
+msgstr "Sevkiyat Yöntemini Sil"
 
 msgid "Delete step"
 msgstr "Adımı sil"
@@ -4981,7 +4981,7 @@ msgid "Delete Storage Type"
 msgstr "Depolama Türünü Sil"
 
 msgid "Delete Storage Unit"
-msgstr "Depo Birimini Sil"
+msgstr "Depolama Birimini Sil"
 
 msgid "Delete Substance"
 msgstr "Madde Sil"
@@ -5003,7 +5003,7 @@ msgstr "Tedarikçi Türünü Sil"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "{0} miktarı için fiyat kırılımı silinsin mi? Bu işlem geri alınamaz."
+msgstr "Miktar {0} için fiyat kademesi silinsin mi? Bu işlem geri alınamaz."
 
 msgid "Delete Timecard"
 msgstr "Çalışma Kaydını Sil"
@@ -5060,7 +5060,7 @@ msgid "Demand Forecast — Driven by"
 msgstr "Talep Tahmini — Kaynaklanan"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "Talep tahmini = Açık satış siparişlerinden, aktif işlerden ve üretim projeksiyonlarından BOM'u açılmış talep."
+msgstr "Talep tahmini = Açık satış siparişlerinden, açık iş emirlerinden ve üretim projeksiyonlarından gelen ürün yapısına göre açılmış talep."
 
 msgid "Demand projection"
 msgstr "Talep Tahmini"
@@ -5117,7 +5117,7 @@ msgid "Depreciation Method (default)"
 msgstr "Amortisman Yöntemi (varsayılan)"
 
 msgid "Depreciation reversal when a fixed asset is disposed"
-msgstr "Sabit bir varlık imha edildiğinde amortisman iptali"
+msgstr "Sabit kıymet elden çıkarıldığında amortisman geri çevirme"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
 msgstr "Bu dönemde sona eren ve hâlâ Taslak durumunda olan amortisman kayıtları deftere geçmelidir, böylece dönem doğru amortisman giderini ve birikmiş amortismanı yansıtır. Bu dönemde amortisman uygulanmıyorsa neden belirterek atlayın."
@@ -5156,7 +5156,7 @@ msgid "Digital Quote"
 msgstr "Dijital Teklif"
 
 msgid "Digital quote accepted by"
-msgstr "Dijital teklif kabul eden"
+msgstr "Dijital teklifi kabul eden"
 
 msgid "Digital quote accepted by email"
 msgstr "Dijital teklif e-posta ile kabul edildi"
@@ -5180,7 +5180,7 @@ msgid "Dimension slots"
 msgstr "Boyut yuvaları"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "Henüz sağlayıcı eşlemesi olmayan defterlerdeki boyut değerleri."
+msgstr "Henüz sağlayıcı eşleşmesi olmayan muhasebeleştirilen muhasebe fişilerinin boyut değerleri."
 
 msgid "dimensions"
 msgstr "boyutlar"
@@ -5219,14 +5219,14 @@ msgid "Discount"
 msgstr "İskonto"
 
 msgid "Discount Days"
-msgstr "İndirim Günleri"
+msgstr "İskonto Günleri"
 
 msgid "Discount Days after {selectedCalculationMethod}"
 msgstr "{selectedCalculationMethod} sonrası İskonto Günleri"
 
 #. placeholder {0}: r.invoiceId
 msgid "Discount for {0}"
-msgstr "{0} için indirim"
+msgstr "İskonto için {0}"
 
 msgid "Discount Percent"
 msgstr "İskonto Yüzdesi"
@@ -5235,10 +5235,10 @@ msgid "Discount Percentage"
 msgstr "İskonto Yüzdesi"
 
 msgid "Discounts earned for early payment to suppliers"
-msgstr "Tedarikçilere erken ödeme için kazanılan indirimler"
+msgstr "Tedarikçilere erken ödeme için kazanılan iskontolar"
 
 msgid "Discounts given to customers for early payment"
-msgstr "Müşterilere erken ödeme için verilen indirimler"
+msgstr "Müşterilere erken ödeme için verilen iskontolar"
 
 msgid "Discovery"
 msgstr "Keşif"
@@ -5247,25 +5247,25 @@ msgid "Dismiss"
 msgstr "Kapat"
 
 msgid "Dispatch"
-msgstr "Görevlendirme"
+msgstr "Bakım emri"
 
 msgid "Dispatch ID"
-msgstr "Görev Atama Kimliği"
+msgstr "Bakım emri kimliği"
 
 msgid "Dispatch priority"
-msgstr "Gönderme Önceliği"
+msgstr "Bakım emri önceliği"
 
 msgid "Dispatches"
-msgstr "Gönderiler"
+msgstr "Bakım emirleri"
 
 msgid "Display Settings"
 msgstr "Görüntü Ayarları"
 
 msgid "Disposal"
-msgstr "İmha"
+msgstr "Elden çıkarma"
 
 msgid "Disposal Date"
-msgstr "İmha Tarihi"
+msgstr "Elden çıkarma Tarihi"
 
 msgid "Dispose"
 msgstr "İmha etmek"
@@ -5277,10 +5277,10 @@ msgid "Disposed"
 msgstr "İtilmiş"
 
 msgid "Disposition"
-msgstr "Durum"
+msgstr "Karar"
 
 msgid "Dispositions"
-msgstr "Durumlar"
+msgstr "Kararlar"
 
 msgid "Do you want to overwrite the user's current permissions with the default permissions for this employee type?"
 msgstr "Kullanıcının mevcut izinlerini bu çalışan türü için varsayılan izinlerle üzerine yazmak ister misiniz?"
@@ -5298,7 +5298,7 @@ msgid "Document"
 msgstr "Belge"
 
 msgid "Document Control"
-msgstr "Doküman Kontrolü"
+msgstr "Belge Yönetimi"
 
 msgid "Document Templates"
 msgstr "Belge Şablonları"
@@ -5313,7 +5313,7 @@ msgid "Documents"
 msgstr "Belgeler"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "Documents faturaları, muhasebe faturalarını ve ödemeleri sağlayıcı belgesi olarak gönderir; muhasebe kayıtları belge tarafından kapsandığı şekilde kaydedilir. Ayrıca sağlayıcıda kaydedilen ödemeleri Carbon'a geri çekerek, eşleşen fatura veya muhasebe faturasını kapatır ve bir Carbon GL muhasebe kaydı oluşturur. Kapalı, bunları kasıtlı olarak hariç tutulmuş olarak kaydeder."
+msgstr "Belgeler, faturaları ve ödemeleri yerel sağlayıcı belgeleri olarak gönderir; ilişkili muhasebe fişileri belge tarafından karşılandığı şekilde kaydedilir. Ayrıca sağlayıcıda kaydedilen ödemeleri Carbon'a geri çeker, eşleşen faturayı kapatır ve Carbon Büyük Defter muhasebe fişi gönderir. Kapalı durum bunları kasıtlı olarak hariç tutulanlar olarak kaydeder."
 
 msgid "Documents you open will show up here for quick access."
 msgstr "Açtığınız belgeler hızlı erişim için burada görünecektir."
@@ -5322,13 +5322,13 @@ msgid "Don't Cancel"
 msgstr "İptal Etme"
 
 msgid "done"
-msgstr "tamamlandı"
+msgstr "bitti"
 
 msgid "Done"
-msgstr "Tamamlandı"
+msgstr "Bitti"
 
 msgid "Done when day-to-day runs without us in the room"
-msgstr "Günlük işlemler bizim olmadan sorunsuz çalıştığında tamamlanır"
+msgstr "Günlük işlemler bizim olmadan kendi kendine çalışırken bitti"
 
 msgid "Download"
 msgstr "İndir"
@@ -5359,7 +5359,7 @@ msgid "Draft is editable; Active is in use and requires a new version to change;
 msgstr "Taslak düzenlenebilir; Aktif kullanımda ve değiştirmek için yeni bir sürüm gerektirir; Arşivlendi kullanımdan kaldırılmıştır."
 
 msgid "Draft Journal Entries"
-msgstr "Taslak Muhasebe Kayıtları"
+msgstr "Taslak Muhasebe Fişleri"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "Dosyaları sürükleyip bırakın veya göz atmak için tıklayın"
@@ -5389,7 +5389,7 @@ msgid "Drawing"
 msgstr "Çekiliyor"
 
 msgid "Drawing Number"
-msgstr "Çizim Numarası"
+msgstr "Resim numarası"
 
 msgid "Drawing replaced. Balloon placements were removed; feature rows are unchanged."
 msgstr "Çizim değiştirildi. Balon yerleşimleri kaldırıldı; özellik satırları değişmedi."
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "Dosyanızı buraya bırakın veya göz atmak için tıklayın."
 
 msgid "Drop-ship"
-msgstr "Doğrudan Gemi"
+msgstr "Doğrudan sevkiyat"
 
 msgid "Due"
 msgstr "Vade"
@@ -5432,10 +5432,10 @@ msgid "Due Date of Last Job"
 msgstr "Son İşin Son Tarihi"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "Toplu batch'teki en erken işin son tarihi; daha sonraki işler bu tarih ile son işin son tarihi arasında eşit şekilde aralıklandırılır."
+msgstr "Toplu iş emri partisindeki en erken iş emrinin son tarihi; sonraki iş emirleri bu tarih ile Son İş Emrinin Son Tarihi arasında eşit şekilde dağıtılır."
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "Toplu batch'teki son işin son tarihi; işleri eşit şekilde aralıklandırmak için ilk işin son tarihi ile birleştirilir."
+msgstr "Toplu iş emri partisindeki son iş emrinin son tarihi; iş emirlerini eşit şekilde dağıtmak için İlk İş Emrinin Son Tarihi ile birleştirilir."
 
 msgid "Due Days"
 msgstr "Vade Günleri"
@@ -5447,7 +5447,7 @@ msgid "Duplicate"
 msgstr "Çoğalt"
 
 msgid "Duplicate Item"
-msgstr "Öğe Kopyala"
+msgstr "Stok Kartını Çoğalt"
 
 msgid "Duplicate Price List"
 msgstr "Fiyat Listesini Çoğalt"
@@ -5459,7 +5459,7 @@ msgid "Duplicate To"
 msgstr "Nereye Çoğaltılacak"
 
 msgid "Duplicate to..."
-msgstr "…’ye kopyala"
+msgstr "Çoğalt..."
 
 msgid "Duration"
 msgstr "Süre"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "örn. 48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "örn. Acme İmalat"
+msgstr "örn. Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "örn. Detroit"
@@ -5519,7 +5519,7 @@ msgid "e.g. Zebra 2x1"
 msgstr "örneğin Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "Her işlemin kullanılmayan malzemesi işlem tamamlandığı anda geri döner."
+msgstr "Her operasyonun kullanılmayan malzemesi operasyon tamamlandıktan hemen sonra geri döner."
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
 msgstr "Her fiziksel birim kendi izlenen varlığını ve benzersiz numarasını alır — bir varlık, bir birim."
@@ -5585,10 +5585,10 @@ msgid "Edit column visibility"
 msgstr "Sütun görünürlüğünü düzenle"
 
 msgid "Edit Contact"
-msgstr "İletişim Bilgisini Düzenle"
+msgstr "İlgili Kişiyi Düzenle"
 
 msgid "Edit Contractor"
-msgstr "Yüklenici Düzenle"
+msgstr "Taşeron Düzenle"
 
 msgid "Edit Cost Center"
 msgstr "Maliyet Merkezini Düzenle"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "Boyutu Düzenle"
 
 msgid "Edit Dispatch"
-msgstr "Görev Düzenle"
+msgstr "Bakım Emri Düzenle"
 
 msgid "Edit Employee"
 msgstr "Çalışanı Düzenle"
@@ -5636,13 +5636,13 @@ msgid "Edit Failure Mode"
 msgstr "Hata Modunu Düzenle"
 
 msgid "Edit Fixed Asset"
-msgstr "Sabit Varlığı Düzenle"
+msgstr "Sabit Kıymet Düzenle"
 
 msgid "Edit Gauge Calibration Record"
-msgstr "Kalibrasyon Kaydını Düzenle"
+msgstr "Ölçüm Aleti Kalibrasyon Kaydı Düzenle"
 
 msgid "Edit Gauge Type"
-msgstr "Ölçüm Tipi Düzenle"
+msgstr "Ölçüm Aleti Türü Düzenle"
 
 msgid "Edit Group"
 msgstr "Grubu Düzenle"
@@ -5651,7 +5651,7 @@ msgid "Edit Holiday"
 msgstr "Tatil Düzenle"
 
 msgid "Edit Inspection Plan"
-msgstr "Muayene Planını Düzenle"
+msgstr "Kontrol Planı Düzenle"
 
 msgid "Edit Item Group"
 msgstr "Ürün Grubunu Düzenle"
@@ -5669,7 +5669,7 @@ msgid "Edit Location"
 msgstr "Konumu Düzenle"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "Bakım Görevini Düzenle"
+msgstr "Bakım Emri Düzenle"
 
 msgid "Edit Material"
 msgstr "Malzemeyi Düzenle"
@@ -5678,16 +5678,16 @@ msgid "Edit Material Dimension"
 msgstr "Malzeme Boyutunu Düzenle"
 
 msgid "Edit Material Finish"
-msgstr "Malzeme Bitirişini Düzenle"
+msgstr "Yüzey İşlemi Düzenle"
 
 msgid "Edit Material Grade"
-msgstr "Malzeme Derecesini Düzenle"
+msgstr "Malzeme Kalitesi Düzenle"
 
 msgid "Edit Material Shape"
-msgstr "Malzeme Şeklini Düzenle"
+msgstr "Şekil Düzenle"
 
 msgid "Edit Material Substance"
-msgstr "Malzeme Maddesini Düzenle"
+msgstr "Ana Malzeme Düzenle"
 
 msgid "Edit Material Type"
 msgstr "Malzeme Tipini Düzenle"
@@ -5711,7 +5711,7 @@ msgid "Edit Payment"
 msgstr "Ödemeyi Düzenle"
 
 msgid "Edit Payment Term"
-msgstr "Ödeme Şartını Düzenle"
+msgstr "Ödeme Koşulu Düzenle"
 
 msgid "Edit permissions"
 msgstr "İzinleri Düzenle"
@@ -5720,7 +5720,7 @@ msgid "Edit Permissions"
 msgstr "Düzenleme İzinleri"
 
 msgid "Edit Picking List"
-msgstr "Seçilen Sipariş Listesini Düzenle"
+msgstr "Toplama Listesi Düzenle"
 
 msgid "Edit Portal"
 msgstr "Portal Düzenle"
@@ -5738,7 +5738,7 @@ msgid "Edit Process"
 msgstr "İşlemi Düzenle"
 
 msgid "Edit Production Event"
-msgstr "Üretim Etkinliğini Düzenle"
+msgstr "Üretim Olayı Düzenle"
 
 msgid "Edit Production Projection"
 msgstr "Üretim Projeksiyonunu Düzenle"
@@ -5774,7 +5774,7 @@ msgid "Edit Scheduled Maintenance"
 msgstr "Planlanmış Bakımı Düzenle"
 
 msgid "Edit Sequence"
-msgstr "Sıralamayı Düzenle"
+msgstr "Numaralandırma Düzenle"
 
 msgid "Edit Serial Number"
 msgstr "Seri Numarasını Düzenle"
@@ -5792,7 +5792,7 @@ msgid "Edit Shipping"
 msgstr "Nakliye Düzenle"
 
 msgid "Edit Shipping Method"
-msgstr "Kargo Yöntemini Düzenle"
+msgstr "Sevkiyat Yöntemi Düzenle"
 
 msgid "Edit Size"
 msgstr "Boyut Düzenle"
@@ -5819,7 +5819,7 @@ msgid "Edit Supplier Part"
 msgstr "Tedarikçi Parçasını Düzenle"
 
 msgid "Edit supplier process"
-msgstr "Tedarikçi sürecini düzenle"
+msgstr "Tedarikçi Prosesi Düzenle"
 
 msgid "Edit Supplier Type"
 msgstr "Tedarikçi Türünü Düzenle"
@@ -5927,7 +5927,7 @@ msgid "Enable digital quotes for your company. This will allow you to send digit
 msgstr "Şirketiniz için dijital teklifleri etkinleştirin. Bu, müşterilerinize dijital teklifler göndermenizi ve onların bunları çevrimiçi olarak kabul etmesine olanak tanır."
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "Yevmiye kayıtları, finansal raporlar ve genel defter kaydı ile tam tahakkuk muhasebesini etkinleştirin."
+msgstr "Muhasebe fişleri, finansal raporlar ve büyük defter muhasebeleştirmesi ile tam tahakkuk muhasebesi etkinleştirin."
 
 msgid "Enable in Settings"
 msgstr "Ayarlarda Etkinleştir"
@@ -5948,13 +5948,13 @@ msgid "Enable to allow shared workstation mode."
 msgstr "Paylaşımlı iş istasyonu moduna izin vermek için etkinleştirin."
 
 msgid "Enable to automatically post transactions to the general ledger."
-msgstr "İşlemleri genel muhasebe defterine otomatik olarak kaydetmek için etkinleştirin."
+msgstr "Hareketleri otomatik olarak büyük deftere muhasebeleştirmek için etkinleştirin."
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
 msgstr "Varlık sınıfları için vergiye özgü amortisman yöntemlerini yapılandırmayı etkinleştirir (örneğin, MACRS, hızlandırılmış)."
 
 msgid "Enable to generate IDs and descriptions for raw materials."
-msgstr "Ham maddeler için kimlik ve açıklamalar oluşturmak üzere etkinleştirin."
+msgstr "Ham maddeler için kimlik numaraları ve açıklamalar oluşturmak için etkinleştirin."
 
 msgid "Enable to start tracking changes to your data."
 msgstr "Verilerinizi izlemeye başlamak için etkinleştirin."
@@ -5994,7 +5994,7 @@ msgid "Enforce — edits are blocked"
 msgstr "Zorunlu — düzenlemeler engellendi"
 
 msgid "Enforce per-item validation and guidelines across receipts, shipments, transfers, and adjustments."
-msgstr "Alışmalar, sevkiyatlar, transferler ve ayarlamalarda kalem bazında doğrulama ve yönergeleri zorunlu kılın."
+msgstr "Mal kabul, sevkiyat, transfer ve düzeltmelerde madde başına doğrulama ve yönergeleri zorunlu kıl."
 
 msgid "Engagement tier"
 msgstr "Katılım seviyesi"
@@ -6009,7 +6009,7 @@ msgid "Engineering Changes and CAD"
 msgstr "Mühendislik Değişiklikleri ve CAD"
 
 msgid "Engineering Contact"
-msgstr "Mühendislik İletişim Kişisi"
+msgstr "Mühendislik İlgili Kişi"
 
 msgid "Enroll"
 msgstr "Kaydol"
@@ -6022,7 +6022,7 @@ msgid "Enter a quantity between 1 and {0}."
 msgstr "1 ile {0} arasında bir miktar girin."
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "Satıcı faturalarını bir PO'ya karşı girin ve onaylayın (üç yönlü eşleştirme)"
+msgstr "Bir satın alma siparişine (PO) karşı satıcı faturalarını girin ve onaylayın (üçlü eşleştirme)"
 
 msgid "Enter number…"
 msgstr "Sayı girin…"
@@ -6085,13 +6085,13 @@ msgid "EORI"
 msgstr "EORI"
 
 msgid "Equity"
-msgstr "Öz Kaynak"
+msgstr "Özkaynak"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "Birikmiş kâr veya zararlar için öz kaynak hesabı"
+msgstr "Birikmiş kar veya zarar için özkaynak hesabı"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "Döviz dönüştürme ayarlamaları (CTA) için öz kaynak hesabı"
+msgstr "Kur çevrimi düzeltmeleri (CTA) için özkaynak hesabı"
 
 msgid "Error"
 msgstr "Hata"
@@ -6109,7 +6109,7 @@ msgid "Error fetching supplier data"
 msgstr "Tedarikçi verileri alınırken hata oluştu"
 
 msgid "Error loading assigned dispatches"
-msgstr "Atanan görevlendirmeler yüklenirken hata oluştu"
+msgstr "Atanan bakım emirleri yüklenirken hata"
 
 msgid "Error loading assigned documents"
 msgstr "Atanan belgeleri yüklenirken hata oluştu"
@@ -6166,10 +6166,10 @@ msgid "Estimated Duration (minutes)"
 msgstr "Tahmini Süre (dakika)"
 
 msgid "Estimated Scrap Quantity"
-msgstr "Tahmini Hurda Miktarı"
+msgstr "Tahmini Fire Miktarı"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "Toplu batch'teki her işe uygulanan tahmini hurda miktarı."
+msgstr "Toplu parti içindeki her iş emrine uygulanan tahmini fire miktarı."
 
 msgid "Estimated time"
 msgstr "Tahmini zaman"
@@ -6202,7 +6202,7 @@ msgid "Every match"
 msgstr "Her eşleşme"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "Dönem kapatılmadan önce gerekli tüm görevler Tamamlandı veya Atlandı olarak işaretlenmelidir."
+msgstr "Dönem kapatılmadan önce her gerekli görev Bitti veya Atlandı olmalıdır."
 
 msgid "Every row was imported successfully."
 msgstr "Her satır başarıyla içe aktarıldı."
@@ -6211,7 +6211,7 @@ msgid "Everything else"
 msgstr "Her şey başka"
 
 msgid "Everything else covers people, imports, integrations and the API — anything that is not one of your workflows."
-msgstr "Her şey başka, insanları, ithalatları, entegrasyonları ve API'yi kapsar — iş akışlarınızdan biri olmayan her şey."
+msgstr "Geri kalan her şey personel, içe aktarmalar, entegrasyonlar ve API'yi kapsar — iş akışlarınızdan biri olmayan herhangi bir şey."
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
 msgstr "Toplamda {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB'ı aşıyor — göndermek için bazı ekler kaldırın."
@@ -6250,7 +6250,7 @@ msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mevcut eşlemeler. Yeniden eşlemek için farklı bir sağlayıcı seçeneği seçin."
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "Mevcut Stripe müşterisi"
 
 msgid "Expand"
 msgstr "Genişlet"
@@ -6293,10 +6293,10 @@ msgid "Expected Receipt Date"
 msgstr "Beklenen Teslim Alma Tarihi"
 
 msgid "Expense account for customer balances written off as uncollectable on AR settlement"
-msgstr "Müşteri bakiyelerinin AR kapatılması sırasında tahsil edilemez olarak silinen gider hesabı"
+msgstr "Alacak hesapları uzlaşması sırasında tahsil edilemez olarak silinen müşteri bakiyeleri için gider hesabı"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
-msgstr "Amortisman üzerindeki ertelenmiş vergi ayarlamaları için gider hesabı"
+msgstr "Amortisman üzerindeki ertelenmiş vergi düzeltmeleri için gider hesabı"
 
 msgid "Expense account for equipment and facility maintenance"
 msgstr "Ekipman ve tesis bakımı için gider hesabı"
@@ -6305,16 +6305,16 @@ msgid "Expense account for FX losses when a payment settles a foreign-currency i
 msgstr "Ödeme, yabancı para biriminde bir faturayı daha az uygun bir oranda kapatırken FX kayıpları için gider hesabı"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
-msgstr "Envanter dışı satın almalar (hizmetler, malzemeler) için gider hesabı"
+msgstr "Stok dışı satın almalar (hizmetler, malzemeler) için gider hesabı"
 
 msgid "Expense account for the cost of items sold"
-msgstr "Envanter bir satışa karşı gönderildiğinde/verildiğinde borçlandırılan gider GL hesabı."
+msgstr "Satılan ürünlerin maliyeti için gider hesabı"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
 msgstr "Ertelenmiş vergi hareketlerinin gider tarafı (ertelenmiş vergi yükümlülüğü ile eşleştirilmiş)."
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "Varlık sınıfı oluşturulamadı: {0}"
+msgstr "Ertelenmiş vergi hareketlerinin gider tarafı (ertelenmiş vergi yükümlülüğü ile eşleştirilmiş)."
 
 msgid "Expenses"
 msgstr "Giderler"
@@ -6332,18 +6332,18 @@ msgid "Expiration Date (applies to all serials on this line)"
 msgstr "Son Kullanma Tarihi (bu satırdaki tüm seri numaraları için geçerlidir)"
 
 msgid "Expired"
-msgstr "Süresi Dolmuş"
+msgstr "Süresi doldu"
 
 #. placeholder {0}: formatDate(date)
 #. placeholder {0}: formatDate(expiresAt)
 msgid "Expired {0}"
-msgstr "Süresi dolmuş {0}"
+msgstr "Süresi doldu {0}"
 
 msgid "Expired batch"
-msgstr "Süresi dolmuş parti"
+msgstr "Süresi doldu parti"
 
 msgid "Expired Batches"
-msgstr "Süresi Dolmuş Lotlar"
+msgstr "Süresi doldu partiler"
 
 msgid "Expires"
 msgstr "Süresi Doluyor"
@@ -6377,7 +6377,7 @@ msgid "Export"
 msgstr "Dışa Aktar"
 
 msgid "Export CSV"
-msgstr "CSV'ye Aktar"
+msgstr "CSV'yi dışa aktar"
 
 msgid "Export Lines to CSV"
 msgstr "Satırları CSV'ye Dışa Aktar"
@@ -6419,10 +6419,10 @@ msgid "Extra information sent with the request, such as an authorization key; he
 msgstr "İstekle gönderilen ek bilgiler, örneğin bir yetkilendirme anahtarı; başlık değerleri çalışma geçmişinde gizli olsa da adları okunabilir kalır."
 
 msgid "Extra tags for slicing your GL reporting"
-msgstr "GL raporlamanızı dilimlemek için ekstra etiketler"
+msgstr "GL raporlamanızı bölümlendirmek için ekstra etiketler"
 
 msgid "Fail"
-msgstr "Başarısız"
+msgstr "Uygun değil"
 
 msgid "Failed"
 msgstr "Başarısız"
@@ -6432,11 +6432,11 @@ msgstr "Başarısız özellikler"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO (ilk son kullanma tarihi, ilk çıkış)"
+msgstr "Varlık sınıfı oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
-msgstr "Tüketilebilir oluşturulamadı: {0}"
+msgstr "Sarf malzemesi oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create cost center: {0}"
@@ -6468,7 +6468,7 @@ msgstr "Başarısız oldu hata modu oluşturulması: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "Jeneratör tipi oluşturulamadı: {0}"
+msgstr "Ölçüm aleti türü oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6488,7 +6488,7 @@ msgstr "Malzeme boyutu oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
-msgstr "Malzeme bitişi oluşturulamadı: {0}"
+msgstr "Yüzey işlemi oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
@@ -6496,11 +6496,11 @@ msgstr "Malzeme formu oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "Malzeme sınıfı oluşturulamadı: {0}"
+msgstr "Malzeme kalitesi oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "Malzeme özü oluşturulamadı: {0}"
+msgstr "Ana malzeme oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
@@ -6512,7 +6512,7 @@ msgstr "Malzeme oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "Boş teklif nedeni oluşturulamadı: {0}"
+msgstr "Teklif yok nedeni oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "Parça oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "Ödeme vadesi oluşturulamadı: {0}"
+msgstr "Ödeme koşulu oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6532,7 +6532,7 @@ msgstr "Hizmet oluşturma başarısız: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create shipping method: {0}"
-msgstr "Gönderi yöntemi oluşturulamadı: {0}"
+msgstr "Sevkiyat yöntemi oluşturulamadı: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "Verileri yüklenemedi"
 
 msgid "Failed to load inbound inspections"
-msgstr "Giriş muayeneleri yüklenemedi"
+msgstr "Girdi kontrolleri yüklenemedi"
 
 msgid "Failed to load item data"
 msgstr "Öğe verileri yüklenemedi"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "Ürün detayları yüklenemedi"
 
 msgid "Failed to load job operations"
-msgstr "İşlem yüklenemedi"
+msgstr "İş emri operasyonları yüklenemedi"
 
 msgid "Failed to load jobs"
-msgstr "İşleri yüklenemedi"
+msgstr "İş emirleri yüklenemedi"
 
 msgid "Failed to load purchase order lines"
 msgstr "Satın alma sipariş satırları yüklenemedi"
@@ -6631,7 +6631,7 @@ msgid "Failed to load sales orders"
 msgstr "Satış siparişleri yüklenemedi"
 
 msgid "Failed to load shipment lines"
-msgstr "Sevkiyat hatları yüklenemedi"
+msgstr "Sevkiyat satırları yüklenemedi"
 
 msgid "Failed to load shipments"
 msgstr "Sevkiyatlar yüklenemedi"
@@ -6656,10 +6656,10 @@ msgid "Failed to remove image: {errorMessage}"
 msgstr "Görsel kaldırılamadı: {errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "Model küçük resmini kaldırmada başarısız oldu"
+msgstr "Model küçük resmi kaldırılamadı"
 
 msgid "Failed to remove purchase order"
-msgstr "Satın alma emri kaldırılamadı"
+msgstr "Satın alma siparişi kaldırılamadı"
 
 msgid "Failed to remove thumbnail"
 msgstr "Küçük resim kaldırılamadı"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "Ücretler"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "Tamamlama"
+msgstr "FEFO (süresi en kısa olanı ilk çıkart)"
 
 msgid "Fetch"
 msgstr "Al\\\\'ındır"
@@ -6871,13 +6871,13 @@ msgid "Finish with material unpicked?"
 msgstr "Seçilmemiş malzeme ile Bitir?"
 
 msgid "Finished goods"
-msgstr "Tamamlamalar"
+msgstr "Mamul"
 
 msgid "Finished Goods"
-msgstr "Bitmiş Ürünler"
+msgstr "Mamul"
 
 msgid "Finished Goods (default)"
-msgstr "Bitmiş Ürünler (varsayılan)"
+msgstr "Mamul (varsayılan)"
 
 msgid "finishes"
 msgstr "Normal MACRS programı başlamadan önce alınan ilk yıl ek indirimi."
@@ -6928,16 +6928,16 @@ msgid "Fixed"
 msgstr "Sabit"
 
 msgid "Fixed asset"
-msgstr "Parti boyutu standarttan farklı olduğunda sabit maliyet amortisman varyansı"
+msgstr "Sabit kıymet"
 
 msgid "Fixed Asset"
 msgstr "Sabit Kıymet"
 
 msgid "Fixed Assets"
-msgstr "Sabit Varlıklar"
+msgstr "Sabit kıymetler"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "Kazançlar ve Zararlar"
+msgstr "Sabit maliyet amortisman sapması parti boyutu standarttan farklı olduğunda"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
 msgstr "Muhasebe dönemleri bir kez nakliye yapıldığında veya kapatıldığında sabitlenir. Değiştirmek için tüm açık dönemleri silin."
@@ -6949,10 +6949,10 @@ msgid "Fixed Shelf Life"
 msgstr "Sabit Raf Ömrü"
 
 msgid "Fixture"
-msgstr "Demirbaş"
+msgstr "Bağlama aparatı"
 
 msgid "Fixture ID"
-msgstr "Demirbaş ID"
+msgstr "Bağlama aparatı ID"
 
 msgid "Flags"
 msgstr "Bayraklar"
@@ -6962,16 +6962,16 @@ msgstr "herhangi bir şey için. Doğru kişiyi çekerler."
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "Tahmin yöntemi: <0>{0}</0>. Bu satır aktif işlerden türetilmediği için üst kaynaklar mevcut değil."
+msgstr "Tahmin yöntemi: <0>{0}</0>. Bu satır etkin iş emirlerinden türetilmedi, bu nedenle üst kaynaklar yok."
 
 msgid "Forgot to Clock Out?"
-msgstr "Çıkış yapmayı unuttunuz mu?"
+msgstr "İş bitişini mi unuttunuz?"
 
 msgid "Format"
 msgstr "Biçim"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "Sahadaki mühendis"
 
 msgid "Foundation"
 msgstr "Temel"
@@ -7018,19 +7018,19 @@ msgid "from on-account credit"
 msgstr "hesap kredisinden"
 
 msgid "From Storage Unit"
-msgstr "Kaynak Depo Birimi"
+msgstr "Depolama biriminden"
 
 msgid "Fulfillment Location"
-msgstr "Yerine Getirme Konumu"
+msgstr "Sevkiyat lokasyonu"
 
 msgid "Full name"
 msgstr "Tam adı"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "Tam kurulum ve göçler"
 
 msgid "Fully Depreciated"
-msgstr "Tamamen Amortismana Tabi Tutulmuş"
+msgstr "Amortismanı tamamlanmış"
 
 msgid "Fully trained for"
 msgstr "Tamamen eğitilmiş"
@@ -7048,49 +7048,49 @@ msgid "Gain on Disposal Account"
 msgstr "Elden Çıkarmada Kar Hesabı"
 
 msgid "Gains recognized on disposal of fixed assets"
-msgstr "Sabit varlıkların elden çıkarılmasında muhasebeleştirilen karlar"
+msgstr "Sabit kıymetlerin elden çıkarılmasında muhasebeleştirilen kazançlar"
 
 msgid "gauge"
-msgstr "Ölçüler"
+msgstr "ölçüm aleti"
 
 msgid "Gauge"
-msgstr "Kalibratör"
+msgstr "Ölçüm aleti"
 
 msgid "Gauge Calibration Notifications"
-msgstr "Kalibrasyon Bildirimleri"
+msgstr "Ölçüm Aleti Kalibrasyon Bildirimleri"
 
 msgid "Gauge ID"
-msgstr "Kalibrasyon Cihazı Kimliği"
+msgstr "Ölçüm aleti ID"
 
 msgid "Gauge not found"
-msgstr "Kalibrasyon cihazı bulunamadı"
+msgstr "Ölçüm aleti bulunamadı"
 
 msgid "Gauge Type"
-msgstr "Kalibrasyon Tipi"
+msgstr "Ölçüm aleti türü"
 
 msgid "Gauge Types"
-msgstr "Ölçüm Tipleri"
+msgstr "Ölçüm aleti türleri"
 
 msgid "gauges"
-msgstr "Soy Ağacı"
+msgstr "ölçüm aletleri"
 
 msgid "Gauges"
-msgstr "Kalibratörler"
+msgstr "Ölçüm aletleri"
 
 msgid "Genealogy"
-msgstr "Genel Muhasebe Defteri"
+msgstr "Soy ağacı"
 
 msgid "General"
 msgstr "Genel"
 
 msgid "General ledger"
-msgstr "Dış işlem operasyonlarında maliyet farklarını yakalayan GL hesabı."
+msgstr "Büyük defter"
 
 msgid "General Ledger"
-msgstr "Genel Defter"
+msgstr "Büyük defter"
 
 msgid "General Ledger and month-end close"
-msgstr "Genel Muhasebe ve ay sonu kapanışı"
+msgstr "Büyük defter ve dönem sonu kapanışı"
 
 msgid "Generate"
 msgstr "Oluştur"
@@ -7114,7 +7114,7 @@ msgid "Generate new PIN"
 msgstr "Yeni PIN oluştur"
 
 msgid "Generate Picking List"
-msgstr "Çekme Listesi Oluştur"
+msgstr "Toplama listesi oluştur"
 
 msgid "Generated IDs are disabled"
 msgstr "Oluşturulan kimlikler devre dışı"
@@ -7129,7 +7129,7 @@ msgid "Get live on Carbon: one system running quoting, purchasing, the shop floo
 msgstr "Carbon'da canlı yayına geçin: alıntı alma, satın alma, atölye tabanı, envanter ve finansmanı çalıştıran ve mevcut araçları değiştiren tek bir sistem."
 
 msgid "Get Method"
-msgstr "Yöntemi Al"
+msgstr "Yöntemi getir"
 
 msgid "Get started"
 msgstr "Başlayın"
@@ -7147,7 +7147,7 @@ msgid "Give it an owner and a date"
 msgstr "Ona bir sahip ve bir tarih verin"
 
 msgid "GL"
-msgstr "GL"
+msgstr "Büyük defter"
 
 msgid "GL Account"
 msgstr "BÜTÇE HESABI"
@@ -7162,16 +7162,16 @@ msgid "GL account capturing differences between BOM-expected and actual material
 msgstr "BOM beklentilerine karşı gerçekten tüketilen malzeme arasındaki farkları yakalayan GL hesabı."
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "Rota beklentilerine karşı gerçek işçilik/makine zamanı arasındaki farkları yakalayan GL hesabı."
+msgstr "Planlanan ve gerçek işçilik/makine süresi arasındaki farkları kaydeden muhasebe hesabı."
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
-msgstr "Gerçek parti boyutu planlananından farklı olduğunda sabit maliyet farklarını yakalayan GL hesabı."
+msgstr "Gerçek parti büyüklüğü planlanandan farklı olduğunda sabit maliyet farklarını kaydeden muhasebe hesabı."
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
 msgstr "Varlık elden çıkarıldığında orijinal maliyetini kaldırmak için kredilendirilmiş GL hesabı."
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "Bir tedarikçi faturası muhasebeleştirildiğinde alacaklandırılan GL hesabı (AP bakiyesi)."
+msgstr "Tedarikçi faturası muhasebeleştirildiğinde alacağa kaydedilen muhasebe hesabı (Borç hesapları bakiyesi)."
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
 msgstr "İşçilik veya makine maliyeti bir üretim işine emildiğinde kredilendirilmiş GL hesabı."
@@ -7189,7 +7189,7 @@ msgid "GL account debited when a fixed asset is acquired (purchase or capitalize
 msgstr "Sabit kıymet satın alındığında borçlandırılan GL hesabı (satın alma veya aktifleştirilen maliyet)."
 
 msgid "GL account for bank service charges and similar fees."
-msgstr "Banka hizmet ücretleri ve benzeri masraflar için GL hesabı."
+msgstr "Banka hizmet bedelleri ve benzeri ücretler için muhasebe hesabı."
 
 msgid "GL account for interest income or expense."
 msgstr "Faiz geliri veya gideri için GL hesabı."
@@ -7198,7 +7198,7 @@ msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "Tedarikçilere ödenen satın alma vergisi için GL hesabı (veya geri alınabilir)."
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "Alıcının kendi kendine değerlendirdiği ters masraf kuralları kapsamında tahakkuk eden vergiler için GL hesabı."
+msgstr "Alıcının kendi değerlendirmesini yaptığı ters muhasebeleştirme kuralları altında tahakkuk eden vergi için muhasebe hesabı."
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "Vergi zamanlaması farkları için GL hesabı (örneğin hızlandırılmış vergi amortismanı ve muhasebe amortismanı)."
@@ -7213,7 +7213,7 @@ msgid "GL account in the target company to credit for this intercompany transact
 msgstr "Bu şirketlerarası işlem için alacaklandırılacak hedef şirkette GL hesabı."
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
-msgstr "Deftere kayıt sırasında sent altı yuvarlama farklarını emilen GL hesabı."
+msgstr "Muhasebeleştirme sırasında sentinden az fark farklarını emen muhasebe hesabı."
 
 msgid "GL account that captures the difference between standard cost and actual purchase cost."
 msgstr "Standart maliyet ile fiili satın alma maliyeti arasındaki farkı yakalayan GL hesabı."
@@ -7222,7 +7222,7 @@ msgid "GL account that carries an asset's original acquisition cost — debited 
 msgstr "Bir varlığın orijinal edinim maliyetini taşıyan GL hesabı — edinildiğinde borçlandırılır, elden çıkarıldığında veya satıldığında brüt maliyetin tamamı üzerinden alacaklandırılır."
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "İşleri tamamlanmış mal olarak kaydetene kadar üretimde olan işlerin değerini tutan GL hesabı."
+msgstr "Üretim aşamasındaki işlerin değerini mamule muhasebeleştirilene kadar tutan muhasebe hesabı."
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
 msgstr "Üretilen malların değerini tutan genel muhasebe hesabı (Üretim ürünleri); iş tamamlandığında borçlandırılır, sevkiyatta alacaklandırılır."
@@ -7234,40 +7234,40 @@ msgid "GL account used when a customer pays before an invoice is issued; cleared
 msgstr "Bir müşteri fatura çıkarılmadan önce ödeme yaptığında kullanılan GL hesabı; fatura nakledildiğinde temizlenir."
 
 msgid "GL account where early-payment discounts given to customers are recorded."
-msgstr "Müşterilere verilen erken ödeme indirimlerinin kaydedildiği GL hesabı."
+msgstr "Müşterilere verilen erken ödeme iskontolarının kaydedildiği muhasebe hesabı."
 
 msgid "GL account where early-payment discounts taken from suppliers are recorded."
-msgstr "Tedarikçilerden alınan erken ödeme indirimlerinin kaydedildiği GL hesabı."
+msgstr "Tedarikçilerden alınan erken ödeme iskontolarının kaydedildiği muhasebe hesabı."
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "Her dönem birikmiş amortisman kaydedildikçe alacaklandırılan ve varlık satıldığında veya hurdaya çıkarıldığında tamamı borçlandırılan GL karşı aktif (contra-asset) hesabı."
+msgstr "Amortisman muhasebeleştirildiğinde her dönem alacağa kaydedilen ve varlık satıldığında veya hurda hale getirildiğinde tam olarak borca kaydedilen muhasebe kontra-varlık hesabı."
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "Sabit varlıklara karşı kaydedilen amortismanı biriken GL contra-aktif hesabı."
+msgstr "Sabit kıymetlere karşı muhasebeleştirilen amortismanı tahakkuk ettiren muhasebe kontra-varlık hesabı."
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "Öz sermaye GL hesabı (CTA rezervi) dönem sonunda yabancı para birimi bakiyelerinin retradüksiyonundan kaynaklanan gerçekleşmemiş FX farklarını tutar; P&L'deki gerçekleşmiş FX kazancı/kaybından ayrı."
+msgstr "Dönem sonunda yabancı para bakiyelerinin yeniden çevirisi sonucu oluşan gerçekleşmemiş döviz farklarını tutan muhasebe özkaynaklar hesabı (CTA yedek); kar/zarar tablosundaki gerçekleşmiş döviz kazanç/zararından ayrıdır."
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "Muhasebe yılının sonunda net gelirin kapatıldığı GL öz sermaye hesabı."
+msgstr "Mali yılın sonunda net gelirin kapatıldığı muhasebe özkaynaklar hesabı."
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "Amortisman nakledildiği her dönem borçlandırılan GL gider hesabı."
+msgstr "Amortisman muhasebeleştirildiğinde her dönem borca kaydedilen muhasebe gider hesabı."
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "Bir varlığın defter değeri değer düşüklüğü (impairment) nedeniyle azaldığında, yani geri kazanılabilir tutarı net defter değerinin (NBV) altına düştüğünde borçlandırılan GL gider hesabı."
+msgstr "Bir varlığın defter değeri zayıflamaya maruz kaldığında, yani geri kazanılabilir tutarı net defter değerinin altına düştüğünde borca kaydedilen muhasebe gider hesabı."
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "Stok dışı satın almalar (malzemeleri, hizmetleri) için GL gider hesabı."
+msgstr "Stok dışı satın almalar (malzeme, hizmet) için muhasebe gider hesabı."
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "Müşterilerden toplanan satış vergisi için alacaklandırılan GL yükümlülük hesabı."
+msgstr "Müşterilerden toplanan satış vergisi için alacağa kaydedilen muhasebe yükümlülük hesabı."
 
 msgid "GL tie-out"
-msgstr "GL mutabakatı"
+msgstr "Muhasebe mutabakatı"
 
 msgid "GL Tie-Out"
-msgstr "GL Mutabakatı"
+msgstr "Muhasebe Mutabakatı"
 
 msgid "Go live right the first time — with our team alongside you"
 msgstr "İlk seferde canlı yayına geç — ekibimiz yanınızda"
@@ -7358,7 +7358,7 @@ msgid "Guided implementation"
 msgstr "Rehberli uygulama"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "Yinelenen ve tersine çevrilen günlük girişleri işleyin"
+msgstr "Tekrarlayan ve iptal edilen muhasebe fişlerini işle"
 
 msgid "Hands-on"
 msgstr "Uygulamalı"
@@ -7400,16 +7400,16 @@ msgid "Historical data older than what's on the Data Migration Map"
 msgstr "Veri Taşıma Haritasında olanlardan daha eski geçmiş veriler"
 
 msgid "Historical Rate (equity)"
-msgstr "Tarihi Oran (Öz Sermaye)"
+msgstr "Tarihsel kur (özkaynak)"
 
 msgid "Historical Rate (Equity)"
-msgstr "Tarihi Oran (Öz Sermaye)"
+msgstr "Tarihsel kur (Özkaynak)"
 
 msgid "History"
 msgstr "Geçmiş"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "Günlüğü uyarı olarak tut ve düzelt."
+msgstr "Düzeltilmesi için uyarı olarak muhasebe fişini beklet."
 
 msgid "Holiday"
 msgstr "Tatil"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "Saat/Adet"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "Bir öğe nasıl genel olarak yenilenir (Satın Al, Yap veya Satın Al ve Yap), öğe başına ayarlanır, satır başına yöntem türünden farklı."
+msgstr "Bir stok kartının genel olarak nasıl tamamlandığı (Satın alma, Üretim veya Satın alma ve üretim), stok kartı başına ayarlanır, satır başına tedarik şeklinden farklı."
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "Bir öğe nasıl yenilenir: Manuel Yeniden Sipariş, Talep Tabanlı Yeniden Sipariş, Sabit Yeniden Sipariş Miktarı veya Maksimum Miktar."
@@ -7454,7 +7454,7 @@ msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set 
 msgstr "Bir öğenin birim maliyeti nasıl değerlendirilir: Standart, Ortalama, FIFO veya LIFO. Madde başına ayarlanır."
 
 msgid "How items roll up for posting and reporting"
-msgstr "Öğelerin deftere nakil ve raporlama için nasıl toplandığı"
+msgstr "Stok kartları muhasebeleştirme ve raporlama için nasıl toplanır"
 
 msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank to use the default."
 msgstr "Her fazın ne kadar sürdüğü, haftalar cinsinden. Plan zaman çizelgesini yönlendirir; varsayılanı kullanmak için boş bırakın."
@@ -7469,7 +7469,7 @@ msgid "How many days a serial or batch of this item stays usable after its start
 msgstr "Bu öğenin bir serisi veya lotu, başlangıç olayından sonra kaç gün kullanılabilir kalır; raf ömrü politikası bu tarihten sonra ne olacağına karar verir."
 
 msgid "How many days after the calculation date the early-payment discount is still available."
-msgstr "Hesaplama tarihinden sonra kaç gün erken ödeme indirimi hala mevcuttur."
+msgstr "Hesaplama tarihinden sonra erken ödeme iskontosunun kaç gün daha kullanılabileceği"
 
 msgid "How many days after the calculation date the full amount is due."
 msgstr "Hesaplama tarihinden sonra kaç gün tam tutar ödenmesi gerekir."
@@ -7484,7 +7484,7 @@ msgid "How many fractional digits to keep when rounding amounts in this currency
 msgstr "Bu para biriminde tutarlar yuvarlanırken kaç kesirli rakam tutulur."
 
 msgid "How many of the successor replace one old part"
-msgstr "Halefi kaç tane eski parçanın yerine geçer"
+msgstr "Bir eski parçanın yerini kaç ardıl alır"
 
 msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
 msgstr "İşin ana öğesinin birini oluşturmak için bu malzemeden ne kadar gerekir; tüketimi boyutlandırmak için iş miktarı ile çarpılır."
@@ -7496,25 +7496,25 @@ msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane toplandı?"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "Bu ölçü ne sıklıkla yeniden kalibre edilmelidir; sonraki kalibrasyon tarihini otomatik olarak yeniden hesaplamak için son kalibrasyon tarihiyle birleştirilir."
+msgstr "Bu ölçüm aletinin ne sıklıkla kalibre edilmesi gerektiği; Son Kalibrasyon Tarihi ile birleştirilerek Sonraki Kalibrasyon Tarihini otomatik olarak yeniden hesaplamak için."
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "Bu bakım ne sıklıkla tekrarlanır — Günlük, Haftalık, Aylık, Döngü Sayısında; Günlük haftanın günü seçicisini açığa çıkarır, diğerleri daha basit aralık matematiği kullanır."
+msgstr "Bu bakım ne sıklıkla tekrarlanır — Günlük, Haftalık, Aylık, Periyodik Sayımında; Günlük seçim haftanın günü seçicisini gösterir, diğerleri daha basit aralık matematiğini kullanır."
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
 msgstr "Son tarih ne kadar katı — Sabit Tarih zamanlama engeller, Esnek Tarih planlamanın uyarı ile itilmesine izin verir, Tarih Yok tamamen görmezden gelir."
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "Malzemenin nasıl tedarik edildiği (üretme, satın alma veya envanterden çekme) ve çekildiği depolama birimi."
+msgstr "Malzemenin nasıl tedarik edildiği (üretim, satın alma veya stoktan kullanım) ve çekildiği depolama birimi."
 
 msgid "How the resolved price was calculated."
 msgstr "Çözülen fiyatın nasıl hesaplandığı."
 
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
-msgstr "Örnek boyutu nasıl kararlaştırılır — Tümünü İncele, İlk N'yi İncele, Lot Yüzdesini veya AQL'yi İncele (Z1.4 / ISO 2859-1). Her mod aşağıda kendi parametre alanlarını ortaya koymaktadır."
+msgstr "Örneklem büyüklüğünün nasıl belirlendiği — Tümünü İncele, İlk N'yi İncele, Lot'un Yüzdesi veya AQL (Z1.4 / ISO 2859-1). Her mod aşağıda kendi parametre alanlarını ortaya koymaktadır."
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "Bu göstergenin nasıl kullanıldığı — Standart (düzenli kontroller) veya Ana (diğer göstergeleri kalibre eder)."
+msgstr "Bu ölçüm aletinin nasıl kullanıldığı — Normal (düzenli kontroller) veya Mastar (diğer ölçüm aletlerini kalibre eder)."
 
 msgid "How this price was calculated"
 msgstr "Bu fiyat nasıl hesaplandı"
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "Bu grafik nasıl okunur"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "Bu despacho ne kadar acildir — Düşük / Orta / Yüksek / Kritik; zamanlama slotsunu kararlaştırmak için Öncelik ve OEE Etkisi ile birleştirilir."
+msgstr "Bu bakım emrinin ne kadar acil olduğu — Düşük / Orta / Yüksek / Kritik; Öncelik ve OEE Etkisi ile birleştirilerek çizelge konumunu belirlemek için."
 
 msgid "How we know we're done"
 msgstr "Nasıl bittiğini bileceğiz"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "Hypercare: ilk haftalar için yoğun destek"
 
 msgid "I (reduced)"
-msgstr "I (azaltılmış)"
+msgstr "I (Gevşetilmiş)"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "Bu kişinin 22 CFR 120.62'de tanımlanan şekilde ABD vatandaşı olduğuna inanmak için makul bir temelem var"
@@ -7586,7 +7586,7 @@ msgid "Identifiers"
 msgstr "Tanımlayıcılar"
 
 msgid "IDs and descriptions are generated for raw materials."
-msgstr "Kimlikler ve açıklamalar ham malzemeler için oluşturulur."
+msgstr "Kimlikler ve açıklamalar hammadde için oluşturulur."
 
 msgid "If"
 msgstr "Eğer"
@@ -7601,7 +7601,7 @@ msgid "If items already exist"
 msgstr "Eğer öğeler zaten varsa"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "Sipariş verilirse, sonraki 48 hafta içinde stok tükenmesi öngörülmemektedir"
+msgstr "Sipariş edildiyse, sonraki 48 haftada stoksuzluk projeksiyonu yoktur"
 
 msgid "If something is off track"
 msgstr "Bir şey yolunda değilse"
@@ -7613,7 +7613,7 @@ msgid "II (normal default)"
 msgstr "II (normal varsayılan)"
 
 msgid "III (tightened)"
-msgstr "III (sıklaştırılmış)"
+msgstr "III (Sıkılaştırılmış)"
 
 msgid "Impact"
 msgstr "Etki"
@@ -7644,7 +7644,7 @@ msgid "in {0}"
 msgstr "{0} içinde"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "Onshape'te bu OAuth uygulamasının izinlerini düzenleyerek \"Application can write to your documents\" iznini ekleyin, ardından yeniden bağlanın."
+msgstr "Onshape'te bu OAuth uygulamasının izinlerini düzenleyerek \"Uygulama belgelerinize yazabilir\" izni ekleyin, ardından yeniden bağlanın."
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "Bu Fiyat Teklifi'ni (RFQ) bir teklife dönüştürmek için tüm satırların dahili bir parça numarasına sahip olması gerekir."
@@ -7698,10 +7698,10 @@ msgid "Inactive"
 msgstr "Pasif"
 
 msgid "Inactive actions will not appear in selection lists"
-msgstr "Etkin olmayan eylemler seçim listelerinde görünmeyecektir"
+msgstr "Pasif eylemler seçim listelerinde görünmeyecektir"
 
 msgid "Inbound inspection"
-msgstr "Gelen Muhasebesi"
+msgstr "Girdi kontrolü"
 
 msgid "Inbox"
 msgstr "Gelen Kutusu"
@@ -7716,7 +7716,7 @@ msgid "Included"
 msgstr "Dahil"
 
 msgid "Includes tax and shipping costs"
-msgstr "Vergiler ve nakliye masrafları dahildir"
+msgstr "Vergi ve nakliye bedelini içerir"
 
 msgid "Income / Balance (inherited)"
 msgstr "Gelir / Bakiye (Devralınan)"
@@ -7737,10 +7737,10 @@ msgid "Incoming"
 msgstr "Gelen"
 
 msgid "Incoterm"
-msgstr "İrsalat Koşulu"
+msgstr "Incoterm"
 
 msgid "Incoterm Location"
-msgstr "Teslim Yeri Şartı Konumu"
+msgstr "Incoterm Lokasyonu"
 
 msgid "Indirect"
 msgstr "Dolaylı"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "Ebeveyn'den miras alındı"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "Gruptan devralınan: üst düzey sınıflandırma (varlık, yükümlülük, öz sermaye, gelir, gider)."
+msgstr "Gruptan miras alınır: üst düzey sınıflandırma (varlık, pasif, özkaynak, hasılat, gider)."
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "Gruptan devralınan: bu hesap finansal tablolarda nerede görünür."
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "Gruptan devralınan: bu hesap birikmiş karları (gelir) kapatır mı yoksa devam eder mi (bakiye)."
+msgstr "Gruptan miras alınır: bu hesabın dağıtılmamış kârlara kapanıp kapanmadığı (gelir) veya ileri taşınıp taşınmadığı (bakiye)."
 
 msgid "Inherited from the parent group."
 msgstr "Ana gruptan devralınan."
@@ -7803,25 +7803,25 @@ msgid "Inspect Item"
 msgstr "Ürünü İncele"
 
 msgid "Inspection"
-msgstr "Kontrol"
+msgstr "Muayene"
 
 msgid "Inspection document"
-msgstr "İnceleme belgesi"
+msgstr "Muayene belgesi"
 
 msgid "Inspection Level"
 msgstr "Muayene Seviyesi"
 
 msgid "Inspection Plan"
-msgstr "Muayene Planı"
+msgstr "Kontrol planı"
 
 msgid "Inspection Plan Assignments"
-msgstr "Muayene Planı Atamalar"
+msgstr "Kontrol Planı Atamaları"
 
 msgid "Inspection Plans"
-msgstr "Muayene Planları"
+msgstr "Kontrol Planları"
 
 msgid "Inspection Status"
-msgstr "Kontrol Durumu"
+msgstr "Muayene Durumu"
 
 msgid "Inspections"
 msgstr "Muayeneler"
@@ -7890,7 +7890,7 @@ msgid "Internal Delta"
 msgstr "Dahili Fark"
 
 msgid "Internal notes"
-msgstr "İç notlar"
+msgstr "Dahili notlar"
 
 msgid "Internal Notes"
 msgstr "Dahili Notlar"
@@ -7917,10 +7917,10 @@ msgid "Inventory actions"
 msgstr "Envanter aksiyonları"
 
 msgid "Inventory Adjustment"
-msgstr "Stok Ayarlaması"
+msgstr "Stok düzeltme"
 
 msgid "Inventory Adjustment (default)"
-msgstr "Envanter Ayarlaması (varsayılan)"
+msgstr "Stok düzeltme (varsayılan)"
 
 msgid "Inventory and purchasing, with automated planning"
 msgstr "Envanter ve satın alma, otomatik planlama ile"
@@ -7953,7 +7953,7 @@ msgid "Inventory Tracking"
 msgstr "Stok Takibi"
 
 msgid "Inventory Unit of Measure"
-msgstr "Stok Birimi"
+msgstr "Envanter Ölçü Birimi"
 
 msgid "Inventory Valuation"
 msgstr "Envanter Değerlemesi"
@@ -7971,7 +7971,7 @@ msgid "Invoice"
 msgstr "Fatura"
 
 msgid "Invoice Contact"
-msgstr "Fatura İletişim Kişisi"
+msgstr "Fatura İlgili Kişisi"
 
 msgid "Invoice customer"
 msgstr "Fatura müşterisi"
@@ -7980,10 +7980,10 @@ msgid "Invoice Customer"
 msgstr "Fatura Müşterisi"
 
 msgid "Invoice customer contact"
-msgstr "Fatura müşteri iletişim"
+msgstr "Fatura müşteri ilgili kişisi"
 
 msgid "Invoice Customer Contact"
-msgstr "Fatura Müşteri İletişim Kişisi"
+msgstr "Fatura Müşteri İlgili Kişisi"
 
 msgid "Invoice customer location"
 msgstr "Fatura müşteri konumu"
@@ -8010,10 +8010,10 @@ msgid "Invoice Supplier"
 msgstr "Fatura Tedarikçisi"
 
 msgid "Invoice supplier contact"
-msgstr "Fatura tedarikçi iletişim"
+msgstr "Fatura tedarikçi ilgili kişisi"
 
 msgid "Invoice Supplier Contact"
-msgstr "Fatura Tedarikçisi İletişim Kişisi"
+msgstr "Fatura Tedarikçi İlgili Kişisi"
 
 msgid "Invoice supplier location"
 msgstr "Fatura tedarikçi konumu"
@@ -8028,10 +8028,10 @@ msgid "Invoiced"
 msgstr "Faturalandırıldı"
 
 msgid "Invoiced Amount:"
-msgstr "Fatura Edilmiş Tutar:"
+msgstr "Faturalandı Tutarı:"
 
 msgid "Invoiced Statuses"
-msgstr "Fatura Durumları"
+msgstr "Faturalandı Durumları"
 
 msgid "Invoices"
 msgstr "Faturalar"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "İş Akışları"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "Sorun iş akışları bir sorun için önceden ayarlanmış değerleri tanımladı. Örneğin, 8D iş akışına veya kapsama iş akışına sahip olabilirsiniz."
+msgstr "Sorun iş akışları, bir sorun için ön ayarlanmış değerleri tanımlar. Örneğin, bir 8D iş akışınız veya çevreleme iş akışınız olabilir."
 
 msgid "Issued"
 msgstr "Çıkış Yapıldı"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "Sorunlar"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "Yeniden bir sürüm yayınlayana kadar çalışmayı durdurur. Hiçbir şey silinmez."
 
 msgid "ITAR Certifications"
 msgstr "ITAR Sertifikaları"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "Ürün Ana Verileri ve Üretim Yöntemleri"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "Madde ana verileri, BOM'lar ve İşlem Listesi"
+msgstr "Stok kartı, BOM ve Operasyon listesi"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "Öğe seçilen bir tür VE seçilen bir grup ile eşleşmelidir"
@@ -8184,13 +8184,13 @@ msgid "Item Scope"
 msgstr "Ürün Kapsamı"
 
 msgid "Item Type"
-msgstr "Ürün Tipi"
+msgstr "Stok kartı türü"
 
 msgid "Item Type (optional)"
-msgstr "Madde Türü (isteğe bağlı)"
+msgstr "Stok kartı türü (isteğe bağlı)"
 
 msgid "Item types"
-msgstr "Ürün tipleri"
+msgstr "Stok kartı türleri"
 
 msgid "items"
 msgstr "öğeler"
@@ -8205,7 +8205,7 @@ msgid "Items inside this window get a yellow badge."
 msgstr "Bu aralıktaki ürünler sarı bir rozet alır."
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "Öğeler: öğe ana verileri, BOM'lar, İşlem Şeması, mühendislik değişiklikleri, CAD"
+msgstr "Stok kartları: stok kartı veritabanı, BOM'lar, operasyon listesi, mühendislik değişiklikleri, CAD"
 
 msgid "Its design may change before the change notice is released."
 msgstr "Tasarımı, değişiklik bildirisi yayınlanmadan önce değişebilir."
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "İş Yeri Konumu"
 
 msgid "Job make method"
-msgstr "İş yapım yöntemi"
+msgstr "İş emri üretim yöntemi"
 
 msgid "Job Materials"
-msgstr "İş Malzemeleri"
+msgstr "İş emri malzemeleri"
 
 msgid "Job operation"
-msgstr "İş operasyonu"
+msgstr "İş emri operasyonu"
 
 msgid "Job Operation"
-msgstr "İşlem"
+msgstr "İş emri operasyonu"
 
 msgid "Job Operations"
-msgstr "İşlem Operasyonları"
+msgstr "İş emri operasyonları"
 
 msgid "Job Priority"
 msgstr "İş Önceliği"
@@ -8244,38 +8244,38 @@ msgid "Job readable"
 msgstr "İş okunabilir"
 
 msgid "Job Traveler"
-msgstr "İş Talimatı"
+msgstr "İş takip kartı"
 
 msgid "Jobs"
-msgstr "İşler"
+msgstr "İş emirleri"
 
 msgid "Jobs Assigned to Me"
-msgstr "Bana Atanan İşler"
+msgstr "Bana Atanan İş emirleri"
 
 msgid "Jobs Required"
-msgstr "İşler Gerekli"
+msgstr "Gereken İş emirleri"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "Malzeme listesinde bu ürünü içeren işler"
+msgstr "Bu stok kartının ürün ağacında bulunduğu iş emirleri"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "Join {0}"
 
 msgid "Journal"
-msgstr "Dergi"
+msgstr "Muhasebe fişi"
 
 msgid "Journal Entries"
-msgstr "Yevrak Girişleri"
+msgstr "Yevmiye kayıtları"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "Bu dönemde tarihli ve hâlâ Taslak durumunda olan muhasebe kayıtları deftere geçmelidir veya daha sonraki bir açık döneme yeniden tarihlendirilmelidir. Taslak kayıtlar defteri kebir'in parçası olmadığı için, borç ve alacakları kapanışta eksik olacaktır."
+msgstr "Bu dönemde tarihlendirilen ve hala Taslak durumunda olan yevmiye kayıtları muhasebeleştirilmeli veya daha sonraki açık bir döneme yeniden tarihlendirilebilir. Taslak kayıtlar muhasebe fişinin parçası olmadığından, borç ve alacakları kapanışta eksik olur."
 
 msgid "Journal Entry"
-msgstr "Muhasebe Kaydı"
+msgstr "Yevmiye kaydı"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "Bu tarih veya öncesine tarihlenmiş yevmiyeler kilitli olarak kabul edilir. Her ikisi de mevcut olduğunda sağlayıcı tarafından bildirilen kilitlenme tarihi ile birleştirilir."
+msgstr "Bu tarihte veya öncesinde tarihlendirilen muhasebe fişleri kilitli olarak değerlendirilir. Her ikisi de mevcutsa sağlayıcı tarafından rapor edilen kilit tarihi ile birleştirilir."
 
 msgid "Just one"
 msgstr "Sadece bir"
@@ -8311,7 +8311,7 @@ msgid "Keep Open"
 msgstr "Açık Tut"
 
 msgid "Keep picking"
-msgstr "Seçmeye Devam Et"
+msgstr "Toplamaya devam et"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Siparişleri, teklifleri ve ayarları ikinci bir kontrolün arkasında tutar"
@@ -8342,7 +8342,7 @@ msgid "Labels"
 msgstr "Etiketler"
 
 msgid "Labor"
-msgstr "İşgücü"
+msgstr "İşçilik"
 
 msgid "Labor & Machine Absorption"
 msgstr "İşçilik ve Makine Emilimi"
@@ -8432,19 +8432,19 @@ msgid "Latitude"
 msgstr "Enlem"
 
 msgid "Lead time"
-msgstr "Teslim Süresi"
+msgstr "tedarik süresi"
 
 msgid "Lead Time"
-msgstr "Teslim Süresi"
+msgstr "Tedarik süresi"
 
 msgid "Lead time (days)"
-msgstr "Teslim süresi (günler)"
+msgstr "tedarik süresi (gün)"
 
 msgid "Lead Time (Days)"
-msgstr "Teslim Süresi (Gün)"
+msgstr "Tedarik süresi (Gün)"
 
 msgid "Lead Time:"
-msgstr "Teslim Süresi:"
+msgstr "Tedarik süresi:"
 
 msgid "Learn"
 msgstr "Öğren"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "Daha az manuel çalışma, daha az hata"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "Üretelim"
 
 msgid "Let's build something"
 msgstr "Bir şeyler inşa edelim"
@@ -8549,7 +8549,7 @@ msgid "Lines need internal part numbers"
 msgstr "Satırlar dahili parça numaralarına ihtiyaç duyuyor"
 
 msgid "Lines need prices or lead times"
-msgstr "Satırlarda fiyat veya teslim süreleri eksik"
+msgstr "Satırlar fiyat veya tedarik süresi gerektirir"
 
 msgid "Lineside"
 msgstr "Üretim Hattı Yanı"
@@ -8558,7 +8558,7 @@ msgid "Link"
 msgstr "Bağlantı"
 
 msgid "Link (optional) — e.g. /x/settings/…"
-msgstr "Bağlantı (isteğe bağlı) — örn. /x/settings/…"
+msgstr "Bağlantı (isteğe bağlı) — ör. /x/settings/…"
 
 msgid "Link Jira Issue"
 msgstr "Jira Sorununu Bağla"
@@ -8567,7 +8567,7 @@ msgid "Link Linear Issue"
 msgstr "Linear sorununu bağla"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "Bu Carbon müşterisini bunlardan birine bağlayın veya ayrı bir Stripe müşterisi oluşturun."
 
 msgid "Link to sales order line"
 msgstr "Satış siparişi satırına bağla"
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "Son yüklenen, kesme noktasında hemen, bu nedenle bakiyeler günceldir."
 
 msgid "Loading associated jobs..."
-msgstr "İlgili işler yükleniyor..."
+msgstr "İlişkili iş emirleri yükleniyor..."
 
 msgid "Loading current quantity…"
 msgstr "Geçerli miktar yükleniyor…"
@@ -8704,7 +8704,7 @@ msgid "Loss on Disposal Account"
 msgstr "Elden Çıkarmada Zarar Hesabı"
 
 msgid "Losses recognized on disposal of fixed assets"
-msgstr "Sabit varlıkların elden çıkarılmasında muhasebeleştirilen zararlar"
+msgstr "Sabit kıymetlerin elden çıkarılmasında tanınan zararlar"
 
 msgid "Lost"
 msgstr "Kaybedildi"
@@ -8713,22 +8713,22 @@ msgid "Lot"
 msgstr "Lot"
 
 msgid "Lot size"
-msgstr "Parti lot boyutu"
+msgstr "parti büyüklüğü"
 
 msgid "Lot Size"
-msgstr "Lot Boyutu"
+msgstr "Parti büyüklüğü"
 
 msgid "Lot Size Variance"
-msgstr "Lot Boyutu Sapması"
+msgstr "Parti büyüklüğü sapması"
 
 msgid "Lot Size Variance (default)"
-msgstr "Lot Boyutu Sapması (varsayılan)"
+msgstr "Parti büyüklüğü sapması (varsayılan)"
 
 msgid "Lot Size:"
-msgstr "Lot Boyutu:"
+msgstr "Parti büyüklüğü:"
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "Alınan malların bir örnekleme planına karşı lot bazında denetlenmesi; birimler alındı bekleme durumuna gelir ve yalnızca lot kabul edildiğine karar verilince kullanılabilir durumuna geçer."
+msgstr "Lot tabanlı alınan malların örnekleme planına karşı muayenesi; birimler mal kabulde Askıda durumunda kaydedilir ve Lot kabul edildi olarak sınıflandırıldıktan sonra Kullanılabilir durumuna serbest bırakılır."
 
 msgid "Low"
 msgstr "Düşük"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "Bakım"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "Bakım Sevkiyat Bildirimleri"
+msgstr "Bakım emri bildirimleri"
 
 msgid "Maintenance Dispatches"
-msgstr "Bakım Görevleri"
+msgstr "Bakım emirleri"
 
 msgid "Maintenance Expense"
 msgstr "Bakım Gideri"
@@ -8836,7 +8836,7 @@ msgid "Make the go / no-go decision"
 msgstr "Go / no-go kararını verin"
 
 msgid "Make to Order"
-msgstr "Sipariş Üzerine Üret"
+msgstr "Siparişe göre üretim"
 
 msgid "Make tracked entities available again"
 msgstr "İzlenen varlıkları tekrar kullanılabilir hale getirir"
@@ -8884,7 +8884,7 @@ msgid "Map accounts"
 msgstr "Hesapları Eşle"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "Carbon hesaplarını sağlayıcının hesap planına haritalayın. Deftere nakledilen yevmiyeler, haritalanan sağlayıcı hesap kodunu kullanarak gönderilir."
+msgstr "Carbon hesaplarını sağlayıcının hesap planı ile eşleştirin. Muhasebeleştirilmiş muhasebe fişleri eşleştirilmiş sağlayıcı hesap kodu kullanılarak iletilir."
 
 msgid "Map Extracted Invoice Lines"
 msgstr "Çıkarılan Fatura Satırlarını Eşle"
@@ -8906,7 +8906,7 @@ msgstr "Eşlenen değerler"
 
 #. placeholder {0}: i18n._(step.gate)
 msgid "Mark \"{0}\" as passed?"
-msgstr "\"{0}\" olarak işaretlensin mi?"
+msgstr "\"{0}\" geçti olarak işaretle?"
 
 msgid "Mark all as configured"
 msgstr "Tümünü yapılandırılmış olarak işaretle"
@@ -8924,7 +8924,7 @@ msgid "Mark as Unpaid"
 msgstr "Ödenmemiş Olarak İşaretle"
 
 msgid "Mark checkpoint passed"
-msgstr "Kontrol noktasını geçildi olarak işaretle"
+msgstr "Kontrol noktasını geçti olarak işaretle"
 
 msgid "Mark Complete"
 msgstr "Tamamlandı Olarak İşaretle"
@@ -8933,16 +8933,16 @@ msgid "Mark Dark Mode"
 msgstr "Koyu Mod Mark"
 
 msgid "Mark done"
-msgstr "Tamamlandı olarak işaretle"
+msgstr "Bitti olarak işaretle"
 
 msgid "Mark Done"
-msgstr "Tamamlandı Olarak İşaretle"
+msgstr "Bitti Olarak İşaretle"
 
 msgid "Mark Light Mode"
 msgstr "Aydınlık Mod Markası"
 
 msgid "Mark not done"
-msgstr "Yapılmadı olarak işaretle"
+msgstr "Bitmedi olarak işaretle"
 
 msgid "Mark scope as agreed"
 msgstr "Kapsamı kabul edildi olarak işaretle"
@@ -8954,7 +8954,7 @@ msgid "Mark to delete"
 msgstr "Silmek için işaretle"
 
 msgid "Master gauge"
-msgstr "Ana Gösterge"
+msgstr "Mastar ölçüm aleti"
 
 msgid "Master records"
 msgstr "Ana kayıtlar"
@@ -9008,19 +9008,19 @@ msgid "Material dimensions use metric units."
 msgstr "Malzeme boyutları metrik birimler kullanır."
 
 msgid "Material Finish"
-msgstr "Malzeme Bitimi"
+msgstr "Yüzey işlemi"
 
 msgid "Material Finishes"
-msgstr "Malzeme Bitirme İşlemleri"
+msgstr "Yüzey işlemleri"
 
 msgid "Material Form"
 msgstr "Malzeme Formu"
 
 msgid "Material Grade"
-msgstr "Malzeme Derecesi"
+msgstr "Malzeme kalitesi"
 
 msgid "Material Grades"
-msgstr "Malzeme Dereceleri"
+msgstr "Malzeme kaliteleri"
 
 msgid "Material ID"
 msgstr "Malzeme Kimliği"
@@ -9038,16 +9038,16 @@ msgid "Material Review Board (MRB)"
 msgstr "Malzeme İnceleme Kurulu (MRB)"
 
 msgid "Material Shape"
-msgstr "Malzeme Şekli"
+msgstr "Şekil"
 
 msgid "Material Shapes"
 msgstr "Malzeme Şekilleri"
 
 msgid "Material Substance"
-msgstr "Malzeme Maddesi"
+msgstr "Ana malzeme"
 
 msgid "Material Substances"
-msgstr "Malzeme Maddeleri"
+msgstr "Ana malzemeler"
 
 msgid "material type"
 msgstr "Malzeme Türü"
@@ -9152,13 +9152,13 @@ msgid "Method Materials"
 msgstr "Metot Malzemeleri"
 
 msgid "Method Operations"
-msgstr "Metot İşlemleri"
+msgstr "Yöntem operasyonları"
 
 msgid "Method type"
-msgstr "Yöntem Türü"
+msgstr "Tedarik şekli"
 
 msgid "Method Type"
-msgstr "Metot Türü"
+msgstr "Tedarik şekli"
 
 msgid "Methods"
 msgstr "Yöntemler"
@@ -9218,10 +9218,10 @@ msgid "Missing Information"
 msgstr "Eksik Bilgi"
 
 msgid "Missing Operations"
-msgstr "Eksik İşlemler"
+msgstr "Eksik operasyonlar"
 
 msgid "Missing Shipping Costs"
-msgstr "Kargo Maliyetleri Eksik"
+msgstr "Eksik nakliye bedelleri"
 
 msgid "Missing Suppliers"
 msgstr "Tedarikçi Eksikleri"
@@ -9308,7 +9308,7 @@ msgid "Move item"
 msgstr "Öğeyi taşı"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "MRB'nin her kısmı ayrı ayrı karar vermesi için miktarın bir kısmını yeni bir elden çıkarma satırına taşıyın (örneğin, bazılarını hurdaya ayırmak, bazılarını yeniden işlemek)."
+msgstr "Miktarın bir kısmını yeni bir karar satırına taşıyın, böylece MRB her bölümü ayrı ayrı karar verebilir (örneğin, bazılarını fire edin, bazılarını yeniden işleyin)."
 
 msgid "Move to"
 msgstr "Taşış"
@@ -9352,7 +9352,7 @@ msgid "Name"
 msgstr "Adı"
 
 msgid "Name an internal project owner with decision authority"
-msgstr "İç proje sahibini karar verme yetkisiyle belirleyin"
+msgstr "Karar verme yetkisine sahip bir dahili proje sahibi belirleyin"
 
 msgid "Names fill in wherever those roles are referenced across the hub."
 msgstr "Adlar, bu rollerin hub genelinde referans verildiği her yerde doldurulur."
@@ -9364,7 +9364,7 @@ msgid "Navigate"
 msgstr "Gözat"
 
 msgid "NCRs by Type"
-msgstr "Tür Tipine Göre DÖF"
+msgstr "Tipe Göre NCR'ler"
 
 msgid "Need by"
 msgstr "Gerektiğinde"
@@ -9385,7 +9385,7 @@ msgid "Needs ordering"
 msgstr "Sipariş gerekli"
 
 msgid "Negative Adjustment"
-msgstr "Negatif Ayarlama"
+msgstr "Negatif düzeltme"
 
 msgid "Net book value"
 msgstr "Net Defter Değeri"
@@ -9442,7 +9442,7 @@ msgid "New Consumable"
 msgstr "Yeni Sarf Malzemesi"
 
 msgid "New Contractor"
-msgstr "Yeni Yüklenici"
+msgstr "Yeni taşeron"
 
 msgid "New Cost Center"
 msgstr "Yeni Maliyet Merkezi"
@@ -9478,16 +9478,16 @@ msgid "New Field"
 msgstr "Yeni Alan"
 
 msgid "New Fixed Asset"
-msgstr "Yeni Sabit Varlık"
+msgstr "Yeni sabit kıymet"
 
 msgid "New Gauge"
-msgstr "Yeni Gösterge"
+msgstr "Yeni ölçüm aleti"
 
 msgid "New Gauge Calibration Record"
-msgstr "Yeni Kalibrasyon Kaydı"
+msgstr "Yeni ölçüm aleti kalibrasyon kaydı"
 
 msgid "New Gauge Type"
-msgstr "Yeni Ölçüm Tipi"
+msgstr "Yeni ölçüm aleti türü"
 
 msgid "New Group"
 msgstr "Yeni Grup"
@@ -9499,7 +9499,7 @@ msgid "New IC Transaction"
 msgstr "Yeni IC İşlemi"
 
 msgid "New Inspection Plan"
-msgstr "Yeni Muayene Planı"
+msgstr "Yeni kontrol planı"
 
 msgid "New Inventory Count"
 msgstr "Yeni Envanter Sayımı"
@@ -9526,7 +9526,7 @@ msgid "New Location"
 msgstr "Yeni Konum"
 
 msgid "New Maintenance Dispatch"
-msgstr "Yeni Bakım Gönderimi"
+msgstr "Yeni bakım emri"
 
 msgid "New Material"
 msgstr "Yeni Malzeme"
@@ -9535,16 +9535,16 @@ msgid "New Material Dimension"
 msgstr "Yeni Malzeme Boyutu"
 
 msgid "New Material Finish"
-msgstr "Yeni Malzeme Bitimi"
+msgstr "Yeni yüzey işlemi"
 
 msgid "New Material Grade"
-msgstr "Yeni Malzeme Derecesi"
+msgstr "Yeni malzeme kalitesi"
 
 msgid "New Material Shape"
-msgstr "Yeni Malzeme Şekli"
+msgstr "Yeni şekil"
 
 msgid "New Material Substance"
-msgstr "Yeni Malzeme Madde"
+msgstr "Yeni ana malzeme"
 
 msgid "New Material Type"
 msgstr "Yeni Malzeme Tipi"
@@ -9556,7 +9556,7 @@ msgid "New Owner"
 msgstr "Yeni Sahip"
 
 msgid "New Part"
-msgstr "Yeni Ürün"
+msgstr "Yeni parça"
 
 msgid "New Password"
 msgstr "Yeni Şifre"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "Yeni Ödeme"
 
 msgid "New Payment Term"
-msgstr "Yeni Ödeme Şartı"
+msgstr "Yeni ödeme koşulu"
 
 msgid "New Picking List"
 msgstr "Yeni Toplama Listesi"
@@ -9646,7 +9646,7 @@ msgid "New Shipment"
 msgstr "Yeni Sevkiyat"
 
 msgid "New Shipping Method"
-msgstr "Yeni Gönderi Yöntemi"
+msgstr "Yeni sevkiyat yöntemi"
 
 msgid "New Size"
 msgstr "Yeni Boyut"
@@ -9721,7 +9721,7 @@ msgid "Next page"
 msgstr "Sonraki sayfa"
 
 msgid "Next Sequence"
-msgstr "Sonraki Sıra"
+msgstr "Sonraki numaralandırma"
 
 msgid "Next step"
 msgstr "Sonraki adım"
@@ -9738,14 +9738,14 @@ msgstr "Hiç {0} bulunamadı"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "{0} eşitleme işlemi yok"
+msgstr "Hiçbir {0} senkronizasyon işlemi yok"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
 msgstr "Henüz {0} yok"
 
 msgid "No abilities added"
-msgstr "Ek yetenek eklenmedi"
+msgstr "Hiçbir yetkinlik eklenmedi"
 
 msgid "No Access"
 msgstr "Erişim Yok"
@@ -9763,7 +9763,7 @@ msgid "No actions selected"
 msgstr "Hiçbir işlem seçilmedi"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "Bu satış siparişi için aktif iş bulunamadı. Sipariş doğrudan iptal edilecektir."
+msgstr "Bu satış siparişi için devam eden iş emirleri bulunamadı. Sipariş doğrudan iptal edilecektir."
 
 msgid "No active plan"
 msgstr "Aktif bir plan yok"
@@ -9785,7 +9785,7 @@ msgstr "Başvuru yok. Ödeme hesap üzerinden yapılacak."
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "Henüz arşivlenmiş günlük yok. {0} günden eski günlükler otomatik olarak arşivlenecek ve buradan indirilmeye hazır olacak."
+msgstr "Henüz arşivlenmiş kayıt yok. {0} günden eski kayıtlar otomatik olarak arşivlenecek ve buradan indirilebilir olacaktır."
 
 msgid "No attachments."
 msgstr "Ek ekli değil."
@@ -9815,10 +9815,10 @@ msgid "No clauses yet. Use Add clause above."
 msgstr "Henüz madde yok. Yukarıda Madde Ekle'yi kullanın."
 
 msgid "No comments yet. Be the first to add a comment."
-msgstr "Henüz yorum yok. İlk yorumu siz yapın."
+msgstr "Henüz yorum yok. İlk yorumu ekleyin."
 
 msgid "No completed jobs within range"
-msgstr "Belirtilen aralıkta tamamlanmış iş yok"
+msgstr "Aralıkta tamamlanmış iş emri yok"
 
 msgid "No condition may match"
 msgstr "Hiçbir koşul eşleşemez"
@@ -9848,13 +9848,13 @@ msgid "No dimension values mapped yet"
 msgstr "Henüz hiçbir boyut değeri eşlenmedi"
 
 msgid "No draft make method for this item yet."
-msgstr "Bu öğe için henüz taslak yapım yöntemi yok."
+msgstr "Bu stok kartı için henüz taslak üretim yöntemi yok."
 
 msgid "No draft versions available"
-msgstr "Taslak sürüm mevcut değil"
+msgstr "Kullanılabilir taslak sürüm yok"
 
 msgid "No due date"
-msgstr "Teslim tarihi yok"
+msgstr "Son tarih yok"
 
 msgid "No editable properties for this item."
 msgstr "Bu öğe için düzenlenebilir özellik yok."
@@ -9875,7 +9875,7 @@ msgid "No extra data sets yet. Add anything specific to this customer."
 msgstr "Henüz ekstra veri seti yok. Bu müşteriye özgü herhangi bir şey ekleyin."
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "Henüz ek gereksinim yok. Bu müşteriye özgü herhangi bir şey ekleyin."
+msgstr "Henüz ek gereklilik yok. Bu müşteriye özgü herhangi bir şey ekleyin."
 
 msgid "No extra setup items yet. Add anything specific to this customer."
 msgstr "Henüz ekstra kurulum öğesi yok. Bu müşteriye özgü herhangi bir şey ekleyin."
@@ -9896,7 +9896,7 @@ msgid "No files uploaded"
 msgstr "Yüklenmiş dosya yok"
 
 msgid "No Gauge Selected"
-msgstr "Seçili Kalibrasyon Cihazı Yok"
+msgstr "Ölçüm aleti seçilmedi"
 
 msgid "No grouped notifications"
 msgstr "Gruplanmış bildirim yok"
@@ -9908,7 +9908,7 @@ msgid "No image"
 msgstr "Resim yok"
 
 msgid "No inspection plans"
-msgstr "Muayene planı yok"
+msgstr "Kontrol planı yok"
 
 msgid "No issue types configured"
 msgstr "Hiçbir sorun türü yapılandırılmamış"
@@ -9920,10 +9920,10 @@ msgid "No items have inventory activity here yet."
 msgstr "Burada henüz hiçbir maddenin envanter hareketi yok."
 
 msgid "No jobs were created"
-msgstr "Hiçbir iş oluşturulmadı"
+msgstr "İş emri oluşturulmadı"
 
 msgid "No journal lines in scope for this period"
-msgstr "Bu dönem için kapsam içinde günlük satırı yok"
+msgstr "Bu dönem için kapsam içinde muhasebe fişi satırı yok"
 
 msgid "No lines to map"
 msgstr "Eşlenecek satır yok"
@@ -9950,7 +9950,7 @@ msgid "No matches. Type to create one."
 msgstr "Eşleşme yok. Bir tane oluşturmak için yazın."
 
 msgid "No matching bins"
-msgstr "Eşleşen kutu yok"
+msgstr "Eşleşen göz yok"
 
 msgid "No new notifications"
 msgstr "Yeni bildirim yok"
@@ -9962,16 +9962,16 @@ msgid "No open invoices"
 msgstr "Açık fatura yok"
 
 msgid "No open orders for this item are available to link."
-msgstr "Bu öğe için bağlanacak açık siparişler mevcut değil."
+msgstr "Bu stok kartı için bağlanacak açık sipariş yok."
 
 msgid "No open sales order lines"
 msgstr "Açık satış sipariş satırı yok"
 
 msgid "No operations found."
-msgstr "İşlem bulunamadı."
+msgstr "Operasyon bulunamadı."
 
 msgid "No operations require picking at this location"
-msgstr "Bu konumda toplama gerektiren işlem yok"
+msgstr "Bu lokasyonda toplama gerektiren operasyon yok"
 
 msgid "No operators."
 msgstr "Hiç operatör yok."
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "Seçenek bulunamadı."
 
 msgid "No other bins hold this item"
-msgstr "Başka hiçbir depo bu maddeyi tutmuyor"
+msgstr "Bu stok kartını tutan başka göz yok"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "Başka çalışan bulunamadı. Mülkiyet devrini etkinleştirmek için çalışan ekleyin."
@@ -10007,7 +10007,7 @@ msgid "No passkeys registered yet."
 msgstr "Henüz hiçbir geçiş anahtarı kaydedilmedi."
 
 msgid "No payables"
-msgstr "Ödeme yükümlülüğü yok"
+msgstr "Borç yok"
 
 msgid "No payments yet."
 msgstr "Henüz ödeme yok."
@@ -10016,10 +10016,10 @@ msgid "No planning data"
 msgstr "Planlama verisi yok"
 
 msgid "No posted journals in this period for this account"
-msgstr "Bu dönem için bu hesapta hiçbir muhasebe kaydı yayınlanmadı"
+msgstr "Bu dönem için bu hesapta muhasebeleştirilmiş muhasebe fişi yok"
 
 msgid "No pricing for selected quantity"
-msgstr "Seçilen miktar için fiyat yok"
+msgstr "Seçilen miktar için fiyatlandırma yok"
 
 msgid "No pricing options found"
 msgstr "Fiyatlandırma seçeneği bulunamadı"
@@ -10034,7 +10034,7 @@ msgid "No process selected"
 msgstr "Hiçbir işlem seçilmedi"
 
 msgid "No production events recorded for this operation yet"
-msgstr "Bu işlem için henüz üretim etkinliği kaydedilmedi"
+msgstr "Bu operasyon için henüz kaydedilmiş üretim olayı yok"
 
 msgid "No purchases in this period"
 msgstr "Bu dönemde satın alma yok"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "Aramanızla eşleşen rapor yok."
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "Bu şirketin hiçbir temsilcisi Carbon GovCloud Rider'ı henüz kabul etmedi. Herhangi biri Carbon'a erişmeden önce bu şirketin bir yöneticisinin kabul etmesi gerekir — Carbon personeli bunu sizin adınıza kabul edemez."
+msgstr "Bu şirketin hiçbir temsilcisi henüz Carbon GovCloud Rider'ı kabul etmemiş. Herhangi biri Carbon'a erişebilmesi için bu şirketteki bir yönetici bunu kabul etmelidir — Carbon personeli bunu sizin adınıza kabul edemez."
 
 msgid "No results"
 msgstr "Sonuç bulunamadı"
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "Bu konumda stok yok"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "Önümüzdeki 48 haftada stok tükenmesi öngörülmemiştir"
+msgstr "Sonraki 48 hafta içinde stoksuzluk öngörülmedi"
 
 msgid "No storage unit"
 msgstr "Depolama birimi yok"
@@ -10100,7 +10100,7 @@ msgid "No suppliers yet"
 msgstr "Henüz tedarikçi yok"
 
 msgid "No sync operations yet"
-msgstr "Henüz hiçbir eşitleme işlemi yok"
+msgstr "Henüz senkronizasyon operasyonu yok"
 
 msgid "No time entries for this week"
 msgstr "Bu hafta için zaman girişi yok"
@@ -10124,7 +10124,7 @@ msgid "No value needed"
 msgstr "Değer gerekmiyor"
 
 msgid "No values available"
-msgstr "Mevcut değerler yok"
+msgstr "Kullanılabilir değer yok"
 
 msgid "No variable matches {query}"
 msgstr "Değişken {query} ile eşleşmiyor"
@@ -10160,10 +10160,10 @@ msgid "Non-conformance (issue)"
 msgstr "Uygunsuzluk (sorun)"
 
 msgid "Non-Inventory"
-msgstr "Envanter Dışı"
+msgstr "Stok dışı"
 
 msgid "Non-Inventory Tracking"
-msgstr "Envanter Dışı Takip"
+msgstr "Stok dışı takip"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
 msgstr "Bu sınıftaki bir varlık net defter değerinin altında satıldığında veya hurda haline getirildiğinde borç kaydedilen işletme dışı gider hesabı."
@@ -10172,7 +10172,7 @@ msgid "Non-operating income account credited when an asset in this class is sold
 msgstr "Bu sınıftaki bir varlık net defter değerinden daha fazlaya satıldığında alacak kaydedilen işletme dışı gelir hesabı."
 
 msgid "Non-Taxable Add-On Cost"
-msgstr "Vergisiz Ek Ücret"
+msgstr "Vergi Dışı Ek Maliyet"
 
 msgid "Non-working days that scheduling and capacity respect"
 msgstr "Planlama ve kapasite tarafından dikkate alınan çalışılmayan günler"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "Normal"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "Bir tablo değil, bir genel muhasebe dengesi: iş malzemeleri verildiğinde maliyetler birikir ve iş envantere alındığında temizlenir."
+msgstr "Bir tablo değil, büyük defter bakiyesi: iş emri malzemeleri çıktıkça maliyet birikir ve iş emri stoka alındığında temizlenir."
 
 msgid "Not certified"
 msgstr "Sertifikalı değil"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "Miktarı karşılayacak yeterli iş yok"
+msgstr "Miktarı karşılamak için yeterli iş emri yok"
 
 msgid "Not reached"
 msgstr "Ulaşılmadı"
@@ -10226,7 +10226,7 @@ msgid "Note"
 msgstr "Not"
 
 msgid "Notes"
-msgstr "Açıklamalar"
+msgstr "Notlar"
 
 msgid "Notes (optional)"
 msgstr "Notlar (isteğe bağlı)"
@@ -10275,13 +10275,13 @@ msgid "Number of lines"
 msgstr "Satır sayısı"
 
 msgid "Number of open operations"
-msgstr "Açık işlem sayısı"
+msgstr "Açık operasyon sayısı"
 
 msgid "Number of open tasks"
 msgstr "Açık görev sayısı"
 
 msgid "Number of operations"
-msgstr "İşlem sayısı"
+msgstr "Operasyon sayısı"
 
 msgid "Numbering sequence"
 msgstr "Numaralandırma Sırası"
@@ -10308,7 +10308,7 @@ msgid "Oldest first"
 msgstr "En eski önce"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
-msgstr "Kesme günü, aşağıdaki kontrol listesini sırasıyla çalışın. Kabul testleri kapsamınızdaki gereksinimlerden gelir. Destek ayrıntıları altta yer almaktadır."
+msgstr "Geçiş gününde, aşağıdaki kontrol listesini sırayla çalışın. Kabul testleri kapsam içi gerekliliklerinizden gelir. Destek ayrıntıları altta yer alır."
 
 msgid "On day"
 msgstr "Belirli gün"
@@ -10329,7 +10329,7 @@ msgid "On Hold"
 msgstr "Askıda"
 
 msgid "On Jobs"
-msgstr "Üretimde"
+msgstr "İş emirlerinde"
 
 msgid "On order"
 msgstr "Siparişte"
@@ -10344,13 +10344,13 @@ msgid "On Sales Order"
 msgstr "Satış Siparişi'nde"
 
 msgid "On Storage Unit"
-msgstr "Depolizdeki"
+msgstr "Depolama biriminde"
 
 msgid "On this operation"
 msgstr "Bu operasyonda"
 
 msgid "On-account credit available"
-msgstr "Hesapta mevcut kredi"
+msgstr "Hesap kredisi kullanılabilir"
 
 msgid "On-hand counts"
 msgstr "Eldeki stok sayıları"
@@ -10362,7 +10362,7 @@ msgid "On-hand inventory remains"
 msgstr "Eldeki envanter kaldı"
 
 msgid "On-hand value by location or item, with GL tie-out"
-msgstr "Konum veya öğeye göre eldeki değer, GL bağlantılı olarak"
+msgstr "Lokasyon veya stok kartına göre eldeki değer, büyük defter eşleştirmesi ile"
 
 msgid "On-hand value of manufactured goods (Make items)"
 msgstr "Üretilen malların (Üretim ürünleri) eldeki değeri"
@@ -10377,13 +10377,13 @@ msgid "One firing of a workflow, recorded step by step with the values each step
 msgstr "Bir iş akışının bir kez çalıştırılması, her adımın kullandığı ve ürettiği değerlerle adım adım kaydedilmiş, iş akışının sahibinin izinleriyle hareket eder."
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Carbon'un bireysel olarak takip ettiği bir seri birim veya bir batch, sona erme tarihi gibi kendi durumu ve öznitelikleri taşıyan."
+msgstr "Carbon tarafından bireysel takip edilen bir seri adet veya bir parti, son kullanma tarihi gibi kendi durumu ve öznitelikleri taşıyan."
 
 msgid "One set of numbers"
 msgstr "Tek bir sayı seti"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "Bir işin yönlendirilmesinde bir adım, bir süreci ve bir iş merkezini adlandırır ve kendi kurulum, işçilik ve makine sürelerini ve oranlarını taşır."
+msgstr "İş emri rotasında bir adım, bir proses ve iş merkezini adlandıran, kendi hazırlık, işçilik, makine süresi ve oranlarını taşıyan."
 
 msgid "One system from quote to cash"
 msgstr "Teklif'ten nakite kadar tek bir sistem"
@@ -10413,7 +10413,7 @@ msgid "Onshape Status"
 msgstr "Onshape Durumu"
 
 msgid "Oops! The link you're trying to access has expired or is no longer valid."
-msgstr "Üzgünüz! Erişim sağlamaya çalıştığınız bağlantı süresi dolmuş veya artık geçerli değil."
+msgstr "Hata! Erişmeye çalıştığınız bağlantı süresi dolmuş veya artık geçerli değil."
 
 msgid "Oops! The link you're trying to access is not valid."
 msgstr "Üzgünüz! Erişim sağlamaya çalıştığınız bağlantı geçerli değil."
@@ -10431,13 +10431,13 @@ msgid "Open an NCR for MRB disposition"
 msgstr "MRB kararı için bir NCR aç"
 
 msgid "Open AP"
-msgstr "Açık AP"
+msgstr "Açık Borç hesapları"
 
 msgid "Open AR"
-msgstr "Açık AR"
+msgstr "Açık Alacak hesapları"
 
 msgid "Open Audit Log"
-msgstr "Denetim Kaydını Aç"
+msgstr "Açık Denetim günlüğü"
 
 msgid "Open date"
 msgstr "Açılış tarihi"
@@ -10446,16 +10446,16 @@ msgid "Open Date"
 msgstr "Açılış Tarihi"
 
 msgid "Open Dispatches"
-msgstr "Açık Görevler"
+msgstr "Açık Bakım emirleri"
 
 msgid "Open in Carbon"
 msgstr "Carbon'da Aç"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "{ids} değişiklik bildirisinde aç. Yeni sürümler veya revizyonlar oluşturmak için bunu yayınlayın."
+msgstr "Değişiklik bildirimi {ids} içinde aç. Yeni sürümler veya revizyonlar oluşturmak için serbest bırak."
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "{ids} değişiklik bildirimlerinde aç. Yeni sürümler veya revizyonlar oluşturmak için bunları yayınlayın."
+msgstr "Değişiklik bildirimleri {ids} içinde aç. Yeni sürümler veya revizyonlar oluşturmak için serbest bırak."
 
 msgid "Open in MES"
 msgstr "MES'te Aç"
@@ -10464,10 +10464,10 @@ msgid "Open Issues"
 msgstr "Açık Sorunlar"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "Açık iş talebi artı bu depodan giden bekleyen transferler"
+msgstr "Bu gözden çıkan açık iş emri talebi ve beklemede transferler"
 
 msgid "Open jobs"
-msgstr "Açık işler"
+msgstr "Açık İş emirleri"
 
 msgid "Open menu"
 msgstr "Menüyü aç"
@@ -10476,7 +10476,7 @@ msgid "Open payables by supplier and age"
 msgstr "Tedarikçi ve yaşa göre açık borçlar"
 
 msgid "Open Purchase Invoices"
-msgstr "Açık Satın Alma Faturaları"
+msgstr "Açık Alış faturaları"
 
 msgid "Open purchase orders"
 msgstr "Açık satın alma siparişleri"
@@ -10539,7 +10539,7 @@ msgid "Operation"
 msgstr "Operasyon"
 
 msgid "Operation lead time"
-msgstr "İşlem teslim süresi"
+msgstr "Operasyon tedarik süresi"
 
 msgid "Operation minimum cost"
 msgstr "İşlem minimum maliyeti"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "İşlem miktarı"
 
 msgid "Operation supplier process"
-msgstr "İşlem tedarikçi süreci"
+msgstr "Operasyon tedarikçi prosesi"
 
 msgid "Operation type"
 msgstr "İşlem türü"
@@ -10569,7 +10569,7 @@ msgid "Operations"
 msgstr "Operasyonlar"
 
 msgid "Operations / steps"
-msgstr "İşlemler / adımlar"
+msgstr "Operasyonlar / Adımlar"
 
 msgid "Operations Type"
 msgstr "Operasyon Türü"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "Bu kural için isteğe bağlı bağlam"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "IAS 21'e göre özsermaye bakiyelerini çevirirken kullanılan isteğe bağlı sabit oran (dönem oranı yerine)."
+msgstr "Özkaynak bakiyelerini IAS 21'e göre çevirirken kullanılan isteğe bağlı sabit kur (dönem kurunun yerine)."
 
 msgid "Optional pages & sections"
 msgstr "İsteğe bağlı sayfalar ve bölümler"
@@ -10645,7 +10645,7 @@ msgid "Order Date"
 msgstr "Sipariş Tarihi"
 
 msgid "Order Multiple"
-msgstr "Sipariş Çarpanı"
+msgstr "Sipariş katı"
 
 msgid "Order Parts"
 msgstr "Parça Sipariş Et"
@@ -10657,7 +10657,7 @@ msgid "Order quantities must be whole multiples of this number (a multiple of 12
 msgstr "Sipariş miktarları bu sayının tam katları olmalıdır (12'nin katı → 12, 24, 36 …)."
 
 msgid "Order rules are evaluated in — for discounts only the highest-priority match applies (no stacking); markups all apply and compound in priority order."
-msgstr "Sipariş kuralları sırayla değerlendirilir — indirimler için yalnızca en yüksek öncelikli eşleşme uygulanır (yığma yok); işaretlemeler hepsi uygulanır ve öncelik sırasına göre birleşir."
+msgstr "Sipariş kuralları şu şekilde değerlendirilir — iskontolar için yalnızca en yüksek öncelikli kural uygulanır (yığılmaz); tüm fiyat artışları uygulanır ve öncelik sırasına göre birikir."
 
 msgid "Order Total"
 msgstr "Toplam Sipariş Tutarı"
@@ -10693,7 +10693,7 @@ msgid "Other Income account for FX gains when a payment settles a foreign-curren
 msgstr "Bir ödeme yabancı para birimindeki bir faturayı daha uygun bir oranda kapatırken FX kazançları için Diğer Gelir hesabı"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "Satıcı bakiyelerinin AP kapatılması sırasında tam ödeme yapılmadan temizlenmesi için Diğer Gelir hesabı"
+msgstr "Tam ödeme yapılmaksızın Borç hesapları mutabakatında kapatılan satıcı bakiyeleri için Diğer gelirler hesabı"
 
 msgid "Other Type"
 msgstr "Diğer Tür"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "Çıktı"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "Çıktı, ham malzemelerinin ömrünü asla aşmaz. Hiçbir girdinin son kullanma tarihi yoksa sabit süreye geri döner."
+msgstr "Ürün asla hammaddelerinden daha uzun sürmez. Hiçbir girdinin son kullanma tarihi olmadığında sabit süreye geri döner."
 
 msgid "Outside operation"
 msgstr "Genel Gider Sapması"
@@ -10723,43 +10723,43 @@ msgid "Overall result"
 msgstr "Genel sonuç"
 
 msgid "Overdue"
-msgstr "Geçmiş"
+msgstr "Gecikmiş"
 
 msgid "Overhead Absorption"
-msgstr "Genel Giderlerin Emilimi"
+msgstr "Genel üretim gideri dağıtımı"
 
 msgid "Overhead Absorption (default)"
-msgstr "Genel Giderlerin Emilimi (varsayılan)"
+msgstr "Genel üretim gideri dağıtımı (varsayılan)"
 
 msgid "Overhead rate"
-msgstr "Genel gider oranı"
+msgstr "Genel üretim giderleri oranı"
 
 msgid "Overhead Rate"
-msgstr "Genel Gider Oranı"
+msgstr "Genel üretim giderleri oranı"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "Genel Gider Oranı (Saatlik)"
+msgstr "Genel üretim giderleri oranı (Saatlik)"
 
 msgid "Overhead Variance"
-msgstr "Genel Gider Sapması (varsayılan)"
+msgstr "Genel üretim giderleri sapması"
 
 msgid "Overhead Variance (default)"
-msgstr "Sahibi (maliyet merkezi)"
+msgstr "Genel üretim giderleri sapması (varsayılan)"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "Geçersiz kılma için envanter:güncelleme izni ve bir gerekçe gerekir."
+msgstr "Geçersiz kılma, inventory:update izni ve bir neden gerektirir."
 
 msgid "Override Price"
-msgstr "Aşırı Fiyat"
+msgstr "Fiyatı Geçersiz Kıl"
 
 msgid "Override price for a single customer"
 msgstr "Tek bir müşteri için fiyatı geçersiz kıl"
 
 msgid "Override price for all customers of a type"
-msgstr "Bir türdeki tüm müşteriler için fiyatı geçersiz kıl"
+msgstr "Bir müşteri türündeki tüm müşterilerin fiyatını geçersiz kıl"
 
 msgid "Override the expiration on {label}."
-msgstr "Süre bitişini {label} üzerinde geçersiz kıl."
+msgstr "{label} üzerindeki son kullanmayı geçersiz kıl."
 
 msgid "Overtime"
 msgstr "Fazla Mesai"
@@ -10780,7 +10780,7 @@ msgid "Owner"
 msgstr "Sahip"
 
 msgid "Owner (cost center)"
-msgstr "Ana maliyet merkezi"
+msgstr "Sahip (Maliyet merkezi)"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10814,7 +10814,7 @@ msgid "Params"
 msgstr "Parametreler"
 
 msgid "Parent cost center"
-msgstr "parça"
+msgstr "Üst maliyet merkezi"
 
 msgid "Parent Cost Center"
 msgstr "Üst Maliyet Merkezi"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "Hata olarak kaydet"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "Değer eşlenene kadar defterin uyarıyla beklet"
+msgstr "Muhasebe fişini değer eşleştirilene kadar uyarı ile park et"
 
 msgid "part"
 msgstr "parçalar"
@@ -10862,7 +10862,7 @@ msgid "Part Number"
 msgstr "Parça Numarası"
 
 msgid "Part Supersession"
-msgstr "Parça Yerini Alma"
+msgstr "Parça İkamesi"
 
 msgid "Partial"
 msgstr "Kısmi"
@@ -10874,7 +10874,7 @@ msgid "Partners"
 msgstr "Ortaklar"
 
 msgid "parts"
-msgstr "Ödenecek Hesaplar"
+msgstr "parçalar"
 
 msgid "Parts"
 msgstr "Parçalar"
@@ -10913,16 +10913,16 @@ msgid "Pay Rate"
 msgstr "Ödeme Oranı"
 
 msgid "Payables"
-msgstr "Ödenecek Hesaplar (varsayılan)"
+msgstr "Borçlar"
 
 msgid "Payables (AP)"
-msgstr "Ödenecek Hesaplar (AP)"
+msgstr "Borçlar (Borç hesapları)"
 
 msgid "Payables (default)"
-msgstr "ödeme terimi"
+msgstr "Borçlar (varsayılan)"
 
 msgid "Payables aging"
-msgstr "Ödenecek hesaplar yaşlandırması"
+msgstr "Borçlar yaşlandırması"
 
 msgid "Payment"
 msgstr "Ödeme"
@@ -10937,16 +10937,16 @@ msgid "Payment ID"
 msgstr "Ödeme Kimliği"
 
 msgid "payment term"
-msgstr "ödeme şartları"
+msgstr "ödeme koşulu"
 
 msgid "Payment term"
-msgstr "Ödeme şartı"
+msgstr "Ödeme koşulu"
 
 msgid "Payment Term"
-msgstr "Ödeme Vadesi"
+msgstr "Ödeme Koşulu"
 
 msgid "payment terms"
-msgstr "insanlar"
+msgstr "ödeme koşulları"
 
 msgid "Payment Terms"
 msgstr "Ödeme Koşulları"
@@ -10982,19 +10982,19 @@ msgid "Pending"
 msgstr "Beklemede"
 
 msgid "people"
-msgstr "Sabit kıymetler için dönemsel amortisman gideri"
+msgstr "personel"
 
 msgid "People"
-msgstr "Kişiler"
+msgstr "Personel"
 
 msgid "Per Unit"
 msgstr "Birim Başı"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "Sipariş başlığının yerine getirme konumunun satır başına geçersiz kılınması; bölünmüş gönderi ve drop-ship için kullanılır."
+msgstr "Sipariş başlığındaki sevkiyat lokasyonunun satır başına geçersiz kılınması; bölünmüş sevkiyatlar ve doğrudan sevkiyatlar için kullanılır."
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "PO başlığının teslimat konumunun satır başına geçersiz kılınması; birden fazla ambar veya drop-ship'e bölünmüş teslimatlar için kullanılır."
+msgstr "PO başlığındaki teslimat lokasyonunun satır başına geçersiz kılınması; birden fazla depoya bölünmüş teslimatlar veya doğrudan sevkiyatlar için kullanılır."
 
 msgid "Percentage"
 msgstr "Yüzde"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "Dönem kilit politikası"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "Toplama, izlenen varlıkları en erken son kullanma tarihine göre sunar, bu nedenle en erken son kullanma tarihine sahip stok varsayılan olarak ilk olarak çıkar."
+msgstr "Sabit kıymetler için dönemsel amortisman gideri"
 
 msgid "Permanently Delete"
 msgstr "Kalıcı Olarak Sil"
@@ -11033,7 +11033,7 @@ msgid "Phase durations"
 msgstr "Faz süreleri"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "Bir öğeyi bir halef parçanın lehine kaldırarak, planlama eski öğenin talebini — bir dönüştürme faktörü ile çarpılarak — yenisine yönlendirir."
+msgstr "Eski stok kartını bir ardıl parça lehine aşamalı olarak devre dışı bırakıp, böylece planlama eski stok kartının talebini — çevrim katsayısı ile çarpılarak — yenisine yönlendirir."
 
 msgid "Phone"
 msgstr "Telefon"
@@ -11090,7 +11090,7 @@ msgid "Pick Order"
 msgstr "Seçim Sırası"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "Stok gereken kutuyu seçin, ardından çekilecek kutuları seçin."
+msgstr "Stok ihtiyacı olan gözü seçin, ardından stoku çekeceğiniz gözleri seçin."
 
 msgid "Pick tracked item"
 msgstr "Takip edilen öğeyi seç"
@@ -11105,22 +11105,22 @@ msgid "Picking Lines"
 msgstr "Toplama Satırları"
 
 msgid "Picking list"
-msgstr "Çekme listesi"
+msgstr "Toplama listesi"
 
 msgid "Picking List"
 msgstr "Toplama Listesi"
 
 msgid "Picking List ID"
-msgstr "Seçim Listesi Kimliği"
+msgstr "Toplama Listesi ID"
 
 msgid "Picking List Notes"
 msgstr "Toplama Listesi Notları"
 
 msgid "Picking Lists"
-msgstr "Toplu Alma Listeleri"
+msgstr "Toplama Listeleri"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "Planlı"
+msgstr "Toplama izlenen varlıkları en yakın son kullanma tarihine göre sunar, bu nedenle en yakında sona erecek stok varsayılan olarak ilk olarak çıkar."
 
 msgid "Pieces/Hour"
 msgstr "Adet/Saat"
@@ -11191,7 +11191,7 @@ msgid "Plants, warehouses"
 msgstr "Fabrikalar, depolar"
 
 msgid "Please contact your administrator to enable audit logging."
-msgstr "Denetim günlük kaydını etkinleştirmek için lütfen yöneticinizle iletişime geçin."
+msgstr "Denetim günlüğünü etkinleştirmek için lütfen yöneticinize başvurun."
 
 msgid "Please enter your email address"
 msgstr "Lütfen e-posta adresinizi girin"
@@ -11239,7 +11239,7 @@ msgid "Portals"
 msgstr "Portal'lar"
 
 msgid "Positive Adjustment"
-msgstr "Pozitif Ayarlama"
+msgstr "Pozitif Düzeltme"
 
 msgid "Post"
 msgstr "Kaydet"
@@ -11251,7 +11251,7 @@ msgid "Post Invoice"
 msgstr "Faturayı Kaydet"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "Uygun hesap ve açıklama kodlarıyla günlük girişleri kaydedin"
+msgstr "Uygun hesap ve açıklama kodları ile muhasebe fişlerini muhasebeleştirin"
 
 msgid "Post Receipt"
 msgstr "Makbuzu Kaydet"
@@ -11278,7 +11278,7 @@ msgid "Posted By"
 msgstr "Gönderen"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "Bu kaynak türlerine sahip nakledilen yevmiye defterleri her zaman senkronize olur. Günlük özet, bir günün yevmiye defteri kayıtlarını sağlayıcı hesabı başına bir girişe gruplandırır."
+msgstr "Bu kaynak türlerine sahip muhasebeleştirildi muhasebe fişleri her zaman senkronize olur. Günlük özet bir günün muhasebe fişlerini hesap başına bir sağlayıcı kaydında gruplandırır."
 
 msgid "Posted once, corrected {corrections} times."
 msgstr "Bir kez deftere kaydedildi, {corrections} kez düzeltildi."
@@ -11290,13 +11290,13 @@ msgid "Posted once, no corrections."
 msgstr "Bir kez deftere kaydedildi, düzeltme yok."
 
 msgid "Posting"
-msgstr "Ön Ödemeler"
+msgstr "Muhasebeleştirme"
 
 msgid "Posting date"
-msgstr "Yayın tarihi"
+msgstr "Muhasebeleştirme tarihi"
 
 msgid "Posting Date"
-msgstr "Yükleme Tarihi"
+msgstr "Muhasebeleştirme Tarihi"
 
 msgid "Potential Data Loss"
 msgstr "Potansiyel Veri Kaybı"
@@ -11311,10 +11311,10 @@ msgid "Prefix"
 msgstr "Ön Ek"
 
 msgid "Prepayments"
-msgstr "Ön Ödemeler (varsayılan)"
+msgstr "Avanslar"
 
 msgid "Prepayments (default)"
-msgstr "Önleyici İşlem"
+msgstr "Avanslar (varsayılan)"
 
 msgid "Present Week"
 msgstr "Mevcut Hafta"
@@ -11323,7 +11323,7 @@ msgid "Prev"
 msgstr "Önceki"
 
 msgid "Preventive action"
-msgstr "Eldeki envanter değerlemesi için ana hesap"
+msgstr "Önleyici eylem"
 
 msgid "Preventive maintenance schedules for your equipment"
 msgstr "Ekipmanınız için önleyici bakım programları"
@@ -11354,13 +11354,13 @@ msgid "Previous value of {0}"
 msgstr "Önceki değeri {0}"
 
 msgid "Price break actions"
-msgstr "Fiyat kırılımı işlemleri"
+msgstr "Fiyat kademesi işlemleri"
 
 msgid "Price Break History"
-msgstr "Fiyat Farkı Geçmişi"
+msgstr "Fiyat Kademesi Geçmişi"
 
 msgid "Price Breaks"
-msgstr "Fiyat Aralıkları"
+msgstr "Fiyat Kademeleri"
 
 msgid "Price List"
 msgstr "Fiyat Listesi"
@@ -11393,7 +11393,7 @@ msgid "Pricing Trace"
 msgstr "Fiyatlandırma İzleme"
 
 msgid "Primary cash account for bank transactions"
-msgstr "prosedür"
+msgstr "Banka işlemleri için birincil nakit hesabı"
 
 msgid "Print"
 msgstr "Yazdır"
@@ -11443,7 +11443,7 @@ msgid "Procedure"
 msgstr "Prosedür"
 
 msgid "procedures"
-msgstr "süreç"
+msgstr "prosedürler"
 
 msgid "Procedures"
 msgstr "Prosedürler"
@@ -11488,7 +11488,7 @@ msgid "Production Event"
 msgstr "Üretim Olayı"
 
 msgid "Production Events"
-msgstr "Üretim Etkinlikleri"
+msgstr "Üretim Olayları"
 
 msgid "Production planning"
 msgstr "Üretim planlama"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "Üretim Miktarı"
 
 msgid "Production variance"
-msgstr "BOM'lar ve tahminlerden açılmış öngörülen talep."
+msgstr "Üretim sapması"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "Üretim: atölye uygulaması ve planlama"
@@ -11530,7 +11530,7 @@ msgid "Project start"
 msgstr "Proje başlangıcı"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "Öngörülen Stok"
+msgstr "BOMLardan ve tahminlerden açılan öngörülen talep."
 
 msgid "Projected inventory"
 msgstr "Öngörülen Eldeki"
@@ -11543,14 +11543,14 @@ msgstr "Tahmini stok"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "{0} haftası için güvenlik stoku altına düşeceği öngörülüyor"
+msgstr "{0} haftasında öngörülen stoksuzluk"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
-msgstr "Güvenlik stoku üstünde kalacağı öngörülüyor"
+msgstr "{0} haftasında emniyet stoku altına düşmesi öngörülüyor"
 
 msgid "Projected to stay above safety stock"
-msgstr "Satın Alma Siparişi"
+msgstr "Emniyet stoku üzerinde kalması öngörülüyor"
 
 msgid "Projection"
 msgstr "Projeksiyon"
@@ -11559,7 +11559,7 @@ msgid "Projections"
 msgstr "Projeksiyonlar"
 
 msgid "Promised Date"
-msgstr "Planlanan Tarih"
+msgstr "Taahhüt Tarihi"
 
 msgid "Properties"
 msgstr "Özellikler"
@@ -11605,16 +11605,16 @@ msgid "Publish Version {0}?"
 msgstr "Sürüm {0} yayınlanmış mı?"
 
 msgid "Published"
-msgstr "Yayımlandı"
+msgstr "Yayınlandı"
 
 msgid "Published by Carbon"
 msgstr "Carbon tarafından yayınlandı"
 
 msgid "Published Version"
-msgstr ""
+msgstr "Yayınlanan Sürüm"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
-msgstr "Yayımlanmış sürümler düzenlenemez. Salt okunur şekilde inceleyin veya değişiklik yapmak için yeni bir sürüm oluşturun."
+msgstr "Yayınlanan sürümler düzenlenemez. Salt okunur olarak göz atın veya değişiklik yapmak için yeni bir sürüm oluşturun."
 
 msgid "Pull"
 msgstr "Çek"
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "Muhasebeden çek"
 
 msgid "Pull from Inventory"
-msgstr "Stoktan Çek"
+msgstr "Stoktan kullan"
 
 msgid "Pull, map, and load your data"
 msgstr "Verilerinizi çekin, eşleyin ve yükleyin"
@@ -11638,22 +11638,22 @@ msgid "Purchase History"
 msgstr "Satın Alma Geçmişi"
 
 msgid "Purchase invoice"
-msgstr "Satın alma faturası"
+msgstr "Alış faturası"
 
 msgid "Purchase Invoice"
-msgstr "Satın Alma Faturası"
+msgstr "Alış faturası"
 
 msgid "Purchase Invoice Amount"
-msgstr "Satın Alma Faturası Tutarı"
+msgstr "Alış faturası tutarı"
 
 msgid "Purchase Invoice Line"
-msgstr "Satın Alma Faturası Kalemi"
+msgstr "Alış faturası satırı"
 
 msgid "Purchase Invoices"
-msgstr "Satın Alma Faturaları"
+msgstr "Alış faturaları"
 
 msgid "Purchase order"
-msgstr "Satın Alma Fiyat Sapması"
+msgstr "Satın alma siparişi"
 
 msgid "Purchase Order"
 msgstr "Satın Alma Siparişi"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "Satın Alma Fiyat Sapması (varsayılan)"
 
 msgid "Purchase Price Variance (default)"
-msgstr "Satın Alma Vergisi Ödenecek"
+msgstr "Satın alma fiyat sapması (varsayılan)"
 
 msgid "Purchase Qty"
 msgstr "Satın Alma Miktarı"
@@ -11707,13 +11707,13 @@ msgid "Purchase Tax Payable"
 msgstr "Satın Alma Vergisi Ödenecek (varsayılan)"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "satın alma"
+msgstr "Ödenecek satın alma vergisi (varsayılan)"
 
 msgid "Purchase to Order"
-msgstr "Sipariş Üretimine"
+msgstr "Siparişe göre satın alma"
 
 msgid "Purchase Unit of Measure"
-msgstr "Satın Alma Birimi"
+msgstr "Satın alma ölçü birimi"
 
 msgid "Purchase Unit:"
 msgstr "Satın Alma Birimi:"
@@ -11737,16 +11737,16 @@ msgid "Purchasing and auto-planning"
 msgstr "Satın alma ve otomatik planlama"
 
 msgid "Purchasing contact"
-msgstr "Satın alma temasi"
+msgstr "Satın alma ilgili kişi"
 
 msgid "Purchasing Contact"
-msgstr "Satın Alma İletişim Kişisi"
+msgstr "Satın alma ilgili kişi"
 
 msgid "Purchasing Invoices"
 msgstr "Satın Alma Faturaları"
 
 msgid "Purchasing Unit of Measure"
-msgstr "Satın Alma Birimi"
+msgstr "Satın alma ölçü birimi"
 
 msgid "Push"
 msgstr "Gönder"
@@ -11758,7 +11758,7 @@ msgid "Push record changes to external systems the moment they happen."
 msgstr "Kayıt değişikliklerini gerçekleştiği anda harici sistemlere gönderin."
 
 msgid "Push the journal without the dimension"
-msgstr "Boyutu olmadan defterin gönder"
+msgstr "Muhasebe fişini boyut olmadan gönder"
 
 msgid "Push to accounting"
 msgstr "Muhasebede gönder"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "Hur. Hurda"
 
 msgid "quality"
-msgstr "Teklif Fiyatından Nakde"
+msgstr "kalite"
 
 msgid "Quality"
 msgstr "Kalite"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "Gelecek miktar — açık satın alma siparişlerinde ve üretim (üretme) siparişlerinde."
 
 msgid "Quantity Breaks"
-msgstr "Miktar Kırılımları"
+msgstr "Miktar kademeleri"
 
 msgid "Quantity complete"
 msgstr "Tamamlanan miktar"
@@ -11840,13 +11840,13 @@ msgid "Quantity must be greater than 0"
 msgstr "Miktar 0'dan büyük olmalıdır"
 
 msgid "Quantity on hand"
-msgstr "Mevcut miktar"
+msgstr "Eldeki miktar"
 
 msgid "Quantity on Hand"
-msgstr "Stoktaki Miktar"
+msgstr "Eldeki miktar"
 
 msgid "Quantity on Jobs"
-msgstr "İşlerdeki Miktar"
+msgstr "İş emirlerindeki miktar"
 
 msgid "Quantity on Purchase Order"
 msgstr "Satın Alma Siparişindeki Miktar"
@@ -11858,10 +11858,10 @@ msgid "Quantity Per Job"
 msgstr "İş Başına Miktar"
 
 msgid "Quantity per Parent"
-msgstr "Ana Ürüne Göre Miktar"
+msgstr "Birim başına miktar"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "Malzemeye atanmış depolama biriminde (rafta) fiziksel olarak bulunan miktar. Bu birimin sağlaması gereken miktarın altına düştüğünde kırmızıya döner."
+msgstr "Malzemenin atanmış depolama biriminde (raf) fiziksel olarak mevcut olan miktar. Bu birim tarafından sağlanması gereken miktardan az olduğunda kırmızıya dönüşür."
 
 msgid "Quantity Range"
 msgstr "Miktar Aralığı"
@@ -11895,19 +11895,19 @@ msgid "Question"
 msgstr "Soru"
 
 msgid "Queued"
-msgstr "Sırada"
+msgstr "Kuyrukta"
 
 msgid "Quote"
 msgstr "Teklif"
 
 msgid "Quote Accepted By"
-msgstr "Teklif Kabul Eden Kişi"
+msgstr "Teklifi Kabul Eden"
 
 msgid "Quote Accepted By Email"
-msgstr "Teklif Kabul Eden E-posta Adresi"
+msgstr "Teklifi Kabul Eden E-posta"
 
 msgid "Quote expired"
-msgstr "Teklif süresi dolmuş"
+msgstr "Teklif süresi doldu"
 
 msgid "Quote ID"
 msgstr "Teklif Kimliği"
@@ -11919,7 +11919,7 @@ msgid "Quote Line"
 msgstr "Teklif Satırı"
 
 msgid "Quote lines whose bill of materials includes this item"
-msgstr "Malzeme listesinde bu ürünü içeren teklif satırları"
+msgstr "Ürün ağacı bu stok kartını içeren teklif satırları"
 
 msgid "Quote Location"
 msgstr "Teklif Konumu"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "Teklif Numarası"
 
 msgid "Quote to cash"
-msgstr "Alacak Hesapları"
+msgstr "Tekliften nakit"
 
 msgid "Quote Type"
 msgstr "Teklif Türü"
@@ -11967,10 +11967,10 @@ msgid "Ratio"
 msgstr "Oran"
 
 msgid "Raw Materials"
-msgstr "Ham Maddeler"
+msgstr "Hammadde"
 
 msgid "Raw Materials (default)"
-msgstr "Ham Maddeler (varsayılan)"
+msgstr "Hammadde (varsayılan)"
 
 msgid "Re-date to first open day"
 msgstr "İlk açık güne yeniden tarihlendir"
@@ -11994,7 +11994,7 @@ msgid "Readable"
 msgstr "Okunabilir"
 
 msgid "Readable ID"
-msgstr "Okunabilir ID"
+msgstr "Okunabilir kimlik"
 
 msgid "Readable id with revision"
 msgstr "Revizyon içeren okunabilir kimlik"
@@ -12042,7 +12042,7 @@ msgid "Reasons"
 msgstr "Nedenler"
 
 msgid "Reassign specific tracked entities from this row to another disposition row."
-msgstr "Bu satırdaki belirli izlenen varlıkları başka bir elden çıkarma satırına yeniden atayın."
+msgstr "Belirli takip edilen varlıkları bu satırdan başka bir karar satırına yeniden atayın."
 
 msgid "Recalculate"
 msgstr "Yeniden Hesapla"
@@ -12066,7 +12066,7 @@ msgid "Receipt Lines"
 msgstr "Mal Kabul Edilen Satırlar"
 
 msgid "Receipt Promised Date"
-msgstr "Tahmini Teslim Tarihi"
+msgstr "Mal kabul taahhüt tarihi"
 
 msgid "Receipt Requested Date"
 msgstr "Talep Edilen Teslim Tarihi"
@@ -12075,7 +12075,7 @@ msgid "Receipts"
 msgstr "Makbuzlar"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "Hâlâ Taslak veya Bekleme durumunda olan makbuzlar, sevkiyatlar, satış faturaları, satın alma faturaları, ödemeler ve alacak/borç notları deftere geçmelidir veya geçersiz kılınmalıdır — hem bu dönemde tarihli belgeler hem de deftere geçtiğinde bu dönemde tarih alacak tarihsiz belgeler. Deftere geçene kadar, tutarları defteri kebir'de olmadığı için, dönem eksik gösterilecektir."
+msgstr "Hala Taslak veya Beklemede olan mal kabuller, sevkiyatlar, satış faturaları, alış faturaları, ödemeler ve alacak/borç muhasebe fişleri muhasebeleştirilmeli veya hükümsüz kılınmalıdır — hem bu dönemde tarihli belgeler hem de muhasebeleştirildiğinde bu dönemde tarih alacak tarihi olmayan belgeler. Muhasebeleştirilene kadar, tutarları büyük defterde yoktur, bu nedenle dönem eksik gösterilecektir."
 
 msgid "Receivables"
 msgstr "Alacak Hesapları (varsayılan)"
@@ -12084,7 +12084,7 @@ msgid "Receivables (AR)"
 msgstr "Alacak Hesapları (AR)"
 
 msgid "Receivables (default)"
-msgstr "Bir satın alma siparişini alınan ve faturalandırılan tutarla uzlaştırma — Carbon'da kapalı, satır miktarları ve GR/IR bakiyesi aracılığıyla."
+msgstr "Alacaklar (varsayılan)"
 
 msgid "Receivables aging"
 msgstr "Alacaklar yaşlandırması"
@@ -12127,7 +12127,7 @@ msgid "Received Qty"
 msgstr "Alınan Miktar"
 
 msgid "Receiving Location"
-msgstr "Teslim Alma Yeri"
+msgstr "Mal kabul lokasyonu"
 
 msgid "Recent"
 msgstr "Son Aramalar"
@@ -12145,7 +12145,7 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "Mutabakat sağlayıcıyla tutarsızlıklar buldu"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "Geri Kazanım Süresi"
+msgstr "Satın alma siparişinin alınan ve faturalandırılana karşı uzlaştırması — Carbon'da satır miktarları ve GR/IR bakiyesi aracılığıyla örtük olarak yapılır."
 
 msgid "Record"
 msgstr "Kayıt"
@@ -12154,7 +12154,7 @@ msgid "Record a credit or debit memo against a customer or supplier. Application
 msgstr "Bir müşteri veya tedarikçiye karşı kredi veya borç notu kaydedin. Belirli faturaların uygulamaları, not oluşturulduktan sonra eklenir."
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
-msgstr "Müşteriden alınan nakit (Makbuz) veya tedarikçiye ödenen nakit (Ödeme) kaydedin. Belirli faturalara yapılan uygulamalar ödeme oluşturulduktan sonra eklenir."
+msgstr "Müşteriden alınan nakiti (Tahsilat) veya tedarikçiye ödenen nakiti (Tediye) kaydedin. Belirli faturaların uygulamaları ödeme oluşturulduktan sonra eklenir."
 
 msgid "Record deleted"
 msgstr "Kayıt silindi"
@@ -12169,10 +12169,10 @@ msgid "Recorded on a calibration that the gauge needs repair before its readings
 msgstr "Ölçü aletiyle ilgili kalibrasyonda, okumaları güvenilir olması için aletin onarılması gerektiği kaydedilmiştir."
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "Bu kalibrasyon sonrasında takip gerektiği kaydedildi; bu göstergeyi açık eylemler kuyruğunda gösterir."
+msgstr "Bu kalibrasyondan sonra takip gerekli olduğu kaydedildi; bu ölçüm aletini açık eylemler kuyruğunda gösterir."
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "Bu kalibrasyon sırasında göstergenin ayarlandığı kaydedildi; kalibrasyon aralığının nasıl yeniden hesaplanacağını etkiler."
+msgstr "Bu kalibrasyon sırasında ölçüm aletinin ayarlandığı kaydedildi; kalibrasyon aralığının yeniden hesaplanmasını etkiler."
 
 msgid "Records"
 msgstr "Kayıtlar"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "Doğrulama sayfasına yönlendiriliyor..."
 
 msgid "Reduced"
-msgstr "Azaltılmış"
+msgstr "Gevşetilmiş"
 
 msgid "Reference"
 msgstr "Referans"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "Kayıtlı"
 
 msgid "Registered"
-msgstr "Kayıtlı"
+msgstr "Kaydedildi"
 
 msgid "Registration failed"
 msgstr "Kayıt Başarısız Oldu"
@@ -12247,16 +12247,16 @@ msgid "Release"
 msgstr "Serbest Bırakma"
 
 msgid "Release change notice"
-msgstr "Değişiklik bildirisini yayınla"
+msgstr "Değişiklik bildirimi serbest bırak"
 
 msgid "Release control"
-msgstr "Yayın kontrolü"
+msgstr "Serbest bırakma kontrolü"
 
 msgid "Release Control"
-msgstr "Yayın Kontrolü"
+msgstr "Serbest Bırakma Kontrolü"
 
 msgid "Release Job"
-msgstr "İşi Yayınla"
+msgstr "İş emrini serbest bırak"
 
 msgid "Released"
 msgstr "Yayınlandı"
@@ -12396,7 +12396,7 @@ msgid "Reordering Policy"
 msgstr "Yeniden Sipariş Politikası"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "Yalnızca sevkiyat sırasını ve iş merkezini yeniden sıralar — yeniden planlamaz. Tarih panosunda tarihleri değiştirin."
+msgstr "Sadece bakım emri sırasını ve iş merkezini yeniden sıralar — yeniden zamanlamaz. Tarih panosunda tarihleri değiştirin."
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "{inputLabel} içindeki her öğe için bir kez tekrarlanır"
@@ -12420,10 +12420,10 @@ msgid "Replenishment"
 msgstr "Yenileştirme"
 
 msgid "Replenishment system"
-msgstr "Yenileme sistemi"
+msgstr "İkmal yöntemi"
 
 msgid "Replenishment System"
-msgstr "Yenileştirme Sistemi"
+msgstr "İkmal Yöntemi"
 
 msgid "Report"
 msgstr "Rapor"
@@ -12447,7 +12447,7 @@ msgid "Request access"
 msgstr "Erişim İste"
 
 msgid "Request Approval"
-msgstr "Onay Talebi Oluştur"
+msgstr "Onay iste"
 
 msgid "Requested Date"
 msgstr "Talep Edilen Tarih"
@@ -12486,28 +12486,28 @@ msgid "Required Actions (in order)"
 msgstr "Gerekli İşlemler (sırayla)"
 
 msgid "Required Date"
-msgstr "Gerekli Tarih"
+msgstr "İhtiyaç Tarihi"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "Kontrollü ortamda gereklidir — denetim günlüğü kapatılamaz."
 
 msgid "Requirement"
-msgstr "Gereksinim"
+msgstr "Gereklilik"
 
 msgid "Requirements"
-msgstr "Gereksinimler"
+msgstr "Gereklilikler"
 
 msgid "Requirements & Process Map"
-msgstr "Gereksinimler & Süreç Haritası"
+msgstr "Gereklilikler & Proses Haritası"
 
 msgid "Requirements and Process Map"
-msgstr "Gereksinimler ve Süreç Haritası"
+msgstr "Gereklilikler ve Proses Haritası"
 
 msgid "Requires Action"
 msgstr "Eylem Gerektirir"
 
 msgid "Requires Adjustment"
-msgstr "Ayarlama Gerektirir"
+msgstr "Düzeltme gerekli"
 
 msgid "Requires Repair"
 msgstr "Onarım Gerektirir"
@@ -12516,7 +12516,7 @@ msgid "Reserve floor"
 msgstr "Rezerv tabanı"
 
 msgid "Reserved"
-msgstr "Ayrılmış"
+msgstr "Rezerve edildi"
 
 msgid "Reset"
 msgstr "Sıfırla"
@@ -12541,13 +12541,13 @@ msgid "Reset view"
 msgstr "Görünümü sıfırla"
 
 msgid "Residual value"
-msgstr "Artık değer"
+msgstr "Kalıntı değer"
 
 msgid "Residual Value %"
-msgstr "Artık değer %"
+msgstr "Kalıntı Değer %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
-msgstr "Bu NC'yi tamamlamadan önce bunları çözün: her satırın Geçici Olmayan bir elden çıkarma durumuna sahip olması ve bağlı varlık miktarlarının satır miktarını eşleştirmesi gerekir."
+msgstr "NCR'yi tamamlamadan önce bunları çöz: her satırın Bekleme Dışı bir Karar'ı olmalı ve onun bağlı varlık miktarları satır miktarıyla eşleşmeli."
 
 msgid "Resolved Price"
 msgstr "Belirlenmiş Fiyat"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "Çöp'ten Geri Yükle"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "Bu varlığı çıkartıldığı depo ve maliyet için kullanılabilir stoka geri yükleyin."
+msgstr "Bu varlığı, hurdaya çıkarıldığı gözde ve maliyette kullanılabilir stoka geri yükle."
 
 msgid "Restore tracked entities to available"
 msgstr "Takip edilen varlıkları kullanılabilir hale getir"
@@ -12583,10 +12583,10 @@ msgid "Resume Receiving"
 msgstr "Alımı Devam Et"
 
 msgid "Retained Earnings"
-msgstr "Biriktirilmiş kârlar"
+msgstr "Dağıtılmamış Kârlar"
 
 msgid "Retained Earnings (default)"
-msgstr "Biriktirilmiş kârlar (varsayılan)"
+msgstr "Dağıtılmamış Kârlar (varsayılan)"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
 msgstr "Bir varlığı hurdaya ayırarak veya satarak hizmetten çekmek; net defter değerine karşı oluşan kâr veya zararı kaydetmek ve durumunu Elden Çıkarıldı olarak ayarlamak."
@@ -12616,22 +12616,22 @@ msgid "Rev {revision}"
 msgstr "Sürüm {revision}"
 
 msgid "Revenue"
-msgstr "Gelir"
+msgstr "Hasılat"
 
 msgid "Revenue and expenses over a period"
-msgstr "Bir dönem içinde gelir ve giderler"
+msgstr "Bir dönem içinde hasılat ve giderler"
 
 msgid "Reverse all inventory adjustments"
-msgstr "Tüm envanter ayarlamalarını geri alır"
+msgstr "Tüm stok düzeltmelerini ters kayıt yap"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "Tüm günlük ve mali defter kayıtlarını tersine çevirir"
+msgstr "Tüm muhasebe fişi ve maliyet defteri kayıtlarını ters kayıt yap"
 
 msgid "Reverse any item ledger entries from this invoice"
 msgstr "Bu faturadaki herhangi bir kalem defteri girişini tersine çevirir"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "Ters kayıt"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Ters yükleme satış vergisi"
@@ -12640,10 +12640,10 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "Ters yükleme satış vergisi (varsayılan)"
 
 msgid "Reverse the related journal entries"
-msgstr "İlgili günlük girişlerini tersine çevir"
+msgstr "İlgili muhasebe fişi kayıtlarını ters kayıt yap"
 
 msgid "Reversed"
-msgstr "Ters Çevrilmiş"
+msgstr "Ters kayıt yapıldı"
 
 msgid "Revert"
 msgstr "Geri Al"
@@ -12655,16 +12655,16 @@ msgid "Review"
 msgstr "İncele"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "Her ürünün değişikliklerini gözden geçirin, sonra onaylayın — yayınlama geri alınamaz."
+msgstr "Her stok kartın değişikliklerini incele, sonra onayla — serbest bırakma geri alınamaz."
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "Dönemin bilançosunu ve gelir tablosunu gözden geçirin ve rakamların doğru göründüğünü doğrulayın. Bu manuel bir onay — bunları gözden geçirdikten sonra bitti olarak işaretleyin."
+msgstr "Dönemin bilançosunu ve gelir tablosunu incele ve rakamların doğru göründüğünü onayla. Bu manuel bir onay işlemi — bunları inceledikten sonra bitti olarak işaretle."
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "Uygulamadan önce önerilen eşleşmeleri gözden geçirin. Bunlar en iyi tahmindir — her birini onaylayın."
+msgstr "Uygulamadan önce önerilen eşleşmeleri incele. Bunlar en iyi tahmini — her birinin doğru olduğunu onayla."
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "Aşağıdaki uyarıları gözden geçirin, ardından ayarlamaları uygulamak için sayımı gönderin."
+msgstr "Aşağıdaki uyarıları incele, sonra düzeltmeleri uygulamak için sayımı muhasebeleştir."
 
 msgid "Revision"
 msgstr "Revizyon"
@@ -12689,13 +12689,13 @@ msgid "Revoke Invites"
 msgstr "Davetleri İptal Et"
 
 msgid "Rework"
-msgstr "Yeniden işçilik"
+msgstr "Yeniden İşleme"
 
 msgid "RFQ"
 msgstr "Teklif Talebi"
 
 msgid "RFQ (request for quote)"
-msgstr "RFQ (fiyat teklifi isteği)"
+msgstr "Teklif talebi"
 
 msgid "RFQ Date"
 msgstr "Teklif Tarihi"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "Teklif Talepleri"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "Carbon boyutlarını gönderilen defterlerle birlikte taşıyın. Her yuva bir Carbon boyutunu bir sağlayıcı analitik hedefine eşler; aşağıdaki değer eşlemesi bireysel boyut değerlerini sağlayıcı seçenekleriyle eşleştirir."
+msgstr "Carbon boyutlarını itilen muhasebe fişlerine dâhil et. Her yuva bir Carbon boyutunu bir sağlayıcı analitik hedefine eşler; aşağıdaki değer eşlemesi bireysel boyut değerlerini sağlayıcı seçenekleriyle eşleştirir."
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12765,10 +12765,10 @@ msgid "Rounding Account (default)"
 msgstr "Yuvarlama hesabı (varsayılan)"
 
 msgid "Route all AP invoices to one address (e.g. corporate headquarters) instead of individual purchasers."
-msgstr "Tüm fatura edilebilir alacak faturalarını bireysel satın alanlar yerine tek bir adrese yönlendirin (örneğin, kurumsal genel merkez)."
+msgstr "Tüm borç hesapları faturalarını bireysel alıcılar yerine tek bir adrese yönlendir (örn. kurumsal genel merkez)."
 
 msgid "Route all AR invoices to one address (e.g. corporate headquarters) instead of individual locations."
-msgstr "Tüm alacak faturalarını bireysel konumlar yerine tek bir adrese yönlendirin (örneğin, kurumsal merkez)."
+msgstr "Tüm Alacak hesapları faturalarını tek bir adrese (örneğin kurumsal merkez) yönlendir, bireysel lokasyonlar yerine."
 
 msgid "Routing"
 msgstr "Operasyon rotası"
@@ -12834,7 +12834,7 @@ msgid "Run the acceptance checklist to a pass"
 msgstr "Kabul kontrol listesini başarıyla tamamlayın"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "Tabletlerde üretim katını yönetin: işçi saatini kaydedin, ilerlemeyi bildirin, talimatları görüntüleyin"
+msgstr "Kat'ı tabletlerde çalıştır: İşçiliği kaydet, ilerleme bildir, talimatları gör"
 
 msgid "Run this workflow now?"
 msgstr "Bu iş akışı şimdi çalıştırılsın mı?"
@@ -12867,17 +12867,17 @@ msgid "S-4 (finest special)"
 msgstr "S-4 (en ince özel)"
 
 msgid "Safety stock"
-msgstr "Güvenlik stoğu"
+msgstr "Emniyet stoku"
 
 msgid "Safety Stock"
-msgstr "Güvenlik Stoğu"
+msgstr "Emniyet Stoku"
 
 #. placeholder {0}: numberFormatter.format(safetyStockValue)
 msgid "Safety stock ({0})"
 msgstr "Emniyet stoku ({0})"
 
 msgid "Safety Stock:"
-msgstr "Güvenlik Stoğu:"
+msgstr "Emniyet Stoku:"
 
 msgid "Sale Price"
 msgstr "Satış Fiyatı"
@@ -12895,19 +12895,19 @@ msgid "Sales & Quoting"
 msgstr "Satış ve Teklifler"
 
 msgid "Sales & Revenue"
-msgstr "Satış ve gelir"
+msgstr "Satış & Hasılat"
 
 msgid "Sales contact"
-msgstr "Satış iletişim"
+msgstr "Satış İlgili kişi"
 
 msgid "Sales Contact"
-msgstr "Satış Temsilcisi"
+msgstr "Satış İlgili Kişi"
 
 msgid "Sales Discounts"
-msgstr "Satış indirimleri"
+msgstr "Satış İskontoları"
 
 msgid "Sales Discounts (default)"
-msgstr "Satış indirimleri (varsayılan)"
+msgstr "Satış İskontoları (varsayılan)"
 
 msgid "Sales Funnel"
 msgstr "Satış Hunisi"
@@ -12958,7 +12958,7 @@ msgid "Sales Person"
 msgstr "Satış Temsilcisi"
 
 msgid "Sales Revenue"
-msgstr "Satış Geliri"
+msgstr "Satış Hasılat"
 
 msgid "Sales Tax Payable"
 msgstr "Ödenmesi gereken satış vergisi"
@@ -12982,7 +12982,7 @@ msgid "Sample"
 msgstr "Örnek"
 
 msgid "Sample Size"
-msgstr "Örnek Boyutu"
+msgstr "Örneklem büyüklüğü"
 
 msgid "Sampling"
 msgstr "Örnekleme"
@@ -13009,7 +13009,7 @@ msgid "Save applications"
 msgstr "Uygulamaları kaydet"
 
 msgid "Save contacts"
-msgstr "Kişileri kaydet"
+msgstr "İlgili Kişileri Kaydet"
 
 msgid "Save dimension settings"
 msgstr "Boyut ayarlarını kaydet"
@@ -13051,7 +13051,7 @@ msgid "Scan or choose a serial number"
 msgstr "Seri numarasını tarayın veya seçin"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "Barkod veya izlenen varlık kimliği, seri numarası veya parti girin"
+msgstr "İzlenen varlık kimliğini tara veya gir, seri numarası veya parti"
 
 msgid "Scan or enter tracking number"
 msgstr "Takip numarasını tarayın veya girin"
@@ -13072,13 +13072,13 @@ msgid "SCAR"
 msgstr "SCAR"
 
 msgid "SCAR (supplier corrective action request)"
-msgstr "SCAR (tedarikçi düzeltici eylem isteği)"
+msgstr "SCAR (Tedarikçi Düzeltici Faaliyet Talebı)"
 
 msgid "Schedule"
 msgstr "Planlama"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "İşleri iş merkezi kapasitesine karşı planlayın"
+msgstr "İş emirlerini iş merkezi kapasitesine karşı çizelgele"
 
 msgid "Schedule Name"
 msgstr "Planlama Adı"
@@ -13108,40 +13108,40 @@ msgid "Scopes"
 msgstr "Kapsamlar"
 
 msgid "Scrap"
-msgstr "Hurda"
+msgstr "Fire"
 
 msgid "Scrap / Cost of Quality"
-msgstr "Atık / Kalite Maliyeti"
+msgstr "Fire / Kalite Maliyeti"
 
 msgid "Scrap Percent"
-msgstr "Hurda Yüzdesi"
+msgstr "Fire Oranı"
 
 msgid "Scrap percentage"
-msgstr "Hurda yüzdesi"
+msgstr "Fire oranı"
 
 msgid "Scrap Qty"
-msgstr "Hurda Miktarı"
+msgstr "Fire Miktarı"
 
 msgid "Scrap quantity"
-msgstr "Hurda miktarı"
+msgstr "Fire miktarı"
 
 msgid "Scrap Quantity"
-msgstr "Hurda Miktarı"
+msgstr "Fire Miktarı"
 
 msgid "Scrap Quantity Per Job"
-msgstr "İş Başına Hurda Miktarı"
+msgstr "İş Emri Başına Fire Miktarı"
 
 msgid "scrap reason"
-msgstr "Hurda nedeni"
+msgstr "Fire nedeni"
 
 msgid "Scrap Reason"
-msgstr "Hurda Nedeni"
+msgstr "Fire Nedeni"
 
 msgid "scrap reasons"
-msgstr "Hurda nedenleri"
+msgstr "Fire nedenleri"
 
 msgid "Scrap Reasons"
-msgstr "Hurdaya Nega"
+msgstr "Fire Nedenleri"
 
 msgid "Scrapped"
 msgstr "Çıkartıldı"
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "Mevcut birini arayın veya yeni bir tane oluşturun"
 
 msgid "Search items or bins"
-msgstr "Maddeleri veya depoları ara"
+msgstr "Stok kartlarını veya gözleri ara"
 
 msgid "Search Job"
 msgstr "İş Ara"
@@ -13192,7 +13192,7 @@ msgid "Search list variables…"
 msgstr "Liste değişkenlerini ara…"
 
 msgid "Search operations…"
-msgstr "İşlemleri ara…"
+msgstr "Operasyonları ara…"
 
 msgid "Search operators..."
 msgstr "Operatörleri ara..."
@@ -13286,13 +13286,13 @@ msgid "Select a reason for why the quote was not created."
 msgstr "Teklifin neden oluşturulmadığına dair bir sebep seçin."
 
 msgid "Select a shape first to see available options"
-msgstr "Mevcut seçenekleri görmek için önce bir şekil seçin"
+msgstr "Kullanılabilir seçenekleri görmek için önce bir şekil seç"
 
 msgid "Select a substance and shape first to see available options"
-msgstr "Mevcut seçenekleri görmek için önce bir madde ve şekil seçin"
+msgstr "Kullanılabilir seçenekleri görmek için önce bir madde ve şekil seç"
 
 msgid "Select a substance first to see available options"
-msgstr "Mevcut seçenekleri görmek için önce bir madde seçin"
+msgstr "Kullanılabilir seçenekleri görmek için önce bir madde seç"
 
 msgid "Select a team"
 msgstr "Bir ekip seçin"
@@ -13334,7 +13334,7 @@ msgid "Select at least one line to convert"
 msgstr "Dönüştürmek için en az bir satır seçin"
 
 msgid "Select Contact"
-msgstr "İletişim Kişisi Seçin"
+msgstr "İlgili Kişi Seç"
 
 msgid "Select Customer Status"
 msgstr "Müşteri Durumu Seçin"
@@ -13361,7 +13361,7 @@ msgid "Select field"
 msgstr "Alan seçin"
 
 msgid "Select Gauge"
-msgstr "Kalıbrasyon Cihazı Seç"
+msgstr "Ölçüm Aleti Seç"
 
 msgid "Select groups or individuals"
 msgstr "Grupları veya bireyleri seçin"
@@ -13376,7 +13376,7 @@ msgid "Select invoices in a single currency"
 msgstr "Tek bir para biriminde faturaları seçin"
 
 msgid "Select Item Type"
-msgstr "Ürün Türü Seçin"
+msgstr "Stok Kartı Türü Seç"
 
 msgid "Select items"
 msgstr "Öğeler seçin"
@@ -13421,7 +13421,7 @@ msgid "Select the groups that should complete this training"
 msgstr "Bu eğitimi tamamlaması gereken grupları seçin"
 
 msgid "Select the invoices this payment settles. Discount and write-off are in invoice currency."
-msgstr "Bu ödemenin kapatacağı faturaları seçin. İndirim ve silme işlemi fatura para birimindedir."
+msgstr "Bu ödemenin kapattığı faturaları seç. İskonto ve Kayıttan Düşme fatura para birimindedir."
 
 msgid "Select value"
 msgstr "Değer seçin"
@@ -13446,10 +13446,10 @@ msgid "Self Managed"
 msgstr "Kendi Yönettiği"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "Kendi barındırılan veya yönetilen"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "Kendi kendine katılım"
 
 msgid "Self-paced"
 msgstr "Kendi hızında"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "E-posta bildirimleri açık olan her alıcıya gönderilir."
 
 msgid "Sequences"
-msgstr "Sıralamalar"
+msgstr "Numaralandırmalar"
 
 msgid "Serial"
 msgstr "Seri"
@@ -13536,10 +13536,10 @@ msgid "Service"
 msgstr "Hizmet"
 
 msgid "Service Charges"
-msgstr "Hizmet ücretleri"
+msgstr "Hizmet bedelleri"
 
 msgid "Service Charges (default)"
-msgstr "Hizmet ücretleri (varsayılan)"
+msgstr "Hizmet bedelleri (varsayılan)"
 
 msgid "Service Details"
 msgstr "Hizmet Detayları"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "Hedef belirle"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "Carbon'ı şirketinizin nasıl çalıştığına göre kurun: siteler, parçalar, BOM'lar, İşlem Faturası ve kullandığınız akışlar."
+msgstr "Carbon'u şirketinizin nasıl çalıştığına göre kurun: lokasyonlar, parçalar, BOM'lar, Operasyon listesi ve kullandığınız iş akışları."
 
 msgid "Set Clock Out"
-msgstr "Çıkış Saati Belirle"
+msgstr "İş bitişi ayarla"
 
 msgid "Set clock-out time"
 msgstr "Çıkış zamanını ayarla"
@@ -13630,10 +13630,10 @@ msgid "Setup Map"
 msgstr "Kurulum Haritası"
 
 msgid "Setup time"
-msgstr "Kurulum süresi"
+msgstr "hazırlık süresi"
 
 msgid "Setup Time"
-msgstr "Kurulum Süresi"
+msgstr "Hazırlık süresi"
 
 msgid "Setup unit"
 msgstr "Kurulum birimi"
@@ -13732,13 +13732,13 @@ msgid "Shipment ID"
 msgstr "Sevkiyat Kimliği"
 
 msgid "Shipment Line"
-msgstr "Sevkiyat Kalemi"
+msgstr "Sevkiyat satırı"
 
 msgid "Shipment Lines"
-msgstr "Sevk Hatları"
+msgstr "Sevkiyat satırları"
 
 msgid "Shipment Location"
-msgstr "Gönderim Konumu"
+msgstr "Sevkiyat lokasyonu"
 
 msgid "Shipments"
 msgstr "Sevkiyatlar"
@@ -13750,10 +13750,10 @@ msgid "Shipping"
 msgstr "Nakliye"
 
 msgid "Shipping Contact"
-msgstr "Nakliye İletişim Kişisi"
+msgstr "Sevkiyat İlgili kişi"
 
 msgid "Shipping Cost"
-msgstr "Nakliye Maliyeti"
+msgstr "Nakliye bedeli"
 
 msgid "Shipping Customer"
 msgstr "Gönderici Müşteri"
@@ -13762,19 +13762,19 @@ msgid "Shipping Location"
 msgstr "Teslimat Adresi"
 
 msgid "shipping method"
-msgstr "gönderim yöntemi"
+msgstr "sevkiyat yöntemi"
 
 msgid "Shipping method"
 msgstr "Sevkiyat yöntemi"
 
 msgid "Shipping Method"
-msgstr "Nakliye Yöntemi"
+msgstr "Sevkiyat yöntemi"
 
 msgid "shipping methods"
-msgstr "gönderim yöntemleri"
+msgstr "sevkiyat yöntemleri"
 
 msgid "Shipping Methods"
-msgstr "Kargo Yöntemleri"
+msgstr "Sevkiyat yöntemleri"
 
 msgid "Shipping Notes"
 msgstr "Sevkiyat Notları"
@@ -13786,13 +13786,13 @@ msgid "Shipping:"
 msgstr "Nakliye:"
 
 msgid "Shop Floor"
-msgstr "Üretim Alanı"
+msgstr "Atölye"
 
 msgid "Shop Floor and Scheduling"
-msgstr "Üretim Tabanı ve Planlama"
+msgstr "Atölye ve Planlama"
 
 msgid "Shop Floor leads, Planner"
-msgstr "Üretim Katı Şefleri, Planlayıcı"
+msgstr "Atölye Şefleri, Plancı"
 
 msgid "Shop-floor app and scheduling"
 msgstr "Üretim katı uygulaması ve planlama"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "İlk 500 satır gösteriliyor"
 
 msgid "Showing the newest 200 journals"
-msgstr "En yeni 200 muhasebe kaydı gösteriliyor"
+msgstr "En yeni 200 muhasebe fişi gösteriliyor"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "Miktar açısından ilk 1.000 grup gösteriliyor"
@@ -13871,7 +13871,7 @@ msgid "Shown to the user when this rule fails."
 msgstr "Bu kural başarısız olduğunda kullanıcıya gösterilir."
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "Carbon'a giriş yapın"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Sihirli bağlantı yerine biyometrik kimlik doğrulama ile oturum açın. Geçiş Anahtarları Face ID, Touch ID veya cihaz PIN'iniz tarafından korunur."
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "Outlook ile giriş yap"
 
 msgid "Sign in with Passkey"
-msgstr "Passkey ile Giriş Yap"
+msgstr "Geçiş anahtarıyla giriş yapın"
 
 msgid "Sign out"
 msgstr "Çıkış yap"
@@ -13958,7 +13958,7 @@ msgid "Slice expenses by location, cost center, or any dimension"
 msgstr "Konum, maliyet merkezi veya herhangi bir boyuta göre giderleri böl"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
-msgstr "Müşteri, müşteri türü veya herhangi bir boyuta göre geliri böl"
+msgstr "Hasılatı müşteriye, müşteri türüne veya herhangi bir boyuta göre böl"
 
 msgid "Smoke-test the core daily flows end to end"
 msgstr "Temel günlük akışları uçtan uca test et"
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "Çözüm Mühendisi"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "PDF'den çıkarılan bazı satırlar envanter öğelerinize otomatik olarak eşleştirilemedi. Aşağıdaki her satırı gözden geçirin ve eşleştirin."
+msgstr "PDF'den çıkarılan bazı satırlar stok kartlarınıza otomatik olarak eşleştirilemedi. Aşağıdaki her satırı gözden geçirin ve eşleştirin."
 
 msgid "Something went wrong. Please try again."
 msgstr "Bir şeyler ters gitti. Lütfen tekrar deneyin."
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "Sevkiyat satırını böl"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "Barındırmayı ayarla"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "Standart faktör"
 
 msgid "Standard Lead Time"
-msgstr "Standart Teslim Süresi"
+msgstr "Normal Tedarik süresi"
 
 msgid "Start"
 msgstr "Başlat"
@@ -14202,7 +14202,7 @@ msgid "Steps are inherited from the assembly instruction."
 msgstr "Adımlar montaj talimatından devralınır."
 
 msgid "Steps are inherited from the inspection plan."
-msgstr "Adımlar muayene planından devralınır."
+msgstr "Adımlar kontrol planından devralınır."
 
 msgid "Stock movement corrected"
 msgstr "Stok hareketi düzeltildi"
@@ -14224,13 +14224,13 @@ msgstr "Stok Transferleri"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Stocked for spares only — successor: <0>{0}</0>"
-msgstr "Yalnızca yedek parçalar için stoklanmış — halef: <0>{0}</0>"
+msgstr "Sadece yedek parçalar için depolanmıştır — ardıl: <0>{0}</0>"
 
 msgid "Stocked for spares only."
 msgstr "Yalnızca yedek parçalar için stoklanmıştır."
 
 msgid "Stockout"
-msgstr "Stok tükenmesi"
+msgstr "Stoksuzluk"
 
 msgid "Stop raising purchase orders after this date"
 msgstr "Bu tarihten sonra satın alma siparişleri vermeyi durdur"
@@ -14281,25 +14281,25 @@ msgid "Store a fixed number of days on this item. Expiry start date is set on ea
 msgstr "Bu öğe için sabit sayıda gün saklayın. Son kullanma tarihi başlangıç tarihi, her parti veya seri alındığında veya oluşturulduğunda (veya tetikleyici işlem ayarlanmışsa çalıştığında) belirlenir."
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "Bu öğeye sabit sayıda gün saklayın. Son kullanma tarihi, her parti veya seri alındığında belirlenir."
+msgstr "Bu stok kartında sabit gün sayılı raf ömrü belirleyin. Partiye veya seriye alındığında, son kullanma başlangıç tarihi ayarlanır."
 
 msgid "Straight line"
 msgstr "Doğrusal"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe'ın zaten bu e-postaya sahip bir müşterisi var"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe Son tarihi"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe faturayı müşteriye e-posta ile gönderir, bu nedenle bir adres gereklidir. Bu, Carbon'daki ilgili kişiye de kaydedilecektir."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe'ın bu Carbon müşterisi için henüz bir müşterisi yok. Muhasebeleştirme, bağlı hesabınızda bir tane oluşturacaktır."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Kanban tablosunda gösterilecek kanban çıktısı stili"
@@ -14314,10 +14314,10 @@ msgid "Subassembly"
 msgstr "Alt Montaj"
 
 msgid "Subcontracting Variance"
-msgstr "Taşeğremenin Farkı"
+msgstr "Taşeronluk Sapması"
 
 msgid "Subcontracting Variance (default)"
-msgstr "Taşeğremenin Farkı (varsayılan)"
+msgstr "Taşeronluk Sapması (varsayılan)"
 
 msgid "Subject"
 msgstr "Konu"
@@ -14332,7 +14332,7 @@ msgid "Submit for approval"
 msgstr "Onay için gönder"
 
 msgid "Submit Inspection"
-msgstr "Muayene Et"
+msgstr "Muayeneyi Gönder"
 
 msgid "Submitted By"
 msgstr "Gönderen"
@@ -14371,13 +14371,13 @@ msgid "Successfully created a new revision"
 msgstr "Başarıyla yeni bir revizyon oluşturuldu"
 
 msgid "Successor effectivity"
-msgstr "Halef geçerlilik"
+msgstr "ardıl geçerliliği"
 
 msgid "Successor Effectivity Date"
-msgstr "Halef Etkinlik Tarihi"
+msgstr "Ardıl Geçerlilik Tarihi"
 
 msgid "Successor Part"
-msgstr "Halef Parça"
+msgstr "Ardıl Parça"
 
 msgid "Suffix"
 msgstr "Sonek"
@@ -14413,13 +14413,13 @@ msgid "Supersedes"
 msgstr "Yerine Geçer"
 
 msgid "Supersession"
-msgstr "Yerine Geçme"
+msgstr "İkame"
 
 msgid "Supersession chain detected"
-msgstr "Süpersesyon zinciri algılandı"
+msgstr "İkame zinciri algılandı"
 
 msgid "Supersession Mode"
-msgstr "Yerine Geçme Modu"
+msgstr "İkame modu"
 
 msgid "supplier"
 msgstr "Tedarikçi"
@@ -14434,10 +14434,10 @@ msgid "Supplier added and selected"
 msgstr "Tedarikçi eklendi ve seçildi"
 
 msgid "Supplier contact"
-msgstr "Tedarikçi iletişim"
+msgstr "tedarikçi ilgili kişisi"
 
 msgid "Supplier Contact"
-msgstr "Tedarikçi İletişim Bilgisi"
+msgstr "Tedarikçi İlgili Kişisi"
 
 msgid "Supplier ID"
 msgstr "Tedarikçi Kimliği"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "Tedarikçi Parçası"
 
 msgid "Supplier Part ID"
-msgstr "Tedarikçi Parça Kimliği"
+msgstr "Tedarikçi parça numarası"
 
 msgid "Supplier Part Number"
 msgstr "Tedarikçi Parça Numarası"
@@ -14479,22 +14479,22 @@ msgid "Supplier Parts"
 msgstr "Tedarikçi Parçaları"
 
 msgid "Supplier Payment Discounts"
-msgstr "Tedarikçi Ödeme İndirimleri"
+msgstr "Tedarikçi ödeme iskontoları"
 
 msgid "Supplier Payment Discounts (default)"
-msgstr "Tedarikçi Ödeme İndirimleri (varsayılan)"
+msgstr "Tedarikçi ödeme iskontoları (varsayılan)"
 
 msgid "Supplier Prepayments"
-msgstr "Tedarikçi Ön Ödemeleri"
+msgstr "Tedarikçi avansları"
 
 msgid "supplier process"
-msgstr "Tedarikçi Süreci"
+msgstr "tedarikçi prosesi"
 
 msgid "supplier processes"
-msgstr "Tedarikçi Süreçleri"
+msgstr "tedarikçi prosesleri"
 
 msgid "Supplier Processes"
-msgstr "Tedarikçi Süreçleri"
+msgstr "Tedarikçi Prosesleri"
 
 msgid "Supplier Quality"
 msgstr "Tedarikçi Kalitesi"
@@ -14557,7 +14557,7 @@ msgid "Suppliers"
 msgstr "Tedarikçiler"
 
 msgid "Supply"
-msgstr "Tedarik"
+msgstr "Arz"
 
 msgid "Supply & Demand"
 msgstr "Arzû ve Talep"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "Değiştir"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "Bir modülü kapatarak her yerde kaldırın: Gereksinimler, Veri, Eğitim, Kapsam."
+msgstr "Bir modülü kapatarak her yerden kaldırın: Gereklilikler, Veriler, Eğitim, Kapsam."
 
 msgid "Switch to pan mode"
 msgstr "Pan moduna geç"
@@ -14651,7 +14651,7 @@ msgid "Target customers by type."
 msgstr "Müşterileri türlerine göre hedefleyin."
 
 msgid "Target disposition row"
-msgstr "Hedef durum satırı"
+msgstr "Hedef karar satırı"
 
 msgid "Target go-live"
 msgstr "Hedef canlı yayın"
@@ -14714,7 +14714,7 @@ msgid "Tax Depreciation Method"
 msgstr "Vergi Amortisman Yöntemi"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "vergiden muaf"
 
 msgid "Tax Exempt"
 msgstr "Vergi Muaf"
@@ -14744,13 +14744,13 @@ msgid "Tax Residual Value %"
 msgstr "Vergi Kalıntı Değeri %"
 
 msgid "Tax Useful Life (default)"
-msgstr "Vergi Faydalı Ömrü (varsayılan)"
+msgstr "Vergi faydalı ömrü (varsayılan)"
 
 msgid "Tax Useful Life (months)"
-msgstr "Vergi Faydalı Ömrü (aylar)"
+msgstr "Vergi faydalı ömrü (aylar)"
 
 msgid "Tax Useful Life (Months)"
-msgstr "Vergi Faydalı Ömrü (Aylar)"
+msgstr "Vergi faydalı ömrü (Aylar)"
 
 msgid "Tax:"
 msgstr "Vergi:"
@@ -14762,7 +14762,7 @@ msgid "Team trained"
 msgstr "Takım eğitildi"
 
 msgid "Technical support"
-msgstr ""
+msgstr "Teknik destek"
 
 msgid "Temperature"
 msgstr "Sıcaklık"
@@ -14805,12 +14805,12 @@ msgstr "Bu ad başka bir adım tarafından zaten kullanılıyor."
 
 #. placeholder {0}: i18n._(step.title)
 msgid "The \"{0}\" phase checks itself off once all of its tasks in the project plan are done."
-msgstr "\"{0}\" aşaması, proje planındaki tüm görevleri tamamlandığında kendini işaretler."
+msgstr "Proje planında tüm görevleri tamamlandığında \"{0}\" aşaması kendini işaretler."
 
 #. placeholder {0}: i18n._(step.title)
 #. placeholder {1}: i18n._(step.gate)
 msgid "The \"{0}\" phase is done — its \"{1}\" checkpoint has been passed."
-msgstr "\"{0}\" aşaması tamamlandı — \"{1}\" kontrol noktası geçildi."
+msgstr "\"{0}\" aşaması tamamlandı — \"{1}\" denetim noktası geçti."
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
@@ -14829,10 +14829,10 @@ msgid "The allowed values for a list-type attribute; users pick from these rathe
 msgstr "Bir liste türü özniteliği için izin verilen değerler; kullanıcılar serbest yazma yerine bunların arasından seçer."
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "Kullanıcıların bu boyutla defterdeki muhasebe işlemlerini etiketlerken seçebilecekleri izin verilen değerler."
+msgstr "Kullanıcıların muhasebeleştirmeleri bu boyutla etiketlerken seçebilecekleri izin verilen değerler."
 
 msgid "The amount of days after the calculation method that the cash discount is available"
-msgstr "Nakit indirimi için mevcut olan gün sayısı hesaplama yönteminden itibaren"
+msgstr "Hesaplama yöntemi sonrası nakit iskontosunun kullanılabilir olduğu gün sayısı"
 
 msgid "The amount of days after the calculation method that the payment is due"
 msgstr "Ödeme vadesinin hesaplama yönteminden sonraki gün sayısı"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "Yetkilendirme Onshape'te reddedildi. Yeniden bağlanmayı deneyin."
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "Tüm kaydedilen günlük satırlarının defteri, hesaba göre özetlenmiş — yalnızca şirket muhasebesi etkinleştirildiğinde yazılır."
+msgstr "Tüm muhasebeleştirilmiş muhasebe fiş satırlarının hesaba göre toplandığı defter — yalnızca şirketin muhasebesi etkin olduğunda yazılır."
 
 msgid "The buckets you track costs against"
 msgstr "Maliyetleri takip ettiğiniz gruplar"
@@ -14868,34 +14868,34 @@ msgid "The carrier and service a shipment goes out on, supplying the tracking-UR
 msgstr "Sevkiyatın çıktığı taşıyıcı ve hizmet, izleme numarasını bir bağlantıya dönüştüren izleme URL şablonunu ve hesap nakliye masraflarını sağlar."
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
-msgstr "Bu tedarikçiden malları teslim eden taşıyıcı, tedarikçinin kendisinden farklı olduğunda (örneğin, tedarikçi satar, FedEx gönderir)."
+msgstr "Bu tedarikçiden malları teslim eden, tedarikçinin kendisinden farklı olduğunda nakliyeci (örn. tedarikçi satar, FedEx gönderir)."
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "Taşıyıcının izleme sayfası URL'si {trackingNumber} yer tutucu olarak — Carbon gönderimdeki bağlantıları oluştururken gerçek numarayı değiştirir."
+msgstr "Nakliyecinin {trackingNumber} yer tutucu ile izleme sayfası URL'si — Carbon, sevkiyatlardaki bağlantıları oluştururken gerçek numarayı yerine koyar."
 
 msgid "The carriers and methods you ship orders with"
-msgstr "Siparişleri gönderdiğiniz taşıyıcılar ve yöntemler"
+msgstr "Siparişleri göndermek için kullandığınız nakliyeciler ve yöntemler"
 
 msgid "The cash discount the customer can take if they pay within the discount window."
-msgstr "Müşterinin indirim penceresi içinde ödeme yapması durumunda alabileceği nakit indirimi."
+msgstr "Müşteri iskonto penceresi içinde ödediğinde alabileceği nakit iskontosunun miktarı."
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "Bu hurda açıklayan katalog nedeni; nicelikten ziyade nedene göre anahtar haline getirilen hurda raporlarına katılır."
+msgstr "Bu fire'ı açıklayan katalog nedeni; fire raporlarında neden ile anahtarlandırılır, miktardan değil."
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "Üzerinde çalıştığınız katalog. Temel veriler yüklendikten sonra yüklenir."
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "Bu birimde izin verilen stok kategorileri; depolama kurallarını uygulamak için kullanılır (örneğin, soğuk zincir, tehlikeli)."
+msgstr "Bu birimde izin verilen stok kategorileri; yerleştirme kurallarını uygulamak için kullanılır (örn. soğuk zincir, tehlikeli)."
 
 msgid "The categories you group your suppliers into"
 msgstr "Tedarikçilerinizi gruplandırdığınız kategoriler"
 
 msgid "The categories your fixed assets fall into"
-msgstr "Sabit varlıklarınızın düştüğü kategoriler"
+msgstr "Sabit kıymetlerinizin düştüğü kategoriler"
 
 msgid "The category a fixed asset belongs to, carrying the GL accounts every asset of that kind posts to."
-msgstr "Sabit bir varlığın ait olduğu kategori, bu tür her varlığın kaydedildiği muhasebe defteri hesaplarını taşır."
+msgstr "Sabit kıymetin ait olduğu kategori, o tür her kıymetin muhasebeleştirdiği muhasebe hesaplarını taşır."
 
 msgid "The category of risk (operational, strategic, financial, compliance, etc.); drives which reports the risk rolls into."
 msgstr "Risk kategorisi (operasyonel, stratejik, finansal, uyum, vb.); riskin hangi raporlara gireceğini belirler."
@@ -14913,7 +14913,7 @@ msgid "The code printed on the kanban card that operators scan to mark the job c
 msgstr "Operatörlerin işi tamamlandı olarak işaretlemek için taradığı kanban kartına basılan kod; boş bırakılırsa otomatik olarak oluşturulur."
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "Yüklenicinin beklenen haftalık kullanılabilirliği; planlama, bu yükleniciye hafta boyunca operasyonlar atarken bunu üst sınır olarak kullanır."
+msgstr "Taşeronun beklenen haftalık kullanılabilirliği; planlama bu taşeronun haftasındaki operasyonlara atanırken bunu üst sınır olarak kullanır."
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "Bu lot/seri numarası için düzeltilmiş son kullanma tarihi; mevcut eldeki stok, değişiklikten sonra raf ömrü politikasına göre yeniden değerlendirilir."
@@ -14922,13 +14922,13 @@ msgid "The currencies you trade in and their rates"
 msgstr "Ticaret yaptığınız para birimleri ve bunların oranları"
 
 msgid "The customer record this portal account links to; only contacts already on that customer can be selected as the account holder below."
-msgstr "Bu portal hesabının bağlı olduğu müşteri kaydı; yalnızca bu müşteri üzerinde bulunan kişiler aşağıda hesap sahibi olarak seçilebilir."
+msgstr "Bu portal hesabının bağlandığı müşteri kaydı; yalnızca zaten o müşteri üzerindeki ilgili kişiler aşağıda hesap sahibi olarak seçilebilir."
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
 msgstr "Malların teslim edildiği müşteri, faturalandırılan müşteriden farklı olduğunda (örneğin, genel merkeze fatura gönder, şubeye gönder)."
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
-msgstr "Bu portal bağlantısının sağlandığı müşteri; yalnızca bu müşteri üzerindeki kişiler bağlantı aracılığıyla oturum açabilir."
+msgstr "Bu portal bağlantısının sağlandığı müşteri; yalnızca bu müşteri üzerindeki ilgili kişiler bağlantı üzerinden oturum açabilir."
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
 msgstr "Bu belge için müşterinin kendi referansı - tipik olarak sistemindeki RFQ veya PO numarası; yazdırılabilir çıktıda görüntülenir ve bunun dönüştürüldüğü herhangi bir belgeye taşınır."
@@ -14955,16 +14955,16 @@ msgid "The date past which this quote's pricing is no longer honored; converting
 msgstr "Bu teklifteki fiyatların artık kabul edilmediği tarih; bu tarihten sonra siparişe dönüştürme yeniden fiyatlandırmaya gerek duyabilir."
 
 msgid "The date the customer expects to receive the goods"
-msgstr "Müşterinin malı almayı beklediği tarih"
+msgstr "Müşterinin malları almayı beklediği tarih"
 
 msgid "The date the goods actually leave the warehouse; recorded on the shipment posting and used for on-time-shipping scoring."
-msgstr "Malların gerçekten depodan ayrıldığı tarih; sevkiyat deftere geçişinde kaydedilir ve zamanında sevkiyat puanlaması için kullanılır."
+msgstr "Malların fiilen depodan ayrıldığı tarih; sevkiyat muhasebeleştirmesine kaydedilir ve zamanında sevkiyat puanlaması için kullanılır."
 
 msgid "The date the item is required on-site to cover the period's projected demand."
 msgstr "Ürünün dönemdeki beklenen talebi karşılamak için sahada gerekli olduğu tarih."
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "Bu varlığın hizmetten çekildiği tarih; amortisман bu tarihte durur ve kalan net defter değeri hurda hesabına kaydedilir."
+msgstr "Bu kıymetin hizmetten çekildiği tarih; amortisman bu tarihte durdurulur ve kalan net defter değeri elden çıkarma hesabına kaydedilir."
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "Bu girişin muhasebe defterine kaydedildiği tarih; düştüğü muhasebe dönemini belirler."
@@ -14979,7 +14979,7 @@ msgid "The deadline to send your quote to the customer."
 msgstr "Müşteriye teklif gönderme son tarihi."
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "Varsayılan sipariş seçme, izlenen varlıkları sunmak için kullanır: FEFO (en erken sona erme önce), FIFO (en eski önce) veya LIFO (en yeni önce)."
+msgstr "Siparişin toplama işleminde sunacağı takip edilen varlıkları seçin: FEFO (en yakında sona erecek ilk), FIFO (en eski ilk), veya LIFO (en yeni ilk)."
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "Bu parça yapıldığında varsayılan çalıştırma miktarı; planlama turları bunun katlarına kadar yenileme yapar."
@@ -14988,10 +14988,10 @@ msgid "The default tax rate applied to this customer's quote and sales-order lin
 msgstr "Bu müşterinin alıntı ve satış siparişi satırlarına uygulanan varsayılan vergi oranı, satır başına geçersiz kılmadan önce; yetki alanına özgü vergi matematik üstünde çalışır."
 
 msgid "The department this one rolls up under for reporting and headcount hierarchies; leave empty for a top-level department."
-msgstr "Bunun raporlama ve başlık sayısı hiyerarşileri için toplandığı bölüm; üst düzey bölüm için boş bırakın."
+msgstr "Bu departmanın raporlama ve personel sayısı hiyerarşisinde bağlı olduğu departman; üst seviye bir departman için boş bırakın."
 
 msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
-msgstr "Sekiz disiplin kalite yöntemi, uyumsuzluk iş akışının görevleriyle modellenir, sabit kodlu değildir."
+msgstr "Sekiz disiplin kalite yöntemi, uygunsuzluk iş akışının görevleriyle modellenmiş olup sabit kodlanmamıştır."
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
 msgstr "Bu maliyet merkezi için sorumlu çalışan — satın alma siparişi onayları açık olduğunda, ona karşı kaydedilen harcamaların onaylayanı olur."
@@ -15003,10 +15003,10 @@ msgid "The endpoint that receives a POST request with the updated data when the 
 msgstr "Tablo güncellendiğinde güncellenmiş verilerle bir POST isteği alan uç nokta"
 
 msgid "The engineering drawing this inspection plan is tied to; inspections recorded against this part reference back to this drawing."
-msgstr "Bu muayene planının bağlı olduğu mühendislik çizimi; bu parça için kaydedilen muayeneler bu çizime geri başvurur."
+msgstr "Bu kontrol planının bağlı olduğu mühendislik çizimi; bu parçaya karşı kaydedilen muayeneler bu çizime geri referans verir."
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "Bu öğenin üretim sırasında kaybedilen çıkışının beklenen yüzdesi; planlama telafi etmek için talebi 1 / (1 - hurda) ile çarpar."
+msgstr "Bu stok kartının üretim sırasında kaybettiği beklenen yüzde; planlama, talep tarafı 1 / (1 − Fire) ile çarpılarak telafi edilir."
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Bu dolaylı harcama satırının nakledildiği gider hesabı; dolaylı satırlar hesabı türetmek için bir envanter defter girişine sahip olmadığından gereklidir."
@@ -15015,7 +15015,7 @@ msgid "the first 3 to 4 weeks"
 msgstr "ilk 3 ila 4 hafta"
 
 msgid "The fixed number of units to inspect from the front of each lot, regardless of lot size."
-msgstr "Lot boyutundan bağımsız olarak her bir lotnun ön tarafından incelenmek üzere sabit birim sayısı."
+msgstr "Her Lot'un önünden incelenecek sabit adet sayısı, Lot büyüklüğü ne olursa olsun."
 
 msgid "The fixed-asset record this purchase capitalizes against; the line's receipt creates the asset entry rather than an inventory entry."
 msgstr "Bu satın almanın aktifleştirildiği sabit varlık kaydı; satırın alındığı bir varlık girişi oluşturur, envanter girişi değil."
@@ -15024,28 +15024,28 @@ msgid "The fixed-asset record this sale disposes; the line's shipment posts the 
 msgstr "Bu satışın elden çıkardığı sabit varlık kaydı; satırın sevkiyatı, COGS yerine varlığın net defter değeri elden çıkarma girişini naktetmesi."
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "Bir varlığın amortisman yaptığı taban; net defter değeri buna ulaştığında, varlık Tamamen Amorti Hale Dönüşür."
+msgstr "Varlığın amortismanının ineceği taban; Net defter değeri buna ulaştığında, varlık Amortismanı tamamlanmış durumuna geçer."
 
 msgid "The floor and the office read the same inventory and cost figures."
 msgstr "Üretim alanı ve ofis aynı envanter ve maliyet rakamlarını görür."
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "Aşağıdaki montajlarda işlem bulunmamaktadır. Lütfen yayınlamadan önce her birine bir işlem atayın."
+msgstr "Aşağıdaki montajların operasyonu yok. Lütfen serbest bırakmadan önce her birine bir Operasyon atayın."
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "Aşağıdaki kalemlerde fiyat veya teslim süresi eksik:"
+msgstr "Aşağıdaki Satırlar eksik Fiyat veya Tedarik süresi içeriyor:"
 
 msgid "The following tasks are not done yet:"
-msgstr "Aşağıdaki görevler henüz tamamlanmadı:"
+msgstr "Aşağıdaki Görevler henüz Bitti değil:"
 
 msgid "The forms and shapes your raw materials come in"
-msgstr "Ham ve malzemelerin geldiği formlar ve şekiller"
+msgstr "Hammaddelerinizin sahip olduğu şekil ve türler"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "Her bir lotnun incelenmesi için kesir; gerçek sayı inceleme sırasında lot boyutundan hesaplanır."
+msgstr "Her Lot'un incelenecek oranı; gerçek sayı, muayene zamanında Lot büyüklüğünden hesaplanır."
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "Satın alma siparişinin fiyatı ile tedarikçi faturası arasındaki fark, fatura muhasebeleştirildiğinde bir varyans hesabına kaydedilir."
+msgstr "Satın alma siparişinin fiyatı ile tedarikçinin faturası arasındaki fark, Fatura muhasebeleştirildiğinde sapma hesabına kaydedilir."
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
 msgstr "Bu taşıyıcı için ücretlerin nakledildiği GL hesabı (nakliye gideri, nakliye giriş/çıkış)."
@@ -15060,28 +15060,28 @@ msgid "The group account this account rolls up to; determines its type, class, a
 msgstr "Bu hesabın toplanacağı grup hesabı; türünü, sınıfını ve beyan yerleşimini belirler."
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "Bu iş merkezinde operatör işçiliğinin saatlik maliyeti; bir işin WIP'sine işçilik maliyetini yüklemek için kaydedilen çalışma saatleri ile birleştirilir."
+msgstr "Bu İş merkezi üzerinde operatör İşçiliğinin saatlik Maliyeti; kaydedilen işçilik saatlerine göre bir İş emrinin Yarı mamul Maliyetine yüklenir."
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
-msgstr "Bu iş merkezinde makineleri çalıştırmanın saatlik maliyeti; bir işin WIP'sine makine maliyetini yüklemek için kaydedilen makine saatleri ile birleştirilir."
+msgstr "Bu İş merkezi üzerinde makinenin çalıştırılmasının saatlik Maliyeti; kaydedilen makine saatlerine göre bir İş emrinin Yarı mamul Maliyetine yüklenir."
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "Bu iş merkezine uygulanan saatlik dolaylı maliyet yükü; işçilik + makine ile tam alıntı oranı arasındaki fark, genel masrafların absorpladığıdır."
+msgstr "Bu İş merkezi üzerine uygulanan saatlik dolaylı Maliyet yükü; İşçilik + Makine ile tam tekliflendirme oranı arasındaki fark Genel üretim giderlerinin absorbe ettiği yerdir."
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
 msgstr "İş akışının webhook adımının gönderdiği https adresi — düz http, yönlendirmeler ve özel ya da link-yerel adreslere çözümlenen konaklar reddedilir ve çağrı on saniyeden sonra vazgeçer."
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "Bir diziden oluşturulan ve kayıtta saklanan, dahili kimlğinden farklı, insan tarafından okunabilir belge numarası (J000001 veya ECO-000001 gibi)."
+msgstr "Bir Numaralandırma kuralından oluşturulmuş ve kayıt üzerinde saklanan İnsan tarafından okunabilir belge numarası (J000001 veya ECO-000001 gibi), iç kimliğinden farklıdır."
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
-msgstr "Müşterinin bu parça için PO'larında kullandığı tanımlayıcı; Carbon bunu sipariş alımında dahili Parça Kimliğimize çözümler."
+msgstr "Müşterinin bu Parçaya kendi Satın alma siparişlerinde kullandığı tanımlayıcı; Carbon, sipariş ithalatında bunu bizim iç Parça kimliğine çözer."
 
 msgid "The identifier the supplier uses for this part on their quotes and invoices; Carbon resolves it to our internal Part ID."
 msgstr "Tedarikçinin bu parça için alıntı ve faturalarında kullandığı tanımlayıcı; Carbon bunu dahili Parça Kimliğimize çözümler."
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
-msgstr "Kök neden bilinmeden etkilenen stok veya işi karantinaya alan acil uyumsuzluk görevü."
+msgstr "Kök neden bilinmeden etkilenen Stok veya işi karantinaya alan hemen yapılan Uygunsuzluk Görevi."
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
 msgstr "Risk gerçekleşirse etki derecelendirmesi (1 = ihmal edilebilir ile 5 = yıkıcı); risk puanını hesaplamak için Olasılıkla eşleştirilmiş."
@@ -15090,13 +15090,13 @@ msgid "The inbound posting document that takes goods into stock (from a PO, tran
 msgstr "Malları stoka alan (bir SO, transfer veya iş çıkışından) ve izlenen varlıklar oluşturan gelen muhasebeleştirme belgesi."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "Bu tedarikçiden gönderilerde kimin navlun ödediğini, kimin riski üstlendiğini ve unvan transferinin nerede meydana geldiğini yöneten Incoterms kuralı (FOB, DAP, EXW, CIF, ...)."
+msgstr "Bu Tedarikçiden gelen Sevkiyatlarda nakliyeyi kimin ödeyeceğini, riski kimin yükleyeceğini ve mülkiyetin transferinin nerede gerçekleşeceğini yönetebilen Incoterm Kuralı (FOB, DAP, EXW, CIF, …)."
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "Bu müşteriye gönderilerde kimin navlun ödediğini, kimin riski üstlendiğini ve unvan transferinin nerede meydana geldiğini yöneten Incoterms kuralı (FOB, DAP, EXW, CIF, ...)."
+msgstr "Bu Müşteriye giden Sevkiyatlarda nakliyeyi kimin ödeyeceğini, riski kimin yükleyeceğini ve mülkiyetin transferinin nerede gerçekleşeceğini yönetebilen Incoterm Kuralı (FOB, DAP, EXW, CIF, …)."
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "Bir sevkiyat muhasebeleştirildiğinde tanınan envanter maliyeti, maddenin maliyet yöntemi ile değerlenir."
+msgstr "Bir Sevkiyat muhasebeleştirildiğinde tanınan ve Stok kartının Maliyetlendirme yöntemiyle değerlendirilen Envanter Maliyeti."
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "Bu varlık için MACRS kapsamında IRS kurtarma süresi sınıfı (3, 5, 7, 10, 15, 20, 27.5, 39 yıl)."
@@ -15108,7 +15108,7 @@ msgid "The job's position in its location's schedule queue — a fractional numb
 msgstr "İşin konumunun planlama kuyruğundaki konumu — Carbon'un son tarih ve deadline türünden hesapladığı kesirli bir sayı, Düşük/Yüksek bir puanlama değil."
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
-msgstr "Bu kural uyguladığı ayarlama türü - iskonto, ek ücret veya sabit geçersiz kılma; her satırda gerçek deltayı hesaplamak için Miktar Türü ile birleştirilmiş."
+msgstr "Bu Kuralın uygulandığı Düzeltmenin türü — İskonto, ek ücret veya sabit Geçersiz kılma; her Satırda gerçek değişimi hesaplamak için Miktar Türüyle birleştirilir."
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
 msgstr "Bu özniteliğin kabul ettiği değer türü (metin, sayı, tarih, boole, liste); öznitelik kaydedilmiş değerlere sahip olduktan sonra kilitlenir."
@@ -15129,19 +15129,19 @@ msgid "The lifecycle stages you track customers through"
 msgstr "Müşterileri takip ettiğiniz yaşam döngüsü aşamaları"
 
 msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.; only Active customers appear in sales-order selectors."
-msgstr "Bu müşterinin yaşam döngüsü durumu - Etkin, Potansiyel Müşteri, Etkin Değil, vb.; yalnızca Etkin müşteriler satış siparişi seçicilerinde görünür."
+msgstr "Bu Müşterinin yaşam döngüsü durumu — Aktif, Potansiyel müşteri, Pasif vb.; sadece Aktif Müşteriler satış siparişi seçicilerinde görünür."
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "Bu tedarikçinin yaşam döngüsü durumu - Etkin, Etkin Değil, Onay Bekleniyor, vb.; yalnızca Etkin tedarikçiler PO / alıntı seçicilerinde görünür."
+msgstr "Bu Tedarikçinin yaşam döngüsü durumu — Aktif, Pasif, Onay Beklemede vb.; sadece Aktif Tedarikçiler Satın alma siparişi / Teklif seçicilerinde görünür."
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "Bu konumun zamanı raporladığı yerel saat dilimi; bu konumdaki zamanlamalar, zaman kartları ve vardiya saatleri, kullanıcının tarayıcı yerel ayarından bağımsız olarak bu bölgede yorumlanır."
+msgstr "Bu Lokasyonda raporlanan yerel saat dilimi; bu Lokasyondaki Çizelgeler, Puantajlar ve Vardiya saatleri kullanıcının tarayıcı yerinden bağımsız olarak bu dilimde yorumlanır."
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "Bu çalışanın varsayılan olarak ayarlandığı konum; zaman kartlarında saat dilimi yorumlanmasını ve iş kaydında varsayılan vardiya seçicilerini sürüyor."
+msgstr "Bu Çalışanın varsayılan olduğu Lokasyon; Puantajlarında saat dilimi yorumunu ve İş emri kaydındaki varsayılan Vardiya seçicilerini yönlendirir."
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
-msgstr "Bu siparişin yerine getirileceği konum; satır başına konumlar ayarlandığında bunu geçersiz kılar."
+msgstr "Bu siparişin yerine getirileceği Lokasyon; satır başı Lokasyonlar ayarlandığında bunu Geçersiz kılırlar."
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
 msgstr "Bir siparişe dönüştürülürse bu teklifin yerine getirileceği konum; planlama tarafından doğru depoda arz projeksiyonu yapmak için kullanılır."
@@ -15150,7 +15150,7 @@ msgid "The location this RFQ would fulfill from if it converts to a quote and th
 msgstr "Bu RFQ'nun, bir alıntıya ve ardından siparişe dönüştürülürse yerine getirileceği konum."
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "Herhangi bir varlığa karşı ortaya konan risklerin ve fırsatların kaydı, her biri bağımsız 1–5 önem derecesi ve olasılığına göre derecelendirilmiş ve çözüme doğru yönlendirilmiştir."
+msgstr "Herhangi bir varlık karşısına açılan Riskler ve fırsatların günlüğü, her biri bağımsız 1–5 Şiddet ve Olasılık tarafından derecelendirilir ve çözüme sürüklenir."
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "Yazdırılan ve e-postayla gönderilen belgelerinizde gösterilen logolar"
@@ -15159,7 +15159,7 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "Bu stok için lot tanımlayıcısı; lot başına bir satır, miktar o lot için eldedir."
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "Lot bu olarak işaretlenecektir. Kayıtlarınız için {fails} örnek başarısızlığı kaydedilmiştir."
+msgstr "Lot, Geçti olarak işaretlenecektir. {fails} örneklenen başarısızlık(lar) kayıtlarınız için kaydedilir."
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Lot yine de reddedilecek, ancak en az bir Hata Türü yapılandırılana kadar Bir Uygunluk Raporu (NCR) oluşturulamaz."
@@ -15168,7 +15168,7 @@ msgid "The lot's per-feature sampling plan will be re-resolved from the selected
 msgstr "Lot'un her özellik başına örnekleme planı seçilen belgeden yeniden çözülecektir."
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "Bu tedarikçinin miktar ne olursa olsun bu işlem için tahsil edeceği minimum tutar; kâr-zarar noktası hacmi altındaki işler hala en az bu tutarına mal olur."
+msgstr "Bu Tedarikçinin bu Proses için miktardan bağımsız olarak ücretlendireceği en düşük tutar; başabaş hacminin altındaki İş emirleri yine de en az bu kadar tutar."
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "Çalışmanızın geçtiği makineler, hücreler ve istasyonlar"
@@ -15207,16 +15207,16 @@ msgid "The new version number of the procedure"
 msgstr "Prosedürün yeni sürüm numarası"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "Tercih edilen tedarikçi ile bir PO yerleştirme ile malların iskeleye varışı arasındaki gün sayısı; planlama talebini bu miktar kadar geriye doğru telafi eder."
+msgstr "Tercih edilen tedarikçi ile Satın alma siparişi yerleştirme ile malların iskeleye ulaşması arasındaki gün sayısı; Planlama talebi bu kadar geriye doğru kaydırır."
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "Bu öğenin bir partisini oluşturmak için gereken gün sayısı, iş yayınından tamamlanmaya kadar ölçülmüştür; planlama talebini bu miktar kadar geriye doğru telafi eder."
+msgstr "Bu Stok kartının bir Partisini üretmek için İş emri serbest bıraklışından tamamlanmaya kadar ölçülen gün sayısı; Planlama talebi bu kadar geriye doğru kaydırır."
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "Beklenen hurdayı telafi etmek için oluşturulacak ek birim sayısı; planlama malzeme rezerve ederken bunu sipariş miktarıyla özetler."
+msgstr "Beklenen Fire'ı telafi etmek için üretilecek fazladan adet sayısı; Planlama bunu malzeme rezerve ederken sipariş miktarıyla toplar."
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "Yüklenicinin çalışmak için haftalık olarak müsait olduğu saat sayısı."
+msgstr "Taşeronun haftada çalışmak için Kullanılabilir olduğu saat sayısı."
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "Bu varlığın amort edileceği ay sayısı."
@@ -15231,16 +15231,16 @@ msgid "The ordered list of tasks issues using this workflow must complete; the o
 msgstr "Bu iş akışını kullanan sorunların tamamlaması gereken görevlerin sıralanmış listesi; buradaki sıra, sorun üzerinde göründükleri sıradadır."
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "Bir işin çalıştırılmış olduğu işlemlerin sıralanmış sırası, yöntemin süreç faturasından kopyalanmıştır."
+msgstr "Bir İş emrinin çalıştırdığı sıralı Operasyonlar dizisi, Yöntemin Operasyon listesinden kopyalanmıştır."
 
 msgid "The original model file is no longer available"
 msgstr "Orijinal model dosyası artık kullanılamıyor"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "Malları envanterten bir müşteriye çıkaran ve yol boyunca COGS'yi deftere geçiren giden deftere nakil belgesi."
+msgstr "Stoktan malları bir Müşteriye çıkartırken Satılan malların maliyetini muhasebeleştiren giden muhasebeleştirme belgesi."
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "Bu işlemi gerçekleştiren dış tedarikçiler; her biri tedarikçi işlem formunda fiyat ve teslim süresi girişlerinin bir satırını alır."
+msgstr "Bu Prosesi yapan dış Tedarikçiler; her biri Tedarikçi prosesi formunda bir Satırda Fiyatlandırma ve Tedarik süresi girdileri alır."
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "İzlenen varlıkların parent-child zinciri - bir birim neyin dışında inşa edilmiş ve ne olmuş."
@@ -15252,19 +15252,19 @@ msgid "The part is taken from existing stock when its parent is built — no new
 msgstr "Parça, ebeveyninin inşa edildiğinde mevcut stoktan alınır - yeni iş veya satın alma siparişi yok."
 
 msgid "The people on the Carbon side who will run your implementation, and how to reach them."
-msgstr "Carbon tarafındaki uygulamanızı yönetecek ve onlara nasıl ulaşacağınızı gösteren kişiler."
+msgstr "Carbon tarafındaki uygulamanızı yönetecek Personel ve onlara ulaşmanız için nasıl yapılır."
 
 msgid "The people on your team and their access to Carbon"
-msgstr "Ekibinizdeki kişiler ve Carbon'a erişimleri"
+msgstr "Ekibinizdeki Personel ve Carbon'a olan erişimleri"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
 msgstr "Belge türünün okunabilir numarasını oluşturan, şirket başına sayaç; ön ek, sıfırla dolgulu sonraki değer ve son eki birleştirerek, her belge oluşturulduğunda ilerler."
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "Uyumsuzluğun etkilenen malzemesine kaydedilen ürün başına sonuç — Beklemede, Tedarikçiye İade, Yeniden İşleme, Hurdaya Çıkarma veya Olduğu Gibi Kullan — her etkilenen partiye veya seriye kendi başına karar verilir."
+msgstr "Bir uygunsuzluk nedeniyle etkilenen malzeme üzerine kaydedilen sonuç — Beklemede, Tedarikçiye İade, Yeniden İşleme, Fire veya Olduğu Gibi Kullanılsın — her etkilenen lot veya seri için ayrı ayrı karar verilir."
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
-msgstr "Nakit indirim yüzdesi. İndirim yoksa 0 kullanın."
+msgstr "Peşin ödeme iskontosunun yüzdesi. İskonto yoksa 0 kullanın."
 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Bu tür yeni çalışanların otomatik olarak aldığı izin kümesi; burada düzenleme, yalnızca gelecekteki işe almalar için şablonu değiştirir - mevcut çalışanlar, açıkça toplu güncellenmediği sürece sahip olduklarını tutarlar."
@@ -15273,25 +15273,25 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Çalışmanızın ve stokunuzun bulunduğu fabrikalar, depolar ve tesisler"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "Bu soruna uygulanan önceden ayarlanmış görev ve onay gereksinimlerinin paketi; ayarlandığında sorun türünün varsayılan iş akışını geçersiz kılar."
+msgstr "Bu soruna uygulanan önceden ayarlanmış görev ve onay gereksinimi paketi; ayarlandığında sorun türünün varsayılan iş akışını geçersiz kılar."
 
 msgid "The principle:"
 msgstr "İlke:"
 
 msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
-msgstr "Riskin meydana gelme olasılığı derecelendirmesi (1 = nadir ile 5 = neredeyse kesin); risk puanını hesaplamak için Önem Derecesi ile eşleştirilmiş."
+msgstr "Riskin oluşma olasılık puanı (1 = nadire 5 = neredeyse kesin); risk puanını hesaplamak için Şiddet ile eşleştirilir."
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
 msgstr "Teknikerin bu bakım gerçekleştirildiğinde izlediği prosedür; kronogramlar zaten oluşturulduktan sonra onu değiştirmek yalnızca gelecekteki örnekleri etkiler."
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "Bu iş merkezinin çalıştırabileceği süreçler; işlem planlanırken işlem seçicilerinde görünür ve hangi işlerin bu iş merkezi aracılığıyla yönlendirilebileceğini sınırlar."
+msgstr "Bu iş merkezinin çalıştırabileceği prosesler; operasyonları zamanlarken proses seçicilerinde görünür ve hangi iş emirlerinin bu iş merkezinden geçebileceğini sınırlar."
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "Sağlayıcı boyut hedefleri sunmaz. Önce sağlayıcıda özelliği etkinleştirin (örneğin, izleme kategorileri, sınıf izleme veya alanlar)."
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "Bu satırın fiyatlandırıldığı miktar kırılım noktaları; her sütun, alıcı-tedarikçi müzakere ve aşağı akış belgelere dönüştürme için kendi birim fiyatını taşır."
+msgstr "Bu satırın fiyatlandırıldığı miktar kesim noktaları; her sütun alıcı-tedarikçi müzakereleri ve aşağı yöndeki belgelere dönüştürme için kendi birim başına fiyatını taşır."
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "Tarama tabanlı yenileme ile yeniden sipariş edilecek ürün miktarı."
@@ -15318,10 +15318,10 @@ msgid "The record a workflow notification points at, named as an id plus its kin
 msgstr "İş akışı bildiriminin işaret ettiği kayıt, bir kimlik ve türü olarak adlandırılır; boş bırakırsanız bildirim iş akışı çalıştırmasının kendisine bağlanır."
 
 msgid "The record that applies a payment or memo to an invoice, carrying the applied, discount, and write-off amounts."
-msgstr "Faturaya ödeme veya muhasebe kaydı uygulayan ve uygulanan, indirim ve silme tutarlarını taşıyan kayıt."
+msgstr "Bir ödeme veya notu bir faturaya uygulayan ve uygulanan, iskonto ve kayıttan düşme tutarlarını taşıyan kayıt."
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
-msgstr "İzlenen varlıkların kaydedilmiş soykütüğü - hangi girdiler hangi çıktıları üretmek için tüketildi, makbuz ile sevkiyat arasında."
+msgstr "İzlenen varlıkların kaydedilmiş soy ağacı — hangi girdilerin hangi çıktıları üretmek için tüketildiği, mal kabul ile sevkiyat arasında."
 
 msgid "The reference data everything else hangs off. Loads first."
 msgstr "Diğer her şeyin bağlı olduğu referans veriler. Önce yüklenir."
@@ -15340,7 +15340,7 @@ msgid "The request body sent verbatim with a JSON content type after workflow va
 msgstr "İş akışı değişkenleri yerine konulduktan sonra JSON içerik türü ile sözcük sözcük gönderilen istek gövdesi, bunu destekleyen yöntemler üzerinde."
 
 msgid "The residual WIP a job has left at close, swept to a Production Variance account — the only variance Carbon books for a job."
-msgstr "Bir işin kapatmada bıraktığı artık WIP, bir üretim varyans hesabına süpürülen - Carbon'un bir iş için kaydettiği tek varyans."
+msgstr "Bir iş emrinin kapatıldığında bıraktığı artık yarı mamul, Üretim Sapması hesabına aktarılan — Carbon'un bir iş emri için kaydedebileceği tek sapma."
 
 msgid "The response from Onshape was missing required parameters. Try connecting again."
 msgstr "Onshape'ten gelen yanıtta gerekli parametreler eksikti. Yeniden bağlanmayı deneyin."
@@ -15352,16 +15352,16 @@ msgid "The revision number of the part"
 msgstr "Parçanın revizyon numarası"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
-msgstr "Bu işin tedarik etmesi için oluşturulan satış siparişi satırı, işi arkasındaki müşteri talebine bağlar."
+msgstr "Bu iş emrinin arzulanacak satış siparişi satırı, iş emrini arkasındaki müşteri talebine bağlayan."
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "Bu varlığın maliyetini faydalı ömrü boyunca yaymak için kullanılan amortisman yöntemi (doğrusal, azalan bakiye, üretim birimleri)."
+msgstr "Bu varlığın maliyetini faydalı ömrüne yaymayla kullanılan çizelge (doğrusal, azalan bakiye, üretim birimleri)."
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "Stokun fiziksel olarak bulunduğu raflar ve kutular"
+msgstr "Stoğun fiziksel olarak bulunduğu raflar ve gözler"
 
 msgid "The shop supplies and consumables you keep on hand"
-msgstr "Tuttuğunuz dükkan malzemeleri ve tüketim maddeleri"
+msgstr "Elinizdeki tezgâh malzemeleri ve sarf malzemeleri"
 
 msgid "The sign-offs every issue using this workflow needs before it can be closed."
 msgstr "Bu iş akışını kullanan her sorunun kapatılmadan önce ihtiyacı olan imzalar."
@@ -15370,19 +15370,19 @@ msgid "The size of the part"
 msgstr "Parçanın boyutu"
 
 msgid "The skills and abilities you track for your people"
-msgstr "İnsanlarınız için izlediğiniz beceriler ve yetenekler"
+msgstr "Personelleriniz için izlediğiniz beceriler ve yetkinlikler"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
 msgstr "Bu tedarikçinin bu parça için bir PO satırında kabul edeceği en küçük miktar; planlama ona yuvarlanır."
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
-msgstr "Bu portal hesabına sahip olacak seçilen müşteri üzerindeki belirli kişi; e-postaları oturum açma tanımlayıcısı olur."
+msgstr "Seçilen müşteri üzerindeki bu portal hesabına sahip olacak belirli ilgili kişi; e-postaları giriş tanımlayıcısı olur."
 
 msgid "The specific contact on the selected supplier who will own this portal account; their email becomes the sign-in identifier."
-msgstr "Bu portal hesabına sahip olacak seçilen tedarikçi üzerindeki belirli kişi; e-postaları oturum açma tanımlayıcısı olur."
+msgstr "Seçilen tedarikçi üzerindeki bu portal hesabına sahip olacak belirli ilgili kişi; e-postaları giriş tanımlayıcısı olur."
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "Bu PO satırının satın aldığı yukarıdaki işteki belirli işlem; yalnızca dış işleme olarak işaretlenen işlemler seçilebilir."
+msgstr "Yukarıdaki iş emrinde bu PO satırının satın aldığı belirli operasyon; yalnızca dış işlem olarak işaretlenmiş operasyonlar seçilebilir."
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
 msgstr "Bu makbuzun nakledildiği spesifik PO, iade veya transfer; kullanılabilir kimlikler yukarıdaki kaynak belge türüne bağlıdır."
@@ -15397,10 +15397,10 @@ msgid "The standard factor (hours, minutes, pieces) operations on this work cent
 msgstr "Standart faktör (saatler, dakikalar, parçalar) bu iş merkezindeki operasyonlar varsayılan olarak ölçülür; işlem başına geçersiz kılmalar ayarlandığında kazanır."
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
-msgstr "Bu işlemi ölçmek için kullanılan standart faktör - saatler, dakikalar, parçalar, fit kare - işlemleri tahmin edilip fiyatlandırıldığında."
+msgstr "Bu prosesi ölçmek için kullanılan standart faktör — saatler, dakikalar, parçalar, metrekare — operasyonları tahmin edilirken ve maliyetlendirilirken."
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "Bu alıntı satırının durumu - Taslak, Alıntı Yok, Tamamlandı; Alıntı Yok Nedeni alanını ortaya çıkarır ve satırı alıntı toplamından hariç tutar."
+msgstr "Bu teklif satırının durumu — Taslak, Teklif Yok, Tamamlandı; Teklif Yok, Neden alanını ortaya çıkarır ve satırı teklif toplamından hariç tutar."
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "Bu grup altındaki tüm hesapların kullanacağı beyan grubu."
@@ -15409,10 +15409,10 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "Adımın ayarları — bu çalıştırma, kullanılan değerleri kaydetmekten öncedir."
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "Bu malzemenin satın alındığı ve tutulduğu stok boyutları; her boyut işler ve PO'lar üzerinde ayrı bir seçilebilir varyant haline gelir."
+msgstr "Bu malzemenin satın alındığı ve tutulduğu stok boyutları; her boyut iş emirleri ve PO'larda ayrı bir seçilebilir varyant haline gelir."
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "Bu satırın seçtiği depolama kutusu; boş ise, seçme öğenin varsayılan depolama birimini kullanır."
+msgstr "Bu satırın toplandığı depolama gözü; boşsa, toplama öğenin Varsayılan Depolama Birimini kullanır."
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "Depolama hizmeti zamanında yanıt vermedi. Lütfen tekrar deneyin."
@@ -15424,7 +15424,7 @@ msgid "The supplier planning suggests first when this item needs to be bought; o
 msgstr "Bu öğenin satın alınması gerektiğinde planlamanın ilk olarak önerdiği tedarikçi; diğer tedarikçiler her PO satırında açılır listede kullanılabilir kalır."
 
 msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
-msgstr "Bu portal hesabının bağlı olduğu tedarikçi kaydı; yalnızca bu tedarikçi üzerinde bulunan kişiler aşağıda hesap sahibi olarak seçilebilir."
+msgstr "Bu portal hesabının bağlandığı tedarikçi kaydı; yalnızca o tedarikçi üzerinde olan ilgili kişiler hesap sahibi olarak seçilebilir."
 
 msgid "The supplier's own quote / proposal number; recorded for traceability on the PO that converts from this quote."
 msgstr "Tedarikçinin kendi alıntı/teklif numarası; bu alıntıdan dönüştürülen PO'da izlenebilirlik için kaydedilmiştir."
@@ -15433,7 +15433,7 @@ msgid "The supplier's own reference for this order (their SO number on their sys
 msgstr "Bu sipariş için tedarikçinin kendi referansı (sistemlerindeki SO numarası); denetim için kaydedilmiş ve makbuzda gösterilmiştir."
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "Tedarikçinin paketleme dekali veya gönderim numarası, denetim için kaydedilmiş; hiçbir deftere nakil mantığı tarafından kullanılmamıştır."
+msgstr "Tedarikçinin ambalaj fişi veya sevkiyat numarası, denetim için kaydedilir; herhangi bir muhasebeleştirme mantığı tarafından kullanılmaz."
 
 msgid "The suppliers and vendors you buy from"
 msgstr "Satın aldığınız tedarikçiler ve satıcılar"
@@ -15442,7 +15442,7 @@ msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that 
 msgstr "Bu RFQ'yu alan tedarikçiler; her biri kendi fiyatlandırmaları ile yanıt verdikleri RFQ'ya kendi satırını alır."
 
 msgid "The surface finishes available on your materials"
-msgstr "Malzemelerinizde mevcut olan yüzey işlemleri"
+msgstr "Malzemelerinizde kullanılabilir yüzey bitişleri"
 
 msgid "The system passes every in-scope acceptance test in your configured system, with your data; the data is validated; and you sign off. Then go-live."
 msgstr "Sistem, yapılandırılmış sisteminizde kapsamdaki her kabul testini geçer, verilerinizle; veriler doğrulanır; ve siz onay verirsiniz. Ardından canlı yayına geçin."
@@ -15457,34 +15457,34 @@ msgid "The timer starts manually"
 msgstr "Zamanlayıcı manuel olarak başlar"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "Operasyonlarınızın güvendiği takım tezgahları ve demirbaşlar"
+msgstr "Operasyonlarınızın güvendiği takım tezgâhları ve bağlama aparatları"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "Bu toplu partide oluşturulan tüm işlerde yapılacak toplam; kaç iş oluşturulacağına karar vermek için İş Başına Miktar ile birleştirilmiş."
+msgstr "Bu toplu işlemde oluşturulan tüm iş emirlerinde yapılacak toplam; kaç iş emri oluşturulacağını belirlemek için İş Başına Miktar ile birleştirilir."
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "Kalibrasyon değerlerinin karşılaştırıldığı izlenebilir referans (örneğin NIST standardı, ana ölçü seri numarası)."
+msgstr "Kalibrasyon değerlerinin karşılaştırıldığı izlenebilir referans (örneğin NIST standardı, mastar ölçüm aleti seri numarası)."
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "Talimat, malzeme listesindeki her parçayı ve miktarını listeler."
+msgstr "İş takip kartı ürün ağacındaki her stok kartını miktarıyla birlikte listeler."
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "Tür, yeni çalışanın aldığı varsayılan izinleri kontrol eder; buradan seçmek, tür şablonundan izin matrisini önceden doldurur."
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "Bu işlem için bu tedarikçiye iş göndermekle geri almak arasında geçen günlerin tipik sayısı; bir tedarikçi seçerken planlama talebi bu miktar kadar telafi eder."
+msgstr "Bu tedarikçiye bu proses için iş göndermekle geri almak arasında geçen tipik gün sayısı; bir tedarikçi seçerken planlama talebi bu kadar kaydırır."
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "Bu fiziksel birim üzerindeki benzersiz tanımlayıcı; seri numarası başına bir satır, miktar her zaman 1'dir."
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "Bir yönlendirme süresinin ifade edildiği birim; örneğin Saat/Parça veya Toplam Saat gibi, Carbon'a zamanın miktarla ölçeklenip ölçeklenmediğini veya çalışma başına sabit olup olmadığını söyler."
+msgstr "Rota zamanının ifade edildiği birim, örneğin Saatler/Parça veya Toplam Saatler, Carbon'a zamanın miktarla ölçeklenip ölçeklenmediğini veya her çalışma başına sabit olup olmadığını söyler."
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "Satın alma zamanındaki birim fiyat"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
-msgstr "Tedarikçilerin bu öğeye fiyat koyduğu ve sevk ettiği birim, envanter biriminden farklı olduğunda (örneğin, kutu vs. her biri); Dönüştürme Faktörü ile eşleştirilmiş."
+msgstr "Tedarikçilerin bu öğeyi fiyatladığı ve gönderdiği birim, envanter biriminden farklı olduğunda (örneğin koli ve tekil); Çevrim Katsayısı ile eşleştirilir."
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each)."
 msgstr "Tedarikçilerin bu öğeye fiyat koyduğu ve sevk ettiği birim, envanter biriminden farklı olduğunda (örneğin, kutu vs. her biri)."
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "Bu alıntının mallarının gönderileceği depo; müşterinin Sevkiyat Konumu, nereye varacakları yer."
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "Ekipmanın arızalanma şekilleri, bakım ve kalite takibi için"
+msgstr "Ekipmanın arıza yapma şekilleri, bakım ve kalite izlemesi için"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "Üretimin çekilmesi için seçilen malzemenin hazırlandığı ve depo kaynak rafının aksine olan iş merkezinin kendi konteynerdir."
+msgstr "İş merkezinin prodüksiyonun çekeceği toplandı malzemenin hazırlandığı kendi gözü, depo kaynak rafı yerine."
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "Çalışma saatleri ve planlama yöneten takvimler"
@@ -15547,7 +15547,7 @@ msgid "These custom fields will only be available for entities with the same tag
 msgstr "Bu özel alanlar yalnızca aynı etiketlere sahip varlıklar için kullanılabilir"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "Bu belgeler defteri kebir'e deftere geçmediği için, tutarları bu dönemde eksiktir. Her birini deftere geçirin veya geçersiz kılın — tarihsiz bir belge deftere geçtiğinde deftere geçiş gününün tarihini alır."
+msgstr "Bu belgeler genel muhasebe defterine muhasebeleştirilmedi, bu nedenle tutarları bu dönemde eksiktir. Her birini muhasebeleştir veya hükümsüz kıl — tarihi olmayan bir belge muhasebeleştirilirken muhasebeleştirme gününün tarihini alır."
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "Bu e-posta adresleri, tedarikçilere gönderilen tüm e-postalara (teklifler, satın alma siparişleri vb.) otomatik olarak CC'lenecektir."
@@ -15559,10 +15559,10 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Bu maddeler için hala seçilecek malzeme var. Şimdi bitirmek listeyi Kısmi olarak işaretler."
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "Bu işler bu iş merkezine atanmış işlemlere sahiptir:"
+msgstr "Bu iş emirlerinin bu iş merkezine atanmış operasyonları vardır:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "Bu muhasebe kayıtları hâlâ Taslak durumundadır, bu nedenle borç ve alacakları bu dönem için defteri kebir'de değildir. Her birini deftere geçirin veya daha sonraki bir açık döneme yeniden tarihlendiriniz."
+msgstr "Bu muhasebe fişleri hala Taslak halinde olduğundan borç ve alacakları bu dönemin defterine girmedi. Her birini muhasebeleştir veya daha sonraki açık bir döneme yeniden tarihle."
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "Bu Carbon örneğinde Onshape OAuth kimlik bilgileri eksik. Bir yöneticiden bunları ayarlamasını isteyin."
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "Bu, Keşif adımını tamamlar."
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "Bu ilgili kişinin e-posta adresi yok"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "Bu muhasebe ortağının ödenmemiş bir borcu yok — ödeme hesap üzerinde kaydedilecektir."
@@ -15586,7 +15586,7 @@ msgid "This download link is invalid or has been tampered with."
 msgstr "Bu indirme bağlantısı geçersiz veya değiştirilmiş."
 
 msgid "This file is no longer available, or you don't have permission to download it."
-msgstr "Bu dosya artık kullanılamıyor veya onu indirme izniniz yok."
+msgstr "Bu dosya artık kullanılabilir değil veya bunu indirme izniniz yok."
 
 msgid "This Fiscal Year"
 msgstr "Bu Mali Yıl"
@@ -15598,17 +15598,17 @@ msgid "This information will be visible to all users, so be careful what you sha
 msgstr "Bu bilgiler tüm kullanıcılar tarafından görülecektir, bu yüzden ne paylaştığınıza dikkat edin."
 
 msgid "this inspection plan"
-msgstr "bu muayene planı"
+msgstr "bu kontrol planı"
 
 #. placeholder {0}: company?.name ?? "Carbon"
 msgid "This invitation to join {0} has expired. You can request a new invite to be sent to your email."
-msgstr "{0} kuruluşuna katılmak için gönderilen bu davet süresi dolmuştur. E-postanıza yeni bir davet gönderilmesini isteyebilirsiniz."
+msgstr "{0} grubuna katılma davetinizin süresi doldu. Yeni bir davet talebinde bulunabilirsiniz ve bu e-postanıza gönderilir."
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "Bu fatura, Stripe için kullanılabilir bir son tarih içermiyor — lütfen bir tane seçin."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "Bu fatura, bu Carbon müşterisine zaten bağlı olan Stripe müşterisine faturalandırılacaktır. Ayrıntılarını değiştirmek için Stripe panosunda düzenleyin."
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "Bu kontrollü bir ortamdır, bu nedenle doğrulayıcı uygulaması gereklidir."
@@ -15620,7 +15620,7 @@ msgid "This is a purchased item — it has no BoM/BoP; only its attributes and d
 msgstr "Bu satın alınan bir üründür — BoM/BoP'si yoktur; yalnızca öznitelikleri ve belgeleri değişebilir."
 
 msgid "This is a unique identifier for the webhook"
-msgstr "Bu, web kancası için benzersiz bir tanımlayıcıdır"
+msgstr "Bu, webhook için benzersiz bir tanımlayıcıdır"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
 msgstr "Bu ITAR tarafından kontrol edilen bir ortamdır. Erişim yalnızca ABD vatandaşları ile sınırlıdır."
@@ -15638,22 +15638,22 @@ msgid "this item"
 msgstr "bu öğe"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "Bu öğe bir configuratör aracılığıyla oluşturulmuş ve bileşenlerini siparişe göre çözer; bunun için oluşturulan işler configuratörün çözülmüş BOM'unu devralır."
+msgstr "Bu stok kartı bir konfigüratör aracılığıyla oluşturulur ve bileşenlerini sipariş başına çözer; bunun için oluşturulan iş emirleri konfigüratörün çözülmüş ürün ağacını devralır."
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "Bu ürünün malzeme listesindeki hiçbir bileşeni raf ömrü özelliğine sahip değil, bu nedenle BOM'dan bir son kullanma tarihi hesaplanmayacaktır."
+msgstr "Bu stok kartının ürün ağacı, raf ömrü etkin olan giriş içermez, bu nedenle ürün ağacından son kullanma tarihi hesaplanmayacaktır."
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "Bu iş envantere alınacak. Artık atölyede bulunmayacaktır."
+msgstr "Bu iş emri envantere alınacaktır. Atölye'de artık kullanılamayacaktır."
 
 msgid "This job will no longer be available on the shop floor."
-msgstr "Bu iş artık atölyede bulunmayacak."
+msgstr "Bu iş emri atölye'de artık kullanılamayacaktır."
 
 msgid "This job's own required quantity for the material."
 msgstr "Bu işin malzeme için kendi gerekli miktarı."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Bu parti süresi dolmuş ve alınamaz."
+msgstr "Bu lot süresi doldu ve toplama yapılamaz."
 
 msgid "This may take a moment. Hang tight."
 msgstr "Bu biraz zaman alabilir. Sabrın."
@@ -15665,7 +15665,7 @@ msgid "This Month"
 msgstr "Bu Ay"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "Bu Implementation Hub sayfası şu anda inşa edilmektedir. Biz bitirirken komut merkezinden başlayın."
+msgstr "Uygulama Hub'ınızın bu sayfası oluşturuluyor. Bunu tamamlarken komuta merkezinden başlayın."
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
 msgstr "Bu parça bu konumda {quantityOnHand} adet stokta bulunmaktadır. Stok Yok, bunun ne planlanacağı ne de tüketileceği anlamına gelir."
@@ -15686,7 +15686,7 @@ msgid "This path only decides what runs next"
 msgstr "Bu yol yalnızca sonra ne çalışacağını belirler"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "Bu döneme nakledilen günlük girişi yoktur ve kalıcı olarak silinebilir. Bu geri alınamaz."
+msgstr "Bu dönem hiçbir muhasebe fişi içermez ve kalıcı olarak silinebilir. Bu işlem geri alınamaz."
 
 msgid "this purchase order"
 msgstr "bu satın alma siparişi"
@@ -15695,7 +15695,7 @@ msgid "This Quarter"
 msgstr "Bu Çeyrek"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "Bu, onların doğrulayıcı uygulamasını kaldırır, bu nedenle bir sonraki oturum açışında yalnızca sihirli bir bağlantıya ihtiyaç duyar. Doğrulayıcıya erişimini kaybettiklerinde bunu kullanın. Ait oldukları her şirket için oturum açışlarını etkiler."
+msgstr "Bu işlem onların kimlik doğrulayıcı uygulamasını kaldırır, bu nedenle sonraki oturum açışları yalnızca sihirli bir bağlantı gerektirir. Kimlik doğrulayıcılarına erişimini kaybettikleri zaman bunu kullanın. Ait oldukları her şirket için oturum açışlarını etkiler."
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
 msgstr "Bu revizyon yayınlanmıştır (Üretim). Değişiklikler normalde bir değişiklik bildirisi yoluyla akmalıdır."
@@ -15710,10 +15710,10 @@ msgid "This runs the workflow for real. It will create records, send notificatio
 msgstr "Bu iş akışını gerçekten çalıştırır. Kayıtlar oluşturur, bildirimler gönderir ve canlı çalıştırmada olduğu gibi tüm webhook'ları çağırır. Bu geri alınamaz."
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "Bu satış siparişi ilgili işlere sahiptir. Onlarla ne yapılacağına karar verin."
+msgstr "Bu satış siparişinin ilişkili iş emirleri var. Bunlarla ne yapacağınızı seçin."
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "Bu satış siparişi, iş oluşturulmasını gerektiren satırlara sahiptir."
+msgstr "Bu satış siparişinde iş emri oluşturulması gereken satırlar var"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15745,10 +15745,10 @@ msgid "This version cannot be opened"
 msgstr "Bu sürüm açılamıyor"
 
 msgid "This version is published"
-msgstr ""
+msgstr "Bu sürüm yayınlandı"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "Bu sürüm yayınlandı. Düzenlemek için yeni bir sürüm oluşturun."
 
 msgid "This version's definition could not be read."
 msgstr "Bu sürümün tanımı okunamadı."
@@ -15766,7 +15766,7 @@ msgid "This will overwrite the existing quote method"
 msgstr "Bu, mevcut teklif yöntemini geçersiz kılacaktır"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "Bu, aktif üretim yönteminin malzeme listesinden ve partileri kullanarak süreçlerden birim maliyeti yeniden hesaplayacaktır. Mevcut maliyet üzerine yazılacaktır. Devam etmek istiyor musunuz?"
+msgstr "Bu, geçerli üretim yönteminin ürün ağacından ve işlemlerinden parti boyutunu kullanarak birim maliyeti yeniden hesaplayacaktır. Mevcut maliyet üzerine yazılacaktır. Devam etmek istiyor musunuz?"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
@@ -15786,7 +15786,7 @@ msgid "This will write off the remaining book value of the asset."
 msgstr "Bu, varlığın kalan net defter değerini silebilir."
 
 msgid "Three-way match"
-msgstr "Üç yönlü eşleşme"
+msgstr "Üçlü eşleştirme"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "Uzlaştırma kullanılamıyor"
 
 msgid "Tightened"
-msgstr "Sıkı"
+msgstr "Sıkılaştırılmış"
 
 msgid "Time of day"
 msgstr "Günün saati"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "Çalışma Saati Kaydı"
 
 msgid "Timecards"
-msgstr "Zaman Kartları"
+msgstr "Puantaj"
 
 msgid "Timecards are disabled"
-msgstr "Zaman kartları devre dışı"
+msgstr "Puantaj devre dışı"
 
 msgid "Timecards are enabled"
-msgstr "Zaman kartları etkinleştirilmiş"
+msgstr "Puantaj etkin"
 
 msgid "Timezone"
 msgstr "Saat Dilim"
@@ -15853,7 +15853,7 @@ msgid "To Date"
 msgstr "Bitiş Tarihi"
 
 msgid "To deactivate, use the row menu and choose Deactivate Account."
-msgstr "Deaktif hale getirmek için, satır menüsünü kullanın ve Hesabı Deaktif Et'i seçin."
+msgstr "Devre dışı bırakmak için satır menüsünü kullanın ve Hesabı Devre Dışı Bırak'ı seçin."
 
 msgid "To Location"
 msgstr "Varış Konumu"
@@ -15862,16 +15862,16 @@ msgid "To reactivate, use the row menu and choose Send Invite. The employee beco
 msgstr "Yeniden etkinleştirmek için, satır menüsünü kullanın ve Davet Gönder'i seçin. Çalışan bunu kabul ettiğinde etkin hale gelir."
 
 msgid "To Receive"
-msgstr "Alınacak"
+msgstr "Mal kabul bekleyen"
 
 msgid "To Ship"
-msgstr "Gönderilecek"
+msgstr "Sevk edilecek"
 
 msgid "To Ship and Receive"
-msgstr "Gönderilecek ve Alınacak"
+msgstr "Sevk edilecek ve Mal kabul bekleyen"
 
 msgid "To Storage Unit"
-msgstr "Hedef Depo Birimi"
+msgstr "Depolama birimine"
 
 msgid "To supplier"
 msgstr "Tedarikçiye"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "Araçlar"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "Üst düzey sınıflandırma (varlık/yükümlülük/öz sermaye/gelir/gider); yalnızca kök gruplarda ayarlanır, çocuklar tarafından devralınır."
+msgstr "Üst düzey sınıflandırma (varlık / yükümlülük / özkaynak / hasılat / gider); yalnızca kök gruplar üzerinde ayarlayın, alt gruplar tarafından devralınır."
 
 msgid "Topic"
 msgstr "Konu"
@@ -15979,10 +15979,10 @@ msgid "Total quantity on hand for the item across all storage units at this loca
 msgstr "Bu konumdaki tüm depolama birimlerinde öğenin toplam eldeki miktarı. Eldeki miktar artı gelenler toplam talebi karşılayamadığında kırmızıya döner."
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "Bu konumdaki tüm aktif işler ve satış siparişleri genelinde gereken toplam miktar — yalnızca bu iş için değil."
+msgstr "Bu konumdaki tüm devam eden iş emirleri ve satış siparişlerinde gerekli olan toplam miktar — yalnızca bu iş emri değil."
 
 msgid "Total scrap quantity"
-msgstr "Toplam atık miktarı"
+msgstr "Toplam fire miktarı"
 
 msgid "Total tax"
 msgstr "Toplam vergi"
@@ -15991,7 +15991,7 @@ msgid "Total Value"
 msgstr "Toplam Değer"
 
 msgid "Total Variance"
-msgstr "Toplam Fark"
+msgstr "Toplam sapma"
 
 msgid "Total:"
 msgstr "Toplam:"
@@ -16015,7 +16015,7 @@ msgid "Track every change to your orders, invoices, customers, suppliers, and mo
 msgstr "Siparişlerinizde, faturalarınızda, müşterilerinizde, tedarikçilerinizde ve daha fazlasında her değişikliği izleyin."
 
 msgid "Track real-time inventory by location and bin"
-msgstr "Konumu ve bölmeye göre gerçek zamanlı envanteri izleyin"
+msgstr "Envanteri konum ve göze göre gerçek zamanlı olarak izleyin"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
 msgstr "Seri/lot numaralarını takip edin ve satış siparişlerini yerine getirin."
@@ -16039,13 +16039,13 @@ msgid "Tracked entity"
 msgstr "İzlenen varlık"
 
 msgid "Tracked Entity"
-msgstr "Takip Edilen Varlık"
+msgstr "İzlenen varlık"
 
 msgid "Tracked entity ID is required but none was found"
-msgstr "Takip edilen varlık kimliği gerekli ancak hiçbiri bulunamadı"
+msgstr "İzlenen varlık kimliği gerekli ancak hiçbiri bulunamadı"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "Takip edilen malzeme, bir çekme listesi olmasa bile, çekme sırasına göre (FEFO) önceden seçilir."
+msgstr "İzlenen malzeme, toplama listesi olmasa bile toplama sırasına (FEFO) göre önceden seçilir."
 
 msgid "Tracking"
 msgstr "Takip"
@@ -16066,7 +16066,7 @@ msgid "Tracking type"
 msgstr "İzleme türü"
 
 msgid "Tracking Type"
-msgstr "Takip Türü"
+msgstr "İzleme türü"
 
 msgid "Tracking URL"
 msgstr "Takip URL'si"
@@ -16096,7 +16096,7 @@ msgid "Trainings"
 msgstr "Eğitimler"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "İşlemler yevmiye kayıtları oluşturacak ve genel muhasebe defterini güncelleyecektir."
+msgstr "İşlemler muhasebe fişileri oluşturacak ve Büyük defteri güncelleyecektir."
 
 msgid "Transfer"
 msgstr "Transfer"
@@ -16249,13 +16249,13 @@ msgid "Unit of measure"
 msgstr "Ölçü birimi"
 
 msgid "Unit of Measure"
-msgstr "Birim"
+msgstr "Ölçü birimi"
 
 msgid "Unit of measure code"
 msgstr "Ölçü birimi kodu"
 
 msgid "Unit of Measures"
-msgstr "Birimler"
+msgstr "Ölçü birimleri"
 
 msgid "Unit price"
 msgstr "Birim fiyatı"
@@ -16270,7 +16270,7 @@ msgid "Units"
 msgstr "Birimler"
 
 msgid "Units of base currency per one unit of this currency; used to translate amounts on posting."
-msgstr "Temel para biriminin bir birimi başına bu para biriminin bir birimi; deftere nakil sırasında tutarları çevirmek için kullanılır."
+msgstr "Bu paranın bir biriminin temel para cinsinden kaç birim olduğunu gösterir; muhasebeleştirme sırasında tutarları çevirmek için kullanılır."
 
 msgid "units of measure"
 msgstr "ölçü birimleri"
@@ -16291,10 +16291,10 @@ msgid "unknown location"
 msgstr "bilinmeyen konum"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "Sınırsız işlevsel destek"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "Sınırsız kayıt"
 
 msgid "Unlink"
 msgstr "Bağlantısını Kes"
@@ -16339,10 +16339,10 @@ msgid "Unposted Documents"
 msgstr "Deftere Geçmemiş Belgeler"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "Yayını kaldır"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "Yayını {name} için kaldır?"
 
 msgid "Unreceived POs"
 msgstr "Alınmamış PO'lar"
@@ -16423,7 +16423,7 @@ msgid "Update Linear issue"
 msgstr "Linear sorununu güncelle"
 
 msgid "Update part lead times from posted purchase receipts."
-msgstr "Yayınlanan satın alma makbuzlarından parça teslim sürelerini güncelleyin."
+msgstr "Muhasebeleştirilen mal kabullerinden parça tedarik sürelerini güncelleştir."
 
 msgid "Update Password"
 msgstr "Şifreyi Güncelle"
@@ -16651,34 +16651,34 @@ msgid "Variables"
 msgstr "Değişkenler"
 
 msgid "Variance"
-msgstr "Varyans"
+msgstr "Sapma"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "Gerçek ve standart BOM bileşen tüketimi arasındaki varyans"
+msgstr "Fiili ve standart BOM bileşen tüketimi arasındaki sapma"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "Gerçek ve standart yönlendirme saatleri ve oranları arasındaki varyans"
+msgstr "Fiili ve standart rota saatleri ve ücretleri arasındaki sapma"
 
 msgid "Variance between actual purchase price and standard cost"
-msgstr "Gerçek satın alma fiyatı ile standart maliyet arasındaki varyans"
+msgstr "Fiili satın alma fiyatı ve standart maliyet arasındaki sapma"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "Gerçek ve uygulanan imalat genel giderleri arasındaki varyans"
+msgstr "Uygulanan ve fiili üretim genel giderleri arasındaki sapma"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "Fiziksel envanter sayısı ayarlamalarından varyans"
+msgstr "Fiziksel envanter sayımı düzeltmelerinden kaynaklanan sapma"
 
 msgid "Variance in outside processing costs"
-msgstr "Dış işleme maliyetlerinde varyans"
+msgstr "Fason işlem maliyetlerinde sapma"
 
 msgid "Variance only"
-msgstr "Yalnızca fark"
+msgstr "Yalnızca sapma"
 
 msgid "VAT Number"
-msgstr "KDV Numarası"
+msgstr "Vergi numarası"
 
 msgid "Vendor Write-Off Income"
-msgstr "Satıcı Silme Geliri"
+msgstr "Tedarikçi Kayıttan Düşme Geliri"
 
 msgid "Verification Error"
 msgstr "Doğrulama Hatası"
@@ -16703,7 +16703,7 @@ msgstr "Sürüm"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "Sürüm {0} şu anda yayınlandı ve değiştirilecektir."
 
 msgid "Version:"
 msgstr "Sürüm:"
@@ -16721,7 +16721,7 @@ msgid "View"
 msgstr "Görüntüle"
 
 msgid "View Active Jobs"
-msgstr "Aktif İşleri Görüntüle"
+msgstr "Aktif İş emirlerini görüntüle"
 
 msgid "View Active Quotes"
 msgstr "Aktif Teklifleri Görüntüle"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "Varlığı Görüntüle"
 
 msgid "View Assigned Jobs"
-msgstr "Atanan Görevleri Görüntüle"
+msgstr "Atanmış İş emirlerini görüntüle"
 
 msgid "View Attachment"
 msgstr "Ek Dosya Görüntüle"
@@ -16748,7 +16748,7 @@ msgid "View Certificate"
 msgstr "Sertifikayı Görüntüle"
 
 msgid "View Contact"
-msgstr "İletişim Bilgilerini Görüntüle"
+msgstr "İlgili kişiyi görüntüle"
 
 msgid "View Contained Issues"
 msgstr "Kontrol Altına Alınan Sorunları Görüntüle"
@@ -16781,13 +16781,13 @@ msgid "View Item Master"
 msgstr "Ürün Ana Verisine Görüntüle"
 
 msgid "View Journal Entry"
-msgstr "Yevmiye Girişini Görüntüle"
+msgstr "Yevmiye kaydını görüntüle"
 
 msgid "View Lists"
 msgstr "Listeleri Görüntüle"
 
 msgid "View maintenance dispatch"
-msgstr "Bakım sevkıyatını görüntüle"
+msgstr "Bakım emrini görüntüle"
 
 msgid "View Memo"
 msgstr "Memo Görüntüle"
@@ -16823,7 +16823,7 @@ msgid "View Open RFQs"
 msgstr "Açık RFQ'ları Görüntüle"
 
 msgid "View Payables"
-msgstr "Ödenecek Hesapları Görüntüle"
+msgstr "Borçları görüntüle"
 
 msgid "View Payment"
 msgstr "Ödemeyi Görüntüle"
@@ -16838,7 +16838,7 @@ msgid "View Permissions"
 msgstr "İzinleri Görüntüle"
 
 msgid "View Picking List"
-msgstr "Seçilen Seçim Listesini Görüntüle"
+msgstr "Toplama listesini görüntüle"
 
 msgid "View Prints"
 msgstr "Yazdırılanları Görüntüle"
@@ -16847,7 +16847,7 @@ msgid "View Production Events"
 msgstr "Üretim Olaylarını Görüntüle"
 
 msgid "View Purchase Invoice"
-msgstr "Satın Alma Faturasını Görüntüle"
+msgstr "Alış faturasını görüntüle"
 
 msgid "View Reactive"
 msgstr "Reaktif Olarak Görüntüle"
@@ -16901,28 +16901,28 @@ msgid "Visible on a user's public profile"
 msgstr "Kullanıcının herkese açık profilinde görünür"
 
 msgid "Void"
-msgstr "İptal"
+msgstr "Hükümsüz kıl"
 
 msgid "Void Invoice"
-msgstr "Faturayı İptal Et"
+msgstr "Faturayı hükümsüz kıl"
 
 msgid "Void Purchase Invoice"
-msgstr "Satın Alma Faturasını İptal Et"
+msgstr "Alış faturasını hükümsüz kıl"
 
 msgid "Void Receipt"
-msgstr "Fişeyi İptal Et"
+msgstr "Mal kabulünü hükümsüz kıl"
 
 msgid "Void Sales Invoice"
-msgstr "Satış Faturasını İptal Et"
+msgstr "Satış faturasını hükümsüz kıl"
 
 msgid "Void Shipment"
-msgstr "Sevkiyatı İptal Et"
+msgstr "Sevkiyatı hükümsüz kıl"
 
 msgid "Voided"
-msgstr "İptal edilmiş"
+msgstr "Hükümsüz"
 
 msgid "Voiding this purchase invoice will:"
-msgstr "Bu satın alma faturasını geçersiz kılmak şunları yapacaktır:"
+msgstr "Bu alış faturasını hükümsüz kılmak şunları yapacaktır:"
 
 msgid "Voiding this receipt will:"
 msgstr "Bu fişin iptali şunları yapacaktır:"
@@ -16931,7 +16931,7 @@ msgid "Voiding this shipment will:"
 msgstr "Bu sevkiyatı geçersiz kılmak şunları yapacaktır:"
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "Her alanı şampiyon ile birlikte gözden geçirin ve kapsam dışında kalan her şeyi değiştirin. Kodlar Module.Area.Number biçiminde okunur (ACC.GL.01 = Accounting, General Ledger, item 1)."
+msgstr "Şampiyon ile her alanı gözden geçirin ve kapsam dışında kalan öğeleri seçin/seçimi kaldırın. Kodlar Modül.Alan.Numara olarak okunur (ACC.GL.01 = Muhasebe, Büyük defter, öğe 1)."
 
 msgid "Walk your current process, systems, and data"
 msgstr "Mevcut sürecinizi, sistemlerinizi ve verilerinizi gözden geçirin"
@@ -16988,13 +16988,13 @@ msgid "We've sent you a magic link to sign in to your account."
 msgstr "Hesabınıza giriş yapmak için size bir sihirli bağlantı gönderdik."
 
 msgid "Webhook"
-msgstr "Web Kancası"
+msgstr "Webhook"
 
 msgid "Webhook Body"
 msgstr "Webhook Gövdesi"
 
 msgid "Webhook Documentation"
-msgstr "Web Kancası Dokümantasyonu"
+msgstr "Webhook Belgeleri"
 
 msgid "Webhook Headers"
 msgstr "Webhook Başlıkları"
@@ -17003,7 +17003,7 @@ msgid "Webhook Method"
 msgstr "Webhook Yöntemi"
 
 msgid "Webhook URL"
-msgstr "Web kancası URL'si"
+msgstr "Webhook URL"
 
 msgid "Webhooks"
 msgstr "Webhook'lar"
@@ -17092,7 +17092,7 @@ msgid "What drove inventory up or down, by any dimension"
 msgstr "Envanterin yükselmesine veya düşmesine neyin sebep olduğu, herhangi bir boyuta göre"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "Kilitli bir dönemde günlüğe tarih atanırsa ne olur?"
+msgstr "Muhasebe fişi kilitli bir dönemde tarihlendirildiğinde ne olur?"
 
 msgid "What is {translatedTerm}?"
 msgstr "{translatedTerm} nedir?"
@@ -17104,10 +17104,10 @@ msgid "What kind of change this is: Version updates how the part is made, Revisi
 msgstr "Bu ne tür bir değişikliktir: Sürüm, parçanın nasıl yapıldığını günceller, Revizyon ayrıntılarını ve belgelerini revize eder, Yedek Parça, eskisinin yerini alan yeni bir parça numarasını değiştirir ve Yeni Parça, önceki parçası olmayan tamamen yeni bir parça sunar."
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
-msgstr "Bu giriş hangi tür çıktıyı kaydediyor — Üretim (iyi birimler), Hurda (kurtarılamaz) veya Yeniden İşlem (düzeltme için geri gönderilen); Hurda olduğunda Hurda Nedeni ortaya çıkar."
+msgstr "Bu kaydın ne tür çıktı kaydettiği — Üretim (iyi birimler), Fire (kurtarılamaz), veya Yeniden işleme (düzeltme için geri gönderilen); Fire seçildiğinde Fire nedenini gösterir."
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "Bu PO'nun türü — standart mallar, hizmetler, dış işleme veya genel uyum; satır düzenini ve GL deftere nakil kurallarını belirler."
+msgstr "Bu satın alma siparişinin tipi — standart mallar, hizmetler, fason işlem, veya sınırsız anlaşma; satır düzenini ve Büyük defter muhasebeleştirme kurallarını belirler."
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
 msgstr "Bu teklif türü nedir — standart tedarikçi teklifi, genel uyum fiyatlı teklif veya sözleşmeli üretim teklifi; dönüştürülürken PO satır düzenini belirler."
@@ -17131,7 +17131,7 @@ msgid "What this task means"
 msgstr "Bu görev ne anlama geliyor"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "Bu zaman girişi neyi sayar — İşçilik (operatör zamanı), Makine (çalışma zamanı) veya Kurulum (değişim zamanı); her biri farklı bir oran altında özetlenir."
+msgstr "Bu zaman girişinin neyi temsil ettiği — İşçilik (operatör zamanı), Makine (işleme süresi), veya Hazırlık (değişim zamanı); her biri farklı bir oran altında toplanır."
 
 msgid "What to set up"
 msgstr "Kurulacak şey"
@@ -17161,13 +17161,13 @@ msgid "When a serial or batch expires, and what happens if used after — a comp
 msgstr "Bir seri veya parti ne zaman süresinin dolduğu ve kullanıldığında ne olduğu — bir şirket politikası Uyar, Engelle veya EngellePrekesiyle yer alabilir."
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
-msgstr "Carbon'un malların gelmesini taahhüt ettiği zaman; gönderme yönteminin transit günleriyle birleştirilmiş, bu Gönderme Tarihi'nin geriye doğru hesaplanmasını sağlar."
+msgstr "Carbon'un malların teslim edilmesine taahhüt ettiği zaman; sevkiyat yönteminin transit günleriyle birleştirildiğinde, bu Sevk Tarihi'ni geriye doğru hesaplar."
 
 msgid "When expired stock is used"
 msgstr "Süresi dolmuş stok kullanıldığında"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "MRP yeni talep için halef kullandığında"
+msgstr "MRP'nin ardılı yeni talebe kullandığında"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "Etkinleştirildiğinde, bu kategorideki öznitelikler bir kişinin genel profilinde görünür; aksi takdirde yalnızca yöneticiler tarafından görülebilir."
@@ -17176,7 +17176,7 @@ msgid "When on, employees can edit this attribute's value on their own profile; 
 msgstr "Etkinleştirildiğinde, çalışanlar bu özniteliğin değerini kendi profillerinde düzenleyebilir; aksi takdirde yalnızca yöneticiler bunu yapabilir."
 
 msgid "When on, pricing rules (volume discounts, promotions) still apply on top of this override; when off, this override is the final price."
-msgstr "Etkinleştirildiğinde, fiyatlandırma kuralları (hacim indirimler, promosyonlar) hala bu geçersiz kılmanın üstüne uygulanır; devre dışı bırakıldığında, bu geçersiz kılma nihai fiyattır."
+msgstr "Açık olduğunda, fiyatlandırma kuralları (hacim indirimleri, promosyonlar) bu geçersiz kılmanın üstüne uygulanır; kapalı olduğunda, bu geçersiz kılma nihai fiyattır."
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
 msgstr "Etkinleştirildiğinde, bu işlemin işlem barkodunu taramak, kalan tüm açık miktarı bir işlemde tamamlandı olarak bildirir; operatörler düzenli olarak kısmiları bildirdiğinde devre dışı bırakın."
@@ -17194,19 +17194,19 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "Tedarikçi yanıtlarının ne zaman beklenmesi gerektiği; tedarikçiler RFQ portalında bu tarihi görür ve Carbon bundan sonra geç yanıtları kabul etmeyi durdurur (yapılandırılabilir)."
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "Alıcı malları istediğinde; tedarikçi Vaat Edilen Tarihte başka bir şey vaat edebilir ve Teslimat Tarihinde yeniden başka bir şey nakdeebilir."
+msgstr "Satın almacının malları istediği zaman; tedarikçi Taahhüt tarihinde başka bir şey taahhüt edebilir ve Teslim tarihinde yine başka bir şey muhasebeleştirebilir."
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "Alıcının bu satırın mallarını rihtımda ihtiyacı olduğu zaman; planlama bu tarihi stok mevcudiyeti ve dış işleme planlaması için kullanır."
+msgstr "Satın almacının bu satırın mallarına rampa üzerinde ihtiyaç duyduğu zaman; planlama bu tarihi stok uygunluğu ve fason işlem planlaması için kullanır."
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
-msgstr "Müşteri teslimi istediğinde; sipariş Vaat Edilen Tarihine bağlıdır, bu da farklı olabilir."
+msgstr "Müşterinin teslimat talebinde bulunduğu zaman; sipariş, farklı olabilecek Taahhüt tarihine bağlanır."
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "Müşteri malları ne zaman almak istediği; teklif müşteri kabul ederse bu tarihte taahhüt eder."
+msgstr "Müşterinin malları almak istediği zaman; teklif, müşteri kabul ettikten sonra bu tarihe bağlanır."
 
 msgid "When the customer asked to receive the goods."
-msgstr "Müşteri malları ne zaman almak istediği."
+msgstr "Müşterinin malları almak istediği zaman."
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "Müşteri bu RFQ'yu ne zaman gönderdi; yanıt saati bu tarihten başlar."
@@ -17221,7 +17221,7 @@ msgid "When the kanban card is scanned, the job is automatically moved out of dr
 msgstr "Kanban kartı tarandığında, iş otomatik olarak taslaktan çıkarılır ve yere yayınlanır."
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "Alıcı konum stoğun gelişini beklediğinde; hedefte MRP mevcudiyetini belirler."
+msgstr "Mal kabul lokasyonunun stokun teslim alınmasını beklediği zaman; varış yerinde MRP uygunluğunu belirler."
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "Tedarikçi teslim etmeyi ne zaman taahhüt etti; planlama bu tarihi gelen stok varışı tahmini için kullanır."
@@ -17239,10 +17239,10 @@ msgid "When this looks right, mark it agreed. That completes the Discovery step 
 msgstr "Bu doğru göründüğünde, kabul edildi olarak işaretleyin. Bu, komut merkezinizde Keşif adımını tamamlar."
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "Bu spesifik satırın gönderim için promise edildiği zaman; sipariş başlığının Vaat Edilen Tarihinin satır bazında geçersiz kılınması bölünmüş shipmentleri için."
+msgstr "Bu belirli satırın sevk edilmek üzere taahhüt edildiği zaman; bölünmüş sevkiyatlar için sipariş başlığının Taahhüt tarihinin satır başına geçersiz kılınması."
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "Bu spesifik lot/seri numarası ne zaman sona erdiği; FEFO seçimini ve tüketimde raf ömrü politikasını belirler."
+msgstr "Bu belirli lot'ün/seri numarasının süresi dolduğu zaman; FEFO toplamasını ve tüketim sırasında raf ömrü ilkesini belirler."
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "Teslim etmeyi taahhüt ettiğiniz zaman; planlama bunu karşılama için talep vadesi tarihi olarak değerlendirir."
@@ -17254,19 +17254,19 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "İş akışı bildiriminin nereye teslim edileceği — uygulama içi her zaman gönderilir, e-posta Business veya Partner planı gerektirir ve Slack, Slack çalışma alanınızın bağlı olması gerekir."
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "Bir operasyonun nerede çalıştırıldığı; işçilik ve teklif oranlarını taşır, genel giderler aralarındaki fark."
+msgstr "Operasyonun çalıştığı yer; işçilik ve teklif oranlarını taşır, genel üretim giderleri aralarındaki farktır."
 
 msgid "Where and how you make things."
 msgstr "Nerede ve nasıl şeyler yaparsınız."
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "Bu PO'daki mallar tedarikçi tarafından varsayılan olarak nereye gönderilir; PO'daki satır başına teslimat konumları bunu drop-ship ve bölünmüş teslim senaryoları için geçersiz kılar."
+msgstr "Bu satın alma siparişindeki mallar varsayılan olarak nereye sevk edilir; doğrudan sevkiyat ve bölünmüş teslimat senaryoları için satın alma siparişindeki satır başına teslimat lokasyonları bunu geçersiz kılar."
 
 msgid "Where it lives today"
 msgstr "Bugün nerede yaşıyor"
 
 msgid "Where new stock of this item lands by default on receipt; per-line storage selections on a receipt override it."
-msgstr "Bu öğenin yeni stoku varsayılan olarak alındığında nereye inerken; bir makbuzda satır başına depolama seçimleri onu geçersiz kılar."
+msgstr "Bu öğenin yeni stoğu varsayılan olarak mal kabul sırasında nereye iner; bir mal kabulde satır başına depolama seçimleri bunu geçersiz kılar."
 
 msgid "Where stock lives and how it ships."
 msgstr "Stokun nerede bulunduğu ve nasıl gönderildiği."
@@ -17275,7 +17275,7 @@ msgid "Where the affected items are used across the system. Informational — no
 msgstr "Etkilenen ürünlerin sistem genelinde nerede kullanıldığı. Bilgilendirici — burada hiçbir şey yayınlamayı engellemiyor."
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
-msgstr "Bu giriş nereden geldi (manuel giriş, satış/satın almadan deftere nakil, yinelenen şablon, vb.)."
+msgstr "Bu girişin nereden kaynaklandığı (manuel giriş, satıştan/satın almadan muhasebeleştirme, yinelenen şablon, vb.)."
 
 msgid "Where this issue was raised from — internal QA, customer complaint, supplier audit, etc.; used for reporting, doesn't gate workflow."
 msgstr "Bu sorun nereden gündeme geldi — dahili QA, müşteri şikayeti, tedarikçi denetimi, vb.; raporlama için kullanılır, iş akışını engellemiyor."
@@ -17284,7 +17284,7 @@ msgid "Where this line's goods land in stock on receipt; if blank, receipts use 
 msgstr "Bu satırın mallarının alındığında envanterde nereye indiği; boş ise, makbuzlar öğenin varsayılan depolama birimini kullanır."
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "Bu bakım isteği nereden kaynaklandı — operatör tarafından rapor edildi, zamanlandı, durum izleme tetiklemesi, iş sonrası teftiş; bakım raporlarında kaynak dökümünü belirler."
+msgstr "Bu bakım talebinin nereden kaynaklandığı — operatör tarafından bildirilen, planlanan, durum izlemesi tetiklemesi, işten sonraki muayene; bakım raporlarında kaynak dağılımını belirler."
 
 msgid "Where you are today"
 msgstr "Bugün nerede olduğunuz"
@@ -17296,28 +17296,28 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "Tutarın, satır fiyatının yüzdesi olarak mı yoksa sabit bir para birimi tutarı olarak mı yorumlanacağı."
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Carbon'ın her birimi (Serial), her lotu (Batch), miktarı (Inventory) mı izlediği yoksa izleme yapmadığı (Non-Inventory) mı."
+msgstr "Carbon'un takip şekli — her birim (Seri), her lot (Parti), miktar (Envanter), veya hiçbir takip (Stok dışı)"
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "Sayacın, seçilen süreç başladığında mı yoksa tamamlandığında mı başlayacağı."
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "Bu lotun/serinin muayeneyi geçip geçmediği (Pass) veya geçemediği (Fail); bir Fail, stoğun kullanılabilir envantere alınmasını engeller."
+msgstr "Bu lot'ün/seri numarasının muayeneden geçip geçmediği (Uygun) veya başarısız olup olmadığı (Uygun değil); Uygun değil stoğu mal kabulde kullanılabilir stoğa almayı engeller."
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "Bu işlemin dahili iş merkezlerinde (Proses, Montaj veya Muayene) mı yoksa dış tedarikçilerde (Dış İşleme) mi çalışıp çalışmadığı; farklı aşağı yönlü alanları ortaya koymakta, bu işlem için planlama rotalarının nasıl çalıştığını değiştirmekte ve yeni işlemlerde işlem türünü varsayılan olarak ayarlamaktadır."
+msgstr "Bu prosesin dahili iş merkezlerinde (Proses, Montaj, veya Muayene) veya dış tedarikçilerde (Fason işlem) çalışıp çalışmadığı; farklı aşağı akış alanlarını ortaya koyar, planlamanın bu proses için nasıl çalıştığını değiştirir ve yeni operasyonlarda operasyon tipini varsayılan ayarlar."
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "Bu işin üretimi bloklayıp (Aşağı), onu bozultuyor (Etki), planlanmış bir kapalı kalma penceresinde (Planlanmış) bulunuyor veya hiçbir üretim etkisi yok (Etki Yok); zamanlama ve müşteriye yönelik kapalı kalma iletişimini bilgilendirir."
+msgstr "Bu işin üretime engel olup olmadığı (Duruş), üretime zarar verip vermediği (Etki), planlanan duruş penceresinde olup olmadığı (Planlandı), veya üretim üzerinde hiçbir etkisi olmadığı (Etki yok); planlama ve müşteriye yönelik duruş iletişimini bilgilendirir."
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "Seçilen izinlerin her kullanıcının zaten sahip olduğu şeylerin üstüne Eklenip Eklenmediği veya her kullanıcının izin setinin aşağıda seçilen kişilerle değiştirilmesi suretiyle Güncelleştirilmesi."
 
 msgid "Which document drives each inspection flow for this item."
-msgstr "Bu öğe için her inceleme akışını hangi belge yönlendirir."
+msgstr "Bu öğe için hangi belgenin her muayene akışını yönettiği."
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "Hangi tür istek göndereceğini: GET bir şey okur, POST oluşturur, PUT ve PATCH günceller, DELETE kaldırır. Yeni bir adım GET'te başlar ve yalnızca POST, PUT ve PATCH gövde taşır."
+msgstr "Gönderilecek isteğin türü: GET bir şey okur, POST oluşturur, PUT ve PATCH güncelle, DELETE kaldırır. Yeni bir adım GET ile başlar ve sadece POST, PUT ve PATCH gövde taşırlar."
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "Hangi üretim olayı raf ömrü saatini başlatır — örneğin, doldurma, mühürleme veya nihai QC."
@@ -17338,22 +17338,22 @@ msgid "Who has to approve quotes, orders, and purchases — and when"
 msgstr "Teklifleri, siparişleri ve satın almaları kimin onaylaması gerektiği — ve ne zaman"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "Bakım ile ilgili sevkiyatlar için kim bildirim almalı?"
+msgstr "Bakım ile ilgili bakım emirleri için kimler bildirim almalıdır?"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "Operasyonlarla ilgili sevkiyatlar için kimler bildirim almalı?"
+msgstr "Operasyonlar ile ilgili bakım emirleri için kimler bildirim almalıdır?"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "Diğer sevkiyatlar için kim bildirim almalı?"
+msgstr "Diğer bakım emirleri için kimler bildirim almalıdır?"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "Kalite ile ilgili sevkiyatlar için kim bildirim almalı?"
+msgstr "Kalite ile ilgili bakım emirleri için kimler bildirim almalıdır?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
 msgstr "Dijital bir teklif kabul edildiğinde veya süresi dolduğunda kimler bildirim almalı?"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "Hangi durumlarda kalibrasyon dışı kalan bir ölçüm cihazı için bildirim almalı?"
+msgstr "Bir ölçüm aletinin kalibrasyon dışında olduğunda kimler bildirim almalıdır?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "Yeni bir öneri gönderildiğinde kimler bildirim almalı?"
@@ -17389,7 +17389,7 @@ msgid "Why is this locked?"
 msgstr "Bu neden kilitli?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "Stok neden değişiyor — Pozitif (bulundu), Negatif (kayıp/hurda) veya Ayarla (sayıyı ölçülen değerle değiştir)."
+msgstr "Stok neden değişiyor — Pozitif (bulundu), Negatif (kayboldu/Fire), veya Ayarla (sayıyı ölçülen bir değerle değiştirin)."
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "Bu satırın neden reddedildiği; yazdırılabilir teklifte gösterilir ve kazanç-kayıp raporlaması için kaydedilir."
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "Yarı Mamul"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "Çekme listesi olmadan, operatörler malzemeyi Tarama sekmesinden seçerler."
+msgstr "Toplama listesi olmadan, operatörler Tara sekmesinden malzemeyi toplarlar."
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17445,16 +17445,16 @@ msgid "Work Centers"
 msgstr "İş Merkezleri"
 
 msgid "Work in process (WIP)"
-msgstr "Devam Eden İş (WIP)"
+msgstr "Üretim'de çalışma (Yarı mamul)"
 
 msgid "Work in progress"
-msgstr "Devam eden işler"
+msgstr "Devam ediyor"
 
 msgid "Work in Progress (default)"
-msgstr "Devam Eden İş (varsayılan)"
+msgstr "Devam ediyor (varsayılan)"
 
 msgid "Work in Progress (WIP)"
-msgstr "Devam Eden İş (WIP)"
+msgstr "Devam ediyor (Yarı mamul)"
 
 msgid "Work instruction"
 msgstr "Çalışma talimatı"
@@ -17487,26 +17487,26 @@ msgid "Worst Performing Machines"
 msgstr "En kötü performans gösteren makineler"
 
 msgid "Write-Down Account"
-msgstr "Değer Düşüş Hesabı"
+msgstr "Değer Düşüklüğü Hesabı"
 
 msgid "Write-off"
-msgstr "Silme"
+msgstr "Kayıttan düşme"
 
 msgid "Write-Off"
-msgstr "Silme"
+msgstr "Kayıttan Düşme"
 
 msgid "Write-Off Account"
-msgstr "Silme Hesabı"
+msgstr "Kayıttan Düşme Hesabı"
 
 #. placeholder {0}: r.invoiceId
 msgid "Write-off for {0}"
-msgstr "{0} için silme"
+msgstr "{0} için kayıttan düşme"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "Muayene reddiyelerinden ve NCR (Uygunluk Dışı Raporları) kararlarıyla atılan veya iade edilen stokun silinmesi"
+msgstr "Muayene redleri ve NCR kararları yoluyla hurdaya çıkarılan veya iade edilen stoğun kayıttan düşmesi"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "Bir varlığın değerini faydalı kullanım süresi boyunca azaltma — oluşturduğunuz, taslak olarak gözden geçirdiğiniz ve deftere naklettiyiniz aylık batch."
+msgstr "Bir varlığın değerini yaşamı boyunca azaltma — her ay oluşturduğunuz, taslak olarak incelediğiniz ve sonra muhasebeleştirdiğiniz bir işlem."
 
 msgid "Year"
 msgstr "Yıl"
@@ -17557,20 +17557,20 @@ msgid "You do not have permission to edit workflows"
 msgstr "İş akışlarını düzenlemek için izniniz yok"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "Bu malzeme listesini düzenleme izniniz yok."
+msgstr "Bu malzeme listesini düzenlemek için izniniz yok"
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "Bu proses faturasını düzenlemek için izniniz yok."
+msgstr "Bu operasyon listesini düzenlemek için izniniz yok"
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "Siz yönetirsiniz; biz doğru yapıldığından emin oluruz. Kurulumunuz, verileriniz ve canlı yayına geçişiniz üzerinde uzman gözler."
+msgstr "Siz yönetirsiniz; biz sağlayalım ki her şey düzgün yapılsın. Sistem ayarları, veriler ve canlı geçişte uzman göz."
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
 msgstr "{0} satırı PDF'den çıkarıldı ancak hiçbir envanter öğesine eşlenmedi."
 
 msgid "You haven't created any contacts yet."
-msgstr "Henüz herhangi bir iletişim bilgisi oluşturmadınız."
+msgstr "Henüz hiç ilgili kişi oluşturmadınız."
 
 msgid "You lead"
 msgstr "Siz yönetiyorsunuz"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "Carbon'da canlısınız"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "Çalışma alanınıza bir adım uzaktasınız."
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "Carbon'ı kendiniz kendi hızınızda ayarlıyorsunuz"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"
+msgstr "{hoursElapsed} saattir işte idiniz. İş bitişini unuttunuz mu?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "Oturum açma bilgileriniz çalınsa bile hesabınız güvenli kalır"
@@ -17630,7 +17630,7 @@ msgid "your Implementation Lead"
 msgstr "sizin Uygulama Müdürünüz"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "Davetiyeniz geçersiz veya zaten kabul edilmiş. Bir hata olduğuna inanıyorsanız lütfen destekle iletişime geçin."
+msgstr "Davetiyeniz geçersiz veya zaten kabul edilmiş. Bunun bir hata olduğunu düşünüyorsanız lütfen destek ile iletişime geçin."
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "Buradaki işiniz: her satırın gerçek bir örneğini kontrol edin, ardından doğrulanmış olarak işaretleyin. Temel veriler önce yüklenir, ardından ana kayıtlar, ardından kesme noktasında açık işlemler."
@@ -17639,7 +17639,7 @@ msgid "Your legal name, addresses, branding, and document defaults"
 msgstr "Yasal adınız, adresler, marka kimliği ve belge varsayılanları"
 
 msgid "Your main point of contact"
-msgstr "Ana iletişim noktanız"
+msgstr "Temel iletişim kişiniz"
 
 msgid "Your Name"
 msgstr "Adınız"
@@ -17684,10 +17684,10 @@ msgid "yourself"
 msgstr "kendiniz"
 
 msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample sizes for the same lot."
-msgstr "Z1.4 muayene seviyesi (I / II / III); daha yüksek seviyeler aynı lot için daha büyük örnek boyutları anlamına gelir."
+msgstr "Z1.4 muayene seviyesi (I / II / III); daha yüksek seviyeler aynı lot için daha büyük örneklem büyüklüğü anlamına gelir."
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4 şiddeti (Normal / Sıklaştırılmış / Azaltılmış); son lot kabulü geçmişine göre kurala göre geçiş yapar."
+msgstr "Z1.4 şiddeti (Normal / Sıkılaştırılmış / Gevşetilmiş); kural tarafından son lot kabul geçmişine göre değişir."
 
 msgid "Zoom Box"
 msgstr "Yakınlaştırma Kutusu"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -304,7 +304,6 @@ msgstr "4s"
 
 msgid "5 user minimum"
 msgstr "5 kullanıcı minimum"
-msgstr "5 kullanıcı minimumu"
 
 msgid "5-8 weeks"
 msgstr "5-8 hafta"
@@ -362,7 +361,6 @@ msgstr "Taşeron, belirli yetkinliklere ve kullanılabilir saatlere sahip bir te
 
 msgid "A custom solution to meet your needs"
 msgstr "Sizin ihtiyaçlarınızı karşılamak için özel bir çözüm"
-msgstr "İhtiyaçlarınızı karşılamak için özel bir çözüm"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "Bir müşteri, parçalarınızı veya hizmetlerinizi satın alan bir işletme veya kişidir."
@@ -479,7 +477,6 @@ msgstr "Carbon'ın yönetilen bulut barındırılan sürümü"
 
 msgid "A managed version with all the advanced features"
 msgstr "Tüm gelişmiş özelliklerle yönetilen sürüm"
-msgstr "Carbon'un yönetilen bulut barındırmalı sürümü"
 
 msgid "A managed version with all the advanced features"
 msgstr "Tüm gelişmiş özellikleri içeren yönetilen bir sürüm"
@@ -1344,7 +1341,6 @@ msgstr "Tüm eylemler seçildi"
 
 msgid "All advanced features available"
 msgstr "Tüm gelişmiş özellikler kullanılabilir"
-msgstr "Tüm gelişmiş özellikler mevcut"
 
 msgid "All Audit Logs"
 msgstr "Tüm Denetim Günlükleri"
@@ -1620,7 +1616,6 @@ msgstr "Carbon verilerinize programatik erişim için API anahtarları."
 
 msgid "API, webhooks, and integrations"
 msgstr "API, webhook'lar ve entegrasyonlar"
-msgstr "API, web kancaları ve entegrasyonlar"
 
 msgid "Applied"
 msgstr "Uygulandı"
@@ -2317,7 +2312,6 @@ msgstr "Denetim günlüğü"
 
 msgid "Audit logging"
 msgstr "Denetim günlüğü tutma"
-msgstr "Denetim günlüğü"
 
 msgid "Audit Logging"
 msgstr "Denetim Kaydı Tutma"
@@ -2630,7 +2624,6 @@ msgstr "Kütüphaneyi göz at"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "Yayınlanan sürümü salt okunur şekilde inceleyin. Düzeni düzenlemek için adımları yine de yeniden düzenleyebilirsiniz."
-msgstr "Yayınlanan sürümü salt okunur olarak göz atın. Düzeni düzenlemek için adımları yeniden düzenleyebilirsiniz."
 
 msgid "Bucket"
 msgstr "Kova"
@@ -3543,7 +3536,6 @@ msgstr "İlgili kişi (İsteğe bağlı)"
 
 msgid "Contact us"
 msgstr "Bize ulaşın"
-msgstr "Bize başvurun"
 
 msgid "contacts"
 msgstr "İlgili kişiler"
@@ -6995,7 +6987,6 @@ msgstr "Biçim"
 
 msgid "Forward deployed engineer"
 msgstr "Sahadaki mühendis"
-msgstr "Ön konuşlandırılmış mühendis"
 
 msgid "Foundation"
 msgstr "Temel"
@@ -7052,7 +7043,6 @@ msgstr "Tam adı"
 
 msgid "Full setup and migrations"
 msgstr "Tam kurulum ve göçler"
-msgstr "Tam kurulum ve geçişler"
 
 msgid "Fully Depreciated"
 msgstr "Amortismanı tamamlanmış"
@@ -8150,7 +8140,6 @@ msgstr "Sorunlar"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Yeniden bir sürüm yayınlayana kadar çalışmayı durdurur. Hiçbir şey silinmez."
-msgstr "Yeniden bir sürüm yayınlayana kadar çalışmayı durduracak. Hiçbir şey silinmez."
 
 msgid "ITAR Certifications"
 msgstr "ITAR Sertifikaları"
@@ -8522,7 +8511,6 @@ msgstr "Daha az manuel çalışma, daha az hata"
 
 msgid "Let's Build"
 msgstr "Üretelim"
-msgstr "Haydi Oluşturalım"
 
 msgid "Let's build something"
 msgstr "Bir şeyler inşa edelim"
@@ -12677,7 +12665,6 @@ msgstr "Bu faturadaki herhangi bir kalem defteri girişini tersine çevirir"
 
 msgid "Reverse charge"
 msgstr "Ters kayıt"
-msgstr "Ters ücret"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "Ters yükleme satış vergisi"
@@ -13496,7 +13483,6 @@ msgstr "Kendi Yönettiği"
 
 msgid "Self-hosted or managed"
 msgstr "Kendi barındırılan veya yönetilen"
-msgstr "Kendi barındırmalı veya yönetilen"
 
 msgid "Self-onboarding"
 msgstr "Kendi kendine katılım"
@@ -13922,7 +13908,6 @@ msgstr "Bu kural başarısız olduğunda kullanıcıya gösterilir."
 
 msgid "Sign in to Carbon"
 msgstr "Carbon'a giriş yapın"
-msgstr "Carbon'da oturum açın"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
 msgstr "Sihirli bağlantı yerine biyometrik kimlik doğrulama ile oturum açın. Geçiş Anahtarları Face ID, Touch ID veya cihaz PIN'iniz tarafından korunur."
@@ -14351,7 +14336,6 @@ msgstr "Stripe faturayı müşteriye e-posta ile gönderir, bu nedenle bir adres
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Bu Carbon müşterisi için Stripe'da henüz müşteri yok. Muhasebeleştirme, bağlı hesabınızda bir tane oluşturacak."
-msgstr "Stripe'da zaten bu e-postaya sahip bir müşteri var"
 
 msgid "Stripe Due Date"
 msgstr "Stripe Son Tarihi"
@@ -14776,7 +14760,6 @@ msgstr "Vergi Amortisman Yöntemi"
 
 msgid "Tax exempt"
 msgstr "vergiden muaf"
-msgstr "Vergi muafiyeti"
 
 msgid "Tax Exempt"
 msgstr "Vergi Muaf"
@@ -15671,7 +15654,6 @@ msgstr "Bu fatura, Stripe için kullanılabilir bir son tarih içermiyor — lü
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Bu fatura, bu Carbon müşterisine zaten bağlı olan Stripe müşterisine faturalandırılacaktır. Ayrıntılarını değiştirmek için Stripe panosunda düzenleyin."
-msgstr "Bu faturanın kullanılabilir bir vade tarihi yok — Stripe için birini seçin."
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "Bu fatura, zaten bu Carbon müşterisine bağlı olan Stripe müşterisine faturalanacak. Ayrıntılarını değiştirmek için Stripe panosunda düzenleyin."
@@ -16364,7 +16346,6 @@ msgstr "Sınırsız işlevsel destek"
 
 msgid "Unlimited records"
 msgstr "Sınırsız kayıt"
-msgstr "Sınırsız kayıtlar"
 
 msgid "Unlink"
 msgstr "Bağlantısını Kes"
@@ -16410,7 +16391,6 @@ msgstr "Yayını kaldır"
 
 msgid "Unpublish {name}?"
 msgstr "Yayını {name} için kaldır?"
-msgstr "Yayınlamayı Kaldır"
 
 msgid "Unpublish {name}?"
 msgstr "{name} yayınlaması kaldırılsın mı?"
@@ -16775,7 +16755,6 @@ msgstr "Sürüm"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "Sürüm {0} şu anda yayınlandı ve değiştirilecektir."
-msgstr "Sürüm {0} şu anda yayınlandı ve değiştirilecek."
 
 msgid "Version:"
 msgstr "Sürüm:"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -3588,7 +3588,7 @@ msgid "Control how operators pick material and track time on the shop floor."
 msgstr "Operatörlerin malzeme nasıl seçtiğini ve atölye katında zamanı nasıl takip ettiğini kontrol edin."
 
 msgid "Control whether item IDs (parts, materials, consumables, tools, and services) may contain lowercase characters."
-msgstr "Ürün kimliklerinin (parçalar, malzemeler, tüketilebilir ürünler, araçlar ve hizmetler) küçük harf karakterler içerebilir olup olmadığını kontrol edin."
+msgstr "Stok kartı ID'lerinin (parçalar, malzeme, sarf malzemeleri, takımlar ve hizmetler) küçük harf içerebilmesini kontrol edin."
 
 msgid "Controller, Accountant"
 msgstr "Kontrolör, Muhasebeci"
@@ -8935,7 +8935,7 @@ msgid "Map Lines Now"
 msgstr "Satırları Şimdi Eşle"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "Muhasebe planınızı sağlayıcıya eşleştirin. Deftere Nakil-varsayılan ve gider hesapları Gerekli olarak işaretlenmiştir; deftere nakledilen günlükler eşleştirilen sağlayıcı hesap kodunu kullanarak gönderilir."
+msgstr "Hesap planınızı sağlayıcıya eşleyin. Muhasebeleştirme varsayılanı ve gider hesapları Gerekli olarak işaretlenmiştir; muhasebeleştirilmiş muhasebe fişleri eşlenen sağlayıcı hesap kodunu kullanarak itilir."
 
 msgid "Map your current process, systems, and data"
 msgstr "Mevcut sürecinizi, sistemlerinizi ve verilerinizi eşleyin"
@@ -14344,23 +14344,23 @@ msgid "Stripe already has a customer with this email"
 msgstr "Stripe'ın zaten bu e-postaya sahip bir müşterisi var"
 
 msgid "Stripe Due Date"
-msgstr "Stripe Son tarihi"
+msgstr "Stripe Son Tarihi"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe faturayı müşteriye e-posta ile gönderir, bu nedenle bir adres gereklidir. Bu, Carbon'daki ilgili kişiye de kaydedilecektir."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe'ın bu Carbon müşterisi için henüz bir müşterisi yok. Muhasebeleştirme, bağlı hesabınızda bir tane oluşturacaktır."
+msgstr "Bu Carbon müşterisi için Stripe'da henüz müşteri yok. Muhasebeleştirme, bağlı hesabınızda bir tane oluşturacak."
 msgstr "Stripe'da zaten bu e-postaya sahip bir müşteri var"
 
 msgid "Stripe Due Date"
-msgstr "Stripe Vade Tarihi"
+msgstr "Stripe Son Tarihi"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
 msgstr "Stripe faturayı müşteriye e-postayla gönderir, bu nedenle bir adres gereklidir. Bu, Carbon'daki ilgili kişiye de kaydedilecek."
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe'da henüz bu Carbon müşterisi için bir müşteri yok. Gönderme, bağlı hesabınızda bir tane oluşturacak."
+msgstr "Bu Carbon müşterisi için Stripe'da henüz müşteri yok. Muhasebeleştirme, bağlı hesabınızda bir tane oluşturacak."
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "Kanban tablosunda gösterilecek kanban çıktısı stili"

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -44,7 +44,7 @@ msgstr "{0} adet tamamlandı"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr "{0} sırada bekleniyor"
+msgstr "{0} kuyrukta"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
@@ -55,7 +55,7 @@ msgid "{0} Scrapped"
 msgstr "{0} Hurdaya Çıkarılmış"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} geçen birim(ler) tamamlanacaktır."
+msgstr "{completions} geçti birim(ler) tamamlanacak."
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
 msgstr "{fails} örnek hata(ları) kaydedildi ve tamamlanmayacak — bunları işlemler menüsünden çözün."
@@ -115,7 +115,7 @@ msgid "All rework"
 msgstr "Tümünü yeniden işle"
 
 msgid "All scrap"
-msgstr "Tümünü hurdaya çıkar"
+msgstr "Hepsi fire"
 
 msgid "Allocate failed units"
 msgstr "Başarısız birimleri tahsis et"
@@ -130,7 +130,7 @@ msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "Bu zaman kartını silmek istediğinizden emin misiniz? Bu geri alınamaz."
 
 msgid "Are you sure you want to end all production events? This will end all active operations without completing or finishing them."
-msgstr "Tüm üretim etkinliklerini sonlandırmak istediğinizden emin misiniz? Bu, tüm aktif operasyonları tamamlamadan veya bitirmeden sonlandıracaktır."
+msgstr "Tüm üretim olaylarını sonlandırmak istediğinizden emin misiniz? Bu, tüm etkin operasyonları tamamlamadan veya bitirmeden sonlandıracaktır."
 
 msgid "Are you sure you want to finish this operation? This will end all active production events for this operation."
 msgstr "Bu işlemi bitirmek istediğinizden emin misiniz? Bu, bu işlem için tüm aktif üretim olaylarını sonlandıracaktır."
@@ -151,16 +151,16 @@ msgid "Authentication Error"
 msgstr "Kimlik Doğrulama Hatası"
 
 msgid "available"
-msgstr "mevcut"
+msgstr "kullanılabilir"
 
 msgid "Available"
-msgstr "Mevcut"
+msgstr "Kullanılabilir"
 
 msgid "Batch"
 msgstr "Parti"
 
 msgid "Batch is not available"
-msgstr "Parti bulunamadı"
+msgstr "Parti kullanılabilir değil"
 
 #. placeholder {0}: index + 1
 msgid "Batch Number {0}"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "Aramayı Temizle"
 
 msgid "Clock In"
-msgstr "Giriş Yap"
+msgstr "İş başlangıcı"
 
 msgid "Clock Out"
-msgstr "Çıkış Yap"
+msgstr "İş bitişi"
 
 msgid "Clocked in since <0/>"
 msgstr "<0/>'den beri kaydedilmiş"
@@ -278,7 +278,7 @@ msgid "Consumed"
 msgstr "Tüketildi"
 
 msgid "Consumed expired"
-msgstr "Tüketilmiş süre dolmuş"
+msgstr "Tüketildi süresi doldu"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "Detaylar"
 
 msgid "Dispatch not found"
-msgstr "Görevlendirme bulunamadı"
+msgstr "Bakım emri bulunamadı"
 
 msgid "Display"
 msgstr "Görüntüleme"
@@ -398,10 +398,10 @@ msgid "Due today?"
 msgstr "Bugün vade bitecek mi?"
 
 msgid "Duplicate batch number"
-msgstr "Tekrarlanan parti numarası"
+msgstr "Çoğaltılmış parti numarası"
 
 msgid "Duplicate serial number"
-msgstr "Tekrarlanan seri numarası"
+msgstr "Çoğaltılmış seri numarası"
 
 msgid "Duration"
 msgstr "Süre"
@@ -444,11 +444,11 @@ msgid "Expand features table"
 msgstr "Özellikler tablosunu genişlet"
 
 msgid "Expired"
-msgstr "Süresi Dolmuş"
+msgstr "Süresi doldu"
 
 #. placeholder {0}: formatDate(date)
 msgid "Expired {0}"
-msgstr "Süresi dolmuş {0}"
+msgstr "Süresi {0} doldu"
 
 msgid "Expires <0/>"
 msgstr "Süresi doluyor <0/>"
@@ -463,10 +463,10 @@ msgid "Failed features"
 msgstr "Başarısız özellikler"
 
 msgid "Failed to complete inventory adjustment"
-msgstr "Envanter ayarlaması tamamlanamadı"
+msgstr "Stok düzeltme tamamlanamadı"
 
 msgid "Failed to end operations"
-msgstr "İşlemler sonlandırılamadı"
+msgstr "Operasyonlar sonlandırılamadı"
 
 msgid "Failed to fetch active operations"
 msgstr "Aktif operasyonlar alınamadı"
@@ -519,19 +519,19 @@ msgid "Finish Anyways"
 msgstr "Yine de Bitir"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "Hesabınızı ayarlamayı tamamlayın"
 
 msgid "Finish with material unpicked?"
 msgstr "Malzeme seçilmeden bitir?"
 
 msgid "Forgot to Clock Out?"
-msgstr "Çıkış yapmayı unuttunuz mu?"
+msgstr "İş bitişini unutmuş musunuz?"
 
 msgid "Go back to operation"
 msgstr "İşleme geri dön"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "Başlangıç adımına git"
 
 msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane alındı?"
@@ -577,10 +577,10 @@ msgid "Insufficient quantity"
 msgstr "Yetersiz miktar"
 
 msgid "Inventory adjustment completed"
-msgstr "Stok ayarlaması tamamlandı"
+msgstr "Stok düzeltme tamamlandı"
 
 msgid "Inventory Adjustments"
-msgstr "Stok Ayarlamaları"
+msgstr "Stok düzeltmeleri"
 
 msgid "is"
 msgstr "eşittir"
@@ -616,19 +616,19 @@ msgid "Job Details"
 msgstr "İş Detayları"
 
 msgid "Job Traveler"
-msgstr "İş Seyir Belgesi"
+msgstr "İş emri takip kartı"
 
 msgid "Jobs"
-msgstr "İşler"
+msgstr "İş emirleri"
 
 msgid "Keep picking"
-msgstr "Seçmeye devam et"
+msgstr "Toplamaya devam et"
 
 msgid "Kit"
 msgstr "Set"
 
 msgid "Labor"
-msgstr "İşgücü"
+msgstr "İşçilik"
 
 msgid "Last completed"
 msgstr "Son olarak tamamlanan"
@@ -672,14 +672,14 @@ msgstr "Yeniden İşlem Kaydet"
 
 #. placeholder {0}: operation.itemReadableId
 msgid "Log rework for {0}"
-msgstr "Rework için kayıt yap {0}"
+msgstr "{0} için yeniden işleme kaydı"
 
 msgid "Log Scrap"
-msgstr "Hurdayı Kaydet"
+msgstr "Fire kaydı"
 
 #. placeholder {0}: operation.itemReadableId
 msgid "Log scrap for {0}"
-msgstr "Hata için kayıt yap {0}"
+msgstr "{0} için fire kaydı"
 
 msgid "Login"
 msgstr "Giriş Yap"
@@ -700,7 +700,7 @@ msgid "Maintenance Completed"
 msgstr "Bakım Tamamlandı"
 
 msgid "Maintenance overdue"
-msgstr "Bakım vadesi geçmiş"
+msgstr "Bakım gecikmiş"
 
 msgid "Make a replacement"
 msgstr "Bir yedek oluştur"
@@ -709,7 +709,7 @@ msgid "Manually add items to inventory"
 msgstr "Envantere öğeler eklemek için manuel olarak"
 
 msgid "Manually remove items from inventory"
-msgstr "Envanterden öğeleri manuel olarak çıkarın"
+msgstr "Envanterden stok kartlarını manuel kaldır"
 
 msgid "Mark Short"
 msgstr "Kısa Teslim Et"
@@ -776,10 +776,10 @@ msgid "No active job at this work center"
 msgstr "Bu iş merkezinde etkin iş yok"
 
 msgid "No active maintenance dispatches"
-msgstr "Aktif bakım sevkıyatı bulunmamaktadır"
+msgstr "Etkin bakım emri yok"
 
 msgid "No active operations"
-msgstr "Aktif işlem yok"
+msgstr "Etkin operasyon yok"
 
 msgid "No active work centers at this location."
 msgstr "Bu konumda etkin iş merkezi yok."
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "Kullanılabilir izlenen varlık bulunamadı"
 
 msgid "No dispatches assigned to you"
-msgstr "Sizeplanlar size atanmadı"
+msgstr "Size atanmış bakım emri yok"
 
 msgid "No files"
 msgstr "Dosya yok"
@@ -818,7 +818,7 @@ msgid "No materials"
 msgstr "Malzeme yok"
 
 msgid "No open jobs"
-msgstr "Açık iş yok"
+msgstr "Açık iş emri yok"
 
 msgid "No open units to allocate"
 msgstr "Tahsis edilecek açık birim yok"
@@ -839,7 +839,7 @@ msgid "No printer configured"
 msgstr "Yazıcı yapılandırılmadı"
 
 msgid "No recent operations"
-msgstr "Son yakın işlemler yok"
+msgstr "Son operasyon yok"
 
 msgid "No remaining entities to inspect."
 msgstr "İncelenecek kalan varlık yok."
@@ -899,20 +899,20 @@ msgid "Nothing scheduled at this work center"
 msgstr "Bu iş merkezinde hiçbir şey planlanmadı"
 
 msgid "Nothing to scrap"
-msgstr "Atılacak hiçbir şey yok"
+msgstr "Fire edilecek birşey yok"
 
 msgid "OEE Impact"
 msgstr "OEE Etkisi"
 
 msgid "OEM Required"
-msgstr "Üretici Tarafından Gerekiyor"
+msgstr "OEM Gerekli"
 
 msgid "Oldest first"
 msgstr "En eski önce"
 
 #. placeholder {0}: batch.quantity
 msgid "Only {0} available"
-msgstr "Yalnızca {0} adet mevcut"
+msgstr "Sadece {0} kullanılabilir"
 
 msgid "Oops. You shouldn't see this page. Eventually it will be a landing page."
 msgstr "Üzgünüz. Bu sayfayı görmemelisiniz. Sonunda bir açılış sayfası olacak."
@@ -927,13 +927,13 @@ msgid "Open an NCR for MRB disposition"
 msgstr "MRB kararı için NCR aç"
 
 msgid "Open Jobs"
-msgstr "Açık İşler"
+msgstr "Açık İş emirleri"
 
 msgid "Operations"
 msgstr "Operasyonlar"
 
 msgid "Operations ended"
-msgstr "İşlemler sonlandırıldı"
+msgstr "Operasyonlar bitti"
 
 msgid "Operator"
 msgstr "Operatör"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "Genel sonuç"
 
 msgid "Overdue PMs?"
-msgstr "Vadesi geçmiş PM'ler?"
+msgstr "Gecikmiş PM'ler?"
 
 msgid "Parameters"
 msgstr "Parametreler"
@@ -963,13 +963,13 @@ msgid "Partial"
 msgstr "Kısmi"
 
 msgid "Partial Disposition"
-msgstr "Kısmi Disposition"
+msgstr "Kısmi Karar"
 
 msgid "Passed Inspection"
-msgstr "Kontrolden Geçti"
+msgstr "Muayenede Geçti"
 
 msgid "Passkey unlock failed"
-msgstr "Parola anahtarı kilidini açma başarısız oldu"
+msgstr "Geçiş anahtarı ile açma başarısız"
 
 msgid "Pause"
 msgstr "Duraklat"
@@ -993,7 +993,7 @@ msgid "Picked up Column {0} at position: {1} of {2}"
 msgstr "Sütun {0} alındı, konumu: {1} / {2}"
 
 msgid "Picking"
-msgstr "Seçim"
+msgstr "Toplama"
 
 msgid "Pin Out"
 msgstr "Çıkış Yap"
@@ -1087,7 +1087,7 @@ msgid "Remove filter"
 msgstr "Filtreyi kaldır"
 
 msgid "Remove Inventory"
-msgstr "Stoktan Çıkar"
+msgstr "Envanter Kaldır"
 
 msgid "Remove part"
 msgstr "Parçayı kaldır"
@@ -1099,7 +1099,7 @@ msgid "Result"
 msgstr "Sonuç"
 
 msgid "Rework"
-msgstr "Revizyon"
+msgstr "Yeniden işleme"
 
 msgid "Rework created successfully"
 msgstr "Yeniden işleme başarıyla oluşturuldu"
@@ -1141,19 +1141,19 @@ msgid "Schedule"
 msgstr "Planlama"
 
 msgid "Scrap"
-msgstr "Hurda"
+msgstr "Fire"
 
 msgid "Scrap {readableId}"
-msgstr "Hurdala {readableId}"
+msgstr "Fire {readableId}"
 
 msgid "Scrap material"
-msgstr "Malzeme hurdası"
+msgstr "Fire malzemesi"
 
 msgid "Scrap quantity"
-msgstr "Hurda miktarı"
+msgstr "Fire miktarı"
 
 msgid "Scrap Reason"
-msgstr "Hurda Nedeni"
+msgstr "Fire nedeni"
 
 msgid "Scrapped"
 msgstr "Hurdaya Ayrılan"
@@ -1186,7 +1186,7 @@ msgid "Select a rework quantity"
 msgstr "Bir yeniden işleme miktarı seçin"
 
 msgid "Select a scrap quantity and reason"
-msgstr "Bir hurda miktarı ve nedeni seçin"
+msgstr "Fire miktarı ve nedeni seçin"
 
 msgid "Select a serial number to continue with this operation"
 msgstr "Bu işlemle devam etmek için bir seri numarası seçin"
@@ -1215,7 +1215,7 @@ msgid "Select Serial Number"
 msgstr "Seri Numarası Seçin"
 
 msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
-msgstr "Geri dönülecek işlemi seçin. O noktadan mevcut işleme kadar olan tüm işlemler yeniden yapılacaktır."
+msgstr "Geri dönülecek operasyonu seçin. O noktadan geçerli operasyona kadar tüm operasyonlar yeniden yapılacaktır."
 
 msgid "Selected"
 msgstr "Seçildi"
@@ -1234,7 +1234,7 @@ msgid "Serial Number {0}"
 msgstr "Seri Numarası {0}"
 
 msgid "Serial number is not available"
-msgstr "Seri numarası mevcut değil"
+msgstr "Seri numarası kullanılabilir değildir"
 
 msgid "Serial number is required"
 msgstr "Seri numarası gereklidir"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "Oturum kilitlendi"
 
 msgid "Set Clock Out"
-msgstr "Çıkış Yap"
+msgstr "İş bitişini ayarla"
 
 msgid "Set clock-out time"
 msgstr "Çıkış zamanını ayarla"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "Outlook ile giriş yap"
 
 msgid "Sign in with Passkey"
-msgstr "Passkey ile Giriş Yap"
+msgstr "Geçiş anahtarı ile oturum aç"
 
 msgid "Sign out"
 msgstr "Oturumu kapat"
@@ -1316,7 +1316,7 @@ msgstr "İstasyon: {stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "İstatistiksel kabul başarısız oldu, bu nedenle {0} birimlik tüm lot uygunsuz olarak kabul edilir (ISO 9001:2015 §8.7) — {passes} örnek geçti ve {fails} hata(lar). Aşağıdaki birimleri hurda veya yeniden işlemeye yönlendirin veya yalnızca kararı kaydedin."
+msgstr "İstatistiksel kabul başarısız oldu, bu nedenle {0} lot'unun tamamı uygun olmayan olarak kabul edilir (ISO 9001:2015 §8.7) — {passes} uygun örnek ve {fails} başarısız. Aşağıdaki birimleri fire veya yeniden işlemeye yönlendirin, ya da sadece kararı kaydedin."
 
 msgid "Status"
 msgstr "Durum"
@@ -1355,13 +1355,13 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "Bu işlem için tamamlanan miktar, gerekli miktar olan {targetQuantity}'dan azdır."
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "Lot Passed olarak işaretlenecek ve {remaining} kalan birim(ler) bu operasyonda tamamlanacaktır."
+msgstr "Lot Geçti olarak işaretlenecek ve {remaining} kalan birim bu operasyonda tamamlanacak."
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "Lot yine de işleme tabi tutulacak, ancak en az bir Sorun Türü yapılandırılana kadar bir NCR oluşturulamaz."
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "Bu malzeme için mevcut veya tüketilmiş izlenen parça bulunmamaktadır."
+msgstr "Bu malzeme için hiçbir kullanılabilir veya tüketilmiş izlenmiş parça yoktur."
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
 msgstr "Malzeme listesindeki seri veya parti takipli malzemeler tam olarak verilmemiş. Vermeden tamamlamak, yanlış izlenebilirlik kayıtlarına neden olabilir."
@@ -1370,13 +1370,13 @@ msgid "These items still have material to pick. Finishing now marks the list Par
 msgstr "Bu öğelerin hala seçilecek malzemesi var. Şimdi bitirmek listeyi Kısmi olarak işaretler."
 
 msgid "This lot is expired and can't be picked."
-msgstr "Bu parti süresi dolmuş ve alınamaz."
+msgstr "Bu lot süresi dolmuştur ve toplanamaz."
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
 msgstr "Bu parça siparişe göre yapılmıştır. Hurdalaması, bir yedek yapmak için rotasını yeniden açabilir."
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "Bu parça stoktan hurdaya çıkarılacaktır. Gereksinimleri açık kalır, böylece bir yedek çıkarabilirsiniz."
+msgstr "Bu parça stoktan fire olacaktır. Gereksinimli açık kalacak, böylece yedek talep edebilirsiniz."
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "Bu birim kalıcı olarak hurdaya çıkarılacak ve yedek bir seri numarası oluşturulacaktır."
@@ -1436,7 +1436,7 @@ msgid "Unlock"
 msgstr "Kilit aç"
 
 msgid "Unlock with passkey"
-msgstr "Parola anahtarı ile kilit aç"
+msgstr "Geçiş anahtarı ile açın"
 
 msgid "Unpick"
 msgstr "Çıkart"
@@ -1446,7 +1446,7 @@ msgid "Unpick {0}"
 msgstr "Çıkart {0}"
 
 msgid "Unplanned downtime"
-msgstr "Planlanmamış kesinti"
+msgstr "Planlanmamış Duruş"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
@@ -1459,7 +1459,7 @@ msgid "Up next"
 msgstr "Sırada"
 
 msgid "Up to {maxAllocatable} unit(s) can be allocated; the rest is recorded without a posting."
-msgstr "En fazla {maxAllocatable} birim ayrılabilir; geri kalanı deftere kaydedilmeden kaydedilir."
+msgstr "En fazla {maxAllocatable} adet tahsis edilebilir; geri kalanı muhasebeleştirme olmadan kaydedilir."
 
 msgid "Update"
 msgstr "Güncelle"
@@ -1486,7 +1486,7 @@ msgid "Verify"
 msgstr "Doğrula"
 
 msgid "View maintenance dispatch"
-msgstr "Bakım sevkıyatını görüntüle"
+msgstr "Bakım emrini Görüntüle"
 
 msgid "We've sent you a magic link to sign in to your account."
 msgstr "Hesabınıza giriş yapmak için size bir sihirli bağlantı gönderdik."
@@ -1510,10 +1510,10 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "Saat <0/>'te kaydedildiniz. Aşağıda çıkış saatinizi düzenleyebilir veya hala çalışmakta olduğunuzu onaylayabilirsiniz."
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "Ne kadar süredir giriş yaptınız? Çıkış yapmayı unuttunuz mu?"
+msgstr "{hoursElapsed} saattir zaman kaydı yapıyorsunuz. İş bitişini yapmayı unuttunuz mu?"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "Hesabınız henüz bir şirkete ait değildir. Devam etmek için Carbon ERP'de yerleşimi tamamlayın."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Kuruluşunuz bir kimlik doğrulama uygulaması gerektirir. Bunu Carbon'da ayarlayın, ardından buraya geri dönün."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -520,7 +520,6 @@ msgstr "Yine de Bitir"
 
 msgid "Finish setting up your account"
 msgstr "Hesabınızı ayarlamayı tamamlayın"
-msgstr "Hesabınızı kurulumunu tamamlayın"
 
 msgid "Finish with material unpicked?"
 msgstr "Malzeme seçilmeden bitir?"
@@ -533,7 +532,6 @@ msgstr "İşleme geri dön"
 
 msgid "Go to onboarding"
 msgstr "Başlangıç adımına git"
-msgstr "Onboarding'e git"
 
 msgid "How many were actually picked?"
 msgstr "Gerçekte kaç tane alındı?"
@@ -1516,7 +1514,6 @@ msgstr "{hoursElapsed} saattir zaman kaydı yapıyorsunuz. İş bitişini yapmay
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "Hesabınız henüz bir şirkete ait değildir. Devam etmek için Carbon ERP'de yerleşimi tamamlayın."
-msgstr "Hesabınız henüz bir şirkete ait değil. Devam etmek için Carbon ERP'de onboarding'i tamamlayın."
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "Kuruluşunuz bir kimlik doğrulama uygulaması gerektirir. Bunu Carbon'da ayarlayın, ardından buraya geri dönün."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -170,7 +170,6 @@ msgstr "第{from}–{to}个工序（共{count}个）"
 
 msgid "{hiddenCount} more: {hiddenNames}"
 msgstr "还有{hiddenCount}个：{hiddenNames}"
-msgstr "{hiddenCount} 更多: {hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
@@ -305,7 +304,6 @@ msgstr "4小时"
 
 msgid "5 user minimum"
 msgstr "最少需要5个用户"
-msgstr "5 个用户最少"
 
 msgid "5-8 weeks"
 msgstr "5-8 周"
@@ -363,7 +361,6 @@ msgstr "外协人员是具有特定技能和可用工时的供应商联系人。
 
 msgid "A custom solution to meet your needs"
 msgstr "满足您需求的定制解决方案"
-msgstr "满足您需求的自定义解决方案"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "客户是购买您的零件或服务的企业或个人。"
@@ -477,7 +474,6 @@ msgstr "一个按订单生产的组件，其零件一起领用到父工单中—
 
 msgid "A managed cloud-hosted version of Carbon"
 msgstr "Carbon 的托管云版本"
-msgstr "Carbon 的托管云托管版本"
 
 msgid "A managed version with all the advanced features"
 msgstr "具有所有高级功能的托管版本"
@@ -505,7 +501,6 @@ msgstr "将使用当前尺寸的副本创建新尺寸"
 
 msgid "A new Stripe customer will be created"
 msgstr "将创建新的 Stripe 客户"
-msgstr "将创建一个新的 Stripe 客户"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
 msgstr "一份非现金文件，根据原因账户结算发票：贷方降低欠额，借方提高欠额。"
@@ -1615,7 +1610,6 @@ msgstr "API密钥用于以编程方式访问您的Carbon数据。"
 
 msgid "API, webhooks, and integrations"
 msgstr "API、Webhook 和集成"
-msgstr "API、webhooks 和集成"
 
 msgid "Applied"
 msgstr "已应用"
@@ -2484,7 +2478,6 @@ msgstr "基础价格"
 
 msgid "Basic ERP, MES, and QMS functionality"
 msgstr "基本的 ERP、MES 和 QMS 功能"
-msgstr "基本 ERP、MES 和 QMS 功能"
 
 msgid "Basic Information"
 msgstr "基本信息"
@@ -2625,7 +2618,6 @@ msgstr "浏览库"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
 msgstr "浏览已发布版本（只读）。您仍然可以重新排列步骤来整理布局。"
-msgstr "浏览已发布的版本（只读）。您仍然可以重新排列步骤来整理布局。"
 
 msgid "Bucket"
 msgstr "存储桶"
@@ -2833,7 +2825,6 @@ msgstr "无法发送询价单"
 
 msgid "Cannot send through Stripe"
 msgstr "无法通过Stripe发送"
-msgstr "无法通过 Stripe 发送"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "无法上传 — 供应商互动尚未创建"
@@ -3042,7 +3033,6 @@ msgstr "检查您的电子邮件"
 
 msgid "Checking Stripe for this customer…"
 msgstr "正在为此客户检查Stripe…"
-msgstr "正在检查该客户的 Stripe…"
 
 msgid "Checkpoint ·"
 msgstr "检查点 ·"
@@ -3953,7 +3943,6 @@ msgstr "创建新的生产工作以完成销售订单"
 
 msgid "Create a new Stripe customer instead"
 msgstr "改为创建新的Stripe客户"
-msgstr "改为创建新的 Stripe 客户"
 
 msgid "Create a new version"
 msgstr "创建新版本"
@@ -6995,7 +6984,6 @@ msgstr "格式"
 
 msgid "Forward deployed engineer"
 msgstr "驻场工程师"
-msgstr "前置部署工程师"
 
 msgid "Foundation"
 msgstr "基础"
@@ -8149,7 +8137,6 @@ msgstr "问题"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "它将停止运行，直到您再次发布版本。不会删除任何内容。"
-msgstr "在您再次发布版本之前，它将停止运行。没有任何内容被删除。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR 认证"
@@ -8521,7 +8508,6 @@ msgstr "更少的手动工作，更少的错误"
 
 msgid "Let's Build"
 msgstr "让我们构建"
-msgstr "让我们开始构建"
 
 msgid "Let's build something"
 msgstr "让我们构建一些东西"
@@ -8603,7 +8589,6 @@ msgstr "关联 Linear 问题"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
 msgstr "将此 Carbon 客户链接到其中一个，或创建单独的 Stripe 客户。"
-msgstr "将此 Carbon 客户链接到其中一个，或创建一个单独的 Stripe 客户。"
 
 msgid "Link to sales order line"
 msgstr "关联销售订单行"
@@ -14348,7 +14333,6 @@ msgstr "Stripe 会向客户发送发票电子邮件，因此需要地址。这�
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
 msgstr "Stripe还没有该Carbon客户对应的客户。过账将在您的连接账户上创建一个。"
-msgstr "Stripe 已有使用此电子邮件的客户"
 
 msgid "Stripe Due Date"
 msgstr "Stripe 到期日期"
@@ -15667,7 +15651,6 @@ msgstr "此发票没有可用的到期日——为Stripe选择一个。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "此发票将为已与此Carbon客户关联的Stripe客户计费。要更改其详细信息，请在Stripe仪表板中编辑。"
-msgstr "此发票没有可用的到期日期 — 为 Stripe 选择一个。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
 msgstr "此发票将计费给已链接到此 Carbon 客户的 Stripe 客户。要更改其详细信息，请在 Stripe 仪表板中编辑它。"
@@ -15811,7 +15794,6 @@ msgstr "这个版本已发布"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "这个版本已发布。创建新版本进行编辑。"
-msgstr "此版本已发布"
 
 msgid "This version is published. Create a new version to edit."
 msgstr "此版本已发布。创建新版本进行编辑。"
@@ -16770,7 +16752,6 @@ msgstr "版本"
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
 msgstr "版本{0}现已发布，将被替换。"
-msgstr "版本 {0} 现已发布，将被替换。"
 
 msgid "Version:"
 msgstr "版本："
@@ -17656,7 +17637,6 @@ msgstr "您已在 Carbon 上线"
 
 msgid "You're one step away from your workspace."
 msgstr "您离您的工作区只有一步之遥。"
-msgstr "您离工作区只有一步之遥。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "您正在按照自己的节奏自行设置 Carbon"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -27,7 +27,7 @@ msgstr ", {years}年"
 
 #. placeholder {0}: fieldDef?.label ?? condition.field
 msgid "\"{0}\" isn't available on the selected surface(s). Pick another field."
-msgstr "\"{0}\"在选定的表面上不可用。请选择另一个字段。"
+msgstr "\"{0}\"在所选表面上不可用。请选择另一个字段。"
 
 msgid "\"{storageUnitName}\" has {childCount} direct nested storage units. Deleting it will also delete them and anything underneath them. This cannot be undone."
 msgstr "\"{storageUnitName}\"有{childCount}个直接嵌套的存储单元。删除它也会删除它们及其下面的所有内容。此操作无法撤销。"
@@ -39,18 +39,18 @@ msgstr "\"${storageUnitName}\"有1个直接嵌套的存储单元。删除它也�
 #. placeholder {1}: setupProgress.done
 #. placeholder {2}: setupProgress.total
 msgid "\"{taskName}\" checks itself off once its {0} Setup Map items are marked \"Configured\" — {1} of {2} so far."
-msgstr "\"{taskName}\"在其{0}个设置地图项目被标记为\"已配置\"后会自动勾选——目前已完成{1}个，共{2}个。"
+msgstr "\"{taskName}\"一旦其{0}个设置映射项被标记为\"已配置\"就自行检查完成——到目前为止{1}个/{2}个。"
 
 #. placeholder {0}: setupProgress.total
 msgid "\"{taskName}\" is done — all {0} of its Setup Map items are configured."
-msgstr "\"{taskName}\"已完成——其所有{0}个设置地图项目都已配置。"
+msgstr "\"{taskName}\"已完成——其所有{0}个设置映射项都已配置。"
 
 msgid "(excluded for this customer)"
 msgstr "(已为此客户排除)"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
-msgstr "{0, plural, one {此物品包含在1个未完成的更改单中} other {此物品包含在#个未完成的更改单中}}"
+msgstr "{0, plural, one {此物料有1个未结的变更通知} other {此物料有#个未结的变更通知}}"
 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
@@ -79,11 +79,11 @@ msgstr "{0} 已成功删除"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} draft journal entries"
-msgstr "{0} 份草稿日记账条目"
+msgstr "{0}个草稿凭证"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
-msgstr "{0} 个作业已创建"
+msgstr "已创建{0}个工单"
 
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
@@ -104,7 +104,7 @@ msgstr "{0} 个订单"
 
 #. placeholder {0}: issues.length
 msgid "{0} problems — not published"
-msgstr "{0} 个问题 — 未发布"
+msgstr "{0}个问题——未发布"
 
 #. placeholder {0}: selectedProcesses.length
 msgid "{0} Processes"
@@ -112,7 +112,7 @@ msgstr "{0} 个流程"
 
 #. placeholder {0}: result.credentialName ?? "Passkey"
 msgid "{0} registered"
-msgstr "{0} 已注册"
+msgstr "{0}已登记"
 
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
@@ -120,7 +120,7 @@ msgstr "{0}个有余额的供应商"
 
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
-msgstr "{0} 个未采样的实体将被释放到可用状态。已采样的合格品保持可用状态，已采样的不合格品保持被拒绝状态。"
+msgstr "{0}个未采样的实体将转为可用。已采样的合格品保持可用，已采样的不合格品保持已拒绝。"
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -129,7 +129,7 @@ msgstr "{0} 个未映射的账户将与 {1} 个提供商账户相匹配。"
 
 #. placeholder {0}: task.autoCheck.count
 msgid "{0} unposted documents"
-msgstr "{0} 份未过账单据"
+msgstr "{0}个未过账的文档"
 
 #. placeholder {0}: file.name
 msgid "{0} uploaded successfully"
@@ -145,36 +145,36 @@ msgid "{0} values missing"
 msgstr "{0} 个值缺失"
 
 msgid "{alreadyPlannedItemCount} parts skipped — they already have open jobs"
-msgstr "{alreadyPlannedItemCount} 个零件已跳过 — 它们已有待处理作业"
+msgstr "{alreadyPlannedItemCount}个零件已跳过——它们已有未结的工单"
 
 msgid "{apOverduePct}% of payables"
-msgstr "{apOverduePct}% 的应付账款"
+msgstr "应付款项的{apOverduePct}%"
 
 msgid "{arOverduePct}% of receivables"
-msgstr "{arOverduePct}% 的应收账款"
+msgstr "应收款项的{arOverduePct}%"
 
 msgid "{chainLabel}. Consider pointing this part directly at the final successor."
-msgstr "{chainLabel}。考虑将此零件直接指向最终后继产品。"
+msgstr "{chainLabel}。考虑直接将此零件指向最终后继物料。"
 
 msgid "{count, plural, one {# course} other {# courses}}"
 msgstr "{count, plural, one {# 门课程} other {# 门课程}}"
 
 msgid "{done} of {total} phases complete"
-msgstr "{done} 个，共 {total} 个阶段已完成"
+msgstr "{done}个/{total}个阶段已完成"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} 共 {count}"
 
 msgid "{from}–{to} of {count} operations"
-msgstr "{from}–{to} / {count} 条操作"
+msgstr "第{from}–{to}个工序（共{count}个）"
 
 msgid "{hiddenCount} more: {hiddenNames}"
-msgstr ""
+msgstr "还有{hiddenCount}个：{hiddenNames}"
 
 #. placeholder {0}: errors.length
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
-msgstr "{inserted}条插入，{updated}条更新，{0}条需要修复，{1}条跳过。"
+msgstr "已插入{inserted}条，已更新{updated}条，需修复{0}条，已跳过{1}条。"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -183,13 +183,13 @@ msgid "{maxSizeMB}MB limit"
 msgstr "{maxSizeMB}MB 限制"
 
 msgid "{mismatchCount} months with mismatched totals"
-msgstr "{mismatchCount} 个月的总额不匹配"
+msgstr "{mismatchCount}个月的总计不匹配"
 
 msgid "{missingCount} journals missing in the provider"
-msgstr "提供商中缺少 {missingCount} 份日记账"
+msgstr "提供商中缺少{missingCount}个凭证"
 
 msgid "{missingCount} missing journals and {mismatchCount} mismatched months"
-msgstr "{missingCount} 份缺失日记账和 {mismatchCount} 个月不匹配"
+msgstr "缺少{missingCount}个凭证，{mismatchCount}个月的总计不匹配"
 
 msgid "{name} deleted"
 msgstr "{name} 已删除"
@@ -208,10 +208,10 @@ msgid "{scopeCount} permissions"
 msgstr "{scopeCount} 个权限"
 
 msgid "{total} phases to get your company live on Carbon. Each one ends at a checkpoint."
-msgstr "{total}个阶段让您的公司在Carbon上线。每个阶段都以检查点结束。"
+msgstr "{total}个阶段使贵公司在Carbon中正式启用。每个阶段都在一个检查点处结束。"
 
 msgid "{total} phases to go live"
-msgstr "{total} 个阶段即可上线"
+msgstr "{total}个阶段即可正式运行"
 
 msgid "{totalQuantity, plural, one {# unit} other {# units}}"
 msgstr "{totalQuantity, plural, one {# 件} other {# 件}}"
@@ -220,13 +220,13 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
 
 msgid "{updatedJobCount} jobs updated"
-msgstr "{updatedJobCount} 个作业已更新"
+msgstr "已更新{updatedJobCount}个工单"
 
 msgid "{uploadedFileName} uploaded — fields filled from the document."
-msgstr "{uploadedFileName} 已上传 — 已根据文档填写字段。"
+msgstr "已上传{uploadedFileName}——字段从文件填充。"
 
 msgid "{variances, plural, one {# line differs from the expected quantity} other {# lines differ from the expected quantity}}"
-msgstr "{variances, plural, one {# 行与预期数量不同} other {# 行与预期数量不同}}"
+msgstr "{variances, plural, one {#行与预期数量不同} other {#行与预期数量不同}}"
 
 msgid "{years}yr"
 msgstr "{years}年"
@@ -235,10 +235,10 @@ msgid "/month/user"
 msgstr "/月/用户"
 
 msgid "% of total"
-msgstr "占总数百分比"
+msgstr "占总计的%"
 
 msgid "% of Total"
-msgstr "占总数的 %"
+msgstr "占总计的%"
 
 #. placeholder {0}: numberFormatter.format(redirectedTotal)
 #. placeholder {1}: redirectedParts.join(", ")
@@ -249,7 +249,7 @@ msgid "<0>Add a supplier part</0> for this item to set a preferred supplier."
 msgstr "<0>为此项目添加供应商零件</0>以设置首选供应商。"
 
 msgid "0 operations"
-msgstr "0 条操作"
+msgstr "0个工序"
 
 msgid "0-4 weeks"
 msgstr "0-4 周"
@@ -258,7 +258,7 @@ msgid "1 day"
 msgstr "1 天"
 
 msgid "1 draft journal entry"
-msgstr "1 份草稿日记账条目"
+msgstr "1个草稿分录"
 
 msgid "1 job created"
 msgstr "1 个作业已创建"
@@ -267,16 +267,16 @@ msgid "1 job updated"
 msgstr "1 个作业已更新"
 
 msgid "1 part skipped — it already has an open job"
-msgstr "1 个零件已跳过 — 它已有待处理作业"
+msgstr "1个零件已跳过——它已有未结的工单"
 
 msgid "1 part skipped — nothing to make"
 msgstr "1 个零件已跳过 — 没有需要生产的"
 
 msgid "1 problem — not published"
-msgstr "1 个问题 — 未发布"
+msgstr "1个问题——未发布"
 
 msgid "1 unposted document"
-msgstr "1 份未过账单据"
+msgstr "1个未过账的文件"
 
 msgid "12 monthly periods"
 msgstr "12个月度期间"
@@ -303,7 +303,7 @@ msgid "4h"
 msgstr "4小时"
 
 msgid "5 user minimum"
-msgstr ""
+msgstr "最少需要5个用户"
 
 msgid "5-8 weeks"
 msgstr "5-8 周"
@@ -330,7 +330,7 @@ msgid "A Carbon-run data migration — you load your own data"
 msgstr "Carbon 运行的数据迁移 — 您加载自己的数据"
 
 msgid "A change notice tracks a controlled engineering or manufacturing change through review and implementation."
-msgstr "更改单跟踪受控工程或制造变更的审核和实施过程。"
+msgstr "变更通知跟踪通过评审和实施的受控工程或制造变更。"
 
 msgid "A clearing account holding the value of goods received but not yet billed; the supplier invoice clears it."
 msgstr "持有已收但未开票商品价值的结算账户；供应商发票将其结清。"
@@ -345,22 +345,22 @@ msgid "A company-defined extra field attached to a core table (customer, part, o
 msgstr "公司定义的额外字段，附加到核心表（客户、零件、订单）；它显示在记录的表单上，与内置字段一起保存，并可通过 API 查询。"
 
 msgid "A company-defined tag axis attached to journal lines so the same accounts can be sliced by location, department, or any custom axis without multiplying the chart of accounts."
-msgstr "公司定义的标签轴附加到日记账行，以便可以按位置、部门或任何自定义轴对相同账户进行切分，而无需增加科目表。"
+msgstr "一个公司定义的标签轴，附加到凭证，以便可以按地点、部门或任何自定义轴切割相同的账户，而不会增加会计科目表。"
 
 msgid "A company-scoped Discount or Markup, by percentage or fixed amount, that adjusts a line's price up or down when the line matches the rule's quantity, date, item, and customer conditions."
 msgstr "公司范围的折扣或加价，按百分比或固定金额，当行匹配规则的数量、日期、物料和客户条件时，调整行的价格上下浮动。"
 
 msgid "A completed job's output, received into inventory at the job's actual accumulated WIP cost."
-msgstr "已完成作业的产出，按作业实际累计在制品成本计入库存。"
+msgstr "已完成工单的产出，按工单实际累计在制品成本收入库存管理。"
 
 msgid "A consumable is a physical item used to make a part that can be used across multiple jobs"
-msgstr "消耗品是用于制造零件的物理项目，可以在多个工作中使用"
+msgstr "耗材是用来制造零件的物理物料，可以在多个工单中使用。"
 
 msgid "A contractor is a supplier contact with particular abilities and available hours"
-msgstr "承包商是具有特定能力和可用工作时间的供应商联系人"
+msgstr "外协人员是具有特定技能和可用工时的供应商联系人。"
 
 msgid "A custom solution to meet your needs"
-msgstr ""
+msgstr "满足您需求的定制解决方案"
 
 msgid "A customer is a business or person who buys your parts or services."
 msgstr "客户是购买您的零件或服务的企业或个人。"
@@ -375,10 +375,10 @@ msgid "A customer's account manager changes"
 msgstr "客户的账户经理已变更"
 
 msgid "A customer's assignee changes"
-msgstr "客户的指派人已变更"
+msgstr "客户的经办人已变更"
 
 msgid "A customer's currency changes"
-msgstr "客户的币种已变更"
+msgstr "客户的货币已变更"
 
 msgid "A customer's name changes"
 msgstr "客户的名称已变更"
@@ -393,28 +393,28 @@ msgid "A customer's type changes"
 msgstr "客户的类型已变更"
 
 msgid "A dated record proving a gauge was checked against a traceable standard; it passes unless a requires-action, -adjustment, or -repair flag is ticked, and resets the gauge's next-due date."
-msgstr "一份日期记录，证明量具已根据可追溯的标准进行了检查；除非勾选了需要操作、调整或维修标志，否则通过，并重置量具的下次到期日期。"
+msgstr "一份有日期的记录，证明量具已根据可追溯标准进行了检查；除非勾选需要行动、调整或维修标志，否则通过检验，并重置量具的下次到期日期。"
 
 msgid "A dated window postings fall into; its close status moves Open → Locked → Closed, and a closed period is frozen against new postings."
-msgstr "一个日期段，分录落入其中；其关闭状态从打开 → 锁定 → 关闭，关闭的期间被冻结以防止新分录。"
+msgstr "过账所属的一个有日期的时间范围；其关闭状态从未结→已锁定→已关闭推进，已关闭的期间被冻结，不允许新的过账。"
 
 msgid "A depreciation method that charges a fixed percentage of remaining book value each period — heavier early, lighter later."
-msgstr "每期对剩余账面价值按固定百分比进行折旧的方法——早期较重，后期较轻。"
+msgstr "一种折旧方法，每期对剩余账面价值收取固定百分比——早期较重，后期较轻。"
 
 msgid "A depreciation method that charges an equal amount each period across the asset's useful life."
-msgstr "在资产的使用寿命期间每期对等额进行折旧的方法。"
+msgstr "一种折旧方法，在资产的使用年限内每期收取等额费用。"
 
 msgid "A firm customer commitment to deliver; fulfillment status splits across ship and invoice before reaching Completed."
-msgstr "客户的确定交付承诺；履行状态在达到完成之前在发货和发票之间分割。"
+msgstr "客户的明确交货承诺；履行状态在装运和发票之间分摊，最终达到已完成。"
 
 msgid "A firm order to a supplier; status moves through receive and invoice before Completed as goods and bills arrive."
-msgstr "对供应商的确定订单；随着商品和发票到达，状态在完成前通过接收和发票进行。"
+msgstr "向供应商发送的明确订单；状态随着货物和账单的到达而通过收货和发票，最终达到已完成。"
 
 msgid "A formal acceptance / sign-off phase"
 msgstr "正式验收/签署阶段"
 
 msgid "A gauge whose role is Master — the reference standard other gauges are calibrated against, rather than one used for routine checks."
-msgstr "一个角色为主量具的量具——其他量具根据它进行校准的参考标准，而不是用于日常检查的量具。"
+msgstr "一个作用为标准器的量具——其他量具根据它进行校准的参考标准，而不是用于日常检查的量具。"
 
 msgid "A issue record tracks quality issues and their resolution process."
 msgstr "问题记录跟踪质量问题及其解决过程。"
@@ -426,16 +426,16 @@ msgid "A job is deleted"
 msgstr "任务已删除"
 
 msgid "A job is put on hold"
-msgstr "任务已暂停"
+msgstr "工单被搁置"
 
 msgid "A job is released"
-msgstr "任务已发布"
+msgstr "工单已下达"
 
 msgid "A job operation is completed"
-msgstr "任务操作已完成"
+msgstr "工单工序已完成"
 
 msgid "A job's assignee changes"
-msgstr "任务的指派人已变更"
+msgstr "工单的经办人已变更"
 
 msgid "A job's deadline type changes"
 msgstr "任务的截止日期类型已变更"
@@ -467,67 +467,67 @@ msgid "A list is wired into {0}, so this step runs once for each item in it — 
 msgstr "列表被接入到 {0}，所以此步骤为其中每个项目运行一次 — 最多 {MAX_LIST_ITEMS} 个。"
 
 msgid "A Make to Order component that gets its own job and routing inside the parent's build."
-msgstr "在父项构建中获得自己的作业和路由的按单生产组件。"
+msgstr "一个按订单生产的组件，在父项构建中获得自己的工单和工艺路线。"
 
 msgid "A Make to Order component whose parts are issued together into the parent job — no separate build."
-msgstr "其零件一起发放到父项作业的按单生产组件——无单独构建。"
+msgstr "一个按订单生产的组件，其零件一起领用到父工单中——无单独构建。"
 
 msgid "A managed cloud-hosted version of Carbon"
-msgstr ""
+msgstr "Carbon 的托管云版本"
 
 msgid "A managed version with all the advanced features"
-msgstr ""
+msgstr "具有所有高级功能的托管版本"
 
 msgid "A material is a physical item used to make a part that can be used across multiple jobs"
-msgstr "材料是用于制造零件的物理项目，可以在多个工作中使用"
+msgstr "原材料是用于制造零件的物质物品，可跨多个工单使用。"
 
 msgid "A measurement instrument (caliper, micrometer, pin gauge, CMM) tracked as a record and held to a recurring calibration schedule."
-msgstr "一个测量仪器（卡尺、千分尺、针规、坐标测量机），作为记录跟踪并遵循定期校准计划。"
+msgstr "一个测量仪器（游标卡尺、千分尺、塞规、CMM）作为记录进行追踪，并按照周期性校准计划进行维护。"
 
 msgid "A name is required to save a view"
-msgstr "保存视图需要一个名称"
+msgstr "需要名称才能保存查看"
 
 msgid "A negotiated price pinned for a specific item — by customer, customer type, or all customers — that replaces the base price outright, optionally with quantity breaks."
-msgstr "为特定物料确定的谈判价格——按客户、客户类型或所有客户——完全替代基础价格，可选地带有数量级差。"
+msgstr "为特定物料约定的固定价格——按客户、客户类型或所有客户——完全替代基准价格，可选择数量阶梯。"
 
 msgid "A new purchase order will be created for each supplier. Alternatively, you can choose an existing draft purchase order for the supplier to add the outside operations to."
-msgstr "将为每个供应商创建一个新的采购订单。或者，您可以为供应商选择现有的草稿采购订单，以添加外包操作。"
+msgstr "将为每个供应商创建一个新的采购订单。或者，您可以选择供应商的现有草稿采购订单以向其添加外协工序。"
 
 msgid "A new revision will be created using a copy of the current revision"
-msgstr "将使用当前版本的副本创建新版本"
+msgstr "将使用当前修订版的副本创建新的修订版"
 
 msgid "A new size will be created using a copy of the current size"
 msgstr "将使用当前尺寸的副本创建新尺寸"
 
 msgid "A new Stripe customer will be created"
-msgstr ""
+msgstr "将创建新的 Stripe 客户"
 
 msgid "A non-cash document that settles an invoice against a reason account: a credit lowers what's owed, a debit raises it."
-msgstr "一份非现金单据，根据原因账户结算发票：贷方降低应付金额，借方提高它。"
+msgstr "一份非现金文件，根据原因账户结算发票：贷方降低欠额，借方提高欠额。"
 
 msgid "A non-conformance shared with a supplier over a login-free /share/scar link, so they can respond to the issue and update its tasks from outside Carbon."
-msgstr "一个与供应商通过无登录 /share/scar 链接共享的不符合，以便他们可以从 Carbon 外部响应问题并更新其任务。"
+msgstr "通过无登录 /share/scar 链接与供应商共享的不合格记录，以便他们可以从 Carbon 外部响应问题并更新其任务。"
 
 msgid "A non-taxable surcharge (e.g. recoverable expenses like permit fees) added to the line; excluded from the tax base."
 msgstr "不可征税的附加费（如可收回的费用，如许可证费用），添加到行中并从税基中排除。"
 
 msgid "A nonconformance task that fixes a confirmed root cause — as opposed to a preventive or immediate containment action."
-msgstr "修正已确认根本原因的不符合任务——与预防性或立即遏制措施相对。"
+msgstr "一项不合格任务，用于修复已确认的根本原因——相对于预防性或立即围堵措施。"
 
 msgid "A nonconformance task that stops the problem recurring elsewhere — distinct from the corrective fix and containment."
-msgstr "防止问题在其他地方重复出现的不符合任务——与纠正措施和遏制措施不同。"
+msgstr "一项不合格任务，用于防止问题在其他地方重复出现——不同于纠正修复和围堵。"
 
 msgid "A part contains the information about a specific item that can be purchased or manufactured."
 msgstr "零件包含可以购买或制造的特定项目的信息。"
 
 msgid "A physical pull signal — a printed card or QR code living with the stock — that raises a purchase order or a job the moment it's scanned to refill a bin."
-msgstr "一个物理拉取信号——一张与库存一起放置的印刷卡片或二维码——在扫描以补充容器时立即生成采购订单或工作。"
+msgstr "一个物理拉动信号——一张印刷卡片或 QR 码与库存一起放置——在扫描时立即提高采购订单或工单以补充料箱。"
 
 msgid "A point in one of Carbon's own flows that a workflow can watch — a job released, a quote accepted, a shipment posted — as opposed to a raw field change; it hands the workflow the records involved by id."
-msgstr "Carbon 自身流程中的一个点，工作流可以监视 — 任务发布、报价被接受、发货已过账 — 与原始字段变更相对；它按 ID 将涉及的记录交给工作流。"
+msgstr "Carbon 自身流程中的一个点，工作流可以监控——工单已下达、报价单已接受、发货已过账——相对于原始字段更改；它通过 ID 将所涉及的记录传递给工作流。"
 
 msgid "A posted accounting entry: a header plus balanced debit and credit lines against GL accounts."
-msgstr "已过帐的会计分录：针对总账账户的收支平衡的标题加借贷行。"
+msgstr "一个已过账的会计分录：标题加上针对总账科目的平衡借方和贷方行。"
 
 msgid "A posted cash transaction — a Receipt from a customer or a Disbursement to a supplier — applied to invoices through settlements, moving Draft → Posted → Voided."
 msgstr "一项已过账的现金交易——来自客户的收据或向供应商的支付——通过结算应用到发票，从草稿 → 已过账 → 已作废。"
@@ -536,7 +536,7 @@ msgid "A pre-written description inserted into every issue that uses this workfl
 msgstr "预先编写的描述，插入到使用此工作流的每个问题中；{itemId}和{location}等占位符在创建时被替换。"
 
 msgid "A priced sales quotation; Draft → Sent → Ordered, or ends Lost, Expired, or Cancelled."
-msgstr "有价格的销售报价；草稿→已发送→已订购，或以丢失、已过期或已取消结束。"
+msgstr "一份标价的销售报价单；草稿 → 已发送 → 已订购，或结束为丢单、已过期或已取消。"
 
 msgid "A purchase invoice is a document that specifies the products or services purchased by a customer and the corresponding cost."
 msgstr "采购发票是一份文件，用于说明客户购买的产品或服务以及相应的成本。"
@@ -551,7 +551,7 @@ msgid "A purchase order is deleted"
 msgstr "采购订单已删除"
 
 msgid "A purchase order's assignee changes"
-msgstr "采购订单的指派人已变更"
+msgstr "采购订单的经办人已变更"
 
 msgid "A purchase order's order date changes"
 msgstr "采购订单的订单日期已变更"
@@ -575,10 +575,10 @@ msgid "A purchase order's type changes"
 msgstr "采购订单的类型已变更"
 
 msgid "A quality issue — a logged deviation or defect with a configurable workflow of investigation and action tasks."
-msgstr "质量问题——已记录的偏差或缺陷，带有可配置的调查和纠正措施工作流。"
+msgstr "一个质量问题——一条记录的偏差许可或缺陷，具有可配置的调查和行动任务工作流。"
 
 msgid "A quantity of identical units shares one tracked entity and batch number — one entity, many units."
-msgstr "一定数量的相同单位共享一个跟踪的实体和批号——一个实体，许多单位。"
+msgstr "相同单位的数量共享一个追踪实体和批号——一个实体，多个件。"
 
 msgid "A quote is a set of prices for specific parts and quantities."
 msgstr "报价是针对特定零件和数量的一组价格。"
@@ -596,10 +596,10 @@ msgid "A quote is sent"
 msgstr "报价单已发送"
 
 msgid "A quote line contains pricing and lead times for a particular part"
-msgstr "报价行包含特定零件的定价和交货期"
+msgstr "报价行包含特定零件的定价和提前期。"
 
 msgid "A quote's assignee changes"
-msgstr "报价单的受理人已更改"
+msgstr "报价单的经办人已变更"
 
 msgid "A quote's completed date changes"
 msgstr "报价单的完成日期已更改"
@@ -608,13 +608,13 @@ msgid "A quote's customer changes"
 msgstr "报价单的客户已更改"
 
 msgid "A quote's due date changes"
-msgstr "报价单的截止日期已更改"
+msgstr "报价单的到期日已变更"
 
 msgid "A quote's estimator changes"
 msgstr "报价单的估价人已更改"
 
 msgid "A quote's expiration date changes"
-msgstr "报价单的过期日期已更改"
+msgstr "报价单的到期日期变更"
 
 msgid "A quote's salesperson changes"
 msgstr "报价单的销售人员已更改"
@@ -632,10 +632,10 @@ msgid "A receipt is posted"
 msgstr "收据已过账"
 
 msgid "A receipt's assignee changes"
-msgstr "收据的受理人已更改"
+msgstr "收货的经办人变更"
 
 msgid "A receipt's invoiced changes"
-msgstr "收据的发票状态已更改"
+msgstr "收货的已开票状态变更"
 
 msgid "A receipt's location changes"
 msgstr "收据的位置已更改"
@@ -653,13 +653,13 @@ msgid "A receipt's supplier changes"
 msgstr "收据的供应商已更改"
 
 msgid "A reusable, versioned set of work instructions attached to a process, giving an operation its ordered steps to record and check plus the parameters it runs at."
-msgstr "一套可重复使用的、版本化的工作说明，附加到流程中，为操作提供有序的步骤以记录和检查，以及它运行的参数。"
+msgstr "一套可重用的、版本化的作业指导书，附加到一个工艺并为工序提供有序的步骤以进行记录和检查，以及运行参数。"
 
 msgid "A routing step on a released job, the job's own copy of an operation, carrying a status the floor drives from Todo through Done."
-msgstr "一个已发布工作的路由步骤，该工作自己的操作副本，携带一个状态，该状态由车间从待办事项驱动到完成。"
+msgstr "已下达工单上的工艺路线步骤，工单对工序的自有副本，其状态由生产车间从待办推进到完成。"
 
 msgid "A sales invoice (you bill a customer) or purchase invoice (a supplier bills you), settled by applying payments and credit or debit memos."
-msgstr "销售发票（你向客户计费）或采购发票（供应商向你计费），通过应用付款和贷项或借项备忘录结算。"
+msgstr "销售发票（您向客户开票）或采购发票（供应商向您开票），通过付款、贷方或借方备忘单结清。"
 
 msgid "A sales invoice is a document that specifies the products or services sold to a customer and the corresponding cost."
 msgstr "销售发票是一份文件，用于说明销售给客户的产品或服务以及相应的成本。"
@@ -683,7 +683,7 @@ msgid "A sales order line contains order details for a particular item"
 msgstr "销售订单行包含特定项目的订单详情"
 
 msgid "A sales order's assignee changes"
-msgstr "销售订单的受理人已更改"
+msgstr "销售订单的经办人变更"
 
 msgid "A sales order's completed date changes"
 msgstr "销售订单的完成日期已更改"
@@ -716,16 +716,16 @@ msgid "A scoped secret sent on the carbon-key request header that authenticates 
 msgstr "在 carbon-key 请求标头上发送的范围内秘密，用于验证对 Carbon 的编程调用，携带自己的权限和速率限制，而不是用户会话的。"
 
 msgid "A separate schedule for tax reporting when tax rules require a method different from book depreciation."
-msgstr "当税收规则要求与账面折旧不同的方法时，用于税务报告的单独时间表。"
+msgstr "当税收规则要求与账面折旧不同的方法时，用于税收报告的单独税收折旧方案。"
 
 msgid "A service is a billable activity that is bought or performed — it is never shipped, received, or stocked"
 msgstr "服务是一种可计费活动，可以购买或执行——它从不被运送、接收或存储"
 
 msgid "A set of companies under one owner that share group-scoped configuration — the chart of accounts, currencies, and dimensions — so the same accounting setup spans every company in the group."
-msgstr "同一所有者下的一组公司，共享组范围的配置——会计科目表、币种和维度——因此同一套会计设置适用于组内的每家公司。"
+msgstr "一组由单一所有者拥有的公司，共享组范围的配置——会计科目表、货币和维度——使得相同的会计设置适用于组中的每家公司。"
 
 msgid "A set of instructions to pull a job's outstanding materials from the warehouse and stage them lineside; a pick moves stock to the point of use rather than consuming it."
-msgstr "一组指令，用于从仓库拉取工作的未交付材料并将其放在生产线旁；领料是将库存转移到使用点，而不是消耗它。"
+msgstr "一套指示，用于从仓库拉取工单所需的物料并在线边准备；拣货操作将库存移到使用点，而不是消耗它。"
 
 msgid "A shipment is created"
 msgstr "发货单已创建"
@@ -737,10 +737,10 @@ msgid "A shipment is posted"
 msgstr "发货单已过账"
 
 msgid "A shipment line sent straight from supplier to customer, bypassing your warehouse — set per line, not on the header."
-msgstr "从供应商直接发送给客户，绕过您仓库的装运行——按行设置，而不是在标题上。"
+msgstr "从供应商直接发送给客户的发货行，绕过您的仓库——按行设置，而不是在标题上。"
 
 msgid "A shipment's assignee changes"
-msgstr "发货单的受理人已更改"
+msgstr "发货的经办人变更"
 
 msgid "A shipment's customer changes"
 msgstr "发货单的客户已更改"
@@ -752,13 +752,13 @@ msgid "A shipment's posting date changes"
 msgstr "发货单的过账日期已更改"
 
 msgid "A shipment's shipping method changes"
-msgstr "发货单的配送方式已更改"
+msgstr "发货的发货方式变更"
 
 msgid "A shipment's status changes"
 msgstr "发货单的状态已更改"
 
 msgid "A shipment's tracking number changes"
-msgstr "货物的跟踪号已更改"
+msgstr "发货的跟踪号变更"
 
 msgid "A step needs a name."
 msgstr "步骤需要一个名称。"
@@ -773,7 +773,7 @@ msgid "A supplier's account manager changes"
 msgstr "供应商的账户经理已更改"
 
 msgid "A supplier's assignee changes"
-msgstr "供应商的受理人已更改"
+msgstr "供应商的经办人变更"
 
 msgid "A supplier's currency changes"
 msgstr "供应商的货币已更改"
@@ -782,7 +782,7 @@ msgid "A supplier's name changes"
 msgstr "供应商的名称已更改"
 
 msgid "A supplier's priced response to a purchasing RFQ — one per supplier; Draft → Active when they submit, or Declined."
-msgstr "供应商对采购RFQ的价格响应——每个供应商一个；草稿→提交时活跃或被拒绝。"
+msgstr "供应商对采购询价单的报价——每个供应商一个；他们提交时从草稿变为启用，或拒绝。"
 
 msgid "A supplier's status changes"
 msgstr "供应商的状态已更改"
@@ -794,25 +794,25 @@ msgid "A supplier's type changes"
 msgstr "供应商的类型已更改"
 
 msgid "A taxable surcharge (handling, setup, fuel) added to the line; rolls into the tax base."
-msgstr "应税附加费（搬运、设置、燃料），添加到行中并包含在税基中。"
+msgstr "应税附加费（处理、换型、燃料）添加到行中；纳入税基。"
 
 msgid "A timed record of Setup, Labor, or Machine work logged against a job operation, whose duration rolls up into the operation's actual cost."
-msgstr "针对工作操作记录的设置、劳动力或机器工作的定时记录，其持续时间汇总到该操作的实际成本中。"
+msgstr "针对工单工序记录的换型、人工或机器工作的计时记录，其时长汇总到该工序的实际成本。"
 
 msgid "A tool is a physical item used to make a part that can be used across multiple jobs"
-msgstr "工具是用于制造零件的物理项目，可以在多个工作中使用"
+msgstr "刀具是用于制造零件的物理物料，可在多个工单中使用"
 
 msgid "A user records the expiry date on each batch or serial when the goods are received. Use when suppliers ship lots with different expiry dates."
-msgstr "用户在收到货物时在每个批次或序列号上记录过期日期。当供应商发货的批次具有不同的过期日期时使用。"
+msgstr "用户在收货时记录每个生产批次或序列号的有效期。当供应商发运具有不同有效期的批次时使用。"
 
 msgid "abilities"
-msgstr "功能"
+msgstr "技能"
 
 msgid "Abilities"
-msgstr "能力"
+msgstr "技能"
 
 msgid "ability"
-msgstr "功能"
+msgstr "技能"
 
 msgid "About"
 msgstr "关于"
@@ -842,11 +842,11 @@ msgid "Acceptance"
 msgstr "验收"
 
 msgid "Acceptance passed"
-msgstr "验收通过"
+msgstr "验收合格"
 
 #. placeholder {0}: formatDate(certification.certifiedAt)
 msgid "Accepted {0}"
-msgstr "于 {0} 接受"
+msgstr "已接受 {0}"
 
 msgid "Account"
 msgstr "账户"
@@ -855,7 +855,7 @@ msgid "Account & Details"
 msgstr "账户和详细信息"
 
 msgid "Account balances with debits and credits"
-msgstr "账户借贷余额"
+msgstr "账户余额包含借方和贷方"
 
 msgid "Account for advance payments made before goods or services are received"
 msgstr "收到商品或服务前支付的预付款的计账。"
@@ -867,7 +867,7 @@ msgid "Account for small rounding differences in transactions"
 msgstr "交易中的小的舍入差异的计账。"
 
 msgid "Account for the cost of fixed assets when disposed"
-msgstr "固定资产处置时的成本计账。"
+msgstr "处置固定资产时计入其成本"
 
 msgid "Account for the purchase cost of fixed assets"
 msgstr "固定资产的收购成本计账。"
@@ -900,7 +900,7 @@ msgid "Accounting"
 msgstr "会计"
 
 msgid "Accounting is currently in beta. Request access to enable reporting, journal entries, accounting periods, fixed assets, and more."
-msgstr "会计功能目前处于测试版。请求访问权限以启用报告、日记账、会计期间、固定资产等功能。"
+msgstr "会计模块当前处于测试版。请求访问权限以启用报告、凭证、会计期间、固定资产等。"
 
 msgid "Accounting is disabled"
 msgstr "会计已禁用"
@@ -939,7 +939,7 @@ msgid "Accounts receivable for amounts owed by customers"
 msgstr "客户应付金额的应收账款。"
 
 msgid "Accounts referenced by posting defaults or journal history that have no provider mapping yet."
-msgstr "由过账默认值或日记账历史记录引用但尚无提供商映射的账户。"
+msgstr "由过账默认值或凭证历史引用但还没有供应商映射的账户。"
 
 msgid "Accumulated Depreciation"
 msgstr "累计折旧"
@@ -972,7 +972,7 @@ msgid "Acknowledged itar"
 msgstr "已确认 ITAR"
 
 msgid "Acquisition Cost"
-msgstr "收购成本"
+msgstr "购置成本"
 
 msgid "Acquisition Date"
 msgstr "收购日期"
@@ -1008,16 +1008,16 @@ msgid "Activation fee · we advise"
 msgstr "激活费 · 我们建议"
 
 msgid "Active"
-msgstr "活跃"
+msgstr "启用"
 
 msgid "Active Jobs"
-msgstr "活跃工作"
+msgstr "启用的工单"
 
 msgid "Active Statuses"
-msgstr "活跃状态"
+msgstr "启用的状态"
 
 msgid "Active Supplier Quotes"
-msgstr "活跃供应商报价"
+msgstr "启用的供应商报价"
 
 msgid "Activity"
 msgstr "活动"
@@ -1047,22 +1047,22 @@ msgid "Add & Issue"
 msgstr "添加并发放"
 
 msgid "Add a column below to sort the view"
-msgstr "在下方添加列以对视图进行排序"
+msgstr "在下方添加一列以对视图进行排序"
 
 msgid "Add a comment..."
 msgstr "添加评论..."
 
 msgid "Add a custom pricing row to override quantity, price, shipping, lead time, and tax"
-msgstr "添加自定义定价行以覆盖数量、价格、运费、交货期和税费"
+msgstr "添加自定义定价行以覆盖数量、价格、运费、提前期和税费"
 
 msgid "Add a materials section that lists each item on the bill of materials with its quantity."
-msgstr "添加一个材料部分，列出物料清单上的每个项目及其数量。"
+msgstr "添加一个列出物料清单上每个物料及其数量的物料部分。"
 
 msgid "Add a printer in the printing settings to print labels directly."
 msgstr "在打印设置中添加打印机以直接打印标签。"
 
 msgid "Add a requirement"
-msgstr "添加需求"
+msgstr "添加要求"
 
 msgid "Add a row"
 msgstr "添加一行"
@@ -1086,7 +1086,7 @@ msgid "Add any notes about your decision..."
 msgstr "添加关于您的决定的任何备注..."
 
 msgid "Add Approval Requirement"
-msgstr "添加批准要求"
+msgstr "添加审批要求"
 
 msgid "Add Authenticator App"
 msgstr "添加身份验证器应用"
@@ -1107,7 +1107,7 @@ msgid "Add condition"
 msgstr "添加条件"
 
 msgid "Add Contractor"
-msgstr "添加承包商"
+msgstr "添加外协人员"
 
 msgid "Add cost center"
 msgstr "添加成本中心"
@@ -1146,7 +1146,7 @@ msgid "Add Note"
 msgstr "添加备注"
 
 msgid "Add notes and documentation for this maintenance dispatch"
-msgstr "为此维护调度添加备注和文档"
+msgstr "为此维护工单添加备注和文档"
 
 msgid "Add Operation"
 msgstr "添加操作"
@@ -1170,7 +1170,7 @@ msgid "Add parts"
 msgstr "添加零件"
 
 msgid "Add Passkey"
-msgstr "添加密钥"
+msgstr "添加通行密钥"
 
 msgid "Add path"
 msgstr "添加路径"
@@ -1221,7 +1221,7 @@ msgid "Add Step"
 msgstr "添加步骤"
 
 msgid "Add steps to preview the operator view."
-msgstr "添加步骤以预览操作员视图。"
+msgstr "添加步骤以预览操作员的视图。"
 
 msgid "Add Stock Transfer"
 msgstr "添加库存转移"
@@ -1325,7 +1325,7 @@ msgid "All {0} cells tie out"
 msgstr "全部 {0} 个单元格对账"
 
 msgid "All {total} phases are done. Nice work — your team is up and running."
-msgstr "所有 {total} 个阶段已完成。做得很好——你的团队已启动并运行。"
+msgstr "所有{total}个阶段都已完成。做得好——您的团队已启动并运行。"
 
 msgid "All accounts"
 msgstr "所有账户"
@@ -1334,7 +1334,7 @@ msgid "All actions selected"
 msgstr "所有操作已选中"
 
 msgid "All advanced features available"
-msgstr ""
+msgstr "所有高级功能可用"
 
 msgid "All Audit Logs"
 msgstr "所有审计日志"
@@ -1352,16 +1352,16 @@ msgid "All Documents"
 msgstr "所有文档"
 
 msgid "All item types"
-msgstr "所有项目类型"
+msgstr "所有物料类型"
 
 msgid "All Items"
-msgstr "所有项目"
+msgstr "所有物料"
 
 msgid "All Locations"
 msgstr "所有位置"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
-msgstr "所选组的所有成员和所选个人将能够批准请求"
+msgstr "所选组的所有成员和所选个人都将能够审批请求"
 
 msgid "All posting accounts are mapped"
 msgstr "所有过账账户已映射"
@@ -1409,10 +1409,10 @@ msgid "Amount"
 msgstr "金额"
 
 msgid "Amount that increases assets/expenses or decreases liabilities/equity/revenue on this line."
-msgstr "在该行增加资产/费用或减少负债/权益/收入的金额。"
+msgstr "增加此行资产/费用或减少此行负债/所有者权益/收入的金额"
 
 msgid "Amount that increases liabilities/equity/revenue or decreases assets/expenses on this line."
-msgstr "在该行增加负债/权益/收入或减少资产/费用的金额。"
+msgstr "增加此行负债/所有者权益/收入或减少此行资产/费用的金额"
 
 #. placeholder {0}: r.memoId
 msgid "Amount to apply for {0}"
@@ -1422,25 +1422,25 @@ msgid "Amount Type"
 msgstr "金额类型"
 
 msgid "An accounting bucket that groups expenses by department or function so the GL can report spend by group, not just by account."
-msgstr "一个会计桶，按部门或职能对支出进行分组，以便GL可以按组而非按账户报告支出。"
+msgstr "一个会计分类，按部门或职能对费用进行分组，以便总账可以按组而不仅按账户报告支出"
 
 msgid "An accounting record for a capitalized item you depreciate rather than expense; Draft → Active → Fully Depreciated → Disposed."
-msgstr "资本化项目的会计记录，您要贬值而不是支出；草稿→活跃→完全贬值→处置。"
+msgstr "一条会计记录，记录您折旧而不是当作费用的固定资产；草稿→启用→已提足折旧→已处置。"
 
 msgid "An alert that something needs a person's attention, fanned out from a carbon/notify event to the in-app inbox plus optional email and Slack, muteable per topic per user."
-msgstr "一个警报，表示某些内容需要人员的注意，从 carbon/notify 事件扇出到应用内收件箱加上可选的电子邮件和 Slack，可按每个用户的每个主题静音。"
+msgstr "一个提醒，表示某件事需要个人关注，从carbon/notify事件分发到应用内收件箱、可选电子邮件和Slack，用户可按主题静音。"
 
 msgid "An approval requirement on a non-conformance whose reviewers (seeded Engineering and Quality) must sign off before the issue can close."
-msgstr "不符合上的批准要求，其审核人（预设为工程和质量）必须签署才能关闭问题。"
+msgstr "不合格上的审批要求，其审核人（默认的工程和质量部门）必须签字才能关闭问题"
 
 msgid "An asset's acquisition cost minus accumulated depreciation — what it's still worth on the books, and the figure it's disposed at."
-msgstr "资产的收购成本减去累计折旧—仍在账簿上的价值和处置的金额。"
+msgstr "资产的购置成本减去累计折旧——其在账面上的剩余价值，以及处置时的价值。"
 
 msgid "An automation you build on a canvas: one trigger, then steps that check conditions, look records up, and act — notifying someone, creating or updating a record, or calling an outside URL."
 msgstr "您在画布上构建的自动化：一个触发器，然后是检查条件、查找记录和执行操作的步骤——通知某人、创建或更新记录或调用外部URL。"
 
 msgid "An engineering change: the affected items whose methods are revised on a draft and released together, superseding the versions they replace."
-msgstr "工程变更：受影响项目的方法在草稿中进行修改，并一起发布，替代它们替换的版本。"
+msgstr "工程变更是指受影响的物料，其方法在草稿上修订后一起下达，以取代之前的版本。"
 
 msgid "An https request Carbon sends to a system of yours when a workflow reaches that step, carrying whatever headers and body you configured."
 msgstr "当工作流到达该步骤时，Carbon向您的系统发送的HTTPS请求，携带您配置的任何标头和请求体。"
@@ -1449,7 +1449,7 @@ msgid "An integration or a custom change — the small slice that's actually cus
 msgstr "一个集成或自定义更改——实际上是自定义的小部分。"
 
 msgid "An invitation is pending. They become active once they accept it."
-msgstr "邀请待审批。他们接受后将变为活跃。"
+msgstr "邀请待处理。他们接受后就会启用"
 
 msgid "An issue is created"
 msgstr "问题已创建"
@@ -1458,13 +1458,13 @@ msgid "An issue is deleted"
 msgstr "问题已删除"
 
 msgid "An issue's assignee changes"
-msgstr "问题的受理人已更改"
+msgstr "问题的经办人更改"
 
 msgid "An issue's close date changes"
 msgstr "问题的关闭日期已更改"
 
 msgid "An issue's due date changes"
-msgstr "问题的截止日期已更改"
+msgstr "问题的到期日更改"
 
 msgid "An issue's location changes"
 msgstr "问题的位置已更改"
@@ -1494,34 +1494,34 @@ msgid "An item is deleted"
 msgstr "物品已删除"
 
 msgid "An item's active changes"
-msgstr "物品的活跃状态已更改"
+msgstr "物料的启用状态更改"
 
 msgid "An item's assignee changes"
-msgstr "项目的分配人更改"
+msgstr "物料的经办人更改"
 
 msgid "An item's default method type changes"
-msgstr "项目的默认方法类型更改"
+msgstr "物料的默认供料方式更改"
 
 msgid "An item's name changes"
 msgstr "项目的名称更改"
 
 msgid "An item's replenishment system changes"
-msgstr "项目的补货系统更改"
+msgstr "物料的补货方式更改"
 
 msgid "An item's revision status changes"
-msgstr "项目的版本状态更改"
+msgstr "物料的修订版状态更改"
 
 msgid "An item's tracking type changes"
-msgstr "项目的跟踪类型更改"
+msgstr "物料的追踪类型更改"
 
 msgid "An item's unit of measure changes"
-msgstr "项目的度量单位更改"
+msgstr "物料的计量单位更改"
 
 msgid "An operation done by an outside supplier rather than an in-house work center, covered by a subcontracting purchase order."
-msgstr "由外部供应商而不是内部工作中心执行的操作，由分包购买订单覆盖。"
+msgstr "一项由外部供应商而非内部工作中心执行的工序，由分包采购订单涵盖。"
 
 msgid "An operation's position in its work center's queue — the order the floor picks work up — set by reordering cards on the Work Centers board without changing any dates."
-msgstr "一个操作在其工作中心队列中的位置——车间拿起工作的顺序——通过在工作中心板上重新排序卡片来设置，无需更改任何日期。"
+msgstr "一个工序在其工作中心队列中的位置 — 车间拾取工作的顺序 — 通过在工作中心看板上重新排序卡片而不改变任何日期来设置。"
 
 msgid "An unexpected error occurred while connecting to Onshape. Try connecting again."
 msgstr "连接 Onshape 时发生意外错误。请重新连接。"
@@ -1564,19 +1564,19 @@ msgid "Another cost center this one rolls up into, letting you nest a sub-depart
 msgstr "该成本中心所归属的另一个成本中心，允许您在其父级下嵌套子成本中心，以进行分层成本报告。"
 
 msgid "Another storage unit this one nests inside (e.g. a bin within a rack); must be in the same location."
-msgstr "嵌套此存储单元的另一个存储单元（例如，架子内的垃圾箱）；必须位于同一位置。"
+msgstr "此存储单元嵌套在其中的另一个存储单元（例如，架内的料箱）；必须在同一地点"
 
 msgid "Any item group"
 msgstr "任何项目组"
 
 msgid "Any item type"
-msgstr "任何物品类型"
+msgstr "任何物料类型"
 
 msgid "Anything not explicitly listed in scope above"
 msgstr "未在上述范围内明确列出的任何内容"
 
 msgid "AP"
-msgstr "AP"
+msgstr "应付账款"
 
 msgid "AP Aging"
 msgstr "应付账款账龄"
@@ -1588,7 +1588,7 @@ msgid "AP Outstanding"
 msgstr "应付账款未结"
 
 msgid "AP Overdue"
-msgstr "应付账款逾期"
+msgstr "应付账款已逾期"
 
 msgid "API Docs"
 msgstr "API 文档"
@@ -1597,19 +1597,19 @@ msgid "API Documentation"
 msgstr "API 文档"
 
 msgid "API key"
-msgstr "API 密钥"
+msgstr "API密钥"
 
 msgid "API Key"
-msgstr "API 密钥"
+msgstr "API密钥"
 
 msgid "API Keys"
-msgstr "API 密钥"
+msgstr "API密钥"
 
 msgid "API keys for programmatic access to your Carbon data."
-msgstr "用于以编程方式访问您的 Carbon 数据的 API 密钥。"
+msgstr "API密钥用于以编程方式访问您的Carbon数据。"
 
 msgid "API, webhooks, and integrations"
-msgstr ""
+msgstr "API、Webhook 和集成"
 
 msgid "Applied"
 msgstr "已应用"
@@ -1643,10 +1643,10 @@ msgid "Apply a demo template"
 msgstr "应用演示模板"
 
 msgid "Apply available credits"
-msgstr "应用可用额度"
+msgstr "应用可用的信用额度"
 
 msgid "Apply credits"
-msgstr "应用额度"
+msgstr "应用信用额度"
 
 msgid "Apply payments and track aging"
 msgstr "应用付款并跟踪账龄"
@@ -1679,16 +1679,16 @@ msgid "Approaching {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB cap."
 msgstr "接近 {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB 上限。"
 
 msgid "Approval Date"
-msgstr "批准日期"
+msgstr "审批日期"
 
 msgid "Approval is required at or above this amount, up to the next rule's minimum"
-msgstr "在此金额或以上需要批准，直到下一条规则的最低金额"
+msgstr "此金额及以上需要审批，直到下一规则的最小值"
 
 msgid "Approval requirements"
-msgstr "批准要求"
+msgstr "审批要求"
 
 msgid "Approval Requirements"
-msgstr "批准要求"
+msgstr "审批要求"
 
 msgid "Approval Rules"
 msgstr "审批规则"
@@ -1697,7 +1697,7 @@ msgid "Approvals"
 msgstr "审批"
 
 msgid "Approve"
-msgstr "批准"
+msgstr "审批"
 
 msgid "Approved By"
 msgstr "批准人"
@@ -1709,10 +1709,10 @@ msgid "AQL (Z1.4 / ISO 2859-1)"
 msgstr "AQL (Z1.4 / ISO 2859-1)"
 
 msgid "AR"
-msgstr "AR"
+msgstr "应收账款"
 
 msgid "AR / AP representation"
-msgstr "AR / AP 表示法"
+msgstr "应收账款/应付账款表示"
 
 msgid "AR Aging"
 msgstr "应收账款账龄"
@@ -1724,10 +1724,10 @@ msgid "AR Outstanding"
 msgstr "应收账款未结"
 
 msgid "AR Overdue"
-msgstr "应收账款逾期"
+msgstr "应收账款已逾期"
 
 msgid "AR/AP"
-msgstr "AR/AP"
+msgstr "应收账款/应付账款"
 
 msgid "Archive"
 msgstr "存档"
@@ -1750,11 +1750,11 @@ msgid "Are you sure you want to activate the process: {name}? It will appear in 
 msgstr "您确定要激活流程：{name}？它将再次出现在下拉菜单中。"
 
 msgid "Are you sure you want to activate this gauge?."
-msgstr "您确定要激活此量规吗？"
+msgstr "确定要启用此量具吗？"
 
 #. placeholder {0}: routeData?.changeNotice?.changeOrderId ?? ""
 msgid "Are you sure you want to cancel {0}? It will be closed and read-only until you reopen it."
-msgstr "您确定要取消 {0} 吗?在您重新打开之前，它将被关闭并处于只读状态。"
+msgstr "您确定要取消{0}吗？在您重新打开之前，它将被已关闭且只读。"
 
 #. placeholder {0}: routeData?.rfqSummary ?.rfqId!
 msgid "Are you sure you want to cancel {0}? This will also cancel all related supplier quotes."
@@ -1767,7 +1767,7 @@ msgid "Are you sure you want to cancel this job? It will no longer be available 
 msgstr "你确定要取消此工作吗？它将不再在车间可用。"
 
 msgid "Are you sure you want to change the {propertyName} property? Since you use generated material IDs this will change the part ID of this part, and all related revisions."
-msgstr "你确定要更改 {propertyName} 属性吗？由于你使用生成的材料 ID，这将更改此零件的零件 ID 及其所有相关版本。"
+msgstr "您确定要更改{propertyName}属性吗？由于您使用自动生成的物料ID，这将更改该零件的零件ID及其所有相关的修订版。"
 
 msgid "Are you sure you want to complete this stock transfer?"
 msgstr "你确定要完成此库存转移吗？"
@@ -1779,7 +1779,7 @@ msgid "Are you sure you want to convert the RFQ to a quote?"
 msgstr "您确定要将RFQ转换为报价吗？"
 
 msgid "Are you sure you want to create jobs for this sales order? This will create jobs for all lines that don't already have jobs."
-msgstr "你确定要为此销售订单创建工作吗？这将为所有还没有工作的行创建工作。"
+msgstr "确定要为此销售订单创建工单吗？这将为所有尚未有工单的行创建工单。"
 
 #. placeholder {0}: routeData?.supplier?.name
 msgid "Are you sure you want to deactivate {0}?"
@@ -1803,7 +1803,7 @@ msgid "Are you sure you want to deactivate these users?"
 msgstr "你确定要停用这些用户吗？"
 
 msgid "Are you sure you want to deactivate this gauge?."
-msgstr "您确定要停用此量规吗？"
+msgstr "确定要停用此量具吗？"
 
 msgid "Are you sure you want to deactivate this user?"
 msgstr "你确定要停用此用户吗？"
@@ -1832,7 +1832,7 @@ msgstr "您确定要删除 {orderLabel} 吗？此操作无法撤销。"
 #. placeholder {0}: activeView.name
 #. placeholder {0}: viewPendingDelete.name
 msgid "Are you sure you want to delete the \"{0}\" view? This cannot be undone."
-msgstr "您确定要删除\"{0}\"视图吗？此操作无法撤销。"
+msgstr "确定要删除\"{0}\"查看吗？此操作无法撤消。"
 
 #. placeholder {0}: selectedCustomField?.name
 msgid "Are you sure you want to delete the {0} field?"
@@ -1855,7 +1855,7 @@ msgstr "您确定要删除账户：{0}{1}吗？此操作无法撤销。"
 
 #. placeholder {0}: apiKey.name
 msgid "Are you sure you want to delete the API key: {0}? This cannot be undone."
-msgstr "您确定要删除 API 密钥：{0}？此操作无法撤销。"
+msgstr "确定要删除API密钥：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: selectedClass.name
 msgid "Are you sure you want to delete the asset class: {0}? This cannot be undone."
@@ -1863,14 +1863,14 @@ msgstr "确定要删除资产类别: {0}吗?此操作无法撤销。"
 
 #. placeholder {0}: requiredAction.name
 msgid "Are you sure you want to delete the change notice action: {0}? This cannot be undone."
-msgstr "您确定要删除更改单操作：{0}？此操作无法撤销。"
+msgstr "确定要删除变更通知操作：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: changeNoticeType.name
 msgid "Are you sure you want to delete the change notice category: {0}? This cannot be undone."
-msgstr "您确定要删除更改单类别：{0}？此操作无法撤销。"
+msgstr "确定要删除变更通知类别：{0}吗？此操作无法撤消。"
 
 msgid "Are you sure you want to delete the contractor: {name}? This cannot be undone."
-msgstr "您确定要删除承包商：{name}？此操作无法撤销。"
+msgstr "确定要删除外协人员：{name}吗？此操作无法撤消。"
 
 #. placeholder {0}: customerPart?.customer?.name ?? ""
 msgid "Are you sure you want to delete the customer part for {0}? This cannot be undone."
@@ -1929,11 +1929,11 @@ msgid "Are you sure you want to delete the location: {name}? This cannot be undo
 msgstr "您确定要删除位置：{name}？此操作无法撤销。"
 
 msgid "Are you sure you want to delete the maintenance schedule: {name}? This cannot be undone."
-msgstr "您确定要删除维护计划：{name}？此操作无法撤销。"
+msgstr "您确定要删除维护计划：{name}吗？此操作无法撤销。"
 
 #. placeholder {0}: materialDimension.name
 msgid "Are you sure you want to delete the material dimension: {0}? This cannot be undone."
-msgstr "您确定要删除材料尺寸：{0}？此操作无法撤销。"
+msgstr "您确定要删除物料维度：{0}吗？此操作无法撤销。"
 
 #. placeholder {0}: materialFinish.name
 msgid "Are you sure you want to delete the material finish: {0}? This cannot be undone."
@@ -1941,30 +1941,30 @@ msgstr "您确定要删除材料表面处理: {0}? 此操作无法撤销。"
 
 #. placeholder {0}: materialForm.name
 msgid "Are you sure you want to delete the material form: {0}? This cannot be undone."
-msgstr "您确定要删除材料表单：{0}？此操作无法撤销。"
+msgstr "您确定要删除物料形式：{0}吗？此操作无法撤销。"
 
 #. placeholder {0}: materialGrade.name
 msgid "Are you sure you want to delete the material grade: {0}? This cannot be undone."
-msgstr "您确定要删除材料等级：{0}？此操作无法撤销。"
+msgstr "确定要删除牌号：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: materialSubstance.name
 msgid "Are you sure you want to delete the material substance: {0}? This cannot be undone."
-msgstr "您确定要删除该物质材料：{0}？此操作无法撤销。"
+msgstr "确定要删除材质：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: materialType.name
 msgid "Are you sure you want to delete the material type: {0}? This cannot be undone."
-msgstr "您确定要删除材料类型：{0}？此操作无法撤销。"
+msgstr "您确定要删除物料类型：{0}吗？此操作无法撤销。"
 
 #. placeholder {0}: noQuoteReason.name
 msgid "Are you sure you want to delete the no quote reason: {0}? This cannot be undone."
-msgstr "您确定要删除无报价原因：{0}？此操作无法撤销。"
+msgstr "确定要删除不报价原因：{0}吗？此操作无法撤消。"
 
 msgid "Are you sure you want to delete the partner: {name}? This cannot be undone."
 msgstr "您确定要删除合作伙伴：{name}？此操作无法撤销。"
 
 #. placeholder {0}: paymentTerm.name
 msgid "Are you sure you want to delete the payment term: {0}? This cannot be undone."
-msgstr "您确定要删除付款条款：{0}？此操作无法撤销。"
+msgstr "确定要删除付款条件：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: pricingRule.name
 msgid "Are you sure you want to delete the pricing rule: {0}? This cannot be undone."
@@ -1991,17 +1991,17 @@ msgstr "您确定要删除销售订单行 {0} {1} 吗？此操作无法撤销。
 
 #. placeholder {0}: scrapReason.name
 msgid "Are you sure you want to delete the scrap reason: {0}? This cannot be undone."
-msgstr "您确定要删除废料原因：{0}？此操作无法撤销。"
+msgstr "确定要删除报废原因：{0}吗？此操作无法撤消。"
 
 msgid "Are you sure you want to delete the serial number sequence for {itemLabel}? This cannot be undone."
-msgstr "你确定要删除 {itemLabel} 的序列号序列吗？这无法撤销。"
+msgstr "确定要删除{itemLabel}的序列号编号规则吗？此操作无法撤消。"
 
 msgid "Are you sure you want to delete the shift: {name} from {locationName}? This cannot be undone."
 msgstr "您确定要删除班次：{name} 从 {locationName}？此操作无法撤销。"
 
 #. placeholder {0}: shippingMethod.name
 msgid "Are you sure you want to delete the shipping method: {0}? This cannot be undone."
-msgstr "您确定要删除运输方式：{0}？此操作无法撤销。"
+msgstr "确定要删除发货方式：{0}吗？此操作无法撤消。"
 
 #. placeholder {0}: storageType.name
 msgid "Are you sure you want to delete the storage type: {0}? This cannot be undone."
@@ -2021,7 +2021,7 @@ msgstr "您确定要删除计量单位：{0}？此操作无法撤销。"
 
 #. placeholder {0}: selectedView.name
 msgid "Are you sure you want to delete the view \"{0}\"?"
-msgstr "你确定要删除视图\"{0}\"吗？"
+msgstr "确定要删除查看\"{0}\"吗？"
 
 #. placeholder {0}: webhook.name
 msgid "Are you sure you want to delete the webhook: {0}? This cannot be undone."
@@ -2031,10 +2031,10 @@ msgid "Are you sure you want to delete this approval rule? This cannot be undone
 msgstr "你确定要删除此审批规则吗？此操作无法撤销。"
 
 msgid "Are you sure you want to delete this change notice?"
-msgstr "您确定要删除此更改单？"
+msgstr "确定要删除此变更通知吗？"
 
 msgid "Are you sure you want to delete this gauge?"
-msgstr "你确定要删除此量规吗？"
+msgstr "确定要删除此量具吗？"
 
 msgid "Are you sure you want to delete this inspection plan?"
 msgstr "你确定要删除此检验计划吗?"
@@ -2052,10 +2052,10 @@ msgid "Are you sure you want to delete this kanban card? This cannot be undone."
 msgstr "你确定要删除此看板卡吗？此操作无法撤销。"
 
 msgid "Are you sure you want to delete this maintenance dispatch? This cannot be undone."
-msgstr "您确定要删除此维护调度吗？此操作无法撤销。"
+msgstr "确定要删除此维护工单吗？此操作无法撤消。"
 
 msgid "Are you sure you want to delete this passkey? You won't be able to use it to sign in anymore."
-msgstr "您确定要删除此密钥吗?您将无法再使用它登录。"
+msgstr "确定要删除此通行密钥吗？您将无法再使用它登录。"
 
 msgid "Are you sure you want to delete this quality document?"
 msgstr "你确定要删除此质量文件吗？"
@@ -2092,7 +2092,7 @@ msgstr "您确定要离开此页面吗？"
 
 #. placeholder {0}: i18n._(step.title)
 msgid "Are you sure you want to pass this checkpoint? The {0} phase still has unfinished tasks."
-msgstr "你确定要通过此检查点吗？{0}阶段仍有未完成的任务。"
+msgstr "您确定要通过此检查点吗？{0}阶段仍有未完成的任务。"
 
 #. placeholder {0}: selectedPurchaseInvoice.invoiceId!
 #. placeholder {0}: selectedSalesInvoice.invoiceId!
@@ -2100,7 +2100,7 @@ msgid "Are you sure you want to permanently delete {0}?"
 msgstr "您确定要永久删除 {0} 吗？"
 
 msgid "Are you sure you want to permanently delete the supplier process?"
-msgstr "您确定要永久删除供应商流程吗？"
+msgstr "确定要永久删除供应商工艺吗？"
 
 msgid "Are you sure you want to post this receipt?"
 msgstr "你确定要过账此收据吗？"
@@ -2112,7 +2112,7 @@ msgid "Are you sure you want to reject this quote?"
 msgstr "你确定要拒绝此报价吗？"
 
 msgid "Are you sure you want to release this job? It will become available to the shop floor, and drive purchasing and production."
-msgstr "你确定要发布此工作吗？它将在车间可用，并推动采购和生产。"
+msgstr "确定要下达此工单吗？它将对车间可用，并驱动采购和生产。"
 
 #. placeholder {0}: supplierName(deleteTarget.supplierId)
 msgid "Are you sure you want to remove {0} as a supplier for this item? This cannot be undone."
@@ -2122,7 +2122,7 @@ msgid "Are you sure you want to remove {supplierName} as a supplier for this ite
 msgstr "您确定要将 {supplierName} 从此项目的供应商中移除吗？此操作无法撤销。"
 
 msgid "Are you sure you want to remove this item from the price list? This cannot be undone."
-msgstr "你确定要从价格列表中删除此项目吗？此操作无法撤销。"
+msgstr "确定要从价格表中移除此物料吗？此操作无法撤消。"
 
 msgid "Are you sure you want to revoke the invitation for this user?"
 msgstr "您确定要撤销此用户的邀请吗？"
@@ -2140,13 +2140,13 @@ msgid "Are you sure you want to void this purchase invoice? This action will rev
 msgstr "您确定要作废此采购发票吗？此操作将反转所有财务交易，无法撤销。"
 
 msgid "Are you sure you want to void this receipt? This action will reverse all inventory transactions and cannot be undone."
-msgstr "您确定要作废此收据吗？此操作将反转所有库存交易，无法撤销。"
+msgstr "您确定要作废此收货吗？此操作将反转所有库存交易，无法撤销。"
 
 msgid "Are you sure you want to void this sales invoice? This action will reverse all financial transactions and cannot be undone."
 msgstr "您确定要作废此销售发票吗？此操作将反转所有财务交易，无法撤销。"
 
 msgid "Are you sure you want to void this shipment? This action will reverse all inventory transactions and cannot be undone."
-msgstr "您确定要作废此发货单吗？此操作将反转所有库存交易，无法撤销。"
+msgstr "您确定要作废此发货吗？此操作将反转所有库存交易，无法撤销。"
 
 msgid "Are you sure?"
 msgstr "你确定吗？"
@@ -2165,7 +2165,7 @@ msgid "As of:"
 msgstr "截至："
 
 msgid "As the company owner, you can transfer ownership to another employee. This will give them full access to billing and administrative settings."
-msgstr "作为公司所有者，您可以将所有权转移给另一名员工。这将授予他们对账单和管理设置的完全访问权限。"
+msgstr "作为公司所有者，您可以将所有权转移给另一名员工。这将给予他们对账单和管理设置的完全访问权限。"
 
 msgid "Ascending"
 msgstr "升序"
@@ -2200,10 +2200,10 @@ msgid "Asset account for advance payments made to suppliers before goods or serv
 msgstr "供应商在收到商品或服务前预先支付的预付款的资产科目"
 
 msgid "Asset Acquisition Cost"
-msgstr "资产收购成本"
+msgstr "资产购置成本"
 
 msgid "Asset Acquisition Cost (default)"
-msgstr "资产收购成本（默认）"
+msgstr "资产购置成本（默认）"
 
 msgid "asset class"
 msgstr "资产类别"
@@ -2233,7 +2233,7 @@ msgid "Assets"
 msgstr "资产"
 
 msgid "Assets, liabilities and equity as of a date"
-msgstr "特定日期的资产、负债和权益"
+msgstr "某一日期的资产、负债和所有者权益"
 
 msgid "Assign printers to locations. Shipping, receiving, and work centers inherit the location default unless overridden."
 msgstr "将打印机分配到位置。运输、接收和工作中心继承位置默认值，除非被覆盖。"
@@ -2248,10 +2248,10 @@ msgid "Assigned"
 msgstr "已分配"
 
 msgid "Assigned to Me"
-msgstr "分配给我"
+msgstr "已分配给我"
 
 msgid "Assignee"
-msgstr "被指派人"
+msgstr "经办人"
 
 msgid "Assignment"
 msgstr "分配"
@@ -2263,7 +2263,7 @@ msgid "Assigns this storage unit to a work center (lineside)"
 msgstr "将此存储单元分配给工作中心（线边）"
 
 msgid "Assigns this unit to a work center for lineside material, so operators see it on the production view; inherited from the parent unit when set there."
-msgstr "将此单元分配给工作中心以用于线边材料，以便操作员在生产视图中看到它；在那里设置时从父单元继承。"
+msgstr "将此库位分配给工作中心以进行线边物料管理，使操作员能在生产视图上看到；从父库位继承该设置。"
 
 msgid "At each gate"
 msgstr "在每个关卡"
@@ -2293,19 +2293,19 @@ msgid "Attribute"
 msgstr "属性"
 
 msgid "Attribute sampling standard used to compute lot sample sizes and accept/reject numbers on inbound inspections."
-msgstr "用于计算入库检验中批量样本量和接受/拒绝数字的属性抽样标准。"
+msgstr "用于计算批次样本量和来料检验中接受/拒绝数量的属性抽样标准。"
 
 msgid "Attributes"
 msgstr "属性"
 
 msgid "Attributes are inherited from the procedure."
-msgstr "属性继承自工序。"
+msgstr "属性从程序文件继承。"
 
 msgid "Audit Log"
 msgstr "审计日志"
 
 msgid "Audit logging"
-msgstr ""
+msgstr "审计日志"
 
 msgid "Audit Logging"
 msgstr "审计日志"
@@ -2338,10 +2338,10 @@ msgid "Auto arrange"
 msgstr "自动排列"
 
 msgid "Auto Release"
-msgstr "自动发放"
+msgstr "自动下达"
 
 msgid "Auto release must be enabled to start a job automatically"
-msgstr "必须启用自动发布才能自动启动作业"
+msgstr "必须启用自动下达才能自动启动工单"
 
 msgid "Auto Start Job"
 msgstr "自动启动作业"
@@ -2353,10 +2353,10 @@ msgid "Auto-generated QR Code"
 msgstr "自动生成的二维码"
 
 msgid "Auto-numbering formats for orders, jobs, parts, and more"
-msgstr "订单、工作、零件等的自动编号格式"
+msgstr "订单、工单、零件等的自动编号格式"
 
 msgid "Auto-suggest purchases from demand and reorder points"
-msgstr "根据需求和重新订购点自动建议采购"
+msgstr "根据需求和再订货点自动建议采购"
 
 msgid "Automate"
 msgstr "自动化"
@@ -2377,13 +2377,13 @@ msgid "Automatic Updates"
 msgstr "自动更新"
 
 msgid "Automatic updates and backups"
-msgstr ""
+msgstr "自动更新和备份"
 
 msgid "Automatic, prorated consumption of a job's untracked materials when output is reported — tracked materials are issued manually."
-msgstr "报告输出时，自动按比例消耗工作的未跟踪材料—跟踪的材料手动发出。"
+msgstr "报告输出时，工单未跟踪原材料的自动、按比例消耗—已跟踪的原材料需手动发放。"
 
 msgid "Automatically release the job when the kanban is scanned"
-msgstr "当扫描看板时自动释放作业"
+msgstr "扫描看板时自动下达工单"
 
 msgid "Automatically start the job when the kanban is scanned"
 msgstr "当扫描看板时自动启动作业"
@@ -2408,7 +2408,7 @@ msgid "Avg Days to Close"
 msgstr "平均关闭天数"
 
 msgid "Awaiting approval"
-msgstr "等待批准"
+msgstr "等待审批"
 
 msgid "Back"
 msgstr "返回"
@@ -2417,7 +2417,7 @@ msgid "Back to traceability"
 msgstr "返回可追溯性"
 
 msgid "Backflush"
-msgstr "反冲"
+msgstr "倒冲"
 
 msgid "Backups"
 msgstr "备份"
@@ -2441,7 +2441,7 @@ msgid "Bank - Cash"
 msgstr "银行-现金"
 
 msgid "Bank - Foreign Currency"
-msgstr "银行-外币"
+msgstr "银行 - 外币"
 
 msgid "Bank - Local Currency"
 msgstr "银行-本地货币"
@@ -2450,7 +2450,7 @@ msgid "Bank — Cash (default)"
 msgstr "银行—现金（默认）"
 
 msgid "Bank — Foreign Currency (default)"
-msgstr "银行—外币（默认）"
+msgstr "银行 — 外币（默认）"
 
 msgid "Bank — Local Currency (default)"
 msgstr "银行—本地货币（默认）"
@@ -2459,7 +2459,7 @@ msgid "Bank / Cash Account"
 msgstr "银行/现金账户"
 
 msgid "Bank account denominated in a foreign currency"
-msgstr "以外币计价的银行账户。"
+msgstr "以外币计价的银行账户"
 
 msgid "Bank account denominated in the local currency"
 msgstr "以本地货币计价的银行账户。"
@@ -2468,7 +2468,7 @@ msgid "Bank and financial service charge expenses"
 msgstr "银行和金融服务费用。"
 
 msgid "Bars show each week's flow: <0>supply</0> pushes inventory up, <1>demand</1> pulls it down. The <2>line</2> is your projected on-hand inventory — when it dips below <3>safety stock</3> you're at risk, and below zero is a <4>stockout</4>."
-msgstr "条形图显示每周的流量：&lt;0&gt;供应&lt;/0&gt;将库存推高，&lt;1&gt;需求&lt;/1&gt;将其拉低。&lt;2&gt;线&lt;/2&gt;是您的预计可用库存—当它低于&lt;3&gt;安全库存&lt;/3&gt;时，您处于风险中，低于零时是&lt;4&gt;缺货&lt;/4&gt;。"
+msgstr "柱状图显示每周的流向：<0>供应</0>推高库存，<1>需求</1>拉低库存。<2>线</2>表示您的预计现有库存 — 当它跌破<3>安全库存</3>时，您面临风险；跌破零则是<4>缺货</4>。"
 
 msgid "Base Currency"
 msgstr "基础货币"
@@ -2477,7 +2477,7 @@ msgid "Base Price"
 msgstr "基础价格"
 
 msgid "Basic ERP, MES, and QMS functionality"
-msgstr ""
+msgstr "基本的 ERP、MES 和 QMS 功能"
 
 msgid "Basic Information"
 msgstr "基本信息"
@@ -2489,7 +2489,7 @@ msgid "Batch / Serial"
 msgstr "批次 / 序列号"
 
 msgid "Batch items require a sales order"
-msgstr "批次项目需要销售订单"
+msgstr "生产批次物料需要销售订单"
 
 msgid "Batch number"
 msgstr "批号"
@@ -2514,7 +2514,7 @@ msgstr "开始"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Being phased out — successor: <0>{0}</0>"
-msgstr "正在逐步淘汰 — 后继产品：<0>{0}</0>"
+msgstr "正在逐步淘汰—后继物料：<0>{0}</0>"
 
 msgid "Below safety stock"
 msgstr "低于安全库存"
@@ -2535,7 +2535,7 @@ msgid "Bill of Materials"
 msgstr "物料清单"
 
 msgid "Bill of Process"
-msgstr "工艺流程"
+msgstr "工序清单"
 
 msgid "Bill To"
 msgstr "账单收款人"
@@ -2578,10 +2578,10 @@ msgid "BoM + BoP"
 msgstr "BoM + BoP"
 
 msgid "BOM synced successfully"
-msgstr "物料清单同步成功"
+msgstr "BOM 同步成功"
 
 msgid "BOMs"
-msgstr "物料清单"
+msgstr "BOMs"
 
 msgid "Bonus Depreciation %"
 msgstr "奖金折旧%"
@@ -2608,19 +2608,19 @@ msgid "Breadcrumb"
 msgstr "面包屑"
 
 msgid "Bring in your parts, BOMs, Bill of Process, and costing — with Carbon's import tools, CSV, or LLM help."
-msgstr "导入您的零件、物料清单、工艺流程和成本——使用 Carbon 的导入工具、CSV 或 LLM 帮助。"
+msgstr "导入您的零件、BOM、工序清单和成本核算—使用 Carbon 的导入工具、CSV 或 LLM 帮助。"
 
 msgid "Browse library"
 msgstr "浏览库"
 
 msgid "Browse the published version read-only. You can still rearrange steps to tidy the layout."
-msgstr ""
+msgstr "浏览已发布版本（只读）。您仍然可以重新排列步骤来整理布局。"
 
 msgid "Bucket"
 msgstr "存储桶"
 
 msgid "Buffer stock the demand-based policy holds back to absorb consumption spikes within the accumulation period."
-msgstr "需求政策为吸收累积期内的消费高峰而保留的缓冲库存。"
+msgstr "基于需求的政策保留的缓冲库存，用于吸收积累期间的消耗尖峰。"
 
 msgid "Bugs and changes"
 msgstr "错误和更改"
@@ -2635,13 +2635,13 @@ msgid "Build integrations and customizations"
 msgstr "构建集成和自定义"
 
 msgid "Build quotes pulling live part, cost, and Bill of Process data"
-msgstr "构建报价，拉取实时零件、成本和工艺单据数据"
+msgstr "通过拉取实时零件、成本和工序清单数据来创建报价单"
 
 msgid "Build role-based training materials"
 msgstr "构建基于角色的培训材料"
 
 msgid "Build tailored, role-based training materials"
-msgstr "构建定制化、基于角色的培训材料"
+msgstr "构建定制的、基于角色的培训材料"
 
 msgid "Built and costed as its own method"
 msgstr "作为独立方法构建和计算成本"
@@ -2650,7 +2650,7 @@ msgid "Bulk Import"
 msgstr "批量导入"
 
 msgid "Bulk Jobs"
-msgstr "批量作业"
+msgstr "批量工单"
 
 msgid "Business moment"
 msgstr "业务时刻"
@@ -2659,10 +2659,10 @@ msgid "Business moments"
 msgstr "业务时刻"
 
 msgid "Buy"
-msgstr "购买"
+msgstr "采购"
 
 msgid "Buy and Make"
-msgstr "购买和制造"
+msgstr "采购与自制"
 
 msgid "Buyer"
 msgstr "采购员"
@@ -2680,7 +2680,7 @@ msgid "By dimension"
 msgstr "按维度"
 
 msgid "By Document Date"
-msgstr "按单据日期"
+msgstr "按文件日期"
 
 msgid "By Due Date"
 msgstr "按到期日期"
@@ -2701,10 +2701,10 @@ msgid "CAD Model"
 msgstr "CAD 模型"
 
 msgid "Calculate from BOM"
-msgstr "从物料清单计算"
+msgstr "从BOM计算"
 
 msgid "Calculated finished-good expiry"
-msgstr "计算成品过期时间"
+msgstr "计算成品有效期"
 
 msgid "Calculation Method"
 msgstr "计算方法"
@@ -2719,7 +2719,7 @@ msgid "Calibration Expiration Notifications"
 msgstr "校准过期通知"
 
 msgid "Calibration Interval (Months)"
-msgstr "校准间隔（月）"
+msgstr "校准周期（月）"
 
 msgid "Calibration Record"
 msgstr "校准记录"
@@ -2740,13 +2740,13 @@ msgid "Call an outside URL"
 msgstr "调用外部 URL"
 
 msgid "Called a method in Carbon — the components plus operations that produce a part."
-msgstr "在Carbon中称为方法—生成零件的组件和操作。"
+msgstr "在Carbon中称为方法 — 生产一个零件的组成部分和工序。"
 
 msgid "Can't delete this period"
 msgstr "无法删除此期间"
 
 msgid "Can't disable the only active break. Add another break or toggle the override's Active instead."
-msgstr "无法禁用唯一的活跃价格段。请添加另一个价格段或改为切换覆盖的\"活跃\"状态。"
+msgstr "无法禁用唯一的启用休息时间。请添加另一个休息时间或改为切换覆盖的启用状态。"
 
 msgid "Can't download this file"
 msgstr "无法下载此文件"
@@ -2755,10 +2755,10 @@ msgid "Cancel"
 msgstr "取消"
 
 msgid "Cancel change notice"
-msgstr "取消更改单"
+msgstr "取消变更通知"
 
 msgid "Cancel Change Notice"
-msgstr "取消更改单"
+msgstr "取消变更通知"
 
 msgid "Cancel Job"
 msgstr "取消工作"
@@ -2815,13 +2815,13 @@ msgid "Cannot place order - no supplier associated with this item"
 msgstr "无法下单 - 此项目没有关联的供应商"
 
 msgid "Cannot post — shipment contains expired tracked entities."
-msgstr "无法发布 — 货运单包含已过期的追踪实体。"
+msgstr "无法过账 — 发货包含已过期的追踪实体。"
 
 msgid "Cannot send RFQ"
 msgstr "无法发送询价单"
 
 msgid "Cannot send through Stripe"
-msgstr ""
+msgstr "无法通过Stripe发送"
 
 msgid "Cannot upload — supplier interaction not yet created"
 msgstr "无法上传 — 供应商互动尚未创建"
@@ -2854,7 +2854,7 @@ msgid "Carbon column"
 msgstr "Carbon 列"
 
 msgid "Carbon is configured the way your company runs, your data is loaded, and your team is confident using it. When that's true, you're ready to go live."
-msgstr "Carbon已按照您公司的运营方式进行配置，您的数据已加载，您的团队对使用它充满信心。当这一切都实现时，您就可以上线了。"
+msgstr "Carbon已按照您的公司运营方式进行配置，您的数据已加载，您的团队对其使用有信心。当这一切都实现时，您就可以准备上线了。"
 
 msgid "Carbon leads"
 msgstr "Carbon 主导"
@@ -2866,7 +2866,7 @@ msgid "Carbon only"
 msgstr "仅限 Carbon"
 
 msgid "Carbon Posted"
-msgstr "Carbon 已记账"
+msgstr "Carbon已过账"
 
 msgid "Carbon value"
 msgstr "Carbon 值"
@@ -2876,7 +2876,7 @@ msgstr "碳值"
 
 #. placeholder {0}: unmapped.length
 msgid "Carbon will use AI to guess a provider account for each of your {0} unmapped accounts. Suggestions are a starting point — you can review them before anything is saved."
-msgstr "Carbon 将使用 AI 为您的每个 {0} 个未映射的账户猜测一个提供商账户。建议是一个起点 — 您可以在保存任何内容之前审查它们。"
+msgstr "Carbon将使用AI为您的{0}个未映射账户各猜测一个供应商账户。建议是一个起点 — 您可以在保存前审查它们。"
 
 msgid "Carbon-only"
 msgstr "仅限Carbon"
@@ -2888,28 +2888,28 @@ msgid "Carbon-only · the customer sees this text, locked."
 msgstr "仅限Carbon · 客户可以看到此文本，已锁定。"
 
 msgid "Carbon's name for a bill of material and bill of process (routing): the components plus the operations that make a part."
-msgstr "Carbon对物料清单和工艺路线的名称：生成零件的组件和操作。"
+msgstr "Carbon对物料清单和工序清单（工艺路线）的称呼：组成零件的物料和工序。"
 
 msgid "Carbon's planning run nets supply against demand and explodes methods, surfacing shortfalls — but it creates no orders itself."
-msgstr "Carbon的规划运行对供应和需求进行净额并展开方法，显示缺陷—但它本身不会创建订单。"
+msgstr "Carbon的计划运行对需求进行净供应和展开方法，表面不足 — 但它本身不创建订单。"
 
 msgid "Carbon's production order — one job builds a quantity of one item from its own copied method and routing."
-msgstr "Carbon的生产订单 — 一个作业从其复制的方法和路由构建一个物品的数量。"
+msgstr "Carbon的生产订单 — 一个工单从其自身复制的方法和工艺路线构建一个物料的数量。"
 
 msgid "Carbon's shop-floor app where operators run operations, report quantities, issue material, and log time against released jobs in real time."
-msgstr "Carbon 的车间应用，操作员在其中运行操作、报告数量、发放材料并实时记录时间以对抗已发放的工作。"
+msgstr "Carbon的车间应用程序，操作员可在其中执行工序、报告数量、领料并对已下达工单实时计工时。"
 
 msgid "Carbon's single record for anything with a part number — Part, Material, Tool, Service, Consumable, or Fixture — that jobs, methods, orders, and inventory all point at."
-msgstr "Carbon 中单一记录任何带有零件号的内容——零件、材料、工具、服务、耗材或夹具——工作、方法、订单和库存都指向它。"
+msgstr "Carbon对任何具有零件号的事物的单一记录 — 零件、原材料、刀具、服务、耗材或工装夹具 — 工单、方法、订单和库存管理都指向。"
 
 msgid "Cards"
 msgstr "卡片"
 
 msgid "Carrier"
-msgstr "承运人"
+msgstr "承运商"
 
 msgid "Carrier Account"
-msgstr "承运人账户"
+msgstr "承运商账户"
 
 msgid "Cash & Banking"
 msgstr "现金和银行"
@@ -2960,28 +2960,28 @@ msgid "Change"
 msgstr "更改"
 
 msgid "Change Document"
-msgstr "变更文档"
+msgstr "变更文件"
 
 msgid "Change Inspection Plan"
 msgstr "更改检验计划"
 
 msgid "Change notice"
-msgstr "更改单"
+msgstr "变更通知"
 
 msgid "Change Notice"
-msgstr "更改单"
+msgstr "变更通知"
 
 msgid "Change Notice Actions"
-msgstr "更改单操作"
+msgstr "变更通知操作"
 
 msgid "Change Notice Types"
-msgstr "更改单类型"
+msgstr "变更通知类型"
 
 msgid "Change Notices"
-msgstr "更改单"
+msgstr "变更通知"
 
 msgid "Change notices could not be loaded, so new versions and revisions are blocked. Reload to try again."
-msgstr "无法加载更改单，因此新版本和修订版本已被阻止。请重新加载以重试。"
+msgstr "无法加载变更通知，因此新版本和修订版被阻止。重新加载以重试。"
 
 msgid "Change order"
 msgstr "变更单"
@@ -2990,7 +2990,7 @@ msgid "Change status"
 msgstr "更改状态"
 
 msgid "Change the item type (e.g. Part, Material, Tool, etc.)"
-msgstr "更改项目类型（例如零件、材料、工具等）"
+msgstr "更改物料类型（例如零件、原材料、刀具等）"
 
 msgid "Change type"
 msgstr "变更类型"
@@ -3023,13 +3023,13 @@ msgid "Chat"
 msgstr "聊天"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
-msgstr "检查物料分类账中期末库存数量为负的任何物料——通常是缺少收货或发布顺序不对导致库存价值和销货成本失真。审查后标记为完成，或跳过并说明原因。"
+msgstr "检查物料分类账以查找期末现有数量为负的任何物料 — 通常是缺少收货或过账顺序错误，导致库存价值和销售成本失真。审查后标记为完成，或因某个理由跳过。"
 
 msgid "Check your email"
 msgstr "检查您的电子邮件"
 
 msgid "Checking Stripe for this customer…"
-msgstr ""
+msgstr "正在为此客户检查Stripe…"
 
 msgid "Checkpoint ·"
 msgstr "检查点 ·"
@@ -3053,7 +3053,7 @@ msgid "Choose another file"
 msgstr "选择另一个文件"
 
 msgid "Choose what appears on the printed job traveler."
-msgstr "选择打印的工作单上显示的内容。"
+msgstr "选择打印工单流转卡上显示的内容。"
 
 msgid "Choose your preferred language for the interface."
 msgstr "选择您偏好的界面语言。"
@@ -3071,16 +3071,16 @@ msgid "Class (inherited)"
 msgstr "类（继承）"
 
 msgid "Classifies a routing operation: Process, Assembly, and Inspection operations run on your own shop floor in the MES — Assembly gets the guided assembly view and Inspection a quality check — while an Outside Processing operation is subcontracted to a supplier and creates a purchase order; the process carries the same type and defaults it on new operations."
-msgstr "对工艺操作进行分类：流程、组装和检测操作在MES中的您自己的车间运行——组装获得引导的组装视图，检测获得质量检查——而外部加工操作则分包给供应商并创建采购订单；流程承载相同的类型，并在新操作上默认设置该类型。"
+msgstr "对工艺路线的工序进行分类：工艺、装配和检验工序在MES的您自有车间运行 — 装配获得导引装配视图，检验进行质量检查 — 而委外加工工序外包给供应商并创建采购订单；该工序类型保留并在新工序上默认使用。"
 
 msgid "Clean and approve the migrated data"
-msgstr "清理并批准迁移的数据"
+msgstr "清理并审批迁移的数据"
 
 msgid "Clear"
 msgstr "清除"
 
 msgid "Clear due date"
-msgstr "清除截止日期"
+msgstr "清除到期日"
 
 msgid "Clear Filters"
 msgstr "清除筛选"
@@ -3095,13 +3095,13 @@ msgid "Clear selection"
 msgstr "清除选择"
 
 msgid "Clear this invoice with the party's posted credits as well as cash. Credits apply directly — no posting needed."
-msgstr "用该方的已过账贷项和现金清算此发票。贷项直接应用——无需过账。"
+msgstr "用交易对方的已过账信用余额和现金清偿此发票。信用直接应用 — 无需过账。"
 
 msgid "Clear value"
 msgstr "清除值"
 
 msgid "Clearing account between goods receipt and supplier invoice; balances when both have posted."
-msgstr "商品收据和供应商发票之间的清算账户; 当两者都已过帐时余额。"
+msgstr "商品收货和供应商发票之间的清算账户；当两者都已过账时对账。"
 
 msgid "Clearing account for goods received / invoice received matching"
 msgstr "商品收据/发票收据匹配的清算账户"
@@ -3119,10 +3119,10 @@ msgid "Click to upload a PDF drawing"
 msgstr "点击上传 PDF 图纸"
 
 msgid "Clock In"
-msgstr "打卡"
+msgstr "开工"
 
 msgid "Clock Out"
-msgstr "打卡下班"
+msgstr "收工"
 
 msgid "Clocked in since <0/>"
 msgstr "自 <0/> 打卡"
@@ -3152,7 +3152,7 @@ msgid "Closed"
 msgstr "已关闭"
 
 msgid "Closed at"
-msgstr "关闭于"
+msgstr "关闭时间"
 
 msgid "Closed by"
 msgstr "关闭人"
@@ -3170,7 +3170,7 @@ msgid "Cloud, or your self-hosted environment."
 msgstr "云端或您自托管的环境。"
 
 msgid "CMMC compliant"
-msgstr ""
+msgstr "符合 CMMC"
 
 msgid "Code"
 msgstr "代码"
@@ -3194,7 +3194,7 @@ msgid "Collapse Machine"
 msgstr "折叠机器"
 
 msgid "Collapse Setup"
-msgstr "折叠设置"
+msgstr "收起换型"
 
 msgid "Collapse subtree"
 msgstr "折叠子树"
@@ -3230,10 +3230,10 @@ msgid "Commit a champion user for each area"
 msgstr "为每个领域指定一名冠军用户"
 
 msgid "Committing a receipt, shipment, or invoice: quantities move, journal entries hit the ledger, and status becomes Posted."
-msgstr "提交收据、发货或发票: 数量移动、日记账分录到达分类账、状态变为已过帐。"
+msgstr "提交收货、发货或发票：数量变动，凭证条目进入分类账，状态变为已过账。"
 
 msgid "Community support"
-msgstr ""
+msgstr "社区支持"
 
 msgid "Companies"
 msgstr "公司"
@@ -3242,16 +3242,16 @@ msgid "Company"
 msgstr "公司"
 
 msgid "Company group"
-msgstr "公司组"
+msgstr "公司集团"
 
 msgid "Company identity, documents, and system defaults."
-msgstr "公司身份、文件和系统默认值。"
+msgstr "公司标识、文档和系统默认设置。"
 
 msgid "Company Name"
 msgstr "公司名称"
 
 msgid "Company policy asks for a different person to inspect inbound items than the one who received them."
-msgstr "公司政策要求由与收货人不同的人员检验入库物品。"
+msgstr "公司政策要求与收货人不同的人检查来料。"
 
 msgid "Company-wide — includes all locations"
 msgstr "公司范围 — 包括所有地点"
@@ -3275,7 +3275,7 @@ msgid "Complete All"
 msgstr "全部完成"
 
 msgid "Complete all quantities on barcode scan"
-msgstr "在条形码扫描时完成所有数量"
+msgstr "在条形码扫码时完成所有数量"
 
 msgid "Complete Job"
 msgstr "完成工作"
@@ -3348,7 +3348,7 @@ msgid "Configure default accounts for vendor and supplier transactions"
 msgstr "配置供应商和供应商交易的默认账户"
 
 msgid "Configure default equity and retained earnings accounts"
-msgstr "配置默认的股权和留存收益账户"
+msgstr "配置默认所有者权益和未分配利润账户"
 
 msgid "Configure defaults for the quality dashboard."
 msgstr "为质量仪表板配置默认值。"
@@ -3357,19 +3357,19 @@ msgid "Configure Item"
 msgstr "配置项目"
 
 msgid "Configure notifications for when gauges go out of calibration."
-msgstr "配置仪表超出校准范围时的通知。"
+msgstr "配置当量具超出校准范围时的通知。"
 
 msgid "Configure notifications for when jobs are completed."
-msgstr "配置作业完成时的通知。"
+msgstr "配置当工单完成时的通知。"
 
 msgid "Configure notifications for when maintenance dispatches are created from the shop floor. Notifications are routed based on the failure mode type."
-msgstr "配置当从车间创建维护派遣时的通知。通知根据故障模式类型进行路由。"
+msgstr "配置当从车间创建维护工单时的通知。通知根据失效模式类型进行路由。"
 
 msgid "Configure notifications for when new suggestions are submitted."
 msgstr "配置在提交新建议时的通知。"
 
 msgid "Configure sites, work centers, Bill of Process, BOMs, costing, roles"
-msgstr "配置站点、工作中心、流程清单、物料清单、成本核算、角色"
+msgstr "配置地点、工作中心、工序清单、BOM、成本核算、角色"
 
 msgid "Configure the default accounts used for various transaction types across your system"
 msgstr "配置用于系统中各种交易类型的默认账户"
@@ -3390,7 +3390,7 @@ msgid "Configure-to-order, automated purchase planning, the shop-floor app."
 msgstr "按订单配置、自动采购计划、车间应用。"
 
 msgid "Configure-to-order: pick options and price automatically"
-msgstr "按订单配置：自动选择选项和价格"
+msgstr "按配置订单：自动选择选项并定价"
 
 msgid "configured"
 msgstr "已配置"
@@ -3406,7 +3406,7 @@ msgid "Confirm {0}"
 msgstr "确认 {0}"
 
 msgid "Confirm & release"
-msgstr "确认并发布"
+msgstr "确认并下达"
 
 msgid "Confirm all"
 msgstr "全部确认"
@@ -3445,13 +3445,13 @@ msgid "Confirm Skip"
 msgstr "确认跳过"
 
 msgid "Confirmed incoming stock — purchase & production orders (bars above zero)."
-msgstr "确认的入库存货 — 采购和生产订单（零以上的条形图）。"
+msgstr "已确认进货 — 采购单和生产订单（上方条形）"
 
 msgid "Confirmed outgoing stock — sales orders & job materials (bars below zero)."
-msgstr "确认的出库存货 — 销售订单和工作物料（零以下的条形图）。"
+msgstr "已确认发货 — 销售订单和工单物料（下方条形）"
 
 msgid "Confirms every posted journal entry in the period has equal debits and credits. If any entry is out of balance the trial balance won't tie out, so it must be corrected before the period can close."
-msgstr "确认期间内每笔已过账日记账条目都有相等的借贷金额。如果任何条目不平衡，试算平衡表将无法对账，因此必须在期间结束前进行更正。"
+msgstr "确认该期间每项已过账分录的借方和贷方相等。如果任何分录不平衡，试算平衡表将无法平衡，必须在期间关闭前进行更正。"
 
 msgid "Conflict reason"
 msgstr "冲突原因"
@@ -3493,28 +3493,28 @@ msgid "Console Operator"
 msgstr "控制台操作员"
 
 msgid "consumable"
-msgstr "消耗品"
+msgstr "耗材"
 
 msgid "Consumable"
-msgstr "消耗品"
+msgstr "耗材"
 
 msgid "Consumable Details"
-msgstr "易耗品详情"
+msgstr "耗材详情"
 
 msgid "Consumable ID"
-msgstr "消耗品ID"
+msgstr "耗材编号"
 
 msgid "consumables"
-msgstr "消耗品"
+msgstr "耗材"
 
 msgid "Consumables"
-msgstr "消耗品"
+msgstr "耗材"
 
 msgid "Consumed"
 msgstr "已消耗"
 
 msgid "Consuming material from inventory into a job, which writes a Consumption entry to the item ledger."
-msgstr "从库存中将材料消耗到工作中，这在物品分类账中写入消费条目。"
+msgstr "从库存管理中消耗原材料到工单中，这会在物料台账中写入消耗分录。"
 
 msgid "contact"
 msgstr "联系人"
@@ -3526,7 +3526,7 @@ msgid "Contact (optional)"
 msgstr "联系人（可选）"
 
 msgid "Contact us"
-msgstr ""
+msgstr "联系我们"
 
 msgid "contacts"
 msgstr "联系人"
@@ -3538,10 +3538,10 @@ msgid "Contained"
 msgstr "已控制"
 
 msgid "Containment"
-msgstr "遏制"
+msgstr "围堵"
 
 msgid "Containment action"
-msgstr "遏制措施"
+msgstr "围堵措施"
 
 msgid "Content"
 msgstr "内容"
@@ -3550,7 +3550,7 @@ msgid "Context"
 msgstr "上下文"
 
 msgid "Contra-asset account for total depreciation of fixed assets"
-msgstr "用于固定资产总折旧的反向资产账户"
+msgstr "固定资产累计折旧对冲资产账户"
 
 msgid "Contra-revenue account for discounts given on sales"
 msgstr "销售折扣的反向收入账户"
@@ -3559,25 +3559,25 @@ msgid "Contra-revenue GL account for discounts given on customer invoices."
 msgstr "客户发票上的折扣的反向收入GL账户。"
 
 msgid "Contractor"
-msgstr "承包商"
+msgstr "外协人员"
 
 msgid "Contractors"
-msgstr "承包商"
+msgstr "外协人员"
 
 msgid "Control design changes with revisions / ECOs"
-msgstr "控制设计变更与修订版本/工程变更单"
+msgstr "通过修订版/ECO控制设计变更"
 
 msgid "Control how operators pick material and track time on the shop floor."
-msgstr "控制操作人员如何在车间选择材料并跟踪时间。"
+msgstr "控制操作员在车间内如何拣货原材料和跟踪时间。"
 
 msgid "Controller, Accountant"
 msgstr "控制器，会计"
 
 msgid "Controls how planning handles a discontinued item: Consume First exhausts on-hand before switching to the successor, Prefer New redirects new demand to the successor immediately, Stock Only keeps only a minimum service reserve, and No Stock drops the item from planning entirely."
-msgstr "控制规划如何处理已停产的物料：优先消耗会在切换到替代物料前耗尽现有库存，优先新品会立即将新需求重定向到替代物料，仅库存会仅保留最少的服务库存，无库存会将物料从规划中完全删除。"
+msgstr "控制计划如何处理已停用物料：先消耗在切换到后继物料前用尽现有库存，优先使用新品立即将新需求重定向到后继物料，仅库存仅保留最小服务储备，无库存将物料从计划中完全删除。"
 
 msgid "Controls whether the bill of material and bill of process of a released (Production) revision can be edited outside a change order."
-msgstr "控制已发布（生产）版本的物料清单和工艺清单是否可以在变更单外部编辑。"
+msgstr "控制已下达（生产）修订版的物料清单和工序清单是否可以在变更单之外进行编辑。"
 
 msgid "Convention"
 msgstr "惯例"
@@ -3586,10 +3586,10 @@ msgid "Conversion"
 msgstr "转换"
 
 msgid "Conversion factor"
-msgstr "转换因子"
+msgstr "换算系数"
 
 msgid "Conversion Factor"
-msgstr "转换系数"
+msgstr "换算系数"
 
 msgid "Conversion:"
 msgstr "转换："
@@ -3604,10 +3604,10 @@ msgid "Convert Line to Job"
 msgstr "将行转换为工作"
 
 msgid "Convert Lines to Jobs"
-msgstr "将行转换为工作"
+msgstr "将行转换为工单"
 
 msgid "Convert MRP suggestions into purchase orders and jobs."
-msgstr "将MRP建议转换为采购订单和工作单。"
+msgstr "将MRP建议转换为采购订单和工单。"
 
 msgid "Convert to Quote"
 msgstr "转换为报价"
@@ -3616,7 +3616,7 @@ msgid "Converting…"
 msgstr "转换中…"
 
 msgid "Converts a supplier's purchase unit to your inventory unit on a PO, receipt, or bill line — buy in cartons of 12, stock in eaches."
-msgstr "将供应商的采购单位转换为采购订单、收据或发票行中的库存单位 — 以12个纸箱购买，以单位储存。"
+msgstr "在采购单、收货或账单行中将供应商的采购单位转换为您的库存管理单位 — 按 12 个纸箱采购，按件库存。"
 
 msgid "Copied link to clipboard"
 msgstr "已复制链接到剪贴板"
@@ -3625,28 +3625,28 @@ msgid "Copy"
 msgstr "复制"
 
 msgid "Copy all items and pricing to another customer or type."
-msgstr "将所有项目和定价复制到另一个客户或类型。"
+msgstr "将所有物料和定价复制到另一个客户或类型。"
 
 msgid "Copy API Key"
-msgstr "复制 API 密钥"
+msgstr "复制API密钥"
 
 msgid "Copy company unique identifier"
 msgstr "复制公司唯一标识符"
 
 msgid "Copy consumable number"
-msgstr "复制消耗品编号"
+msgstr "复制耗材编号"
 
 msgid "Copy dispatch ID"
-msgstr "复制调度ID"
+msgstr "复制维护工单ID"
 
 msgid "Copy dispatch number"
-msgstr "复制派工单号"
+msgstr "复制维护工单编号"
 
 msgid "Copy document name"
-msgstr "复制文档名称"
+msgstr "复制文件名"
 
 msgid "Copy document unique identifier"
-msgstr "复制文档唯一标识符"
+msgstr "复制文件唯一标识符"
 
 msgid "Copy ID"
 msgstr "复制 ID"
@@ -3664,16 +3664,16 @@ msgid "Copy link"
 msgstr "复制链接"
 
 msgid "Copy link to change notice"
-msgstr "复制更改单链接"
+msgstr "复制变更通知链接"
 
 msgid "Copy link to consumable"
-msgstr "复制消耗品链接"
+msgstr "复制耗材链接"
 
 msgid "Copy link to dispatch"
-msgstr "复制调度链接"
+msgstr "复制维护工单链接"
 
 msgid "Copy link to document"
-msgstr "复制文档链接"
+msgstr "复制文件链接"
 
 msgid "Copy link to issue"
 msgstr "复制问题链接"
@@ -3682,13 +3682,13 @@ msgid "Copy link to Job"
 msgstr "复制工作链接"
 
 msgid "Copy link to material"
-msgstr "复制材料链接"
+msgstr "复制原材料链接"
 
 msgid "Copy link to part"
 msgstr "复制零件链接"
 
 msgid "Copy link to procedure"
-msgstr "复制程序链接"
+msgstr "复制程序文件链接"
 
 msgid "Copy link to service"
 msgstr "复制服务链接"
@@ -3700,10 +3700,10 @@ msgid "Copy link to training"
 msgstr "复制培训链接"
 
 msgid "Copy material number"
-msgstr "复制物料编号"
+msgstr "复制原材料编号"
 
 msgid "Copy material unique identifier"
-msgstr "复制材料唯一标识符"
+msgstr "复制原材料唯一标识符"
 
 msgid "Copy MCP Command"
 msgstr "复制 MCP 命令"
@@ -3724,13 +3724,13 @@ msgid "Copy pricing to all customers of a type"
 msgstr "将定价复制到该类型的所有客户"
 
 msgid "Copy Procedure"
-msgstr "复制程序"
+msgstr "复制程序文件"
 
 msgid "Copy procedure name"
-msgstr "复制程序名称"
+msgstr "复制程序文件名"
 
 msgid "Copy procedure unique identifier"
-msgstr "复制程序唯一标识符"
+msgstr "复制程序文件唯一标识符"
 
 msgid "Copy Quality Document"
 msgstr "复制质量文件"
@@ -3817,7 +3817,7 @@ msgid "Cost Centers"
 msgstr "成本中心"
 
 msgid "Cost History"
-msgstr "成本历史"
+msgstr "成本历史记录"
 
 msgid "Cost of Goods Sold"
 msgstr "销售成本"
@@ -3832,16 +3832,16 @@ msgid "Cost of Sales"
 msgstr "销售成本"
 
 msgid "Costing"
-msgstr "成本"
+msgstr "成本核算"
 
 msgid "Costing & Posting"
-msgstr "成本与过账"
+msgstr "成本核算与过账"
 
 msgid "Costing method"
 msgstr "成本核算方法"
 
 msgid "Costing Method"
-msgstr "成本计算方法"
+msgstr "成本核算方法"
 
 msgid "Could not analyze cropped region"
 msgstr "无法分析裁剪区域"
@@ -3858,7 +3858,7 @@ msgstr "无法准备区域图像以进行分析"
 
 #. placeholder {0}: extraction?.error ?? ""
 msgid "Could not read the document: {0}"
-msgstr "无法读取文档：{0}"
+msgstr "无法读取文件：{0}"
 
 msgid "Could not save"
 msgstr "无法保存"
@@ -3870,7 +3870,7 @@ msgid "Couldn't load documents"
 msgstr "无法加载文档"
 
 msgid "Couldn't load related documents. Refresh before creating a new one to avoid duplicates."
-msgstr "无法加载相关文档。创建新文档前请先刷新以避免重复。"
+msgstr "无法加载相关文档。创建新文档前请刷新以避免重复。"
 
 msgid "Couldn't load the provider's dimension targets — check the connection and reload."
 msgstr "无法加载提供商的维度目标 — 检查连接并重新加载。"
@@ -3885,7 +3885,7 @@ msgid "Count"
 msgstr "数量"
 
 msgid "Count History"
-msgstr "盘点历史"
+msgstr "计数历史记录"
 
 msgid "Count ID"
 msgstr "盘点ID"
@@ -3921,7 +3921,7 @@ msgid "Create & Snapshot"
 msgstr "创建并快照"
 
 msgid "Create a change notice for the new revision and open it"
-msgstr "为新版本创建更改单并打开它"
+msgstr "为新修订版创建变更通知并打开"
 
 msgid "Create a job"
 msgstr "创建工作"
@@ -3930,13 +3930,13 @@ msgid "Create a new kanban card for scan-based replenishment."
 msgstr "为扫描式补货创建新的看板卡。"
 
 msgid "Create a new maintenance dispatch to track equipment repairs and maintenance activities"
-msgstr "创建新的维护派工单以跟踪设备维修和维护活动"
+msgstr "创建新的维护工单以跟踪设备维修和维护活动"
 
 msgid "Create a new production job to fulfill the sales order"
 msgstr "创建新的生产工作以完成销售订单"
 
 msgid "Create a new Stripe customer instead"
-msgstr ""
+msgstr "改为创建新的Stripe客户"
 
 msgid "Create a new version"
 msgstr "创建新版本"
@@ -3963,19 +3963,19 @@ msgid "Create an issue"
 msgstr "创建问题"
 
 msgid "Create and approve purchase orders"
-msgstr "创建并批准采购订单"
+msgstr "创建并审批采购订单"
 
 msgid "Create audit trail entries"
 msgstr "创建审计跟踪条目"
 
 msgid "Create Change Notice"
-msgstr "创建更改单"
+msgstr "创建变更通知"
 
 msgid "Create Issue"
 msgstr "创建问题"
 
 msgid "Create Jobs"
-msgstr "创建工作"
+msgstr "创建工单"
 
 msgid "Create Kanban"
 msgstr "创建看板"
@@ -3996,7 +3996,7 @@ msgid "Create Projection"
 msgstr "创建预测"
 
 msgid "Create Quote Revision"
-msgstr "创建报价修订"
+msgstr "创建报价单修订版"
 
 msgid "Create Revision"
 msgstr "创建修订版"
@@ -4038,13 +4038,13 @@ msgid "Created By"
 msgstr "由...创建"
 
 msgid "Created change notice action"
-msgstr "已创建更改单操作"
+msgstr "已创建变更通知操作"
 
 msgid "Created change notice type"
-msgstr "已创建更改单类型"
+msgstr "已创建变更通知类型"
 
 msgid "Created consumable"
-msgstr "已创建易耗品"
+msgstr "已创建耗材"
 
 msgid "Created cost center"
 msgstr "已创建成本中心"
@@ -4078,40 +4078,40 @@ msgid "Created location"
 msgstr "已创建位置"
 
 msgid "Created maintenance schedule"
-msgstr "已创建维护计划"
+msgstr "已创建维护排程"
 
 msgid "Created material"
-msgstr "已创建物料"
+msgstr "已创建原材料"
 
 msgid "Created material dimension"
-msgstr "已创建材料尺寸"
+msgstr "已创建原材料维度"
 
 msgid "Created material finish"
 msgstr "已创建材料表面处理"
 
 msgid "Created material form"
-msgstr "已创建材料表单"
+msgstr "已创建原材料规格"
 
 msgid "Created material grade"
-msgstr "已创建材料等级"
+msgstr "已创建牌号"
 
 msgid "Created material substance"
-msgstr "已创建物质材料"
+msgstr "已创建材质"
 
 msgid "Created material type"
-msgstr "已创建材料类型"
+msgstr "已创建原材料类型"
 
 msgid "Created no quote reason"
-msgstr "已创建无报价原因"
+msgstr "已创建不报价原因"
 
 msgid "Created non conformance type"
-msgstr "已创建不符合项类型"
+msgstr "已创建不合格类型"
 
 msgid "Created part"
 msgstr "已创建零件"
 
 msgid "Created payment term"
-msgstr "已创建付款条款"
+msgstr "已创建付款条件"
 
 msgid "Created process"
 msgstr "已创建流程"
@@ -4126,10 +4126,10 @@ msgid "Created service"
 msgstr "创建服务"
 
 msgid "Created shipping method"
-msgstr "已创建配送方式"
+msgstr "已创建发货方式"
 
 msgid "Created stock transfer line"
-msgstr "已创建库存转移行"
+msgstr "已创建库存调拨行"
 
 msgid "Created storage type"
 msgstr "已创建存储类型"
@@ -4151,50 +4151,50 @@ msgid "Created work center"
 msgstr "已创建工作中心"
 
 msgid "Creates the 12 monthly periods for a fiscal year. Periods that already exist are kept."
-msgstr "为会计年度创建12个月度期间。已存在的期间保持不变。"
+msgstr "为会计年度创建12个每月期间。已有期间保留不变。"
 
 msgid "Creating part..."
 msgstr "正在创建零件..."
 
 msgid "Credit"
-msgstr "信用"
+msgstr "贷方"
 
 #. placeholder {0}: parentCurrency ?? "Translated"
 msgid "Credit ({0})"
 msgstr "贷方 ({0})"
 
 msgid "Credit / debit memo"
-msgstr "贷项 / 借项备忘录"
+msgstr "贷方/借方备忘录"
 
 msgid "Credit / Debit Memos"
-msgstr "贷项/借项备忘录"
+msgstr "贷方/借方备忘录"
 
 msgid "Credit Account"
-msgstr "信用账户"
+msgstr "贷方科目"
 
 msgid "Credit account when labor/machine time is absorbed into WIP"
-msgstr "当劳动力/机器时间被吸收到WIP中时的信用账户"
+msgstr "当人工/机器工时吸收入在制品时的贷方科目"
 
 msgid "Credit account when overhead is absorbed into WIP"
-msgstr "制造费用吸收到在产品中时的贷方科目"
+msgstr "当制造费用吸收入在制品时的贷方科目"
 
 msgid "Credit accounts used when manufacturing costs are absorbed into WIP"
-msgstr "制造成本吸收到在产品中时使用的贷方科目"
+msgstr "当制造成本吸收入在制品时使用的贷方科目"
 
 msgid "Credit Memo"
-msgstr "贷方备忘录"
+msgstr "贷项凭证"
 
 msgid "Credits"
 msgstr "贷方"
 
 msgid "Credits & Debits"
-msgstr "贷项和借项"
+msgstr "贷方和借方"
 
 msgid "Credits applied"
-msgstr "已应用的额度"
+msgstr "已应用的贷方"
 
 msgid "Critical"
-msgstr "关键"
+msgstr "严重"
 
 msgid "CSV column"
 msgstr "CSV 列"
@@ -4218,10 +4218,10 @@ msgid "Currency code"
 msgstr "货币代码"
 
 msgid "Currency Translation"
-msgstr "货币换算"
+msgstr "货币折算"
 
 msgid "Currency Translation (default)"
-msgstr "货币换算（默认）"
+msgstr "货币折算（默认）"
 
 msgid "current"
 msgstr "当前"
@@ -4230,7 +4230,7 @@ msgid "Current"
 msgstr "当前"
 
 msgid "Current Net Book Value:"
-msgstr "当前净账面价值:"
+msgstr "当前账面净值："
 
 msgid "Current Password"
 msgstr "当前密码"
@@ -4251,7 +4251,7 @@ msgid "Custom {label}"
 msgstr "自定义 {label}"
 
 msgid "Custom attributes you track against your people"
-msgstr "您针对员工跟踪的自定义属性"
+msgstr "针对人员跟踪的自定义属性"
 
 msgid "Custom development beyond what's listed"
 msgstr "超出列表范围的自定义开发"
@@ -4269,7 +4269,7 @@ msgid "Custom Fields"
 msgstr "自定义字段"
 
 msgid "Custom fields are not available for items yet."
-msgstr "自定义字段尚不适用于项目。"
+msgstr "暂不支持物料的自定义字段。"
 
 msgid "Custom SOW · we manage"
 msgstr "自定义 SOW · 我们管理"
@@ -4326,22 +4326,22 @@ msgid "Customer Part"
 msgstr "客户零件"
 
 msgid "Customer Part ID"
-msgstr "客户零件ID"
+msgstr "客户料号"
 
 msgid "Customer Part Number"
 msgstr "客户零件号"
 
 msgid "Customer Part Revision"
-msgstr "客户零件版本"
+msgstr "客户零件修订版"
 
 msgid "Customer Parts"
 msgstr "客户零件"
 
 msgid "Customer Payment Discounts"
-msgstr "客户支付折扣"
+msgstr "客户付款折扣"
 
 msgid "Customer Payment Discounts (default)"
-msgstr "客户支付折扣（默认）"
+msgstr "客户付款折扣（默认）"
 
 msgid "Customer PO"
 msgstr "客户采购订单"
@@ -4365,7 +4365,7 @@ msgid "Customer Reference"
 msgstr "客户参考"
 
 msgid "Customer Revision"
-msgstr "客户版本"
+msgstr "客户修订版"
 
 msgid "Customer RFQ"
 msgstr "客户询价"
@@ -4407,7 +4407,7 @@ msgid "Customers"
 msgstr "客户"
 
 msgid "Customizations, training, and integrations"
-msgstr ""
+msgstr "定制、培训和集成"
 
 msgid "Customize"
 msgstr "自定义"
@@ -4437,13 +4437,13 @@ msgid "Daily"
 msgstr "每日"
 
 msgid "Daily check-ins while your team finds its feet on the live system"
-msgstr "每日检查，帮助您的团队在实时系统上站稳脚跟"
+msgstr "当您的班组在实时系统上适应时的每日检查"
 
 msgid "Daily summary"
 msgstr "每日汇总"
 
 msgid "Daily Usage"
-msgstr "日常使用"
+msgstr "每日使用"
 
 msgid "Dark"
 msgstr "深色"
@@ -4464,7 +4464,7 @@ msgid "Data Migration Map"
 msgstr "数据迁移地图"
 
 msgid "Data migration of the items on the Data Migration Map"
-msgstr "数据迁移映射表中的项目数据迁移"
+msgstr "数据迁移映射中物料的数据迁移"
 
 msgid "Data scattered across spreadsheets and disconnected tools"
 msgstr "数据分散在电子表格和断开连接的工具中"
@@ -4525,7 +4525,7 @@ msgid "Days Due"
 msgstr "到期天数"
 
 msgid "Days from ordering a part to having it available; planning offsets demand backward by this much."
-msgstr "从订购零件到可用之间的天数; 规划将需求向后偏移此数量。"
+msgstr "从订购零件到库存可用的天数；计划偏移按此向后推移需求。"
 
 msgid "Days Off"
 msgstr "休息日"
@@ -4590,22 +4590,22 @@ msgid "Decide what an operator sees if they try to issue a batch or serial that'
 msgstr "决定操作员在尝试发放已过期的批次或序列号时看到的内容。"
 
 msgid "Decide what happens when an operator presses Finish on the shop floor with material still unpicked."
-msgstr "决定当操作员在车间按下完成时但材料仍未拣选时会发生什么。"
+msgstr "决定当操作员在车间按下完成时且原材料仍未拣货时发生的情况。"
 
 msgid "Decide when material picked to a work center but not consumed flows back to the warehouse."
-msgstr "决定当物料拣配到工作中心但未消耗时何时流回仓库。"
+msgstr "决定何时将拣货到工作中心但未消耗的原材料流回仓库。"
 
 msgid "Decimal Places"
 msgstr "小数位数"
 
 msgid "Declining balance"
-msgstr "递减余额"
+msgstr "余额递减法"
 
 msgid "Default"
 msgstr "默认"
 
 msgid "Default account for posting sales revenue from invoices"
-msgstr "用于记录发票销售收入的默认账户"
+msgstr "用于从发票过账销售收入的默认科目"
 
 msgid "Default Accounts"
 msgstr "默认账户"
@@ -4614,13 +4614,13 @@ msgid "Default accounts for business expenses"
 msgstr "业务费用的默认账户"
 
 msgid "Default accounts for customer transactions and receivables"
-msgstr "客户交易和应收账款的默认账户"
+msgstr "客户交易和应收款项的默认科目"
 
 msgid "Default accounts for long-term assets and depreciation"
 msgstr "长期资产和折旧的默认账户"
 
 msgid "Default accounts for sales and income"
-msgstr "销售和收入的默认账户"
+msgstr "销售和收益的默认科目"
 
 msgid "Default accounts for tax-related transactions"
 msgstr "税务交易的默认账户"
@@ -4656,10 +4656,10 @@ msgid "Default GL account used for cash transactions when no specific bank accou
 msgstr "未选择特定银行账户时用于现金交易的默认GL账户。"
 
 msgid "Default GL expense account for equipment and facility maintenance."
-msgstr "设备和设施维护的默认GL支出账户。"
+msgstr "设备和设施维护的默认总账费用科目"
 
 msgid "Default GL expense account for periodic depreciation runs."
-msgstr "定期折旧运行的默认GL支出账户。"
+msgstr "定期折旧处理的默认总账费用科目"
 
 msgid "Default Method"
 msgstr "默认方法"
@@ -4668,10 +4668,10 @@ msgid "Default method that pre-fills on new assets in this class (still editable
 msgstr "在此类中新资产上预填充的默认方法（仍可按资产编辑）。"
 
 msgid "Default method type"
-msgstr "默认方法类型"
+msgstr "默认供料方式"
 
 msgid "Default Method Type"
-msgstr "默认方法类型"
+msgstr "默认供料方式"
 
 msgid "Default Permissions"
 msgstr "默认权限"
@@ -4692,7 +4692,7 @@ msgid "Default Source"
 msgstr "默认来源"
 
 msgid "Default Storage Unit"
-msgstr "默认存储单位"
+msgstr "默认存储单元"
 
 msgid "Default tax depreciation method for new assets in this class."
 msgstr "此类中新资产的默认税务折旧方法。"
@@ -4704,7 +4704,7 @@ msgid "Default Unit"
 msgstr "默认单位"
 
 msgid "Default useful life that pre-fills on new assets in this class."
-msgstr "在此类中新资产上预填充的默认使用寿命。"
+msgstr "新增此类资产时预填充的默认使用年限"
 
 msgid "Defaults"
 msgstr "默认值"
@@ -4725,7 +4725,7 @@ msgid "Define a manufacturing operation first."
 msgstr "首先定义制造操作。"
 
 msgid "Define multi-level BOMs and Bill of Process (make methods)"
-msgstr "定义多级物料清单和工艺流程（制造方法）"
+msgstr "定义多级BOM和工序清单（制造方法）"
 
 msgid "Delete"
 msgstr "删除"
@@ -4750,7 +4750,7 @@ msgid "Delete Action"
 msgstr "删除操作"
 
 msgid "Delete API Key"
-msgstr "删除 API 密钥"
+msgstr "删除API密钥"
 
 msgid "Delete Asset"
 msgstr "删除资产"
@@ -4771,7 +4771,7 @@ msgid "Delete Category"
 msgstr "删除分类"
 
 msgid "Delete Change Notice"
-msgstr "删除更改单"
+msgstr "删除变更通知"
 
 msgid "Delete Consumable"
 msgstr "删除耗材"
@@ -4780,7 +4780,7 @@ msgid "Delete Contact"
 msgstr "删除联系人"
 
 msgid "Delete Contractor"
-msgstr "删除承包商"
+msgstr "删除外协人员"
 
 msgid "Delete Count"
 msgstr "删除计数"
@@ -4804,10 +4804,10 @@ msgid "Delete Dimension"
 msgstr "删除维度"
 
 msgid "Delete Dispatch"
-msgstr "删除派工"
+msgstr "删除维护工单"
 
 msgid "Delete Document"
-msgstr "删除文档"
+msgstr "删除文件"
 
 msgid "Delete Employee Type"
 msgstr "删除员工类型"
@@ -4834,7 +4834,7 @@ msgid "Delete Item Group"
 msgstr "删除物品组"
 
 msgid "Delete Journal Entry"
-msgstr "删除日记账条目"
+msgstr "删除分录"
 
 msgid "Delete line"
 msgstr "删除行"
@@ -4846,22 +4846,22 @@ msgid "Delete Location"
 msgstr "删除位置"
 
 msgid "Delete Material"
-msgstr "删除物料"
+msgstr "删除原材料"
 
 msgid "Delete Material Dimension"
-msgstr "删除物料尺寸"
+msgstr "删除原材料维度"
 
 msgid "Delete Material Finish"
 msgstr "删除材料表面处理"
 
 msgid "Delete Material Grade"
-msgstr "删除材料等级"
+msgstr "删除牌号"
 
 msgid "Delete Material Shape"
 msgstr "删除材料形状"
 
 msgid "Delete Material Type"
-msgstr "删除材料类型"
+msgstr "删除原材料类型"
 
 msgid "Delete Memo"
 msgstr "删除备忘录"
@@ -4873,16 +4873,16 @@ msgid "Delete Partner"
 msgstr "删除合作伙伴"
 
 msgid "Delete passkey"
-msgstr "删除密钥"
+msgstr "删除通行密钥"
 
 msgid "Delete Passkey"
-msgstr "删除密钥"
+msgstr "删除通行密钥"
 
 msgid "Delete Payment"
 msgstr "删除付款"
 
 msgid "Delete Payment Term"
-msgstr "删除付款条款"
+msgstr "删除付款条件"
 
 msgid "Delete Period"
 msgstr "删除期间"
@@ -4900,7 +4900,7 @@ msgid "Delete Pricing Rule"
 msgstr "删除定价规则"
 
 msgid "Delete Procedure"
-msgstr "删除流程"
+msgstr "删除程序文件"
 
 msgid "Delete Process"
 msgstr "删除流程"
@@ -4930,7 +4930,7 @@ msgid "Delete receipt line"
 msgstr "删除收货单行"
 
 msgid "Delete requirement"
-msgstr "删除需求"
+msgstr "删除要求"
 
 msgid "Delete RFQ"
 msgstr "删除询价单"
@@ -4951,7 +4951,7 @@ msgid "Delete Sales Order"
 msgstr "删除销售订单"
 
 msgid "Delete Schedule"
-msgstr "删除计划"
+msgstr "删除排程"
 
 msgid "Delete Service"
 msgstr "删除服务"
@@ -4966,7 +4966,7 @@ msgid "Delete shipment line"
 msgstr "删除发货行"
 
 msgid "Delete Shipping Method"
-msgstr "删除配送方式"
+msgstr "删除发货方式"
 
 msgid "Delete step"
 msgstr "删除步骤"
@@ -5003,7 +5003,7 @@ msgstr "删除供应商类型"
 
 #. placeholder {0}: pendingDelete.quantity
 msgid "Delete the price break for quantity {0}? This can't be undone."
-msgstr "删除数量{0}的价格区间？此操作无法撤销。"
+msgstr "删除数量{0}的价格阶梯？此操作无法撤销。"
 
 msgid "Delete Timecard"
 msgstr "删除时间卡"
@@ -5018,7 +5018,7 @@ msgid "Delete Transfer"
 msgstr "删除转移"
 
 msgid "Delete Transfer Line"
-msgstr "删除转移行"
+msgstr "删除调拨行"
 
 msgid "Delete Type"
 msgstr "删除类型"
@@ -5027,10 +5027,10 @@ msgid "Delete Unit of Measure"
 msgstr "删除计量单位"
 
 msgid "Delete view"
-msgstr "删除视图"
+msgstr "删除查看"
 
 msgid "Delete View"
-msgstr "删除视图"
+msgstr "删除查看"
 
 msgid "Delete Warehouse Transfer"
 msgstr "删除仓库转移"
@@ -5060,7 +5060,7 @@ msgid "Demand Forecast — Driven by"
 msgstr "需求预测 — 驱动因素"
 
 msgid "Demand forecast = BOM-exploded demand from open sales orders, active jobs, and production projections."
-msgstr "需求预测 = 来自未结销售订单、活跃工作和生产预测的物料清单展开需求。"
+msgstr "需求预测 = 来自未结销售订单、启用工单和生产预测的BOM展开需求。"
 
 msgid "Demand projection"
 msgstr "需求预测"
@@ -5117,16 +5117,16 @@ msgid "Depreciation Method (default)"
 msgstr "折旧方法（默认）"
 
 msgid "Depreciation reversal when a fixed asset is disposed"
-msgstr "处置固定资产时的折旧冲回"
+msgstr "固定资产已处置时的折旧冲销"
 
 msgid "Depreciation runs ending in this period that are still Draft should be posted so the period reflects the correct depreciation expense and accumulated depreciation. Skip with a reason if depreciation doesn't apply this period."
-msgstr "在本期结束的折旧运行若仍为草稿状态，应进行过账，以便期间反映正确的折旧费用和累积折旧。如果本期不适用折旧，请说明原因跳过。"
+msgstr "在本期间内结束的仍为草稿的折旧运行应该过账，以便该期间反映正确的折旧费用和累计折旧。如果本期间不适用折旧，可以跳过并提供原因。"
 
 msgid "Depreciation Start Date"
 msgstr "折旧开始日期"
 
 msgid "Derive this item's shelf life from the shortest shelf life of its components, ignoring the Days field above."
-msgstr "从其组件的最短货架寿命推导该物品的货架寿命，忽略上面的Days字段。"
+msgstr "从其组件的最短保质期推导该物料的保质期，忽略上面的天数字段。"
 
 msgid "Description"
 msgstr "描述"
@@ -5156,16 +5156,16 @@ msgid "Digital Quote"
 msgstr "数字报价"
 
 msgid "Digital quote accepted by"
-msgstr "数字报价由以下人士接受"
+msgstr "数字化报价单已接受者"
 
 msgid "Digital quote accepted by email"
-msgstr "通过电子邮件接受数字报价"
+msgstr "通过电子邮件接受的数字化报价单"
 
 msgid "Digital quote rejected by"
-msgstr "数字报价被拒绝"
+msgstr "数字化报价单已拒绝者"
 
 msgid "Digital quote rejected by email"
-msgstr "通过电子邮件拒绝数字报价"
+msgstr "通过电子邮件拒绝的数字化报价单"
 
 msgid "Digital Quotes"
 msgstr "数字报价"
@@ -5174,19 +5174,19 @@ msgid "dimension"
 msgstr "维度"
 
 msgid "Dimension"
-msgstr "尺寸"
+msgstr "维度"
 
 msgid "Dimension slots"
 msgstr "维度插槽"
 
 msgid "Dimension values on posted journals that have no provider mapping yet."
-msgstr "已发布日记账上尚未映射到提供商的维度值。"
+msgstr "已过账的凭证中没有提供商映射的维度值。"
 
 msgid "dimensions"
 msgstr "维度"
 
 msgid "Dimensions"
-msgstr "尺寸"
+msgstr "维度"
 
 msgid "Direct"
 msgstr "直接"
@@ -5247,16 +5247,16 @@ msgid "Dismiss"
 msgstr "关闭"
 
 msgid "Dispatch"
-msgstr "派遣"
+msgstr "维护工单"
 
 msgid "Dispatch ID"
-msgstr "调度ID"
+msgstr "维护工单ID"
 
 msgid "Dispatch priority"
-msgstr "派遣优先级"
+msgstr "维护工单优先级"
 
 msgid "Dispatches"
-msgstr "派遣"
+msgstr "维护工单"
 
 msgid "Display Settings"
 msgstr "显示设置"
@@ -5295,25 +5295,25 @@ msgid "Docs & videos"
 msgstr "文档和视频"
 
 msgid "Document"
-msgstr "文档"
+msgstr "文件"
 
 msgid "Document Control"
 msgstr "文件控制"
 
 msgid "Document Templates"
-msgstr "文档模板"
+msgstr "文件模板"
 
 msgid "Document Type"
-msgstr "文档类型"
+msgstr "文件类型"
 
 msgid "Document:"
-msgstr "文档："
+msgstr "文件:"
 
 msgid "Documents"
 msgstr "文档"
 
 msgid "Documents pushes invoices, bills and payments as native provider documents; their journals are recorded as covered by the document. It also pulls payments recorded in the provider back into Carbon, closing the matching invoice or bill and posting a Carbon GL journal. Off records them as deliberately excluded."
-msgstr "文档将发票、账单和付款推送为原生提供商文档；其日记被记录为由文档覆盖。它还将在提供商中记录的付款拉回到Carbon，关闭匹配的发票或账单并发布Carbon GL日记。关闭时将其记录为故意排除。"
+msgstr "文档推送发票、账单和付款作为本地提供商文件；其凭证被记录为由该文件覆盖。它还将在提供商中记录的付款拉回到Carbon，关闭匹配的发票或账单并过账一个Carbon总账凭证。关闭时将其记录为故意排除。"
 
 msgid "Documents you open will show up here for quick access."
 msgstr "您打开的文档将显示在此处以便快速访问。"
@@ -5356,10 +5356,10 @@ msgid "Draft"
 msgstr "草稿"
 
 msgid "Draft is editable; Active is in use and requires a new version to change; Archived is retired."
-msgstr "草稿可编辑；活动中正在使用，需要新版本才能更改；已归档已停用。"
+msgstr "草稿可编辑；启用表示正在使用，需要新版本才能更改；已归档表示已停用。"
 
 msgid "Draft Journal Entries"
-msgstr "草稿日记账条目"
+msgstr "草稿分录"
 
 msgid "Drag & drop files, or click to browse"
 msgstr "拖放文件，或点击浏览"
@@ -5389,7 +5389,7 @@ msgid "Drawing"
 msgstr "提取"
 
 msgid "Drawing Number"
-msgstr "图纸编号"
+msgstr "图号"
 
 msgid "Drawing replaced. Balloon placements were removed; feature rows are unchanged."
 msgstr "图纸已替换。气球位置已移除；功能行保持不变。"
@@ -5407,7 +5407,7 @@ msgid "Drop your file here, or click to browse."
 msgstr "将文件拖放到此处，或点击浏览。"
 
 msgid "Drop-ship"
-msgstr "直接发货"
+msgstr "直发"
 
 msgid "Due"
 msgstr "到期"
@@ -5426,16 +5426,16 @@ msgid "Due Date (job)"
 msgstr "到期日期（工作）"
 
 msgid "Due Date of First Job"
-msgstr "第一个工作的截止日期"
+msgstr "第一个工单的到期日"
 
 msgid "Due Date of Last Job"
-msgstr "最后一个工作的截止日期"
+msgstr "最后一个工单的到期日"
 
 msgid "Due date of the earliest job in the bulk batch; later jobs space evenly between this date and Due Date of Last Job."
-msgstr "批量批次中最早工作的截止日期; 后续工作在此日期和最后一个工作的截止日期之间均匀间隔。"
+msgstr "批量批次中最早工单的到期日；之后的工单在该日期与最后一个工单的到期日之间均匀分布。"
 
 msgid "Due date of the final job in the bulk batch; combined with Due Date of First Job to space the jobs evenly."
-msgstr "批量批次中最后一个工作的截止日期; 与第一个工作的截止日期相结合以均匀间隔工作。"
+msgstr "批量批次中最后一个工单的到期日；与第一个工单的到期日结合以均匀分布工单。"
 
 msgid "Due Days"
 msgstr "到期天数"
@@ -5486,7 +5486,7 @@ msgid "e.g. 48201"
 msgstr "例：48201"
 
 msgid "e.g. Acme Manufacturing"
-msgstr "例：Acme Manufacturing"
+msgstr "例如 Acme Manufacturing"
 
 msgid "e.g. Detroit"
 msgstr "例：Detroit"
@@ -5519,10 +5519,10 @@ msgid "e.g. Zebra 2x1"
 msgstr "例如 Zebra 2x1"
 
 msgid "Each operation's unused material returns as soon as the operation is done."
-msgstr "每个操作的未使用物料在操作完成后立即返回。"
+msgstr "每个工序的未使用原材料在工序完成后立即退回。"
 
 msgid "Each physical unit gets its own tracked entity and unique number — one entity, one unit."
-msgstr "每个物理单位都获得自己的跟踪实体和唯一编号 — 一个实体、一个单位。"
+msgstr "每个物理件获得其自己的追踪实体和唯一编号——一个实体，一个件。"
 
 msgid "Each, lb, ft…"
 msgstr "每个、磅、英尺…"
@@ -5534,7 +5534,7 @@ msgid "Easier to extend"
 msgstr "更容易扩展"
 
 msgid "Economic Operators Registration and Identification number; required for goods crossing customs borders in the EU / UK."
-msgstr "经济运营人注册和识别号码; 对于在欧盟/英国关税边界通关的货物必需。"
+msgstr "经济营运人注册和识别号；对于在欧盟/英国海关边界跨越的货物为必需。"
 
 msgid "Edit"
 msgstr "编辑"
@@ -5549,7 +5549,7 @@ msgid "Edit Action"
 msgstr "编辑操作"
 
 msgid "Edit API Key"
-msgstr "编辑 API 密钥"
+msgstr "编辑API密钥"
 
 msgid "Edit Approval Rule"
 msgstr "编辑审批规则"
@@ -5573,13 +5573,13 @@ msgid "Edit Category"
 msgstr "编辑分类"
 
 msgid "Edit Change Notice"
-msgstr "编辑更改单"
+msgstr "编辑变更通知"
 
 msgid "Edit Change Notice Action"
-msgstr "编辑更改单操作"
+msgstr "编辑变更通知操作"
 
 msgid "Edit Change Notice Type"
-msgstr "编辑更改单类型"
+msgstr "编辑变更通知类型"
 
 msgid "Edit column visibility"
 msgstr "编辑列可见性"
@@ -5588,7 +5588,7 @@ msgid "Edit Contact"
 msgstr "编辑联系人"
 
 msgid "Edit Contractor"
-msgstr "编辑承包商"
+msgstr "编辑外协人员"
 
 msgid "Edit Cost Center"
 msgstr "编辑成本中心"
@@ -5618,7 +5618,7 @@ msgid "Edit Dimension"
 msgstr "编辑维度"
 
 msgid "Edit Dispatch"
-msgstr "编辑派工"
+msgstr "编辑维护工单"
 
 msgid "Edit Employee"
 msgstr "编辑员工"
@@ -5627,10 +5627,10 @@ msgid "Edit Employee Type"
 msgstr "编辑员工类型"
 
 msgid "Edit expiration date"
-msgstr "编辑过期日期"
+msgstr "编辑到期日期"
 
 msgid "Edit Expiry"
-msgstr "编辑过期日期"
+msgstr "编辑有效期"
 
 msgid "Edit Failure Mode"
 msgstr "编辑故障模式"
@@ -5657,7 +5657,7 @@ msgid "Edit Item Group"
 msgstr "编辑项目组"
 
 msgid "Edit Journal Entry"
-msgstr "编辑日记账条目"
+msgstr "编辑分录"
 
 msgid "Edit Kanban"
 msgstr "编辑看板"
@@ -5669,34 +5669,34 @@ msgid "Edit Location"
 msgstr "编辑位置"
 
 msgid "Edit Maintenance Dispatch"
-msgstr "编辑维护调度"
+msgstr "编辑维护工单"
 
 msgid "Edit Material"
-msgstr "编辑材料"
+msgstr "编辑原材料"
 
 msgid "Edit Material Dimension"
-msgstr "编辑材料尺寸"
+msgstr "编辑原材料维度"
 
 msgid "Edit Material Finish"
-msgstr "编辑材料饰面"
+msgstr "编辑表面处理"
 
 msgid "Edit Material Grade"
-msgstr "编辑材料等级"
+msgstr "编辑牌号"
 
 msgid "Edit Material Shape"
 msgstr "编辑材料形状"
 
 msgid "Edit Material Substance"
-msgstr "编辑物质材料"
+msgstr "编辑 材质"
 
 msgid "Edit Material Type"
-msgstr "编辑材料类型"
+msgstr "编辑 原材料 类型"
 
 msgid "Edit Memo"
 msgstr "编辑备忘录"
 
 msgid "Edit Non Conformance Type"
-msgstr "编辑不符合项类型"
+msgstr "编辑 不合格 类型"
 
 msgid "Edit Part"
 msgstr "编辑零件"
@@ -5705,13 +5705,13 @@ msgid "Edit Partner"
 msgstr "编辑合作伙伴"
 
 msgid "Edit Passkey"
-msgstr "编辑密钥"
+msgstr "编辑 通行密钥"
 
 msgid "Edit Payment"
 msgstr "编辑付款"
 
 msgid "Edit Payment Term"
-msgstr "编辑付款条款"
+msgstr "编辑 付款条件"
 
 msgid "Edit permissions"
 msgstr "编辑权限"
@@ -5768,13 +5768,13 @@ msgid "Edit Rule"
 msgstr "编辑规则"
 
 msgid "Edit Schedule"
-msgstr "编辑计划"
+msgstr "编辑 排程"
 
 msgid "Edit Scheduled Maintenance"
 msgstr "编辑计划维护"
 
 msgid "Edit Sequence"
-msgstr "编辑序列"
+msgstr "编辑 编号规则"
 
 msgid "Edit Serial Number"
 msgstr "编辑序列号"
@@ -5792,7 +5792,7 @@ msgid "Edit Shipping"
 msgstr "编辑运费"
 
 msgid "Edit Shipping Method"
-msgstr "编辑配送方式"
+msgstr "编辑 发货方式"
 
 msgid "Edit Size"
 msgstr "编辑尺寸"
@@ -5819,7 +5819,7 @@ msgid "Edit Supplier Part"
 msgstr "编辑供应商零件"
 
 msgid "Edit supplier process"
-msgstr "编辑供应商流程"
+msgstr "编辑 供应商工艺"
 
 msgid "Edit Supplier Type"
 msgstr "编辑供应商类型"
@@ -5840,7 +5840,7 @@ msgid "Edit Transfer"
 msgstr "编辑转移"
 
 msgid "Edit Transfer Line"
-msgstr "编辑转移行"
+msgstr "编辑 调拨行"
 
 msgid "Edit Type"
 msgstr "编辑类型"
@@ -5849,7 +5849,7 @@ msgid "Edit Unit of Measure"
 msgstr "编辑计量单位"
 
 msgid "Edit View"
-msgstr "编辑视图"
+msgstr "编辑查看"
 
 msgid "Edit Webhook"
 msgstr "编辑 Webhook"
@@ -5927,19 +5927,19 @@ msgid "Enable digital quotes for your company. This will allow you to send digit
 msgstr "为您的公司启用数字报价。这将允许您向客户发送数字报价，并允许他们在线接受。"
 
 msgid "Enable full accrual accounting with journal entries, financial reports, and general ledger posting."
-msgstr "启用完整的权责发生制会计，包括日记账分录、财务报告和总账过账。"
+msgstr "启用完整权责发生制会计，包括凭证、财务报告和总账过账。"
 
 msgid "Enable in Settings"
 msgstr "在设置中启用"
 
 msgid "Enable notifications when an RFQ is marked as ready for quote."
-msgstr "在RFQ标记为准备报价时启用通知。"
+msgstr "当询价单标记为可报价时启用通知。"
 
 msgid "Enable shared workstation mode for MES terminals. Operators identify themselves via PIN before performing work."
 msgstr "为MES终端启用共享工作站模式。操作员在执行工作前通过PIN进行身份识别。"
 
 msgid "Enable this rule to automatically require approval for matching documents"
-msgstr "启用此规则以自动要求匹配文档的批准"
+msgstr "启用此规则以自动要求匹配文档的审批"
 
 msgid "Enable timecard tracking for work shifts."
 msgstr "启用工作班次的时间卡跟踪。"
@@ -5948,7 +5948,7 @@ msgid "Enable to allow shared workstation mode."
 msgstr "启用以允许共享工作站模式。"
 
 msgid "Enable to automatically post transactions to the general ledger."
-msgstr "启用以自动将交易过账到总分类账。"
+msgstr "启用以自动将交易过账到总账。"
 
 msgid "Enable to configure tax-specific depreciation methods on asset classes (e.g., MACRS, accelerated)."
 msgstr "启用以在资产类别上配置特定于税收的折旧方法（例如，MACRS、加速）。"
@@ -5963,7 +5963,7 @@ msgid "Enable to start tracking work shifts."
 msgstr "启用以开始跟踪工作班次。"
 
 msgid "Enable to use metric units for material dimensions."
-msgstr "启用以使用公制单位表示材料尺寸。"
+msgstr "启用以对原材料尺寸使用公制单位。"
 
 msgid "Enabled"
 msgstr "已启用"
@@ -5972,7 +5972,7 @@ msgid "End Date"
 msgstr "结束日期"
 
 msgid "End of Last Fiscal Year"
-msgstr "上一财政年度末"
+msgstr "上个会计年度末"
 
 msgid "End of Last Month"
 msgstr "上月末"
@@ -6015,14 +6015,14 @@ msgid "Enroll"
 msgstr "注册"
 
 msgid "Enter a batch number before setting the expiration date"
-msgstr "在设置过期日期前请输入批号"
+msgstr "在设置到期日期前输入生产批次号"
 
 #. placeholder {0}: target.maxQuantity - 1
 msgid "Enter a quantity between 1 and {0}."
 msgstr "请输入 1 至 {0} 之间的数量。"
 
 msgid "Enter and approve vendor bills against a PO (three-way match)"
-msgstr "输入并批准针对采购订单的供应商账单（三方匹配）"
+msgstr "输入和审批供应商账单与采购单进行三单匹配"
 
 msgid "Enter number…"
 msgstr "输入数字…"
@@ -6040,7 +6040,7 @@ msgid "Enter the 6-digit code from your authenticator app to resume."
 msgstr "输入您的身份验证器应用中的 6 位数字代码以继续。"
 
 msgid "Enter the quantity this movement should have been. An opposite movement for the difference is posted next to the original, in the original's time period."
-msgstr "输入此移动应该的数量。差异的相反移动将在原始时期内的原始移动旁发布。"
+msgstr "输入此移动应该的数量。差异的相反移动在原始时期内的原始旁边过账。"
 
 msgid "Entered At Receipt"
 msgstr "在收货时输入"
@@ -6055,7 +6055,7 @@ msgid "Entities to move"
 msgstr "要移动的实体"
 
 msgid "Entities to split off"
-msgstr "要分割的实体"
+msgstr "要拆分的物料"
 
 msgid "Entity"
 msgstr "实体"
@@ -6085,13 +6085,13 @@ msgid "EORI"
 msgstr "EORI"
 
 msgid "Equity"
-msgstr "股权"
+msgstr "所有者权益"
 
 msgid "Equity account for accumulated profits or losses"
-msgstr "累积利润或亏损的股权账户"
+msgstr "所有者权益科目，用于累计利润或损失"
 
 msgid "Equity account for currency translation adjustments (CTA)"
-msgstr "货币转换调整 (CTA) 的股权账户"
+msgstr "所有者权益科目，用于货币折算调整(CTA)"
 
 msgid "Error"
 msgstr "错误"
@@ -6109,13 +6109,13 @@ msgid "Error fetching supplier data"
 msgstr "获取供应商数据出错"
 
 msgid "Error loading assigned dispatches"
-msgstr "加载已分配的派工单时出错"
+msgstr "加载已分配的维护工单出错"
 
 msgid "Error loading assigned documents"
-msgstr "加载分配的文档时出错"
+msgstr "加载已分配的文档出错"
 
 msgid "Error loading assigned issues"
-msgstr "加载分配的问题时出错"
+msgstr "加载已分配的领料出错"
 
 msgid "Error loading job tree."
 msgstr "加载工作树出错。"
@@ -6166,10 +6166,10 @@ msgid "Estimated Duration (minutes)"
 msgstr "预计时长（分钟）"
 
 msgid "Estimated Scrap Quantity"
-msgstr "估计废料数量"
+msgstr "估计报废数量"
 
 msgid "Estimated scrap quantity applied to every job in the bulk batch."
-msgstr "应用于批量批次中每个工作的估计废料数量。"
+msgstr "应用于批量生产批次中每个工单的估计报废数量。"
 
 msgid "Estimated time"
 msgstr "预计时间"
@@ -6196,13 +6196,13 @@ msgid "Every condition must match"
 msgstr "每个条件都必须匹配"
 
 msgid "Every in-scope test passes in your configured system, with your data."
-msgstr "您配置的系统中的每项范围内测试都通过了，使用您的数据。"
+msgstr "您配置的系统中的每项范围内测试都通过了您的数据。"
 
 msgid "Every match"
 msgstr "每次匹配"
 
 msgid "Every required task must be Done or Skipped before the period can be closed."
-msgstr "期间关闭前，每项必需任务都必须完成或跳过。"
+msgstr "每项必需任务必须在完成或已跳过后期间才能关闭。"
 
 msgid "Every row was imported successfully."
 msgstr "每一行都已成功导入。"
@@ -6214,7 +6214,7 @@ msgid "Everything else covers people, imports, integrations and the API — anyt
 msgstr "其他所有内容涵盖人员、导入、集成和 API — 任何不属于您的工作流的内容。"
 
 msgid "Exceeds {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB total — remove some attachments to send."
-msgstr "超过 {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB 总限制 — 请删除一些附件以发送。"
+msgstr "超过 {PO_EMAIL_ATTACHMENT_LIMIT_MB} MB 总限制 — 删除一些附件进行发送。"
 
 msgid "Exchange rate"
 msgstr "汇率"
@@ -6244,13 +6244,13 @@ msgid "Exemption Reason"
 msgstr "豁免原因"
 
 msgid "Existing mappings. Pick a different provider account to re-map."
-msgstr "现有映射。选择不同的提供商账户以重新映射。"
+msgstr "现有映射。选择不同的提供商账户进行重新映射。"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
-msgstr "现有映射。选择不同的提供商选项以重新映射。"
+msgstr "现有映射。选择不同的提供商选项进行重新映射。"
 
 msgid "Existing Stripe customer"
-msgstr ""
+msgstr "现有 Stripe 客户"
 
 msgid "Expand"
 msgstr "展开"
@@ -6275,7 +6275,7 @@ msgid "Expand Machine"
 msgstr "展开机器"
 
 msgid "Expand Setup"
-msgstr "展开设置"
+msgstr "展开 换型"
 
 msgid "Expand subtree"
 msgstr "展开子树"
@@ -6296,25 +6296,25 @@ msgid "Expense account for customer balances written off as uncollectable on AR 
 msgstr "应收账款结算时作为无法收回的客户余额的费用账户"
 
 msgid "Expense account for deferred tax adjustments on depreciation"
-msgstr "折旧延期税调整的费用账户"
+msgstr "用于折旧的递延所得税调整的费用科目"
 
 msgid "Expense account for equipment and facility maintenance"
 msgstr "设备和设施维护的费用账户"
 
 msgid "Expense account for FX losses when a payment settles a foreign-currency invoice at a less favorable rate"
-msgstr "支付结算外币发票时汇率不利而产生的外汇损失的费用账户"
+msgstr "付款以不利汇率结算外币发票时的外汇损失费用科目"
 
 msgid "Expense account for non-inventory purchases (services, supplies)"
 msgstr "非库存采购（服务、物资）的费用账户"
 
 msgid "Expense account for the cost of items sold"
-msgstr "当库存根据销售被发运/发放时借记的费用GL账户。"
+msgstr "销售物料成本的费用科目"
 
 msgid "Expense GL account debited when inventory is shipped/issued against a sale."
-msgstr "递延税款变动的费用方面（与递延税款负债配对）。"
+msgstr "当库存管理针对销售发货/发出时借记的费用总账科目"
 
 msgid "Expense side of deferred tax movements (paired with deferred tax liability)."
-msgstr "无法创建资产类别: {0}"
+msgstr "递延所得税移动的费用端（与递延所得税负债配对）"
 
 msgid "Expenses"
 msgstr "费用"
@@ -6323,13 +6323,13 @@ msgid "Expert guidance"
 msgstr "专家指导"
 
 msgid "Expiration date"
-msgstr "过期日期"
+msgstr "到期日期"
 
 msgid "Expiration Date"
 msgstr "到期日期"
 
 msgid "Expiration Date (applies to all serials on this line)"
-msgstr "过期日期（适用于此行上的所有序列号）"
+msgstr "到期日期（适用于此行上的所有序列号）"
 
 msgid "Expired"
 msgstr "已过期"
@@ -6340,10 +6340,10 @@ msgid "Expired {0}"
 msgstr "已过期 {0}"
 
 msgid "Expired batch"
-msgstr "过期批次"
+msgstr "已过期的生产批次"
 
 msgid "Expired Batches"
-msgstr "过期批次"
+msgstr "已过期的生产批次"
 
 msgid "Expires"
 msgstr "过期"
@@ -6362,16 +6362,16 @@ msgid "Expiring first"
 msgstr "先到期"
 
 msgid "Expiry"
-msgstr "过期"
+msgstr "有效期"
 
 msgid "Expiry begins when the selected process completes."
-msgstr "过期期限从所选流程完成时开始。"
+msgstr "有效期在选定的工艺完成时开始。"
 
 msgid "Expiry begins when the selected process starts."
 msgstr "有效期从选定的流程开始时开始。"
 
 msgid "Expiry trace"
-msgstr "过期追踪"
+msgstr "有效期追踪"
 
 msgid "Export"
 msgstr "导出"
@@ -6392,7 +6392,7 @@ msgid "External Delta"
 msgstr "外部差异"
 
 msgid "External document"
-msgstr "外部文档"
+msgstr "外部文件"
 
 msgid "External ID"
 msgstr "外部 ID"
@@ -6422,7 +6422,7 @@ msgid "Extra tags for slicing your GL reporting"
 msgstr "用于切分总账报告的额外标签"
 
 msgid "Fail"
-msgstr "失败"
+msgstr "不合格"
 
 msgid "Failed"
 msgstr "失败"
@@ -6432,7 +6432,7 @@ msgstr "失效特性"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create asset class: {0}"
-msgstr "FEFO（先到期先出）"
+msgstr "创建资产类别失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create consumable: {0}"
@@ -6468,7 +6468,7 @@ msgstr "创建故障模式失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create gauge type: {0}"
-msgstr "创建仪表类型失败：{0}"
+msgstr "创建量具类型失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create item group: {0}"
@@ -6480,11 +6480,11 @@ msgstr "创建位置失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create maintenance schedule: {0}"
-msgstr "创建维护计划失败：{0}"
+msgstr "创建维护日程失败: {0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material dimension: {0}"
-msgstr "创建材料尺寸失败：{0}"
+msgstr "创建原材料维度失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material finish: {0}"
@@ -6492,27 +6492,27 @@ msgstr "创建材料表面处理失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material form: {0}"
-msgstr "创建材料表单失败：{0}"
+msgstr "创建原材料表单失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material grade: {0}"
-msgstr "创建材料等级失败：{0}"
+msgstr "创建牌号失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material substance: {0}"
-msgstr "创建物质失败：{0}"
+msgstr "创建材质失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material type: {0}"
-msgstr "创建材料类型失败：{0}"
+msgstr "创建原材料类型失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create material: {0}"
-msgstr "创建材料失败：{0}"
+msgstr "创建原材料失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create no quote reason: {0}"
-msgstr "创建无报价原因失败：{0}"
+msgstr "创建不报价原因失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create part: {0}"
@@ -6520,7 +6520,7 @@ msgstr "创建零件失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create payment term: {0}"
-msgstr "创建付款条款失败：{0}"
+msgstr "创建付款条件失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create process: {0}"
@@ -6532,11 +6532,11 @@ msgstr "创建服务失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create shipping method: {0}"
-msgstr "创建配送方式失败：{0}"
+msgstr "创建发货方式失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create stock transfer line: {0}"
-msgstr "创建库存转移行失败：{0}"
+msgstr "创建库存调拨行失败：{0}"
 
 #. placeholder {0}: fetcher.data.error.message
 msgid "Failed to create storage type: {0}"
@@ -6598,7 +6598,7 @@ msgid "Failed to load data"
 msgstr "加载数据失败"
 
 msgid "Failed to load inbound inspections"
-msgstr "加载入站检验失败"
+msgstr "加载来料检验失败"
 
 msgid "Failed to load item data"
 msgstr "加载项目数据失败"
@@ -6607,10 +6607,10 @@ msgid "Failed to load item details"
 msgstr "加载项目详情失败"
 
 msgid "Failed to load job operations"
-msgstr "加载工作操作失败"
+msgstr "加载工单工序失败"
 
 msgid "Failed to load jobs"
-msgstr "加载工作失败"
+msgstr "加载工单失败"
 
 msgid "Failed to load purchase order lines"
 msgstr "加载采购订单行失败"
@@ -6631,10 +6631,10 @@ msgid "Failed to load sales orders"
 msgstr "加载销售订单失败"
 
 msgid "Failed to load shipment lines"
-msgstr "加载发货单行失败"
+msgstr "加载发货行失败"
 
 msgid "Failed to load shipments"
-msgstr "加载货运失败"
+msgstr "加载发货失败"
 
 msgid "Failed to load supplier part details"
 msgstr "未能加载供应商零件详情"
@@ -6650,19 +6650,19 @@ msgid "Failed to regenerate thumbnail"
 msgstr "未能重新生成缩略图"
 
 msgid "Failed to register passkey"
-msgstr "注册密钥失败"
+msgstr "注册通行密钥失败"
 
 msgid "Failed to remove image: {errorMessage}"
-msgstr "删除图像失败：{errorMessage}"
+msgstr "移除图片失败：{errorMessage}"
 
 msgid "Failed to remove model thumbnail"
-msgstr "未能删除模型缩略图"
+msgstr "移除模型缩略图失败"
 
 msgid "Failed to remove purchase order"
-msgstr "未能删除采购订单"
+msgstr "移除采购订单失败"
 
 msgid "Failed to remove thumbnail"
-msgstr "删除缩略图失败"
+msgstr "移除缩略图失败"
 
 msgid "Failed to resize image"
 msgstr "调整图像大小失败"
@@ -6788,7 +6788,7 @@ msgid "Fees"
 msgstr "费用"
 
 msgid "FEFO (first-expiry-first-out)"
-msgstr "表面处理"
+msgstr "先到期先出（先到期先出）"
 
 msgid "Fetch"
 msgstr "获取"
@@ -6850,7 +6850,7 @@ msgid "Finalize"
 msgstr "完成"
 
 msgid "Finalizing a fiscal month through the Open → Locked → Closed lifecycle; a closed period is frozen and its balances snapshotted, reversible only by explicit reopen."
-msgstr "通过打开 → 锁定 → 关闭生命周期完成财政月份；关闭的期间被冻结并其余额快照，仅可通过显式重新打开来反转。"
+msgstr "通过未结 → 已锁定 → 已关闭的生命周期来最终化会计期间；已关闭的期间被冻结并且其余额被快照处理，仅通过明确的重新打开才可以逆转。"
 
 msgid "Financial Statements"
 msgstr "财务报表"
@@ -6868,10 +6868,10 @@ msgid "Finish To"
 msgstr "完成至"
 
 msgid "Finish with material unpicked?"
-msgstr "完成但物料未领取？"
+msgstr "不拣货原材料就完成？"
 
 msgid "Finished goods"
-msgstr "表面处理"
+msgstr "成品"
 
 msgid "Finished Goods"
 msgstr "成品"
@@ -6886,10 +6886,10 @@ msgid "Finishes"
 msgstr "表面处理"
 
 msgid "Finishing an incomplete pick"
-msgstr "完成不完整的拣选"
+msgstr "完成不完整的拣货"
 
 msgid "Finishing is refused until every line is picked or marked Short."
-msgstr "拒绝完成，直到每一行都被拣选或标记为缺少。"
+msgstr "在所有行都被拣货或标记为短缺后才能完成。"
 
 msgid "First name"
 msgstr "名字"
@@ -6901,25 +6901,25 @@ msgid "First Operation"
 msgstr "首次操作"
 
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
-msgstr "固定资产"
+msgstr "在常规MACRS折旧计划开始之前的第一年额外扣除。"
 
 msgid "Fiscal year"
 msgstr "会计年度"
 
 msgid "Fiscal Year"
-msgstr "财政年度"
+msgstr "会计年度"
 
 msgid "Fiscal Year Settings"
-msgstr "财政年度设置"
+msgstr "会计年度设置"
 
 msgid "Fiscal Year to Date"
-msgstr "财政年度至今"
+msgstr "会计年度至今"
 
 msgid "Fiscal Years"
-msgstr "财政年度"
+msgstr "会计年度"
 
 msgid "Fit view"
-msgstr "适应视图"
+msgstr "缩放到适应"
 
 msgid "Fix the problems with this workflow before testing it"
 msgstr "在测试之前修复此工作流的问题"
@@ -6928,7 +6928,7 @@ msgid "Fixed"
 msgstr "固定"
 
 msgid "Fixed asset"
-msgstr "批量大小与标准不同时的固定成本摊销差异"
+msgstr "固定资产"
 
 msgid "Fixed Asset"
 msgstr "固定资产"
@@ -6937,10 +6937,10 @@ msgid "Fixed Assets"
 msgstr "固定资产"
 
 msgid "Fixed cost amortization variance when batch size differs from standard"
-msgstr "收益和损失"
+msgstr "当批量与标准不符时的固定成本摊销差异"
 
 msgid "Fixed once accounting periods have been posted to or closed. Delete all open periods to change it."
-msgstr "会计期间过账或关闭后即固定。删除所有开放期间以更改。"
+msgstr "一旦会计期间已过账或已关闭即被固定。删除所有未结期间以更改它。"
 
 msgid "Fixed Reorder"
 msgstr "固定重新订购"
@@ -6949,29 +6949,29 @@ msgid "Fixed Shelf Life"
 msgstr "固定保质期"
 
 msgid "Fixture"
-msgstr "夹具"
+msgstr "工装夹具"
 
 msgid "Fixture ID"
-msgstr "夹具ID"
+msgstr "工装夹具ID"
 
 msgid "Flags"
 msgstr "标志"
 
 msgid "for anything. They'll pull in the right person."
-msgstr "用于任何事情。他们会找到合适的人。"
+msgstr "用于任何事项。他们会调配合适的人员。"
 
 #. placeholder {0}: forecastMethod ?? "unknown"
 msgid "Forecast method: <0>{0}</0>. This row was not derived from active jobs, so no parent sources are available."
-msgstr "预测方法：<0>{0}</0>。此行不是从活跃工作派生的，因此没有可用的父源。"
+msgstr "预测方法: <0>{0}</0>。此行不是从活跃工单派生的，因此没有可用的父源。"
 
 msgid "Forgot to Clock Out?"
-msgstr "忘记打卡下班了？"
+msgstr "忘记收工了吗？"
 
 msgid "Format"
 msgstr "格式"
 
 msgid "Forward deployed engineer"
-msgstr ""
+msgstr "驻场工程师"
 
 msgid "Foundation"
 msgstr "基础"
@@ -6983,7 +6983,7 @@ msgid "Freeze the old system, no new transactions"
 msgstr "冻结旧系统，禁止新交易"
 
 msgid "Freight billed to the customer for this line, separate from the line's unit price."
-msgstr "向客户收取的此行运费，与该行单位价格分开。"
+msgstr "此行向客户收取的运费，与该行的单价分开。"
 
 msgid "Freight charged by this supplier for this line, when it itemizes shipping rather than rolling it into unit price."
 msgstr "该供应商为此行收取的运费，当其单独列明运费而不是将其包括在单价中时。"
@@ -7015,22 +7015,22 @@ msgid "From Location"
 msgstr "从位置"
 
 msgid "from on-account credit"
-msgstr "从应收账款信用额度"
+msgstr "来自应收账款信用"
 
 msgid "From Storage Unit"
-msgstr "从存储单位"
+msgstr "从存储单元"
 
 msgid "Fulfillment Location"
-msgstr "履行地点"
+msgstr "发货地点"
 
 msgid "Full name"
 msgstr "全名"
 
 msgid "Full setup and migrations"
-msgstr ""
+msgstr "完整设置和迁移"
 
 msgid "Fully Depreciated"
-msgstr "完全折旧"
+msgstr "已提足折旧"
 
 msgid "Fully trained for"
 msgstr "完全培训"
@@ -7051,43 +7051,43 @@ msgid "Gains recognized on disposal of fixed assets"
 msgstr "固定资产处置认可的获利"
 
 msgid "gauge"
-msgstr "规格"
+msgstr "量具"
 
 msgid "Gauge"
-msgstr "量规"
+msgstr "量具"
 
 msgid "Gauge Calibration Notifications"
-msgstr "仪表校准通知"
+msgstr "量具校准通知"
 
 msgid "Gauge ID"
-msgstr "仪表ID"
+msgstr "量具ID"
 
 msgid "Gauge not found"
 msgstr "量具未找到"
 
 msgid "Gauge Type"
-msgstr "仪表类型"
+msgstr "量具类型"
 
 msgid "Gauge Types"
-msgstr "量规类型"
+msgstr "量具类型"
 
 msgid "gauges"
-msgstr "产品谱系"
+msgstr "量具"
 
 msgid "Gauges"
-msgstr "量规"
+msgstr "量具"
 
 msgid "Genealogy"
-msgstr "总分类账"
+msgstr "谱系"
 
 msgid "General"
 msgstr "常规"
 
 msgid "General ledger"
-msgstr "捕获外协加工操作成本差异的GL账户。"
+msgstr "总账"
 
 msgid "General Ledger"
-msgstr "总分类账"
+msgstr "总账"
 
 msgid "General Ledger and month-end close"
 msgstr "总账和月末结账"
@@ -7108,7 +7108,7 @@ msgid "Generate Fiscal Year"
 msgstr "生成会计年度"
 
 msgid "Generate material IDs and descriptions based on the properties of the material."
-msgstr "根据材料的属性生成材料ID和描述。"
+msgstr "根据原材料的属性生成原材料ID和描述。"
 
 msgid "Generate new PIN"
 msgstr "生成新PIN"
@@ -7126,7 +7126,7 @@ msgid "Generating suggestions…"
 msgstr "正在生成建议…"
 
 msgid "Get live on Carbon: one system running quoting, purchasing, the shop floor, inventory, and finance, replacing the current tools."
-msgstr "在 Carbon 上线：一个系统运行报价、采购、车间、库存和财务，替代当前工具。"
+msgstr "在Carbon上线：一套系统运行报价、采购、车间、库存管理和财务，取代当前工具。"
 
 msgid "Get Method"
 msgstr "获取方法"
@@ -7147,40 +7147,40 @@ msgid "Give it an owner and a date"
 msgstr "给它分配一个负责人和截止日期"
 
 msgid "GL"
-msgstr "GL"
+msgstr "总账"
 
 msgid "GL Account"
 msgstr "总账账户"
 
 msgid "GL account capturing cost differences on outside-processing operations."
-msgstr "捕获委外加工作业成本差异的GL账户。"
+msgstr "捕获外包工序成本差异的总账科目。"
 
 msgid "GL account capturing differences between applied and actual manufacturing overhead."
-msgstr "捕获应用和实际制造间接费用差异的GL账户。"
+msgstr "记录分配和实际制造费用之间差异的总账科目。"
 
 msgid "GL account capturing differences between BOM-expected and actual material consumed."
-msgstr "捕获物料清单预期和实际消耗材料差异的GL账户。"
+msgstr "捕获物料清单预期与实际消耗原材料之间差异的总账科目。"
 
 msgid "GL account capturing differences between routing-expected and actual labor/machine time."
-msgstr "捕获工艺路线预期和实际劳动/机器时间差异的GL账户。"
+msgstr "记录工艺预期和实际人工/机器工时之间差异的总账科目。"
 
 msgid "GL account capturing fixed-cost differences when actual lot size differs from planned."
-msgstr "当实际批量大小与计划不同时捕获固定成本差异的GL账户。"
+msgstr "当实际批量与计划不同时，捕获固定成本差异的总账科目。"
 
 msgid "GL account credited to remove the asset's original cost when it is disposed."
-msgstr "在处置资产时记入贷方以删除资产原始成本的GL账户。"
+msgstr "当资产被处置时，用来冲销资产原始成本的贷方总账科目。"
 
 msgid "GL account credited when a supplier invoice is posted (AP balance)."
-msgstr "当供应商发票过账时记入贷方的GL账户（应付账款余额）。"
+msgstr "当供应商发票过账时贷方的总账科目（应付账款余额）。"
 
 msgid "GL account credited when labor or machine cost is absorbed into a production job."
-msgstr "当劳动力或机器成本被吸收到生产工作中时记入贷方的GL账户。"
+msgstr "人工或机器成本并入生产工单时的总账科目"
 
 msgid "GL account credited when manufacturing overhead is absorbed into a production job."
 msgstr "当制造费用被吸收到生产作业中时被贷记的总分类账科目。"
 
 msgid "GL account debited to clear accumulated depreciation when an asset is disposed."
-msgstr "在处置资产时借记以清除累积折旧的GL账户。"
+msgstr "当资产被处置时，用来冲销累计折旧的借方总账科目。"
 
 msgid "GL account debited when a customer invoice posts; cleared when the customer pays."
 msgstr "当客户发票过账时借记的GL账户；当客户支付时清除。"
@@ -7192,25 +7192,25 @@ msgid "GL account for bank service charges and similar fees."
 msgstr "用于银行服务费及类似费用的GL账户。"
 
 msgid "GL account for interest income or expense."
-msgstr "利息收入或利息费用的GL账户。"
+msgstr "利息收入或费用的总账科目。"
 
 msgid "GL account for purchase tax paid to suppliers (or reclaimable)."
 msgstr "支付给供应商的购买税的GL账户（或可收回）。"
 
 msgid "GL account for tax accrued under reverse-charge rules where the buyer self-assesses."
-msgstr "在买方自我评估的反向征收规则下应计税款的GL账户。"
+msgstr "根据买方自评的反向征税规则计提的税款总账科目。"
 
 msgid "GL account for tax timing differences (e.g. accelerated tax depreciation vs. book depreciation)."
 msgstr "税务时间差异的GL账户（例如加速税务折旧与账面折旧的差异）。"
 
 msgid "GL account hit when physical counts differ from system inventory."
-msgstr "当实物盘点数量与系统库存不符时受影响的GL账户。"
+msgstr "当实际盘点与系统库存不符时记入的总账科目。"
 
 msgid "GL account in the source company to debit for this intercompany transaction."
-msgstr "源公司中用于此关联方交易借记的GL账户。"
+msgstr "源公司中用于借记此内部交易的总账科目。"
 
 msgid "GL account in the target company to credit for this intercompany transaction."
-msgstr "目标公司中用于此关联方交易贷记的GL账户。"
+msgstr "目标公司中用于贷记此内部交易的总账科目。"
 
 msgid "GL account that absorbs sub-cent rounding differences on posting."
 msgstr "用于吸收过账时尾差的GL账户。"
@@ -7219,16 +7219,16 @@ msgid "GL account that captures the difference between standard cost and actual 
 msgstr "捕获标准成本和实际采购成本之间差异的GL账户。"
 
 msgid "GL account that carries an asset's original acquisition cost — debited when acquired and credited at full gross cost when it is disposed or sold."
-msgstr "记录资产原始购置成本的GL账户——获取时借记，处置或出售时按全额原始成本贷记。"
+msgstr "承载资产原始购置成本的总账科目——获取时借方记录，处置或出售时按总成本贷方记录。"
 
 msgid "GL account that holds the value of jobs in production until they post to finished goods."
-msgstr "持有生产中的工作价值的GL账户，直到它们过帐到成品。"
+msgstr "持有生产工单价值直至其过账至成品的总账科目"
 
 msgid "GL account that holds the value of manufactured goods (Make items); debited on job completion, credited on shipment."
-msgstr "持有制造商品（制造项）价值的总帐账户；在工作完成时记借，在发货时记贷。"
+msgstr "承载自制商品价值的总账科目；在工单完成时借方记录，在发货时贷方记录。"
 
 msgid "GL account that holds the value of purchased stock and components (Buy items); debited on receipt, credited on issue/shipment."
-msgstr "持有采购的库存和组件（采购项）价值的总帐账户；在收货时记借，在发货/发货时记贷。"
+msgstr "承载采购库存和组件价值的总账科目；在收货时借方记录，在领料/发货时贷方记录。"
 
 msgid "GL account used when a customer pays before an invoice is issued; cleared when the invoice posts."
 msgstr "当客户在发票签发前付款时使用的GL账户; 发票过帐时清除。"
@@ -7240,28 +7240,28 @@ msgid "GL account where early-payment discounts taken from suppliers are recorde
 msgstr "记录从供应商那里获取的提前付款折扣的GL账户。"
 
 msgid "GL contra-asset account credited as depreciation posts each period and debited in full when the asset is sold or scrapped."
-msgstr "GL反向资产账户，随每期折旧过账而贷记；资产出售或报废时全额借记。"
+msgstr "资产对冲类总账科目，在每期折旧过账时贷方记录，当资产出售或报废时整额借方记录。"
 
 msgid "GL contra-asset account that accumulates depreciation booked against fixed assets."
-msgstr "累积对固定资产计提的折旧的GL反向资产账户。"
+msgstr "累积针对固定资产折旧的资产对冲类总账科目。"
 
 msgid "GL equity account (CTA reserve) that holds unrealized FX differences from re-translating foreign-currency balances at period-end; separate from realized FX gain/loss in P&L."
-msgstr "GL权益账户（CTA准备金），在期末对外币余额重新转换产生的未实现外汇差异；与P&L中实现的外汇收益/损失分开。"
+msgstr "权益类总账科目（汇兑储备），存放期末重新转换外币余额产生的未实现汇兑差异；与损益表中已实现汇兑差益分开。"
 
 msgid "GL equity account where net income closes at fiscal year-end."
-msgstr "财政年度末净收入关闭的GL权益账户。"
+msgstr "财政年末净收益结转的权益类总账科目。"
 
 msgid "GL expense account debited each period when depreciation posts."
-msgstr "折旧过帐每期借记的GL支出账户。"
+msgstr "每期折旧过账时借方记录的费用类总账科目。"
 
 msgid "GL expense account debited when an asset's carrying value is reduced by impairment, i.e. when its recoverable amount falls below net book value."
-msgstr "当资产账面价值因减值而降低时借记的GL支出账户，即可收回金额低于账面净值时。"
+msgstr "资产因减值（即其可收回金额低于账面净值）而减少其账面价值时借方记录的费用类总账科目。"
 
 msgid "GL expense account for non-inventory purchases (supplies, services)."
-msgstr "非库存购买（用品、服务）的GL支出账户。"
+msgstr "非库存采购（物品、服务）的费用类总账科目。"
 
 msgid "GL liability account credited for sales tax collected from customers."
-msgstr "从客户征收的销售税的GL负债账户。"
+msgstr "从客户处收取销售税贷方记录的负债类总账科目。"
 
 msgid "GL tie-out"
 msgstr "总账对账"
@@ -7270,7 +7270,7 @@ msgid "GL Tie-Out"
 msgstr "总账对账"
 
 msgid "Go live right the first time — with our team alongside you"
-msgstr "立即上线，一次就做对——我们的团队与您同行"
+msgstr "第一次就上线成功 — 我们的团队陪伴您"
 
 #. placeholder {0}: i18n._(action.refTitle)
 msgid "Go to {0}"
@@ -7292,7 +7292,7 @@ msgid "Go-live and acceptance sign-off"
 msgstr "上线和验收签字"
 
 msgid "Go-live timing holds if each gate is cleared on schedule"
-msgstr "如果每个阶段都按时通过，上线时间表将保持不变"
+msgstr "如果每个关键节点都按计划完成，上线时间是稳定的"
 
 msgid "Going live on Carbon"
 msgstr "在 Carbon 上线"
@@ -7310,10 +7310,10 @@ msgid "Good morning, {0}"
 msgstr "早上好，{0}"
 
 msgid "Google Places API key not configured"
-msgstr "Google Places API 密钥未配置"
+msgstr "Google Places API密钥未配置"
 
 msgid "GR/IR (goods received, not invoiced)"
-msgstr "GR/IR（已收商品，未开票）"
+msgstr "GR/IR（已收货，未开票）"
 
 msgid "GR/IR Clearing"
 msgstr "GR/IR清算"
@@ -7358,7 +7358,7 @@ msgid "Guided implementation"
 msgstr "引导式实施"
 
 msgid "Handle recurring and reversing journal entries"
-msgstr "处理循环和冲销日记账分录"
+msgstr "处理循环和冲销凭证"
 
 msgid "Hands-on"
 msgstr "动手实践"
@@ -7385,7 +7385,7 @@ msgid "Hide raw"
 msgstr "隐藏原始内容"
 
 msgid "Hide system quantities until the review step"
-msgstr "隐藏系统数量直到审核步骤"
+msgstr "在评审步骤前隐藏系统数量"
 
 msgid "Hide, pin and reorder columns"
 msgstr "隐藏、固定和重新排序列"
@@ -7403,13 +7403,13 @@ msgid "Historical Rate (equity)"
 msgstr "历史汇率（权益）"
 
 msgid "Historical Rate (Equity)"
-msgstr "历史汇率（权益）"
+msgstr "历史汇率（所有者权益）"
 
 msgid "History"
-msgstr "历史"
+msgstr "历史记录"
 
 msgid "Hold the journal as a warning to fix."
-msgstr "暂存该日记帐作为警告以供修复"
+msgstr "保留凭证作为需要修正的警告"
 
 msgid "Holiday"
 msgstr "假期"
@@ -7442,7 +7442,7 @@ msgid "Hours/Piece"
 msgstr "小时/件"
 
 msgid "How an item is replenished overall (Buy, Make, or Buy and Make), set per item, unlike the per-line method type."
-msgstr "物品如何整体补充（购买、制造或购买和制造），按物品设置，与按行方法类型不同。"
+msgstr "物料整体的补货方式（采购、自制或采购与自制），按物料设定，与按行的供料方式不同"
 
 msgid "How an item is replenished: Manual Reorder, Demand-Based Reorder, Fixed Reorder Quantity, or Maximum Quantity."
 msgstr "物品如何补充：手动重新订购、基于需求的重新订购、固定重新订购数量或最大数量。"
@@ -7451,16 +7451,16 @@ msgid "How an item is sourced when added to a method or BOM line."
 msgstr "将物品添加到方法或BOM行时如何采购。"
 
 msgid "How an item's unit cost is valued: Standard, Average, FIFO, or LIFO. Set per item."
-msgstr "物品单位成本的估值方式：标准、平均、FIFO或LIFO。按物品设置。"
+msgstr "物料的单位成本估价方法：标准成本、平均成本、先进先出或后进先出。按物料设置。"
 
 msgid "How items roll up for posting and reporting"
-msgstr "项目如何汇总用于过账和报告"
+msgstr "物料如何汇总用于过账和报告"
 
 msgid "How long each phase runs, in weeks. Drives the Plan timeline; leave blank to use the default."
 msgstr "每个阶段运行多长时间（以周为单位）。驱动计划时间表；留空以使用默认值。"
 
 msgid "How long one execution of this schedule typically takes; scheduling blocks the work center for this many minutes on each scheduled instance."
-msgstr "此计划的一次执行通常需要多长时间; 调度在每个计划的实例上将工作中心锁定此分钟数。"
+msgstr "此排程的一次执行通常需要多长时间；排程将工作中心锁定此分钟数"
 
 msgid "How many"
 msgstr "多少"
@@ -7484,37 +7484,37 @@ msgid "How many fractional digits to keep when rounding amounts in this currency
 msgstr "使用此货币舍入金额时保留多少位小数。"
 
 msgid "How many of the successor replace one old part"
-msgstr "后继产品替换一个旧零件的数量"
+msgstr "后继物料中的多少个替代一个旧零件"
 
 msgid "How many of this material it takes to build one of the job's parent item; multiplied by job quantity to size the consumption."
-msgstr "需要多少此材料来构建工作的父项的一个; 乘以工作数量来改变消费量。"
+msgstr "构建一个工单的父物料需要多少这种原材料；乘以工单数量来确定消耗量"
 
 msgid "How many units each individual job in the bulk batch builds; the last job's quantity may be smaller if Total Quantity doesn't divide evenly."
-msgstr "批量批次中的每个单独工作构建多少单位; 如果总数量不能均匀分配，则最后一个工作的数量可能较小。"
+msgstr "批量生产批次中每个单独工单生产的件数；如果总数量不能均匀整除，最后一个工单的数量可能较小。"
 
 msgid "How many were actually picked?"
-msgstr "实际上捡了多少件？"
+msgstr "实际拣货了多少件？"
 
 msgid "How often this gauge must be recalibrated; combined with Last Calibration Date to recompute Next Calibration Date automatically."
-msgstr "此测量仪需要重新校准的频率; 与上次校准日期结合，自动重新计算下次校准日期。"
+msgstr "此量具必须多久重新校准一次；与上次校准日期结合自动重新计算下次校准日期"
 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
-msgstr "此维护重复的频率——每日、每周、每月、循环计数时; 每日显示星期几选择器，其他使用更简单的间隔数学。"
+msgstr "此维护的重复频率——每日、每周、每月、循环盘点；每日会显示星期选择器，其他则使用更简单的间隔计算。"
 
 msgid "How strict the Due Date is — Hard Deadline blocks scheduling past it, Soft Deadline lets planning push out with a warning, No Deadline ignores it entirely."
-msgstr "截止日期有多严格——硬期限阻止计划，软期限允许计划以警告方式推动，无期限完全忽略。"
+msgstr "到期日的严格程度——硬期限阻止排程超过它，软期限允许计划推迟但会显示警告，无期限则完全忽略它。"
 
 msgid "How the material is sourced (make, purchase, or pull from inventory) and the storage unit it's pulled from."
-msgstr "物料的获取方式（制造、采购或从库存中提取）以及提取所用的存储单元。"
+msgstr "原材料如何采购（自制、采购或从库存领用），以及从哪个存储单元中拉取。"
 
 msgid "How the resolved price was calculated."
 msgstr "已解决价格的计算方式。"
 
 msgid "How the sample size is decided — Inspect All, Inspect First N, Percentage of Lot, or AQL (Z1.4 / ISO 2859-1). Each mode reveals its own parameter fields below."
-msgstr "样本大小如何确定——检查全部、检查前N个、批次百分比或AQL（Z1.4 / ISO 2859-1）。每种模式在下面显示自己的参数字段。"
+msgstr "样本量如何确定——检验全部、检验前N个、批次百分比或AQL（Z1.4 / ISO 2859-1）。每种模式显示其自身的参数字段。"
 
 msgid "How this gauge is used — Standard (regular checks) or Master (calibrates other gauges)."
-msgstr "此量具的使用方式——标准（定期检查）或主（校准其他量具）。"
+msgstr "此量具的用途——正常检验（定期检查）或标准器（校准其他量具）。"
 
 msgid "How this price was calculated"
 msgstr "此价格是如何计算的"
@@ -7526,7 +7526,7 @@ msgid "How to read this chart"
 msgstr "如何阅读此图表"
 
 msgid "How urgent this dispatch is — Low / Medium / High / Critical; combined with Priority and OEE Impact to decide schedule slot."
-msgstr "此派送的紧急程度——低/中/高/关键; 与优先级和OEE影响相结合来决定计划时段。"
+msgstr "此维护工单的紧急程度——低/中/高/严重；与优先级和OEE影响结合以确定排程时段。"
 
 msgid "How we know we're done"
 msgstr "我们如何知道已完成"
@@ -7547,7 +7547,7 @@ msgid "How your quotes, orders, and invoices look when they go out"
 msgstr "您的报价单、订单和发票发出时的外观"
 
 msgid "How your team is organized into departments"
-msgstr "您的团队如何组织成部门"
+msgstr "您的班组如何组织成部门"
 
 msgid "Humidity"
 msgstr "湿度"
@@ -7562,7 +7562,7 @@ msgid "Hypercare: intense support for the first weeks"
 msgstr "超级护理：前几周的密集支持"
 
 msgid "I (reduced)"
-msgstr "I（已减少）"
+msgstr "I（放宽检验）"
 
 msgid "I have a reasonable basis to believe this individual is a U.S. person as defined in 22 CFR 120.62"
 msgstr "我有合理的理由相信该个人是根据 22 CFR 120.62 定义的美国人"
@@ -7595,13 +7595,13 @@ msgid "If it can't wait for the next call, the leads on both sides decide."
 msgstr "如果不能等到下次通话，双方的负责人会做出决定。"
 
 msgid "If it's blocking or a date is at risk, it gets an owner and is tracked."
-msgstr "如果它阻碍了进度或日期有风险，它会被分配所有者并被跟踪。"
+msgstr "如果它正在阻塞或日期处于风险中，它会获得一个负责人并被跟踪。"
 
 msgid "If items already exist"
-msgstr "如果项目已存在"
+msgstr "如果物料已经存在"
 
 msgid "If ordered, no stockout projected in the next 48 weeks"
-msgstr "如果下单，未来48周内预计不会缺货"
+msgstr "如果已订购，未来48周内无缺货预测"
 
 msgid "If something is off track"
 msgstr "如果有什么偏离轨道"
@@ -7613,7 +7613,7 @@ msgid "II (normal default)"
 msgstr "II（正常默认值）"
 
 msgid "III (tightened)"
-msgstr "III（紧化的）"
+msgstr "III（加严检验）"
 
 msgid "Impact"
 msgstr "影响"
@@ -7637,14 +7637,14 @@ msgid "Import results"
 msgstr "导入结果"
 
 msgid "Import your BOM"
-msgstr "导入您的物料清单"
+msgstr "导入您的BOM"
 
 #. placeholder {0}: precise?.text
 msgid "in {0}"
 msgstr "{0} 后"
 
 msgid "In Onshape, edit this OAuth application's permissions to include \"Application can write to your documents\", then connect again."
-msgstr "请在 Onshape 中编辑此 OAuth 应用的权限，加入“Application can write to your documents”，然后重新连接。"
+msgstr "在Onshape中编辑此OAuth应用程序的权限以包括\"应用程序可以写入您的文档\"，然后重新连接。"
 
 msgid "In order to convert this RFQ to a quote, all lines must have an internal part number."
 msgstr "为了将此RFQ转换为报价，所有行必须具有内部零件编号。"
@@ -7695,13 +7695,13 @@ msgid "In-app notifications are always delivered. Choose which topics also reach
 msgstr "应用内通知始终会被传递。选择哪些主题也通过电子邮件发送给您。"
 
 msgid "Inactive"
-msgstr "未激活"
+msgstr "已停用"
 
 msgid "Inactive actions will not appear in selection lists"
-msgstr "不活跃的操作将不会出现在选择列表中"
+msgstr "已停用的操作不会出现在选择列表中"
 
 msgid "Inbound inspection"
-msgstr "入站检验"
+msgstr "来料检验"
 
 msgid "Inbox"
 msgstr "收件箱"
@@ -7710,7 +7710,7 @@ msgid "Include extra parts in shipment"
 msgstr "在发货中包含额外零件"
 
 msgid "Include Inactive"
-msgstr "包括不活跃"
+msgstr "包括已停用"
 
 msgid "Included"
 msgstr "已包含"
@@ -7719,16 +7719,16 @@ msgid "Includes tax and shipping costs"
 msgstr "包括税费和运费"
 
 msgid "Income / Balance (inherited)"
-msgstr "收入/余额（已继承）"
+msgstr "收益/余额（继承）"
 
 msgid "Income Statement"
 msgstr "利润表"
 
 msgid "Income Tax"
-msgstr "所得税"
+msgstr "收益税"
 
 msgid "Income/Balance"
-msgstr "收入/余额"
+msgstr "收益/余额"
 
 msgid "incoming"
 msgstr "来货"
@@ -7746,10 +7746,10 @@ msgid "Indirect"
 msgstr "间接"
 
 msgid "Indirect Materials & Services"
-msgstr "间接材料和服务"
+msgstr "间接原材料及服务"
 
 msgid "Indirect Materials & Services (default)"
-msgstr "间接材料和服务（默认）"
+msgstr "间接原材料及服务（默认）"
 
 msgid "Infrastructure"
 msgstr "基础设施"
@@ -7758,10 +7758,10 @@ msgid "Inherit"
 msgstr "继承"
 
 msgid "Inherit document default"
-msgstr "继承文档默认值"
+msgstr "继承文件默认值"
 
 msgid "Inherit From Materials"
-msgstr "从材料继承"
+msgstr "从原材料继承"
 
 msgid "Inherited"
 msgstr "已继承"
@@ -7770,13 +7770,13 @@ msgid "Inherited from parent"
 msgstr "从父级继承"
 
 msgid "Inherited from the group: top-level classification (asset, liability, equity, revenue, expense)."
-msgstr "从组继承：顶级分类（资产、负债、权益、收入、支出）。"
+msgstr "从分类继承：顶级分类（资产、负债、所有者权益、收入、费用）。"
 
 msgid "Inherited from the group: where this account appears on financial statements."
 msgstr "从组继承：此账户在财务报表中出现的位置。"
 
 msgid "Inherited from the group: whether this account closes to retained earnings (income) or carries forward (balance)."
-msgstr "从组继承：此账户是否关闭到留存收益（收入）或结转（余额）。"
+msgstr "从公司继承：此账户是结转至未分配利润（收益）还是结转至资产负债表（余额）。"
 
 msgid "Inherited from the parent group."
 msgstr "从父组继承。"
@@ -7806,7 +7806,7 @@ msgid "Inspection"
 msgstr "检验"
 
 msgid "Inspection document"
-msgstr "检验文档"
+msgstr "检验文件"
 
 msgid "Inspection Level"
 msgstr "检验水平"
@@ -7827,10 +7827,10 @@ msgid "Inspections"
 msgstr "检验"
 
 msgid "Inspections, nonconformance, and CAPA"
-msgstr "检验、不符合和CAPA"
+msgstr "检验、不合格和CAPA"
 
 msgid "Inspections, Nonconformance, CAPA"
-msgstr "检验、不符合、纠正预防措施"
+msgstr "检验、不合格、CAPA"
 
 msgid "Inspections: Require Different Inspector"
 msgstr "检验：需要不同的检验员"
@@ -7845,7 +7845,7 @@ msgid "Instructions"
 msgstr "说明"
 
 msgid "Instructions are inherited from the procedure."
-msgstr "说明继承自工序。"
+msgstr "说明从程序文件继承。"
 
 msgid "Integration"
 msgstr "集成"
@@ -7881,7 +7881,7 @@ msgid "Interest (default)"
 msgstr "利息（默认）"
 
 msgid "Interest income or expense from banking activities"
-msgstr "来自银行活动的利息收入或支出"
+msgstr "银行活动产生的利息收益或费用"
 
 msgid "Internal"
 msgstr "内部"
@@ -7905,16 +7905,16 @@ msgid "Invalid Invite"
 msgstr "无效邀请"
 
 msgid "inventory"
-msgstr "库存"
+msgstr "库存管理"
 
 msgid "Inventory"
-msgstr "库存"
+msgstr "库存管理"
 
 msgid "Inventory accuracy"
-msgstr "库存准确性"
+msgstr "库存管理准确性"
 
 msgid "Inventory actions"
-msgstr "库存操作"
+msgstr "库存管理操作"
 
 msgid "Inventory Adjustment"
 msgstr "库存调整"
@@ -7923,25 +7923,25 @@ msgid "Inventory Adjustment (default)"
 msgstr "库存调整（默认）"
 
 msgid "Inventory and purchasing, with automated planning"
-msgstr "库存和采购，具有自动化规划"
+msgstr "库存管理和采购，具有自动化计划"
 
 msgid "Inventory balances"
-msgstr "库存余额"
+msgstr "库存管理余额"
 
 msgid "Inventory Control"
-msgstr "库存控制"
+msgstr "库存管理控制"
 
 msgid "Inventory control and counts"
-msgstr "库存控制和盘点"
+msgstr "库存管理控制和盘点"
 
 msgid "Inventory Count"
 msgstr "库存盘点"
 
 msgid "Inventory History"
-msgstr "库存历史"
+msgstr "库存历史记录"
 
 msgid "Inventory Job Notifications"
-msgstr "库存工作通知"
+msgstr "库存工单通知"
 
 msgid "Inventory Movements"
 msgstr "库存移动"
@@ -7950,13 +7950,13 @@ msgid "Inventory Qty"
 msgstr "库存数量"
 
 msgid "Inventory Tracking"
-msgstr "库存追踪"
+msgstr "库存跟踪"
 
 msgid "Inventory Unit of Measure"
 msgstr "库存计量单位"
 
 msgid "Inventory Valuation"
-msgstr "库存估值"
+msgstr "库存估价"
 
 msgid "Invite"
 msgstr "邀请"
@@ -8022,7 +8022,7 @@ msgid "Invoice Supplier Location"
 msgstr "发票供应商位置"
 
 msgid "Invoice Total"
-msgstr "发票总额"
+msgstr "发票总计"
 
 msgid "Invoiced"
 msgstr "已开票"
@@ -8037,7 +8037,7 @@ msgid "Invoices"
 msgstr "发票"
 
 msgid "Invoices this memo has been applied to. Click a row to open the document."
-msgstr "此备忘录已应用到的发票。单击一行以打开文档。"
+msgstr "此备忘录已应用的发票。点击一行打开文件。"
 
 msgid "Invoicing"
 msgstr "开票"
@@ -8073,7 +8073,7 @@ msgid "Issue"
 msgstr "问题"
 
 msgid "Issue (material)"
-msgstr "发行（材料）"
+msgstr "领料（原材料）"
 
 msgid "Issue description"
 msgstr "问题描述"
@@ -8112,7 +8112,7 @@ msgid "Issue Workflows"
 msgstr "问题工作流"
 
 msgid "Issue workflows defined the preset values for an issue. For example, you can have an 8D workflow or a containment workflow."
-msgstr "问题工作流定义了问题的预设值。例如，您可以有8D工作流或遏制工作流。"
+msgstr "领料工作流定义了领料的预设值。例如，您可以创建 8D 工作流或围堵工作流。"
 
 msgid "Issued"
 msgstr "已发放"
@@ -8124,7 +8124,7 @@ msgid "Issues"
 msgstr "问题"
 
 msgid "It will stop running until you publish a version again. Nothing is deleted."
-msgstr ""
+msgstr "它将停止运行，直到您再次发布版本。不会删除任何内容。"
 
 msgid "ITAR Certifications"
 msgstr "ITAR 认证"
@@ -8169,7 +8169,7 @@ msgid "Item Master and Make Methods"
 msgstr "物料主数据和制造方法"
 
 msgid "Item master, BOMs and Bill of Process"
-msgstr "物料主数据、物料清单和工艺流程"
+msgstr "物料主数据、BOM 和工序清单"
 
 msgid "Item must match a selected type AND a selected group"
 msgstr "项目必须匹配选定的类型和选定的组"
@@ -8184,31 +8184,31 @@ msgid "Item Scope"
 msgstr "物品范围"
 
 msgid "Item Type"
-msgstr "物品类型"
+msgstr "物料类型"
 
 msgid "Item Type (optional)"
-msgstr "物品类型（可选）"
+msgstr "物料类型（可选）"
 
 msgid "Item types"
-msgstr "物品类型"
+msgstr "物料类型"
 
 msgid "items"
-msgstr "项目"
+msgstr "物料"
 
 msgid "Items"
-msgstr "物品"
+msgstr "物料"
 
 msgid "Items & Production"
-msgstr "项目与生产"
+msgstr "物料与生产"
 
 msgid "Items inside this window get a yellow badge."
-msgstr "此窗口内的项目会获得黄色徽章。"
+msgstr "此窗口内的物料将获得黄色徽章。"
 
 msgid "Items: item master, BOMs, Bill of Process, engineering changes, CAD"
-msgstr "项目：项目主数据、物料清单、工艺流程、工程变更、CAD"
+msgstr "物料：物料主数据、BOM、工序清单、工程变更、CAD"
 
 msgid "Its design may change before the change notice is released."
-msgstr "在更改单发布前，其设计可能会发生变化。"
+msgstr "在变更通知下达前，其设计可能会改变。"
 
 msgid "Job"
 msgstr "工作"
@@ -8223,19 +8223,19 @@ msgid "Job Location"
 msgstr "工作地点"
 
 msgid "Job make method"
-msgstr "作业制造方式"
+msgstr "工单制造方法"
 
 msgid "Job Materials"
-msgstr "工作物料"
+msgstr "工单物料"
 
 msgid "Job operation"
-msgstr "工作操作"
+msgstr "工单工序"
 
 msgid "Job Operation"
-msgstr "工作操作"
+msgstr "工单工序"
 
 msgid "Job Operations"
-msgstr "工作操作"
+msgstr "工单工序"
 
 msgid "Job Priority"
 msgstr "工作优先级"
@@ -8244,38 +8244,38 @@ msgid "Job readable"
 msgstr "工作可读性"
 
 msgid "Job Traveler"
-msgstr "工作单"
+msgstr "工单流转卡"
 
 msgid "Jobs"
-msgstr "工作"
+msgstr "工单"
 
 msgid "Jobs Assigned to Me"
-msgstr "分配给我的工作"
+msgstr "分配给我的工单"
 
 msgid "Jobs Required"
-msgstr "所需的工作"
+msgstr "所需工单"
 
 msgid "Jobs that have this item on their bill of materials"
-msgstr "物料清单中包含此物品的工作"
+msgstr "物料清单中包含此物料的工单"
 
 #. placeholder {0}: company?.name ?? "Company"
 msgid "Join {0}"
 msgstr "加入 {0}"
 
 msgid "Journal"
-msgstr "日记"
+msgstr "凭证"
 
 msgid "Journal Entries"
-msgstr "日记账分录"
+msgstr "凭证分录"
 
 msgid "Journal entries dated in this period that are still Draft must be posted, or re-dated into a later open period. Draft entries aren't part of the ledger, so their debits and credits would be missing from the close."
-msgstr "本期日期的日记账条目如仍为草稿状态，必须进行过账或重新标记日期至较晚的开放期间。草稿条目不属于分类账，因此其借贷金额会在结账时遗漏。"
+msgstr "本期日期的凭证如果仍为草稿状态必须过账，或将其日期改为后期的未结期间。草稿凭证不属于总账的一部分，所以它们的借方和贷方将在结账时遗漏。"
 
 msgid "Journal Entry"
-msgstr "日记账条目"
+msgstr "分录"
 
 msgid "Journals dated on or before this date are treated as locked. Merged with the provider-reported lock date when both exist."
-msgstr "日期在此日期及之前的日记账被视为已锁定。当两者都存在时，与提供商报告的锁定日期合并。"
+msgstr "在此日期或之前日期的凭证被视为已锁定。当两者都存在时，与提供商报告的锁定日期合并。"
 
 msgid "Just one"
 msgstr "仅一个"
@@ -8299,19 +8299,19 @@ msgid "Keep Current"
 msgstr "保持当前"
 
 msgid "Keep existing pricing, only add new items"
-msgstr "保留现有定价，仅添加新项目"
+msgstr "保留现有定价，仅添加新物料"
 
 msgid "Keep only items where…"
-msgstr "仅保留符合以下条件的项目…"
+msgstr "仅保留满足以下条件的物料…"
 
 msgid "Keep only the {entityName} where…"
 msgstr "仅保留符合以下条件的{entityName}…"
 
 msgid "Keep Open"
-msgstr "保持开放"
+msgstr "保持未结"
 
 msgid "Keep picking"
-msgstr "继续领取"
+msgstr "继续拣货"
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "让订单、报价单和设置受到第二道检查的保护"
@@ -8342,40 +8342,40 @@ msgid "Labels"
 msgstr "标签"
 
 msgid "Labor"
-msgstr "劳动力"
+msgstr "人工"
 
 msgid "Labor & Machine Absorption"
-msgstr "劳动力和机器吸收"
+msgstr "人工机器吸收"
 
 msgid "Labor & Machine Absorption (default)"
-msgstr "劳动力和机器吸收（默认）"
+msgstr "人工机器吸收（默认）"
 
 msgid "Labor & Machine Variance"
-msgstr "劳动力和机器差异"
+msgstr "人工机器差异"
 
 msgid "Labor & Machine Variance (default)"
-msgstr "劳动力和机器差异（默认）"
+msgstr "人工机器差异（默认）"
 
 msgid "Labor rate"
-msgstr "劳动费率"
+msgstr "人工费率"
 
 msgid "Labor Rate"
-msgstr "劳动力成本"
+msgstr "人工费率"
 
 msgid "Labor Rate (Hourly)"
-msgstr "劳动力费率（每小时）"
+msgstr "人工费率（每小时）"
 
 msgid "Labor time"
-msgstr "劳动时间"
+msgstr "人工工时"
 
 msgid "Labor Time"
-msgstr "劳动时间"
+msgstr "人工工时"
 
 msgid "Labor unit"
-msgstr "劳动单位"
+msgstr "人工单位"
 
 msgid "Labor Unit"
-msgstr "劳动单位"
+msgstr "人工单位"
 
 msgid "Language"
 msgstr "语言"
@@ -8399,7 +8399,7 @@ msgid "Last day"
 msgstr "最后一天"
 
 msgid "Last Fiscal Year"
-msgstr "上一财政年度"
+msgstr "上一个会计年度"
 
 msgid "Last Login"
 msgstr "最后登录"
@@ -8432,7 +8432,7 @@ msgid "Latitude"
 msgstr "纬度"
 
 msgid "Lead time"
-msgstr "交货期"
+msgstr "提前期"
 
 msgid "Lead Time"
 msgstr "提前期"
@@ -8441,10 +8441,10 @@ msgid "Lead time (days)"
 msgstr "提前期（天）"
 
 msgid "Lead Time (Days)"
-msgstr "交期（天）"
+msgstr "提前期（天）"
 
 msgid "Lead Time:"
-msgstr "交货时间："
+msgstr "提前期："
 
 msgid "Learn"
 msgstr "学习"
@@ -8459,7 +8459,7 @@ msgid "Leave blank for built-in"
 msgstr "留空以使用内置"
 
 msgid "Leave blank to use the next revision automatically"
-msgstr "留空以自动使用下一版本"
+msgstr "留空以自动使用下一个修订版"
 
 msgid "Leave empty for exact match"
 msgstr "留空以精确匹配"
@@ -8477,7 +8477,7 @@ msgid "Leftover Parts Detected"
 msgstr "检测到剩余零件"
 
 msgid "Leftover staged material returns when the whole job completes."
-msgstr "当整个工作完成时，剩余的暂存物料返回。"
+msgstr "当整个工单完成时，剩余的暂存原材料将被退回。"
 
 msgid "Less manual work"
 msgstr "更少的手动工作"
@@ -8486,7 +8486,7 @@ msgid "Less manual work, fewer errors"
 msgstr "更少的手动工作，更少的错误"
 
 msgid "Let's Build"
-msgstr ""
+msgstr "让我们构建"
 
 msgid "Let's build something"
 msgstr "让我们构建一些东西"
@@ -8540,7 +8540,7 @@ msgid "Line Status"
 msgstr "行状态"
 
 msgid "Linear Team"
-msgstr "Linear 团队"
+msgstr "线性班组"
 
 msgid "Lines"
 msgstr "行"
@@ -8549,10 +8549,10 @@ msgid "Lines need internal part numbers"
 msgstr "行需要内部零件号"
 
 msgid "Lines need prices or lead times"
-msgstr "行需要价格或交期"
+msgstr "行需要价格或提前期"
 
 msgid "Lineside"
-msgstr "生产线旁"
+msgstr "线边"
 
 msgid "Link"
 msgstr "链接"
@@ -8567,7 +8567,7 @@ msgid "Link Linear Issue"
 msgstr "关联 Linear 问题"
 
 msgid "Link this Carbon customer to one of them, or create a separate Stripe customer."
-msgstr ""
+msgstr "将此 Carbon 客户链接到其中一个，或创建单独的 Stripe 客户。"
 
 msgid "Link to sales order line"
 msgstr "关联销售订单行"
@@ -8613,7 +8613,7 @@ msgid "Loaded last, right at cutover, so balances are current."
 msgstr "最后加载，在切换时进行，以便余额是最新的。"
 
 msgid "Loading associated jobs..."
-msgstr "正在加载关联的工作..."
+msgstr "加载相关工单..."
 
 msgid "Loading current quantity…"
 msgstr "正在加载当前数量…"
@@ -8661,10 +8661,10 @@ msgid "Locked"
 msgstr "已锁定"
 
 msgid "Locking makes the period read-only for operational documents (receipts, shipments, invoices) while still allowing accounting adjustments like depreciation and disposals. A period must be locked before it can be closed."
-msgstr "锁定使期间对于业务单据（收据、装运、发票）为只读，同时仍允许进行折旧和处置等会计调整。期间在结束前必须被锁定。"
+msgstr "锁定使该期间对运营凭证（收货、发货、发票）为只读，同时仍允许会计调整（如折旧和处置）。期间必须先锁定才能关闭。"
 
 msgid "Log nonconformances and drive a CAPA"
-msgstr "记录不符合项并推动纠正和预防措施"
+msgstr "记录不合格并推动 CAPA"
 
 msgid "Login or create a new account"
 msgstr "登录或创建新账户"
@@ -8683,7 +8683,7 @@ msgstr "徽标"
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "Logs older than {0} days are automatically archived."
-msgstr "超过 {0} 天的日志会自动存档。"
+msgstr "超过{0}天的日志将自动归档。"
 
 msgid "Long Description"
 msgstr "长描述"
@@ -8707,7 +8707,7 @@ msgid "Losses recognized on disposal of fixed assets"
 msgstr "固定资产处置认可的亏损"
 
 msgid "Lost"
-msgstr "已失败"
+msgstr "丢单"
 
 msgid "Lot"
 msgstr "批次"
@@ -8719,16 +8719,16 @@ msgid "Lot Size"
 msgstr "批量大小"
 
 msgid "Lot Size Variance"
-msgstr "批次大小差异"
+msgstr "批量差异"
 
 msgid "Lot Size Variance (default)"
-msgstr "批次大小差异（默认）"
+msgstr "批量差异（默认）"
 
 msgid "Lot Size:"
 msgstr "批量大小："
 
 msgid "Lot-based inspection of received goods against a sampling plan; the units post On Hold at receipt and only release to Available once the lot is dispositioned as accepted."
-msgstr "基于批次的已接收商品对抽样计划的检验；单位在收货时过账为保留，仅当批次被处置为已接收时才释放到可用。"
+msgstr "对收到的货物进行基于批次的检验（根据抽样方案）；单位在收货时过账至搁置状态，只有在批次被处置为已接受后才能下达至可用。"
 
 msgid "Low"
 msgstr "低"
@@ -8746,10 +8746,10 @@ msgid "Machine Rate (Hourly)"
 msgstr "机器费率（每小时）"
 
 msgid "Machine time"
-msgstr "机器时间"
+msgstr "机器工时"
 
 msgid "Machine Time"
-msgstr "机器时间"
+msgstr "机器工时"
 
 msgid "Machine unit"
 msgstr "机器单位"
@@ -8779,10 +8779,10 @@ msgid "Maintenance"
 msgstr "维护"
 
 msgid "Maintenance Dispatch Notifications"
-msgstr "维护调度通知"
+msgstr "维护工单通知"
 
 msgid "Maintenance Dispatches"
-msgstr "维护派遣"
+msgstr "维护工单"
 
 msgid "Maintenance Expense"
 msgstr "维护费用"
@@ -8791,7 +8791,7 @@ msgid "Maintenance Expense (default)"
 msgstr "维护费用 (默认)"
 
 msgid "Maintenance Schedules"
-msgstr "维护计划"
+msgstr "维护排程"
 
 msgid "Maintenance Type"
 msgstr "维护类型"
@@ -8800,7 +8800,7 @@ msgid "Make"
 msgstr "制造"
 
 msgid "Make Active"
-msgstr "激活"
+msgstr "启用"
 
 msgid "Make Default"
 msgstr "设为默认"
@@ -8809,7 +8809,7 @@ msgid "Make Inactive"
 msgstr "停用"
 
 msgid "Make items cannot be invoiced directly. Change method to Pick to continue."
-msgstr "制造项目无法直接开票。请将方法更改为\"拣选\"以继续。"
+msgstr "自制物料无法直接开票。将方法更改为从库存领用以继续。"
 
 msgid "Make Method Version"
 msgstr "制造方法版本"
@@ -8836,22 +8836,22 @@ msgid "Make the go / no-go decision"
 msgstr "做出上线/不上线决定"
 
 msgid "Make to Order"
-msgstr "按单制造"
+msgstr "按订单生产"
 
 msgid "Make tracked entities available again"
 msgstr "使跟踪的实体再次可用"
 
 msgid "Makes this document active again."
-msgstr "使此文档再次激活。"
+msgstr "再次启用此文件。"
 
 msgid "Makes this document active and visible."
-msgstr "使此文档处于活跃状态并可见。"
+msgstr "启用此文件并使其可见。"
 
 msgid "Manage"
 msgstr "管理"
 
 msgid "Manage how shelf life is tracked, computed, and enforced across inventory."
-msgstr "管理如何在整个库存中跟踪、计算和执行保质期。"
+msgstr "管理保质期在库存管理中的跟踪、计算和执行方式。"
 
 msgid "Manage Ownership"
 msgstr "管理所有权"
@@ -8884,7 +8884,7 @@ msgid "Map accounts"
 msgstr "映射科目"
 
 msgid "Map Carbon accounts to the provider's chart of accounts. Posted journals push using the mapped provider account code."
-msgstr "将 Carbon 账户映射到提供商的科目表。已过账日记账使用映射的提供商账户代码推送。"
+msgstr "将Carbon账户映射到提供商的会计科目表。已过账凭证使用映射的提供商账户代码进行推送。"
 
 msgid "Map Extracted Invoice Lines"
 msgstr "映射提取的发票行项目"
@@ -8993,49 +8993,49 @@ msgid "Matching Pairs"
 msgstr "匹配对"
 
 msgid "material"
-msgstr "材料"
+msgstr "原材料"
 
 msgid "Material"
-msgstr "材料"
+msgstr "原材料"
 
 msgid "Material Dimension"
-msgstr "物料尺寸"
+msgstr "原材料维度"
 
 msgid "Material Dimensions"
-msgstr "物料尺寸"
+msgstr "原材料维度"
 
 msgid "Material dimensions use metric units."
-msgstr "材料尺寸使用公制单位。"
+msgstr "原材料维度使用公制单位。"
 
 msgid "Material Finish"
-msgstr "材料饰面"
+msgstr "表面处理"
 
 msgid "Material Finishes"
-msgstr "材料饰面"
+msgstr "表面处理"
 
 msgid "Material Form"
-msgstr "材料形式"
+msgstr "原材料表单"
 
 msgid "Material Grade"
-msgstr "材料等级"
+msgstr "牌号"
 
 msgid "Material Grades"
-msgstr "材料等级"
+msgstr "牌号"
 
 msgid "Material ID"
-msgstr "物料ID"
+msgstr "原材料ID"
 
 msgid "Material IDs"
-msgstr "物料ID"
+msgstr "原材料IDs"
 
 msgid "Material is pre-selected"
-msgstr "材料已预先选择"
+msgstr "原材料已预选"
 
 msgid "Material Properties"
-msgstr "材料属性"
+msgstr "原材料属性"
 
 msgid "Material Review Board (MRB)"
-msgstr "物料评审委员会 (MRB)"
+msgstr "材料评审委员会(MRB)"
 
 msgid "Material Shape"
 msgstr "材料形状"
@@ -9044,40 +9044,40 @@ msgid "Material Shapes"
 msgstr "材料形状"
 
 msgid "Material Substance"
-msgstr "物质材料"
+msgstr "材质"
 
 msgid "Material Substances"
-msgstr "物质材料"
+msgstr "材质"
 
 msgid "material type"
-msgstr "材料类型"
+msgstr "原材料类型"
 
 msgid "Material Type"
-msgstr "材料类型"
+msgstr "原材料类型"
 
 msgid "material types"
-msgstr "材料类型"
+msgstr "原材料类型"
 
 msgid "Material Types"
-msgstr "材料类型"
+msgstr "原材料类型"
 
 msgid "Material Usage Variance"
-msgstr "材料使用差异"
+msgstr "原材料使用差异"
 
 msgid "Material Usage Variance (default)"
-msgstr "材料使用差异 (默认)"
+msgstr "原材料使用差异(默认)"
 
 msgid "materials"
-msgstr "材料"
+msgstr "原材料"
 
 msgid "Materials"
-msgstr "材料"
+msgstr "原材料"
 
 msgid "Materials are included"
-msgstr "包含材料"
+msgstr "已包含原材料"
 
 msgid "Materials are not included"
-msgstr "不包含材料"
+msgstr "未包含原材料"
 
 msgid "Max Qty"
 msgstr "最大数量"
@@ -9149,16 +9149,16 @@ msgid "Method Id"
 msgstr "方法 ID"
 
 msgid "Method Materials"
-msgstr "方法材料"
+msgstr "方法原材料"
 
 msgid "Method Operations"
-msgstr "方法操作"
+msgstr "方法工序"
 
 msgid "Method type"
-msgstr "方法类型"
+msgstr "供料方式"
 
 msgid "Method Type"
-msgstr "方法类型"
+msgstr "供料方式"
 
 msgid "Methods"
 msgstr "方法"
@@ -9191,7 +9191,7 @@ msgid "Minimum Cost"
 msgstr "最低成本"
 
 msgid "Minimum Order Quantity"
-msgstr "最小订单数量"
+msgstr "最小起订量"
 
 msgid "Minimum Order:"
 msgstr "最小订单:"
@@ -9218,7 +9218,7 @@ msgid "Missing Information"
 msgstr "缺少信息"
 
 msgid "Missing Operations"
-msgstr "缺少操作"
+msgstr "缺失的工序"
 
 msgid "Missing Shipping Costs"
 msgstr "缺少运费"
@@ -9308,16 +9308,16 @@ msgid "Move item"
 msgstr "移动项目"
 
 msgid "Move some of the quantity into a new disposition row so MRB can decide each portion separately (e.g. scrap some, rework some)."
-msgstr "将部分数量移至新的处置行，以便 MRB 可以分别决定每个部分（例如报废一些、返工一些）。"
+msgstr "将部分数量移动到新的处置行，以便MRB可以分别决定每一部分（例如报废部分、返工部分）。"
 
 msgid "Move to"
-msgstr "移至"
+msgstr "移动到"
 
 msgid "Move to Group"
-msgstr "移至分组"
+msgstr "移动到组"
 
 msgid "Move to Trash"
-msgstr "移至垃圾箱"
+msgstr "移动到垃圾箱"
 
 #. placeholder {0}: file.name
 #. placeholder {1}: targetBucket === "parts" ? "Parts" : "Opportunity"
@@ -9346,7 +9346,7 @@ msgid "My Documents"
 msgstr "我的文档"
 
 msgid "My Saved View"
-msgstr "我的已保存视图"
+msgstr "我的保存视图"
 
 msgid "Name"
 msgstr "名称"
@@ -9364,7 +9364,7 @@ msgid "Navigate"
 msgstr "导航"
 
 msgid "NCRs by Type"
-msgstr "按类型分类的不符合项"
+msgstr "按类型分类的NCR"
 
 msgid "Need by"
 msgstr "需要日期"
@@ -9388,7 +9388,7 @@ msgid "Negative Adjustment"
 msgstr "负调整"
 
 msgid "Net book value"
-msgstr "净账面价值"
+msgstr "账面净值"
 
 msgid "Net Book Value"
 msgstr "账面净值"
@@ -9397,7 +9397,7 @@ msgid "Net Change"
 msgstr "净变化"
 
 msgid "Net Income"
-msgstr "净收入"
+msgstr "净收益"
 
 msgid "Never"
 msgstr "永不"
@@ -9412,7 +9412,7 @@ msgid "New Account"
 msgstr "新账户"
 
 msgid "New API Key"
-msgstr "新 API 密钥"
+msgstr "新建API密钥"
 
 msgid "New Approval Rule"
 msgstr "新审批规则"
@@ -9430,25 +9430,25 @@ msgid "New Attribute Category"
 msgstr "新属性类别"
 
 msgid "New Change Notice"
-msgstr "新建更改单"
+msgstr "新建变更通知"
 
 msgid "New Change Notice Action"
-msgstr "新建更改单操作"
+msgstr "新建变更通知操作"
 
 msgid "New Change Notice Type"
-msgstr "新建更改单类型"
+msgstr "新建变更通知类型"
 
 msgid "New Consumable"
-msgstr "新消耗品"
+msgstr "新建耗材"
 
 msgid "New Contractor"
-msgstr "新承包商"
+msgstr "新建外协人员"
 
 msgid "New Cost Center"
 msgstr "新建成本中心"
 
 msgid "New Credit / Debit Memo"
-msgstr "新的贷项/借项备忘录"
+msgstr "新建贷方/借方备忘录"
 
 msgid "New Custom Field"
 msgstr "新建自定义字段"
@@ -9469,7 +9469,7 @@ msgid "New Employee Type"
 msgstr "新员工类型"
 
 msgid "New expiration date"
-msgstr "新的过期日期"
+msgstr "新到期日期"
 
 msgid "New Failure Mode"
 msgstr "新故障模式"
@@ -9481,13 +9481,13 @@ msgid "New Fixed Asset"
 msgstr "新固定资产"
 
 msgid "New Gauge"
-msgstr "新测量仪"
+msgstr "新建量具"
 
 msgid "New Gauge Calibration Record"
-msgstr "新的仪表校准记录"
+msgstr "新建量具校准记录"
 
 msgid "New Gauge Type"
-msgstr "新量规类型"
+msgstr "新建量具类型"
 
 msgid "New Group"
 msgstr "新建群组"
@@ -9502,7 +9502,7 @@ msgid "New Inspection Plan"
 msgstr "新检验计划"
 
 msgid "New Inventory Count"
-msgstr "新库存盘点"
+msgstr "新建库存盘点"
 
 msgid "New Invoice"
 msgstr "新发票"
@@ -9526,34 +9526,34 @@ msgid "New Location"
 msgstr "新位置"
 
 msgid "New Maintenance Dispatch"
-msgstr "新的维护调度"
+msgstr "新建维护工单"
 
 msgid "New Material"
-msgstr "新物料"
+msgstr "新建原材料"
 
 msgid "New Material Dimension"
-msgstr "新材料尺寸"
+msgstr "新建原材料维度"
 
 msgid "New Material Finish"
 msgstr "新材料表面处理"
 
 msgid "New Material Grade"
-msgstr "新材料等级"
+msgstr "新建牌号"
 
 msgid "New Material Shape"
 msgstr "新材料形状"
 
 msgid "New Material Substance"
-msgstr "新材料物质"
+msgstr "新建材质"
 
 msgid "New Material Type"
-msgstr "新材料类型"
+msgstr "新建原材料类型"
 
 msgid "New Non Conformance Type"
-msgstr "新的不符合项类型"
+msgstr "新建不合格类型"
 
 msgid "New Owner"
-msgstr "新所有者"
+msgstr "新建负责人"
 
 msgid "New Part"
 msgstr "新零件"
@@ -9565,7 +9565,7 @@ msgid "New Payment"
 msgstr "新付款"
 
 msgid "New Payment Term"
-msgstr "新付款条款"
+msgstr "新建付款条件"
 
 msgid "New Picking List"
 msgstr "新拣货单"
@@ -9583,7 +9583,7 @@ msgid "New Pricing Rule"
 msgstr "新定价规则"
 
 msgid "New Procedure"
-msgstr "新程序"
+msgstr "新建程序文件"
 
 msgid "New Process"
 msgstr "新流程"
@@ -9646,7 +9646,7 @@ msgid "New Shipment"
 msgstr "新发货"
 
 msgid "New Shipping Method"
-msgstr "新运输方法"
+msgstr "新建发货方式"
 
 msgid "New Size"
 msgstr "新尺寸"
@@ -9676,7 +9676,7 @@ msgid "New Transfer"
 msgstr "新转账"
 
 msgid "New Transfer Line"
-msgstr "新转移行"
+msgstr "新建调拨行"
 
 msgid "New Unit of Measure"
 msgstr "新计量单位"
@@ -9721,7 +9721,7 @@ msgid "Next page"
 msgstr "下一页"
 
 msgid "Next Sequence"
-msgstr "下一个序列"
+msgstr "下一个编号规则"
 
 msgid "Next step"
 msgstr "下一步"
@@ -9738,14 +9738,14 @@ msgstr "未找到 {0}"
 
 #. placeholder {0}: status.toLowerCase()
 msgid "No {0} sync operations"
-msgstr "没有 {0} 同步操作"
+msgstr "无{0}个同步操作"
 
 #. placeholder {0}: copy.pluralNoun
 msgid "No {0} yet"
 msgstr "还没有{0}"
 
 msgid "No abilities added"
-msgstr "未添加任何能力"
+msgstr "没有添加技能"
 
 msgid "No Access"
 msgstr "无权限"
@@ -9763,29 +9763,29 @@ msgid "No actions selected"
 msgstr "未选择任何操作"
 
 msgid "No active jobs found for this sales order. The order will be cancelled directly."
-msgstr "未找到此销售订单的活跃工作。订单将直接取消。"
+msgstr "未找到此销售订单的活跃工单。订单将直接取消。"
 
 msgid "No active plan"
-msgstr "没有活跃的计划"
+msgstr "没有启用的计划"
 
 msgid "No Active Quotes"
-msgstr "没有活跃报价"
+msgstr "没有启用的报价单"
 
 msgid "No addresses found"
 msgstr "未找到地址"
 
 msgid "No affected items to assess."
-msgstr "没有要评估的受影响项目。"
+msgstr "没有要评估的受影响物料。"
 
 msgid "No affected items."
-msgstr "没有受影响的项目。"
+msgstr "没有受影响的物料。"
 
 msgid "No applications. Payment will be on-account."
 msgstr "无应用。付款将按账户处理。"
 
 #. placeholder {0}: auditConfig.retentionDays
 msgid "No archived logs yet. Logs older than {0} days will be automatically archived and available for download here."
-msgstr "还没有存档日志。超过 {0} 天的日志将自动存档，并可在此处下载。"
+msgstr "暂无已归档日志。超过{0}天的日志将自动归档，并可在此下载。"
 
 msgid "No attachments."
 msgstr "没有附件。"
@@ -9797,7 +9797,7 @@ msgid "No available tracked entities found"
 msgstr "未找到可用的追踪实体"
 
 msgid "No BOM input has a shelf-life policy"
-msgstr "没有物料清单输入具有保质期政策"
+msgstr "没有 BOM 输入具有保质期策略"
 
 msgid "No CAD model to preview."
 msgstr "没有CAD模型可预览。"
@@ -9818,7 +9818,7 @@ msgid "No comments yet. Be the first to add a comment."
 msgstr "还没有评论。成为第一个添加评论的人。"
 
 msgid "No completed jobs within range"
-msgstr "范围内没有已完成的工作"
+msgstr "范围内没有已完成的工单"
 
 msgid "No condition may match"
 msgstr "没有条件可以匹配"
@@ -9854,13 +9854,13 @@ msgid "No draft versions available"
 msgstr "没有可用的草稿版本"
 
 msgid "No due date"
-msgstr "无截止日期"
+msgstr "没有到期日"
 
 msgid "No editable properties for this item."
 msgstr "此项目没有可编辑的属性。"
 
 msgid "No employees assigned yet. Add groups to see status."
-msgstr "还未分配员工。添加组以查看状态。"
+msgstr "尚未分配员工。添加群组以查看状态。"
 
 msgid "No employees found"
 msgstr "未找到员工"
@@ -9875,10 +9875,10 @@ msgid "No extra data sets yet. Add anything specific to this customer."
 msgstr "还没有额外的数据集。添加此客户特定的任何内容。"
 
 msgid "No extra requirements yet. Add anything specific to this customer."
-msgstr "还没有额外的需求。添加特定于此客户的任何内容。"
+msgstr "还没有额外要求。添加特定于此客户的任何内容。"
 
 msgid "No extra setup items yet. Add anything specific to this customer."
-msgstr "还没有额外的设置项。添加此客户特定的任何内容。"
+msgstr "还没有额外的换型物料。添加特定于此客户的任何内容。"
 
 msgid "No failure path — the run stops here and is marked failed"
 msgstr "无失败路径 — 运行在此停止并标记为失败"
@@ -9902,7 +9902,7 @@ msgid "No grouped notifications"
 msgstr "没有分组通知"
 
 msgid "No groups assigned"
-msgstr "未分配任何组"
+msgstr "没有已分配的组"
 
 msgid "No image"
 msgstr "没有图像"
@@ -9914,16 +9914,16 @@ msgid "No issue types configured"
 msgstr "未配置问题类型"
 
 msgid "No items"
-msgstr "无项目"
+msgstr "没有物料"
 
 msgid "No items have inventory activity here yet."
-msgstr "此处尚无项目的库存活动。"
+msgstr "此处尚无物料库存活动。"
 
 msgid "No jobs were created"
-msgstr "没有创建任何作业"
+msgstr "没有创建工单"
 
 msgid "No journal lines in scope for this period"
-msgstr "本期范围内没有日记账行"
+msgstr "此期间范围内没有凭证行"
 
 msgid "No lines to map"
 msgstr "没有行需要映射"
@@ -9950,7 +9950,7 @@ msgid "No matches. Type to create one."
 msgstr "无匹配项。输入内容以创建一个。"
 
 msgid "No matching bins"
-msgstr "无匹配的箱子"
+msgstr "没有匹配的料箱"
 
 msgid "No new notifications"
 msgstr "没有新通知"
@@ -9962,19 +9962,19 @@ msgid "No open invoices"
 msgstr "没有未结发票"
 
 msgid "No open orders for this item are available to link."
-msgstr "此项目没有可链接的未结订单。"
+msgstr "此物料没有未结订单可供链接。"
 
 msgid "No open sales order lines"
 msgstr "没有未结销售订单行"
 
 msgid "No operations found."
-msgstr "未找到操作。"
+msgstr "未找到工序。"
 
 msgid "No operations require picking at this location"
-msgstr "此位置不需要进行任何操作拣选"
+msgstr "此地点没有工序需要拣货"
 
 msgid "No operators."
-msgstr "没有运算符。"
+msgstr "没有操作员。"
 
 msgid "No option found."
 msgstr "未找到选项。"
@@ -9983,7 +9983,7 @@ msgid "No options found."
 msgstr "未找到选项。"
 
 msgid "No other bins hold this item"
-msgstr "其他地点没有此项目"
+msgstr "没有其他料箱存放此物料"
 
 msgid "No other employees found. Add employees to enable ownership transfer."
 msgstr "未找到其他员工。添加员工以启用所有权转移。"
@@ -10004,19 +10004,19 @@ msgid "No parts"
 msgstr "没有零件"
 
 msgid "No passkeys registered yet."
-msgstr "尚未注册任何密钥。"
+msgstr "还没有已登记的通行密钥。"
 
 msgid "No payables"
-msgstr "无应付款"
+msgstr "没有应付款项"
 
 msgid "No payments yet."
 msgstr "还没有付款。"
 
 msgid "No planning data"
-msgstr "没有规划数据"
+msgstr "没有计划数据"
 
 msgid "No posted journals in this period for this account"
-msgstr "此期间此账户没有已记账日记账"
+msgstr "此期间此账户没有已过账的凭证"
 
 msgid "No pricing for selected quantity"
 msgstr "所选数量无定价"
@@ -10040,16 +10040,16 @@ msgid "No purchases in this period"
 msgstr "此期间无采购"
 
 msgid "No Quote"
-msgstr "无报价"
+msgstr "不报价"
 
 msgid "No Quote Reason"
-msgstr "无报价原因"
+msgstr "不报价原因"
 
 msgid "No Quote Reasons"
-msgstr "无报价原因"
+msgstr "不报价原因"
 
 msgid "No receivables"
-msgstr "无应收账款"
+msgstr "没有应收款项"
 
 msgid "No records found"
 msgstr "未找到记录"
@@ -10064,7 +10064,7 @@ msgid "No reports match your search."
 msgstr "未找到与搜索条件匹配的报告。"
 
 msgid "No representative of this company has accepted the Carbon GovCloud Rider yet. An administrator at this company must accept it before anyone can access Carbon — Carbon staff cannot accept it on your behalf."
-msgstr "本公司尚无代表接受 Carbon GovCloud Rider。在任何人访问 Carbon 之前，必须由本公司的管理员接受 — Carbon 员工无法代表贵公司接受。"
+msgstr "该公司还没有代表接受 Carbon GovCloud Rider。该公司的管理员必须先接受它，然后任何人才能访问 Carbon — Carbon 员工不能代表您接受。"
 
 msgid "No results"
 msgstr "无结果"
@@ -10076,13 +10076,13 @@ msgid "No rows here."
 msgstr "这里没有行。"
 
 msgid "No rules assigned"
-msgstr "未分配规则"
+msgstr "没有已分配的规则"
 
 msgid "No single, trusted number for inventory or job status"
-msgstr "没有单一的、可信的库存或工作状态数字"
+msgstr "库存管理或工单状态没有单一的可信数字"
 
 msgid "No sorts applied to this view"
-msgstr "此视图未应用排序"
+msgstr "此查看未应用任何排序"
 
 msgid "No stock"
 msgstr "无库存"
@@ -10091,7 +10091,7 @@ msgid "No stock at this location"
 msgstr "此位置没有库存"
 
 msgid "No stockout projected in the next 48 weeks"
-msgstr "未来48周内未预测到库存短缺"
+msgstr "未来 48 周内没有预计缺货"
 
 msgid "No storage unit"
 msgstr "无存储单元"
@@ -10100,7 +10100,7 @@ msgid "No suppliers yet"
 msgstr "还没有供应商"
 
 msgid "No sync operations yet"
-msgstr "尚无同步操作"
+msgstr "还没有同步操作"
 
 msgid "No time entries for this week"
 msgstr "本周没有时间条目"
@@ -10133,7 +10133,7 @@ msgid "No variables available"
 msgstr "没有可用的变量"
 
 msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
-msgstr "此项目没有仓库库存记录。您仍然可以拣选它——现有库存将变为负数，直到库存被核对。"
+msgstr "此物料的仓库库存无记录。您仍然可以拣货 — 在手库存将变为负数，直到盘点协调。"
 
 msgid "No work center utilization data within range"
 msgstr "范围内没有工作中心利用率数据"
@@ -10148,16 +10148,16 @@ msgid "Nominal Cost"
 msgstr "名义成本"
 
 msgid "Non conformance"
-msgstr "不符合"
+msgstr "不合格"
 
 msgid "Non Conformance Type"
-msgstr "不符合项类型"
+msgstr "不合格类型"
 
 msgid "Non conformance workflow"
-msgstr "不符合工作流"
+msgstr "不合格工作流"
 
 msgid "Non-conformance (issue)"
-msgstr "不符合（问题）"
+msgstr "不合格(领料)"
 
 msgid "Non-Inventory"
 msgstr "非库存"
@@ -10166,10 +10166,10 @@ msgid "Non-Inventory Tracking"
 msgstr "非库存追踪"
 
 msgid "Non-operating expense account debited when an asset in this class is sold or scrapped below its net book value."
-msgstr "资产出售或报废价格低于其净账面价值时借记的营业外支出账户。"
+msgstr "本类资产出售或报废价值低于账面净值时计入的非营业费用账户"
 
 msgid "Non-operating income account credited when an asset in this class is sold for more than its net book value."
-msgstr "资产出售价格高于其净账面价值时贷记的营业外收入账户。"
+msgstr "本类资产出售价值高于账面净值时计入的非营业收益账户"
 
 msgid "Non-Taxable Add-On Cost"
 msgstr "非应税附加成本"
@@ -10184,13 +10184,13 @@ msgid "Normal"
 msgstr "正常"
 
 msgid "Not a table but a general-ledger balance: cost accumulates as job materials are issued and clears when the job is received to stock."
-msgstr "不是表格而是总账余额：当发出工作物料时成本积累，当工作收到库存时清除。"
+msgstr "不是表，而是总账余额：成本随着工单物料的领料而累积，工单收到库存时清空。"
 
 msgid "Not certified"
 msgstr "未认证"
 
 msgid "Not enough jobs to cover quantity"
-msgstr "工作数量不足以覆盖数量"
+msgstr "工单数量不足以覆盖所需数量"
 
 msgid "Not reached"
 msgstr "未到达"
@@ -10269,22 +10269,22 @@ msgid "Number"
 msgstr "数字"
 
 msgid "Number of inventory units per purchase unit"
-msgstr "每个采购单位的库存单位数"
+msgstr "每个采购件的库存件数"
 
 msgid "Number of lines"
 msgstr "行数"
 
 msgid "Number of open operations"
-msgstr "未结操作数"
+msgstr "未结工序数量"
 
 msgid "Number of open tasks"
 msgstr "未结任务数"
 
 msgid "Number of operations"
-msgstr "操作数"
+msgstr "工序数量"
 
 msgid "Numbering sequence"
-msgstr "编号序列"
+msgstr "编号规则"
 
 msgid "OEE Impact"
 msgstr "OEE 影响"
@@ -10299,7 +10299,7 @@ msgid "Off — handled outside the sync"
 msgstr "关闭 — 在同步外处理"
 
 msgid "Off — released revisions stay editable"
-msgstr "关闭 — 已发布的版本保持可编辑"
+msgstr "关闭 — 已下达修订版保持可编辑"
 
 msgid "OK"
 msgstr "确定"
@@ -10308,7 +10308,7 @@ msgid "Oldest first"
 msgstr "最早优先"
 
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
-msgstr "在切换日期，按顺序完成下面的检查清单。验收测试来自您的范围内需求。支持详情在下方。"
+msgstr "在转换日，按顺序完成下列检查清单。验收测试来自您范围内的要求。支持详情见下方。"
 
 msgid "On day"
 msgstr "在某天"
@@ -10326,10 +10326,10 @@ msgid "On Hand"
 msgstr "现有"
 
 msgid "On Hold"
-msgstr "暂停"
+msgstr "搁置"
 
 msgid "On Jobs"
-msgstr "在工作中"
+msgstr "在工单上"
 
 msgid "On order"
 msgstr "已订购"
@@ -10350,7 +10350,7 @@ msgid "On this operation"
 msgstr "在此工序上"
 
 msgid "On-account credit available"
-msgstr "账户信用额度可用"
+msgstr "可用账户贷方"
 
 msgid "On-hand counts"
 msgstr "现有库存数量"
@@ -10359,40 +10359,40 @@ msgid "On-hand floor to maintain for service use at this location"
 msgstr "在此位置维护用于服务的最低库存"
 
 msgid "On-hand inventory remains"
-msgstr "现有库存仍然存在"
+msgstr "剩余可用库存"
 
 msgid "On-hand value by location or item, with GL tie-out"
 msgstr "按地点或物品统计的在手价值，含总账对账"
 
 msgid "On-hand value of manufactured goods (Make items)"
-msgstr "制造商品（制造项）的现有价值"
+msgstr "自制物料的库存价值"
 
 msgid "On-hand value of purchased stock and components (Buy items)"
-msgstr "采购的库存和组件（采购项）的现有价值"
+msgstr "采购物料的库存价值"
 
 msgid "On-time delivery"
 msgstr "准时交付"
 
 msgid "One firing of a workflow, recorded step by step with the values each step used and produced, acting throughout with the permissions of the workflow's owner."
-msgstr "工作流的一次执行，逐步记录每个步骤使用和生成的值，始终以工作流所有者的权限作用。"
+msgstr "一次工作流执行，逐步记录每个步骤使用和产生的值，始终以工作流负责人的权限行动。"
 
 msgid "One serial unit or one batch that Carbon follows individually, carrying its own status and attributes such as an expiry date."
-msgstr "Carbon单独跟踪的一个序列号单位或一个批次，具有自己的状态和属性，例如过期日期。"
+msgstr "Carbon单独跟踪的一个编号件或一个生产批次，具有自己的状态和属性，例如有效期。"
 
 msgid "One set of numbers"
 msgstr "一套数字"
 
 msgid "One step in a job's routing, naming a process and a work center and carrying its own setup, labor, and machine times and rates."
-msgstr "工作路线中的一个步骤，命名流程和工作中心，并携带自己的设置、劳动和机器时间以及费率。"
+msgstr "工单工艺路线中的一个步骤，命名一个工艺和工作中心，并包含其自己的换型、人工和机器工时及费率。"
 
 msgid "One system from quote to cash"
-msgstr "从报价到收款的一个系统"
+msgstr "从报价单到现金的一个系统"
 
 msgid "Only Draft procedures are editable. Create a new version to change an Active or Archived procedure."
-msgstr "只有草稿程序可以编辑。创建新版本以更改活动或已归档的程序。"
+msgstr "仅草稿程序文件可编辑。创建新版本以更改启用或已归档程序文件。"
 
 msgid "Only empty, open periods can be deleted."
-msgstr "仅可删除空白的开放期间。"
+msgstr "仅可删除空的、未结会计期间。"
 
 msgid "Onshape authorized the connection but saving it failed. Try connecting again."
 msgstr "Onshape 已授权此连接，但保存失败。请重新连接。"
@@ -10419,52 +10419,52 @@ msgid "Oops! The link you're trying to access is not valid."
 msgstr "哎呀！您尝试访问的链接无效。"
 
 msgid "Open"
-msgstr "打开"
+msgstr "未结"
 
 msgid "Open a change notice"
-msgstr "打开更改单"
+msgstr "打开变更通知"
 
 msgid "Open Actions"
-msgstr "开放操作"
+msgstr "未结操作"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "为MRB处置打开NCR"
+msgstr "打开 NCR 进行 MRB 处置"
 
 msgid "Open AP"
 msgstr "未结应付账款"
 
 msgid "Open AR"
-msgstr "未结应收"
+msgstr "未结应收账款"
 
 msgid "Open Audit Log"
 msgstr "打开审计日志"
 
 msgid "Open date"
-msgstr "开始日期"
+msgstr "打开日期"
 
 msgid "Open Date"
-msgstr "开放日期"
+msgstr "打开日期"
 
 msgid "Open Dispatches"
-msgstr "未结派工单"
+msgstr "未结维护工单"
 
 msgid "Open in Carbon"
 msgstr "在 Carbon 中打开"
 
 msgid "Open in change notice {ids}. Release it to create new versions or revisions."
-msgstr "在更改单{ids}中打开。发布它以创建新版本或修订版。"
+msgstr "打开于变更通知 {ids}。下达它来创建新版本或修订版。"
 
 msgid "Open in change notices {ids}. Release them to create new versions or revisions."
-msgstr "在更改单{ids}中打开。发布它们以创建新版本或修订版。"
+msgstr "打开于变更通知 {ids}。下达它们来创建新版本或修订版。"
 
 msgid "Open in MES"
-msgstr "在MES中打开"
+msgstr "在 MES 中打开"
 
 msgid "Open Issues"
-msgstr "未解决的问题"
+msgstr "未结领料"
 
 msgid "Open job demand plus outstanding transfers out of this bin"
-msgstr "未完成工作需求加上此地点的未完成转移"
+msgstr "未结工单需求加上从此料箱转出的未清调拨"
 
 msgid "Open jobs"
 msgstr "未结工单"
@@ -10473,7 +10473,7 @@ msgid "Open menu"
 msgstr "打开菜单"
 
 msgid "Open payables by supplier and age"
-msgstr "按供应商和账龄统计的未清应付账款"
+msgstr "按供应商和期限打开应付款项"
 
 msgid "Open Purchase Invoices"
 msgstr "未结采购发票"
@@ -10488,10 +10488,10 @@ msgid "Open Quotes"
 msgstr "未结报价"
 
 msgid "Open Reactive"
-msgstr "开放反应"
+msgstr "打开 Reactive"
 
 msgid "Open receivables by customer and age"
-msgstr "按客户和账龄统计的未清应收账款"
+msgstr "按客户和期限打开应收款项"
 
 msgid "Open RFQs"
 msgstr "未结RFQ"
@@ -10503,7 +10503,7 @@ msgid "Open Sales Orders"
 msgstr "未结销售订单"
 
 msgid "Open Scheduled"
-msgstr "开放计划"
+msgstr "打开 Scheduled"
 
 msgid "Open task details"
 msgstr "打开任务详情"
@@ -10533,7 +10533,7 @@ msgid "Operating Expenses"
 msgstr "运营费用"
 
 msgid "Operating Income"
-msgstr "营业收入"
+msgstr "营运收益"
 
 msgid "Operation"
 msgstr "操作"
@@ -10554,7 +10554,7 @@ msgid "Operation quantity"
 msgstr "操作数量"
 
 msgid "Operation supplier process"
-msgstr "操作供应商流程"
+msgstr "工序供应商工艺"
 
 msgid "Operation type"
 msgstr "操作类型"
@@ -10566,13 +10566,13 @@ msgid "Operation unit cost"
 msgstr "操作单位成本"
 
 msgid "Operations"
-msgstr "操作"
+msgstr "工序"
 
 msgid "Operations / steps"
-msgstr "操作/步骤"
+msgstr "工序/步骤"
 
 msgid "Operations Type"
-msgstr "运营类型"
+msgstr "工序类型"
 
 msgid "Operator"
 msgstr "操作员"
@@ -10581,10 +10581,10 @@ msgid "Operator gets a warning. Stock still goes through."
 msgstr "操作员收到警告。库存仍然可以通过。"
 
 msgid "Operator must pick a different batch/serial."
-msgstr "操作员必须选择不同的批次/序列号。"
+msgstr "操作员必须选择不同的生产批次/序列号。"
 
 msgid "Operator sees the missing items, can acknowledge & finish. The list is flagged Partial."
-msgstr "操作员看到缺失的项目，可以确认并完成。列表被标记为部分。"
+msgstr "操作员看到缺失的物料，可以确认并完成。列表被标记为部分。"
 
 msgid "Operators"
 msgstr "操作员"
@@ -10593,13 +10593,13 @@ msgid "Operators can use shared workstations with PIN authentication."
 msgstr "操作员可以使用带有PIN身份验证的共享工作站。"
 
 msgid "Operators start on the Scan tab"
-msgstr "操作人员从扫描选项卡开始"
+msgstr "操作员从扫码选项卡开始"
 
 msgid "Operators start the timer themselves when they begin an operation."
-msgstr "操作人员在开始一个操作时自己启动计时器。"
+msgstr "操作员在开始工序时自己启动计时器。"
 
 msgid "Opportunity"
-msgstr "机会"
+msgstr "商机"
 
 msgid "Optimized for fast previews — downloads always serve the original uploaded file"
 msgstr "针对快速预览优化 — 下载始终提供原始上载的文件"
@@ -10611,7 +10611,7 @@ msgid "Optional context for this rule"
 msgstr "此规则的可选上下文"
 
 msgid "Optional fixed rate used when translating equity balances per IAS 21 (instead of the period rate)."
-msgstr "根据IAS 21翻译股权余额时使用的可选固定汇率（而不是期间汇率）。"
+msgstr "在根据IAS 21转换所有者权益余额时使用的可选固定汇率（而不是期间汇率）。"
 
 msgid "Optional pages & sections"
 msgstr "可选页面和部分"
@@ -10645,7 +10645,7 @@ msgid "Order Date"
 msgstr "订单日期"
 
 msgid "Order Multiple"
-msgstr "订单倍数"
+msgstr "订购倍数"
 
 msgid "Order Parts"
 msgstr "订购零件"
@@ -10660,7 +10660,7 @@ msgid "Order rules are evaluated in — for discounts only the highest-priority 
 msgstr "订单规则按顺序评估 — 对于折扣，只应用最高优先级的匹配（不叠加）；加价全部应用并按优先级顺序复合。"
 
 msgid "Order Total"
-msgstr "订单总额"
+msgstr "订单总计"
 
 msgid "Ordered"
 msgstr "已订购"
@@ -10684,16 +10684,16 @@ msgid "Original Count"
 msgstr "原始盘点"
 
 msgid "Other Expense"
-msgstr "其他费用"
+msgstr "营业外支出"
 
 msgid "Other Income"
-msgstr "其他收入"
+msgstr "营业外收入"
 
 msgid "Other Income account for FX gains when a payment settles a foreign-currency invoice at a more favorable rate"
-msgstr "当付款以更优惠的汇率结清外币发票时，外汇收益的其他收入账户"
+msgstr "当付款以更优惠的汇率结算外币发票时用于外汇收益的营业外收入账户"
 
 msgid "Other Income account for vendor balances cleared without full payment on AP settlement"
-msgstr "其他收入账户，用于在应付账款结算时清除未全额支付的供应商余额"
+msgstr "在应付账款结算时，未全额付款清除的供应商余额使用的营业外收入账户"
 
 msgid "Other Type"
 msgstr "其他类型"
@@ -10711,7 +10711,7 @@ msgid "Output"
 msgstr "输出"
 
 msgid "Output never outlasts its raw materials. Falls back to the fixed duration when no input has an expiry date."
-msgstr "输出永远不会超过其原材料的保质期。当没有输入具有过期日期时，回退到固定期限。"
+msgstr "产出的有效期永远不会超过其原材料的有效期。当没有输入具有有效期时，回退到固定期限。"
 
 msgid "Outside operation"
 msgstr "间接费用差异"
@@ -10723,31 +10723,31 @@ msgid "Overall result"
 msgstr "总体结果"
 
 msgid "Overdue"
-msgstr "逾期"
+msgstr "已逾期"
 
 msgid "Overhead Absorption"
-msgstr "制造费用吸收"
+msgstr "制造费用分配"
 
 msgid "Overhead Absorption (default)"
-msgstr "制造费用吸收（默认）"
+msgstr "制造费用分配（默认）"
 
 msgid "Overhead rate"
-msgstr "间接费用率"
+msgstr "制造费用率"
 
 msgid "Overhead Rate"
-msgstr "间接费率"
+msgstr "制造费用率"
 
 msgid "Overhead Rate (Hourly)"
-msgstr "间接费率（每小时）"
+msgstr "制造费用率（小时）"
 
 msgid "Overhead Variance"
-msgstr "间接费用差异（默认）"
+msgstr "制造费用差异"
 
 msgid "Overhead Variance (default)"
-msgstr "所有者（成本中心）"
+msgstr "制造费用差异（默认）"
 
 msgid "Override needs the inventory:update permission and a reason."
-msgstr "覆盖需要 inventory:update 权限和原因。"
+msgstr "覆盖需要库存管理:更新权限和原因。"
 
 msgid "Override Price"
 msgstr "覆盖价格"
@@ -10777,10 +10777,10 @@ msgid "Overwrite the target manufacturing method with the quote method"
 msgstr "用报价方法覆盖目标制造方法"
 
 msgid "Owner"
-msgstr "所有者"
+msgstr "负责人"
 
 msgid "Owner (cost center)"
-msgstr "主成本中心"
+msgstr "负责人（成本中心）"
 
 #. placeholder {0}: i18n._(member.owns)
 msgid "Owns: {0}"
@@ -10808,13 +10808,13 @@ msgid "Parameters"
 msgstr "参数"
 
 msgid "Parameters are inherited from the procedure."
-msgstr "参数继承自工序。"
+msgstr "参数从程序文件继承。"
 
 msgid "Params"
 msgstr "参数"
 
 msgid "Parent cost center"
-msgstr "零件"
+msgstr "父成本中心"
 
 msgid "Parent Cost Center"
 msgstr "父成本中心"
@@ -10829,7 +10829,7 @@ msgid "Parent Item"
 msgstr "父项目"
 
 msgid "Parent items. (If you click into one of the parent parts below, you'll see this item included as a component on the bill of material.)"
-msgstr "上级物品。(如果您点击下方其中一个上级零件，您将看到此物品作为组件包含在物料清单中。)"
+msgstr "父级物料。（如果您点击下面的一个父级零件，您将看到此物料作为组件包含在物料清单中。）"
 
 msgid "Parent Storage Unit"
 msgstr "父存储单元"
@@ -10841,7 +10841,7 @@ msgid "Park as error"
 msgstr "停靠为错误"
 
 msgid "Park the journal with a warning until the value is mapped"
-msgstr "将日记账停放，并显示警告，直到该值被映射"
+msgstr "暂停凭证并显示警告，直到值被分配"
 
 msgid "part"
 msgstr "零件"
@@ -10862,7 +10862,7 @@ msgid "Part Number"
 msgstr "零件编号"
 
 msgid "Part Supersession"
-msgstr "零件取代"
+msgstr "零件替代"
 
 msgid "Partial"
 msgstr "部分"
@@ -10874,37 +10874,37 @@ msgid "Partners"
 msgstr "合作伙伴"
 
 msgid "parts"
-msgstr "应付账款"
+msgstr "零件"
 
 msgid "Parts"
 msgstr "零件"
 
 msgid "Parts & items"
-msgstr "零件和物品"
+msgstr "零件和物料"
 
 msgid "Parts, materials, and how you classify them."
-msgstr "零件、材料及其分类方式。"
+msgstr "零件、原材料及其分类方式"
 
 msgid "Party Type"
 msgstr "方当事人类型"
 
 msgid "Pass"
-msgstr "通过"
+msgstr "合格"
 
 msgid "Passed"
 msgstr "已通过"
 
 msgid "Passkey name"
-msgstr "密钥名称"
+msgstr "通行密钥名称"
 
 msgid "Passkey unlock failed"
-msgstr "密钥解锁失败"
+msgstr "通行密钥解锁失败"
 
 msgid "Passkeys"
-msgstr "密钥"
+msgstr "通行密钥"
 
 msgid "Passkeys are disabled"
-msgstr "密钥已禁用"
+msgstr "通行密钥已禁用"
 
 msgid "Path"
 msgstr "路径"
@@ -10913,16 +10913,16 @@ msgid "Pay Rate"
 msgstr "支付汇率"
 
 msgid "Payables"
-msgstr "应付账款（默认）"
+msgstr "应付款项"
 
 msgid "Payables (AP)"
-msgstr "应付账款 (AP)"
+msgstr "应付款项（应付账款）"
 
 msgid "Payables (default)"
-msgstr "付款条件"
+msgstr "应付款项（默认）"
 
 msgid "Payables aging"
-msgstr "应付账款账龄"
+msgstr "应付款项账龄"
 
 msgid "Payment"
 msgstr "付款"
@@ -10940,31 +10940,31 @@ msgid "payment term"
 msgstr "付款条件"
 
 msgid "Payment term"
-msgstr "付款条款"
+msgstr "付款条件"
 
 msgid "Payment Term"
-msgstr "付款条款"
+msgstr "付款条件"
 
 msgid "payment terms"
-msgstr "人"
+msgstr "付款条件"
 
 msgid "Payment Terms"
-msgstr "付款条款"
+msgstr "付款条件"
 
 msgid "Payment terms like Net 30 or due on receipt"
-msgstr "像 Net 30 或到期时支付这样的付款条款"
+msgstr "付款条件，如净30天或收货即付"
 
 msgid "Payments"
 msgstr "付款"
 
 msgid "Payments and credits applied to this invoice. Click a row to open the source document."
-msgstr "已应用于此发票的付款和贷项。点击一行以打开源文档。"
+msgstr "应用于此发票的付款和贷方。单击一行以打开源单据。"
 
 msgid "PDF"
 msgstr "PDF"
 
 msgid "PDF (Document)"
-msgstr "PDF（文档）"
+msgstr "PDF（文件）"
 
 msgid "PDF downloaded"
 msgstr "PDF已下载"
@@ -10982,7 +10982,7 @@ msgid "Pending"
 msgstr "待处理"
 
 msgid "people"
-msgstr "固定资产定期折旧费用"
+msgstr "人员"
 
 msgid "People"
 msgstr "人员"
@@ -10991,10 +10991,10 @@ msgid "Per Unit"
 msgstr "每单位"
 
 msgid "Per-line override of the order header's fulfillment Location; used for split shipments and drop-ships."
-msgstr "订单头部履行位置的按行覆盖；用于分割出货和代理出货。"
+msgstr "对订单标题的发货地点的按行覆盖；用于分批发货和直发。"
 
 msgid "Per-line override of the PO header's Delivery Location; used for split deliveries to multiple warehouses or drop-shipments."
-msgstr "采购单标题交付位置的按行覆盖；用于分割交付到多个仓库或代理交付。"
+msgstr "对采购订单标题的交货地点的按行覆盖；用于分批交货到多个仓库或直发。"
 
 msgid "Percentage"
 msgstr "百分比"
@@ -11015,7 +11015,7 @@ msgid "Period lock policy"
 msgstr "期间锁定政策"
 
 msgid "Periodic depreciation expense for fixed assets"
-msgstr "拣选按最早过期日期优先提供跟踪实体，因此最快过期的库存默认首先出库。"
+msgstr "固定资产的定期折旧费用"
 
 msgid "Permanently Delete"
 msgstr "永久删除"
@@ -11027,13 +11027,13 @@ msgid "Permissions"
 msgstr "权限"
 
 msgid "Person"
-msgstr "人员"
+msgstr "个人"
 
 msgid "Phase durations"
 msgstr "阶段时长"
 
 msgid "Phasing out an item in favor of a successor part, so planning redirects the old item's demand — times a conversion factor — to the new one."
-msgstr "逐步淘汰某个物料，转而使用替代物料，以便计划将旧物料的需求——乘以转换系数——重定向到新物料。"
+msgstr "逐步淘汰一个物料以支持后继零件，以便计划将旧物料的需求 — 乘以换算系数 — 重定向到新的。"
 
 msgid "Phone"
 msgstr "电话"
@@ -11051,22 +11051,22 @@ msgid "Physical printers available for assignment."
 msgstr "可用于分配的物理打印机。"
 
 msgid "Pick"
-msgstr "拣选"
+msgstr "拣货"
 
 msgid "Pick a Carbon dimension and the provider target it posts to. Auto-create adds missing provider options by name at push time."
-msgstr "选择一个 Carbon 维度和它发布到的提供商目标。自动创建在推送时按名称添加缺失的提供商选项。"
+msgstr "选择一个 Carbon 维度和它过账到的提供商目标。自动创建在推送时按名称添加缺失的提供商选项。"
 
 msgid "Pick a column to sort by"
 msgstr "选择要排序的列"
 
 msgid "Pick a customer or customer type to view their pricing."
-msgstr "选择客户或客户类型以查看其定价。"
+msgstr "选择一个客户或客户类型以查看其定价。"
 
 msgid "Pick a date or leave blank to clear it."
-msgstr "选择日期或留空以清除。"
+msgstr "选择一个日期或留空以清除它。"
 
 msgid "Pick a list variable…"
-msgstr "选择列表变量…"
+msgstr "选择一个列表变量…"
 
 msgid "Pick a property"
 msgstr "选择属性"
@@ -11078,7 +11078,7 @@ msgid "Pick a record type…"
 msgstr "选择记录类型…"
 
 msgid "Pick a value from an earlier step"
-msgstr "从之前的步骤中选择值"
+msgstr "从早期步骤选择一个值"
 
 msgid "Pick a variable…"
 msgstr "选择变量…"
@@ -11087,25 +11087,25 @@ msgid "Pick List"
 msgstr "拣货单"
 
 msgid "Pick Order"
-msgstr "拣选顺序"
+msgstr "拣货单"
 
 msgid "Pick the bin that needs stock, then pick the bins to pull it from."
-msgstr "先选择需要库存的箱，再选择要从中提取库存的箱。"
+msgstr "选择需要库存的料箱，然后选择要从中拣货的料箱。"
 
 msgid "Pick tracked item"
-msgstr "拣选追踪项目"
+msgstr "拣货追踪物料"
 
 msgid "Picked and consumed as separate components"
-msgstr "作为独立组件拣选和消耗"
+msgstr "已拣货且作为单独组件已消耗"
 
 msgid "Picked quantity"
-msgstr "已拣选数量"
+msgstr "已拣货数量"
 
 msgid "Picking Lines"
 msgstr "拣货行"
 
 msgid "Picking list"
-msgstr "捡料单"
+msgstr "拣货单"
 
 msgid "Picking List"
 msgstr "拣货单"
@@ -11120,7 +11120,7 @@ msgid "Picking Lists"
 msgstr "拣货单"
 
 msgid "Picking offers tracked entities earliest-expiry-first, so the soonest-to-expire stock leaves first by default."
-msgstr "计划"
+msgstr "拣货按最早有效期优先的方式处理可追踪实体，以便最即将过期的库存首先出库。"
 
 msgid "Pieces/Hour"
 msgstr "件/小时"
@@ -11149,22 +11149,22 @@ msgid "Plan Type"
 msgstr "计划类型"
 
 msgid "Planned"
-msgstr "过账"
+msgstr "已计划"
 
 msgid "Planned End"
-msgstr "计划结束"
+msgstr "计划完成"
 
 msgid "Planned End Time"
 msgstr "计划结束时间"
 
 msgid "Planned job"
-msgstr "计划作业"
+msgstr "已计划工单"
 
 msgid "Planned Order"
 msgstr "计划订单"
 
 msgid "Planned order = MRP suggestion to cover projected demand based on the item's reorder policy (or manually added)."
-msgstr "计划订单 = MRP 建议，用于根据物品的重新订购政策（或手动添加）覆盖预计需求。"
+msgstr "计划订单 = MRP建议，用于根据物料的重新订购政策覆盖预计需求（或手动添加）。"
 
 msgid "Planned purchase order"
 msgstr "计划采购订单"
@@ -11176,16 +11176,16 @@ msgid "Planned Start Time"
 msgstr "计划开始时间"
 
 msgid "Planning"
-msgstr "规划"
+msgstr "计划"
 
 msgid "Planning rounds suggested replenishment up to a whole multiple of this number."
-msgstr "规划回合建议补充到此数字的整数倍。"
+msgstr "计划将建议的补货数量舍入至该数字的整数倍。"
 
 msgid "Planning's lower bound on a suggested replenishment quantity; distinct from a supplier's MOQ, which lives on the supplier-part record."
-msgstr "建议补充数量的规划下界；不同于位于供应商零件记录上的供应商的MOQ。"
+msgstr "计划对建议补货数量的下限；不同于供应商的最小订购量 (MOQ)，该值位于供应商-物料记录上。"
 
 msgid "Planning's upper bound on a single suggested replenishment; quantities above this are split into multiple orders."
-msgstr "单个建议补充的规划上界；超过此值的数量被分成多个订单。"
+msgstr "计划对单次建议补货的上限；超过此限制的数量将拆分为多个订单。"
 
 msgid "Plants, warehouses"
 msgstr "工厂、仓库"
@@ -11230,7 +11230,7 @@ msgid "Policy"
 msgstr "政策"
 
 msgid "Policy & Procedure"
-msgstr "政策与程序"
+msgstr "政策与程序文件"
 
 msgid "Portal Link"
 msgstr "门户链接"
@@ -11251,13 +11251,13 @@ msgid "Post Invoice"
 msgstr "过账发票"
 
 msgid "Post journal entries with proper account and description codes"
-msgstr "使用正确的账户和描述代码过账日记账分录"
+msgstr "使用正确的科目和描述代码过账凭证。"
 
 msgid "Post Receipt"
 msgstr "过账收据"
 
 msgid "Post Shipment"
-msgstr "发布货运"
+msgstr "过账发货"
 
 msgid "Postal code"
 msgstr "邮政编码"
@@ -11266,31 +11266,31 @@ msgid "Postal Code"
 msgstr "邮政编码"
 
 msgid "Posted"
-msgstr "已发布"
+msgstr "已过账"
 
 msgid "Posted At"
-msgstr "发布于"
+msgstr "过账时间"
 
 msgid "Posted by"
-msgstr "发布者"
+msgstr "过账人"
 
 msgid "Posted By"
-msgstr "发布者"
+msgstr "过账人"
 
 msgid "Posted journals with these source types always sync. Daily summary groups a day's journals into one provider entry per account."
-msgstr "这些来源类型的已过账日记账始终进行同步。每日汇总将一天的日记账合并为每个账户的一条提供商记录。"
+msgstr "具有这些来源类型的已过账凭证始终同步。每日汇总将一天的凭证按账户分组为一个供应商条目。"
 
 msgid "Posted once, corrected {corrections} times."
-msgstr "发布一次，修正了 {corrections} 次。"
+msgstr "过账一次，已更正{corrections}次。"
 
 msgid "Posted once, corrected 1 time."
-msgstr "发布一次，修正了 1 次。"
+msgstr "过账一次，已更正1次。"
 
 msgid "Posted once, no corrections."
-msgstr "发布一次，无修正。"
+msgstr "过账一次，无更正。"
 
 msgid "Posting"
-msgstr "预付款"
+msgstr "过账"
 
 msgid "Posting date"
 msgstr "过账日期"
@@ -11302,7 +11302,7 @@ msgid "Potential Data Loss"
 msgstr "潜在数据丢失"
 
 msgid "Pre-filled for a new item when expiry is Fixed Duration."
-msgstr "当过期时间设置为固定期限时，为新项目预填充。"
+msgstr "当有效期为固定期间时，为新物料预填充。"
 
 msgid "Preferred Supplier"
 msgstr "首选供应商"
@@ -11314,7 +11314,7 @@ msgid "Prepayments"
 msgstr "预付款（默认）"
 
 msgid "Prepayments (default)"
-msgstr "预防措施"
+msgstr "预付款（默认）"
 
 msgid "Present Week"
 msgstr "本周"
@@ -11323,10 +11323,10 @@ msgid "Prev"
 msgstr "上一页"
 
 msgid "Preventive action"
-msgstr "现有库存估值的主要账户"
+msgstr "预防性行动"
 
 msgid "Preventive maintenance schedules for your equipment"
-msgstr "您设备的预防性维护计划"
+msgstr "您的设备预防性维护排程"
 
 msgid "Preview"
 msgstr "预览"
@@ -11347,7 +11347,7 @@ msgid "Previous page"
 msgstr "上一页"
 
 msgid "Previous step"
-msgstr "上一步"
+msgstr "上一步骤"
 
 #. placeholder {0}: humanizeField(watchedField)
 msgid "Previous value of {0}"
@@ -11357,7 +11357,7 @@ msgid "Price break actions"
 msgstr "价格阶梯操作"
 
 msgid "Price Break History"
-msgstr "价格阶梯历史"
+msgstr "价格阶梯历史记录"
 
 msgid "Price Breaks"
 msgstr "价格阶梯"
@@ -11393,7 +11393,7 @@ msgid "Pricing Trace"
 msgstr "定价追踪"
 
 msgid "Primary cash account for bank transactions"
-msgstr "程序"
+msgstr "银行交易的主要现金账户"
 
 msgid "Print"
 msgstr "打印"
@@ -11403,7 +11403,7 @@ msgid "Print {0} Labels"
 msgstr "打印 {0} 个标签"
 
 msgid "Print Jobs"
-msgstr "打印任务"
+msgstr "打印工单"
 
 msgid "Print Label"
 msgstr "打印标签"
@@ -11437,16 +11437,16 @@ msgid "Private"
 msgstr "私密"
 
 msgid "procedure"
-msgstr "程序"
+msgstr "程序文件"
 
 msgid "Procedure"
-msgstr "程序"
+msgstr "程序文件"
 
 msgid "procedures"
-msgstr "流程"
+msgstr "程序文件"
 
 msgid "Procedures"
-msgstr "程序"
+msgstr "程序文件"
 
 msgid "process"
 msgstr "流程"
@@ -11506,7 +11506,7 @@ msgid "Production Quantity"
 msgstr "生产数量"
 
 msgid "Production variance"
-msgstr "从物料清单和预测中分解的预计需求。"
+msgstr "生产差异"
 
 msgid "Production: shop-floor app and scheduling"
 msgstr "生产：车间应用和排程"
@@ -11521,7 +11521,7 @@ msgid "Project"
 msgstr "项目"
 
 msgid "Project owner"
-msgstr "项目所有者"
+msgstr "项目负责人"
 
 msgid "Project Plan"
 msgstr "项目计划"
@@ -11530,10 +11530,10 @@ msgid "Project start"
 msgstr "项目开始"
 
 msgid "Projected demand exploded from BOMs and forecasts."
-msgstr "预测库存"
+msgstr "由 BOM 和预测分解出来的需求。"
 
 msgid "Projected inventory"
-msgstr "预测现有量"
+msgstr "预计库存"
 
 msgid "Projected on hand"
 msgstr "{0}周的预计缺货"
@@ -11543,14 +11543,14 @@ msgstr "预计库存"
 
 #. placeholder {0}: formatWeek(stockoutDate)
 msgid "Projected stockout the week of {0}"
-msgstr "预计{0}周低于安全库存"
+msgstr "第 {0} 周预计缺货"
 
 #. placeholder {0}: formatWeek(belowSafetyDate)
 msgid "Projected to drop below safety stock the week of {0}"
 msgstr "预计保持在安全库存以上"
 
 msgid "Projected to stay above safety stock"
-msgstr "采购订单"
+msgstr "预计将保持在安全库存以上"
 
 msgid "Projection"
 msgstr "预测"
@@ -11608,10 +11608,10 @@ msgid "Published"
 msgstr "已发布"
 
 msgid "Published by Carbon"
-msgstr "由 Carbon 发布"
+msgstr "由Carbon发布"
 
 msgid "Published Version"
-msgstr ""
+msgstr "已发布版本"
 
 msgid "Published versions can't be edited. Look around read-only, or branch a new version to make changes."
 msgstr "已发布的版本无法编辑。以只读方式浏览，或创建新版本以进行更改。"
@@ -11626,7 +11626,7 @@ msgid "Pull from accounting"
 msgstr "从会计系统拉取"
 
 msgid "Pull from Inventory"
-msgstr "从库存中提取"
+msgstr "从库存领用"
 
 msgid "Pull, map, and load your data"
 msgstr "拉取、映射和加载您的数据"
@@ -11635,7 +11635,7 @@ msgid "Purchase & manufacture from MRP"
 msgstr "从 MRP 采购和制造"
 
 msgid "Purchase History"
-msgstr "采购历史"
+msgstr "采购历史记录"
 
 msgid "Purchase invoice"
 msgstr "采购发票"
@@ -11653,7 +11653,7 @@ msgid "Purchase Invoices"
 msgstr "采购发票"
 
 msgid "Purchase order"
-msgstr "采购价格差异"
+msgstr "采购订单"
 
 msgid "Purchase Order"
 msgstr "采购订单"
@@ -11677,7 +11677,7 @@ msgid "Purchase order removed successfully"
 msgstr "采购订单已成功删除"
 
 msgid "Purchase Order Type"
-msgstr "采购单类型"
+msgstr "采购订单类型"
 
 msgid "Purchase Orders"
 msgstr "采购订单"
@@ -11698,7 +11698,7 @@ msgid "Purchase Price Variance"
 msgstr "采购价格差异（默认）"
 
 msgid "Purchase Price Variance (default)"
-msgstr "应付采购税"
+msgstr "采购价格差异（默认）"
 
 msgid "Purchase Qty"
 msgstr "采购数量"
@@ -11707,7 +11707,7 @@ msgid "Purchase Tax Payable"
 msgstr "应付采购税（默认）"
 
 msgid "Purchase Tax Payable (default)"
-msgstr "采购"
+msgstr "应交税金（默认）"
 
 msgid "Purchase to Order"
 msgstr "按订单采购"
@@ -11731,7 +11731,7 @@ msgid "Purchasing"
 msgstr "采购"
 
 msgid "Purchasing & Inventory"
-msgstr "采购和库存"
+msgstr "采购和库存管理"
 
 msgid "Purchasing and auto-planning"
 msgstr "采购和自动规划"
@@ -11752,13 +11752,13 @@ msgid "Push"
 msgstr "推送"
 
 msgid "Push it re-dated to the first open day, keeping the original date in the narration."
-msgstr "将其推送至第一个可用日期，在备注中保留原始日期"
+msgstr "将其重新日期设置为第一个开放日，在叙述中保留原始日期。"
 
 msgid "Push record changes to external systems the moment they happen."
 msgstr "将记录更改实时推送到外部系统。"
 
 msgid "Push the journal without the dimension"
-msgstr "推送不包含维度的日记账"
+msgstr "发布不包含维度的凭证"
 
 msgid "Push to accounting"
 msgstr "推送到会计系统"
@@ -11795,7 +11795,7 @@ msgid "Qty. Scrapped"
 msgstr "数量. 报废"
 
 msgid "quality"
-msgstr "报价到现金"
+msgstr "质量"
 
 msgid "Quality"
 msgstr "质量"
@@ -11804,13 +11804,13 @@ msgid "Quality Document approval rule"
 msgstr "质量文件审批规则"
 
 msgid "Quality Documents"
-msgstr "质量文件"
+msgstr "质量文档"
 
 msgid "Quality Type"
 msgstr "质量类型"
 
 msgid "Quality: inspections, nonconformance, CAPA"
-msgstr "质量：检验、不符合项、纠正和预防措施"
+msgstr "质量：检验、不合格、CAPA"
 
 msgid "Quantities"
 msgstr "数量"
@@ -11822,7 +11822,7 @@ msgid "Quantity arriving — on open purchase orders plus on production (make) o
 msgstr "即将到货的数量——来自未结采购订单以及生产（制造）订单。"
 
 msgid "Quantity Breaks"
-msgstr "数量档次"
+msgstr "数量阶梯"
 
 msgid "Quantity complete"
 msgstr "数量完成"
@@ -11840,13 +11840,13 @@ msgid "Quantity must be greater than 0"
 msgstr "数量必须大于0"
 
 msgid "Quantity on hand"
-msgstr "库存数量"
+msgstr "现有量"
 
 msgid "Quantity on Hand"
-msgstr "现有数量"
+msgstr "现有量"
 
 msgid "Quantity on Jobs"
-msgstr "工作订单数量"
+msgstr "工单数量"
 
 msgid "Quantity on Purchase Order"
 msgstr "采购订单数量"
@@ -11858,16 +11858,16 @@ msgid "Quantity Per Job"
 msgstr "每个工作的数量"
 
 msgid "Quantity per Parent"
-msgstr "每个父项的数量"
+msgstr "单位用量"
 
 msgid "Quantity physically on the material's assigned storage unit (shelf). Turns red when it's below what that unit needs to supply."
-msgstr "物料所分配的存储单元（货架）上实际存在的数量。当低于该单元需要供应的数量时变为红色。"
+msgstr "原材料在其分配的货架上的实际数量。当低于该存储单元需要供应的数量时显示为红色。"
 
 msgid "Quantity Range"
 msgstr "数量范围"
 
 msgid "Quantity received to inventory"
-msgstr "入库数量"
+msgstr "收到库存的数量"
 
 msgid "Quantity reworked"
 msgstr "返工数量"
@@ -11889,13 +11889,13 @@ msgid "Quantity: {0}"
 msgstr "数量：{0}"
 
 msgid "Quarterly"
-msgstr "季度"
+msgstr "每季度"
 
 msgid "Question"
 msgstr "问题"
 
 msgid "Queued"
-msgstr "已排队"
+msgstr "排队中"
 
 msgid "Quote"
 msgstr "报价"
@@ -11904,7 +11904,7 @@ msgid "Quote Accepted By"
 msgstr "报价已接受者"
 
 msgid "Quote Accepted By Email"
-msgstr "报价接受者邮箱"
+msgstr "通过电子邮件已接受的报价单"
 
 msgid "Quote expired"
 msgstr "报价已过期"
@@ -11928,7 +11928,7 @@ msgid "Quote Markups"
 msgstr "报价加价"
 
 msgid "Quote Materials"
-msgstr "报价物料"
+msgstr "报价单原材料"
 
 msgid "Quote not found"
 msgstr "报价未找到"
@@ -11937,7 +11937,7 @@ msgid "Quote Number"
 msgstr "报价单号"
 
 msgid "Quote to cash"
-msgstr "应收账款"
+msgstr "从报价单到现金"
 
 msgid "Quote Type"
 msgstr "报价类型"
@@ -11985,7 +11985,7 @@ msgid "Reactivate"
 msgstr "重新激活"
 
 msgid "Read this through — what Carbon will and won't do for your setup. When it looks right, mark it agreed below."
-msgstr "通读以下内容——Carbon 将为您的设置做什么和不会做什么。当看起来合适时，在下方标记为已同意。"
+msgstr "仔细阅读此内容——Carbon将为您的设置做什么和不做什么。当看起来正确时，在下面标记同意。"
 
 msgid "Read this through. When it's right, sign off at the bottom. It's the statement your commercial agreement points to, with no prices or legal terms here."
 msgstr "通读此内容。确认无误后，在底部签署。这是您商业协议所指向的声明，不包含价格或法律条款。"
@@ -11997,22 +11997,22 @@ msgid "Readable ID"
 msgstr "可读ID"
 
 msgid "Readable id with revision"
-msgstr "可读 ID（含版本）"
+msgstr "可读ID与修订版"
 
 msgid "Reading the document..."
-msgstr "正在读取文档..."
+msgstr "正在读取文件..."
 
 msgid "Ready"
 msgstr "就绪"
 
 msgid "Ready for Quote"
-msgstr "准备报价"
+msgstr "可报价"
 
 msgid "ready to keep or revert"
-msgstr "准备好保留或还原"
+msgstr "就绪保存或恢复"
 
 msgid "Real-time inventory and shop-floor visibility"
-msgstr "实时库存和车间可见性"
+msgstr "实时库存管理和车间可见性"
 
 msgid "Real-time questions during hypercare"
 msgstr "超护期间的实时问题"
@@ -12069,45 +12069,45 @@ msgid "Receipt Promised Date"
 msgstr "收货承诺日期"
 
 msgid "Receipt Requested Date"
-msgstr "收货请求日期"
+msgstr "收货要求日期"
 
 msgid "Receipts"
 msgstr "收据"
 
 msgid "Receipts, shipments, sales invoices, purchase invoices, payments, and credit/debit memos that are still Draft or Pending must be posted or voided — both documents dated in this period and undated documents that would receive a date in it when posted. Until they post, their amounts aren't in the general ledger, so the period would be understated."
-msgstr "仍为草稿或待处理状态的收据、装运、销售发票、采购发票、付款和贷方/借方备忘录必须进行过账或作废 — 包括本期日期的单据和过账时将在本期确定日期的无日期单据。在它们过账前，其金额不在总账中，因此期间会被低估。"
+msgstr "还处于草稿或待处理状态的收货、发货、销售发票、采购发票、付款以及借方/贷方备忘录必须过账或作废——包括本期日期的文件和未日期但过账时会获得本期日期的文件。在它们过账之前，它们的金额不在总账中，因此本期将被低估。"
 
 msgid "Receivables"
-msgstr "应收账款（默认）"
+msgstr "应收款项"
 
 msgid "Receivables (AR)"
-msgstr "应收账款 (AR)"
+msgstr "应收款项（应收账款）"
 
 msgid "Receivables (default)"
-msgstr "将采购订单与所收货物和发票进行对账——在Carbon中隐含进行，通过行数量和GR/IR余额。"
+msgstr "应收款项（默认）"
 
 msgid "Receivables aging"
-msgstr "应收账款账龄"
+msgstr "应收款项账龄"
 
 msgid "Receive"
 msgstr "接收"
 
 #. placeholder {0}: job.jobId
 msgid "Receive {0} to Inventory"
-msgstr "将 {0} 接收到库存"
+msgstr "将{0}收货至库存管理"
 
 msgid "Receive against a PO and update inventory"
-msgstr "根据采购订单收货并更新库存"
+msgstr "根据采购订单收货并更新库存管理"
 
 msgid "Receive Payment"
-msgstr "收款"
+msgstr "收取付款"
 
 #. placeholder {0}: selectedInvoices.length
 msgid "Receive Payment · {0} invoices"
-msgstr "收款 · {0} 张发票"
+msgstr "收取付款 · {0}份发票"
 
 msgid "Receive to Inventory"
-msgstr "接收到库存"
+msgstr "收货至库存管理"
 
 msgid "Received"
 msgstr "已接收"
@@ -12145,13 +12145,13 @@ msgid "Reconciliation found discrepancies with the provider"
 msgstr "对账发现与提供商的差异"
 
 msgid "Reconciling a purchase order against what was received and invoiced — implicit in Carbon, via the line quantities and GR/IR balance."
-msgstr "回收期"
+msgstr "将采购订单与已收货和已开票的内容进行对账——在Carbon中隐含进行，通过行数量和GR/IR余额。"
 
 msgid "Record"
 msgstr "录音"
 
 msgid "Record a credit or debit memo against a customer or supplier. Applications to specific invoices are added after the memo is created."
-msgstr "记录针对客户或供应商的贷项或借项备忘录。针对特定发票的应用在备忘录创建后添加。"
+msgstr "针对客户或供应商记录贷方或借方备忘录。对特定发票的应用在创建备忘录后添加。"
 
 msgid "Record cash received from a customer (Receipt) or paid to a supplier (Disbursement). Applications to specific invoices are added after the payment is created."
 msgstr "记录从客户收到的现金（收据）或支付给供应商的现金（支付）。对特定发票的应用在创建付款后添加。"
@@ -12169,10 +12169,10 @@ msgid "Recorded on a calibration that the gauge needs repair before its readings
 msgstr "在校准记录中标记该量具需要修理才能使其读数可信。"
 
 msgid "Recorded that follow-up is needed after this calibration; surfaces this gauge on the open-actions queue."
-msgstr "记录在此校准后需要跟进；将此测量仪显示在打开的操作队列中。"
+msgstr "记录此校准后需要后续行动；将此量具呈现在待处理操作队列中。"
 
 msgid "Recorded that the gauge was adjusted during this calibration; affects how the calibration interval recalculates."
-msgstr "记录在此校准期间调整了测量仪；影响校准间隔如何重新计算。"
+msgstr "记录在此校准期间调整了量具；影响校准周期的重新计算方式。"
 
 msgid "Records"
 msgstr "记录"
@@ -12184,7 +12184,7 @@ msgid "Redirecting to verification page..."
 msgstr "正在重定向到验证页面..."
 
 msgid "Reduced"
-msgstr "减少"
+msgstr "放宽检验"
 
 msgid "Reference"
 msgstr "参考"
@@ -12208,7 +12208,7 @@ msgid "Register Existing Asset"
 msgstr "已注册"
 
 msgid "Registered"
-msgstr "重新订购点"
+msgstr "已登记"
 
 msgid "Registration failed"
 msgstr "注册失败"
@@ -12229,7 +12229,7 @@ msgid "Rejected"
 msgstr "已拒绝"
 
 msgid "Rejected By"
-msgstr "被拒绝者"
+msgstr "拒绝人"
 
 msgid "Rejected Date"
 msgstr "拒绝日期"
@@ -12238,43 +12238,43 @@ msgid "Relabels the hub and frames the deal."
 msgstr "重新标记中心并框架化交易。"
 
 msgid "Relative timeline · dates set in Setup & Controls"
-msgstr "相对时间线 · 日期在设置和控制中设置"
+msgstr "相对时间表·在设置和控制中设置的日期"
 
 msgid "Relative timeline · dates to be confirmed"
-msgstr "相对时间线 · 日期待确认"
+msgstr "相对时间表·待确认的日期"
 
 msgid "Release"
-msgstr "释放"
+msgstr "下达"
 
 msgid "Release change notice"
-msgstr "发布更改单"
+msgstr "下达变更通知"
 
 msgid "Release control"
-msgstr "发布控制"
+msgstr "下达控制"
 
 msgid "Release Control"
-msgstr "发布控制"
+msgstr "下达控制"
 
 msgid "Release Job"
-msgstr "发布工作"
+msgstr "下达工单"
 
 msgid "Released"
-msgstr "已发布"
+msgstr "已下达"
 
 msgid "Released date"
-msgstr "发布日期"
+msgstr "下达日期"
 
 msgid "Released revision"
-msgstr "已发布的版本"
+msgstr "已下达修订版"
 
 msgid "Released revision is locked"
-msgstr "已发布的版本已锁定"
+msgstr "已下达修订版已锁定"
 
 msgid "Remaining"
 msgstr "剩余"
 
 msgid "Remaining after split stays on the original row."
-msgstr "分割后的剩余部分保留在原始行上。"
+msgstr "拆分后的剩余部分保留在原始行上。"
 
 msgid "Remember this PIN. You will need it to exit console mode on MES terminals."
 msgstr "记住此PIN。您需要它来退出MES终端上的控制台模式。"
@@ -12284,7 +12284,7 @@ msgstr "移除"
 
 #. placeholder {0}: item.label
 msgid "Remove {0}"
-msgstr "删除 {0}"
+msgstr "移除{0}"
 
 msgid "Remove {label}"
 msgstr "移除 {label}"
@@ -12308,10 +12308,10 @@ msgid "Remove from Price List"
 msgstr "从价格列表中移除"
 
 msgid "Remove line"
-msgstr "删除行"
+msgstr "移除行"
 
 msgid "Remove order"
-msgstr "删除订单"
+msgstr "移除订单"
 
 msgid "Remove pair"
 msgstr "移除配对"
@@ -12323,7 +12323,7 @@ msgid "Remove path"
 msgstr "移除路径"
 
 msgid "Remove row"
-msgstr "删除行"
+msgstr "移除行"
 
 msgid "Remove slide"
 msgstr "移除幻灯片"
@@ -12332,7 +12332,7 @@ msgid "Remove slot"
 msgstr "移除插槽"
 
 msgid "Remove sort by column"
-msgstr "删除按列排序"
+msgstr "移除按列排序"
 
 msgid "Remove this storage type from all referencing storage units and delete it. This cannot be undone."
 msgstr "从所有引用此存储类型的存储单元中移除它并将其删除。此操作无法撤销。"
@@ -12341,7 +12341,7 @@ msgid "Remove tool"
 msgstr "移除工具"
 
 msgid "Remove two-factor authentication"
-msgstr "移除双因素身份验证"
+msgstr "移除双因素认证"
 
 msgid "Removed"
 msgstr "已移除"
@@ -12366,13 +12366,13 @@ msgid "Reorder Group"
 msgstr "重新排序组"
 
 msgid "Reorder point"
-msgstr "重新订购点"
+msgstr "再订货点"
 
 msgid "Reorder Point"
-msgstr "重新订购点"
+msgstr "再订货点"
 
 msgid "Reorder Point:"
-msgstr "重新订购点："
+msgstr "再订货点："
 
 msgid "Reorder Policy"
 msgstr "重新订购政策"
@@ -12390,13 +12390,13 @@ msgid "Reorder Quantity:"
 msgstr "重新订购数量："
 
 msgid "Reordering policy"
-msgstr "重新订购政策"
+msgstr "补货策略"
 
 msgid "Reordering Policy"
-msgstr "重新订购政策"
+msgstr "补货策略"
 
 msgid "Reorders dispatch sequence and work center only — does not reschedule. Change dates on the Dates board."
-msgstr "仅重新排列调度顺序和工作中心 — 不重新排程。在日期面板上更改日期。"
+msgstr "仅重新排序维护工单序列和工作中心——不重新安排日程。在日期板上更改日期。"
 
 msgid "Repeats once for each item in {inputLabel}"
 msgstr "为 {inputLabel} 中的每个项目重复一次"
@@ -12414,16 +12414,16 @@ msgid "Replace this company's data with a demo dataset — snapshotted first, so
 msgstr "用演示数据集替换此公司的数据——首先快照，以便您可以还原。"
 
 msgid "Replacing the PDF removes all balloon placements on this document. Feature rows and their values stay; you can place balloons again on the new drawing."
-msgstr "替换 PDF 将删除此文档上的所有气球标注。功能行及其值保持不变；您可以在新绘图上重新放置气球。"
+msgstr "替换 PDF 会移除此文件上的所有气球位置。功能行及其值保持不变；你可以在新绘图上重新放置气球。"
 
 msgid "Replenishment"
 msgstr "补货"
 
 msgid "Replenishment system"
-msgstr "补充系统"
+msgstr "补货方式"
 
 msgid "Replenishment System"
-msgstr "补充系统"
+msgstr "补货方式"
 
 msgid "Report"
 msgstr "报告"
@@ -12447,25 +12447,25 @@ msgid "Request access"
 msgstr "请求访问"
 
 msgid "Request Approval"
-msgstr "请求批准"
+msgstr "请求审批"
 
 msgid "Requested Date"
-msgstr "请求日期"
+msgstr "要求日期"
 
 msgid "Require a 6-digit code from an authenticator app when signing in."
 msgstr "登录时需要来自身份验证器应用的 6 位数字代码。"
 
 msgid "Require an authenticator app before anyone can open this company. Their other companies are unaffected. Visit the <0>employee accounts page</0> to see each person's status."
-msgstr "在任何人打开此公司之前需要身份验证器应用。他们的其他公司不受影响。访问<0>员工账户页面</0>以查看每个人的状态。"
+msgstr "需要身份验证应用程序才能打开此公司。他们的其他公司不受影响。访问<0>员工账户页面</0>以查看每个人的状态。"
 
 msgid "Require approval before suppliers can be set to Active"
-msgstr "在供应商可以设置为活跃之前需要批准"
+msgstr "供应商设置为启用前需要审批"
 
 msgid "Require approval for purchase orders based on amount thresholds"
-msgstr "根据金额阈值要求采购订单获得批准"
+msgstr "根据金额阈值对采购订单需要审批"
 
 msgid "Require approval for quality documents in your workflow"
-msgstr "在您的工作流程中需要质量文件的批准"
+msgstr "工作流中的质量文档需要审批"
 
 msgid "Require two-factor authentication"
 msgstr "需要双因素认证"
@@ -12486,22 +12486,22 @@ msgid "Required Actions (in order)"
 msgstr "必需的操作（按顺序）"
 
 msgid "Required Date"
-msgstr "所需日期"
+msgstr "需求日期"
 
 msgid "Required in a controlled environment — audit logging cannot be turned off."
 msgstr "在受控环境中需要 — 审计日志无法关闭。"
 
 msgid "Requirement"
-msgstr "需求"
+msgstr "要求"
 
 msgid "Requirements"
-msgstr "需求"
+msgstr "要求"
 
 msgid "Requirements & Process Map"
-msgstr "需求与流程图"
+msgstr "要求与工艺路线图"
 
 msgid "Requirements and Process Map"
-msgstr "需求和流程图"
+msgstr "要求和工艺路线图"
 
 msgid "Requires Action"
 msgstr "需要采取行动"
@@ -12541,10 +12541,10 @@ msgid "Reset view"
 msgstr "重置视图"
 
 msgid "Residual value"
-msgstr "残差值"
+msgstr "残值"
 
 msgid "Residual Value %"
-msgstr "残差值 %"
+msgstr "残值 %"
 
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "在完成NCR之前解决这些问题：每一行必须有一个非待处理的处置，其关联实体数量必须与行数量匹配。"
@@ -12562,7 +12562,7 @@ msgid "Restore from Trash"
 msgstr "从垃圾箱恢复"
 
 msgid "Restore this entity to available stock at the bin and cost it was scrapped from."
-msgstr "将此实体恢复到报废时所在的仓位和成本的可用库存。"
+msgstr "将此实体恢复到来自其被报废的料箱和成本的可用库存。"
 
 msgid "Restore tracked entities to available"
 msgstr "将跟踪的实体恢复为可用"
@@ -12583,10 +12583,10 @@ msgid "Resume Receiving"
 msgstr "恢复接收"
 
 msgid "Retained Earnings"
-msgstr "留存收益"
+msgstr "未分配利润"
 
 msgid "Retained Earnings (default)"
-msgstr "留存收益 (默认)"
+msgstr "未分配利润（默认）"
 
 msgid "Retiring an asset from service by scrapping or sale, booking any gain or loss against net book value and setting its status to Disposed."
 msgstr "通过报废或出售将资产退出使用，将收益或损失计入账面净值，并将其状态设为已处置。"
@@ -12607,13 +12607,13 @@ msgid "Returned"
 msgstr "已返回"
 
 msgid "Returning unused picked material"
-msgstr "返回未使用的拣配物料"
+msgstr "返回未使用的已拣货原材料"
 
 msgid "Returns:"
 msgstr "返回："
 
 msgid "Rev {revision}"
-msgstr "Rev {revision}"
+msgstr "修订版 {revision}"
 
 msgid "Revenue"
 msgstr "收入"
@@ -12625,13 +12625,13 @@ msgid "Reverse all inventory adjustments"
 msgstr "反转所有库存调整"
 
 msgid "Reverse all journal and cost ledger entries"
-msgstr "反转所有日记账和成本分类账条目"
+msgstr "反转所有凭证和成本账册条目"
 
 msgid "Reverse any item ledger entries from this invoice"
 msgstr "反转此发票中的任何项目分类账条目"
 
 msgid "Reverse charge"
-msgstr ""
+msgstr "反向收费"
 
 msgid "Reverse Charge Sales Tax"
 msgstr "反向收费销售税"
@@ -12640,7 +12640,7 @@ msgid "Reverse Charge Sales Tax (default)"
 msgstr "反向收费销售税 (默认)"
 
 msgid "Reverse the related journal entries"
-msgstr "反转相关日记账分录"
+msgstr "反转相关凭证条目"
 
 msgid "Reversed"
 msgstr "已冲销"
@@ -12652,19 +12652,19 @@ msgid "Reverting"
 msgstr "正在还原"
 
 msgid "Review"
-msgstr "查看"
+msgstr "评审"
 
 msgid "Review each item's changes, then confirm — releasing can't be undone."
-msgstr "审查每个项目的更改，然后确认 — 发布无法撤销。"
+msgstr "评审每个物料的更改，然后确认——发布无法撤销。"
 
 msgid "Review the period's balance sheet and income statement and confirm the figures look right. This is a manual sign-off — mark it done once you have reviewed them."
-msgstr "审查期间的资产负债表和损益表，并确认数字正确。这是手动签核 — 审查后标记为完成。"
+msgstr "评审期间的资产负债表和利润表，并确认数字正确。这是手动签核——一旦您评审完毕即标记为完成。"
 
 msgid "Review the suggested matches before applying. These are a best guess — confirm each is correct."
-msgstr "在应用之前审查建议的匹配项。这些是最佳猜测 — 确认每个都是正确的。"
+msgstr "应用前评审建议的匹配。这些是最佳猜测——确认每个匹配正确。"
 
 msgid "Review the warnings below, then post the count to apply the adjustments."
-msgstr "查看下面的警告，然后过账盘点以应用调整。"
+msgstr "评审下方的警告，然后过账计数以应用调整。"
 
 msgid "Revision"
 msgstr "修订版"
@@ -12674,10 +12674,10 @@ msgid "Revision {0}"
 msgstr "修订版本 {0}"
 
 msgid "Revision status"
-msgstr "版本状态"
+msgstr "修订版状态"
 
 msgid "Revisions"
-msgstr "版本"
+msgstr "修订版"
 
 msgid "Revoke"
 msgstr "撤销"
@@ -12719,7 +12719,7 @@ msgid "RFQs"
 msgstr "询价单"
 
 msgid "Ride Carbon dimensions along on pushed journals. Each slot maps one Carbon dimension to one provider analytics target; the value mapping below pairs individual dimension values with provider options."
-msgstr "在推送的日记账上附加 Carbon 维度。每个插槽将一个 Carbon 维度映射到一个提供商分析目标；下面的值映射将单个维度值与提供商选项配对。"
+msgstr "在推送的凭证上传递Carbon维度。每个槽位将一个Carbon维度映射到一个供应商分析目标；下方的值映射将各个维度值与供应商选项配对。"
 
 #. placeholder {0}: certification.docVersion
 msgid "Rider v{0}"
@@ -12810,7 +12810,7 @@ msgid "Run failed"
 msgstr "运行失败"
 
 msgid "Run hands-on sessions and sign off your team"
-msgstr "进行实践培训课程并获得团队的批准"
+msgstr "运行实操课程并签核您的班组"
 
 msgid "Run hands-on sessions with your champions"
 msgstr "与您的冠军用户进行实践培训课程"
@@ -12831,10 +12831,10 @@ msgid "Run Test"
 msgstr "运行测试"
 
 msgid "Run the acceptance checklist to a pass"
-msgstr "运行验收清单直到通过"
+msgstr "运行验收清单至合格"
 
 msgid "Run the floor on tablets: clock labor, report progress, see instructions"
-msgstr "在平板电脑上运行车间：记录劳动力、报告进度、查看说明"
+msgstr "在平板电脑上运行车间：计时人工、报告进度、查看说明"
 
 msgid "Run this workflow now?"
 msgstr "立即运行此工作流？"
@@ -12843,7 +12843,7 @@ msgid "Running"
 msgstr "运行中"
 
 msgid "Running inventory after each week's supply and demand — the line."
-msgstr "每周供应和需求后运行的库存 — 该行。"
+msgstr "每周供应和需求后运行库存管理——这一行"
 
 msgid "Running Total"
 msgstr "运行总计"
@@ -12991,7 +12991,7 @@ msgid "Sampling — Feature {featureLabel}"
 msgstr "抽样 — 功能 {featureLabel}"
 
 msgid "Sampling Standard"
-msgstr "抽样标准"
+msgstr "抽样正常检验"
 
 msgid "Saturday"
 msgstr "星期六"
@@ -13027,7 +13027,7 @@ msgid "Saved"
 msgstr "已保存"
 
 msgid "Saved Views"
-msgstr "已保存视图"
+msgstr "已保存的视图"
 
 msgid "Saving a copy of your current data"
 msgstr "正在保存您当前数据的副本"
@@ -13039,34 +13039,34 @@ msgid "Saving…"
 msgstr "保存中…"
 
 msgid "Scan"
-msgstr "扫描"
+msgstr "扫码"
 
 msgid "Scan a label or search by item ID or tracking ID."
-msgstr "扫描标签或按项目 ID 或跟踪 ID 搜索。"
+msgstr "扫码或按物料ID或追踪ID搜索。"
 
 msgid "Scan or choose a batch number"
-msgstr "扫描或选择批号"
+msgstr "扫码或选择一个生产批次号"
 
 msgid "Scan or choose a serial number"
-msgstr "扫描或选择序列号"
+msgstr "扫码或选择一个序列号"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "扫描或输入跟踪实体ID、序列号或批次号"
+msgstr "扫码或输入追踪实体ID、序列号或生产批次"
 
 msgid "Scan or enter tracking number"
-msgstr "扫描或输入追踪号"
+msgstr "扫码或输入追踪号"
 
 msgid "Scan or search..."
-msgstr "扫描或搜索..."
+msgstr "扫码或搜索..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "从此批次扫描或选择被追踪的实体以将其作为样本列添加，然后在网格中记录其结果。"
+msgstr "扫码或从此批次中选择一个追踪实体，将其添加为采样列，然后在网格中记录其结果。"
 
 msgid "Scan this QR code with your authenticator app (e.g. Google Authenticator or 1Password), then enter the 6-digit code it shows."
-msgstr "使用您的身份验证器应用(例如 Google Authenticator 或 1Password)扫描此 QR 码,然后输入它显示的 6 位数字代码。"
+msgstr "用你的身份验证应用程序（如 Google Authenticator 或 1Password）扫描此 QR 代码，然后输入它显示的 6 位数代码。"
 
 msgid "Scan this with your authenticator app, then enter the 6-digit code it shows."
-msgstr "使用您的身份验证器应用扫描此内容，然后输入它显示的6位数代码。"
+msgstr "用你的身份验证应用程序扫描此代码，然后输入它显示的 6 位数代码。"
 
 msgid "SCAR"
 msgstr "SCAR"
@@ -13075,13 +13075,13 @@ msgid "SCAR (supplier corrective action request)"
 msgstr "SCAR（供应商纠正措施申请）"
 
 msgid "Schedule"
-msgstr "日程"
+msgstr "排程"
 
 msgid "Schedule jobs against work-center capacity"
-msgstr "根据工作中心产能安排工作"
+msgstr "根据工作中心产能排程工单"
 
 msgid "Schedule Name"
-msgstr "计划名称"
+msgstr "排程名称"
 
 msgid "Scheduled Maintenance"
 msgstr "定期维护"
@@ -13090,7 +13090,7 @@ msgid "Scheduled Maintenances"
 msgstr "定时维护"
 
 msgid "Schedules"
-msgstr "日程"
+msgstr "排程"
 
 msgid "Scope"
 msgstr "范围"
@@ -13111,22 +13111,22 @@ msgid "Scrap"
 msgstr "报废"
 
 msgid "Scrap / Cost of Quality"
-msgstr "废品 / 质量成本"
+msgstr "报废/质量成本"
 
 msgid "Scrap Percent"
-msgstr "废料百分比"
+msgstr "报废率"
 
 msgid "Scrap percentage"
-msgstr "报废百分比"
+msgstr "报废率"
 
 msgid "Scrap Qty"
-msgstr "废料数量"
+msgstr "报废数量"
 
 msgid "Scrap quantity"
 msgstr "报废数量"
 
 msgid "Scrap Quantity"
-msgstr "废料数量"
+msgstr "报废数量"
 
 msgid "Scrap Quantity Per Job"
 msgstr "每个工作的报废数量"
@@ -13183,7 +13183,7 @@ msgid "Search for existing or create a new one"
 msgstr "搜索现有问题或创建新问题"
 
 msgid "Search items or bins"
-msgstr "搜索项目或位置"
+msgstr "搜索物料或料箱"
 
 msgid "Search Job"
 msgstr "搜索任务"
@@ -13192,10 +13192,10 @@ msgid "Search list variables…"
 msgstr "搜索列表变量…"
 
 msgid "Search operations…"
-msgstr "搜索操作…"
+msgstr "搜索工序…"
 
 msgid "Search operators..."
-msgstr "搜索运算符..."
+msgstr "搜索操作员..."
 
 msgid "Search parts..."
 msgstr "搜索零件..."
@@ -13207,7 +13207,7 @@ msgid "Search records…"
 msgstr "搜索记录…"
 
 msgid "Search related items..."
-msgstr "搜索相关项目..."
+msgstr "搜索相关物料..."
 
 msgid "Search suppliers..."
 msgstr "搜索供应商..."
@@ -13246,7 +13246,7 @@ msgid "Select"
 msgstr "选择"
 
 msgid "Select a assignee"
-msgstr "选择受理人"
+msgstr "选择经办人"
 
 msgid "Select a default approver"
 msgstr "选择默认审批人"
@@ -13258,7 +13258,7 @@ msgid "Select a document"
 msgstr "选择文件"
 
 msgid "Select a new owner"
-msgstr "选择新的所有者"
+msgstr "选择新的负责人"
 
 msgid "Select a new parent group for this account."
 msgstr "为此账户选择新的父分组。"
@@ -13295,7 +13295,7 @@ msgid "Select a substance first to see available options"
 msgstr "请先选择物质以查看可用选项"
 
 msgid "Select a team"
-msgstr "选择一个团队"
+msgstr "选择班组"
 
 msgid "Select account"
 msgstr "选择账户"
@@ -13307,7 +13307,7 @@ msgid "Select an action…"
 msgstr "选择一个操作…"
 
 msgid "Select an assignee"
-msgstr "选择受理人"
+msgstr "选择经办人"
 
 msgid "Select an event…"
 msgstr "选择一个事件…"
@@ -13376,10 +13376,10 @@ msgid "Select invoices in a single currency"
 msgstr "选择单一货币中的发票"
 
 msgid "Select Item Type"
-msgstr "选择项目类型"
+msgstr "选择物料类型"
 
 msgid "Select items"
-msgstr "选择项目"
+msgstr "选择物料"
 
 msgid "Select method..."
 msgstr "选择方法..."
@@ -13440,16 +13440,16 @@ msgstr "已选择的操作"
 
 #. placeholder {0}: target.maxQuantity - selectedSum
 msgid "Selected: {selectedSum} / remaining after split: {0}"
-msgstr "已选择: {selectedSum} / 分割后剩余: {0}"
+msgstr "已选择：{selectedSum} / 拆分后剩余：{0}"
 
 msgid "Self Managed"
 msgstr "自我管理"
 
 msgid "Self-hosted or managed"
-msgstr ""
+msgstr "自托管或托管"
 
 msgid "Self-onboarding"
-msgstr ""
+msgstr "自助入职"
 
 msgid "Self-paced"
 msgstr "自主学习"
@@ -13482,7 +13482,7 @@ msgid "Sending defective units back to an earlier operation to be corrected inst
 msgstr "将有缺陷的单位送回较早的操作进行更正，而不是报废。"
 
 msgid "Sends this document for approval before it can go active."
-msgstr "在文档激活前将其发送以供批准。"
+msgstr "在文件启用前发送进行审批。"
 
 msgid "Sent complete date"
 msgstr "发送完成日期"
@@ -13491,7 +13491,7 @@ msgid "Sent to each recipient who has email notifications turned on."
 msgstr "发送给打开了电子邮件通知的每个收件人。"
 
 msgid "Sequences"
-msgstr "序列"
+msgstr "编号规则"
 
 msgid "Serial"
 msgstr "序列号"
@@ -13500,7 +13500,7 @@ msgid "Serial / Batch"
 msgstr "序列号 / 批次"
 
 msgid "Serial items require a sales order"
-msgstr "序列项目需要销售订单"
+msgstr "序列号物料需要销售订单"
 
 msgid "Serial Number"
 msgstr "序列号"
@@ -13560,10 +13560,10 @@ msgid "Set a target"
 msgstr "设置目标"
 
 msgid "Set Carbon up around how your company runs: sites, parts, BOMs, Bill of Process, and the flows you use."
-msgstr "根据您公司的运营方式设置 Carbon：站点、零件、BOM、工艺流程和您使用的流程。"
+msgstr "根据公司运营方式设置 Carbon：地点、零件、BOM、工序清单和您使用的流程。"
 
 msgid "Set Clock Out"
-msgstr "设置打卡下班时间"
+msgstr "设置收工"
 
 msgid "Set clock-out time"
 msgstr "设置打卡下班时间"
@@ -13578,7 +13578,7 @@ msgid "Set demand projection values for each week"
 msgstr "为每周设置需求预测值"
 
 msgid "Set due date"
-msgstr "设置截止日期"
+msgstr "设置到期日"
 
 msgid "Set Pricing"
 msgstr "设置定价"
@@ -13593,10 +13593,10 @@ msgid "Set up the right way"
 msgstr "以正确的方式设置"
 
 msgid "Set up two-factor authentication"
-msgstr "设置双因素身份验证"
+msgstr "设置双因素认证"
 
 msgid "Set up your company with a step-by-step implementation plan covering setup, data, training, and go-live."
-msgstr "通过涵盖设置、数据、培训和上线的分步实施计划来设置您的公司。"
+msgstr "通过分步的实施计划设置公司，涵盖换型、数据、培训和上线。"
 
 msgid "Set up your own data with import tools and LLM help"
 msgstr "使用导入工具和LLM帮助设置您自己的数据"
@@ -13606,46 +13606,46 @@ msgstr "设置您的资源和设置"
 
 #. placeholder {0}: selectedVersion.version
 msgid "Set Version {0} as Active Version?"
-msgstr "将版本 {0} 设置为活跃版本？"
+msgstr "将版本 {0} 设置为启用版本？"
 
 msgid "Set your default location in profile settings to pick a storage unit."
-msgstr "在个人资料设置中设置默认位置以选择存储单位。"
+msgstr "在个人资料设置中设置默认地点以选择存储单元。"
 
 msgid "Settings"
 msgstr "设置"
 
 msgid "Setup"
-msgstr "设置"
+msgstr "换型"
 
 msgid "Setup & Controls"
-msgstr "设置和控制"
+msgstr "换型与控制"
 
 msgid "Setup failed"
-msgstr "设置失败"
+msgstr "换型失败"
 
 msgid "Setup instructions"
-msgstr "设置说明"
+msgstr "换型说明"
 
 msgid "Setup Map"
-msgstr "设置地图"
+msgstr "换型地图"
 
 msgid "Setup time"
-msgstr "设置时间"
+msgstr "换型时间"
 
 msgid "Setup Time"
-msgstr "设置时间"
+msgstr "换型时间"
 
 msgid "Setup unit"
-msgstr "设置单位"
+msgstr "换型单位"
 
 msgid "Setup Unit"
-msgstr "设置单位"
+msgstr "换型单位"
 
 msgid "Severities"
 msgstr "严重程度"
 
 msgid "Severity"
-msgstr "严重程度"
+msgstr "严重度"
 
 msgid "shape"
 msgstr "形状"
@@ -13693,7 +13693,7 @@ msgid "Shelf-Life"
 msgstr "保质期"
 
 msgid "Shelf-Life History"
-msgstr "保质期历史"
+msgstr "保质期历史记录"
 
 msgid "shift"
 msgstr "班次"
@@ -13723,7 +13723,7 @@ msgid "Ship-From Location"
 msgstr "发货地点"
 
 msgid "Shipment"
-msgstr "货运"
+msgstr "发货"
 
 msgid "Shipment Date"
 msgstr "发货日期"
@@ -13732,10 +13732,10 @@ msgid "Shipment ID"
 msgstr "发货单ID"
 
 msgid "Shipment Line"
-msgstr "发货单行"
+msgstr "发货行"
 
 msgid "Shipment Lines"
-msgstr "发货单行"
+msgstr "发货行"
 
 msgid "Shipment Location"
 msgstr "发货地点"
@@ -13762,19 +13762,19 @@ msgid "Shipping Location"
 msgstr "配送地点"
 
 msgid "shipping method"
-msgstr "运输方式"
+msgstr "发货方式"
 
 msgid "Shipping method"
-msgstr "运输方式"
+msgstr "发货方式"
 
 msgid "Shipping Method"
-msgstr "配送方式"
+msgstr "发货方式"
 
 msgid "shipping methods"
-msgstr "运输方式"
+msgstr "发货方式"
 
 msgid "Shipping Methods"
-msgstr "运输方式"
+msgstr "发货方式"
 
 msgid "Shipping Notes"
 msgstr "运输备注"
@@ -13828,10 +13828,10 @@ msgid "Show Durations"
 msgstr "显示时长"
 
 msgid "Show one inventory number the floor and office both trust"
-msgstr "显示一个车间和办公室都信任的库存数字"
+msgstr "显示一个楼层和办公室都信任的库存数字"
 
 msgid "Show parent items"
-msgstr "显示父项"
+msgstr "显示父物料"
 
 msgid "Show raw"
 msgstr "显示原始"
@@ -13859,7 +13859,7 @@ msgid "Showing the first 500 lines"
 msgstr "显示前500行"
 
 msgid "Showing the newest 200 journals"
-msgstr "显示最新的 200 条日记账"
+msgstr "显示最新的 200 个凭证"
 
 msgid "Showing the top 1,000 groups by amount"
 msgstr "按金额显示前1,000个分组"
@@ -13871,10 +13871,10 @@ msgid "Shown to the user when this rule fails."
 msgstr "当此规则失败时向用户显示。"
 
 msgid "Sign in to Carbon"
-msgstr ""
+msgstr "登录 Carbon"
 
 msgid "Sign in with biometrics instead of a magic link. Passkeys are secured by Face ID, Touch ID, or your device PIN."
-msgstr "使用生物识别而不是魔法链接登录。密钥由 Face ID、Touch ID 或您的设备 PIN 保护。"
+msgstr "使用生物识别而不是魔法链接登录。通行密钥由 Face ID、Touch ID 或您的设备 PIN 保护。"
 
 msgid "Sign in with Email"
 msgstr "用邮箱登录"
@@ -13886,7 +13886,7 @@ msgid "Sign in with Outlook"
 msgstr "使用 Outlook 登录"
 
 msgid "Sign in with Passkey"
-msgstr "使用密钥登录"
+msgstr "使用通行密钥登录"
 
 msgid "Sign out"
 msgstr "登出"
@@ -13898,10 +13898,10 @@ msgid "Sign out instead"
 msgstr "改为登出"
 
 msgid "Sign-off review before moving to the next step"
-msgstr "签署审查后再进行下一步"
+msgstr "在进入下一步骤前进行签署评审"
 
 msgid "Sign-offs that must be recorded before this issue can be closed; in addition to any required by the workflow."
-msgstr "在关闭此问题之前必须记录的签署；除了工作流程所需的之外。"
+msgstr "必须在此问题关闭前记录的签核；除工作流要求的外。"
 
 msgid "Signed in as {name}"
 msgstr "以 {name} 身份登录"
@@ -13943,7 +13943,7 @@ msgid "Skip scheduled maintenance on company holidays"
 msgstr "跳过公司假期的计划维护"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
-msgstr "跳过已发布但未启动的状态 - 扫描时工作立即开始。"
+msgstr "跳过已发布但未启动状态 — 扫码时工单立即启动。"
 
 msgid "Skipped"
 msgstr "已跳过"
@@ -13955,13 +13955,13 @@ msgid "Slice asset activity by location, item, or any dimension"
 msgstr "按位置、项目或任何维度细分资产活动"
 
 msgid "Slice expenses by location, cost center, or any dimension"
-msgstr "按位置、成本中心或任何维度细分支出"
+msgstr "按地点、成本中心或任何维度分割费用"
 
 msgid "Slice revenue by customer, customer type, or any dimension"
 msgstr "按客户、客户类型或任何维度划分收入"
 
 msgid "Smoke-test the core daily flows end to end"
-msgstr "端到端烟雾测试核心日常流程"
+msgstr "进行核心日常流程的端到端冒烟测试"
 
 msgid "so you can assign it here."
 msgstr "这样你可以在这里分配它。"
@@ -13970,7 +13970,7 @@ msgid "Solutions Engineer"
 msgstr "解决方案工程师"
 
 msgid "Some lines extracted from the PDF could not be automatically mapped to your inventory items. Review and map each line below."
-msgstr "从PDF提取的某些行无法自动映射到您的库存项目。请查看并映射下面的每一行。"
+msgstr "从 PDF 提取的某些行无法自动映射到你的库存物料。查看并映射下面的每一行。"
 
 msgid "Something went wrong. Please try again."
 msgstr "出现问题。请重试。"
@@ -13979,7 +13979,7 @@ msgid "Soon"
 msgstr "即将推出"
 
 msgid "Soonest expiry across every material sets the finished good."
-msgstr "最早的过期日期决定了成品的保质期。"
+msgstr "所有原材料中最早的有效期确定了成品。"
 
 msgid "Sort"
 msgstr "排序"
@@ -14003,16 +14003,16 @@ msgid "Source Company"
 msgstr "源公司"
 
 msgid "Source document"
-msgstr "源文档"
+msgstr "源单据"
 
 msgid "Source Document"
-msgstr "源文档"
+msgstr "源单据"
 
 msgid "Source Document ID"
 msgstr "源单据ID"
 
 msgid "Source document readable"
-msgstr "源文档可读"
+msgstr "源单据可读"
 
 msgid "Source Item"
 msgstr "源项目"
@@ -14054,19 +14054,19 @@ msgid "Specific Customers"
 msgstr "特定客户"
 
 msgid "Specific Items"
-msgstr "特定项目"
+msgstr "特定物料"
 
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "按供应商、项目或类别的支出 — 您最大的成本驱动因素"
 
 msgid "Split"
-msgstr "分割"
+msgstr "拆分"
 
 msgid "Split line"
 msgstr "拆分行"
 
 msgid "Split off quantity"
-msgstr "分割数量"
+msgstr "拆分数量"
 
 msgid "Split receipt line"
 msgstr "拆分收据行"
@@ -14075,7 +14075,7 @@ msgid "Split shipment line"
 msgstr "拆分发货行"
 
 msgid "SSO/SAML"
-msgstr ""
+msgstr "SSO/SAML"
 
 msgid "Stand up hosting"
 msgstr "建立托管"
@@ -14084,10 +14084,10 @@ msgid "Stand up hosting (cloud or self-hosted)"
 msgstr "建立托管（云端或自托管）"
 
 msgid "Standard"
-msgstr "标准"
+msgstr "正常检验"
 
 msgid "Standard cloud Carbon fits how your company runs"
-msgstr "标准云 Carbon 适合您公司的运营方式"
+msgstr "标准云 Carbon 适合你的公司运营方式"
 
 msgid "Standard Cost Variances"
 msgstr "标准成本差异"
@@ -14096,7 +14096,7 @@ msgid "Standard factor"
 msgstr "标准系数"
 
 msgid "Standard Lead Time"
-msgstr "标准交货期"
+msgstr "标准提前期"
 
 msgid "Start"
 msgstr "开始"
@@ -14130,7 +14130,7 @@ msgid "Start Now"
 msgstr "立即开始"
 
 msgid "Start of Fiscal Year"
-msgstr "财政年度开始"
+msgstr "会计年度开始"
 
 msgid "Start of Tax Year"
 msgstr "税年开始"
@@ -14156,7 +14156,7 @@ msgstr "州/省"
 #. placeholder {0}: lotEntities.length
 #. placeholder {1}: Math.max(0, lotEntities.length - inspected)
 msgid "Statistical acceptance failed, so the entire lot is considered non-conforming (ISO 9001:2015 §8.7). All {0} entities — {passes} sampled pass(es), {fails} failure(s), and {1} un-inspected — will be marked Rejected."
-msgstr "统计验收失败，因此整个批次被视为不符合要求 (ISO 9001:2015 §8.7)。所有 {0} 个实体 — {passes} 个抽样合格品、{fails} 个不合格品和 {1} 个未检验品 — 将被标记为拒收。"
+msgstr "统计接收失败，因此整个批次被视为不符合规范（ISO 9001:2015 §8.7）。所有 {0} 个实体 — {passes} 个抽样合格，{fails} 个不合格，和 {1} 个未检验 — 将被标记为已拒绝。"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s)."
@@ -14190,7 +14190,7 @@ msgid "Step Records"
 msgstr "步骤记录"
 
 msgid "Step removed — pick a new value"
-msgstr "步骤已删除 — 选择新值"
+msgstr "步骤已移除 — 选择新值"
 
 msgid "steps"
 msgstr "步骤"
@@ -14211,7 +14211,7 @@ msgid "Stock Transfer ID"
 msgstr "库存转移ID"
 
 msgid "Stock Transfer Lines"
-msgstr "库存转移行"
+msgstr "库存调拨行"
 
 msgid "Stock Transfer Notes"
 msgstr "库存转移备注"
@@ -14224,7 +14224,7 @@ msgstr "库存转移"
 
 #. placeholder {0}: successorItem.readableIdWithRevision
 msgid "Stocked for spares only — successor: <0>{0}</0>"
-msgstr "仅作为备件库存 — 后继产品：<0>{0}</0>"
+msgstr "仅为备件存储 — 后继物料：<0>{0}</0>"
 
 msgid "Stocked for spares only."
 msgstr "仅库存备件。"
@@ -14257,49 +14257,49 @@ msgid "Storage Types"
 msgstr "存储类型"
 
 msgid "storage unit"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Storage unit"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Storage Unit"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Storage Unit (optional)"
-msgstr "存储单位（可选）"
+msgstr "存储单元（可选）"
 
 msgid "storage units"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Storage Units"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's created (or when the trigger process runs, if set)."
-msgstr "在此项目上存储固定的天数。过期开始日期在创建每个批次或序列号时设置（或在触发流程运行时设置，如果已设置）。"
+msgstr "在此物料上存储固定天数。在创建每个生产批次或序列号时（或触发工艺运行时，如果已设置）设置有效期开始日期。"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received or created (or when the trigger process runs, if set)."
-msgstr "在此项目上存储固定的天数。过期开始日期在每个批次或序列号被接收或创建时设置（或在触发流程运行时设置，如果已设置）。"
+msgstr "在此物料上存储固定天数。在收到或创建每个生产批次或序列号时（或触发工艺运行时，如果已设置）设置有效期开始日期。"
 
 msgid "Store a fixed number of days on this item. Expiry start date is set on each batch or serial when it's received."
-msgstr "在此项目上存储固定天数。每个批次或序列号在收到时设置过期开始日期。"
+msgstr "在此物料上存储固定天数。在收到每个生产批次或序列号时设置有效期开始日期。"
 
 msgid "Straight line"
 msgstr "直线法"
 
 msgid "Stripe"
-msgstr ""
+msgstr "Stripe"
 
 msgid "Stripe already has a customer with this email"
-msgstr ""
+msgstr "Stripe 已拥有此电子邮件的客户"
 
 msgid "Stripe Due Date"
-msgstr ""
+msgstr "Stripe 到期日"
 
 msgid "Stripe emails the invoice to the customer, so an address is required. This will also be saved to the contact in Carbon."
-msgstr ""
+msgstr "Stripe 会向客户发送发票电子邮件，因此需要地址。这也将保存到 Carbon 中的联系人。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr ""
+msgstr "Stripe 还没有此 Carbon 客户的客户。过账将在您的关联账户上创建一个。"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "看板输出在看板表中显示的样式"
@@ -14311,7 +14311,7 @@ msgid "Sub-Departments"
 msgstr "子部门"
 
 msgid "Subassembly"
-msgstr "小组件"
+msgstr "子装配件"
 
 msgid "Subcontracting Variance"
 msgstr "外包差异"
@@ -14329,7 +14329,7 @@ msgid "Submit anonymously"
 msgstr "匿名提交"
 
 msgid "Submit for approval"
-msgstr "提交以供批准"
+msgstr "提交以审批"
 
 msgid "Submit Inspection"
 msgstr "提交检验"
@@ -14368,16 +14368,16 @@ msgid "Successfully copied quote"
 msgstr "成功复制报价"
 
 msgid "Successfully created a new revision"
-msgstr "成功创建新版本"
+msgstr "成功创建新修订版"
 
 msgid "Successor effectivity"
-msgstr "后续生效性"
+msgstr "后继物料生效日期"
 
 msgid "Successor Effectivity Date"
-msgstr "后继产品生效日期"
+msgstr "后继物料生效日期"
 
 msgid "Successor Part"
-msgstr "后继零件"
+msgstr "后继物料"
 
 msgid "Suffix"
 msgstr "后缀"
@@ -14434,7 +14434,7 @@ msgid "Supplier added and selected"
 msgstr "供应商已添加并选中"
 
 msgid "Supplier contact"
-msgstr "供应商联系方式"
+msgstr "供应商联系人"
 
 msgid "Supplier Contact"
 msgstr "供应商联系人"
@@ -14467,7 +14467,7 @@ msgid "Supplier Part"
 msgstr "供应商零件"
 
 msgid "Supplier Part ID"
-msgstr "供应商零件ID"
+msgstr "供应商料号"
 
 msgid "Supplier Part Number"
 msgstr "供应商零件号"
@@ -14488,13 +14488,13 @@ msgid "Supplier Prepayments"
 msgstr "供应商预付款"
 
 msgid "supplier process"
-msgstr "供应商流程"
+msgstr "供应商工艺"
 
 msgid "supplier processes"
-msgstr "供应商流程"
+msgstr "供应商工艺"
 
 msgid "Supplier Processes"
-msgstr "供应商流程"
+msgstr "供应商工艺"
 
 msgid "Supplier Quality"
 msgstr "供应商质量"
@@ -14579,7 +14579,7 @@ msgid "Switch"
 msgstr "切换"
 
 msgid "Switch a module off to remove it everywhere: Requirements, Data, Training, Scope."
-msgstr "关闭模块以将其从任何地方移除：需求、数据、培训、范围。"
+msgstr "关闭一个模块以从所有位置移除它：要求、数据、培训、范围。"
 
 msgid "Switch to pan mode"
 msgstr "切换到平移模式"
@@ -14630,7 +14630,7 @@ msgid "Tailor this hub for the customer. Changes apply live for everyone viewing
 msgstr "为客户定制此中心。更改对所有查看者实时生效。永远不会向客户显示此内容。"
 
 msgid "Take the shortest remaining shelf life across the materials consumed to make this item. Use when the product's expiry depends on its ingredients."
-msgstr "采用消耗的材料中最短的剩余保质期来制造此物品。当产品的有效期取决于其成分时使用。"
+msgstr "采用制造此物料所消耗的原材料中最短的保质期。当产品的有效期取决于其成分时使用。"
 
 msgid "taken"
 msgstr "已采取"
@@ -14648,7 +14648,7 @@ msgid "Target Company"
 msgstr "目标公司"
 
 msgid "Target customers by type."
-msgstr "目标项目"
+msgstr "按类型定位客户。"
 
 msgid "Target disposition row"
 msgstr "目标处置行"
@@ -14663,13 +14663,13 @@ msgid "Target Method"
 msgstr "目标方法"
 
 msgid "Target number of open issues shown as a reference line on the Issue Trend chart."
-msgstr "在问题趋势图表上显示为参考线的开放问题的目标数量。"
+msgstr "在问题趋势图表上显示为参考线的未结问题的目标数量。"
 
 msgid "Target one or more customers."
 msgstr "针对一个或多个客户。"
 
 msgid "Target one or more items."
-msgstr "目标版本"
+msgstr "定位一个或多个物料。"
 
 msgid "Target quantity"
 msgstr "目标数量"
@@ -14687,16 +14687,16 @@ msgid "Tasks"
 msgstr "任务"
 
 msgid "Tasks still open"
-msgstr "任务仍未完成"
+msgstr "任务仍未结"
 
 msgid "Tasks that must be completed before this issue can be closed; selecting actions here adds them on top of whatever the workflow specifies."
-msgstr "在关闭此问题之前必须完成的任务；在此处选择操作会将其添加到工作流程指定的内容之外。"
+msgstr "必须在此问题关闭前完成的任务；选择此处的操作会将其添加到工作流指定的任何项目之上。"
 
 msgid "Tax"
 msgstr "税"
 
 msgid "Tax & Additional Costs"
-msgstr "税费和额外费用"
+msgstr "税 & 额外成本"
 
 msgid "Tax & Shipping"
 msgstr "税费和运费"
@@ -14714,7 +14714,7 @@ msgid "Tax Depreciation Method"
 msgstr "税务折旧方法"
 
 msgid "Tax exempt"
-msgstr ""
+msgstr "免税"
 
 msgid "Tax Exempt"
 msgstr "免税"
@@ -14744,13 +14744,13 @@ msgid "Tax Residual Value %"
 msgstr "税务残值 %"
 
 msgid "Tax Useful Life (default)"
-msgstr "税务使用寿命（默认）"
+msgstr "税使用年限（默认）"
 
 msgid "Tax Useful Life (months)"
-msgstr "税务使用寿命（月）"
+msgstr "税使用年限（月）"
 
 msgid "Tax Useful Life (Months)"
-msgstr "税务使用寿命（月）"
+msgstr "税使用年限（月份）"
 
 msgid "Tax:"
 msgstr "税:"
@@ -14759,10 +14759,10 @@ msgid "Taxes"
 msgstr "税"
 
 msgid "Team trained"
-msgstr "团队已培训"
+msgstr "班组已培训"
 
 msgid "Technical support"
-msgstr ""
+msgstr "技术支持"
 
 msgid "Temperature"
 msgstr "温度"
@@ -14774,7 +14774,7 @@ msgid "Templates"
 msgstr "模板"
 
 msgid "Temporary disposal-clearing account debited for an asset's net book value on shipment and credited for its net book value on invoicing, netting to zero over the sale cycle."
-msgstr "临时处置清算账户，发货时按资产账面净值借记，开票时按账面净值贷记，在销售周期结束时归零。"
+msgstr "临时处置清算账户，在发货时按资产账面净值做借方记录，在开票时按其账面净值做贷方记录，在销售周期内结余为零。"
 
 msgid "Terms and Privacy"
 msgstr "条款和隐私"
@@ -14814,22 +14814,22 @@ msgstr "\"{0}\"阶段已完成——其\"{1}\"检查点已通过。"
 
 #. placeholder {0}: steps.length
 msgid "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
-msgstr "The {0} phases to go live, each ending at a checkpoint. Tick off each task as you complete it."
+msgstr "达成上线的{0}个阶段，每个阶段以检查点结束。当您完成每个任务时，将其勾选。"
 
 msgid "The accounting dimension that categorizes items for reporting and analysis."
-msgstr "将项目分类以进行报告和分析的会计维度。"
+msgstr "对物料进行分类以用于报告和分析的会计维度。"
 
 msgid "The accounts Carbon posts to automatically"
 msgstr "Carbon 自动记账的账户"
 
 msgid "The action that copies a saved method (its materials, operations, and work instructions) onto a job or quote line."
-msgstr "将保存的方法（其物料、工序和工作说明）复制到工作或报价行的操作。"
+msgstr "将保存的方法（其原材料、工序和作业指导书）复制到工单或报价行的操作。"
 
 msgid "The allowed values for a list-type attribute; users pick from these rather than free-typing."
-msgstr "列表类型属性的允许值；用户从这些中选择而不是自由输入。"
+msgstr "列表类型属性的允许值；用户从这些值中选择而不是自由输入。"
 
 msgid "The allowed values users can pick when tagging postings with this dimension."
-msgstr "用户在使用该维度标记记录时可以选择的允许值。"
+msgstr "用户在用此维度标记过账时可以选择的允许值。"
 
 msgid "The amount of days after the calculation method that the cash discount is available"
 msgstr "计算方法后可用现金折扣的天数"
@@ -14844,7 +14844,7 @@ msgid "The authorization was refused in Onshape. Try connecting again."
 msgstr "授权在 Onshape 中被拒绝。请重新连接。"
 
 msgid "The book of all posted journal lines, summed by account — written only when the company has accounting enabled."
-msgstr "所有已记账的日记账行书，按账户汇总 - 仅在公司启用会计时编写。"
+msgstr "所有已过账凭证行的汇总簿，按账户汇总——仅当公司启用会计时才编制。"
 
 msgid "The buckets you track costs against"
 msgstr "您用来追踪成本的分类"
@@ -14853,7 +14853,7 @@ msgid "The capital assets you own and depreciate"
 msgstr "您拥有并折旧的固定资产"
 
 msgid "The Carbon user currently responsible for working this record, set per record and independent of ownership fields like Account Manager or Sales Person."
-msgstr "当前负责处理此记录的Carbon用户，按记录设置，与账户经理或销售代表等所有权字段无关。"
+msgstr "当前负责处理此记录的 Carbon 用户，按记录设置，独立于所有权字段（如客户经理或销售人员）。"
 
 msgid "The Carbon user responsible for this customer relationship; emails and reminders about this customer route to them."
 msgstr "负责此客户关系的Carbon用户；关于此客户的电子邮件和提醒会路由给他们。"
@@ -14865,13 +14865,13 @@ msgid "The Carbon user who owns this RFQ; supplier responses and reminders route
 msgstr "拥有此RFQ的Carbon用户；供应商响应和提醒会路由给他们。"
 
 msgid "The carrier and service a shipment goes out on, supplying the tracking-URL template that turns a tracking number into a link and the account freight charges post to."
-msgstr "货运承运商和服务，提供跟踪URL模板，将跟踪号转换为链接并将账户运费费用发布到。"
+msgstr "发货所用的承运商和服务，提供跟踪 URL 模板，将跟踪号转换为链接，以及应付运费所过账的账户。"
 
 msgid "The carrier that delivers goods from this supplier, when different from the supplier itself (e.g. supplier sells, FedEx ships)."
-msgstr "从此供应商交付商品的承运人，当不同于供应商本身时（例如，供应商销售，FedEx配送）。"
+msgstr "从此供应商处交付货物的承运商，当其与供应商本身不同时（例如供应商销售，FedEx 配送）。"
 
 msgid "The carrier's tracking-page URL with {trackingNumber} as a placeholder — Carbon substitutes the actual number when generating links on shipments."
-msgstr "运输公司的追踪页面URL，以{trackingNumber}作为占位符 — Carbon在生成出货链接时替换实际号码。"
+msgstr "承运商的跟踪页面 URL，以 {trackingNumber} 作为占位符——Carbon 在生成发货链接时替换实际号码。"
 
 msgid "The carriers and methods you ship orders with"
 msgstr "您用来发货订单的承运商和方法"
@@ -14880,13 +14880,13 @@ msgid "The cash discount the customer can take if they pay within the discount w
 msgstr "如果客户在折扣期限内付款，可以获得的现金折扣。"
 
 msgid "The catalog reason that explains this scrap; rolls up into scrap reports keyed by reason rather than by quantity."
-msgstr "解释此废料的目录原因；汇总到按原因而不是按数量键控的废料报告中。"
+msgstr "说明此报废的目录原因；汇总到按原因而非按数量键入的报废报告中。"
 
 msgid "The catalog you run on. Loads once foundation is in."
 msgstr "您运行的目录。在基础数据加载后加载。"
 
 msgid "The categories of stock allowed in this unit; used to enforce putaway rules (e.g. cold chain, hazardous)."
-msgstr "该单元中允许的库存类别；用于强制执行放货规则（例如，冷链、危险品）。"
+msgstr "此库位允许的库存类别；用于执行上架规则（例如冷链、危险品）。"
 
 msgid "The categories you group your suppliers into"
 msgstr "您将供应商分组的类别"
@@ -14910,10 +14910,10 @@ msgid "The category this supplier belongs to (raw-material, services, contract-m
 msgstr "此供应商所属的类别（原材料、服务、合同制造商）；确定默认GL账户和报告分组。"
 
 msgid "The code printed on the kanban card that operators scan to mark the job complete; auto-generated when left blank."
-msgstr "印在看板卡上的代码，操作员扫描该代码以将工作标记为完成；如果留空，则自动生成。"
+msgstr "打印在看板卡上的代码，操作员扫码以标记工单完成；留空时自动生成。"
 
 msgid "The contractor's expected weekly availability; scheduling uses this as the upper bound when assigning this contractor to operations across the week."
-msgstr "承包商的预期周可用性；在将此承包商分配给整周的操作时，计划将其用作上限。"
+msgstr "外协人员的预期每周可用性；排程在整周将此外协人员分配给工序时使用此作为上限。"
 
 msgid "The corrected expiration for this lot/serial; existing on-hand stock is re-evaluated against shelf-life policy after the change."
 msgstr "此批次/序列号的修正有效期；更改后，现有库存会根据保质期政策重新评估。"
@@ -14925,34 +14925,34 @@ msgid "The customer record this portal account links to; only contacts already o
 msgstr "此门户帐户链接到的客户记录；只有该客户上已有的联系人才能被选为以下帐户持有人。"
 
 msgid "The customer that goods are delivered to, when different from the customer being invoiced (e.g. invoice to HQ, ship to branch)."
-msgstr "交付商品的客户，与开票客户不同时（例如，总部开票，分支机构发货）。"
+msgstr "货物交付的客户，当其与被开票的客户不同时（例如向总部开票，向分支发货）。"
 
 msgid "The customer this portal link is provisioned for; only contacts on this customer can sign in through the link."
 msgstr "为其提供此门户链接的客户；只有该客户上的联系人才能通过链接登录。"
 
 msgid "The customer's own reference for this document — typically their RFQ or PO number on their system; surfaced on the printable output and carried forward into any document this one converts into."
-msgstr "此文档的客户自己的参考 - 通常是其系统上的RFQ或PO编号；显示在可打印的输出上，并转发到此文档转换为的任何文档。"
+msgstr "客户对此文件的自有参考——通常是他们系统上的询价单或采购单号码；显示在可打印输出上并转入此文件转换成的任何文件。"
 
 msgid "The customer's revision tag for their Part ID, when it differs from ours; pinned at the cross-reference level, not on our revision."
-msgstr "其零件ID的客户修订标记，当与我们的不同时；在交叉引用级别固定，而不是在我们的修订上。"
+msgstr "客户对其零件 ID 的修订版标记，当其与我们的不同时；固定在交叉参考级别，而不是我们的修订版上。"
 
 msgid "The customers who go live fastest own these well. The full ours/yours split is below."
-msgstr "最快上线的客户掌握这些内容最好。完整的我们/你们分配如下。"
+msgstr "上线最快的客户能很好地掌握这些。完整的我们的/你们的分割如下。"
 
 msgid "The customers you sell and ship to"
 msgstr "您销售和运送的客户"
 
 msgid "The dashed threshold you don't want inventory to fall below."
-msgstr "不希望库存低于的虚线阈值。"
+msgstr "你不希望库存跌破的虚线阈值。"
 
 msgid "The date a job's quantity is needed, which together with Deadline Type sets the job's place in its location's schedule queue."
-msgstr "一个作业数量所需的日期，它与截止日期类型一起设置作业在其位置的调度队列中的位置。"
+msgstr "需要工单数量的日期，与截止类型一起设置工单在其地点排程队列中的位置。"
 
 msgid "The date depreciation begins for this asset; usually the in-service date."
 msgstr "资产开始折旧的日期；通常是投入使用日期。"
 
 msgid "The date past which this quote's pricing is no longer honored; converting to an order after this date may require re-quoting."
-msgstr "此报价的价格不再有效的日期；该日期之后转换为订单可能需要重新报价。"
+msgstr "此报价单定价不再有效的日期之后；在此日期之后转换为订单可能需要重新报价。"
 
 msgid "The date the customer expects to receive the goods"
 msgstr "客户期望收到货物的日期"
@@ -14964,7 +14964,7 @@ msgid "The date the item is required on-site to cover the period's projected dem
 msgstr "该项目需要在现场到达的日期，以满足该期间的预计需求。"
 
 msgid "The date this asset is retired from service; depreciation stops on this date and remaining net book value is booked to the disposal account."
-msgstr "资产退役的日期；折旧在该日期停止，剩余净账面价值记入处置账户。"
+msgstr "此资产退役日期；折旧在此日期停止，剩余账面净值计入处置账户。"
 
 msgid "The date this entry hits the ledger; determines the accounting period it falls in."
 msgstr "该条目记入总账的日期；确定它所在的会计期间。"
@@ -14973,13 +14973,13 @@ msgid "The date this intercompany transaction hits both companies' ledgers."
 msgstr "该公司间交易记入两家公司总账的日期。"
 
 msgid "The date you received this RFQ from the customer. Defaults to today."
-msgstr "您收到此询价单（RFQ）的日期。默认为今天。"
+msgstr "您从客户收到此询价单的日期。默认为今天。"
 
 msgid "The deadline to send your quote to the customer."
 msgstr "向客户发送报价的截止日期。"
 
 msgid "The default order picking uses to offer tracked entities: FEFO (earliest-expiry first), FIFO (oldest first), or LIFO (newest first)."
-msgstr "默认订单拣选用于提供跟踪的实体：FEFO（最早到期），FIFO（最旧优先）或LIFO（最新优先）。"
+msgstr "订单拣货使用的默认方式，用于提供被跟踪实体：先到期先出（最早过期优先）、先进先出（最旧优先）或后进先出（最新优先）。"
 
 msgid "The default run quantity when this part is made; planning rounds replenishment up to multiples of this."
 msgstr "制造此零件时的默认运行数量；计划轮次为此补充的倍数。"
@@ -14991,10 +14991,10 @@ msgid "The department this one rolls up under for reporting and headcount hierar
 msgstr "该部门汇总用于报告和人员数量层级的部门；对于顶级部门，请留空。"
 
 msgid "The eight-disciplines quality method, modeled with the nonconformance workflow's tasks rather than hard-coded."
-msgstr "8D质量方法，用不符合工作流程的任务建模，而不是硬编码。"
+msgstr "八大纪律质量方法，通过不合格工作流的任务建模，而非硬编码。"
 
 msgid "The employee accountable for this cost center — when purchase order approvals are on, they're the approver for spend posted against it."
-msgstr "负责该成本中心的员工——启用采购订单批准时，他是对其进行的支出的批准人。"
+msgstr "对此成本中心负责的员工 — 当启用采购订单审批时，他们是针对其发生的支出的批准人。"
 
 msgid "The end-to-end commercial flow from quoting a customer to collecting payment: RFQ to quote to sales order, then shipment, invoice, and settled payment."
 msgstr "从客户报价到收款的端到端商业流程：询价到报价到销售订单，然后发货、发票和已结清的付款。"
@@ -15006,10 +15006,10 @@ msgid "The engineering drawing this inspection plan is tied to; inspections reco
 msgstr "此检验计划关联的工程图纸；针对此零件记录的检验将引用此图纸。"
 
 msgid "The expected percentage of this item's output lost during production; planning multiplies demand by 1 / (1 − scrap) to compensate."
-msgstr "生产期间此项目的预期产出百分比丢失；规划将需求乘以1 / (1 −废料)来补偿。"
+msgstr "此物料产出在生产期间预期丢失的百分比；计划将需求乘以 1 / (1 − 报废) 来补偿。"
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
-msgstr "该间接支出行过账的支出帐户；由于间接行没有项目分类帐条目来派生帐户，因此是必需的。"
+msgstr "此间接支出行过账至的费用科目；因为间接行没有物料分类账条目来推导科目，所以这是必需的。"
 
 msgid "the first 3 to 4 weeks"
 msgstr "前3到4周"
@@ -15018,22 +15018,22 @@ msgid "The fixed number of units to inspect from the front of each lot, regardle
 msgstr "从每批前面检查的固定单位数，与批量大小无关。"
 
 msgid "The fixed-asset record this purchase capitalizes against; the line's receipt creates the asset entry rather than an inventory entry."
-msgstr "此购买资本化的固定资产记录；行的收据创建资产条目而不是库存条目。"
+msgstr "此采购资本化对应的固定资产记录；该行的收货创建资产条目而非库存管理条目。"
 
 msgid "The fixed-asset record this sale disposes; the line's shipment posts the asset's net-book-value disposal entry rather than COGS."
 msgstr "此销售处置的固定资产记录；行的发货将资产的净账面价值处置条目而不是销售成本过账。"
 
 msgid "The floor an asset depreciates down to; when net book value reaches it, the asset flips to Fully Depreciated."
-msgstr "资产折旧的下限；当净账面价值达到时，资产变为完全折旧。"
+msgstr "资产折旧至的底线；当账面净值达到它时，资产转为已提足折旧。"
 
 msgid "The floor and the office read the same inventory and cost figures."
-msgstr "车间和办公室读取相同的库存和成本数据。"
+msgstr "车间和办公室读取相同的库存管理和成本数据。"
 
 msgid "The following assemblies have no operations. Please assign an operation to each before releasing."
-msgstr "以下装配体没有操作。请在发布前为每个装配体分配一个操作。"
+msgstr "以下装配体没有工序。请在发布前为每个装配体分配一个工序。"
 
 msgid "The following line items are missing prices or lead times:"
-msgstr "以下行项目缺少价格或交货期："
+msgstr "以下行物料缺少价格或提前期："
 
 msgid "The following tasks are not done yet:"
 msgstr "以下任务尚未完成："
@@ -15042,37 +15042,37 @@ msgid "The forms and shapes your raw materials come in"
 msgstr "您的原材料所采用的形式和形状"
 
 msgid "The fraction of each lot to inspect; the actual count is computed from lot size at the time of inspection."
-msgstr "每批检查的部分；实际计数在检查时从批量大小计算。"
+msgstr "每个批次的检验比例；实际数量在检验时从批量计算得出。"
 
 msgid "The gap between a purchase order's price and the supplier's bill, posted to a variance account when the invoice posts."
-msgstr "采购订单价格与供应商账单之间的差异，在发票记账时记入差异账户。"
+msgstr "采购订单价格与供应商账单之间的差异，当发票过账时过账到差异账户。"
 
 msgid "The GL account charges for this carrier post to (freight expense, freight in/out)."
-msgstr "该运输公司费用过账的GL帐户（运费、运费进出）。"
+msgstr "此承运商费用过账至的总账科目（运费、运入/运出）。"
 
 msgid "The goal"
 msgstr "目标"
 
 msgid "The grades that classify your materials"
-msgstr "对您的材料进行分类的等级"
+msgstr "对原材料进行分类的等级"
 
 msgid "The group account this account rolls up to; determines its type, class, and statement placement."
 msgstr "该账户汇总到的集团账户；确定其类型、级别和报表中的位置。"
 
 msgid "The hourly cost of operator labor on this work center; combined with logged labor hours to charge labor cost into a job's WIP."
-msgstr "此工作中心的操作员劳动的每小时成本；与记录的劳动时间结合，以将劳动成本计入工作的在制品。"
+msgstr "此工作中心的操作员人工时薪；与记录的人工小时数相结合，将人工成本计入工单的在制品。"
 
 msgid "The hourly cost of running the machinery on this work center; combined with logged machine hours to charge machine cost into a job's WIP."
 msgstr "此工作中心运行机械的每小时成本；与记录的机器小时结合，以将机器成本计入工作的在制品。"
 
 msgid "The hourly indirect-cost burden applied to this work center; the difference between labor + machine and the full quoting rate is what overhead absorbs."
-msgstr "应用于此工作中心的每小时间接成本负担；劳动+机器与完整报价率之间的差异就是间接费用吸收的内容。"
+msgstr "应用于此工作中心的每小时间接成本负担；人工 + 机器与完整报价率之间的差异就是制造费用吸收的内容。"
 
 msgid "The https address a workflow's webhook step posts to — plain http, redirects, and hosts resolving to private or link-local addresses are refused, and the call gives up after ten seconds."
-msgstr "工作流的网络钩子步骤发布到的 https 地址 — 拒绝纯 http、重定向和解析为私有或本地链接地址的主机，调用在十秒后放弃。"
+msgstr "工作流的 Webhook 步骤过账至的 https 地址——拒绝纯 http、重定向和解析为私有或链接本地地址的主机，调用在十秒后放弃。"
 
 msgid "The human-readable document number (like J000001 or ECO-000001) minted from a sequence and stored on the record, distinct from its internal id."
-msgstr "从序列生成并存储在记录上的人类可读的文档编号（如J000001或ECO-000001），与其内部ID不同。"
+msgstr "从编号规则生成并存储在记录上的可读文件编号（如 J000001 或 ECO-000001），与其内部 id 不同。"
 
 msgid "The identifier the customer uses for this part on their POs; Carbon resolves it to our internal Part ID on order import."
 msgstr "客户在其采购单上用于此零件的标识符；Carbon在订单导入时将其解析为我们的内部零件ID。"
@@ -15081,7 +15081,7 @@ msgid "The identifier the supplier uses for this part on their quotes and invoic
 msgstr "供应商在其报价和发票上用于此零件的标识符；Carbon将其解析为我们的内部零件ID。"
 
 msgid "The immediate nonconformance task that quarantines affected stock or work before the root cause is known."
-msgstr "根本原因已知之前，隔离受影响库存或作业的立即不符合任务。"
+msgstr "在了解根本原因之前隔离受影响库存或工作的直接不合格任务。"
 
 msgid "The impact rating if the risk is realized (1 = negligible to 5 = catastrophic); paired with Likelihood to compute the risk score."
 msgstr "如果风险实现，影响评级（1 =可忽视，5 =灾难性）；与可能性配对以计算风险评分。"
@@ -15090,13 +15090,13 @@ msgid "The inbound posting document that takes goods into stock (from a PO, tran
 msgstr "接收商品进入库存（从采购订单、转移或作业输出）并创建任何被追踪实体的入站过账文件。"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments from this supplier."
-msgstr "Incoterms规则（FOB、DAP、EXW、CIF等），管制从该供应商发货时谁支付运费、谁承担风险以及所有权转让在何处发生。"
+msgstr "贸易术语规则（FOB、DAP、EXW、CIF 等），规定在来自此供应商的发货中谁支付运费、谁承担风险以及所有权转让发生的地点。"
 
 msgid "The Incoterm rule (FOB, DAP, EXW, CIF, …) that governs who pays freight, who bears risk, and where the transfer of title occurs on shipments to this customer."
-msgstr "Incoterms规则（FOB、DAP、EXW、CIF等），管制向该客户发货时谁支付运费、谁承担风险以及所有权转让在何处发生。"
+msgstr "贸易术语规则（FOB、DAP、EXW、CIF 等），规定在发往此客户的发货中谁支付运费、谁承担风险以及所有权转让发生的地点。"
 
 msgid "The inventory cost recognized when a shipment posts, valued by the item's costing method."
-msgstr "发货过账时确认的库存成本，按物品的成本计算方法评估。"
+msgstr "发货过账时确认的库存管理成本，按物料的成本核算方法计值。"
 
 msgid "The IRS recovery-period class for this asset under MACRS (3, 5, 7, 10, 15, 20, 27.5, 39-year)."
 msgstr "根据MACRS，该资产的国税局回收期类别（3、5、7、10、15、20、27.5、39年）。"
@@ -15105,19 +15105,19 @@ msgid "The job whose operation this outside-processing line covers; the line's r
 msgstr "该外部处理行所涵盖的操作工作；行的收据关闭对该工作的操作。"
 
 msgid "The job's position in its location's schedule queue — a fractional number Carbon computes from the due date and deadline type, not a Low/High rating."
-msgstr "作业在其位置的调度队列中的位置 — Carbon 根据截止日期和截止日期类型计算的小数，而不是低/高评级。"
+msgstr "工单在其地点排程队列中的位置——一个 Carbon 根据到期日和截止日期类型计算的小数，而非低/高评级。"
 
 msgid "The kind of adjustment this rule applies — discount, surcharge, or fixed override; combined with Amount Type to compute the actual delta on each line."
 msgstr "该规则应用的调整类型 - 折扣、附加费或固定覆盖；与金额类型结合以计算每行的实际增量。"
 
 msgid "The kind of value this attribute accepts (text, number, date, boolean, list); locked after the attribute has any recorded values."
-msgstr "此属性接受的值的类型（文本、数字、日期、布尔值、列表）；属性具有记录的值后被锁定。"
+msgstr "此属性接受的值类型（文本、数字、日期、布尔值、列表）；属性有任何记录值后已锁定。"
 
 msgid "The label and document printers your company prints to"
-msgstr "您公司打印到的标签和文档打印机"
+msgstr "您公司打印至的标签和文件打印机"
 
 msgid "The latest date to place this PO so it arrives by the need-by date, given the supplier's lead time."
-msgstr "最迟下达此采购订单的日期，以便在考虑供应商交货期的情况下按需求日期前送达。"
+msgstr "放置此采购订单的最迟日期，以便在给定供应商提前期的情况下按需要日期到达。"
 
 msgid "The legal entity to bill, when different from the customer who receives the goods — for parent / subsidiary or third-party billing arrangements."
 msgstr "要开票的法律实体，当不同于接收商品的客户时 — 用于母公司/子公司或第三方开票安排。"
@@ -15129,28 +15129,28 @@ msgid "The lifecycle stages you track customers through"
 msgstr "您跟踪客户所经历的生命周期阶段"
 
 msgid "The lifecycle state of this customer — Active, Prospect, Inactive, etc.; only Active customers appear in sales-order selectors."
-msgstr "此客户的生命周期状态 - 活跃、前景、非活跃等；只有活跃的客户才会显示在销售订单选择器中。"
+msgstr "此客户的生命周期状态——启用、潜在客户、已停用等；只有启用客户出现在销售订单选择器中。"
 
 msgid "The lifecycle state of this supplier — Active, Inactive, Pending Approval, etc.; only Active suppliers appear in PO / quote selectors."
-msgstr "此供应商的生命周期状态 - 活跃、非活跃、待批准等；只有活跃的供应商才会显示在采购单/报价选择器中。"
+msgstr "此供应商的生命周期状态 — 启用、已停用、待批准等；仅启用的供应商出现在采购订单/报价单选择器中。"
 
 msgid "The local timezone this location reports time in; schedules, timecards, and shift hours at this location are interpreted in this zone regardless of the user's browser locale."
-msgstr "该位置报告时间的本地时区；该位置的时间表、时间卡和班次小时数将在此时区中解释，无论用户的浏览器区域设置如何。"
+msgstr "此地点报告时间所在的本地时区；此地点的排程、工时记录和班次小时数在此时区中解释，无论用户的浏览器区域设置如何。"
 
 msgid "The location this employee defaults to; drives timezone interpretation on their timecards and the default shift selectors on their job record."
-msgstr "此员工默认的位置；驱动他们的时间卡上的时区解释和工作记录上的默认班次选择器。"
+msgstr "此员工默认的地点；驱动其工时记录上的时区解释和其工单记录上的默认班次选择器。"
 
 msgid "The location this order will fulfill from; per-line locations override this when set."
 msgstr "此订单将从中履行的位置；按行设置的位置在设置时会覆盖这个。"
 
 msgid "The location this quote will fulfill from if it converts to an order; used by planning to project supply at the right warehouse."
-msgstr "如果此报价转换为订单，将履行此报价的位置；规划用于在正确的仓库投影供应。"
+msgstr "如果转换为订单，此报价单将从其中履行的地点；计划用于在正确的仓库处预测供应。"
 
 msgid "The location this RFQ would fulfill from if it converts to a quote and then an order."
 msgstr "如果此报价请求转换为报价，然后转换为订单，将履行此报价请求的位置。"
 
 msgid "The log of risks and opportunities raised against any entity, each rated by independent 1–5 severity and likelihood and driven to a resolution."
-msgstr "针对任何实体记录的风险和机会日志，每个都由独立的1-5严重程度和可能性评级，并推动解决。"
+msgstr "针对任何实体提出的风险和机遇日志，每个均由独立的 1–5 严重度和可能性评级，并推动到解决方案。"
 
 msgid "The logos shown on your printed and emailed documents"
 msgstr "显示在您打印和电子邮件文档上的徽标"
@@ -15159,16 +15159,16 @@ msgid "The lot identifier for this stock; one row per batch, quantity is the on-
 msgstr "此库存的批号标识符；每批一行，数量是该批的库存。"
 
 msgid "The lot will be marked Passed. {fails} sampled failure(s) are recorded for your records."
-msgstr "该批次将被标记为通过。{fails} 个抽样失败已记录在案。"
+msgstr "批次将标记为已通过。{fails} 个抽样失败已记录在案。"
 
 msgid "The lot will still be rejected, but an NCR cannot be created until at least one Issue Type is configured."
-msgstr "该批次仍将被拒收，但在至少配置一个问题类型之前，无法创建NCR。"
+msgstr "批次仍将被拒绝，但在配置至少一个问题类型之前无法创建 NCR。"
 
 msgid "The lot's per-feature sampling plan will be re-resolved from the selected document."
-msgstr "该批次的按特性抽样计划将从选定的文件中重新解析。"
+msgstr "批次的每个特征抽样方案将从选定的文件重新解析。"
 
 msgid "The lowest amount this supplier will charge for this process, regardless of quantity; jobs below the breakeven volume still cost at least this much."
-msgstr "此供应商无论数量如何为此流程收费的最低金额；低于损益平衡点的工作仍至少花费此金额。"
+msgstr "此供应商对此工艺收费的最低金额，无论数量如何；低于盈亏平衡量的工单仍至少成本此金额。"
 
 msgid "The machines, cells, and stations your work runs through"
 msgstr "您的工作运行所经过的机器、单元和工作站"
@@ -15177,19 +15177,19 @@ msgid "The master data to set up when first configuring Carbon, grouped by modul
 msgstr "首次配置 Carbon 时要设置的主数据，按模块分组。配置每个模块时进行标记。"
 
 msgid "The material is purchased from a supplier for that specific order, rather than made or pulled from stock."
-msgstr "该材料从供应商购买用于该特定订单，而不是制造或从库存中提取。"
+msgstr "原材料是从供应商购买用于该特定订单，而不是制造或从库存中提取。"
 
 msgid "The material types you organize your stock by"
-msgstr "您组织库存的材料类型"
+msgstr "您用来组织库存的原材料类型"
 
 msgid "The month your financial year begins; periods are numbered from this month."
 msgstr "财政年度开始的月份；期间从该月份开始编号。"
 
 msgid "The month your tax year begins; may differ from the fiscal year in some jurisdictions."
-msgstr "税务年度开始的月份；在某些司法管辖区可能与财政年度不同。"
+msgstr "你的税年开始的月份；在某些司法管辖区可能与会计年度不同。"
 
 msgid "The monthly periods you post into and close"
-msgstr "您过账并关闭的月度期间"
+msgstr "您过账和关闭的每月期间"
 
 msgid "The most likely failure mode the requester suspects; the technician confirms or replaces this on close-out, and the difference between suspected and actual feeds reliability reports."
 msgstr "请求者怀疑的最可能的失败模式；技术人员在关闭时确认或替换此项，疑似与实际之间的差异会影响可靠性报告。"
@@ -15198,25 +15198,25 @@ msgid "The negotiated price per unit on this line; the inline trace icon shows w
 msgstr "此行协商的单价；内联跟踪图标显示哪个定价规则或覆盖生成了它。"
 
 msgid "The new version number of the document"
-msgstr "文档的新版本号"
+msgstr "文件的新版本号"
 
 msgid "The new version number of the method"
 msgstr "该方法的新版本号"
 
 msgid "The new version number of the procedure"
-msgstr "程序的新版本号"
+msgstr "程序文件的新版本号"
 
 msgid "The number of days between placing a PO with the preferred supplier and the goods arriving on the dock; planning offsets demand backward by this much."
-msgstr "向首选供应商下订单与商品到达码头之间的天数；规划将需求向后偏移此金额。"
+msgstr "从向首选供应商下达采购订单到货物到达装卸码头的天数;计划偏移以此向后推移需求。"
 
 msgid "The number of days to build one batch of this item, measured from job release to completion; planning offsets demand backward by this much."
-msgstr "构建此项目一批所需的天数，从工作发布到完成；规划将需求向后偏移此金额。"
+msgstr "从下达工单到完成一个该物料生产批次所需的天数;计划以此向后推移需求。"
 
 msgid "The number of extra units to build to compensate for expected scrap; planning sums this with the order quantity when reserving materials."
-msgstr "为补偿预期废料而构建的额外单位数；规划在预留物料时将其与订单数量相加。"
+msgstr "为补偿预期报废而额外生产的件数;计划在保留原材料时将此与订购数量求和。"
 
 msgid "The number of hours per week the contractor is available to work."
-msgstr "承包商每周可用工作的小时数。"
+msgstr "外协人员每周可用的工作小时数。"
 
 msgid "The number of months over which this asset will be depreciated."
 msgstr "此资产将折旧的月数。"
@@ -15225,22 +15225,22 @@ msgid "The on-hand level that triggers a new replenishment order under the quant
 msgstr "按数量触发新补充订单的库存水平根据基于数量的政策。"
 
 msgid "The operations and steps your parts move through"
-msgstr "您的零件经过的操作和步骤"
+msgstr "您的零件所经历的工序和步骤"
 
 msgid "The ordered list of tasks issues using this workflow must complete; the order here is the order they appear on the issue."
-msgstr "使用此工作流的问题必须完成的任务的有序列表；此处的顺序是它们在问题上出现的顺序。"
+msgstr "使用此工作流的问题必须完成的有序任务列表;此处的顺序是它们在问题上的出现顺序。"
 
 msgid "The ordered sequence of operations a job runs through, copied from the method's bill of process."
-msgstr "工作执行的操作的有序序列，从方法的流程清单中复制。"
+msgstr "工单经历的工序有序序列,从该方法的工序清单复制。"
 
 msgid "The original model file is no longer available"
 msgstr "原始模型文件不再可用"
 
 msgid "The outbound posting document that takes goods out of stock to a customer, posting COGS as it goes."
-msgstr "将商品从库存中取出给客户的出账凭证，沿途过账销售成本。"
+msgstr "将货物从库存发出给客户的出库过账凭证,在此过程中过账COGS。"
 
 msgid "The outside suppliers that perform this process; each gets a row of pricing and lead-time inputs on the supplier process form."
-msgstr "执行此流程的外部供应商；每个人在供应商流程表单上都获得一行价格和交货期输入。"
+msgstr "执行此工艺的外部供应商；每个供应商在供应商工艺表单上获得一行定价和交期输入。"
 
 msgid "The parent-child chain of tracked entities — what a unit was built from and what it became."
 msgstr "跟踪实体的父子链 - 一个单位从什么构成以及它变成了什么。"
@@ -15255,13 +15255,13 @@ msgid "The people on the Carbon side who will run your implementation, and how t
 msgstr "Carbon 方面将运行您的实施的人员，以及如何联系他们。"
 
 msgid "The people on your team and their access to Carbon"
-msgstr "您团队中的人员及其对 Carbon 的访问权限"
+msgstr "您团队中的人员及其对Carbon的访问权限"
 
 msgid "The per-company counter behind a document type's readable number, assembling the prefix, the zero-padded next value, and the suffix, and advancing as each document is created."
-msgstr "按公司分别维护的计数器，用于生成文档类型的可读编号，将前缀、零填充的序列号和后缀组合在一起，每创建一个文档时自动递增。"
+msgstr "每家公司的文件类型可读编号后的计数器,组合前缀、零填充的下一个值和后缀,并在创建每个文件时前进。"
 
 msgid "The per-item outcome recorded on a non-conformance's affected material — Pending, Return to Supplier, Rework, Scrap, or Use As Is — decided for each affected lot or serial on its own."
-msgstr "在不符合项的受影响物料上记录的逐项结果——待处理、退回供应商、返工、报废或照原样使用——针对每个受影响的批次或序列号单独决定。"
+msgstr "在不合格品的受影响原材料上记录的单件结果——待处理、退货给供应商、返工、报废或按现状使用——分别为每个受影响批次或序列号决定。"
 
 msgid "The percentage of the cash discount. Use 0 for no discount."
 msgstr "现金折扣的百分比。使用 0 表示无折扣。"
@@ -15273,25 +15273,25 @@ msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "您的工作和库存所在的工厂、仓库和场所"
 
 msgid "The preset bundle of tasks and approval requirements applied to this issue; overrides the issue type's default workflow when set."
-msgstr "应用于此问题的任务和批准要求的预设包；设置时覆盖问题类型的默认工作流。"
+msgstr "应用于此问题的预设任务和审批要求捆绑；设置时覆盖问题类型的默认工作流。"
 
 msgid "The principle:"
 msgstr "原则："
 
 msgid "The probability rating that the risk occurs (1 = rare to 5 = almost certain); paired with Severity to compute the risk score."
-msgstr "风险发生的概率评级（1 =罕见，5 =几乎肯定）；与严重程度配对以计算风险评分。"
+msgstr "风险发生的概率等级（1 = 罕见到 5 = 几乎肯定）；与严重度配对计算风险分数。"
 
 msgid "The procedure technicians follow when this maintenance is performed; replacing it after schedules have already been generated only affects future instances."
-msgstr "技术人员在执行此维护时遵循的程序；在已生成计划之后替换它仅影响将来的实例。"
+msgstr "技术人员执行此维护时遵循的程序文件；在已生成排程后替换它仅影响将来的实例。"
 
 msgid "The processes this work center can run; appears in process-pickers when scheduling operations, and limits which jobs can route through this work center."
-msgstr "该工作中心可以运行的流程；在安排操作时显示在流程选择器中，并限制哪些工作可以通过该工作中心路由。"
+msgstr "此工作中心可以运行的工艺；在排程工序时显示在工艺选择器中，并限制哪些工单可以通过此工作中心。"
 
 msgid "The provider offers no dimension targets. Enable the feature in the provider first (e.g. tracking categories, class tracking, or fields)."
 msgstr "提供商不提供维度目标。首先在提供商中启用该功能（例如跟踪类别、类跟踪或字段）。"
 
 msgid "The quantity breakpoints this line is priced at; each column carries its own per-unit price for buyer–supplier negotiation and for converting to downstream documents."
-msgstr "此行定价的数量断点；每列为买卖方谈判和转换为下游文件的自己的单价。"
+msgstr "此行定价的数量断点;每一列都有自己的单位价格,用于采购方–供应商谈判和转换为下游文件。"
 
 msgid "The quantity of the item to be reordered on scan-based replenishment."
 msgstr "扫描补货时要重新订购的物品数量。"
@@ -15303,10 +15303,10 @@ msgid "The quote has been created"
 msgstr "报价已创建"
 
 msgid "The quote will be copied with a revision suffix"
-msgstr "该报价将被复制并带有修订后缀"
+msgstr "报价单将使用修订版后缀进行复制"
 
 msgid "The raw stock and material master you buy and consume"
-msgstr "您购买和消耗的原始库存和物料主数据"
+msgstr "您购买和消耗的原材料库存及物料主档"
 
 msgid "The reasons you record when parts get scrapped"
 msgstr "零件报废时记录的原因"
@@ -15321,7 +15321,7 @@ msgid "The record that applies a payment or memo to an invoice, carrying the app
 msgstr "将付款或备忘录应用于发票的记录，包含应用、折扣和核销金额。"
 
 msgid "The recorded genealogy of tracked entities — which inputs were consumed to produce which outputs, receipt through shipment."
-msgstr "跟踪实体的记录系统 - 消费了哪些输入来生成哪些输出，从收据到发货。"
+msgstr "已跟踪实体的记录谱系——哪些输入被消耗以生产哪些输出,从收货到发货。"
 
 msgid "The reference data everything else hangs off. Loads first."
 msgstr "参考数据是其他一切的基础。首先加载。"
@@ -15334,7 +15334,7 @@ msgstr "剩余的 {0} {1} 将被再次预期并计入传入供应。"
 #. placeholder {0}: line.quantityToReceive
 #. placeholder {1}: line.purchaseUnitOfMeasureCode ?? ""
 msgid "The remaining {0} {1} will no longer be expected. On-order supply and MRP will stop counting it. The ordered quantity and pricing are unchanged."
-msgstr "剩余的 {0} {1} 将不再被预期。在途供应和 MRP 将停止计算它。订购数量和价格保持不变。"
+msgstr "剩余的 {0} {1} 将不再被期望。在途供应和MRP将停止计算它。已订购的数量和定价保持不变。"
 
 msgid "The request body sent verbatim with a JSON content type after workflow variables inside it are substituted, on the methods that carry one."
 msgstr "在替换其中的工作流变量后，使用 JSON 内容类型逐字发送的请求体，在提供请求体的方法上。"
@@ -15349,31 +15349,31 @@ msgid "The result will not appear on the Runs page."
 msgstr "结果不会出现在运行页面上。"
 
 msgid "The revision number of the part"
-msgstr "零件的修订号"
+msgstr "零件的修订版号"
 
 msgid "The sales order line this job was created to supply, tying the job to the customer demand behind it."
 msgstr "为供应而创建此作业的销售订单行，将作业与其后的客户需求联系起来。"
 
 msgid "The schedule used to spread this asset's cost over its useful life (straight-line, declining balance, units of production)."
-msgstr "用于在资产的使用寿命内分配该资产成本的折旧方法（直线法、递减余额法、生产单位法）。"
+msgstr "用于在其使用年限内分摊此资产成本的排程（直线法、余额递减法、生产单位法）。"
 
 msgid "The shelves and bins where stock physically sits"
-msgstr "库存物理上存放的货架和箱子"
+msgstr "库存实际存放的货架和料箱"
 
 msgid "The shop supplies and consumables you keep on hand"
-msgstr "您随时准备的店铺用品和消耗品"
+msgstr "你随时拥有的耗材和消耗品"
 
 msgid "The sign-offs every issue using this workflow needs before it can be closed."
-msgstr "使用此工作流的每个问题在关闭前需要的签署。"
+msgstr "使用此工作流的每个问题被关闭前需要的签核。"
 
 msgid "The size of the part"
 msgstr "零件的尺寸"
 
 msgid "The skills and abilities you track for your people"
-msgstr "您为员工跟踪的技能和能力"
+msgstr "你为人员跟踪的技能和能力"
 
 msgid "The smallest quantity this supplier will accept on a PO line for this part; planning rounds up to it."
-msgstr "此供应商将接受此零件的采购单行的最小数量；规划将其四舍五入。"
+msgstr "此供应商将在此零件的采购单行上接受的最小数量；计划向上舍入到它。"
 
 msgid "The specific contact on the selected customer who will own this portal account; their email becomes the sign-in identifier."
 msgstr "将拥有此门户帐户的选定客户上的特定联系人；他们的电子邮件成为登录标识符。"
@@ -15382,25 +15382,25 @@ msgid "The specific contact on the selected supplier who will own this portal ac
 msgstr "将拥有此门户帐户的选定供应商上的特定联系人；他们的电子邮件成为登录标识符。"
 
 msgid "The specific operation on the job above that this PO line is purchasing; only operations marked outside-processing are selectable."
-msgstr "此采购单行购买的上述工作中的特定操作；只有标记为外部处理的操作才可选择。"
+msgstr "此采购单行正在采购的上述工单上的特定工序；仅可选择标记为外协的工序。"
 
 msgid "The specific PO, return, or transfer this receipt posts against; available IDs depend on the source document type above."
-msgstr "此收据过账的特定采购单、退货或转移；可用ID取决于上面的源文档类型。"
+msgstr "此收货过账的特定采购单、退货或调拨；可用的 ID 取决于上述源单据类型。"
 
 msgid "The specific SO, transfer, or RMA this shipment posts against; available IDs depend on the source document type above."
-msgstr "此出货过账的特定销售订单、转移或退货授权；可用ID取决于上面的源文档类型。"
+msgstr "此发货过账的特定销售订单、调拨或 RMA；可用的 ID 取决于上述源单据类型。"
 
 msgid "The standard dimensions your materials are stocked in"
-msgstr "您的原材料库存的标准尺寸"
+msgstr "您的原材料储存的标准尺寸"
 
 msgid "The standard factor (hours, minutes, pieces) operations on this work center are measured in by default; per-operation overrides win when set."
-msgstr "标准系数（小时、分钟、件数）此工作中心的操作默认测量；按操作覆盖在设置时生效。"
+msgstr "此工作中心上的工序默认测量的标准系数(小时、分钟、件数);按工序覆盖优先被应用。"
 
 msgid "The standard factor used to measure this process — hours, minutes, pieces, square feet — when its operations are estimated and costed."
-msgstr "用于衡量此流程的标准系数 - 小时、分钟、件数、平方英尺 - 当估算和成本计算其操作时。"
+msgstr "用于测量此工艺的标准系数——小时、分钟、件数、平方英尺——当其工序被估计和成本计算时。"
 
 msgid "The state of this quote line — Draft, No Quote, Complete; No Quote reveals the Reason field and excludes the line from the quote total."
-msgstr "此报价行的状态 - 草稿、无报价、完成；无报价显示原因字段并将行从报价总计中排除。"
+msgstr "报价行的状态 — 草稿、不报价、完成；不报价时显示原因字段并将该行从报价总计中排除。"
 
 msgid "The statement bucket all accounts under this group will use."
 msgstr "此组下所有帐户将使用的报表组。"
@@ -15409,19 +15409,19 @@ msgid "The step's settings — this run predates recording the values it used."
 msgstr "步骤的设置 — 此运行早于记录其使用的值。"
 
 msgid "The stock sizes this material is purchased and held in; each size becomes a separate selectable variant on jobs and POs."
-msgstr "购买和保持此材料的库存尺寸；每个尺寸在工作和采购单上成为单独的可选变体。"
+msgstr "该原材料购买和存放的规格尺寸；每种规格在工单和采购单中都是可选的变体。"
 
 msgid "The storage bin this line picks from; if blank, picking uses the item's Default Storage Unit."
-msgstr "此行从中拣选的存储箱；如果为空，拣选使用项目的默认存储单位。"
+msgstr "该行拣货所用的料箱；如果为空，拣货将使用该物料的默认存储单元。"
 
 msgid "The storage service didn't respond in time. Please try again."
 msgstr "存储服务未及时响应。请重试。"
 
 msgid "The substances your materials are made of"
-msgstr "您的材料所由成分组成"
+msgstr "你的原材料由什么物质制成"
 
 msgid "The supplier planning suggests first when this item needs to be bought; other suppliers stay available in the dropdown on each PO line."
-msgstr "当需要购买此商品时，规划首先建议的供应商；其他供应商在每条采购单行的下拉列表中保持可用。"
+msgstr "当需要购买该物料时计划首先建议的供应商;其他供应商在每条采购订单行的下拉列表中保持可用。"
 
 msgid "The supplier record this portal account links to; only contacts already on that supplier can be selected as the account holder below."
 msgstr "此门户帐户链接到的供应商记录；只有该供应商上已有的联系人才能被选为以下帐户持有人。"
@@ -15433,22 +15433,22 @@ msgid "The supplier's own reference for this order (their SO number on their sys
 msgstr "此订单的供应商自己的参考（他们系统上的SO编号）；为审计而记录并显示在收据上。"
 
 msgid "The supplier's packing-slip or shipment number, recorded for audit; not used by any posting logic."
-msgstr "供应商的包装单或装运编号，为审计而记录；不由任何过账逻辑使用。"
+msgstr "供应商的装箱单或发货号，记录以供审计；不被任何过账逻辑使用。"
 
 msgid "The suppliers and vendors you buy from"
-msgstr "您购买的供应商和供应商"
+msgstr "你采购的供应商和卖家"
 
 msgid "The suppliers receiving this RFQ; each gets its own line on the RFQ that they respond to with their own pricing."
 msgstr "接收此RFQ的供应商；每个都在RFQ上获得自己的行，他们用自己的定价进行响应。"
 
 msgid "The surface finishes available on your materials"
-msgstr "您的材料上可用的表面处理"
+msgstr "你的原材料可用的表面处理工艺"
 
 msgid "The system passes every in-scope acceptance test in your configured system, with your data; the data is validated; and you sign off. Then go-live."
-msgstr "系统通过了您配置的系统中的所有范围内验收测试，使用您的数据；数据已验证；您签署同意。然后上线。"
+msgstr "系统在您配置的系统中通过了每个范围内的验收测试,使用您的数据;数据已验证;您签署确认。然后上线。"
 
 msgid "The thread linking a sales RFQ, its quote, and the resulting sales order — a join, not a document with its own status."
-msgstr "链接销售RFQ、其报价和生成的销售订单的线程 - 连接，而不是具有自己状态的文档。"
+msgstr "连接销售询价单、其报价和生成的销售订单的线索——一个关联关系，而不是具有自己状态的文件。"
 
 msgid "The timer starts automatically"
 msgstr "计时器自动启动"
@@ -15457,58 +15457,58 @@ msgid "The timer starts manually"
 msgstr "计时器手动启动"
 
 msgid "The tooling and fixtures your operations rely on"
-msgstr "您的运营所依赖的工具和夹具"
+msgstr "你的工序依赖的工装和工装夹具"
 
 msgid "The total to make across all jobs created in this bulk batch; combined with Quantity Per Job to decide how many jobs to create."
-msgstr "在此批量批次中创建的所有工作中要制造的总量；与每项工作的数量结合以决定要创建多少项工作。"
+msgstr "在此批量批次中创建的所有工单中要生产的总计;与每个工单的数量结合以决定创建多少工单。"
 
 msgid "The traceable reference (e.g. NIST standard, master gauge serial) the calibration values were compared against."
-msgstr "对其进行校准值比较的可追踪参考（例如NIST标准，主测量仪序列号）。"
+msgstr "校准值进行比对的可追溯参考(例如NIST标准、标准器序列号)。"
 
 msgid "The traveler lists each item on the bill of materials with its quantity."
-msgstr "工作单列出物料清单上的每个项目及其数量。"
+msgstr "流转卡列出物料清单上的每个物料及其数量。"
 
 msgid "The type controls which default permissions the new employee receives; selecting it here pre-fills the permission matrix from the type's template."
 msgstr "类型控制新员工接收的默认权限；在此处选择它会从类型的模板预填充权限矩阵。"
 
 msgid "The typical number of days between sending work to this supplier for this process and getting it back; planning offsets demand by this much when picking a supplier."
-msgstr "为此流程向此供应商发送工作与收回之间的典型天数；选择供应商时，规划将需求补偿此金额。"
+msgstr "将工作发送给此供应商进行此工艺和取回之间的典型天数;选择供应商时计划以此偏移需求。"
 
 msgid "The unique identifier on this physical unit; one row per serial, quantity is always 1."
 msgstr "此物理单元的唯一标识符；每个序列号一行，数量始终为1。"
 
 msgid "The unit a routing time is expressed in, such as Hours/Piece or Total Hours, telling Carbon whether the time scales with quantity or is fixed per run."
-msgstr "路由时间表示的单位，例如小时/件或总小时数，告诉 Carbon 时间是否随数量变化或每次运行固定。"
+msgstr "路线工时的表达单位,例如小时/件或总小时数,告诉Carbon时间是否随数量扩展或每次运行固定。"
 
 msgid "The unit price of the item at the time of the purchase"
 msgstr "购买时该商品的单价"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each); paired with Conversion Factor."
-msgstr "供应商为此物品定价和发货的单位，当不同于库存单位时（例如，盒子与每个）；与转换因子配对。"
+msgstr "供应商为该物料定价和发货的单位,当与库存单位不同时(例如箱vs件);与换算系数配对。"
 
 msgid "The unit suppliers price and ship this item in, when different from the inventory unit (e.g. case vs each)."
-msgstr "供应商为此物品定价和发货的单位，当不同于库存单位时（例如，盒子与每个）。"
+msgstr "供应商为该物料定价和发货的单位,当与库存单位不同时(例如箱vs件)。"
 
 msgid "The units of measure you buy, stock, and sell in"
 msgstr "您购买、库存和销售的计量单位"
 
 msgid "The US tax depreciation system with IRS property-class tables, run as a separate tax schedule alongside the book schedule."
-msgstr "具有IRS资产等级表的美国税收折旧制度，作为单独的税收计划与账面计划一起运行。"
+msgstr "美国税务折旧系统,包含国税局资产等级表,作为独立的税务计划与账簿计划并行运行。"
 
 msgid "The users in this group; group-scoped permissions and notifications apply to each member, and users may belong to multiple groups (effective permissions are the union)."
 msgstr "此组中的用户；组范围的权限和通知适用于每个成员，用户可以属于多个组（有效权限是并集）。"
 
 msgid "The version of the new document"
-msgstr "新文档的版本"
+msgstr "新文件的版本"
 
 msgid "The version of the new procedure"
-msgstr "新程序的版本"
+msgstr "新程序文件的版本"
 
 msgid "The version stamp for this document; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "此文档的版本戳；新版本创建替换前一个版本而不删除它的副本。"
+msgstr "此文件的版本标记；新版本创建一个副本，取代前一个版本而不删除它。"
 
 msgid "The version stamp for this procedure; new versions create a copy that supersedes the previous one without deleting it."
-msgstr "此程序的版本戳；新版本创建替换前一个版本而不删除它的副本。"
+msgstr "此程序文件的版本标记；新版本创建一个副本，取代前一个版本而不删除它。"
 
 msgid "The warehouse goods on this order will ship from; the customer's Shipping Location is where they'll arrive."
 msgstr "此订单的商品将从其发货的仓库；客户的发货地点是他们到达的地方。"
@@ -15517,10 +15517,10 @@ msgid "The warehouse goods on this quote will ship from; the customer's Shipping
 msgstr "此报价的商品将从其发货的仓库；客户的发货地点是他们到达的地方。"
 
 msgid "The ways equipment fails, for maintenance and quality tracking"
-msgstr "设备故障的方式，用于维护和质量跟踪"
+msgstr "设备失效的方式,用于维护和质量追踪"
 
 msgid "The work center's own bin where picked material is staged for production to draw down, as opposed to its warehouse source shelf."
-msgstr "工作中心自己的料仓，用于暂存拣取的物料供生产领用，与其仓库源货架相对。"
+msgstr "工作中心自身的料箱,拣货的原材料在此暂存供生产领取,与其仓库源货架相对。"
 
 msgid "The working hours and calendars that drive scheduling"
 msgstr "驱动日程安排的工作时间和日历"
@@ -15535,19 +15535,19 @@ msgid "Then by"
 msgstr "然后按"
 
 msgid "There are no active supplier quotes to compare for this RFQ."
-msgstr "此RFQ没有有效的供应商报价可比较。"
+msgstr "此询价单没有可比较的启用供应商报价。"
 
 msgid "There are outside operations associated with this job that have no suppliers. Please assign a supplier to each outside operation before releasing it."
-msgstr "此工作有无供应商的外部操作。请在发布前为每个外部操作分配一个供应商。"
+msgstr "有与此工单相关的外包工序但没有分配供应商。请在发放之前为每个外包工序分配一个供应商。"
 
 msgid "There's nothing outstanding to apply these credits to."
-msgstr "没有未结清的发票可以应用这些信用额。"
+msgstr "没有可应用这些贷方的未结款项。"
 
 msgid "These custom fields will only be available for entities with the same tags"
-msgstr "这些自定义字段仅适用于具有相同标签的实体"
+msgstr "这些自定义字段仅对具有相同标签的实体可用"
 
 msgid "These documents haven't posted to the general ledger, so their amounts are missing from this period. Post or void each one — an undated document receives the posting day's date when it posts."
-msgstr "这些单据尚未过账到总账，因此其金额在本期缺失。过账或作废每一份 — 无日期单据过账时将收到过账日的日期。"
+msgstr "这些文件尚未过账到总账,因此其金额在此期间缺失。过账或作废每一个——无日期的文件在过账时会收到过账日期。"
 
 msgid "These email addresses will be automatically CC'd on all emails sent to suppliers (quotes, purchase orders, etc.)."
 msgstr "这些电子邮件地址将自动抄送到发送给供应商的所有电子邮件（报价单、采购订单等）。"
@@ -15556,13 +15556,13 @@ msgid "These email addresses will be automatically CC'd on all quote emails sent
 msgstr "这些电子邮件地址将自动抄送到发送给客户的所有报价电子邮件中。"
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
-msgstr "这些物料仍需领取。现在完成将标记列表为部分。"
+msgstr "这些物料仍有原材料需要拣货。现在完成将标记列表为部分。"
 
 msgid "These jobs have operations assigned to this work center:"
-msgstr "这些工作有分配给此工作中心的操作："
+msgstr "这些工单在此工作中心分配了工序:"
 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
-msgstr "这些日记账条目仍为草稿状态，因此其借贷金额不在本期分类账中。过账每一份，或将其重新标记日期至较晚的开放期间。"
+msgstr "这些凭证仍是草稿，所以其借方和贷方不在此期间的账簿中。过账每一个，或将其重新标注日期到更后的未结期间。"
 
 msgid "This Carbon instance is missing its Onshape OAuth credentials. Ask an administrator to set them."
 msgstr "此 Carbon 实例缺少 Onshape 的 OAuth 凭据。请让管理员进行设置。"
@@ -15577,7 +15577,7 @@ msgid "This completes the Discovery step."
 msgstr "这完成了发现步骤。"
 
 msgid "This contact has no email address"
-msgstr ""
+msgstr "此联系人没有电子邮件地址"
 
 msgid "This counterparty has nothing outstanding — the payment will be recorded on-account."
 msgstr "该交易对手没有未结余额——该付款将记录为应收账款。"
@@ -15589,10 +15589,10 @@ msgid "This file is no longer available, or you don't have permission to downloa
 msgstr "此文件不再可用，或您没有权限下载它。"
 
 msgid "This Fiscal Year"
-msgstr "本财政年度"
+msgstr "此会计年度"
 
 msgid "This information will be used on document headers"
-msgstr "此信息将用于文档标题"
+msgstr "此信息将用于文件标题"
 
 msgid "This information will be visible to all users, so be careful what you share."
 msgstr "此信息将对所有用户可见，请谨慎分享。"
@@ -15605,10 +15605,10 @@ msgid "This invitation to join {0} has expired. You can request a new invite to 
 msgstr "加入 {0} 的邀请已过期。您可以请求将新邀请发送到您的电子邮件。"
 
 msgid "This invoice has no usable due date — choose one for Stripe."
-msgstr ""
+msgstr "此发票没有可用的到期日——为Stripe选择一个。"
 
 msgid "This invoice will be billed to the Stripe customer already linked to this Carbon customer. To change its details, edit it in the Stripe dashboard."
-msgstr ""
+msgstr "此发票将为已与此Carbon客户关联的Stripe客户计费。要更改其详细信息，请在Stripe仪表板中编辑。"
 
 msgid "This is a controlled environment, so an authenticator app is required."
 msgstr "这是受控环境，因此需要身份验证器应用。"
@@ -15623,13 +15623,13 @@ msgid "This is a unique identifier for the webhook"
 msgstr "这是webhook的唯一标识符"
 
 msgid "This is an ITAR-controlled environment. Access is restricted to U.S. Persons."
-msgstr "这是一个 ITAR 受控环境。访问仅限于美国人。"
+msgstr "这是一个ITAR管制环境。访问仅限于美国人。"
 
 msgid "This is taking longer than expected. It may still finish — if it doesn't, retry the revert to put your data back."
 msgstr "这比预期花费的时间更长。它可能仍会完成——如果没有，请重试还原以恢复您的数据。"
 
 msgid "This is the month your fiscal year starts."
-msgstr "这是您的财政年度开始的月份。"
+msgstr "这是你会计年度开始的月份。"
 
 msgid "This is the month your tax year starts."
 msgstr "这是您的税务年度开始的月份。"
@@ -15638,22 +15638,22 @@ msgid "this item"
 msgstr "此物料"
 
 msgid "This item is built via a configurator and resolves its components per-order; jobs created for it inherit the configurator's resolved BOM."
-msgstr "该项目通过配置器构建，并按订单解析其组件；为其创建的工作继承配置器的解析BOM。"
+msgstr "这个物料是通过配置器构建的，根据订单解析其组件；为它创建的工单继承配置器已解析的 BOM。"
 
 msgid "This item's bill of materials has no inputs with shelf-life enabled, so no expiry will be calculated from the BOM."
-msgstr "此项目的物料清单没有启用保质期的输入，因此不会从物料清单计算过期日期。"
+msgstr "这个物料的物料清单中没有启用保质期的输入，因此不会从 BOM 计算有效期。"
 
 msgid "This job will be received to inventory. It will no longer be available on the shop floor."
-msgstr "此工作将被接收到库存中。它将不再在车间可用。"
+msgstr "该工单将被收入库存。它将不再在车间可用。"
 
 msgid "This job will no longer be available on the shop floor."
 msgstr "此工作将不再在车间可用。"
 
 msgid "This job's own required quantity for the material."
-msgstr "此作业自身对该物料的所需数量。"
+msgstr "这个工单所需的原材料数量。"
 
 msgid "This lot is expired and can't be picked."
-msgstr "此批次已过期，无法领取。"
+msgstr "此批次已过期且无法拣货。"
 
 msgid "This may take a moment. Hang tight."
 msgstr "这可能需要一些时间。请稍候。"
@@ -15665,13 +15665,13 @@ msgid "This Month"
 msgstr "本月"
 
 msgid "This page of your Implementation Hub is being built. Start from the command center while we finish it."
-msgstr "您的实现中心的此页面正在构建中。请从命令中心开始，我们将继续完成它。"
+msgstr "这个实施中心页面正在开发中。在我们完成之前，请从指挥中心开始。"
 
 msgid "This part has {quantityOnHand} on hand at this location. No Stock means it will be neither planned nor consumed."
-msgstr "此零件在此位置有 {quantityOnHand} 件现货。\"无库存\"意味着它既不会被计划也不会被消耗。"
+msgstr "此零件在该地点现有 {quantityOnHand} 件。无库存表示不会被计划或消耗。"
 
 msgid "This part is activated when change notice {activationLockId} is released."
-msgstr "此零件将在更改单 {activationLockId} 发布后激活。"
+msgstr "当变更通知 {activationLockId} 已下达时，这个零件被激活。"
 
 msgid "This part is being phased out."
 msgstr "这个零件正在逐步淘汰。"
@@ -15686,7 +15686,7 @@ msgid "This path only decides what runs next"
 msgstr "此路径仅决定接下来运行什么"
 
 msgid "This period has no journal entries posted to it and can be permanently deleted. This cannot be undone."
-msgstr "此期间未过账任何日记账分录，可以永久删除。此操作无法撤销。"
+msgstr "此期间没有已过账的凭证，可以永久删除。此操作无法撤销。"
 
 msgid "this purchase order"
 msgstr "此采购订单"
@@ -15695,25 +15695,25 @@ msgid "This Quarter"
 msgstr "本季度"
 
 msgid "This removes their authenticator app, so their next sign-in only needs a magic link. Use this when they have lost access to their authenticator. It affects their sign-in for every company they belong to."
-msgstr "这将移除他们的身份验证器应用，因此他们的下次登录只需要一个魔法链接。当他们失去对身份验证器的访问权限时，请使用此选项。它会影响他们对所属每个公司的登录。"
+msgstr "此操作移除其身份验证应用，因此其下次登录只需要魔法链接。当他们无法访问其身份验证器时使用此选项。它影响其所属每个公司的登录。"
 
 msgid "This revision is released (Production). Changes should normally flow through a change notice."
-msgstr "此修订版已发布（生产版）。更改应该通过更改单进行。"
+msgstr "这个修订版已下达（生产）。更改应该通常通过变更通知进行。"
 
 msgid "This revision is released (Production). Open a change notice to modify it."
-msgstr "此修订版已发布（生产版）。打开更改单以修改它。"
+msgstr "此修订版已下达（生产）。打开变更通知以修改它。"
 
 msgid "This run has more steps than we show here. Only the first {MAX_RUN_STEPS} are listed."
 msgstr "此运行的步骤比我们此处显示的要多。仅列出前 {MAX_RUN_STEPS} 个。"
 
 msgid "This runs the workflow for real. It will create records, send notifications and call any webhooks exactly as a live run would. This cannot be undone."
-msgstr "这将真实运行工作流。它将完全按照实时运行的方式创建记录、发送通知和调用任何网络钩子。这无法撤销。"
+msgstr "这会实际运行工作流。它将创建记录、发送通知并调用任何 Webhook，就像实际运行一样。这不能撤销。"
 
 msgid "This sales order has associated jobs. Choose what to do with them."
-msgstr "此销售订单有关联的工作。选择如何处理它们。"
+msgstr "这个销售订单有关联的工单。选择如何处理它们。"
 
 msgid "This sales order has lines that require jobs to be created"
-msgstr "此销售订单有需要创建工作的行项目"
+msgstr "这个销售订单有需要创建工单的行。"
 
 #. placeholder {0}: usageCount === 1 ? "" : "s"
 msgid "This storage type is currently used by {usageCount} storage unit{0}."
@@ -15723,7 +15723,7 @@ msgid "this supplier"
 msgstr "此供应商"
 
 msgid "This tool is activated when change notice {activationLockId} is released."
-msgstr "此工具将在更改单 {activationLockId} 发布后激活。"
+msgstr "当变更通知 {activationLockId} 已下达时，这个刀具被激活。"
 
 msgid "This updates the theme for all users of the application"
 msgstr "这会更新应用程序所有用户的主题"
@@ -15735,7 +15735,7 @@ msgid "This usually takes a few seconds. You can leave the page — it keeps run
 msgstr "这通常需要几秒钟。您可以离开页面——它会继续运行。"
 
 msgid "This version belongs to an open <0>change notice</0>. Edit it there."
-msgstr "此版本属于开放的<0>变更通知</0>。请在那里编辑。"
+msgstr "这个版本属于一个未结的 <0>变更通知</0>。在那里编辑它。"
 
 #. placeholder {0}: lock.readableId
 msgid "This version belongs to change notice <0>{0}</0>. Edit it there."
@@ -15745,16 +15745,16 @@ msgid "This version cannot be opened"
 msgstr "无法打开此版本"
 
 msgid "This version is published"
-msgstr ""
+msgstr "这个版本已发布"
 
 msgid "This version is published. Create a new version to edit."
-msgstr ""
+msgstr "这个版本已发布。创建新版本进行编辑。"
 
 msgid "This version's definition could not be read."
 msgstr "无法读取此版本的定义。"
 
 msgid "This will make this version read-only and replace any material make methods with this version."
-msgstr "这将使此版本为只读，并用此版本替换任何物料制造方法。"
+msgstr "这会使这个版本成为只读，并将任何原材料的制造方法替换为这个版本。"
 
 msgid "This will overwrite the existing job method"
 msgstr "这将覆盖现有的工作方法"
@@ -15766,7 +15766,7 @@ msgid "This will overwrite the existing quote method"
 msgstr "这将覆盖现有的报价方法"
 
 msgid "This will recalculate the unit cost from the active make method's bill of materials and processes using the batch size. The current cost will be overwritten. Do you want to continue?"
-msgstr "这将根据活跃制造方法的物料清单和工艺流程使用批量大小重新计算单位成本。当前成本将被覆盖。您要继续吗？"
+msgstr "这将根据启用的制造方法的物料清单和工艺使用生产批次重新计算单位成本。当前成本将被覆盖。您想继续吗？"
 
 #. placeholder {0}: routeData?.job?.jobId
 #. placeholder {1}: routeData?.job?.salesOrderReadableId
@@ -15774,19 +15774,19 @@ msgid "This will remove {0}'s link to {1}. The job will no longer appear under t
 msgstr "这将移除 {0} 与 {1} 的关联。该工作单将不再显示在销售订单下，发货单也将无法找到它。"
 
 msgid "This will replace all method materials of other revisions with this revision."
-msgstr "这将用此修订版本替换其他修订版本的所有方法材料。"
+msgstr "这将用此修订版替换其他修订版的所有方法原材料。"
 
 msgid "This will replace all method materials of other sizes with this size."
-msgstr "这将用此尺寸替换其他尺寸的所有方法材料。"
+msgstr "这将用此尺寸替换其他尺寸的所有方法原材料。"
 
 msgid "This will set the current version of the make method to Active, making it read-only."
-msgstr "这将把制造方法的当前版本设置为活跃状态，使其变为只读。"
+msgstr "这会将制造方法的当前版本设置为启用，使其成为只读。"
 
 msgid "This will write off the remaining book value of the asset."
 msgstr "这将注销资产的剩余净账面价值。"
 
 msgid "Three-way match"
-msgstr "三方对账"
+msgstr "三单匹配"
 
 #. placeholder {0}: formatDate(endDate)
 msgid "Through {0}"
@@ -15826,7 +15826,7 @@ msgid "Tie-Out unavailable"
 msgstr "结账检验不可用"
 
 msgid "Tightened"
-msgstr "紧张"
+msgstr "加严检验"
 
 msgid "Time of day"
 msgstr "一天中的时间"
@@ -15835,13 +15835,13 @@ msgid "Timecard"
 msgstr "时间卡"
 
 msgid "Timecards"
-msgstr "时间卡"
+msgstr "工时记录"
 
 msgid "Timecards are disabled"
-msgstr "时间卡已禁用"
+msgstr "工时记录已禁用"
 
 msgid "Timecards are enabled"
-msgstr "时间卡已启用"
+msgstr "工时记录已启用"
 
 msgid "Timezone"
 msgstr "时区"
@@ -15859,10 +15859,10 @@ msgid "To Location"
 msgstr "至位置"
 
 msgid "To reactivate, use the row menu and choose Send Invite. The employee becomes active once they accept."
-msgstr "要重新激活，请使用行菜单并选择发送邀请。员工接受后即会激活。"
+msgstr "要重新激活，请使用行菜单并选择发送邀请。员工接受后将变为启用。"
 
 msgid "To Receive"
-msgstr "待接收"
+msgstr "待收货"
 
 msgid "To Ship"
 msgstr "待发货"
@@ -15871,7 +15871,7 @@ msgid "To Ship and Receive"
 msgstr "待发货和待收货"
 
 msgid "To Storage Unit"
-msgstr "至存储单位"
+msgstr "至存储单元"
 
 msgid "To supplier"
 msgstr "给供应商"
@@ -15886,10 +15886,10 @@ msgid "Toggle"
 msgstr "切换"
 
 msgid "Toggle Assignee"
-msgstr "切换受理人"
+msgstr "切换经办人"
 
 msgid "Toggle break active"
-msgstr "切换中断活动"
+msgstr "切换休息启用"
 
 msgid "Toggle column"
 msgstr "切换列"
@@ -15940,7 +15940,7 @@ msgid "Tools"
 msgstr "工具"
 
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
-msgstr "顶级分类（资产/负债/权益/收益/费用）；仅在根组上设置，由子组继承。"
+msgstr "顶级分类（资产/负债/所有者权益/收入/费用）；仅在根组上设置，由子项继承。"
 
 msgid "Topic"
 msgstr "主题"
@@ -15955,34 +15955,34 @@ msgid "Total Amount"
 msgstr "总金额"
 
 msgid "Total capitalized cost of the asset (purchase price plus freight, install, and other costs that become part of book value)."
-msgstr "资产的总资本化成本（购买价格加运输、安装和其他成为账面价值一部分的成本）。"
+msgstr "资产的总资本化成本（购买价格加运费、安装和其他成为账面价值一部分的成本）。"
 
 msgid "Total discount"
 msgstr "总折扣"
 
 msgid "Total expected production units for units-of-production depreciation; cost is spread per unit produced."
-msgstr "生产单位折旧的总预期生产单位；成本按生产的单位分摊。"
+msgstr "按产量折旧法的预期生产总单位数；成本按生产的每个单位分摊。"
 
 msgid "Total Hours"
-msgstr "总小时"
+msgstr "总计小时"
 
 msgid "Total Minutes"
-msgstr "总分钟"
+msgstr "总计分钟"
 
 msgid "Total Price"
-msgstr "总价"
+msgstr "总价格"
 
 msgid "Total Quantity"
 msgstr "总数量"
 
 msgid "Total quantity on hand for the item across all storage units at this location. Turns red when on hand plus incoming can't cover total demand."
-msgstr "此地点所有存储单元中该物料的现有总数量。当现有数量加上在途数量无法满足总需求时变为红色。"
+msgstr "该地点全部存储单元中物料的总现有量。当现有量加上预期入库无法满足总需求时变为红色。"
 
 msgid "Total quantity required across all active jobs and sales orders at this location — not just this job."
-msgstr "此地点所有活动作业和销售订单所需的总数量——而不仅仅是此作业。"
+msgstr "此地点所有启用的工单和销售订单所需的总数量——不仅仅是此工单。"
 
 msgid "Total scrap quantity"
-msgstr "总废料数量"
+msgstr "总报废数量"
 
 msgid "Total tax"
 msgstr "总税额"
@@ -15997,7 +15997,7 @@ msgid "Total:"
 msgstr "总计："
 
 msgid "Totals"
-msgstr "合计"
+msgstr "总计"
 
 msgid "Traceability"
 msgstr "可追溯性"
@@ -16015,7 +16015,7 @@ msgid "Track every change to your orders, invoices, customers, suppliers, and mo
 msgstr "跟踪对您的订单、发票、客户、供应商等的每项更改。"
 
 msgid "Track real-time inventory by location and bin"
-msgstr "按位置和仓位实时跟踪库存"
+msgstr "按地点和料箱跟踪实时库存"
 
 msgid "Track serial/lot numbers and fulfil sales orders."
 msgstr "跟踪序列号/批号并履行销售订单。"
@@ -16036,16 +16036,16 @@ msgid "Tracked Entities"
 msgstr "追踪实体"
 
 msgid "Tracked entity"
-msgstr "跟踪的实体"
+msgstr "追踪实体"
 
 msgid "Tracked Entity"
 msgstr "追踪实体"
 
 msgid "Tracked entity ID is required but none was found"
-msgstr "已跟踪实体ID是必需的，但未找到"
+msgstr "追踪实体ID是必需的，但未找到"
 
 msgid "Tracked material is pre-selected by pick order (FEFO), even without a picking list."
-msgstr "追踪的材料按照提货顺序（FEFO）预先选择，即使没有提货单。"
+msgstr "追踪原材料按拣货顺序（先到期先出）预选，即使没有拣货单。"
 
 msgid "Tracking"
 msgstr "追踪"
@@ -16063,7 +16063,7 @@ msgid "Tracking Number"
 msgstr "跟踪号码"
 
 msgid "Tracking type"
-msgstr "跟踪类型"
+msgstr "追踪类型"
 
 msgid "Tracking Type"
 msgstr "追踪类型"
@@ -16078,7 +16078,7 @@ msgid "Train & go live"
 msgstr "培训和上线"
 
 msgid "Train the rest of your team (after train-the-trainer)"
-msgstr "培训您团队的其他成员（在培训师培训之后）"
+msgstr "培训班组其余成员（在完成讲师培训后）"
 
 msgid "Training"
 msgstr "培训"
@@ -16090,13 +16090,13 @@ msgid "Training Plan"
 msgstr "培训计划"
 
 msgid "Training your team via the Academy and in-app guides"
-msgstr "通过Academy和应用内指南培训您的团队"
+msgstr "通过 Academy 和应用内指南培训班组"
 
 msgid "Trainings"
 msgstr "培训"
 
 msgid "Transactions will create journal entries and update the general ledger."
-msgstr "交易将创建日记账分录并更新总账。"
+msgstr "交易将创建凭证并更新总账。"
 
 msgid "Transfer"
 msgstr "转移"
@@ -16111,7 +16111,7 @@ msgid "Transfer ID"
 msgstr "转账ID"
 
 msgid "Transfer Lines"
-msgstr "转移行"
+msgstr "调拨行"
 
 msgid "Transfer Ownership"
 msgstr "转移所有权"
@@ -16153,16 +16153,16 @@ msgid "Two-factor authentication"
 msgstr "双因素认证"
 
 msgid "Two-factor authentication disabled"
-msgstr "双因素身份验证已禁用"
+msgstr "双因素认证已禁用"
 
 msgid "Two-factor authentication enabled"
-msgstr "双因素身份验证已启用"
+msgstr "双因素认证已启用"
 
 msgid "Two-Factor Authentication Enforcement"
 msgstr "双因素认证强制执行"
 
 msgid "Two-factor authentication is not enabled."
-msgstr "双因素身份验证未启用。"
+msgstr "双因素认证未启用。"
 
 msgid "Type"
 msgstr "类型"
@@ -16192,7 +16192,7 @@ msgid "Types"
 msgstr "类型"
 
 msgid "U.S. Person Attestation"
-msgstr "美国人证明"
+msgstr "美国人身份证明"
 
 msgid "Unable to unlock"
 msgstr "无法解锁"
@@ -16219,13 +16219,13 @@ msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未计数的行在过账时保持不变——它们不会被清零。"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
-msgstr "在基于需求的重新订购下，规划在计算补充数量时对此滚动窗口内的需求求和。"
+msgstr "在基于需求的再订购下，计划在计算补货数量时对该滚动窗口内的需求进行求和。"
 
 msgid "Under Fixed Reorder Quantity, the exact quantity planning orders each time the reorder point trips."
-msgstr "在固定重新订购数量下,每次触发重新订购点时,计划订单均为精确数量。"
+msgstr "在固定再订货量下，每次达到再订货点时计划订购的确切数量。"
 
 msgid "Under Maximum Quantity policy, planning orders up to this on-hand level when the reorder point trips."
-msgstr "在最大数量政策下,当重新订购点被触发时,计划订单会达到此现有库存水平。"
+msgstr "在最大数量政策下，当达到再订货点时，计划订购至此现有量水平。"
 
 msgid "Undo"
 msgstr "撤销"
@@ -16246,13 +16246,13 @@ msgid "unit of measure"
 msgstr "计量单位"
 
 msgid "Unit of measure"
-msgstr "度量单位"
+msgstr "计量单位"
 
 msgid "Unit of Measure"
 msgstr "计量单位"
 
 msgid "Unit of measure code"
-msgstr "度量单位代码"
+msgstr "计量单位代码"
 
 msgid "Unit of Measures"
 msgstr "计量单位"
@@ -16291,10 +16291,10 @@ msgid "unknown location"
 msgstr "未知位置"
 
 msgid "Unlimited functional support"
-msgstr ""
+msgstr "无限功能支持"
 
 msgid "Unlimited records"
-msgstr ""
+msgstr "无限记录"
 
 msgid "Unlink"
 msgstr "取消链接"
@@ -16306,7 +16306,7 @@ msgid "Unlock"
 msgstr "解锁"
 
 msgid "Unlock with passkey"
-msgstr "使用密钥解锁"
+msgstr "使用通行密钥解锁"
 
 msgid "Unmapped accounts"
 msgstr "未映射的账户"
@@ -16336,13 +16336,13 @@ msgid "Unpin {0}"
 msgstr "取消固定{0}"
 
 msgid "Unposted Documents"
-msgstr "未过账单据"
+msgstr "未过账文档"
 
 msgid "Unpublish"
-msgstr ""
+msgstr "取消发布"
 
 msgid "Unpublish {name}?"
-msgstr ""
+msgstr "取消发布 {name}？"
 
 msgid "Unreceived POs"
 msgstr "未收到的采购订单"
@@ -16360,7 +16360,7 @@ msgid "Unshipped orders"
 msgstr "未发货订单"
 
 msgid "Unsupported source document type: {sourceDocument}"
-msgstr "不支持的源文档类型：{sourceDocument}"
+msgstr "不支持的源单据类型：{sourceDocument}"
 
 msgid "Untitled Diagram"
 msgstr "未命名图表"
@@ -16369,7 +16369,7 @@ msgid "Untitled line"
 msgstr "未命名行"
 
 msgid "Unused picked material flushed back from the work center to the warehouse."
-msgstr "未使用的拣配物料从工作中心冲回仓库。"
+msgstr "未使用的已拣货物料从工作中心冲回至仓库。"
 
 msgid "UoM"
 msgstr "计量单位"
@@ -16441,7 +16441,7 @@ msgid "Update Rule"
 msgstr "更新规则"
 
 msgid "Update source document quantities"
-msgstr "更新源文档数量"
+msgstr "更新源单据数量"
 
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "更新看板信息以进行扫描式补货。"
@@ -16475,7 +16475,7 @@ msgid "Upgrade to unlock {0} rules"
 msgstr "升级以解锁 {0} 规则"
 
 msgid "Upgrade to unlock audit history"
-msgstr "升级以解锁审计历史"
+msgstr "升级以解锁审计历史记录"
 
 msgid "Upload"
 msgstr "上传"
@@ -16528,10 +16528,10 @@ msgid "Usage/Day (90d)"
 msgstr "用量/天 (90天)"
 
 msgid "Use ... to get the next consumable ID"
-msgstr "使用...获取下一个消耗品ID"
+msgstr "使用...获取下一个耗材ID"
 
 msgid "Use ... to get the next material ID"
-msgstr "使用 ... 获取下一个物料 ID"
+msgstr "使用...获取下一个原材料ID"
 
 msgid "Use ... to get the next part ID"
 msgstr "使用 ... 获取下一个零件 ID"
@@ -16549,7 +16549,7 @@ msgid "Use a different email"
 msgstr "使用不同的电子邮件"
 
 msgid "Use metric system for default material dimensions."
-msgstr "使用公制系统作为默认材料尺寸。"
+msgstr "使用公制作为默认原材料尺寸。"
 
 msgid "Used In"
 msgstr "用于"
@@ -16567,19 +16567,19 @@ msgid "Used on the home screen in dark mode"
 msgstr "在深色模式下用于主屏幕"
 
 msgid "Used to categorize items for reporting and analysis"
-msgstr "用于对项目进行分类以用于报告和分析"
+msgstr "用于对物料进行分类以进行报告和分析"
 
 msgid "Used when a cell is empty or doesn't match an option above. Clear it to leave those rows blank."
 msgstr "当单元格为空或与上述任何选项不匹配时使用。清除它以将这些行留空。"
 
 msgid "Useful Life (default)"
-msgstr "使用寿命(默认)"
+msgstr "使用年限（默认）"
 
 msgid "Useful Life (months)"
-msgstr "使用寿命(月)"
+msgstr "使用年限（个月）"
 
 msgid "Useful Life (Months)"
-msgstr "使用寿命(月)"
+msgstr "使用年限（月）"
 
 msgid "User"
 msgstr "用户"
@@ -16594,10 +16594,10 @@ msgid "Users"
 msgstr "用户"
 
 msgid "Users and groups allowed to open or download this document; the uploader is always included."
-msgstr "允许打开或下载此文档的用户和群组;上传者始终包含在内。"
+msgstr "允许打开或下载此文件的用户和组；上传者始终包括在内。"
 
 msgid "Users and groups allowed to rename, replace, or re-label this document; the uploader is always included, and edit access implies view access."
-msgstr "允许重命名、替换或重新标记此文档的用户和群组;上传者始终包含在内,编辑权限隐含查看权限。"
+msgstr "允许用户和组重命名、替换或重新标记此文件；上传者始终被包含，编辑访问权限意味着查看访问权限。"
 
 msgid "Users can update this value for themselves"
 msgstr "用户可以自行更新此值"
@@ -16615,7 +16615,7 @@ msgid "Valid To"
 msgstr "有效期至"
 
 msgid "Validate a sample and approve the migrated data"
-msgstr "验证样本并批准迁移的数据"
+msgstr "验证示例并审批迁移的数据"
 
 msgid "validated"
 msgstr "已验证"
@@ -16654,22 +16654,22 @@ msgid "Variance"
 msgstr "差异"
 
 msgid "Variance between actual and standard BOM component consumption"
-msgstr "实际与标准物料清单成分消耗之间的差异"
+msgstr "实际与标准 BOM 组件消耗的差异"
 
 msgid "Variance between actual and standard routing hours and rates"
-msgstr "实际与标准工艺路线时数和费率之间的差异"
+msgstr "实际与标准工艺路线工时和费率的差异"
 
 msgid "Variance between actual purchase price and standard cost"
 msgstr "实际采购价格与标准成本之间的差异"
 
 msgid "Variance between applied and actual manufacturing overhead"
-msgstr "应用制造间接费与实际制造间接费之间的差异"
+msgstr "应用与实际制造费用之间的差异"
 
 msgid "Variance from physical inventory count adjustments"
-msgstr "物理库存计数调整的差异"
+msgstr "物理库存盘点调整的差异"
 
 msgid "Variance in outside processing costs"
-msgstr "外部加工成本的差异"
+msgstr "委外加工成本的差异"
 
 msgid "Variance only"
 msgstr "仅差异"
@@ -16678,7 +16678,7 @@ msgid "VAT Number"
 msgstr "增值税号"
 
 msgid "Vendor Write-Off Income"
-msgstr "供应商核销收入"
+msgstr "供应商核销收益"
 
 msgid "Verification Error"
 msgstr "验证错误"
@@ -16703,7 +16703,7 @@ msgstr "版本"
 
 #. placeholder {0}: published.versionNumber
 msgid "Version {0} is published now and will be replaced."
-msgstr ""
+msgstr "版本{0}现已发布，将被替换。"
 
 msgid "Version:"
 msgstr "版本："
@@ -16721,10 +16721,10 @@ msgid "View"
 msgstr "查看"
 
 msgid "View Active Jobs"
-msgstr "查看活跃工作"
+msgstr "查看启用工单"
 
 msgid "View Active Quotes"
-msgstr "查看活跃报价"
+msgstr "查看启用报价单"
 
 msgid "View all"
 msgstr "查看全部"
@@ -16736,7 +16736,7 @@ msgid "View Asset"
 msgstr "查看资产"
 
 msgid "View Assigned Jobs"
-msgstr "查看分配的工作"
+msgstr "查看已分配工单"
 
 msgid "View Attachment"
 msgstr "查看附件"
@@ -16766,7 +16766,7 @@ msgid "View Employees"
 msgstr "查看员工"
 
 msgid "View History"
-msgstr "查看历史"
+msgstr "查看历史记录"
 
 msgid "View in Academy"
 msgstr "在学院中查看"
@@ -16787,7 +16787,7 @@ msgid "View Lists"
 msgstr "查看列表"
 
 msgid "View maintenance dispatch"
-msgstr "查看维护派遣"
+msgstr "查看维护工单"
 
 msgid "View Memo"
 msgstr "查看备忘录"
@@ -16799,22 +16799,22 @@ msgid "View notes"
 msgstr "查看备注"
 
 msgid "View Open"
-msgstr "查看开放"
+msgstr "查看未结"
 
 msgid "View Open Actions"
-msgstr "查看开放操作"
+msgstr "查看未结动作"
 
 msgid "View Open Invoices"
 msgstr "查看未结发票"
 
 msgid "View Open Issues"
-msgstr "查看开放问题"
+msgstr "查看未结问题"
 
 msgid "View Open Orders"
 msgstr "查看未结订单"
 
 msgid "View Open POs"
-msgstr "查看开放采购订单"
+msgstr "查看未结采购订单"
 
 msgid "View Open Quotes"
 msgstr "查看未结报价"
@@ -16823,7 +16823,7 @@ msgid "View Open RFQs"
 msgstr "查看未结束的询价单"
 
 msgid "View Payables"
-msgstr "查看应付账款"
+msgstr "查看应付款项"
 
 msgid "View Payment"
 msgstr "查看付款"
@@ -16856,7 +16856,7 @@ msgid "View Receipt"
 msgstr "查看收据"
 
 msgid "View Receivables"
-msgstr "查看应收账款"
+msgstr "查看应收款项"
 
 msgid "View Run"
 msgstr "查看运行"
@@ -16928,16 +16928,16 @@ msgid "Voiding this receipt will:"
 msgstr "作废此收据将："
 
 msgid "Voiding this shipment will:"
-msgstr "取消此货运将会："
+msgstr "作废此发货将："
 
 msgid "Walk each area with your champion and toggle anything out of scope. Codes read Module.Area.Number (ACC.GL.01 = Accounting, General Ledger, item 1)."
-msgstr "与您的项目冠军一起逐个领域进行审查，并切换任何超出范围的内容。代码格式为 Module.Area.Number（ACC.GL.01 = 会计、总账、项目 1）。"
+msgstr "与您的冠军一起查看每个区域，切换任何超出范围的内容。代码格式为 Module.Area.Number（ACC.GL.01 = 会计、总账、项目 1）。"
 
 msgid "Walk your current process, systems, and data"
 msgstr "浏览您当前的流程、系统和数据"
 
 msgid "Want our team alongside you? Expert eyes on your setup, data, and go-live."
-msgstr "想要我们的团队与您并肩同行？专家为您的设置、数据和上线把关。"
+msgstr "希望我们的班组与您合作？专家眼光审视您的设置、数据和上线。"
 
 msgid "Warehouse Transfer"
 msgstr "仓库转移"
@@ -16958,10 +16958,10 @@ msgid "Warn but allow"
 msgstr "警告但允许"
 
 msgid "Warn this many days before expiry"
-msgstr "在过期前的这么多天发出警告"
+msgstr "在有效期前提醒多少天"
 
 msgid "Warn when the person inspecting an inbound item is the same person who received it."
-msgstr "当检查入库物品的人员与收货人员相同时发出警告。"
+msgstr "当检验入库物料的人与收货人相同时发出警告。"
 
 msgid "Warning"
 msgstr "警告"
@@ -16976,7 +16976,7 @@ msgid "We auto-matched each column. Review the values below before continuing."
 msgstr "我们自动匹配了每一列。继续前请查看下面的值。"
 
 msgid "We triage and fix issues fast while your team settles in"
-msgstr "我们快速分类和修复问题，同时您的团队逐步适应"
+msgstr "在您的班组适应期间，我们快速分类和修复问题"
 
 msgid "We've sent a verification code to {email}"
 msgstr "我们已向 {email} 发送了验证码"
@@ -17062,13 +17062,13 @@ msgid "Weeks 7 to 8"
 msgstr "第7至8周"
 
 msgid "Weeks Open"
-msgstr "周数开放"
+msgstr "未结周数"
 
 msgid "Weighted Average"
 msgstr "加权平均"
 
 msgid "Weighted average cost over last year calculated when the invoice is posted"
-msgstr "去年加权平均成本，在发票过账时计算"
+msgstr "上年加权平均成本在发票过账时计算"
 
 msgid "Welcome to Carbon"
 msgstr "欢迎来到 Carbon"
@@ -17077,22 +17077,22 @@ msgid "Welcome, {companyName}"
 msgstr "欢迎，{companyName}"
 
 msgid "What category of failure this is — Mechanical, Electrical, Software, Operator, Material, etc.; rolls up into the failure-mode pareto report so the category breakdown is meaningful."
-msgstr "这是哪种故障类别 — 机械、电气、软件、操作员、材料等;在故障模式帕累托报告中汇总,以便类别明细具有意义。"
+msgstr "这是什么类别的故障 — 机械、电气、软件、操作员、原材料等；汇总到故障模式帕累托报告中，以便类别细分有意义。"
 
 msgid "What changes day to day"
 msgstr "每天变化的内容"
 
 msgid "What changes when you move to Carbon, and roughly what it's worth. Estimates, not a forecast."
-msgstr "当您迁移到 Carbon 时会发生什么变化，以及大致的价值。这些是估计值，而非预测。"
+msgstr "当您切换到 Carbon 时会发生什么变化，以及大致价值。估计值，不是预测。"
 
 msgid "What data"
 msgstr "什么数据"
 
 msgid "What drove inventory up or down, by any dimension"
-msgstr "按任何维度推动库存上升或下降的因素"
+msgstr "什么驱动库存管理增加或减少，按任何维度"
 
 msgid "What happens when a journal is dated in a locked period."
-msgstr "当日记帐日期在锁定期间时会发生什么"
+msgstr "当凭证的日期在已锁定的期间时会发生什么。"
 
 msgid "What is {translatedTerm}?"
 msgstr "{translatedTerm}是什么?"
@@ -17101,16 +17101,16 @@ msgid "What it is"
 msgstr "它是什么"
 
 msgid "What kind of change this is: Version updates how the part is made, Revision revises its details and documents, Replacement Part swaps in a new part number that supersedes the old one, and New Part introduces a net-new part with no predecessor."
-msgstr "这是什么类型的变更：版本更新部件的制造方式，修订版修改其详细信息和文档，替代部件交换新部件编号以取代旧编号，新部件引入没有前身的全新部件。"
+msgstr "这是什么类型的变更：版本更新零件的制造方式，修订版修订其详细信息和文档，替换零件用新的零件编号替换旧零件，新零件引入没有前驱的全新零件。"
 
 msgid "What kind of output this entry records — Production (good units), Scrap (unrecoverable), or Rework (sent back for correction); reveals Scrap Reason when Scrap."
 msgstr "此条目记录的输出类型 — 生产(合格单位)、报废(无法恢复)或返工(送回纠正);当报废时显示报废原因。"
 
 msgid "What kind of PO this is — standard goods, services, outside-processing, or blanket agreement; drives the line layout and the GL posting rules."
-msgstr "这是哪种PO — 标准商品、服务、外部加工或总括协议;确定行布局和GL过账规则。"
+msgstr "这是什么类型的采购订单 — 标准货物、服务、外协或框架协议；驱动行布局和总账过账规则。"
 
 msgid "What kind of quote this is — standard supplier quote, blanket-agreement priced quote, or contract-manufacturing quote; drives the PO line layout when converted."
-msgstr "这是哪种报价 — 标准供应商报价、总括协议价格报价或合同制造报价;转换时确定PO行布局。"
+msgstr "这是什么类型的报价单 — 标准供应商报价、框架协议定价报价单或合同制造报价单；在转换时驱动采购订单行布局。"
 
 msgid "What source this dimension pulls its allowed values from (custom list or an existing entity like customer, location, employee)."
 msgstr "该维度从哪个来源获取其允许的值(自定义列表或现有实体,如客户、位置、员工)。"
@@ -17125,13 +17125,13 @@ msgid "What this receipt is fulfilling — a purchase order, a return, an inboun
 msgstr "此收据正在履行 — 采购订单、退货、入库转移或无父级的手动收据。"
 
 msgid "What this shipment is fulfilling — a sales order, an outbound transfer, an RMA return, or a manual shipment."
-msgstr "此出货正在履行 — 销售订单、出站转移、RMA退货或手动出货。"
+msgstr "这个发货履行什么——销售订单、出站调拨、RMA 退回或手动发货。"
 
 msgid "What this task means"
 msgstr "此任务的含义"
 
 msgid "What this time entry counts as — Labor (operator time), Machine (run time), or Setup (changeover time); each rolls up under a different rate."
-msgstr "此时间条目计数为 — 劳动(操作员时间)、机器(运行时间)或设置(切换时间);每个在不同的费率下汇总。"
+msgstr "这个时间记录计为——人工(操作员时间)、机器(加工时间)或换型(换型时间)；每个都按不同费率累积。"
 
 msgid "What to set up"
 msgstr "要设置什么"
@@ -17155,19 +17155,19 @@ msgid "When {name} changes"
 msgstr "当 {name} 更改时"
 
 msgid "When a finished product's shelf life is set to Calculated, pick which consumed inputs feed the calculation."
-msgstr "当成品的保质期设置为\"计算\"时，选择哪些消耗的投入物料用于计算。"
+msgstr "当成品的保质期设置为计算时，选择哪些已消耗的输入项用于计算。"
 
 msgid "When a serial or batch expires, and what happens if used after — a company policy can Warn, Block, or BlockWithOverride."
 msgstr "当序列号或批次过期时,以及之后使用时会发生什么 — 公司政策可以警告、阻止或使用覆盖阻止。"
 
 msgid "When Carbon committed to having the goods arrive; combined with the shipping method's transit days, this drives Ship Date back-calc."
-msgstr "Carbon何时承诺货物到达;与运输方法的运送天数相结合,这决定了发货日期的向后计算。"
+msgstr "货物的承诺到达日期；结合发货方式的运输天数，这驱动发货日期的反向计算。"
 
 msgid "When expired stock is used"
-msgstr "当使用过期库存时"
+msgstr "当使用已过期库存时"
 
 msgid "When MRP uses the successor for new demand"
-msgstr "当 MRP 为新需求使用后继产品时"
+msgstr "当 MRP 将后继物料用于新需求时"
 
 msgid "When on, attributes in this category show up on a person's public profile; otherwise they're visible to admins only."
 msgstr "启用后,此类别中的属性会显示在人员的公开个人资料中;否则,仅管理员可见。"
@@ -17179,13 +17179,13 @@ msgid "When on, pricing rules (volume discounts, promotions) still apply on top 
 msgstr "启用后,定价规则(批量折扣、促销)仍适用于此覆盖;禁用时,此覆盖是最终价格。"
 
 msgid "When on, scanning this process's operation barcode reports all remaining open quantity as complete in one action; turn off when operators routinely report partials."
-msgstr "启用后,扫描此流程的操作条形码会在一个操作中将所有剩余的未处理数量报告为已完成;当操作员定期报告部分时禁用。"
+msgstr "打开时，扫描此工艺的工序条形码会在一个操作中报告所有剩余未结数量为完成；当操作员例行报告部分时关闭。"
 
 msgid "When on, this party's invoices skip tax calculation; the party is responsible for keeping the exemption certificate current."
 msgstr "启用后,该方的发票会跳过税计算;该方负责使豁免证书保持最新。"
 
 msgid "When on, this price override applies to matching orders; turning off without deleting preserves the history for audit."
-msgstr "启用后,此价格覆盖适用于匹配的订单;禁用时,覆盖被保留而不删除以保留审计历史。"
+msgstr "打开时，此价格覆盖适用于匹配的订单；关闭但不删除会保留历史记录以供审计。"
 
 msgid "When on, this rule fires for every target of its type. Assignment rows are ignored but preserved."
 msgstr "启用时，此规则对其类型的每个目标都会触发。分配行被忽略但保留。"
@@ -17194,19 +17194,19 @@ msgid "When supplier responses are expected back; suppliers see this date on the
 msgstr "何时预期供应商回复;供应商在RFQ门户上看到该日期,Carbon在之后停止接受迟到的回复(可配置)。"
 
 msgid "When the buyer asked for the goods; the supplier may promise something else on Promised Date and post something else again on Delivery Date."
-msgstr "买方何时要求货物;供应商可以在承诺日期承诺其他内容,在交货日期再次过账其他内容。"
+msgstr "当采购员要求货物时；供应商可能在承诺日期承诺其他内容，在交货日期再过账其他内容。"
 
 msgid "When the buyer needs this line's goods on the dock; planning uses this date for stock-availability and outside-processing scheduling."
-msgstr "当买方在码头需要该行的货物时;计划使用该日期进行库存可用性和外部处理调度。"
+msgstr "当采购员需要此行的货物在码头时；计划使用此日期进行库存可用性和委外加工调度。"
 
 msgid "When the customer asked for delivery; the order commits to Promised Date, which may differ."
 msgstr "当客户要求交货时;订单承诺承诺日期,这可能会有所不同。"
 
 msgid "When the customer asked to receive the goods; the quote commits to this date if the customer accepts."
-msgstr "当客户希望接收货物时;如果客户接受,报价承诺该日期。"
+msgstr "客户要求接收货物的时间；如果客户接受，报价单承诺这个日期。"
 
 msgid "When the customer asked to receive the goods."
-msgstr "当客户希望接收货物时。"
+msgstr "客户要求接收货物的时间。"
 
 msgid "When the customer submitted this RFQ; the response clock starts from this date."
 msgstr "当客户提交此RFQ时;响应时钟从该日期开始。"
@@ -17218,10 +17218,10 @@ msgid "When the goods actually arrived; recorded on the receipt and used for sup
 msgstr "货物实际到达时;在收据上记录,用于供应商准时交货评分。"
 
 msgid "When the kanban card is scanned, the job is automatically moved out of draft and released to the floor."
-msgstr "当扫描看板卡时,作业自动从草稿中删除并发布到楼层。"
+msgstr "当扫描看板卡时，工单自动从草稿移出并已下达到工厂。"
 
 msgid "When the receiving location expects the stock to arrive; drives MRP availability at the destination."
-msgstr "当接收位置期望库存到达时;驱动目标地点的MRP可用性。"
+msgstr "当收货地点期望库存到达时；驱动目的地的 MRP 可用性。"
 
 msgid "When the supplier committed to deliver; planning uses this date for the inbound-stock arrival projection."
 msgstr "供应商何时承诺交货;计划使用该日期进行入库库存到达预测。"
@@ -17233,16 +17233,16 @@ msgid "When this gauge becomes due for calibration; once past due it reads Out-o
 msgstr "该量具何时需要校准；过期后读数显示为失准。"
 
 msgid "When this gauge was last successfully calibrated; the next-calibration date recomputes from this value plus the interval."
-msgstr "此仪表上次成功校准时;下一校准日期从该值加上间隔重新计算。"
+msgstr "此量具最后一次成功校准时；下一个校准日期从此值加上间隔重新计算。"
 
 msgid "When this looks right, mark it agreed. That completes the Discovery step on your command center."
 msgstr "当这看起来正确时，将其标记为已同意。这将完成您的指挥中心上的发现步骤。"
 
 msgid "When this specific line is promised to ship; per-line override of the order header's Promised Date for split shipments."
-msgstr "当该特定行被承诺发货时;订单标题的承诺日期的行级别覆盖以分割发货。"
+msgstr "何时承诺发货此特定行；订单抬头承诺日期的按行覆盖用于拆分发货。"
 
 msgid "When this specific lot/serial expires; drives FEFO picking and the shelf-life policy on consumption."
-msgstr "当此特定批次/序列号过期时;驱动FEFO选择和消费时的保质期政策。"
+msgstr "当此特定批次/序列号过期时；驱动先到期先出拣货和消耗时的保质期政策。"
 
 msgid "When you committed to deliver; planning treats this as the demand-due-date for fulfillment."
 msgstr "当您承诺交货时;计划将其视为履行的需求到期日期。"
@@ -17254,13 +17254,13 @@ msgid "Where a workflow notification is delivered — in-app is always sent, whi
 msgstr "工作流通知的传送位置 — 应用内始终发送，电子邮件需要业务或合作伙伴计划，Slack 需要连接您的 Slack 工作区。"
 
 msgid "Where an operation runs; carries labor and quoting rates, with overhead the difference between them."
-msgstr "操作执行的位置。carries劳动和报价费率,开销是它们之间的差异。"
+msgstr "工序运行的位置；携带人工和报价费率，制造费用是它们之间的差异。"
 
 msgid "Where and how you make things."
 msgstr "你在哪里以及如何制造产品。"
 
 msgid "Where goods on this PO are shipped to by default; per-line delivery locations on the PO override this for drop-ship and split-delivery scenarios."
-msgstr "此PO上的货物默认情况下由供应商发送到哪里;PO上每行的交货地点会覆盖此项以进行辅助和分割交货场景。"
+msgstr "此采购订单上的货物默认发货到的位置；采购订单上的按行交货地点为直发和分割交货情景覆盖此设置。"
 
 msgid "Where it lives today"
 msgstr "它今天在哪里"
@@ -17272,7 +17272,7 @@ msgid "Where stock lives and how it ships."
 msgstr "库存存放位置及其发货方式。"
 
 msgid "Where the affected items are used across the system. Informational — nothing here blocks releasing."
-msgstr "受影响的项目在整个系统中的使用位置。仅供参考 — 此处没有任何内容阻止发布。"
+msgstr "受影响的物料在整个系统中的使用位置。仅供参考——此处没有任何内容阻止已下达。"
 
 msgid "Where this entry originated (manual entry, posting from sales/purchasing, recurring template, etc.)."
 msgstr "此条目的来源(手动输入、来自销售/采购的过账、重复模板等)。"
@@ -17281,10 +17281,10 @@ msgid "Where this issue was raised from — internal QA, customer complaint, sup
 msgstr "此问题从何处提出 — 内部QA、客户投诉、供应商审计等;用于报告,不会阻止工作流。"
 
 msgid "Where this line's goods land in stock on receipt; if blank, receipts use the item's Default Storage Unit."
-msgstr "此行的货物在收据时登陆库存的位置;如果为空,收据使用该项目的默认存储单位。"
+msgstr "此行的货物在收货时在库存中的位置；如果为空，收货使用物料的默认存储单元。"
 
 msgid "Where this maintenance request originated — operator-reported, scheduled, condition-monitoring trigger, post-job inspection; drives the source breakdown in maintenance reports."
-msgstr "此维护请求的来源 — 操作员报告、计划、状态监控触发、工作后检查;驱动维护报告中的来源细分。"
+msgstr "此维护请求的来源——操作员报告、计划、条件监控触发、工单后检验；驱动维护报告中的来源分布。"
 
 msgid "Where you are today"
 msgstr "你今天的位置"
@@ -17296,19 +17296,19 @@ msgid "Whether Amount is interpreted as a percentage of the line price or as a f
 msgstr "金额是按行价格的百分比解释，还是按固定货币金额解释。"
 
 msgid "Whether Carbon follows each unit (Serial), each lot (Batch), the quantity (Inventory), or no tracking (Non-Inventory)."
-msgstr "Carbon 是跟踪每个单位 (Serial)、每个批次 (Batch)、数量 (Inventory)，还是不跟踪 (Non-Inventory)。"
+msgstr "Carbon 是否跟踪每个件(序列号)、每个生产批次(批次)、数量(库存管理)或不跟踪(非库存)。"
 
 msgid "Whether the clock starts when the chosen process begins or when it completes."
 msgstr "计时是在所选工序开始时启动，还是在其完成时启动。"
 
 msgid "Whether this lot/serial passes inspection (Pass) or fails (Fail); a Fail blocks the stock from being received into available inventory."
-msgstr "此批次/序列是否通过检验 (Pass) 或未通过 (Fail)；Fail 会阻止库存被收入可用库存。"
+msgstr "此批次/序列号是合格（合格）还是不合格（不合格）；不合格会阻止库存进入可用库存。"
 
 msgid "Whether this process runs on internal work centers (Process, Assembly, or Inspection) or at outside suppliers (Outside Processing); reveals different downstream fields, changes how planning routes work for this process, and defaults the operation type on new operations."
-msgstr "该流程是在内部工作中心（流程、组装或检测）还是在外部供应商处运行（外部加工）；显示不同的下游字段，更改此流程的规划路由工作方式，并默认设置新操作的操作类型。"
+msgstr "此工艺是在内部工作中心(工艺、装配或检验)还是在外部供应商处(委外加工)运行；揭示不同的下游字段，改变计划如何为此工艺路由工作，并为新工序默认操作类型。"
 
 msgid "Whether this work blocks production (Down), degrades it (Impact), is on a planned downtime window (Planned), or has no production impact (No Impact); informs scheduling and customer-facing downtime communication."
-msgstr "此工作是否阻止生产(关闭)、降低生产(影响)、处于计划停机时间窗口(计划)或没有生产影响(无影响);告知计划和面向客户的停机通信。"
+msgstr "此工作是否阻止生产（停机）、降低生产（影响）、处于计划停机时间窗口（已计划）或没有生产影响（无影响）；影响计划和面向客户的停机时间通信。"
 
 msgid "Whether to Add the selected permissions on top of what each user already has, or Update by replacing each user's permission set wholesale with the selection below."
 msgstr "是否将选定的权限添加到每个用户已有的权限之上,或通过将每个用户的权限集替换为下面的选择来更新。"
@@ -17317,49 +17317,49 @@ msgid "Which document drives each inspection flow for this item."
 msgstr "哪份文件驱动此物料的每个检验流程。"
 
 msgid "Which kind of request to send: GET reads something, POST creates, PUT and PATCH update, DELETE removes. A new step starts at GET, and only POST, PUT, and PATCH carry a body."
-msgstr "要发送的请求类型：GET 读取内容，POST 创建，PUT 和 PATCH 更新，DELETE 删除。新步骤从 GET 开始，只有 POST、PUT 和 PATCH 才能携带正文。"
+msgstr "发送哪种类型的请求：GET 读取内容，POST 创建，PUT 和 PATCH 更新，DELETE 删除。新步骤从 GET 开始，仅 POST、PUT 和 PATCH 携带正文。"
 
 msgid "Which manufacturing event starts the shelf-life clock — for example, fill, seal, or final QC."
 msgstr "哪个制造事件启动保质期时钟 — 例如填充、密封或最终QC。"
 
 msgid "Who Can Approve"
-msgstr "谁可以批准"
+msgstr "谁可以审批"
 
 msgid "Who can do what"
 msgstr "谁可以做什么"
 
 msgid "Who does what, across the six steps. Your side is highlighted up top. Own it well and the project moves."
-msgstr "谁做什么，跨越六个步骤。你的部分在上面突出显示。做好它，项目就会推进。"
+msgstr "谁在六个步骤中做什么。您的部分在上面突出显示。做好它，项目就会推进。"
 
 msgid "Who gets trained on what, in what format. Your part: protect the hands-on session time on your champions' calendars early. It's what slips most when companies get busy."
 msgstr "谁接受什么培训，采用什么形式。你的职责：尽早在你的冠军们的日程表上保护动手操作的会议时间。这是公司忙碌时最容易被推迟的事情。"
 
 msgid "Who has to approve quotes, orders, and purchases — and when"
-msgstr "谁必须批准报价、订单和采购 — 以及何时"
+msgstr "谁必须审批报价单、订单和采购——以及何时"
 
 msgid "Who should receive notifications for maintenance-related dispatches?"
-msgstr "谁应该接收维护相关派遣的通知？"
+msgstr "谁应该接收与维护相关的维护工单的通知？"
 
 msgid "Who should receive notifications for operations-related dispatches?"
-msgstr "谁应该接收运营相关派遣的通知？"
+msgstr "谁应该接收与工序相关的维护工单的通知？"
 
 msgid "Who should receive notifications for other dispatches?"
-msgstr "谁应该接收其他派遣的通知？"
+msgstr "谁应该接收其他维护工单的通知？"
 
 msgid "Who should receive notifications for quality-related dispatches?"
-msgstr "谁应该接收与质量相关的派遣通知？"
+msgstr "谁应该接收质量相关维护工单的通知?"
 
 msgid "Who should receive notifications when a digital quote is accepted or expired?"
-msgstr "当数字报价被接受或过期时，谁应该收到通知？"
+msgstr "当数字报价单已接受或已过期时，谁应该收到通知？"
 
 msgid "Who should receive notifications when a gauge goes out of calibration?"
-msgstr "仪表超出校准范围时，谁应该收到通知？"
+msgstr "当量具需要校准时,谁应该接收通知?"
 
 msgid "Who should receive notifications when a new suggestion is submitted?"
 msgstr "当提交新建议时，谁应该收到通知？"
 
 msgid "Who should receive notifications when a RFQ is marked ready for quote?"
-msgstr "当RFQ标记为准备报价时，谁应该收到通知？"
+msgstr "当询价单标记为可报价时,谁应该接收通知?"
 
 msgid "Who should receive notifications when a sales job is completed?"
 msgstr "销售工作完成时，谁应该收到通知？"
@@ -17368,10 +17368,10 @@ msgid "Who should receive notifications when a supplier quote is submitted?"
 msgstr "供应商报价提交时，谁应该收到通知？"
 
 msgid "Who should receive notifications when an inventory job is completed?"
-msgstr "当库存工作完成时，谁应该收到通知？"
+msgstr "当库存管理工单已完成时,谁应该接收通知?"
 
 msgid "Who you buy from."
-msgstr "你从谁那里购买。"
+msgstr "你从哪里采购。"
 
 msgid "Who you sell to and at what price."
 msgstr "你销售给谁以及价格是多少。"
@@ -17386,10 +17386,10 @@ msgid "Why is this included?"
 msgstr "为什么包括这个？"
 
 msgid "Why is this locked?"
-msgstr "为什么这被锁定了？"
+msgstr "为什么这个被已锁定了?"
 
 msgid "Why stock is changing — Positive (found), Negative (lost/scrap), or Set (replace count with a measured value)."
-msgstr "库存为何变化 — 正数(已找到)、负数(丢失/报废)或设置(用测量值替换计数)。"
+msgstr "为什么库存在变化 — 正向（发现）、负向（丢失/报废）或设置（用测量值替换计数）。"
 
 msgid "Why this line is being declined; surfaced on the printable quote and recorded for win-loss reporting."
 msgstr "该行被拒绝的原因;显示在可打印报价上,并为损益报告记录。"
@@ -17404,7 +17404,7 @@ msgid "WIP"
 msgstr "在制品"
 
 msgid "Without a picking list, operators pick material from the Scan tab."
-msgstr "没有提货单，操作人员从扫描选项卡中选择材料。"
+msgstr "没有拣货单的情况下,操作员从扫码选项卡中拣选原材料。"
 
 #. placeholder {0}: quarter.start + 1
 #. placeholder {1}: quarter.end
@@ -17448,25 +17448,25 @@ msgid "Work in process (WIP)"
 msgstr "在制品(WIP)"
 
 msgid "Work in progress"
-msgstr "在制品"
+msgstr "进行中的工作"
 
 msgid "Work in Progress (default)"
-msgstr "在制品(默认)"
+msgstr "在制品（默认）"
 
 msgid "Work in Progress (WIP)"
-msgstr "在制品(WIP)"
+msgstr "在制品（在制品）"
 
 msgid "Work instruction"
-msgstr "工作指令"
+msgstr "作业指导书"
 
 msgid "Work Instructions"
-msgstr "工作说明"
+msgstr "作业指导书"
 
 msgid "Work Phone"
 msgstr "工作电话"
 
 msgid "Work shift tracking is active."
-msgstr "工作班次跟踪处于活跃状态。"
+msgstr "班次跟踪已启用。"
 
 msgid "Workflow"
 msgstr "工作流"
@@ -17487,7 +17487,7 @@ msgid "Worst Performing Machines"
 msgstr "性能最差的机器"
 
 msgid "Write-Down Account"
-msgstr "评估减少账户"
+msgstr "减值账户"
 
 msgid "Write-off"
 msgstr "核销"
@@ -17503,10 +17503,10 @@ msgid "Write-off for {0}"
 msgstr "{0}的核销"
 
 msgid "Write-off of stock scrapped or returned via inspection rejects and NCR dispositions"
-msgstr "通过检验拒绝和不符合项处置报废或退回的库存的报销"
+msgstr "库存核销报废或通过检验拒收和 NCR 处置退回"
 
 msgid "Writing an asset's value down over its life — a monthly batch you create, review as a draft, then post."
-msgstr "在资产的使用寿命期间降低其价值 — 您创建、作为草稿审阅然后过账的月度批次。"
+msgstr "在资产的生命周期内减少其价值——你创建的每月批次,作为草稿进行评审,然后过账。"
 
 msgid "Year"
 msgstr "年份"
@@ -17533,7 +17533,7 @@ msgid "You"
 msgstr "你"
 
 msgid "You belong to more than one company. Pick where to work."
-msgstr "你属于多个公司。选择你要工作的地方。"
+msgstr "您属于多个公司。选择在哪个公司工作。"
 
 msgid "You can change the UI style any time through the theme setting"
 msgstr "您可以随时通过主题设置更改UI样式"
@@ -17551,23 +17551,23 @@ msgid ""
 "                        {0} than the\n"
 "                        ordered quantity of {1}. What would you like\n"
 "                        to do with the extra parts?"
-msgstr "您完成了 {leftoverQuantity} 个以上的 {0}，超过了订购数量 {1}。您想如何处理这些额外的零件？"
+msgstr "您完成了 {leftoverQuantity} 个以上 \n                        {0}，比 \n                        订购数量 {1} 多。您想 \n                        用多余的零件怎么办？"
 
 msgid "You do not have permission to edit workflows"
 msgstr "您没有权限编辑工作流"
 
 msgid "You don't have permission to edit this bill of material."
-msgstr "您没有编辑此物料清单的权限。"
+msgstr "您没有权限编辑此物料清单。"
 
 msgid "You don't have permission to edit this bill of process."
-msgstr "您没有权限编辑此工艺流程单。"
+msgstr "你没有权限编辑此工序清单。"
 
 msgid "You drive it; we make sure it's done right. Expert eyes on your setup, data, and go-live."
-msgstr "你来主导；我们确保一切正确无误。我们的专家会审视你的设置、数据和上线过程。"
+msgstr "您来驾驶；我们确保做得正确。专家的目光关注您的设置、数据和上线。"
 
 #. placeholder {0}: unmappedLines.length
 msgid "You have {0} lines extracted from a PDF that are not mapped to any inventory items."
-msgstr "您有 {0} 行从 PDF 中提取的数据未映射到任何库存项目。"
+msgstr "您有从 PDF 中提取的 {0} 行未映射到任何库存物料。"
 
 msgid "You haven't created any contacts yet."
 msgstr "你还没有创建任何联系人。"
@@ -17576,7 +17576,7 @@ msgid "You lead"
 msgstr "你主导"
 
 msgid "You name a project owner with decision authority"
-msgstr "您指定一个具有决策权的项目所有者"
+msgstr "你指定一个具有决定权的项目负责人"
 
 msgid "You received this item"
 msgstr "您收到了此项目"
@@ -17588,13 +17588,13 @@ msgid "You're live on Carbon"
 msgstr "您已在 Carbon 上线"
 
 msgid "You're one step away from your workspace."
-msgstr ""
+msgstr "您离您的工作区只有一步之遥。"
 
 msgid "You're setting Carbon up yourself, at your own pace"
 msgstr "您正在按照自己的节奏自行设置 Carbon"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "您已打卡 {hoursElapsed} 小时。您忘记打卡下班了吗？"
+msgstr "你已打卡{hoursElapsed}小时。你忘记收工了吗?"
 
 msgid "Your account stays safe even if your login is stolen"
 msgstr "即使您的登录被盗，您的账户也保持安全"
@@ -17603,7 +17603,7 @@ msgid "Your books and how money flows."
 msgstr "您的账簿和资金流向。"
 
 msgid "Your changes go into a new draft version released with this change notice."
-msgstr "您的更改将进入与此更改单一起发布的新草稿版本中。"
+msgstr "您的更改进入与此变更通知一起发布的新草稿版本。"
 
 msgid "Your Console PIN"
 msgstr "您的控制台PIN"
@@ -17630,13 +17630,13 @@ msgid "your Implementation Lead"
 msgstr "你的实施负责人"
 
 msgid "Your invitation is invalid or has already been accepted. Please contact support if you believe this is an error."
-msgstr "您的邀请无效或已被接受。如果您认为这是一个错误，请联系支持。"
+msgstr "您的邀请无效或已被接受。如果您认为这是错误，请联系支持。"
 
 msgid "Your job here: check a real sample of each row, then mark it validated. Foundation data loads first, then master records, then open transactions at cutover."
 msgstr "你的工作是：检查每一行的真实样本，然后标记为已验证。基础数据首先加载，然后是主记录，最后是截止时的未结交易。"
 
 msgid "Your legal name, addresses, branding, and document defaults"
-msgstr "您的法定名称、地址、品牌和文档默认设置"
+msgstr "你的法定名称、地址、品牌和文件默认值"
 
 msgid "Your main point of contact"
 msgstr "您的主要联系人"
@@ -17663,19 +17663,19 @@ msgid "Your real data is loaded and you have checked a sample and approved it."
 msgstr "您的真实数据已加载，您已检查样本并批准了它。"
 
 msgid "Your session was locked after inactivity."
-msgstr "您的会话因不活动而被锁定。"
+msgstr "你的会话因不活动而被已锁定。"
 
 msgid "Your source data is accessible and reasonably clean"
 msgstr "您的源数据可访问且相对干净"
 
 msgid "Your team can free up time to learn Carbon and load your data"
-msgstr "您的团队可以腾出时间学习 Carbon 并加载您的数据"
+msgstr "您的班组可以腾出时间来学习 Carbon 并加载您的数据"
 
 msgid "Your team leads learn Carbon first using the in-app guides and Academy, then bring everyone else up to speed."
-msgstr "您的团队负责人首先使用应用内指南和 Academy 学习 Carbon，然后帮助其他人快速上手。"
+msgstr "您的班组负责人首先使用应用内指南和学院学习 Carbon，然后让其他人都跟上进度。"
 
 msgid "Your team, structure, and access."
-msgstr "您的团队、结构和访问权限。"
+msgstr "您的班组、结构和访问权限。"
 
 msgid "Your vendor list"
 msgstr "您的供应商列表"
@@ -17687,7 +17687,7 @@ msgid "Z1.4 inspection level (I / II / III); higher levels mean larger sample si
 msgstr "Z1.4检验水平(I / II / III);较高级别意味着同一批次的样本量更大。"
 
 msgid "Z1.4 severity (Normal / Tightened / Reduced); switches by rule based on recent lot-acceptance history."
-msgstr "Z1.4严重程度(正常/加严/减少);根据最近的批次接受历史按规则切换。"
+msgstr "Z1.4 严重度（正常检验/加严检验/放宽检验）；根据最近的批次接收历史按规则切换。"
 
 msgid "Zoom Box"
 msgstr "缩放框"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -1088,7 +1088,7 @@ msgid "Add Affected Item"
 msgstr "添加受影响项目"
 
 msgid "Add an extra layer of security by requiring a code from an authenticator app when signing in."
-msgstr "通过在登录时要求来自身份验证应用的代码来增加额外的安全层。"
+msgstr "通过在登录时要求身份验证器应用的代码来添加额外的安全层级。"
 
 msgid "Add any notes about your decision..."
 msgstr "添加关于您的决定的任何备注..."
@@ -8935,7 +8935,7 @@ msgid "Map Lines Now"
 msgstr "立即映射行"
 
 msgid "Map your chart of accounts to the provider's. Posting-default and expense accounts are marked Required; posted journals push using the mapped provider account code."
-msgstr "将您的科目表映射到提供商的科目表。默认过账科目和费用科目标记为必需；已过账日记账使用映射的提供商科目代码进行推送。"
+msgstr "将您的会计科目表映射到提供商的。过账默认账户和费用账户标记为必需；已过账凭证使用映射的提供商账户代码进行推送。"
 
 msgid "Map your current process, systems, and data"
 msgstr "映射您当前的流程、系统和数据"
@@ -11619,7 +11619,7 @@ msgid "Protect training time and attend"
 msgstr "保护培训时间并参加"
 
 msgid "Protect your company with advanced security controls like two-factor authentication enforcement."
-msgstr "使用双因素身份验证等高级安全控制措施保护您的公司。"
+msgstr "通过双因素认证强制执行等高级安全控制来保护您的公司。"
 
 msgid "Protects your company's data"
 msgstr "保护您公司的数据"
@@ -14347,7 +14347,7 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe 会向客户发送发票电子邮件，因此需要地址。这也将保存到 Carbon 中的联系人。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe 还没有此 Carbon 客户的客户。过账将在您的关联账户上创建一个。"
+msgstr "Stripe还没有该Carbon客户对应的客户。过账将在您的连接账户上创建一个。"
 msgstr "Stripe 已有使用此电子邮件的客户"
 
 msgid "Stripe Due Date"
@@ -14357,7 +14357,7 @@ msgid "Stripe emails the invoice to the customer, so an address is required. Thi
 msgstr "Stripe 将发票发送给客户，因此需要地址。这也将保存到 Carbon 中的联系人。"
 
 msgid "Stripe has no customer for this Carbon customer yet. Posting will create one on your connected account."
-msgstr "Stripe 还没有该 Carbon 客户的客户。发布将在您连接的帐户上创建一个。"
+msgstr "Stripe还没有该Carbon客户对应的客户。过账将在您的连接账户上创建一个。"
 
 msgid "Style of kanban output to show in the Kanban table"
 msgstr "看板输出在看板表中显示的样式"
@@ -16219,7 +16219,7 @@ msgid "Two-factor authentication"
 msgstr "双因素认证"
 
 msgid "Two-Factor Authentication"
-msgstr "双因素身份验证"
+msgstr "双因素认证"
 
 msgid "Two-factor authentication disabled"
 msgstr "双因素认证已禁用"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -19,7 +19,7 @@ msgstr "{0} - 组 {1}"
 
 #. placeholder {0}: employeeIds.length
 msgid "{0} Active"
-msgstr "{0} 个活跃"
+msgstr "{0} 启用"
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -44,7 +44,7 @@ msgstr "{0} / {1} 已完成"
 
 #. placeholder {0}: rows.length
 msgid "{0} queued"
-msgstr "已排队 {0} 个"
+msgstr "{0} 排队中"
 
 #. placeholder {0}: activeWork.length
 msgid "{0} running"
@@ -55,10 +55,10 @@ msgid "{0} Scrapped"
 msgstr "{0} 已报废"
 
 msgid "{completions} passed unit(s) will be completed."
-msgstr "{completions} 个合格单位将被完成。"
+msgstr "{completions} 个已通过的件将被完成。"
 
 msgid "{fails} sampled failure(s) are recorded and will NOT be completed — resolve them from the actions menu."
-msgstr "{fails} 个抽样失败已记录，将不会完成 — 请从操作菜单中解决。"
+msgstr "{fails} 个抽样不合格已被记录，将不会被完成 — 从操作菜单解决它们。"
 
 msgid "+{overflow} more"
 msgstr "还有 +{overflow} 个"
@@ -67,13 +67,13 @@ msgid "About"
 msgstr "关于"
 
 msgid "Accept"
-msgstr "接收"
+msgstr "接受"
 
 msgid "Accept Lot"
-msgstr "接收批次"
+msgstr "接受批次"
 
 msgid "Accept lot?"
-msgstr "接收批次？"
+msgstr "接受批次？"
 
 msgid "Account Settings"
 msgstr "账户设置"
@@ -82,7 +82,7 @@ msgid "Acknowledge & finish"
 msgstr "确认并完成"
 
 msgid "Active"
-msgstr "活跃"
+msgstr "启用"
 
 msgid "Actual"
 msgstr "实际"
@@ -97,7 +97,7 @@ msgid "Add a printer in the printing settings to print labels directly."
 msgstr "在打印设置中添加打印机以直接打印标签。"
 
 msgid "Add Inventory"
-msgstr "添加库存"
+msgstr "添加库存管理"
 
 msgid "Add Sample"
 msgstr "添加样本"
@@ -130,10 +130,10 @@ msgid "Are you sure you want to delete this timecard? This cannot be undone."
 msgstr "确定要删除此考勤记录吗？此操作无法撤销。"
 
 msgid "Are you sure you want to end all production events? This will end all active operations without completing or finishing them."
-msgstr "确定要结束所有生产事件吗？这将终止所有活跃工序，而不会完成它们。"
+msgstr "您确定要结束所有生产事件吗？这会结束所有活跃工序而不完成或结束它们。"
 
 msgid "Are you sure you want to finish this operation? This will end all active production events for this operation."
-msgstr "您确定要完成此操作吗？这将结束此操作的所有活跃生产事件。"
+msgstr "您确定要完成此工序吗？这会结束此工序的所有活跃生产事件。"
 
 msgid "Are you sure you want to leave this page?"
 msgstr "您确定要离开此页面吗？"
@@ -142,10 +142,10 @@ msgid "Assigned"
 msgstr "已分配"
 
 msgid "Assigned to Me"
-msgstr "分配给我"
+msgstr "已分配给我"
 
 msgid "Assignee"
-msgstr "负责人"
+msgstr "经办人"
 
 msgid "Authentication Error"
 msgstr "认证错误"
@@ -216,10 +216,10 @@ msgid "Clear Search"
 msgstr "清除搜索"
 
 msgid "Clock In"
-msgstr "上班打卡"
+msgstr "开工"
 
 msgid "Clock Out"
-msgstr "下班打卡"
+msgstr "收工"
 
 msgid "Clocked in since <0/>"
 msgstr "自 <0/> 起打卡"
@@ -278,7 +278,7 @@ msgid "Consumed"
 msgstr "已消耗"
 
 msgid "Consumed expired"
-msgstr "已消耗过期"
+msgstr "已消耗已过期"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -317,7 +317,7 @@ msgid "Default"
 msgstr "默认"
 
 msgid "Default Storage Unit"
-msgstr "默认存储单位"
+msgstr "默认存储单元"
 
 msgid "Delete"
 msgstr "删除"
@@ -341,7 +341,7 @@ msgid "Details"
 msgstr "详情"
 
 msgid "Dispatch not found"
-msgstr "未找到工单"
+msgstr "找不到维护工单"
 
 msgid "Display"
 msgstr "显示"
@@ -360,7 +360,7 @@ msgid "Down for maintenance · {0}"
 msgstr "正在维护 · {0}"
 
 msgid "Down for planned maintenance"
-msgstr "计划维护中"
+msgstr "因已计划维护停机"
 
 msgid "Download"
 msgstr "下载"
@@ -388,7 +388,7 @@ msgid "Due {0}"
 msgstr "截止 {0}"
 
 msgid "Due Date"
-msgstr "截止日期"
+msgstr "到期日"
 
 #. placeholder {0}: board.dueSoon.days
 msgid "Due in the next {0} days?"
@@ -398,10 +398,10 @@ msgid "Due today?"
 msgstr "今天到期？"
 
 msgid "Duplicate batch number"
-msgstr "重复的批次号"
+msgstr "生产批次号重复"
 
 msgid "Duplicate serial number"
-msgstr "重复的序列号"
+msgstr "序列号重复"
 
 msgid "Duration"
 msgstr "时长"
@@ -413,7 +413,7 @@ msgid "Elapsed"
 msgstr "已用时长"
 
 msgid "Email Address"
-msgstr "电子邮箱"
+msgstr "电子邮件地址"
 
 msgid "Empty work centers"
 msgstr "空的工作中心"
@@ -438,7 +438,7 @@ msgid "Estimated"
 msgstr "估计"
 
 msgid "Every unit has a verdict: {passes} passed and {fails} failed. The lot closes with each unit routed to its own outcome."
-msgstr "每个单位都有判定结果：{passes} 个合格，{fails} 个不合格。批次关闭，每个单位按其各自的结果进行处理。"
+msgstr "每件都有一个结果：{passes} 个已通过，{fails} 个不合格。批次随着每件分配到其结果而关闭。"
 
 msgid "Expand features table"
 msgstr "展开功能表"
@@ -519,22 +519,22 @@ msgid "Finish Anyways"
 msgstr "仍然完成"
 
 msgid "Finish setting up your account"
-msgstr ""
+msgstr "完成账户设置"
 
 msgid "Finish with material unpicked?"
-msgstr "物料未拣选完毕，是否完成？"
+msgstr "物料未拣货的情况下要完成吗？"
 
 msgid "Forgot to Clock Out?"
-msgstr "忘记打卡下班了？"
+msgstr "忘记收工了吗？"
 
 msgid "Go back to operation"
 msgstr "返回操作"
 
 msgid "Go to onboarding"
-msgstr ""
+msgstr "前往入门"
 
 msgid "How many were actually picked?"
-msgstr "实际上捡了多少个？"
+msgstr "实际拣了多少？"
 
 msgid "How many?"
 msgstr "多少个？"
@@ -592,7 +592,7 @@ msgid "Issue"
 msgstr "发放"
 
 msgid "Issue Material"
-msgstr "发放物料"
+msgstr "领料"
 
 msgid "Issue Type"
 msgstr "问题类型"
@@ -619,10 +619,10 @@ msgid "Job Traveler"
 msgstr "工单流转卡"
 
 msgid "Jobs"
-msgstr "工作"
+msgstr "工单"
 
 msgid "Keep picking"
-msgstr "继续拣选"
+msgstr "继续拣货"
 
 msgid "Kit"
 msgstr "套件"
@@ -700,16 +700,16 @@ msgid "Maintenance Completed"
 msgstr "维护已完成"
 
 msgid "Maintenance overdue"
-msgstr "维护逾期"
+msgstr "维护已逾期"
 
 msgid "Make a replacement"
 msgstr "制作替换件"
 
 msgid "Manually add items to inventory"
-msgstr "手动添加物料到库存"
+msgstr "手动添加物料至库存管理"
 
 msgid "Manually remove items from inventory"
-msgstr "手动从库存中移除物料"
+msgstr "手动从库存管理中移除物料"
 
 msgid "Mark Short"
 msgstr "标记短缺"
@@ -718,7 +718,7 @@ msgid "matches"
 msgstr "匹配"
 
 msgid "Materials"
-msgstr "物料"
+msgstr "原材料"
 
 msgid "Maximum number of records reached"
 msgstr "已达到最大记录数"
@@ -773,16 +773,16 @@ msgid "No"
 msgstr "否"
 
 msgid "No active job at this work center"
-msgstr "该工作中心没有活跃作业"
+msgstr "此工作中心无活跃工单"
 
 msgid "No active maintenance dispatches"
-msgstr "无活跃的维护工单"
+msgstr "没有启用的维护工单"
 
 msgid "No active operations"
-msgstr "无活跃工序"
+msgstr "没有启用的工序"
 
 msgid "No active work centers at this location."
-msgstr "该位置没有活跃工作中心。"
+msgstr "此地点没有启用的工作中心。"
 
 msgid "No assigned operations"
 msgstr "无已分配工序"
@@ -797,7 +797,7 @@ msgid "No available tracked entities found"
 msgstr "未找到可用的追踪实体"
 
 msgid "No dispatches assigned to you"
-msgstr "没有分配给您的工单"
+msgstr "没有分配给您的维护工单"
 
 msgid "No files"
 msgstr "无文件"
@@ -815,13 +815,13 @@ msgid "No matches. Type to create one."
 msgstr "没有匹配项。输入以创建一个。"
 
 msgid "No materials"
-msgstr "无物料"
+msgstr "没有原材料"
 
 msgid "No open jobs"
-msgstr "没有开放的工作"
+msgstr "没有未结的工单"
 
 msgid "No open units to allocate"
-msgstr "没有可分配的开放单位"
+msgstr "没有未结的件可分配"
 
 msgid "No operators"
 msgstr "无操作员"
@@ -833,7 +833,7 @@ msgid "No options found."
 msgstr "未找到选项。"
 
 msgid "No picking lists assigned"
-msgstr "未分配拣货单"
+msgstr "没有分配的拣货单"
 
 msgid "No printer configured"
 msgstr "未配置打印机"
@@ -875,7 +875,7 @@ msgid "No time entries for this week"
 msgstr "本周无考勤记录"
 
 msgid "No warehouse stock is on record for this item. You can still pick it — on-hand will go negative until the count is reconciled."
-msgstr "此项目没有仓库库存记录。您仍然可以领取它——现有库存将变为负数，直到库存被核对。"
+msgstr "此物料的仓库库存无记录。您仍可拣货 — 库存将为负数，直到数量被核对。"
 
 msgid "No Work Center"
 msgstr "无工作中心"
@@ -918,16 +918,16 @@ msgid "Oops. You shouldn't see this page. Eventually it will be a landing page."
 msgstr "抱歉，您不应该看到此页面。此页面最终将成为首页。"
 
 msgid "Open"
-msgstr "打开"
+msgstr "未结"
 
 msgid "Open a display on the screen mounted at the work center and leave it running. Each board refreshes on its own."
-msgstr "在安装在工作中心的屏幕上打开显示，然后让其运行。每个面板都会自动刷新。"
+msgstr "在安装于工作中心的屏幕上打开显示屏并保持其运行。每个看板自动刷新。"
 
 msgid "Open an NCR for MRB disposition"
-msgstr "为 MRB 处置打开 NCR"
+msgstr "为MRB处置打开NCR"
 
 msgid "Open Jobs"
-msgstr "开放工作"
+msgstr "未结工单"
 
 msgid "Operations"
 msgstr "工序"
@@ -951,7 +951,7 @@ msgid "Overall result"
 msgstr "总体结果"
 
 msgid "Overdue PMs?"
-msgstr "逾期的 PM？"
+msgstr "已逾期的PM？"
 
 msgid "Parameters"
 msgstr "参数"
@@ -966,34 +966,34 @@ msgid "Partial Disposition"
 msgstr "部分处置"
 
 msgid "Passed Inspection"
-msgstr "检验通过"
+msgstr "已通过检验"
 
 msgid "Passkey unlock failed"
-msgstr "密钥解锁失败"
+msgstr "通行密钥解锁失败"
 
 msgid "Pause"
 msgstr "暂停"
 
 msgid "Pick"
-msgstr "拣选"
+msgstr "拣货"
 
 msgid "Pick tracked item"
-msgstr "拣选追踪项目"
+msgstr "拣货追踪物料"
 
 msgid "Picked"
-msgstr "已拣选"
+msgstr "已拣货"
 
 msgid "Picked quantity"
-msgstr "已拣选数量"
+msgstr "已拣货数量"
 
 #. placeholder {0}: startColumn?.title
 #. placeholder {1}: startIndex + 1
 #. placeholder {2}: columnOrder.length
 msgid "Picked up Column {0} at position: {1} of {2}"
-msgstr "已拾取列 {0}，位于第 {1} 个位置（共 {2} 个）"
+msgstr "在位置{1}（共{2}）处选取了列{0}"
 
 msgid "Picking"
-msgstr "拣选"
+msgstr "拣货"
 
 msgid "Pin Out"
 msgstr "退出登录"
@@ -1008,7 +1008,7 @@ msgid "Please select an item"
 msgstr "请选择一个物料"
 
 msgid "PM schedule lapsed"
-msgstr "PM 计划已过期"
+msgstr "PM排程已逾期"
 
 msgid "Prev"
 msgstr "上一个"
@@ -1026,7 +1026,7 @@ msgid "Priority"
 msgstr "优先级"
 
 msgid "Procedure"
-msgstr "程序"
+msgstr "程序文件"
 
 msgid "Process"
 msgstr "工艺"
@@ -1075,10 +1075,10 @@ msgid "Record Partial"
 msgstr "记录部分"
 
 msgid "Reject"
-msgstr "退收"
+msgstr "拒绝"
 
 msgid "Reject Lot"
-msgstr "退收批次"
+msgstr "拒绝批次"
 
 msgid "Remove"
 msgstr "移除"
@@ -1087,13 +1087,13 @@ msgid "Remove filter"
 msgstr "移除筛选"
 
 msgid "Remove Inventory"
-msgstr "移除库存"
+msgstr "移除库存管理"
 
 msgid "Remove part"
 msgstr "移除零件"
 
 msgid "Reopen the subassembly and create a replacement unit"
-msgstr "重新打开子装配体并创建替换单元"
+msgstr "重新打开子装配件并创建替代件"
 
 msgid "Result"
 msgstr "结果"
@@ -1117,25 +1117,25 @@ msgid "Save"
 msgstr "保存"
 
 msgid "Scan"
-msgstr "扫描"
+msgstr "扫码"
 
 msgid "Scan a tracked entity to add the first sample column."
-msgstr "扫描跟踪实体以添加第一个样本列。"
+msgstr "扫码追踪实体以添加第一个样本列。"
 
 msgid "Scan or enter serial number"
-msgstr "扫描或输入序列号"
+msgstr "扫码或输入序列号"
 
 msgid "Scan or enter tracked entity ID, serial, or batch"
-msgstr "扫描或输入跟踪实体 ID、序列号或批次"
+msgstr "扫码或输入追踪实体ID、序列号或生产批次"
 
 msgid "Scan or enter tracking number"
-msgstr "扫描或输入追踪号"
+msgstr "扫码或输入追踪号"
 
 msgid "Scan or search serial number..."
-msgstr "扫描或搜索序列号..."
+msgstr "扫码或搜索序列号..."
 
 msgid "Scan or select a tracked entity from this lot to add it as a sample column, then record its result in the grid."
-msgstr "从此批次扫描或选择跟踪实体以将其添加为样本列，然后在网格中记录其结果。"
+msgstr "从此批次中扫码或选择追踪实体并将其添加为样本列，然后在网格中记录其结果。"
 
 msgid "Schedule"
 msgstr "排程"
@@ -1147,7 +1147,7 @@ msgid "Scrap {readableId}"
 msgstr "报废 {readableId}"
 
 msgid "Scrap material"
-msgstr "报废物料"
+msgstr "报废原材料"
 
 msgid "Scrap quantity"
 msgstr "报废数量"
@@ -1215,7 +1215,7 @@ msgid "Select Serial Number"
 msgstr "选择序列号"
 
 msgid "Select the operation to go back to. All operations from that point to the current operation will be redone."
-msgstr "选择要返回的操作。从该点到当前操作的所有操作都将重新进行。"
+msgstr "选择要回到的工序。从该点到当前工序的所有工序都将重新执行。"
 
 msgid "Selected"
 msgstr "已选择"
@@ -1249,7 +1249,7 @@ msgid "Session locked"
 msgstr "会话已锁定"
 
 msgid "Set Clock Out"
-msgstr "设置下班时间"
+msgstr "设置收工"
 
 msgid "Set clock-out time"
 msgstr "设置下班打卡时间"
@@ -1258,7 +1258,7 @@ msgid "Set up in Carbon"
 msgstr "在 Carbon 中设置"
 
 msgid "Setup"
-msgstr "设置"
+msgstr "换型"
 
 msgid "short"
 msgstr "短缺"
@@ -1279,7 +1279,7 @@ msgid "Sign in with Outlook"
 msgstr "使用 Outlook 登录"
 
 msgid "Sign in with Passkey"
-msgstr "使用密钥登录"
+msgstr "使用通行密钥登录"
 
 msgid "Sign out"
 msgstr "登出"
@@ -1316,7 +1316,7 @@ msgstr "工位：{stationName}"
 
 #. placeholder {0}: inspection.lotSize
 msgid "Statistical acceptance failed, so the entire lot of {0} is considered non-conforming (ISO 9001:2015 §8.7) — {passes} sampled pass(es) and {fails} failure(s). Route the units below to scrap or rework, or record the verdict only."
-msgstr "统计验收失败，因此整个批次 {0} 被视为不符合要求 (ISO 9001:2015 §8.7) — {passes} 个样品合格和 {fails} 个失败。将下面的单位路由到报废或返工，或仅记录判定结果。"
+msgstr "统计验收失败，因此全部 {0} 的批次被视为不合格（ISO 9001:2015 §8.7）— {passes} 个样品合格，{fails} 个不合格。将下列单位路由到报废或返工，或仅记录判定。"
 
 msgid "Status"
 msgstr "状态"
@@ -1334,7 +1334,7 @@ msgid "Steps are missing"
 msgstr "缺少步骤"
 
 msgid "Storage Unit"
-msgstr "存储单位"
+msgstr "存储单元"
 
 msgid "Submit anonymously"
 msgstr "匿名提交"
@@ -1355,28 +1355,28 @@ msgid "The completed quantity for this operation is less than the required quant
 msgstr "此工序的完成数量小于所需数量 {targetQuantity}。"
 
 msgid "The lot will be marked Passed and {remaining} remaining unit(s) will be completed at this operation."
-msgstr "该批次将被标记为\"通过\"，{remaining} 个剩余单位将在此操作中完成。"
+msgstr "批次将标记为已通过，{remaining} 个剩余件将在此工序完成。"
 
 msgid "The lot will still be dispositioned, but an NCR cannot be created until at least one Issue Type is configured."
 msgstr "该批次仍将进行处置，但在至少配置一个问题类型之前，无法创建NCR。"
 
 msgid "There are no available or consumed tracked parts for this material."
-msgstr "此材料没有可用或已消耗的追踪件。"
+msgstr "此原材料没有可用或已消耗的受追踪零件。"
 
 msgid "There are serial or batch tracked materials on the bill of material that have not been fully issued. Completing without issuing may result in incorrect traceability records."
-msgstr "物料清单中有序列号或批次追踪的物料尚未完全发放。不发放即完成可能导致追溯记录不正确。"
+msgstr "物料清单中有序列号或生产批次追踪的物料尚未完全领料。未完全领料情况下完成可能导致可追溯性记录不正确。"
 
 msgid "These items still have material to pick. Finishing now marks the list Partial."
-msgstr "这些项目仍有物料需要拣选。现在完成将把列表标记为部分完成。"
+msgstr "这些物料仍有原材料需要拣货。现在完成将标记列表为部分。"
 
 msgid "This lot is expired and can't be picked."
-msgstr "此批次已过期，无法领取。"
+msgstr "此批次已过期，无法拣货。"
 
 msgid "This part was made to order. Scrapping it can reopen its routing to make a replacement."
-msgstr "此部件是按订单生产的。报废它可以重新打开其路线以制作替换件。"
+msgstr "此零件是按订单制造的。将其报废可重新打开其工艺路线以制造替换件。"
 
 msgid "This part will be scrapped from stock. Its requirement stays open so you can issue a replacement."
-msgstr "此部件将从库存中报废。其需求保持打开状态，以便您可以发放替换件。"
+msgstr "此零件将从库存报废。其要求保持未结，以便您可以领料替代品。"
 
 msgid "This unit will be permanently scrapped and a replacement serial number will be created."
 msgstr "此单元将被永久报废，并将创建替换序列号。"
@@ -1402,14 +1402,14 @@ msgstr "总数量"
 
 #. placeholder {0}: formatDuration(totalDuration)
 msgid "Total time: {0}"
-msgstr "总时间：{0}"
+msgstr "总耗时：{0}"
 
 #. placeholder {0}: formatTotalHours(entries)
 msgid "Total: {0}"
-msgstr "合计：{0}"
+msgstr "总计：{0}"
 
 msgid "Tracked Entity"
-msgstr "跟踪实体"
+msgstr "追踪实体"
 
 msgid "Tracking"
 msgstr "追踪"
@@ -1427,7 +1427,7 @@ msgid "Unable to unlock"
 msgstr "无法解锁"
 
 msgid "Unissued serial/batch materials"
-msgstr "未发放的序列号/批次物料"
+msgstr "未领料的序列号/生产批次物料"
 
 msgid "Unknown"
 msgstr "未知"
@@ -1436,7 +1436,7 @@ msgid "Unlock"
 msgstr "解锁"
 
 msgid "Unlock with passkey"
-msgstr "使用密钥解锁"
+msgstr "使用通行密钥解锁"
 
 msgid "Unpick"
 msgstr "取消拣选"
@@ -1450,7 +1450,7 @@ msgstr "非计划停机时间"
 
 #. placeholder {0}: board.unplannedCount.days
 msgid "Unplanned maintenance items, last {0} days"
-msgstr "过去 {0} 天的非计划维护项目"
+msgstr "最近{0}天的计划外维护项"
 
 msgid "Unsaved changes"
 msgstr "未保存的更改"
@@ -1510,13 +1510,13 @@ msgid "You clocked in at <0/>. You can edit your clock-out time below or acknowl
 msgstr "您在 <0/> 打卡。您可以编辑下方的下班时间，或确认您仍在工作。"
 
 msgid "You've been clocked in for {hoursElapsed} hours. Did you forget to clock out?"
-msgstr "您已打卡上班 {hoursElapsed} 小时。您是否忘记打卡下班了？"
+msgstr "您已打卡 {hoursElapsed} 小时。您是否忘记收工？"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
-msgstr ""
+msgstr "您的账户尚未属于任何公司。完成 Carbon ERP 入职流程以继续。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "您的组织需要身份验证器应用。在 Carbon 中设置，然后返回此处。"
 
 msgid "Your session was locked after inactivity."
-msgstr "您的会话因不活动而被锁定。"
+msgstr "您的会话因不活跃而被锁定。"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -520,7 +520,6 @@ msgstr "仍然完成"
 
 msgid "Finish setting up your account"
 msgstr "完成账户设置"
-msgstr "完成您的账户设置"
 
 msgid "Finish with material unpicked?"
 msgstr "物料未拣货的情况下要完成吗？"
@@ -533,7 +532,6 @@ msgstr "返回操作"
 
 msgid "Go to onboarding"
 msgstr "前往入门"
-msgstr "前往入职"
 
 msgid "How many were actually picked?"
 msgstr "实际拣了多少？"
@@ -1516,7 +1514,6 @@ msgstr "您已打卡 {hoursElapsed} 小时。您是否忘记收工？"
 
 msgid "Your account isn't part of a company yet. Complete onboarding in the Carbon ERP to continue."
 msgstr "您的账户尚未属于任何公司。完成 Carbon ERP 入职流程以继续。"
-msgstr "您的账户尚未关联任何公司。请在Carbon ERP中完成入职以继续。"
 
 msgid "Your organization requires an authenticator app. Set it up in Carbon, then come back here."
 msgstr "您的组织需要身份验证器应用。在 Carbon 中设置，然后返回此处。"


### PR DESCRIPTION
## What does this PR do?

- Makes all 12 translated languages use one agreed word for each Carbon term. Translations were produced in parallel batches that each picked their own wording, so the same thing could be named several different ways on one screen (Chinese had six different words for "Job" across 165 strings).
- Adds an approved term list covering 448 Carbon terms in every language, so there is now one source of truth instead of per-batch guesswork.
- Adds a checker that flags translations disagreeing with the approved term, because the existing missing-translation check passes happily while the wording is wrong. That is how this shipped unnoticed.
- Fills the 52 Spanish strings that were never translated, so no language has blank text left.
- Teaches the translation tooling to hand the translator the relevant approved terms for each batch, so new strings come out consistent by default rather than being fixed afterwards.
