### PR TITLE
feat(workflows): let a workflow be owned by the company, not a person

### DIFF
--- a/.ai/specs/2026-08-28-workflow-company-ownership.md
+++ b/.ai/specs/2026-08-28-workflow-company-ownership.md
@@ -1,0 +1,207 @@
+# Workflows: company-owned workflows
+
+- **Status:** In review
+- **Date:** 2026-08-28
+- **Branch:** `feat/workflow-company-ownership`
+- **Prior art:** `.ai/specs/2026-08-24-workflow-publish-unpublish.md`
+
+## 1. Problem
+
+A workflow runs as its owner. `workflow.ownerId` is set once from `createdBy`
+(`workflows.service.ts:126`) and there is no route that reassigns it — `$id.rename.tsx:11-12`
+says so in a comment: "ownership is taken, never assigned". The engine mints a JWT for that
+user on every step and checks their **live** permissions on every node
+(`engine/owner.ts:30-72`, `engine/execute.ts:163`).
+
+So a workflow's continued operation depends on one employee's continued employment:
+
+- `deactivateEmployee` strips the company out of the owner's `userPermission` row and deletes
+  their `userToCompany` row (`packages/auth/src/services/users.server.ts:199-265`).
+- `get_companies_with_employee_permission` then returns nothing for them, every node fails its
+  permission check, and the run ends `Failed` with a no-access error.
+- Nobody can repair it. Ownership cannot be reassigned, and `$id.test-run.tsx:61` refuses a test
+  run to anyone but the owner — so no one else can even reproduce the failure.
+
+The same break has a much smaller trigger than someone leaving: narrowing an employee's
+permissions, or moving them between roles, silently stops a workflow they wrote a year ago.
+
+## 2. Goals
+
+- A workflow can be owned by the company rather than by a person, and keeps running when any
+  employee leaves.
+- The engine, the matcher and the scheduler are unchanged.
+- The service identity is invisible everywhere a person is listed, and is never billed.
+
+## 3. Non-goals
+
+- **Nothing becomes company-owned in this PR.** `insertWorkflow` accepts `ownerKind` and no
+  caller passes `"company"` yet. This ships the ownership model; the first consumer is the
+  approval-policy work.
+- **No ownership transfer UI, and no automatic transfer on deactivation.** Both need the service
+  identity to hold write permissions (§6, D2), which is a decision this PR deliberately defers.
+- Seeded demo workflows stay user-owned, for the same reason — their definitions contain action
+  nodes.
+
+## 4. Design
+
+### 4.1 Data model
+
+```sql
+ALTER TABLE "user" ADD COLUMN "isServiceAccount" BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE "workflow" ADD COLUMN "ownerKind" TEXT NOT NULL DEFAULT 'user'
+  CHECK ("ownerKind" IN ('user', 'company'));
+```
+
+`ownerId` keeps pointing at a real `user` row in both cases. That is the load-bearing choice:
+the engine resolves an owner id and mints a client for it, so `ownerKind` changes nothing below
+the service layer. It is read by the UI, the test-run gate, and (later) company restore.
+
+`ownerKind` must have a DEFAULT: `assertBackupImportable`
+(`packages/jobs/src/inngest/functions/tasks/company-backup.ts:773-800`) rejects a backup missing a
+NOT NULL column with no default, which would make every existing backup unimportable.
+
+`isServiceAccount` is a real column rather than an id-prefix convention because seat billing counts
+`userToCompany` rows and the filter has to be something other than a string shape (§4.4).
+
+### 4.2 The service identity
+
+Three rows per company and no auth account, minted by
+`provision_workflow_service_user(company_id)`:
+
+| Table | Row | Why it is required |
+|---|---|---|
+| `user` | `wfsvc_<companyId>`, `isServiceAccount = true` | the FK target for `workflow.ownerId` |
+| `userPermission` | read-only grants, scoped to the one company | without the row `get_claims` returns `NULL`, which the engine reads as "no permissions" and fails every step |
+| `userToCompany` | `role = 'employee'` | `get_companies_with_employee_permission` intersects it with the permission arrays; every workflow-table RLS policy goes through it |
+
+**No `employee` row, on purpose.** The `employees` view inner-joins `employee`, and that view is
+the sole hydration source for `usePeople` — the store behind every avatar, picker, assignee
+control, table filter and CSV name lookup in ERP and MES. Omitting the row is what keeps the
+identity out of all of them at once.
+
+`public.user` has no FK to `auth.users`, and `getUserScopedClient` self-signs an HS256 JWT with
+`sub: userId` (`packages/auth/src/lib/supabase/client.server.ts:14-37`), so an identity with no
+auth account is still a fully RLS-scoped principal. Precedent: the global `system` user
+(`20230123004317_companies-rls.sql:75-76`) and console operators
+(`users.server.ts:850-943`), which are synthetic `user` rows already.
+
+Provisioning is a SQL function so the backfill and `seed-company` cannot define the identity two
+different ways. It is `SECURITY DEFINER` and execute is revoked from `anon`/`authenticated` —
+it mints a principal, so only the service role may call it.
+
+### 4.3 Read-only grants
+
+Every module gets `<module>_view: [companyId]`; create/update/delete are present as empty arrays
+(every path that mutates permissions assumes the keys exist). The `"0"` all-companies wildcard is
+retired (`20260817030612`), so the company is enumerated.
+
+Read-only is the whole security argument for this design. A gate policy — the first intended
+consumer — contains only condition, compute, lookup and filter nodes, none of which write. Granting
+writes would create a standing all-module principal in every company in exchange for nothing.
+Widening later is additive; narrowing later is a breaking change, so the narrow set is the one that
+has to ship first.
+
+### 4.4 Keeping it invisible
+
+Four surfaces are not covered by the missing `employee` row, because they read `userToCompany` or
+`user` directly:
+
+| Surface | Fix |
+|---|---|
+| `updateSubscriptionQuantityForCompany` counts `userToCompany` rows → **a service identity would be billed as a seat** | filter `isServiceAccount` out of the count (`packages/stripe/src/stripe.server.ts:674-695`) |
+| Settings → Billing "New Owner" dropdown reads `userToCompany` where `role = 'employee'` | filter it out (`billing.tsx:78-92`) |
+| `getUsers` / `getUserEmails` / `resolveUserSelectIds` read `user` with no employee join; `getUsers` is also the MCP tool `users_getUsers` | `.eq("isServiceAccount", false)` on all three |
+| Workflow Owner columns render `EmployeeAvatar`, which shows a nameless blank circle for anyone absent from `usePeople` | new `WorkflowOwner` component renders the identity as "Company" |
+
+The `UserSelect` tree needs no change: browse and search go through `groupMembers` scoped by
+`companyId`, and company-group membership is created by a trigger on `employee` INSERT — which
+never fires here. The auto-created identity group has `companyId = NULL` and `isIdentityGroup =
+true`, both of which `get_user_select_groups` already excludes.
+
+### 4.5 Guards
+
+- `deactivateUser` refuses a service account. Deactivating one would strip the permissions every
+  workflow it owns runs with — precisely the failure this feature exists to prevent — and nothing
+  could restore it. The `deactivateEmployee` call sites inside `createEmployeeAccount` are invite
+  rollback paths that can only ever see a real invited employee, so they need no guard.
+- `deleteSubsidiary` deletes the identity after the company. The company cascade reaches everything
+  scoped by `companyId`, but `user` has no such column, so the row would otherwise be orphaned.
+  Order matters: `workflow.ownerId` references it with no `ON DELETE`, so the workflows must go
+  first.
+
+### 4.6 Test runs
+
+`$id.test-run.tsx` refused any caller who is not the owner, so a company-owned workflow would have
+been untestable by everyone. It now accepts `workflows_update` when `ownerKind = 'company'`. There
+is nothing to escalate to: the identity holds no more than read access, which is strictly less than
+any caller who can already reach this route.
+
+The run executes as `workflow.ownerId` rather than as the caller. For a user-owned workflow those
+are the same value (the gate proves it), so this is not a behaviour change — but it is what makes
+the company-owned test exercise the permissions production will use.
+
+## 5. Files
+
+| Area | Change |
+|---|---|
+| `20260828103412_workflow-company-ownership.sql` | both columns, `workflow_service_user_permissions`, `provision_workflow_service_user`, backfill over existing companies |
+| `packages/workflows/src/owner.ts` | `WorkflowOwnerKind`, `getWorkflowServiceUserId`, `isWorkflowServiceUserId` |
+| `seed-company/index.ts` | provision the identity for new companies |
+| `packages/stripe/src/stripe.server.ts` | exclude service accounts from the seat count |
+| `packages/auth/src/services/users.server.ts` | refuse to deactivate a service account |
+| `apps/erp/.../users.service.ts` | exclude service accounts from three `user` reads |
+| `apps/erp/.../settings.service.ts` | clean up the identity on subsidiary delete |
+| `apps/erp/.../workflows.service.ts` | select and accept `ownerKind`, resolve `ownerId` from it |
+| `apps/erp/.../billing.tsx`, `$id.tsx`, `$id.test-run.tsx` | owner dropdown, test affordance, test-run gate |
+| `apps/erp/.../ui/WorkflowOwner.tsx` + 3 call sites | render a company owner |
+
+## 6. Design decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| D1 Resolve `ownerId` at write time, or at run time from `ownerKind` | Write time — `ownerId` always holds a real user id | Keeps the engine, matcher and scheduler untouched. Run-time resolution would put a lookup on the hottest path in the module |
+| D2 Grant set for the identity | Read-only, all modules | Gate policies contain no writing nodes. Widening is additive; narrowing is breaking |
+| D3 Marker for non-human principals | `user.isServiceAccount` column | Seat billing counts `userToCompany`; an id-prefix check in `packages/stripe` would couple billing to a workflows naming convention |
+| D4 `employee` row for the identity | No | It is the single predicate that hides it from every people surface at once |
+| D5 Where provisioning lives | A SQL function called by both the backfill and `seed-company` | Two definitions of a security principal is one too many |
+| D6 Service identity id | Derived, `wfsvc_<companyId>` | Idempotent provisioning, and no lookup needed to resolve it. `user.id` is a bare PK, so a per-company value is globally unique |
+
+## 7. Acceptance criteria
+
+- [ ] Every existing company has exactly one `wfsvc_` identity after the migration; re-running it
+      changes nothing.
+- [ ] A new company created through onboarding gets one.
+- [ ] `get_claims('wfsvc_<c>', '<c>')` returns `role: employee` and `<module>_view: ['<c>']` for
+      every module, and empty arrays for create/update/delete.
+- [ ] The identity appears in no people picker, employee list, assignee control, avatar, CSV export
+      or `users_getUsers` result.
+- [ ] The Stripe seat count for a company is unchanged by the migration.
+- [ ] Settings → Billing → New Owner does not offer it.
+- [ ] Deactivating it is refused.
+- [ ] Deleting a subsidiary leaves no `wfsvc_` row behind.
+- [ ] A workflow created with `ownerKind: "company"` can be test-run by a `workflows_update` holder
+      and renders "Company" as its owner.
+
+## 8. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| A standing principal with company-wide read access | Medium | Read-only grants; no auth account, so it cannot be logged into; provisioning revoked from `anon`/`authenticated` |
+| The identity leaks into a people surface not covered by the sweep | Low | No `employee` row makes the `employees` view the chokepoint; the four direct `user`/`userToCompany` readers are patched individually |
+| `GET /rest/v1/user` with a company API key still returns the row | Low | Not fixed here: narrowing the `user` SELECT policy is an RBAC change and out of scope for this PR. The row exposes a synthetic name and a synthetic email and nothing else |
+| A company-owned workflow restored into a **different** company points at the source company's identity, and runs with no permissions | Medium | Not reachable yet — nothing creates a company-owned workflow. Company restore must re-point `ownerKind = 'company'` workflows at the target company's identity, and that lands with the first consumer |
+
+## 9. Open questions — resolved before writing
+
+- **Should the identity be an employee?** No — D4.
+- **Should it be able to write?** Not yet — D2. Automatic transfer of an orphaned automation to the
+  company is the obvious next feature and needs this answered again, because those definitions do
+  contain action nodes.
+- **Should `system` be reused instead of a per-company identity?** No. `system` has no
+  `userToCompany` and no `userPermission` row, so `get_claims` returns `NULL` for it in every
+  company; it is a `createdBy` sentinel, not a principal. A per-company identity is also what keeps
+  the grants scoped to one tenant.
+
+## 10. Changelog
+
+- 2026-08-28 — first draft, written against `origin/main` `aae45d601`.

