### PR TITLE
fix(quality): make Add Actions on an issue actually create the task rows

### DIFF
--- a/apps/erp/app/modules/quality/ui/Issue/ActionTasksList.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/ActionTasksList.tsx
@@ -1,4 +1,6 @@
-import { useCallback } from "react";
+import { toast } from "@carbon/react";
+import { useLingui } from "@lingui/react/macro";
+import { useCallback, useEffect } from "react";
 import { useFetcher, useParams } from "react-router";
 import { ActionTaskList } from "~/components/ActionTasks/ActionTaskList";
 import { useRouteData } from "~/hooks";
@@ -19,33 +21,46 @@ export function ActionTasksList({
   suppliers: { supplierId: string; externalLinkId: string | null }[];
   isDisabled: boolean;
 }) {
+  const { t } = useLingui();
   const { id } = useParams();
   if (!id) throw new Error("id not found");
 
-  const routeData = useRouteData<{ requiredActions: ListItem[] }>(
-    path.to.issue(id)
-  );
-  const addFetcher = useFetcher();
+  const routeData = useRouteData<{
+    requiredActions: ListItem[];
+    nonConformance: { requiredActionIds: string[] | null };
+  }>(path.to.issue(id));
+  const addFetcher = useFetcher<{ error: { message: string } | null }>();
+
+  useEffect(() => {
+    if (addFetcher.data?.error) toast.error(addFetcher.data.error.message);
+  }, [addFetcher.data]);
+
+  const existingIds = routeData?.nonConformance?.requiredActionIds ?? [];
 
   const onAdd = useCallback(
     (selectedIds: string[]) => {
+      // bulkUpdateIssue REPLACES requiredActionIds, so send existing + new.
+      const merged = Array.from(new Set([...existingIds, ...selectedIds]));
       const formData = new FormData();
       formData.append("ids", id);
       formData.append("field", "requiredActionIds");
-      formData.append("value", selectedIds.join(","));
+      formData.append("value", merged.join(","));
       addFetcher.submit(formData, {
         method: "post",
         action: path.to.bulkUpdateIssue
       });
     },
-    [id, addFetcher]
+    [id, addFetcher, existingIds]
   );
 
   return (
     <ActionTaskList
       tasks={tasks}
       reorderAction={path.to.issueActionTasksOrder}
-      templates={routeData?.requiredActions ?? []}
+      templates={(routeData?.requiredActions ?? []).filter(
+        (a) => !existingIds.includes(a.id)
+      )}
+      addEmptyMessage={t`Every required action has already been added.`}
       onAdd={onAdd}
       isAddSubmitting={addFetcher.state !== "idle"}
       isDisabled={isDisabled}

--- a/apps/erp/app/routes/x+/issue+/update.tsx
+++ b/apps/erp/app/routes/x+/issue+/update.tsx
@@ -59,18 +59,28 @@ export async function action({ request }: ActionFunctionArgs) {
       }
 
       const serviceRole = await getCarbonServiceRole();
-      await Promise.all(
-        ids.map(async (id) => {
-          await serviceRole.functions.invoke("create", {
+      // A silent reconcile failure leaves the column and the task list disagreeing.
+      const reconciled = await Promise.all(
+        ids.map((id) =>
+          serviceRole.functions.invoke("create", {
             body: {
               type: "nonConformanceTasks",
               id,
               companyId,
               userId
             }
-          });
-        })
+          })
+        )
       );
+
+      const reconcileError = reconciled.find((r) => r.error)?.error;
+      if (reconcileError) {
+        logger.error(reconcileError);
+        return {
+          error: { message: "Failed to update issue tasks" },
+          data: null
+        };
+      }
 
       return { data: update.data };
     case "source":

--- a/packages/database/supabase/functions/create/index.ts
+++ b/packages/database/supabase/functions/create/index.ts
@@ -383,13 +383,13 @@ serve(async (req: Request) => {
           if (actionTasksToDelete.length > 0) {
             await trx
               .deleteFrom("nonConformanceActionTask")
-              .where("id", "=", actionTasksToDelete)
+              .where("id", "in", actionTasksToDelete)
               .execute();
           }
           if (approvalTasksToDelete.length > 0) {
             await trx
               .deleteFrom("nonConformanceApprovalTask")
-              .where("id", "=", approvalTasksToDelete)
+              .where("id", "in", approvalTasksToDelete)
               .execute();
           }
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Jeder Test im Umfang wird in Ihrem konfigurierten System mit Ihren Daten
 msgid "Every match"
 msgstr "Jede Übereinstimmung"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Jede erforderliche Aufgabe muss erledigt oder übersprungen werden, bevor der Zeitraum geschlossen werden kann."
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Every in-scope test passes in your configured system, with your data."
 msgid "Every match"
 msgstr "Every match"
 
+msgid "Every required action has already been added."
+msgstr "Every required action has already been added."
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Every required task must be Done or Skipped before the period can be closed."
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Todas las pruebas dentro del alcance se aprueban en su sistema configura
 msgid "Every match"
 msgstr "Cada coincidencia"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Todas las tareas requeridas deben estar Completadas u Omitidas antes de que se pueda cerrar el período."
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Tous les tests dans le périmètre réussissent dans votre système conf
 msgid "Every match"
 msgstr "Chaque correspondance"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Chaque tâche requise doit être terminée ou ignorée avant que la période puisse être fermée."
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -6204,6 +6204,9 @@ msgstr "आपकी कॉन्फ़िगर की गई सिस्ट�
 msgid "Every match"
 msgstr "हर मेल"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "अवधि बंद करने से पहले प्रत्येक आवश्यक कार्य को पूर्ण या छोड़ा जाना चाहिए।"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Ogni test nell'ambito passa nel tuo sistema configurato, con i tuoi dati
 msgid "Every match"
 msgstr "Ogni corrispondenza"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Ogni attività richiesta deve essere Completata o Saltata prima che il periodo possa essere chiuso."
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -6204,6 +6204,9 @@ msgstr "スコープ内のすべてのテストが、設定されたシステム
 msgid "Every match"
 msgstr "すべてのマッチ"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "期間を閉じる前に、すべての必須タスクが完了またはスキップされている必要があります。"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -6204,6 +6204,9 @@ msgstr "설정한 시스템에서 귀사의 데이터로 범위 내 모든 테�
 msgid "Every match"
 msgstr "모든 일치"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "기간을 종료하기 전에 모든 필수 작업을 완료하거나 건너뛰어야 합니다."
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Każdy test w zakresie przechodzi w Twoim skonfigurowanym systemie, z Tw
 msgid "Every match"
 msgstr "Każde dopasowanie"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Każde wymagane zadanie musi być oznaczone jako Wykonane lub Pominięte zanim okres będzie mógł być zamknięty."
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Todos os testes no escopo passam no seu sistema configurado, com seus da
 msgid "Every match"
 msgstr "Cada correspondência"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Toda tarefa obrigatória deve ser Concluída ou Saltada antes que o período possa ser fechado."
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Все тесты в области действия проходят в
 msgid "Every match"
 msgstr "Каждое совпадение"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Каждая требуемая задача должна быть завершена или пропущена перед закрытием периода."
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -6204,6 +6204,9 @@ msgstr "Kapsamdaki her test, yapılandırılmış sisteminizde, verilerinizle ge
 msgid "Every match"
 msgstr "Her eşleşme"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "Dönem kapatılmadan önce gerekli tüm görevler Tamamlandı veya Atlandı olarak işaretlenmelidir."
 

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -6204,6 +6204,9 @@ msgstr "您配置的系统中的每项范围内测试都通过了，使用您的
 msgid "Every match"
 msgstr "每次匹配"
 
+msgid "Every required action has already been added."
+msgstr ""
+
 msgid "Every required task must be Done or Skipped before the period can be closed."
 msgstr "期间关闭前，每项必需任务都必须完成或跳过。"
 


### PR DESCRIPTION
## What does this PR do?

- Adding an action to an issue (NCR) now actually creates the action task. Picking an action updated the "Required Actions" list in the right sidebar but the task never appeared in the Actions list, because the background step that creates task rows was crashing on a bad database query and silently rolling everything back.
- Adding an action no longer wipes the actions already on the issue. The Add Actions modal was sending only the newly ticked items as the issue's complete list, so previous ones were dropped. Actions already added are also hidden from the picker now.
- A failed action update now shows an error instead of looking like it worked, so the sidebar and the Actions list can't silently disagree again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevents adding required actions that are already on an issue.
  * Displays a localized error notification when action updates fail.

* **Bug Fixes**
  * Issue task updates now report failures instead of silently succeeding.
  * Correctly removes all obsolete action and approval tasks during reconciliation.

* **Localization**
  * Added the new required-action message to supported locale catalogs. Translations remain pending for several languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->