### PR TITLE
fix(react): modal background grey → white (bg-background → bg-card)

### DIFF
--- a/packages/react/src/Modal.tsx
+++ b/packages/react/src/Modal.tsx
@@ -50,7 +50,7 @@ const ModalContentVariants = cva(
     "data-[state=closed]:slide-out-to-left-[0%] data-[state=closed]:slide-out-to-top-[0%",
     "data-[state=open]:slide-in-from-left-[0%] data-[state=open]:slide-in-from-top-[0%]",
     "sm:rounded-2xl md:w-full",
-    "bg-background focus-visible:outline-none focus-visible:ring-0",
+    "bg-card focus-visible:outline-none focus-visible:ring-0",
     "dark:shadow-[inset_0_0.5px_0_rgb(255_255_255_/_0.08),_inset_0_0_1px_rgb(255_255_255_/_0.24),_0_0_0_0.5px_rgb(0,0,0,1),0px_0px_4px_rgba(0,_0,_0,_0.08)]"
   ),
   {


### PR DESCRIPTION
## What

One-line change in `ModalContentVariants` (`packages/react/src/Modal.tsx`): the modal surface now uses `bg-card` instead of `bg-background`.

## Why

In light mode `--background` is the grey page color, so every modal rendered with a grey surface instead of the white card surface the rest of the elevated UI uses. `bg-card` is the correct elevation token. Dark mode is unaffected — both tokens resolve to the same card surface there, and the existing inset shadow keeps doing the elevation work.

## Verification

- Biome check on the file: clean.
- Pure Tailwind class-string literal change — no type or logic surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated modal content styling to use the card background color for a more consistent visual appearance.
  * Preserved existing focus outlines and accessibility indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->