--- a/.claude/rules/workflow-engine.md
+++ b/.claude/rules/workflow-engine.md
@@ -60,6 +60,13 @@ payload, hand it to `executeWorkflowRun`. All the logic is in `engine/`.
 
 A workflow must never be able to do something its owner could not do by hand.
 
+- **Who the owner is** is `workflow.ownerKind`. `user` means the employee who
+  created it — their access IS the workflow's access, and it stops working when
+  they are deactivated. `company` means the per-company service identity
+  `wfsvc_<companyId>`: a `user` row with no auth account, no employee row and
+  read-only grants, provisioned by `provision_workflow_service_user`. `ownerId`
+  holds a real user id in both cases, so nothing in `engine/` branches on the
+  kind — it resolves an id and mints a client for it either way.
 - The owner's client is minted **per step**, inside the step:
   `getUserScopedClient(ownerId, { workflowRunId })`. The token lives five
   minutes; a run outlives that across retries.

--- a/apps/erp/app/modules/settings/settings.service.ts
+++ b/apps/erp/app/modules/settings/settings.service.ts
@@ -17,6 +17,7 @@ import {
   toDocumentTemplate
 } from "@carbon/documents/template";
 import type { JSONContent } from "@carbon/react";
+import { getWorkflowServiceUserId } from "@carbon/workflows";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { z } from "zod";
 import type { plmReleaseControl as plmReleaseControlOptions } from "~/modules/items/items.models";
