### PR TITLE
fix(infra): add IP-reputation and known-bad-inputs WAF rule groups

### DIFF
--- a/.ai/plans/2026-08-28-aws-cost-guardrails.md
+++ b/.ai/plans/2026-08-28-aws-cost-guardrails.md
@@ -13,7 +13,13 @@ No WAF was associated; billing/anomaly tooling doesn't exist in GovCloud.
    `mes.nodes.loadBalancer.arn`. This is the primary control for the incident class —
    the scanner's ~2,700 req/5min from a source IP now trips the rate rule, and the
    managed set flags the `/etc/passwd`, `../`, `@fs` traversal probes.
-2. **Request-count autoscaling.** Added `requestCount: 500` to both services' `scaling`
+2. **Two more free managed rule groups on `AppAlbWebAcl`** (ERP + MES):
+   `AWSManagedRulesAmazonIpReputationList` (priority 3) blocks IPs AWS already classifies
+   as bots/scanners/malicious before they cost anything; `AWSManagedRulesKnownBadInputsRuleSet`
+   (priority 4) directly catches the `.env` / `/etc/passwd` / SSRF-probe patterns the
+   common set only partially covers. ~927 WCU total, under the 1500-WCU default max. $0
+   marginal cost, no effect on legitimate traffic.
+3. **Request-count autoscaling.** Added `requestCount: 500` to both services' `scaling`
    (kept `min: 1`, `max: 10`). CPU/mem triggers never fired under the I/O-bound pile-up;
    this adds capacity for *legitimate* sustained bursts. Safe now that the WAF blocks
    floods before they reach targets — otherwise it would scale out to serve garbage.