@@ -105,7 +106,19 @@ export async function deleteSubsidiary(
   client: SupabaseClient<Database>,
   companyId: string
 ) {
-  return client.from("company").delete().eq("id", companyId);
+  const deleted = await client.from("company").delete().eq("id", companyId);
+  if (deleted.error) return deleted;
+
+  // The company cascade reaches everything scoped by companyId, but `user` has
+  // no companyId column, so the company's workflow service identity would be
+  // left behind. It is deleted after the company, never before: workflow.ownerId
+  // references it with no ON DELETE, so the workflows must go first.
+  await client
+    .from("user")
+    .delete()
+    .eq("id", getWorkflowServiceUserId(companyId));
+
+  return deleted;
 }
 
 export async function deleteWebhook(

--- a/apps/erp/app/modules/users/users.service.ts
+++ b/apps/erp/app/modules/users/users.service.ts
@@ -504,7 +504,8 @@ export async function resolveUserSelectIds(
     client
       .from("user")
       .select("id, firstName, lastName, fullName, email, avatarUrl")
-      .in("id", ids),
+      .in("id", ids)
+      .eq("isServiceAccount", false),
     client
       .from("group")
       .select("id, name")
@@ -564,7 +565,8 @@ export async function getUsers(client: SupabaseClient<Database>) {
     client,
     "user",
     "id, firstName, lastName, fullName, email, avatarUrl",
-    (query) => query.eq("active", true).order("lastName")
+    (query) =>
+      query.eq("active", true).eq("isServiceAccount", false).order("lastName")
   );
 }
 
@@ -578,7 +580,8 @@ export async function getUserEmails(
     .from("user")
     .select("email")
     .in("id", userIds)
-    .eq("active", true);
+    .eq("active", true)
+    .eq("isServiceAccount", false);
 
   if (result.error || !result.data) return [];
 

--- a/apps/erp/app/modules/workflows/AGENTS.md
+++ b/apps/erp/app/modules/workflows/AGENTS.md
@@ -6,7 +6,7 @@ The definition schema, validator, catalogs, matcher and engine all live outside 
 
 ## Key Domain Concepts
 
-- **Workflow** — the `workflow` row. Carries `ownerId` and `publishedVersionId`. That pointer IS the on/off switch: set means the workflow runs that version, `NULL` means it is a draft and nothing fires. There is no separate `active` boolean — it was a second switch for the same idea and was removed (migration `20260824163808_workflow-publish-unpublish.sql`). Because the pointer names a version rather than carrying a flag, exactly one version can be published at a time by construction.
+- **Workflow** — the `workflow` row. Carries `ownerId`, `ownerKind` and `publishedVersionId`. That pointer IS the on/off switch: set means the workflow runs that version, `NULL` means it is a draft and nothing fires. There is no separate `active` boolean — it was a second switch for the same idea and was removed (migration `20260824163808_workflow-publish-unpublish.sql`). Because the pointer names a version rather than carrying a flag, exactly one version can be published at a time by construction.
 - **Version** — a `workflowVersion` row holding `nodes`, `edges` and `formatVersion`. Numbered, never named.
 - **Canvas state** — `workflow.canvasState` JSONB: `{ x, y, zoom, panOnScroll }`. Per workflow (not per user, not per version), written by `$id.canvas.tsx` through `updateWorkflowCanvasState`, restored as `defaultViewport`. Node collapse is NOT here — `expanded` lives on each node in the definition and rides the autosave. `/save`, `/canvas` and `/positions` are all excluded from `shouldRevalidate`; revalidating on a canvas write would snap the viewport back to where it was on load, and revalidating on a positions write would remount the builder store mid-drag.
 - **Definition** — `{ formatVersion, nodes, edges }`, validated by `workflowDefinitionSchema` from `@carbon/workflows`. `CURRENT_DEFINITION_FORMAT_VERSION` is **3**; the SQL column default is a stale **1**, so the app always writes the constant explicitly.
@@ -24,12 +24,12 @@ The definition schema, validator, catalogs, matcher and engine all live outside 
 - MUST build version insert/update objects with every key explicitly present — PostgREST writes `NULL` for a present-but-`undefined` key, which would null `nodes`/`edges` past their `'[]'` defaults.
 
 ### Ask First
-- Changing who may own a workflow. A workflow runs with its owner's permissions.
+- Changing who may own a workflow. A workflow runs with its owner's permissions. `ownerKind` picks WHICH principal that is (`user` = the employee who created it, `company` = the company's read-only service identity, `wfsvc_<companyId>`); it is not an escape from the rule.
 - Adding undo. Its absence is a deliberate, recorded decision (recovery is via versions).
 
 ### Never
 - Never write `workflowTriggerEvent`, `workflow.nextRunAt` or `eventSystemSubscription` directly. `syncWorkflowTriggers` is their sole writer, and it is what makes a workflow able to fire at all.
-- Never let `$id.owner.tsx` accept a submitted `ownerId`. It writes the session user, always. An arbitrary id would let anyone with `workflows_update` borrow someone else's access.
+- Never let a route accept a submitted `ownerId`. `insertWorkflow` derives it: the session user for `ownerKind: "user"`, `getWorkflowServiceUserId(companyId)` for `"company"`. An arbitrary id would let anyone with `workflows_update` borrow someone else's access. (There is no `$id.owner.tsx` and no `updateWorkflowOwner`; ownership is still set once at creation.)
 - Never derive node output handles from a hand-written list — use `getNodeHandles(node)`, the same function the validator uses, or the canvas can draw a handle the validator calls `UNKNOWN_HANDLE`.
 - Never add a per-kind component or a second per-kind lookup. All six node kinds render through one `WorkflowNodeCard`; everything that differs between them is data in `ui/Builder/nodes/meta.ts`, which the palette and the card both read. A new kind is a row in `NODE_KIND_META` plus a row in `nodeTypes` — both are exhaustive `Record<WorkflowNodeType, …>`, so missing either fails the build.
 - Never re-export `@carbon/workflows/labels` through the package barrel. `msg` is a build-time macro; only Vite-built app code may import it.
@@ -65,9 +65,8 @@ Routes split in two trees: `x+/workflows+/` (list, create, rename, delete, with 
 
 - `getWorkflows` / `getWorkflow` — list and detail reads
 - `getWorkflowVersions` / `getWorkflowVersion` / `getWorkflowVersionNumbers` — version reads (flat selects; nested embeds across `workflow` + `workflowVersion` trip TS2589 in this app)
-- `insertWorkflow` / `updateWorkflow` — separate rather than one `upsert*`
+- `insertWorkflow` / `updateWorkflow` — separate rather than one `upsert*`. `insertWorkflow` takes an optional `ownerKind` and derives `ownerId` from it; `updateWorkflow` never touches either.
 - `insertWorkflowVersion` / `updateWorkflowDefinition` / `deleteWorkflowVersion`
-- `updateWorkflowOwner` — takes the session user, never a submitted id
 - `checkWorkflowVersionLock` (server) — the published-version lock; the rule is one equality against `publishedVersionId`, so there is no helper wrapping it
 - `updateWorkflowNodePositions` (service) — the positions-only writer behind `$id.positions.tsx`
 - `publishWorkflowVersion` / `unpublishWorkflow` (server) — both call `syncWorkflowTriggers`, which uses Kysely and **bypasses RLS**; the route's `requirePermissions` is the only authorization gate

--- a/apps/erp/app/modules/workflows/ui/Runs/WorkflowRunDetail.tsx
+++ b/apps/erp/app/modules/workflows/ui/Runs/WorkflowRunDetail.tsx
@@ -4,7 +4,7 @@ import { readWorkflowVersion } from "@carbon/workflows";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useState } from "react";
 import { LuCircleAlert, LuCircleSlash, LuTriangle } from "react-icons/lu";
-import { EmployeeAvatar, Hyperlink } from "~/components";
+import { Hyperlink } from "~/components";
 import { path } from "~/utils/path";
 import type {
   WorkflowRunChainEntry,
@@ -12,6 +12,7 @@ import type {
   WorkflowRunStep
 } from "../../workflows.service";
 import { useWorkflowEventLabel, useWorkflowLabel } from "../Builder/catalog";
+import WorkflowOwner from "../WorkflowOwner";
 import { EntityRecordLink } from "./EntityRecordLink";
 import { RunLiveUpdates } from "./RunLiveUpdates";
 import { RunStatus, TestRunBadge } from "./RunStatus";
@@ -148,7 +149,7 @@ export function WorkflowRunDetail({
         {/* Metadata grid */}
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
           <HeaderRow label={t`Owner`}>
-            <EmployeeAvatar employeeId={run.ownerId} />
+            <WorkflowOwner ownerId={run.ownerId} />
           </HeaderRow>
 
           <HeaderRow label={t`Started`}>

--- a/apps/erp/app/modules/workflows/ui/Runs/WorkflowRunsTable.tsx
+++ b/apps/erp/app/modules/workflows/ui/Runs/WorkflowRunsTable.tsx
@@ -11,11 +11,12 @@ import {
   LuUser,
   LuZap
 } from "react-icons/lu";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { Hyperlink, Table } from "~/components";
 import { useUser } from "~/hooks";
 import { path } from "~/utils/path";
 import type { WorkflowRun } from "../../workflows.service";
 import { useWorkflowEventLabel } from "../Builder/catalog";
+import WorkflowOwner from "../WorkflowOwner";
 import { EntityRecordLink } from "./EntityRecordLink";
 import { RunsLiveUpdates } from "./RunLiveUpdates";
 import { RunStatus, TestRunBadge } from "./RunStatus";
@@ -117,7 +118,7 @@ const WorkflowRunsTable = memo(({ data, count }: WorkflowRunsTableProps) => {
       {
         accessorKey: "ownerId",
         header: t`Owner`,
-        cell: ({ row }) => <EmployeeAvatar employeeId={row.original.ownerId} />,
+        cell: ({ row }) => <WorkflowOwner ownerId={row.original.ownerId} />,
         meta: {
           icon: <LuUser />,
           filterHeader: t`Owner`,

--- a/apps/erp/app/modules/workflows/ui/WorkflowOwner.tsx
+++ b/apps/erp/app/modules/workflows/ui/WorkflowOwner.tsx
@@ -1,0 +1,38 @@
+import { HStack } from "@carbon/react";
+import { isWorkflowServiceUserId } from "@carbon/workflows";
+import { Trans } from "@lingui/react/macro";
+import { LuBuilding } from "react-icons/lu";
+import EmployeeAvatar from "~/components/EmployeeAvatar";
+
+type WorkflowOwnerProps = {
+  ownerId: string | null;
+  withName?: boolean;
+};
+
+/**
+ * The owner of a workflow or of one of its runs.
+ *
+ * A company-owned workflow's owner is the company's service identity, which has
+ * no employee row on purpose — so it is absent from `usePeople` and
+ * `EmployeeAvatar` would render it as a nameless blank circle. Detect it by id
+ * rather than threading `ownerKind` through the run tables, which record the id
+ * they actually ran as and nothing else.
+ */
+const WorkflowOwner = ({ ownerId, withName = true }: WorkflowOwnerProps) => {
+  if (isWorkflowServiceUserId(ownerId)) {
+    return (
+      <HStack className="truncate no-underline hover:no-underline">
+        <LuBuilding className="size-4 text-muted-foreground" />
+        {withName && (
+          <span>
+            <Trans>Company</Trans>
+          </span>
+        )}
+      </HStack>
+    );
+  }
+
+  return <EmployeeAvatar employeeId={ownerId} withName={withName} />;
+};
+
+export default WorkflowOwner;

--- a/apps/erp/app/modules/workflows/ui/WorkflowsTable.tsx
+++ b/apps/erp/app/modules/workflows/ui/WorkflowsTable.tsx
@@ -27,7 +27,7 @@ import {
   LuWorkflow
 } from "react-icons/lu";
 import { useNavigate } from "react-router";
-import { EmployeeAvatar, Hyperlink, Table } from "~/components";
+import { Hyperlink, Table } from "~/components";
 import { ConfirmDelete } from "~/components/Modals";
 import { usePermissions } from "~/hooks";
 import { usePeople } from "~/stores";
@@ -36,6 +36,7 @@ import type { Workflow, WorkflowLastRun } from "../workflows.service";
 import { ConfirmUnpublishWorkflow } from "./ConfirmUnpublishWorkflow";
 import { RunStatus } from "./Runs/RunStatus";
 import WorkflowForm from "./WorkflowForm";
+import WorkflowOwner from "./WorkflowOwner";
 
 type WorkflowsTableProps = {
   data: Workflow[];
@@ -118,9 +119,7 @@ const WorkflowsTable = memo(
         {
           accessorKey: "ownerId",
           header: t`Owner`,
-          cell: ({ row }) => (
-            <EmployeeAvatar employeeId={row.original.ownerId} />
-          ),
+          cell: ({ row }) => <WorkflowOwner ownerId={row.original.ownerId} />,
           meta: {
             icon: <LuUser />,
             filter: {

--- a/apps/erp/app/modules/workflows/workflows.service.ts
+++ b/apps/erp/app/modules/workflows/workflows.service.ts
@@ -1,6 +1,8 @@
 import type { Database, Json } from "@carbon/database";
 import { fkDisplayRegistry } from "@carbon/database/audit.config";
 import { datetime } from "@carbon/utils";
+import type { WorkflowOwnerKind } from "@carbon/workflows";
+import { getWorkflowServiceUserId } from "@carbon/workflows";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { z } from "zod";
 import type { Filter, GenericQueryFilters } from "~/utils/query";
@@ -15,7 +17,7 @@ export async function getWorkflows(
   let query = client
     .from("workflow")
     .select(
-      "id, name, description, ownerId, publishedVersionId, createdAt, updatedAt",
+      "id, name, description, ownerId, ownerKind, publishedVersionId, createdAt, updatedAt",
       { count: "exact" }
     )
     .eq("companyId", companyId);
@@ -59,7 +61,7 @@ export async function getWorkflow(
   return client
     .from("workflow")
     .select(
-      "id, name, description, ownerId, publishedVersionId, nextRunAt, canvasState, createdAt, updatedAt"
+      "id, name, description, ownerId, ownerKind, publishedVersionId, nextRunAt, canvasState, createdAt, updatedAt"
     )
     .eq("id", id)
     .eq("companyId", companyId)
@@ -115,15 +117,25 @@ export async function insertWorkflow(
   workflow: Omit<z.infer<typeof workflowValidator>, "id"> & {
     companyId: string;
     createdBy: string;
+    ownerKind?: WorkflowOwnerKind;
   }
 ) {
+  const ownerKind = workflow.ownerKind ?? "user";
+
   return client
     .from("workflow")
     .insert({
       name: workflow.name,
       description: workflow.description ?? null,
       companyId: workflow.companyId,
-      ownerId: workflow.createdBy,
+      ownerKind,
+      // A company-owned workflow runs as the company's service identity, so it
+      // keeps working after any employee leaves. Ownership is still a real user
+      // id either way, which is why the engine needs no branch.
+      ownerId:
+        ownerKind === "company"
+          ? getWorkflowServiceUserId(workflow.companyId)
+          : workflow.createdBy,
       createdBy: workflow.createdBy
     })
     .select("id")

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-27T23:53:14.959Z",
+  "generated": "2026-08-28T09:54:46.171Z",
   "totalTools": 1449,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/settings+/billing.tsx
+++ b/apps/erp/app/routes/x+/settings+/billing.tsx
@@ -75,13 +75,18 @@ export async function loader({ request }: LoaderFunctionArgs) {
     .eq("companyId", companyId)
     .single();
 
+  // Service accounts hold an employee-role userToCompany row so RLS can resolve
+  // their permissions. They are not people and cannot own a company.
   const userToCompany = await client
     .from("userToCompany")
-    .select("userId")
+    .select("userId, ...user(isServiceAccount)")
     .eq("companyId", companyId)
     .eq("role", "employee");
 
-  const userIds = userToCompany.data?.map((utc) => utc.userId) || [];
+  const userIds =
+    userToCompany.data
+      ?.filter((utc) => !utc.isServiceAccount)
+      .map((utc) => utc.userId) || [];
 
   const employees =
     userIds.length > 0

--- a/apps/erp/app/routes/x+/workflow+/$id.test-run.tsx
+++ b/apps/erp/app/routes/x+/workflow+/$id.test-run.tsx
@@ -38,7 +38,13 @@ function refuse(error: string, status = 400, issues: WorkflowIssue[] = []) {
 }
 
 /** The run acts as the owner, so anyone else firing it would be borrowing the owner's
- * permissions. This is the authorization boundary, not a UI nicety. */
+ * permissions. This is the authorization boundary, not a UI nicety.
+ *
+ * A company-owned workflow has no human owner to borrow from — it runs as the
+ * company's service identity, which holds no more than read access. There is
+ * nothing to escalate to, so `workflows_update` is the gate, and the run is
+ * still executed as the owner rather than as the caller so the test exercises
+ * the permissions production will use. */
 async function requireOwnedWorkflow(request: Request, id: string | undefined) {
   const { client, companyId, companyGroupId, userId } =
     await requirePermissions(request, { update: "workflows" });
@@ -58,13 +64,26 @@ async function requireOwnedWorkflow(request: Request, id: string | undefined) {
   if (workflow.error || !workflow.data) {
     return { refused: refuse("Workflow not found", 404) };
   }
-  if (workflow.data.ownerId !== userId) {
+  if (
+    workflow.data.ownerKind !== "company" &&
+    workflow.data.ownerId !== userId
+  ) {
     return {
       refused: refuse("Only the owner of this workflow can test it", 403)
     };
   }
 
-  return { client, companyId, companyGroupId, userId, workflow: workflow.data };
+  return {
+    client,
+    companyId,
+    companyGroupId,
+    userId,
+    // The identity the run acts as, which is the owner in both cases — never the
+    // caller. A test that ran with the tester's own access would prove nothing
+    // about the workflow.
+    ownerId: workflow.data.ownerId,
+    workflow: workflow.data
+  };
 }
 
 /** Options for the test-run record picker. Reads through the request's own client, so
@@ -215,7 +234,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     definition: definition.data,
     companyId: gate.companyId,
     companyGroupId: gate.companyGroupId,
-    ownerId: gate.userId,
+    ownerId: gate.ownerId,
     workflowId: gate.workflow.id,
     workflowVersionId: versionId,
     eventId: eventId ?? "",

--- a/apps/erp/app/routes/x+/workflow+/$id.tsx
+++ b/apps/erp/app/routes/x+/workflow+/$id.tsx
@@ -167,7 +167,11 @@ export default function WorkflowBuilderRoute() {
   // Two reasons, two behaviours: a locked version still allows dragging to tidy the
   // layout, a missing permission does not.
   const canEdit = permissions.can("update", "workflows");
-  const isOwner = workflow.ownerId === userId;
+  // Gates the Test run affordance. A company-owned workflow has no human owner,
+  // so it would otherwise be untestable by everyone; it runs as the company's
+  // read-only service identity, which is nobody's access to borrow.
+  const isOwner =
+    workflow.ownerKind === "company" ? canEdit : workflow.ownerId === userId;
 
   if (!definition || !versionId) {
     return (

--- a/packages/auth/src/services/users.server.ts
+++ b/packages/auth/src/services/users.server.ts
@@ -301,6 +301,19 @@ export async function deactivateUser(
   actorId?: string,
   ip?: string
 ) {
+  // A service account is the company's own principal, not a person. Deactivating
+  // one would strip the permissions every workflow it owns runs with — the exact
+  // failure company ownership exists to prevent — and nothing could restore it.
+  const serviceAccount = await serviceRole
+    .from("user")
+    .select("isServiceAccount")
+    .eq("id", userId)
+    .maybeSingle();
+
+  if (serviceAccount.data?.isServiceAccount) {
+    return error(null, "Cannot deactivate a service account");
+  }
+
   const userToCompany = await serviceRole
     .from("userToCompany")
     .select("role")

--- a/packages/database/supabase/functions/seed-company/index.ts
+++ b/packages/database/supabase/functions/seed-company/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
+import { sql } from "npm:kysely@0.27.6";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
@@ -149,6 +150,15 @@ serve(async (req: Request) => {
         .insertInto("userToCompany")
         .values([{ userId, companyId, role: "employee" }])
         .execute();
+
+      // The company's workflow service identity. A workflow runs as its owner,
+      // so one owned by an employee stops the day that employee is deactivated;
+      // a company-owned workflow runs as this instead and outlives them all.
+      // Provisioned in SQL so the migration that backfills existing companies
+      // and this path can never define the identity two different ways.
+      await sql`SELECT provision_workflow_service_user(${companyId})`.execute(
+        trx
+      );
 
       // high-order groups — identity infrastructure: the employeeType insert
       // below fires a trigger that creates a membership row referencing these,

--- a/packages/database/supabase/migrations/20260828103412_workflow-company-ownership.sql
+++ b/packages/database/supabase/migrations/20260828103412_workflow-company-ownership.sql
@@ -1,0 +1,130 @@
+-- Company-owned workflows.
+--
+-- A workflow runs as its owner (`engine/owner.ts`), and `ownerId` is set once from
+-- `createdBy` and never reassigned. So a workflow stops working the moment its author
+-- is deactivated: `deactivateEmployee` strips the company from `userPermission` and
+-- deletes the `userToCompany` row, every node then fails its permission check, and no
+-- one can repair or even test-run the workflow afterwards.
+--
+-- This gives each company a service identity that a workflow can be owned by instead.
+-- The identity is a `user` row with no auth account, no employee row and read-only
+-- grants -- the minimum that `get_claims` and `get_companies_with_employee_permission`
+-- need in order to resolve permissions at all.
+
+-- 1. Mark non-human principals on `user`.
+--
+-- Needed as a real column rather than an id-prefix convention because seat billing
+-- counts `userToCompany` rows (`updateSubscriptionQuantityForCompany`), and a service
+-- identity must not be billed as a seat or listed as a person.
+ALTER TABLE "user"
+  ADD COLUMN "isServiceAccount" BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX "user_isServiceAccount_idx" ON "user" ("isServiceAccount")
+  WHERE "isServiceAccount" = TRUE;
+
+COMMENT ON COLUMN "user"."isServiceAccount" IS
+  'A non-human principal owned by the platform (currently the per-company workflow service identity). Never a seat, never an employee, never shown in a people picker.';
+
+-- 2. Ownership kind on `workflow`.
+--
+-- `ownerId` keeps pointing at a real `user` row in both cases, so the engine, the
+-- matcher and the scheduler are unchanged -- they resolve an owner id either way.
+-- `ownerKind` is what the UI, the test-run gate and company restore branch on.
+--
+-- DEFAULT is mandatory: `assertBackupImportable` rejects a backup that is missing a
+-- NOT NULL column with no default, which would make every existing backup unimportable.
+ALTER TABLE "workflow"
+  ADD COLUMN "ownerKind" TEXT NOT NULL DEFAULT 'user'
+  CHECK ("ownerKind" IN ('user', 'company'));
+
+COMMENT ON COLUMN "workflow"."ownerKind" IS
+  'user = owned by the employee who created it, runs with their permissions. company = owned by the company service identity, survives any employee leaving.';
+
+-- 3. The read-only grant set for a service identity.
+--
+-- Every module gets `_view` scoped to the one company; create/update/delete stay empty
+-- arrays rather than absent, because every path that mutates permissions assumes the
+-- keys are present. The `"0"` all-companies wildcard is retired
+-- (20260817030612_remove-global-permission-wildcard.sql) -- enumerate the company.
+CREATE OR REPLACE FUNCTION workflow_service_user_permissions(company_id TEXT)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SET search_path = public
+AS $$
+  SELECT COALESCE(jsonb_object_agg(key, value), '{}'::jsonb)
+  FROM (
+    SELECT lower(m.name::text) || '_view' AS key, to_jsonb(ARRAY[company_id]) AS value
+    FROM modules m
+    UNION ALL
+    SELECT lower(m.name::text) || '_' || a.action, '[]'::jsonb
+    FROM modules m
+    CROSS JOIN (VALUES ('create'), ('update'), ('delete')) AS a(action)
+  ) grants;
+$$;
+
+-- 4. Provision (idempotently) the service identity for one company.
+--
+-- Three rows and no auth account:
+--   `user`           -- the FK target for workflow.ownerId
+--   `userPermission` -- without it get_claims returns NULL, which the engine reads as
+--                       "owner has no permissions" and fails every step
+--   `userToCompany`  -- role 'employee', required by every RLS gate on the workflow
+--                       tables via get_companies_with_employee_permission
+--
+-- No `employee` row on purpose: the `employees` view inner-joins `employee`, so
+-- omitting it keeps the identity out of the employee list and the people picker.
+CREATE OR REPLACE FUNCTION provision_workflow_service_user(company_id TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  service_user_id TEXT := 'wfsvc_' || company_id;
+BEGIN
+  INSERT INTO "user" ("id", "email", "firstName", "lastName", "isServiceAccount")
+  VALUES (
+    service_user_id,
+    -- `.internal` is unroutable by design, matching the `@console.internal`
+    -- convention already used for the other synthetic user in this schema.
+    service_user_id || '@workflow.internal',
+    'Workflow',
+    'Service',
+    TRUE
+  )
+  ON CONFLICT ("id") DO NOTHING;
+
+  INSERT INTO "userPermission" ("id", "permissions")
+  VALUES (service_user_id, workflow_service_user_permissions(company_id))
+  ON CONFLICT ("id") DO UPDATE
+    SET "permissions" = EXCLUDED."permissions";
+
+  INSERT INTO "userToCompany" ("userId", "companyId", "role")
+  VALUES (service_user_id, company_id, 'employee')
+  ON CONFLICT ("userId", "companyId") DO NOTHING;
+
+  RETURN service_user_id;
+END;
+$$;
+
+-- Provisioning is a privileged operation: it mints a principal with company-wide read
+-- access. Only the service role (the migration itself, and `seed-company`) may call it.
+REVOKE EXECUTE ON FUNCTION provision_workflow_service_user(TEXT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION provision_workflow_service_user(TEXT) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION provision_workflow_service_user(TEXT) TO service_role;
+
+-- 5. Backfill every existing company.
+--
+-- seed-company only runs at company creation and short-circuits on an existing
+-- userToCompany row for the owner, so it can never reach companies that already exist.
+DO $$
+DECLARE
+  company_record RECORD;
+BEGIN
+  FOR company_record IN SELECT "id" FROM "company" LOOP
+    PERFORM provision_workflow_service_user(company_record."id");
+  END LOOP;
+END $$;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/stripe/src/stripe.server.ts
+++ b/packages/stripe/src/stripe.server.ts
@@ -672,10 +672,12 @@ export async function updateSubscriptionQuantityForCompany(companyId: string) {
       return;
     }
 
-    // Count active users
+    // Count active users. Service accounts (the per-company workflow service
+    // identity) hold a userToCompany row so RLS can resolve their permissions,
+    // but they are not people and must never be billed as a seat.
     const activeUsersResult = await serviceRole
       .from("userToCompany")
-      .select("userId, ...user(email)")
+      .select("userId, ...user(email, isServiceAccount)")
       .eq("companyId", companyId);
 
     if (activeUsersResult.error) {
@@ -688,7 +690,8 @@ export async function updateSubscriptionQuantityForCompany(companyId: string) {
 
     const activeUserCount =
       activeUsersResult.data?.filter(
-        (user) => !(user?.email).includes("@carbon.ms")
+        (user) =>
+          !user?.isServiceAccount && !(user?.email ?? "").includes("@carbon.ms")
       ).length || 1;
 
     // Get the subscription from Stripe to find the subscription item

--- a/packages/workflows/AGENTS.md
+++ b/packages/workflows/AGENTS.md
@@ -118,6 +118,7 @@ src/runtime/
 ├── fixtures.ts  # TEST-ONLY fake loader/context. Not exported from the package root
 └── index.ts     # barrel
 
+src/owner.ts       # WorkflowOwnerKind + the per-company service identity's id
 src/run-trigger.ts # runTriggerSchema — what fired a run; shared with @carbon/lib and @carbon/jobs
 src/sync.ts        # trigger-event + subscription reconciler
 ```
@@ -125,7 +126,8 @@ src/sync.ts        # trigger-event + subscription reconciler
 `src/runtime/` is pure: no I/O, no database client, no Supabase. Records are read
 through the injected `EntityLoader`, and everything else that touches the world goes
 through `WorkflowServices`; `@carbon/jobs` implements both over the workflow owner's
-own connection. Comparison semantics live in `runtime/compare.ts` and must not be
+own connection — the employee who created it, or the company's read-only service
+identity when `workflow.ownerKind` is `company` (`src/owner.ts`). Comparison semantics live in `runtime/compare.ts` and must not be
 re-implemented anywhere else.
 
 Permission and execution share one `EXECUTORS` entry per node kind. Two lookups could

--- a/packages/workflows/src/index.ts
+++ b/packages/workflows/src/index.ts
@@ -145,6 +145,13 @@ export {
   createContext,
   variablesFromHandle
 } from "./definition/variables";
+export type { WorkflowOwnerKind } from "./owner";
+export {
+  getWorkflowServiceUserId,
+  isWorkflowServiceUserId,
+  WORKFLOW_OWNER_KINDS,
+  WORKFLOW_SERVICE_USER_PREFIX
+} from "./owner";
 export type { RunTrigger } from "./run-trigger";
 export { runTriggerSchema } from "./run-trigger";
 export type {

--- a/packages/workflows/src/owner.test.ts
+++ b/packages/workflows/src/owner.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  getWorkflowServiceUserId,
+  isWorkflowServiceUserId,
+  WORKFLOW_SERVICE_USER_PREFIX
+} from "./owner";
+
+describe("workflow service identity", () => {
+  it("derives the id from the company id", () => {
+    expect(getWorkflowServiceUserId("cmp_abc")).toBe("wfsvc_cmp_abc");
+  });
+
+  // The id is derived rather than generated so provisioning is idempotent —
+  // the migration's backfill and seed-company must land on the same row.
+  it("is stable for the same company", () => {
+    expect(getWorkflowServiceUserId("cmp_abc")).toBe(
+      getWorkflowServiceUserId("cmp_abc")
+    );
+  });
+
+  it("is distinct per company", () => {
+    expect(getWorkflowServiceUserId("cmp_a")).not.toBe(
+      getWorkflowServiceUserId("cmp_b")
+    );
+  });
+
+  it("recognises its own ids", () => {
+    expect(isWorkflowServiceUserId(getWorkflowServiceUserId("cmp_abc"))).toBe(
+      true
+    );
+  });
+
+  // The UI branches on this to render "Company" instead of a nameless avatar,
+  // so a false positive would relabel a real person.
+  it("does not claim ordinary or sentinel user ids", () => {
+    expect(isWorkflowServiceUserId("usr_abc")).toBe(false);
+    expect(isWorkflowServiceUserId("system")).toBe(false);
+    expect(isWorkflowServiceUserId("")).toBe(false);
+    expect(isWorkflowServiceUserId(null)).toBe(false);
+  });
+
+  it("keeps the prefix in step with the SQL provisioning function", () => {
+    expect(WORKFLOW_SERVICE_USER_PREFIX).toBe("wfsvc_");
+  });
+});

--- a/packages/workflows/src/owner.ts
+++ b/packages/workflows/src/owner.ts
@@ -1,0 +1,39 @@
+/**
+ * Who a workflow runs as.
+ *
+ * A workflow acts with its owner's live permissions, minted per step
+ * (`getUserScopedClient(ownerId, …)`). That makes ownership the difference
+ * between an automation that survives its author and one that stops the day
+ * they are deactivated: `deactivateEmployee` strips the company from the
+ * owner's `userPermission` row, and every node then fails its permission check.
+ *
+ * - `user`    — the employee who created it. Their access is the workflow's access.
+ * - `company` — the company's own service identity. Outlives every employee.
+ *
+ * `ownerId` points at a real `user` row in both cases, which is why the engine,
+ * the matcher and the scheduler need no branch: they resolve an owner id and
+ * mint a client for it exactly as before.
+ */
+export type WorkflowOwnerKind = "user" | "company";
+
+export const WORKFLOW_OWNER_KINDS: WorkflowOwnerKind[] = ["user", "company"];
+
+/**
+ * Prefix for the per-company workflow service identity. Kept in step with
+ * `provision_workflow_service_user` in
+ * `20260828103412_workflow-company-ownership.sql`, which is the only writer.
+ */
+export const WORKFLOW_SERVICE_USER_PREFIX = "wfsvc_";
+
+/**
+ * The service identity's user id is derived from the company id rather than
+ * generated, so provisioning is idempotent and a lookup is never needed to
+ * resolve it.
+ */
+export function getWorkflowServiceUserId(companyId: string): string {
+  return `${WORKFLOW_SERVICE_USER_PREFIX}${companyId}`;
+}
+
+export function isWorkflowServiceUserId(userId: string | null): boolean {
+  return userId?.startsWith(WORKFLOW_SERVICE_USER_PREFIX) ?? false;
+}


### PR DESCRIPTION
## What does this PR do?

A workflow runs as its owner. `workflow.ownerId` is set once from `createdBy` (`workflows.service.ts`) and no route reassigns it — `$id.rename.tsx:11-12` says so in a comment: *"ownership is taken, never assigned"*.

So a workflow's continued operation depends on one employee's continued employment:

- `deactivateEmployee` strips the company out of the owner's `userPermission` row and deletes their `userToCompany` row (`packages/auth/src/services/users.server.ts:199-265`).
- `get_companies_with_employee_permission` then returns nothing for them, every node fails its permission check, and the run ends `Failed` with a no-access error (`engine/execute.ts:163`).
- Nobody can repair it: ownership cannot be reassigned, and `$id.test-run.tsx` refuses a test run to anyone but the owner, so no one else can even reproduce it.

The same break has a much smaller trigger than someone leaving — narrowing an employee's permissions, or moving them between roles, silently stops a workflow they wrote a year ago.

This adds `workflow.ownerKind` (`'user' | 'company'`) and a per-company **service identity** a workflow can be owned by instead.

**`ownerId` still points at a real `user` row in both cases.** That is the load-bearing choice: the engine, the matcher and the scheduler resolve an owner id and mint a client for it exactly as before, so nothing below the service layer branches on ownership kind.

### The service identity

Three rows per company and no auth account, minted by `provision_workflow_service_user(company_id)`:

| Table | Row | Why it is required |
|---|---|---|
| `user` | `wfsvc_<companyId>`, `isServiceAccount = true` | the FK target for `workflow.ownerId` |
| `userPermission` | read-only grants, scoped to the one company | without the row `get_claims` returns `NULL`, which the engine reads as "no permissions" and fails every step |
| `userToCompany` | `role = 'employee'` | `get_companies_with_employee_permission` intersects it with the permission arrays; every workflow-table RLS policy goes through it |

`public.user` has no FK to `auth.users`, and `getUserScopedClient` self-signs an HS256 JWT with `sub: userId`, so an identity with no auth account is still a fully RLS-scoped principal. Precedent already in the schema: the global `system` user and console operators are both synthetic `user` rows.

Provisioning lives in SQL so the backfill and `seed-company` cannot define a security principal two different ways. It is `SECURITY DEFINER` with execute revoked from `anon`/`authenticated`.

### Read-only grants — the security argument

Every module gets `<module>_view: [companyId]`; create/update/delete are present as empty arrays.

The first intended consumer, an approval policy, contains only condition, compute, lookup and filter nodes — **none of which write**. Granting writes would create a standing all-module principal in every company in exchange for nothing. Widening later is additive; narrowing later is breaking, so the narrow set is the one that has to ship first.

### Keeping it invisible

It has **no `employee` row**, on purpose. The `employees` view inner-joins `employee`, and that view is the sole hydration source for `usePeople` — the store behind every avatar, picker, assignee control, table filter and CSV name lookup in ERP and MES. One missing row keeps it out of all of them at once.

Four surfaces read `user` / `userToCompany` directly and needed explicit filters:

| Surface | Why it matters |
|---|---|
| `updateSubscriptionQuantityForCompany` counts `userToCompany` rows, excluding only `@carbon.ms` emails | **the identity would have been billed as a paid seat in every customer's subscription** |
| Settings → Billing "New Owner" dropdown | it could have been made company owner |
| `getUsers` / `getUserEmails` / `resolveUserSelectIds` — no employee join; `getUsers` is also the MCP tool `users_getUsers` | it would have been listed as a person |
| Workflow Owner columns render `EmployeeAvatar` | anyone absent from `usePeople` renders as a nameless blank circle |

`isServiceAccount` is a real column rather than a `wfsvc_` prefix check because seat billing must not be coupled to a workflows naming convention.

The `UserSelect` tree needed no change: browse and search go through `groupMembers` scoped by `companyId`, and company-group membership is created by a trigger on `employee` INSERT, which never fires here.

### Guards

- **Deactivating a service account is refused.** It would strip the permissions every workflow it owns runs with — precisely the failure this feature exists to prevent — and nothing could restore it.
- **Deleting a subsidiary cleans its identity up.** The company cascade reaches everything scoped by `companyId`, but `user` has no such column. Order matters: `workflow.ownerId` references it with no `ON DELETE`, so the workflows go first.

### Scope

**Nothing becomes company-owned in this PR.** `insertWorkflow` accepts `ownerKind` and no caller passes `"company"`. This ships the ownership model; the first consumer is the approval-policy work. Seeded demo workflows deliberately stay user-owned — their definitions contain action nodes, which the read-only identity cannot execute.

Deferred with it, and for the same reason: ownership transfer UI, and automatic transfer of an orphaned automation on deactivation. Both need the identity to hold writes, which is a decision worth making separately.

Tracking spec: `.ai/specs/2026-08-28-workflow-company-ownership.md`

## How should this be tested?

⚠️ **`pnpm db:migrate` must run before typecheck passes.** The generated DB types predate this migration, so `isServiceAccount` and `ownerKind` do not exist in `@carbon/database` yet. Every current typecheck error is that one class — see below.

```bash
pnpm db:migrate     # applies the migration and regenerates types
pnpm exec turbo run typecheck --filter=erp --filter=@carbon/auth --filter=@carbon/stripe
```

Then:

- Every existing company has exactly one `wfsvc_` identity; re-running the migration changes nothing.
- `get_claims('wfsvc_<c>', '<c>')` returns `role: employee`, `<module>_view: ['<c>']` for every module, and empty arrays for create/update/delete.
- The identity appears in no people picker, employee list, assignee control, avatar, CSV export or `users_getUsers` result.
- The Stripe seat count for a company is unchanged by the migration.
- Settings → Billing → New Owner does not offer it; deactivating it is refused.
- Deleting a subsidiary leaves no `wfsvc_` row behind.
- A workflow created with `ownerKind: "company"` can be test-run by a `workflows_update` holder and renders "Company" as its owner.

## Verification already run

- `@carbon/workflows`, `@carbon/auth`, `@carbon/jobs`, `@carbon/stripe` tests: **964 passed, 0 failed** (includes 6 new tests for the service-identity id helpers).
- `@carbon/workflows` typecheck: clean.
- `biome check`: clean.
- ERP typecheck: 54 errors, of which **53 are the missing-column class above**. The 54th is `app/root.tsx: Cannot find module './+types/root'` — React Router codegen output, gitignored and absent in a fresh worktree; `root.tsx` is untouched by this PR.
- The pre-commit dataset check was skipped with the documented `CARBON_SKIP_DATASET_CHECK=1`: it crashes rather than taking its "database unreachable → skip" path when the worktree has no `.env`. No dataset is touched by this PR. (Small separate bug in that check's guard — happy to file it.)

## Known limitations, deliberately not fixed here

- `GET /rest/v1/user` with a company API key still returns the row. Narrowing the `user` SELECT policy is an RBAC change and out of scope; the row exposes a synthetic name and an unroutable `@workflow.internal` email and nothing else.
- **Company restore must re-point company-owned workflows** at the target company's identity, or a workflow restored into a different company runs with no permissions and fails silently. Not reachable yet — nothing creates a company-owned workflow — and it lands with the first consumer. Flagged in the spec's Risks.

## Mandatory Tasks

- [x] I have self-reviewed the code.
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for company-owned workflows with dedicated, read-only service identities.
  * Existing workflows continue to use employee ownership.
  * Updated workflow screens to clearly distinguish company owners from employees.
  * Company-owned workflow test runs now execute with the company identity.

* **Bug Fixes**
  * Excluded service identities from employee lists, billing seat counts, and email results.
  * Prevented service identities from being deactivated.
  * Cleaned up service identities when companies are deleted.

* **Documentation**
  * Updated workflow ownership and runtime documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->