@@ -76,6 +82,45 @@ new aws.costexplorer.AnomalySubscription("ServiceAnomalySubscription", {
 ```
 Optional hard backstop: a **Budget Action** at a ceiling that applies a restrictive IAM
 policy / notifies SNS. Blunt — prefer `max` + WAF + anomaly alerts for prod.
+
+## To do — Supabase auth rate limit (terraform, NOT SST)
+
+The `/auth/v1/*` endpoints (signup/otp/recover/magiclink) are served by the **Supabase
+edge**, not the ERP/MES ALBs: the `k8s-carbonpublic` ALB's `/*` catch-all fronts Supabase,
+protected by the `carbon-supabase-dev-app` WebACL — which is tagged `ManagedBy: terraform`
+(`Compliance: fedramp-moderate`). That ACL already has `RateLimit` (priority 1) +
+`AWSManagedCommon` (priority 2). So this rule can't be added through `sst.config.ts`; it
+belongs in the Supabase terraform stack. Each auth hit triggers an SES send + DB write, so
+a tight per-IP cap here caps email-bombing/enumeration cost — the global 1000/5min is far
+too loose to stop that. WAFv2 rule to add there (rate-based + scope-down on the URI path):
+
+```hcl
+rule {
+  name     = "AuthEndpointRateLimit"
+  priority = 0   # evaluate before the existing global RateLimit
+  action { block {} }
+  statement {
+    rate_based_statement {
+      limit              = 100   # per IP / 5-min window; tune to real signup volume
+      aggregate_key_type = "IP"
+      scope_down_statement {
+        regex_match_statement {
+          regex_string = "^/auth/v1/(signup|otp|recover|magiclink)"
+          field_to_match { uri_path {} }
+          text_transformation { priority = 0, type = "LOWERCASE" }
+        }
+      }
+    }
+  }
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
+    metric_name                = "AuthEndpointRateLimit"
+  }
+}
+```
+The same two managed groups (IP reputation, known-bad-inputs) are worth adding to that ACL
+too, for parity — also a terraform change, not SST.
 
 ## To do — ALB access logs (GovCloud/SST, follow-up)
 

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -241,7 +241,50 @@ export default $config({
       },
     };
 
-    // WAF web ACL: rate-limit (1000 req/IP/5min) + AWS managed common rule set.
+    // AWS-classified malicious/bot/scanner IPs — blocked before they cost
+    // anything. Free managed group; not part of the common rule set.
+    const amazonIpReputationRule = {
+      name: "AmazonIpReputation",
+      statement: {
+        managedRuleGroupStatement: {
+          name: "AWSManagedRulesAmazonIpReputationList",
+          vendorName: "AWS",
+        },
+      },
+      priority: 3,
+      overrideAction: {
+        none: {},
+      },
+      visibilityConfig: {
+        cloudwatchMetricsEnabled: true,
+        sampledRequestsEnabled: true,
+        metricName: "AmazonIpReputation",
+      },
+    };
+
+    // Catches the .env / /etc/passwd / SSRF-probe patterns from the #1500
+    // scanner incident that the common rule set only partially covers. Free.
+    const knownBadInputsRule = {
+      name: "KnownBadInputs",
+      statement: {
+        managedRuleGroupStatement: {
+          name: "AWSManagedRulesKnownBadInputsRuleSet",
+          vendorName: "AWS",
+        },
+      },
+      priority: 4,
+      overrideAction: {
+        none: {},
+      },
+      visibilityConfig: {
+        cloudwatchMetricsEnabled: true,
+        sampledRequestsEnabled: true,
+        metricName: "KnownBadInputs",
+      },
+    };
+
+    // WAF web ACL: rate-limit (1000 req/IP/5min) + AWS managed rule groups
+    // (common, IP reputation, known-bad-inputs). ~927 WCU, under the 1500 max.
     const webAcl = new aws.wafv2.WebAcl("AppAlbWebAcl", {
       defaultAction: { allow: {} },
       scope: "REGIONAL",
@@ -250,7 +293,12 @@ export default $config({
         sampledRequestsEnabled: true,
         metricName: "AppAlbWebAcl",
       },
-      rules: [rateLimitRule, awsManagedRules],
+      rules: [
+        rateLimitRule,
+        awsManagedRules,
+        amazonIpReputationRule,
+        knownBadInputsRule,
+      ],
     });
 
     // Associate the web ACL with each service's ALB so the rules actually run.


### PR DESCRIPTION
Stacked on #1500 (base = `fix/erp-alb-waf-cost-guardrails`). Retarget to `main` once #1500 merges.

## What

Two **free** AWS managed rule groups added to `AppAlbWebAcl` (covers ERP + MES), on top of the existing rate-limit + common rule set:

- **`AWSManagedRulesAmazonIpReputationList`** (priority 3) — blocks IPs AWS already classifies as bots/scanners/malicious before they cost anything. The common rule set doesn't include this.
- **`AWSManagedRulesKnownBadInputsRuleSet`** (priority 4) — directly catches the `.env` / `/etc/passwd` / SSRF-probe patterns from the #1500 scanner incident that the common set only partially covers.

## Why

#1500 associated the WAF and fixed the immediate exposure; these two groups close the remaining coverage gaps at **$0 marginal cost** (managed groups are free; the ACL + WCU are already paid for) and **no effect on legitimate traffic**.

## Cost / capacity

WCU: common (700) + known-bad-inputs (200) + IP-reputation (25) + rate-based (2) = **~927 WCU, under the 1500-WCU default max** — no capacity change needed.

## Not included — the third gap (Supabase auth rate limit)

The `/auth/v1/*` endpoints (signup/otp/recover/magiclink — each hit = SES send + DB write, the real cost vector) are **not** on the ERP/MES ALBs. They're behind the `k8s-carbonpublic` ALB, governed by the **terraform-managed `carbon-supabase-dev-app` WebACL** (`Compliance: fedramp-moderate`). So a path-scoped rate limit there is a **terraform** change, not SST. Ready-to-add HCL (rate-based + scope-down regex on `^/auth/v1/(signup|otp|recover|magiclink)`) is in `.ai/plans/2026-08-28-aws-cost-guardrails.md`.

## Validate

Same as #1500 — `sst.config.ts` can't be typechecked locally (`.sst/platform` types are generated at deploy). Run `npx --yes sst@3.17.24 diff --stage prod`; the added rule groups should appear as rule changes on the existing ACL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)