### PR TITLE
fix(mcp): general fixes for quote-setup tool schema, auth & classification bugs

### DIFF
--- a/.ai/plans/2026-08-28-quote-mcp-tool-bugs.md
+++ b/.ai/plans/2026-08-28-quote-mcp-tool-bugs.md
@@ -1,0 +1,98 @@
+# Fix Carbon MCP quote-setup tool bugs
+
+Reported by Anthan (via Brad) while using the Carbon MCP for quote setup. Nine
+items; #1 is client-side (not fixable here). The rest are generator, executor,
+classification, and service-behavior bugs. One PR.
+
+Ground truth: `scripts/generate-mcp.ts` parses `{module}.service.ts` signatures
+textually → `tool-metadata.json`; `api+/mcp+/lib/direct-executor.ts` runs tools
+positionally and stamps auth via `enrichWithAuthContext`.
+
+## Root causes (confirmed)
+
+- **#2** `quoteLinePrices` shows `type:object` not `array`. `buildToolSchema`'s
+  multi-param branch special-cases `startsWith("{")` → `parseInlineObjectType`,
+  which swallows the trailing `[]`. `typeToJsonSchema` already handles `{...}[]`
+  (array check precedes object check) — the branch just bypasses it.
+- **#5** `upsertQuoteLine` drops `quantity` (+ every field after the first
+  `errorMap`). The depth counters (`splitAtTopLevel`/`findTopLevelColon`/
+  `splitObjectFields`) treat the `>` in a `=>` arrow as a generic close, driving
+  depth negative so no further top-level commas split. Affects EVERY validator
+  with an arrow (errorMap, refine) before later fields — many tools.
+  (`externalNotes`/`internalNotes` are not in `quoteLineValidator` at all → out
+  of scope; documented as a follow-up.)
+- **#3** `createdBy` NOT NULL but never injected into array elements.
+  `enrichWithAuthContext` returns arrays untouched (`Array.isArray → return`).
+- **#9** `items_upsertService` param is opaque `{}`. Type is
+  `applyStorageAndShelfLifeRefines(itemValidator.merge(z.object({...})))` — not a
+  bare `z.object(`, so `parseValidatorFields` returns null → fallback `{}`.
+- **#8** delete-and-reinsert classified WRITE (name-based `upsert*`→WRITE).
+- **#7** `leadTime`/`discount`/`shipping` silently ignored: carry-over
+  `existing?.X ?? p.X` (recalc route depends on this to preserve stored values).
+- **#4** `quoteLine.quantity[]` not synced to the rewritten price rows.
+- **#6** new break defaults to `priceSource:"system"` at raw unitPrice.
+
+## Changes
+
+### A. Generator (`scripts/generate-mcp.ts`)
+1. Depth counters ignore `=>`: when `ch === ">"` and prev char is `=`, don't
+   decrement. Apply in `splitAtTopLevel`, `findTopLevelColon`, `splitObjectFields`.
+   (Fixes #5 broadly.)
+2. `buildToolSchema` multi-param branch: replace the `startsWith("{")` special
+   case with `typeToJsonSchema(param.typeStr)` so `{...}[]` → array. Do the same
+   in the single-param inline branch, but when the resolved schema is an array
+   wrap it under `param.name` (can't flatten an array into top-level props).
+   (Fixes #2.)
+3. Add `CLASSIFICATION_OVERRIDES: Record<string,"READ"|"WRITE"|"DESTRUCTIVE">`
+   (mirrors `INJECT_AUTH_OVERRIDES`); `sales_upsertQuoteLinePrices → DESTRUCTIVE`.
+   Also add `INJECT_AUTH_OVERRIDES['sales_upsertQuoteLinePrices'] =
+   ['companyId','createdBy']` so DESTRUCTIVE classification doesn't strip the
+   per-row createdBy injection. (Fixes #8.)
+4. Add `SCHEMA_OVERRIDES: Record<string, object>` for tools whose param type the
+   parser can't resolve; author `items_upsertService` with the real fields +
+   `_operation`, and a description note: `id` is the Service ID (used as
+   readableId); never pass `readableIdWithRevision` (generated column). (Fixes #9.)
+5. `DESCRIPTION_OVERRIDES` for the two pricing tools describing destructive-by-
+   omission + carry-over + explicit-set semantics.
+
+### B. Executor (`api+/mcp+/lib/direct-executor.ts`)
+- `enrichWithAuthContext`: when `value` is an array, map each object element,
+  injecting ONLY `companyId` + `createdBy` (never `updatedBy` — avoids spreading
+  a column the element table may not have). Non-object elements pass through.
+  (Fixes #3.)
+
+### C. Service (`sales.service.ts` `rewriteQuoteLinePrices` + input type)
+- Make `leadTime`/`discountPercent`/`shippingCost`/`quantity`... keep required
+  except make `leadTime`/`discountPercent`/`shippingCost` optional on
+  `QuoteLinePriceInput`; change carry-over to `p.X ?? existing?.X ?? default`
+  (explicit wins, omitted → carry). (#7)
+- `priceSource: p.priceSource ?? existing?.priceSource ?? "manual"` (was
+  `"system"`) — a hand-set API price with no source is manual. Recalc still sets
+  `"system"` explicitly. (#6)
+- After an EXPLICIT `quoteLinePrices` rewrite (not the precision rebuild, not the
+  empty no-op), sync `quoteLine.quantity` to the sorted distinct quantities of
+  the inserted rows, inside the same trx. (#4)
+
+### D. Caller (`x+/quote+/$quoteId.$lineId.recalculate-price.tsx`)
+- Stop passing `discountPercent:0, leadTime:0`; omit them so carry-over preserves
+  the stored values (now that explicit values win). Quantities unchanged → #4
+  sync is a no-op here.
+
+### E. Regenerate + verify
+- `npx tsx scripts/generate-mcp.ts`; eyeball the 3 tools; sanity-check that the
+  `=>` fix only ADDED fields (no tool lost properties); totalTools unchanged.
+
+### F. Tests + docs
+- `sales.utils`/service test: explicit leadTime/discount wins; omitted carries;
+  quantity sync; priceSource default manual. Generator unit checks for the `=>`
+  and `[]` cases if a harness exists (else rely on metadata diff).
+- Sync `quote-discount-system.md`, sales `AGENTS.md`, `mcp-tools-reference.md`.
+
+## Out of scope (documented)
+- #1 MCP eviction (client/transport).
+- #5 notes fields (not in the validator; separate rich-text write path).
+
+## Verify
+- `pnpm exec turbo run typecheck --filter=erp`
+- `cd apps/erp && pnpm exec vitest run app/modules/sales`
+- generated `tool-metadata.json` diff review

--- a/.claude/rules/mcp-tools-reference.md
+++ b/.claude/rules/mcp-tools-reference.md
@@ -67,7 +67,12 @@ registered individually:
 - `tool-metadata.json` provides `serviceParams` (positional arg order, e.g.
   `["client", "args"]`) and `injectAuth`. The executor builds the positional
   arg array: `client`/`userId`/`companyId`/`companyGroupId` come from `ctx`;
-  payload params are stamped with auth fields via `enrichWithAuthContext`.
+  payload params are stamped with auth fields via `enrichWithAuthContext`. When a
+  payload param is an **array** of rows, `enrichWithAuthContext` stamps
+  `createdBy` into each element (insert only) — the top-level stamp never reached
+  inside, so a NOT NULL `createdBy` on the row table (e.g. `quoteLinePrice`) used
+  to fail. Only `createdBy` is injected per element; `companyId`/`updatedBy` are
+  left to the service, since element keys spread straight into an INSERT.
 - Blocked tools (`lib/mcp-blocked-tools.ts`, `MCP_BLOCKED_TOOL_NAMES`) are rejected
   in both `call_tool` and the executor. Currently only `settings_seedCompany`.
 - Supabase query builders returned by services are awaited; result is
@@ -86,13 +91,19 @@ namespace), and writes `apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json`
 `{ name, module, classification, description, paramCount, serviceParams, injectAuth, schema }`.
 
 - **Classification** (`classifyFunction`): `delete*` → `DESTRUCTIVE`;
-  `get|list|fetch|search|find|count|check|is|has*` → `READ`; everything else →
+  `get|list|fetch|search|find|count|check|is|has*` → `READ`; a WRITE whose
+  **body issues a delete** (`.delete(` / `.deleteFrom(`, detected by
+  `functionBodyDeletes`) → `DESTRUCTIVE` too — a delete-and-reinsert `upsert*`
+  (e.g. `upsertQuoteLinePrices`, `replace*Steps`, favourite toggles) is
+  destructive-by-omission and the client must treat it as such; everything else →
   `WRITE`. Drives the MCP annotations (`READ_ONLY_/WRITE_/DESTRUCTIVE_ANNOTATIONS`
   in `lib/types.ts`).
-- **injectAuth** (`computeInjectAuth`): READ/DESTRUCTIVE → `["companyId"]`;
-  `upsert|create|insert|add|new|copy|duplicate|generate*` →
-  `["companyId","createdBy","updatedBy"]`; `update|set|sync|run|…*` →
-  `["companyId","updatedBy"]`.
+- **injectAuth** (`computeInjectAuth`): keyed off the **name verb, not the
+  classification** — only `READ` takes `["companyId"]`. `upsert|create|insert|
+  add|new|copy|duplicate|generate*` → `["companyId","createdBy","updatedBy"]`;
+  `update|set|sync|run|…*` → `["companyId","updatedBy"]`; anything else (incl. a
+  genuine `delete*`) → `["companyId"]`. A DESTRUCTIVE-classified `upsert*` still
+  inserts rows, so it keeps its `createdBy` — the label is only a caller hint.
 
 - **`_operation`** (`usesCreatedByDiscriminator`): the ~96 tools whose service picks
   insert-vs-update with `if ("createdBy" in …)` get a **required**
@@ -115,11 +126,17 @@ namespace), and writes `apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json`
 
 ## Gotchas
 
-- The generator reads a service's **parameter list textually**. A parameter typed
-  with a named alias (`prices: QuoteLinePriceInput[]`) publishes as an untyped
-  `{"type":"array","items":{}}` — only literal object types get inlined — and a
-  `//` comment inside the parameter list is parsed as a property name. Spell the
-  object type out inline and keep comments above the function.
+- The generator reads a service's **parameter list textually**, but resolves more
+  shapes than it used to. An **inline** array-of-objects
+  (`prices: { quantity: number; ... }[]`) now publishes as a typed
+  `{"type":"array","items":{...}}`; a `z.infer<typeof V>` validator param resolves
+  `V.merge(z.object({...}))` / `applyX(...)` wrappers / referenced `*Validator`s
+  (same models file) into real fields; and an `errorMap: () => (...)` inside a
+  validator no longer truncates the fields after it. A parameter typed with a bare
+  **named alias** (`prices: QuoteLinePriceInput[]`) still publishes with opaque
+  `items` — the alias isn't resolved — so spell the object type out inline. Keep
+  `//` comments above the function, not inside the parameter list (a comment there
+  is parsed as a property name).
 - A service whose first parameter is `db` (a Kysely transaction client) is served
   `getDatabaseClient()` by `direct-executor.ts`, the same way `client` is served
   the supabase one. A first parameter named anything else falls through to the

--- a/.claude/rules/quote-discount-system.md
+++ b/.claude/rules/quote-discount-system.md
@@ -69,13 +69,24 @@ Standalone rules, `id` default `id('pr')`, scoped to a company. Columns: `name`,
 
 `upsertQuoteLinePrices(db, companyId, quoteId, lineId, prices)` deletes and
 re-inserts rows **inside one Kysely transaction** (so a failed insert rolls the
-delete back instead of leaving the line with no pricing), **preserving** the
-existing `discountPercent`, `leadTime`, `shippingCost`, `categoryMarkups`, and
-`priceSource` per quantity when present (an explicit caller `categoryMarkups` or
-`priceSource` wins over the stored value; the rest always keep the stored one). It takes a `Kysely<KyselyDatabase>`, not a supabase client,
-so it bypasses RLS — every statement is scoped by `companyId` explicitly and the
-route must authorize with `requirePermissions` first. Any user-entered column added to `quoteLinePrice` has to be added
-to that carry-over list or the delete+reinsert silently resets it to its default.
+delete back instead of leaving the line with no pricing). Per-quantity carry-over
+of the user-entered fields (`discountPercent`, `leadTime`, `shippingCost`,
+`categoryMarkups`, `priceSource`) is **explicit-wins, omit-preserves**
+(`resolvePreservedQuoteLinePriceFields` in `sales.utils.ts`): a value the caller
+provides is written, a field the caller omits keeps the stored value for that
+quantity, and a brand-new row with neither falls back to the column default —
+`priceSource` defaulting to `"manual"` (a hand-set price with no declared source
+is a manual override, not a system cost-plus price). This is why the recalc route
+(`$quoteId.$lineId.recalculate-price.tsx`) passes ONLY the recomputed `unitPrice`
+(+ explicit `priceSource: "system"`) and omits lead time / discount / shipping —
+so the user's entries survive. When an explicit `prices` array is passed, the
+rewrite also **syncs `quoteLine.quantity`** to the sorted distinct quantities of
+the rows (the precision rebuild, which omits `prices`, leaves the breaks alone).
+It takes a `Kysely<KyselyDatabase>`, not a supabase client, so it bypasses RLS —
+every statement is scoped by `companyId` explicitly and the route must authorize
+with `requirePermissions` first. Any user-entered column added to `quoteLinePrice`
+has to be added to `resolvePreservedQuoteLinePriceFields` or the delete+reinsert
+silently resets it to its default.
 The rewrite throws if the quote or line is missing for that company, because the
 insert's `companyId` is overwritten by a trigger from the parent quote — without
 the check it would write into whichever company owns the quote. An **empty**

--- a/apps/erp/app/modules/sales/AGENTS.md
+++ b/apps/erp/app/modules/sales/AGENTS.md
@@ -28,7 +28,7 @@ Quotes (with cost rollup and pricing), sales orders, sales RFQs, customer manage
 
 ### Never
 - Bypass the `convert` edge function for quote→order or RFQ→quote conversions.
-- Delete `quoteLinePrice` rows when *rewriting* a line's pricing — that must preserve `discountPercent`, `leadTime`, `shippingCost`, and `categoryMarkups` via `upsertQuoteLinePrices`. Deleting rows for a quantity break the line no longer offers is different and required: see `reconcileQuantityBreaks` (`sales.utils.ts`) and its use in `x+/quote+/$quoteId.$lineId.details.tsx`. Orphaned rows render as selectable options on the customer share page.
+- Delete `quoteLinePrice` rows when *rewriting* a line's pricing — go through `upsertQuoteLinePrices`, which delete-and-reinserts inside one transaction and carries over any user-entered field (`discountPercent`, `leadTime`, `shippingCost`, `categoryMarkups`, `priceSource`) you **omit** (explicit-wins, omit-preserves via `resolvePreservedQuoteLinePriceFields`). Deleting rows for a quantity break the line no longer offers is different and required: see `reconcileQuantityBreaks` (`sales.utils.ts`) and its use in `x+/quote+/$quoteId.$lineId.details.tsx`. Orphaned rows render as selectable options on the customer share page.
 - Store `discountPercent` as a whole number (e.g., 10 instead of 0.10).
 
 ## Validation Commands

--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -62,7 +62,12 @@ import type {
   selectedLinesValidator
 } from "./sales.models";
 import { costCategoryKeys, OPEN_SALES_ORDER_STATUSES } from "./sales.models";
-import { decideRecalcPricing, getEffectiveDefaultMarkups } from "./sales.utils";
+import type { CategoryMarkups, QuoteLinePriceSource } from "./sales.utils";
+import {
+  decideRecalcPricing,
+  getEffectiveDefaultMarkups,
+  resolvePreservedQuoteLinePriceFields
+} from "./sales.utils";
 import type {
   MatchedRule,
   OverrideEntry,
@@ -3919,10 +3924,13 @@ export async function upsertQuoteLineAdditionalCharges(
 type QuoteLinePriceInput = {
   quoteLineId: string;
   unitPrice: number;
-  leadTime: number;
-  discountPercent: number;
   quantity: number;
   createdBy: string;
+  // Optional: an explicit value wins, an omitted one preserves the stored value
+  // for that quantity (so a cost recalc can leave user-entered fields alone).
+  leadTime?: number;
+  discountPercent?: number;
+  shippingCost?: number;
   categoryMarkups?: Record<string, number>;
   priceSource?: "system" | "manual";
 };
@@ -3935,10 +3943,11 @@ export async function upsertQuoteLinePrices(
   quoteLinePrices: {
     quoteLineId: string;
     unitPrice: number;
-    leadTime: number;
-    discountPercent: number;
     quantity: number;
     createdBy: string;
+    leadTime?: number;
+    discountPercent?: number;
+    shippingCost?: number;
     categoryMarkups?: Record<string, number>;
     priceSource?: "system" | "manual";
   }[]
@@ -4019,16 +4028,40 @@ async function rewriteQuoteLinePrices(
           companyId,
           quoteId,
           unitPrice: round(p.unitPrice, quoteLine.unitPricePrecision),
-          discountPercent: existing?.discountPercent ?? p.discountPercent,
-          leadTime: existing?.leadTime ?? p.leadTime,
-          shippingCost: existing?.shippingCost ?? 0,
-          categoryMarkups: p.categoryMarkups ?? existing?.categoryMarkups ?? {},
-          priceSource: p.priceSource ?? existing?.priceSource ?? "system",
+          // Explicit value wins, omitted value is preserved from the stored row.
+          ...resolvePreservedQuoteLinePriceFields(p, {
+            leadTime: existing ? Number(existing.leadTime) : undefined,
+            discountPercent: existing
+              ? Number(existing.discountPercent)
+              : undefined,
+            shippingCost: existing ? Number(existing.shippingCost) : undefined,
+            categoryMarkups:
+              (existing?.categoryMarkups as CategoryMarkups | null) ??
+              undefined,
+            priceSource:
+              (existing?.priceSource as QuoteLinePriceSource | null) ??
+              undefined
+          }),
           exchangeRate: quote.exchangeRate ?? 1
         };
       })
     )
     .execute();
+
+  // Keep quoteLine.quantity in step with the rows that now exist, but only when
+  // the caller supplied an explicit price set — the precision rebuild
+  // (quoteLinePrices omitted) must not touch the line's quantity breaks.
+  if (quoteLinePrices) {
+    const quantities = [
+      ...new Set(replacements.map((p) => Number(p.quantity)))
+    ].sort((a, b) => a - b);
+    await trx
+      .updateTable("quoteLine")
+      .set({ quantity: quantities })
+      .where("id", "=", lineId)
+      .where("companyId", "=", companyId)
+      .execute();
+  }
 }
 
 async function buildCostEffects(

--- a/apps/erp/app/modules/sales/sales.utils.test.ts
+++ b/apps/erp/app/modules/sales/sales.utils.test.ts
@@ -2,8 +2,58 @@ import { describe, expect, it } from "vitest";
 import {
   decideRecalcPricing,
   getEffectiveDefaultMarkups,
-  reconcileQuantityBreaks
+  reconcileQuantityBreaks,
+  resolvePreservedQuoteLinePriceFields
 } from "./sales.utils";
+
+describe("resolvePreservedQuoteLinePriceFields", () => {
+  const stored = {
+    leadTime: 14,
+    discountPercent: 0.1,
+    shippingCost: 5,
+    categoryMarkups: { laborCost: 25 },
+    priceSource: "system" as const
+  };
+
+  it("preserves stored values when the caller omits a field", () => {
+    expect(resolvePreservedQuoteLinePriceFields({}, stored)).toEqual({
+      leadTime: 14,
+      discountPercent: 0.1,
+      shippingCost: 5,
+      categoryMarkups: { laborCost: 25 },
+      priceSource: "system"
+    });
+  });
+
+  it("lets an explicit value win over the stored one", () => {
+    const result = resolvePreservedQuoteLinePriceFields(
+      { leadTime: 3, discountPercent: 0.2, shippingCost: 0 },
+      stored
+    );
+    expect(result.leadTime).toBe(3);
+    expect(result.discountPercent).toBe(0.2);
+    // An explicit zero is a real value, not "omitted".
+    expect(result.shippingCost).toBe(0);
+  });
+
+  it("falls back to column defaults for a brand-new row", () => {
+    expect(resolvePreservedQuoteLinePriceFields({}, null)).toEqual({
+      leadTime: 0,
+      discountPercent: 0,
+      shippingCost: 0,
+      categoryMarkups: {},
+      // A hand-set price with no declared source is manual, not system.
+      priceSource: "manual"
+    });
+  });
+
+  it("marks an explicit price system when the caller says so", () => {
+    expect(
+      resolvePreservedQuoteLinePriceFields({ priceSource: "system" }, null)
+        .priceSource
+    ).toBe("system");
+  });
+});
 
 describe("reconcileQuantityBreaks", () => {
   it("reports nothing when the breaks are unchanged", () => {

--- a/apps/erp/app/modules/sales/sales.utils.ts
+++ b/apps/erp/app/modules/sales/sales.utils.ts
@@ -19,6 +19,48 @@ export function getEffectiveDefaultMarkups(
 }
 
 /**
+ * The user-entered fields on a `quoteLinePrice` row that must survive a
+ * delete-and-reinsert rewrite. An explicitly provided value wins; an omitted one
+ * preserves the value stored for that quantity; if neither exists it falls back
+ * to the column default. This is what lets a cost recalc pass only the recomputed
+ * `unitPrice` and leave the user's lead time / discount / shipping untouched.
+ *
+ * `priceSource` defaults to `manual` for a brand-new row: a hand-set price with
+ * no declared source is a manual override, not a system (cost-plus) price that a
+ * later rollup would reprice.
+ */
+export function resolvePreservedQuoteLinePriceFields(
+  input: {
+    leadTime?: number;
+    discountPercent?: number;
+    shippingCost?: number;
+    categoryMarkups?: CategoryMarkups;
+    priceSource?: QuoteLinePriceSource;
+  },
+  existing?: {
+    leadTime?: number | null;
+    discountPercent?: number | null;
+    shippingCost?: number | null;
+    categoryMarkups?: CategoryMarkups | null;
+    priceSource?: QuoteLinePriceSource | null;
+  } | null
+): {
+  leadTime: number;
+  discountPercent: number;
+  shippingCost: number;
+  categoryMarkups: CategoryMarkups;
+  priceSource: QuoteLinePriceSource;
+} {
+  return {
+    discountPercent: input.discountPercent ?? existing?.discountPercent ?? 0,
+    leadTime: input.leadTime ?? existing?.leadTime ?? 0,
+    shippingCost: input.shippingCost ?? existing?.shippingCost ?? 0,
+    categoryMarkups: input.categoryMarkups ?? existing?.categoryMarkups ?? {},
+    priceSource: input.priceSource ?? existing?.priceSource ?? "manual"
+  };
+}
+
+/**
  * Reconcile the quantity breaks a quote line currently offers against the
  * `quoteLinePrice` rows that exist for it, in BOTH directions.
  *

--- a/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
+++ b/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
@@ -71,12 +71,13 @@ function enrichWithAuthContext(
   // the row table failed. Only createdBy is injected into elements (and only for
   // an insert): element keys are spread straight into an INSERT, so injecting
   // companyId/updatedBy could add a column the row table doesn't have. The
-  // service owns companyId for these rows.
+  // service owns companyId for these rows. createdBy is stamped AFTER the spread
+  // so a caller can't forge audit attribution by supplying it in a row.
   if (Array.isArray(value)) {
     if (operation === "update" || !fields.includes("createdBy")) return value;
     return value.map((element) =>
       element && typeof element === "object" && !Array.isArray(element)
-        ? { createdBy: context.userId, ...(element as Record<string, unknown>) }
+        ? { ...(element as Record<string, unknown>), createdBy: context.userId }
         : element
     );
   }

--- a/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
+++ b/apps/erp/app/routes/api+/mcp+/lib/direct-executor.ts
@@ -63,8 +63,23 @@ function enrichWithAuthContext(
   fields: AuthField[],
   operation?: McpOperation
 ): unknown {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return value;
+  if (!value || typeof value !== "object") return value;
   if (fields.length === 0) return value;
+
+  // Array payloads (e.g. the row list for upsertQuoteLinePrices) need per-element
+  // stamping — enrichment never reached inside them, so a NOT NULL createdBy on
+  // the row table failed. Only createdBy is injected into elements (and only for
+  // an insert): element keys are spread straight into an INSERT, so injecting
+  // companyId/updatedBy could add a column the row table doesn't have. The
+  // service owns companyId for these rows.
+  if (Array.isArray(value)) {
+    if (operation === "update" || !fields.includes("createdBy")) return value;
+    return value.map((element) =>
+      element && typeof element === "object" && !Array.isArray(element)
+        ? { createdBy: context.userId, ...(element as Record<string, unknown>) }
+        : element
+    );
+  }
 
   const enriched: Record<string, unknown> = {
     ...(value as Record<string, unknown>)

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-08-27T23:53:14.959Z",
+  "generated": "2026-08-28T16:35:40.658Z",
   "totalTools": 1449,
   "modules": 15,
   "tools": [
@@ -1678,7 +1678,7 @@
     {
       "name": "accounting_reopenAccountingPeriod",
       "module": "accounting",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "reopen accounting period",
       "paramCount": 1,
       "serviceParams": [
@@ -1968,7 +1968,7 @@
       "module": "accounting",
       "classification": "WRITE",
       "description": "upsert period close task definition",
-      "paramCount": 3,
+      "paramCount": 9,
       "serviceParams": [
         "client",
         "definition"
@@ -1988,11 +1988,32 @@
             "type": "string"
           },
           "taskType": {
+            "type": "string"
+          },
+          "autoCheckKey": {
+            "type": "string"
+          },
+          "sortOrder": {
             "type": "number"
+          },
+          "required": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "active": {
+            "type": "string"
+          },
+          "defaultAssigneeId": {
+            "type": "string"
           }
         },
         "required": [
-          "name"
+          "name",
+          "taskType",
+          "required",
+          "active"
         ]
       }
     },
@@ -2400,7 +2421,7 @@
       "module": "accounting",
       "classification": "WRITE",
       "description": "update fiscal year settings",
-      "paramCount": 1,
+      "paramCount": 2,
       "serviceParams": [
         "client",
         "fiscalYearSettings"
@@ -2414,10 +2435,14 @@
         "properties": {
           "startMonth": {
             "type": "string"
+          },
+          "taxStartMonth": {
+            "type": "string"
           }
         },
         "required": [
-          "startMonth"
+          "startMonth",
+          "taxStartMonth"
         ]
       }
     },
@@ -2793,7 +2818,7 @@
     {
       "name": "accounting_upsertDimension",
       "module": "accounting",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert dimension",
       "paramCount": 2,
       "serviceParams": [
@@ -2906,7 +2931,7 @@
     {
       "name": "accounting_saveJournalLineDimensions",
       "module": "accounting",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "save journal line dimensions",
       "paramCount": 2,
       "serviceParams": [
@@ -3363,7 +3388,7 @@
       "module": "accounting",
       "classification": "WRITE",
       "description": "upsert journal entry line",
-      "paramCount": 1,
+      "paramCount": 35,
       "serviceParams": [
         "client",
         "data"
@@ -3376,10 +3401,131 @@
       "schema": {
         "type": "object",
         "properties": {
-          "data": {}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "active": {
+            "type": "string"
+          },
+          "required": {
+            "type": "string"
+          },
+          "dimensionValues": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "depreciationMethod": {
+            "type": "string"
+          },
+          "usefulLifeMonths": {
+            "type": "number"
+          },
+          "residualValuePercent": {
+            "type": "number"
+          },
+          "assetAccountId": {
+            "type": "string"
+          },
+          "accumulatedDepreciationAccountId": {
+            "type": "string"
+          },
+          "depreciationExpenseAccountId": {
+            "type": "string"
+          },
+          "writeOffAccountId": {
+            "type": "string"
+          },
+          "writeDownAccountId": {
+            "type": "string"
+          },
+          "gainOnDisposalAccountId": {
+            "type": "string"
+          },
+          "lossOnDisposalAccountId": {
+            "type": "string"
+          },
+          "taxDepreciationMethod": {
+            "type": "string"
+          },
+          "taxUsefulLifeMonths": {
+            "type": "number"
+          },
+          "taxResidualValuePercent": {
+            "type": "number"
+          },
+          "macrsPropertyClass": {
+            "type": "string"
+          },
+          "macrsConvention": {
+            "type": "string"
+          },
+          "bonusDepreciationPercent": {
+            "type": "number"
+          },
+          "fixedAssetClassId": {
+            "type": "string"
+          },
+          "serialNumber": {
+            "type": "string"
+          },
+          "assetLifetimeUsage": {
+            "type": "number"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "periodEnd": {
+            "type": "string"
+          },
+          "fixedAssetId": {
+            "type": "string"
+          },
+          "periodStart": {
+            "type": "string"
+          },
+          "unitsProduced": {
+            "type": "number"
+          },
+          "disposalDate": {
+            "type": "string"
+          },
+          "acquisitionCost": {
+            "type": "number"
+          },
+          "acquisitionDate": {
+            "type": "string"
+          },
+          "accumulatedDepreciation": {
+            "type": "number"
+          }
         },
         "required": [
-          "data"
+          "name",
+          "entityType",
+          "active",
+          "required",
+          "depreciationMethod",
+          "assetAccountId",
+          "accumulatedDepreciationAccountId",
+          "depreciationExpenseAccountId",
+          "writeOffAccountId",
+          "writeDownAccountId",
+          "gainOnDisposalAccountId",
+          "lossOnDisposalAccountId",
+          "fixedAssetClassId",
+          "periodEnd",
+          "fixedAssetId",
+          "periodStart",
+          "disposalDate",
+          "acquisitionDate"
         ]
       }
     },
@@ -3411,7 +3557,7 @@
     {
       "name": "accounting_saveJournalEntryWithLines",
       "module": "accounting",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "save journal entry with lines",
       "paramCount": 4,
       "serviceParams": [
@@ -4007,7 +4153,7 @@
     {
       "name": "accounting_insertDepreciationRun",
       "module": "accounting",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "insert depreciation run",
       "paramCount": 3,
       "serviceParams": [
@@ -4681,7 +4827,10 @@
             "type": "string"
           },
           "labels": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "readGroups": {
             "type": "string"
@@ -4710,7 +4859,7 @@
     {
       "name": "documents_updateDocumentFavorite",
       "module": "documents",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update document favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -4740,7 +4889,7 @@
     {
       "name": "documents_updateDocumentLabels",
       "module": "documents",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update document labels",
       "paramCount": 2,
       "serviceParams": [
@@ -4758,7 +4907,10 @@
             "type": "string"
           },
           "labels": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "required": [
@@ -5815,7 +5967,7 @@
     {
       "name": "inventory_reconcileReceiptSerialEntities",
       "module": "inventory",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "reconcile receipt serial entities",
       "paramCount": 2,
       "serviceParams": [
@@ -6970,7 +7122,7 @@
       "module": "inventory",
       "classification": "WRITE",
       "description": "insert manual inventory adjustment",
-      "paramCount": 1,
+      "paramCount": 30,
       "serviceParams": [
         "client",
         "// `requiresSerialTracking` is a form-only flag for the validator's serial\n  // quantity guard — the route strips it before calling this.\n  inventoryAdjustment"
@@ -6982,10 +7134,110 @@
       "schema": {
         "type": "object",
         "properties": {
-          "// `requiresSerialTracking` is a form-only flag for the validator's serial\n  // quantity guard — the route strips it before calling this.\n  inventoryAdjustment": {}
+          "correctedQuantity": {
+            "type": "number"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "postingDate": {
+            "type": "string"
+          },
+          "entryType": {
+            "type": "string"
+          },
+          "documentType": {
+            "type": "string"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "storageUnitId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "receiptId": {
+            "type": "string"
+          },
+          "sourceDocument": {
+            "type": "string"
+          },
+          "sourceDocumentId": {
+            "type": "string"
+          },
+          "externalDocumentId": {
+            "type": "string"
+          },
+          "sourceDocumentReadableId": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "warehouseId": {
+            "type": "string"
+          },
+          "parentId": {
+            "type": "string"
+          },
+          "workCenterId": {
+            "type": "string"
+          },
+          "storageTypeIds": {
+            "type": "string"
+          },
+          "shipmentId": {
+            "type": "string"
+          },
+          "trackingNumber": {
+            "type": "string"
+          },
+          "shippingMethodId": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "carrier": {
+            "type": "string"
+          },
+          "carrierAccountId": {
+            "type": "string"
+          },
+          "trackingUrl": {
+            "type": "string"
+          },
+          "documentLineId": {
+            "type": "string"
+          }
         },
         "required": [
-          "// `requiresSerialTracking` is a form-only flag for the validator's serial\n  // quantity guard — the route strips it before calling this.\n  inventoryAdjustment"
+          "entryType",
+          "documentType",
+          "itemId",
+          "quantity",
+          "id",
+          "receiptId",
+          "name",
+          "locationId",
+          "shipmentId",
+          "carrier",
+          "documentId",
+          "documentLineId"
         ]
       }
     },
@@ -7276,7 +7528,7 @@
     {
       "name": "inventory_generateInventoryCountLines",
       "module": "inventory",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "generate inventory count lines",
       "paramCount": 4,
       "serviceParams": [
@@ -7618,7 +7870,7 @@
       "module": "inventory",
       "classification": "WRITE",
       "description": "upsert shipping method",
-      "paramCount": 3,
+      "paramCount": 5,
       "serviceParams": [
         "client",
         "shippingMethod"
@@ -7640,6 +7892,12 @@
           "carrier": {
             "type": "string"
           },
+          "carrierAccountId": {
+            "type": "string"
+          },
+          "trackingUrl": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -7651,6 +7909,7 @@
         },
         "required": [
           "name",
+          "carrier",
           "_operation"
         ]
       }
@@ -7755,7 +8014,7 @@
       "module": "inventory",
       "classification": "WRITE",
       "description": "upsert stock transfer line",
-      "paramCount": 1,
+      "paramCount": 5,
       "serviceParams": [
         "client",
         "stockTransferLine"
@@ -7768,7 +8027,21 @@
       "schema": {
         "type": "object",
         "properties": {
-          "stockTransferLine": {},
+          "id": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "stockTransferId": {
+            "type": "string"
+          },
+          "trackedEntityId": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -7779,7 +8052,10 @@
           }
         },
         "required": [
-          "stockTransferLine",
+          "itemId",
+          "locationId",
+          "stockTransferId",
+          "trackedEntityId",
           "_operation"
         ]
       }
@@ -7789,7 +8065,7 @@
       "module": "inventory",
       "classification": "WRITE",
       "description": "upsert stock transfer lines",
-      "paramCount": 3,
+      "paramCount": 2,
       "serviceParams": [
         "client",
         "args"
@@ -7802,18 +8078,14 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "lines": {},
+          "stockTransferId": {
             "type": "string"
-          },
-          "locationId": {
-            "type": "string"
-          },
-          "lines": {
-            "type": "number"
           }
         },
         "required": [
-          "locationId"
+          "lines",
+          "stockTransferId"
         ]
       }
     },
@@ -8745,7 +9017,7 @@
     {
       "name": "inventory_generatePickingList",
       "module": "inventory",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "generate picking list",
       "paramCount": 4,
       "serviceParams": [
@@ -8823,7 +9095,7 @@
     {
       "name": "inventory_insertStockTransfer",
       "module": "inventory",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "Create a stock transfer with lines. Generates sequence ID automatically.",
       "paramCount": 4,
       "serviceParams": [
@@ -9648,7 +9920,7 @@
     {
       "name": "invoicing_insertPurchaseInvoice",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "insert purchase invoice",
       "paramCount": 15,
       "serviceParams": [
@@ -9802,7 +10074,7 @@
     {
       "name": "invoicing_upsertPurchaseInvoice",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert purchase invoice",
       "paramCount": 15,
       "serviceParams": [
@@ -9945,7 +10217,7 @@
       "module": "invoicing",
       "classification": "WRITE",
       "description": "update purchase invoice line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -9957,23 +10229,34 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
     {
       "name": "invoicing_insertSalesInvoice",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "insert sales invoice",
       "paramCount": 14,
       "serviceParams": [
@@ -10124,7 +10407,7 @@
     {
       "name": "invoicing_upsertSalesInvoice",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert sales invoice",
       "paramCount": 15,
       "serviceParams": [
@@ -10267,7 +10550,7 @@
       "module": "invoicing",
       "classification": "WRITE",
       "description": "update sales invoice line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -10279,16 +10562,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -10671,7 +10965,7 @@
     {
       "name": "invoicing_replaceInvoiceSettlements",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "replace invoice settlements",
       "paramCount": 2,
       "serviceParams": [
@@ -10952,7 +11246,7 @@
     {
       "name": "invoicing_applyCreditsToInvoices",
       "module": "invoicing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "apply credits to invoices",
       "paramCount": 4,
       "serviceParams": [
@@ -14202,7 +14496,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "update material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -14214,16 +14508,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -14232,7 +14537,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "update operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -14244,16 +14549,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -14477,7 +14793,7 @@
     {
       "name": "items_upsertItemShelfLife",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert item shelf life",
       "paramCount": 6,
       "serviceParams": [
@@ -14519,7 +14835,7 @@
     {
       "name": "items_upsertPickMethodWithShelfLife",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert pick method with shelf life",
       "paramCount": 6,
       "serviceParams": [
@@ -14550,9 +14866,7 @@
             "type": "string"
           },
           "customFields": {},
-          "shelfLife: {\n      mode": {
-            "type": "string"
-          }
+          "shelfLife: {\n      mode": {}
         },
         "required": [
           "itemId",
@@ -14626,7 +14940,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert consumable",
-      "paramCount": 1,
+      "paramCount": 12,
       "serviceParams": [
         "client",
         "consumable"
@@ -14639,7 +14953,42 @@
       "schema": {
         "type": "object",
         "properties": {
-          "consumable": {},
+          "id": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -14650,7 +14999,12 @@
           }
         },
         "required": [
-          "consumable",
+          "id",
+          "name",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
           "_operation"
         ]
       }
@@ -14711,7 +15065,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert part",
-      "paramCount": 1,
+      "paramCount": 15,
       "serviceParams": [
         "client",
         "part"
@@ -14724,7 +15078,51 @@
       "schema": {
         "type": "object",
         "properties": {
-          "part": {},
+          "id": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "lotSize": {
+            "type": "number"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -14735,7 +15133,13 @@
           }
         },
         "required": [
-          "part",
+          "id",
+          "name",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
+          "revision",
           "_operation"
         ]
       }
@@ -14745,7 +15149,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "update item",
-      "paramCount": 5,
+      "paramCount": 12,
       "serviceParams": [
         "client",
         "item"
@@ -14771,12 +15175,36 @@
           },
           "replenishmentSystem": {
             "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
           }
         },
         "required": [
           "id",
           "name",
-          "replenishmentSystem"
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode"
         ]
       }
     },
@@ -14785,7 +15213,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert item cost",
-      "paramCount": 3,
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "itemCost"
@@ -14805,6 +15233,9 @@
             "type": "string"
           },
           "costingMethod": {
+            "type": "string"
+          },
+          "unitCost": {
             "type": "number"
           }
         },
@@ -14975,9 +15406,9 @@
     {
       "name": "items_upsertItemSupersession",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert item supersession",
-      "paramCount": 1,
+      "paramCount": 36,
       "serviceParams": [
         "client",
         "itemSupersession"
@@ -14990,10 +15421,130 @@
       "schema": {
         "type": "object",
         "properties": {
-          "itemSupersession": {}
+          "itemId": {
+            "type": "string"
+          },
+          "preferredSupplierId": {
+            "type": "string"
+          },
+          "conversionFactor": {
+            "type": "number"
+          },
+          "leadTime": {
+            "type": "number"
+          },
+          "purchasingUnitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitSalePrice": {
+            "type": "number"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "materialFormId": {
+            "type": "string"
+          },
+          "materialSubstanceId": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "lotSize": {
+            "type": "number"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "defaultStorageUnitId": {
+            "type": "string"
+          },
+          "sortMethod": {
+            "type": "string"
+          },
+          "shelfLifeMode": {
+            "type": "string"
+          },
+          "shelfLifeTriggerTiming": {
+            "type": "string"
+          },
+          "shelfLifeCalculateFromBom": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "supplierPartId": {
+            "type": "string"
+          },
+          "supplierUnitOfMeasureCode": {
+            "type": "string"
+          },
+          "minimumOrderQuantity": {
+            "type": "number"
+          },
+          "orderMultiple": {
+            "type": "number"
+          },
+          "unitPrice": {
+            "type": "number"
+          }
         },
         "required": [
-          "itemSupersession"
+          "itemId",
+          "name",
+          "materialFormId",
+          "materialSubstanceId",
+          "code",
+          "id",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
+          "revision",
+          "locationId",
+          "shelfLifeCalculateFromBom",
+          "supplierId"
         ]
       }
     },
@@ -15209,7 +15760,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert method material",
-      "paramCount": 4,
+      "paramCount": 12,
       "serviceParams": [
         "client",
         "methodMaterial"
@@ -15234,6 +15785,30 @@
           "itemType": {
             "type": "string"
           },
+          "kit": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "sourcingType": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "methodOperationId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "storageUnitIds": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -15246,6 +15821,11 @@
         "required": [
           "id",
           "makeMethodId",
+          "itemType",
+          "methodType",
+          "sourcingType",
+          "unitOfMeasureCode",
+          "storageUnitIds",
           "_operation"
         ]
       }
@@ -15450,7 +16030,7 @@
     {
       "name": "items_replaceMethodMaterialSteps",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "replace method material steps",
       "paramCount": 2,
       "serviceParams": [
@@ -15483,7 +16063,7 @@
     {
       "name": "items_setMethodMaterialStepLink",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "set method material step link",
       "paramCount": 4,
       "serviceParams": [
@@ -15523,7 +16103,7 @@
     {
       "name": "items_setMethodOperationToolStepLink",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "set method operation tool step link",
       "paramCount": 4,
       "serviceParams": [
@@ -15563,7 +16143,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert material",
-      "paramCount": 1,
+      "paramCount": 19,
       "serviceParams": [
         "client",
         "material"
@@ -15576,7 +16156,66 @@
       "schema": {
         "type": "object",
         "properties": {
-          "material": {},
+          "id": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
+          "materialSubstanceId": {
+            "type": "string"
+          },
+          "materialFormId": {
+            "type": "string"
+          },
+          "materialTypeId": {
+            "type": "string"
+          },
+          "finishId": {
+            "type": "string"
+          },
+          "gradeId": {
+            "type": "string"
+          },
+          "dimensionId": {
+            "type": "string"
+          },
+          "sizes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -15587,7 +16226,12 @@
           }
         },
         "required": [
-          "material",
+          "id",
+          "name",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
           "_operation"
         ]
       }
@@ -15947,7 +16591,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert service",
-      "paramCount": 1,
+      "paramCount": 13,
       "serviceParams": [
         "client",
         "service"
@@ -15960,7 +16604,45 @@
       "schema": {
         "type": "object",
         "properties": {
-          "service": {},
+          "id": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -15971,7 +16653,13 @@
           }
         },
         "required": [
-          "service",
+          "id",
+          "name",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
+          "revision",
           "_operation"
         ]
       }
@@ -16015,7 +16703,7 @@
       "module": "items",
       "classification": "WRITE",
       "description": "upsert tool",
-      "paramCount": 1,
+      "paramCount": 15,
       "serviceParams": [
         "client",
         "tool"
@@ -16028,7 +16716,51 @@
       "schema": {
         "type": "object",
         "properties": {
-          "tool": {},
+          "id": {
+            "type": "string"
+          },
+          "readableId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "replenishmentSystem": {
+            "type": "string"
+          },
+          "defaultMethodType": {
+            "type": "string"
+          },
+          "itemTrackingType": {
+            "type": "string"
+          },
+          "postingGroupId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "shelfLifeDays": {
+            "type": "number"
+          },
+          "shelfLifeTriggerProcessId": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "lotSize": {
+            "type": "number"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -16039,7 +16771,13 @@
           }
         },
         "required": [
-          "tool",
+          "id",
+          "name",
+          "replenishmentSystem",
+          "defaultMethodType",
+          "itemTrackingType",
+          "unitOfMeasureCode",
+          "revision",
           "_operation"
         ]
       }
@@ -16596,7 +17334,7 @@
     {
       "name": "items_createChangeNoticeDraftMethod",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "create change notice draft method",
       "paramCount": 4,
       "serviceParams": [
@@ -16632,7 +17370,7 @@
     {
       "name": "items_addChangeNoticeAffectedItem",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "add change notice affected item",
       "paramCount": 5,
       "serviceParams": [
@@ -16658,7 +17396,39 @@
             "type": "string"
           },
           "newPart": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "readableId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "itemType": {
+                "type": "string",
+                "enum": [
+                  "Part",
+                  "Tool"
+                ]
+              },
+              "replenishmentSystem": {
+                "type": "string",
+                "enum": [
+                  "Buy",
+                  "Make",
+                  "Buy and Make"
+                ]
+              },
+              "itemTrackingType": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "readableId",
+              "name",
+              "itemType",
+              "replenishmentSystem"
+            ]
           }
         },
         "required": [
@@ -16758,7 +17528,7 @@
     {
       "name": "items_removeChangeNoticeAffectedItem",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "remove change notice affected item",
       "paramCount": 1,
       "serviceParams": [
@@ -17163,7 +17933,7 @@
     {
       "name": "items_setChangeNoticeActionTasks",
       "module": "items",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "set change notice action tasks",
       "paramCount": 2,
       "serviceParams": [
@@ -18088,7 +18858,7 @@
       "module": "people",
       "classification": "WRITE",
       "description": "update attribute sort order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -18100,16 +18870,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21508,7 +22289,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21520,16 +22301,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -21538,7 +22330,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21550,16 +22342,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -21568,7 +22371,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update job operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21580,16 +22383,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21631,7 +22445,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update quote operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21643,16 +22457,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21661,7 +22486,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update method operation step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21673,16 +22498,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21758,7 +22594,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update procedure step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -21770,16 +22606,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -21788,7 +22635,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "upsert production event",
-      "paramCount": 1,
+      "paramCount": 49,
       "serviceParams": [
         "client",
         "productionEvent"
@@ -21801,7 +22648,156 @@
       "schema": {
         "type": "object",
         "properties": {
-          "productionEvent": {},
+          "startDate": {
+            "type": "string"
+          },
+          "dueDate": {
+            "type": "string"
+          },
+          "periodId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "existingId": {
+            "type": "string"
+          },
+          "existingQuantity": {
+            "type": "number"
+          },
+          "existingReadableId": {
+            "type": "string"
+          },
+          "existingStatus": {
+            "type": "string"
+          },
+          "isASAP": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          },
+          "columnId": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "oeeImpact": {
+            "type": "string"
+          },
+          "workCenterId": {
+            "type": "string"
+          },
+          "suspectedFailureModeId": {
+            "type": "string"
+          },
+          "plannedStartTime": {
+            "type": "string"
+          },
+          "plannedEndTime": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "maintenanceDispatchId": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "description": {
+            "type": "string"
+          },
+          "frequency": {
+            "type": "string"
+          },
+          "estimatedDuration": {
+            "type": "number"
+          },
+          "active": {
+            "type": "string"
+          },
+          "maintenanceScheduleId": {
+            "type": "string"
+          },
+          "periods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          },
+          "copyFromId": {
+            "type": "string"
+          },
+          "motion": {
+            "type": "string"
+          },
+          "camera": {
+            "type": "string"
+          },
+          "componentNodeIds": {
+            "type": "string"
+          },
+          "updates": {
+            "type": "number"
+          },
+          "stepId": {
+            "type": "string"
+          },
+          "sortOrder": {
+            "type": "number"
+          },
+          "partId": {
+            "type": "string"
+          },
+          "drawingNumber": {
+            "type": "string"
+          },
+          "pdfUrl": {
+            "type": "string"
+          },
+          "annotations": {
+            "type": "string"
+          },
+          "features": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -21812,7 +22808,28 @@
           }
         },
         "required": [
-          "productionEvent",
+          "periodId",
+          "id",
+          "columnId",
+          "priority",
+          "locationId",
+          "name",
+          "status",
+          "maintenanceDispatchId",
+          "comment",
+          "itemId",
+          "unitOfMeasureCode",
+          "workCenterId",
+          "frequency",
+          "active",
+          "maintenanceScheduleId",
+          "modelUploadId",
+          "operationId",
+          "copyFromId",
+          "componentNodeIds",
+          "updates",
+          "stepId",
+          "partId",
           "_operation"
         ]
       }
@@ -22151,7 +23168,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "upsert job operation",
-      "paramCount": 1,
+      "paramCount": 24,
       "serviceParams": [
         "client",
         "jobOperation"
@@ -22164,7 +23181,78 @@
       "schema": {
         "type": "object",
         "properties": {
-          "jobOperation": {},
+          "id": {
+            "type": "string"
+          },
+          "jobMakeMethodId": {
+            "type": "string"
+          },
+          "order": {
+            "type": "number"
+          },
+          "operationOrder": {
+            "type": "string"
+          },
+          "operationType": {
+            "type": "string"
+          },
+          "processId": {
+            "type": "string"
+          },
+          "procedureId": {
+            "type": "string"
+          },
+          "assemblyInstructionId": {
+            "type": "string"
+          },
+          "inspectionDocumentId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "setupUnit": {
+            "type": "string"
+          },
+          "setupTime": {
+            "type": "number"
+          },
+          "laborUnit": {
+            "type": "string"
+          },
+          "laborTime": {
+            "type": "number"
+          },
+          "machineUnit": {
+            "type": "string"
+          },
+          "machineTime": {
+            "type": "number"
+          },
+          "machineRate": {
+            "type": "number"
+          },
+          "overheadRate": {
+            "type": "number"
+          },
+          "laborRate": {
+            "type": "number"
+          },
+          "operationSupplierProcessId": {
+            "type": "string"
+          },
+          "operationMinimumCost": {
+            "type": "number"
+          },
+          "operationUnitCost": {
+            "type": "number"
+          },
+          "operationLeadTime": {
+            "type": "number"
+          },
+          "workCenterId": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -22175,7 +23263,11 @@
           }
         },
         "required": [
-          "jobOperation",
+          "id",
+          "jobMakeMethodId",
+          "operationOrder",
+          "operationType",
+          "processId",
           "_operation"
         ]
       }
@@ -22346,7 +23438,7 @@
     {
       "name": "production_replaceJobMaterialSteps",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "replace job material steps",
       "paramCount": 2,
       "serviceParams": [
@@ -22379,7 +23471,7 @@
     {
       "name": "production_setJobMaterialStepLink",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "set job material step link",
       "paramCount": 4,
       "serviceParams": [
@@ -22419,7 +23511,7 @@
     {
       "name": "production_setJobOperationToolStepLink",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "set job operation tool step link",
       "paramCount": 4,
       "serviceParams": [
@@ -23051,7 +24143,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "upsert maintenance dispatch event",
-      "paramCount": 1,
+      "paramCount": 18,
       "serviceParams": [
         "client",
         "event"
@@ -23064,7 +24156,63 @@
       "schema": {
         "type": "object",
         "properties": {
-          "event": {},
+          "id": {
+            "type": "string"
+          },
+          "maintenanceDispatchId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "workCenterId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "frequency": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "estimatedDuration": {
+            "type": "number"
+          },
+          "active": {
+            "type": "string"
+          },
+          "maintenanceScheduleId": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "periods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "operationId": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -23075,7 +24223,18 @@
           }
         },
         "required": [
-          "event",
+          "maintenanceDispatchId",
+          "itemId",
+          "unitOfMeasureCode",
+          "workCenterId",
+          "name",
+          "frequency",
+          "priority",
+          "active",
+          "maintenanceScheduleId",
+          "locationId",
+          "modelUploadId",
+          "operationId",
           "_operation"
         ]
       }
@@ -23290,7 +24449,7 @@
     {
       "name": "production_upsertDemandForecasts",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert demand forecasts",
       "paramCount": 1,
       "serviceParams": [
@@ -23315,7 +24474,7 @@
     {
       "name": "production_upsertDemandProjections",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert demand projections",
       "paramCount": 1,
       "serviceParams": [
@@ -23663,7 +24822,7 @@
     {
       "name": "production_invalidateAssemblyModelCache",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "invalidate assembly model cache",
       "paramCount": 1,
       "serviceParams": [
@@ -23835,7 +24994,7 @@
     {
       "name": "production_reassignAssemblyStepComponents",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "reassign assembly step components",
       "paramCount": 4,
       "serviceParams": [
@@ -23920,7 +25079,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update assembly instruction step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -23932,16 +25091,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -24226,7 +25396,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "update assembly instruction step material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -24238,16 +25408,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -24685,20 +25866,25 @@
             }
           },
           "existingSynced": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "assemblyInstructionStepId": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
               },
-              "assemblyInstructionStepId": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "id",
-              "assemblyInstructionStepId"
-            ]
+              "required": [
+                "id",
+                "assemblyInstructionStepId"
+              ]
+            }
           }
         },
         "required": [
@@ -24712,7 +25898,7 @@
       "module": "production",
       "classification": "WRITE",
       "description": "max tool quantity by item",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "sourceTools"
       ],
@@ -24722,17 +25908,30 @@
       "schema": {
         "type": "object",
         "properties": {
-          "itemId": {
-            "type": "string"
-          },
-          "quantity": {
+          "sourceTools": {
             "type": "array",
-            "items": {}
+            "items": {
+              "type": "object",
+              "properties": {
+                "itemId": {
+                  "type": "string"
+                },
+                "quantity": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "itemId",
+                "quantity"
+              ]
+            }
           }
         },
         "required": [
-          "itemId",
-          "quantity"
+          "sourceTools"
         ]
       }
     },
@@ -24755,16 +25954,18 @@
         "type": "object",
         "properties": {
           "sourceSteps": {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "id"
-            ]
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id"
+              ]
+            }
           },
           "toolsByStep": {},
           "toolRowIdByItemId": {},
@@ -24781,7 +25982,7 @@
     {
       "name": "production_syncAssemblyInstructionToOperation",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "sync assembly instruction to operation",
       "paramCount": 2,
       "serviceParams": [
@@ -24811,7 +26012,7 @@
     {
       "name": "production_generateAssemblyStepsFromPlan",
       "module": "production",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "generate assembly steps from plan",
       "paramCount": 2,
       "serviceParams": [
@@ -26803,7 +28004,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "insert supplier",
-      "paramCount": 4,
+      "paramCount": 9,
       "serviceParams": [
         "client",
         "supplier"
@@ -26827,11 +28028,25 @@
           },
           "supplierStatus": {
             "type": "string"
+          },
+          "supplierTypeId": {
+            "type": "string"
+          },
+          "accountManagerId": {
+            "type": "string"
+          },
+          "currencyCode": {
+            "type": "string"
+          },
+          "purchasingContactId": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string"
           }
         },
         "required": [
-          "name",
-          "supplierStatus"
+          "name"
         ]
       }
     },
@@ -26840,7 +28055,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "insert supplier contact",
-      "paramCount": 2,
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "supplierContact"
@@ -26853,13 +28068,19 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "supplierId": {
             "type": "string"
           },
+          "contact": {},
           "supplierLocationId": {
             "type": "string"
-          }
-        }
+          },
+          "customFields": {}
+        },
+        "required": [
+          "supplierId",
+          "contact"
+        ]
       }
     },
     {
@@ -27040,7 +28261,7 @@
     {
       "name": "purchasing_updatePurchaseOrderFavorite",
       "module": "purchasing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update purchase order favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -27155,7 +28376,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update supplier contact",
-      "paramCount": 2,
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "supplierContact"
@@ -27167,13 +28388,19 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "contactId": {
             "type": "string"
           },
+          "contact": {},
           "supplierLocationId": {
             "type": "string"
-          }
-        }
+          },
+          "customFields": {}
+        },
+        "required": [
+          "contactId",
+          "contact"
+        ]
       }
     },
     {
@@ -27279,7 +28506,7 @@
     {
       "name": "purchasing_updateSupplierQuoteFavorite",
       "module": "purchasing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update supplier quote favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -27582,9 +28809,7 @@
       "schema": {
         "type": "object",
         "properties": {
-          "purchaseOrder": {
-            "type": "string"
-          },
+          "purchaseOrder": {},
           "receiptRequestedDate": {
             "type": "string"
           }
@@ -27649,7 +28874,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update purchase order line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -27661,16 +28886,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -27755,7 +28991,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "upsert supplier",
-      "paramCount": 4,
+      "paramCount": 9,
       "serviceParams": [
         "client",
         "supplier"
@@ -27780,6 +29016,21 @@
           "supplierStatus": {
             "type": "string"
           },
+          "supplierTypeId": {
+            "type": "string"
+          },
+          "accountManagerId": {
+            "type": "string"
+          },
+          "currencyCode": {
+            "type": "string"
+          },
+          "purchasingContactId": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -27791,7 +29042,6 @@
         },
         "required": [
           "name",
-          "supplierStatus",
           "_operation"
         ]
       }
@@ -27969,7 +29219,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "upsert supplier quote",
-      "paramCount": 1,
+      "paramCount": 17,
       "serviceParams": [
         "client",
         "supplierQuote"
@@ -27982,7 +29232,63 @@
       "schema": {
         "type": "object",
         "properties": {
-          "supplierQuote": {},
+          "id": {
+            "type": "string"
+          },
+          "rfqId": {
+            "type": "string"
+          },
+          "rfqDate": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "employeeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "supplierIds": {
+            "type": "string"
+          },
+          "purchasingRfqId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "purchaseUnitOfMeasureCode": {
+            "type": "string"
+          },
+          "inventoryUnitOfMeasureCode": {
+            "type": "string"
+          },
+          "conversionFactor": {
+            "type": "number"
+          },
+          "order": {
+            "type": "number"
+          },
+          "suppliers": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -27993,7 +29299,11 @@
           }
         },
         "required": [
-          "supplierQuote",
+          "rfqDate",
+          "supplierIds",
+          "purchasingRfqId",
+          "itemId",
+          "quantity",
           "_operation"
         ]
       }
@@ -28028,7 +29338,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update supplier quote line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -28040,16 +29350,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -28455,7 +29776,7 @@
       "module": "purchasing",
       "classification": "WRITE",
       "description": "update purchasing r f q line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -28467,23 +29788,34 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
     {
       "name": "purchasing_upsertPurchasingRFQSuppliers",
       "module": "purchasing",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert purchasing r f q suppliers",
       "paramCount": 2,
       "serviceParams": [
@@ -30199,7 +31531,7 @@
     {
       "name": "quality_updateIssueActionProcesses",
       "module": "quality",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update issue action processes",
       "paramCount": 2,
       "serviceParams": [
@@ -30357,7 +31689,7 @@
       "module": "quality",
       "classification": "WRITE",
       "description": "update quality document step order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -30369,16 +31701,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -31010,7 +32353,10 @@
             "type": "string"
           },
           "requiredActionIds": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "approvalRequirements": {
             "type": "string"
@@ -31037,7 +32383,10 @@
             "type": "number"
           },
           "items": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "jobOperationId": {
             "type": "string"
@@ -31076,7 +32425,7 @@
       "module": "quality",
       "classification": "WRITE",
       "description": "upsert issue workflow",
-      "paramCount": 3,
+      "paramCount": 7,
       "serviceParams": [
         "client",
         "nonConformanceWorkflow"
@@ -31098,6 +32447,18 @@
           "content": {
             "type": "string"
           },
+          "priority": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "requiredActionIds": {
+            "type": "string"
+          },
+          "approvalRequirements": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -31109,6 +32470,9 @@
         },
         "required": [
           "name",
+          "content",
+          "priority",
+          "source",
           "_operation"
         ]
       }
@@ -31260,7 +32624,7 @@
       "module": "quality",
       "classification": "WRITE",
       "description": "upsert risk",
-      "paramCount": 6,
+      "paramCount": 12,
       "serviceParams": [
         "client",
         "risk"
@@ -31290,10 +32654,33 @@
           },
           "notes": {
             "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
           }
         },
         "required": [
-          "likelihood"
+          "likelihood",
+          "severity",
+          "source",
+          "status",
+          "title",
+          "type"
         ]
       }
     },
@@ -31506,7 +32893,7 @@
     {
       "name": "quality_upsertItemInspectionDocumentAssignment",
       "module": "quality",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert item inspection document assignment",
       "paramCount": 2,
       "serviceParams": [
@@ -31529,7 +32916,8 @@
           }
         },
         "required": [
-          "itemId"
+          "itemId",
+          "usage"
         ]
       }
     },
@@ -33682,7 +35070,7 @@
       "module": "resources",
       "classification": "WRITE",
       "description": "update training question order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -33694,23 +35082,34 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
     {
       "name": "resources_upsertContractor",
       "module": "resources",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert contractor",
       "paramCount": 1,
       "serviceParams": [
@@ -34144,7 +35543,7 @@
       "module": "resources",
       "classification": "WRITE",
       "description": "upsert maintenance dispatch event",
-      "paramCount": 1,
+      "paramCount": 41,
       "serviceParams": [
         "client",
         "event"
@@ -34157,7 +35556,136 @@
       "schema": {
         "type": "object",
         "properties": {
-          "event": {},
+          "id": {
+            "type": "string"
+          },
+          "maintenanceDispatchId": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "unitCost": {
+            "type": "number"
+          },
+          "status": {
+            "type": "string"
+          },
+          "priority": {
+            "type": "string"
+          },
+          "severity": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "oeeImpact": {
+            "type": "string"
+          },
+          "workCenterId": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "suspectedFailureModeId": {
+            "type": "string"
+          },
+          "plannedStartTime": {
+            "type": "string"
+          },
+          "plannedEndTime": {
+            "type": "string"
+          },
+          "assignee": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "maintenanceDispatchItemId": {
+            "type": "string"
+          },
+          "adjustmentType": {
+            "type": "string",
+            "enum": [
+              "Positive Adjmt.",
+              "Negative Adjmt."
+            ]
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "maintenanceScheduleId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "frequency": {
+            "type": "string"
+          },
+          "estimatedDuration": {
+            "type": "number"
+          },
+          "nextDueAt": {
+            "type": "string"
+          },
+          "active": {
+            "type": "string"
+          },
+          "tuesday": {
+            "type": "string"
+          },
+          "wednesday": {
+            "type": "string"
+          },
+          "thursday": {
+            "type": "string"
+          },
+          "friday": {
+            "type": "string"
+          },
+          "saturday": {
+            "type": "string"
+          },
+          "sunday": {
+            "type": "string"
+          },
+          "supplierId": {
+            "type": "string"
+          },
+          "hoursPerWeek": {
+            "type": "number"
+          },
+          "trainingId": {
+            "type": "string"
+          },
+          "groupIds": {
+            "type": "string"
+          },
+          "trainingAssignmentId": {
+            "type": "string"
+          },
+          "employeeId": {
+            "type": "string"
+          },
+          "period": {
+            "type": "string"
+          },
           "_operation": {
             "type": "string",
             "enum": [
@@ -34168,7 +35696,31 @@
           }
         },
         "required": [
-          "event",
+          "maintenanceDispatchId",
+          "itemId",
+          "unitOfMeasureCode",
+          "status",
+          "priority",
+          "locationId",
+          "workCenterId",
+          "maintenanceDispatchItemId",
+          "adjustmentType",
+          "children",
+          "maintenanceScheduleId",
+          "name",
+          "frequency",
+          "active",
+          "tuesday",
+          "wednesday",
+          "thursday",
+          "friday",
+          "saturday",
+          "sunday",
+          "id",
+          "trainingId",
+          "groupIds",
+          "trainingAssignmentId",
+          "employeeId",
           "_operation"
         ]
       }
@@ -34447,7 +35999,7 @@
     {
       "name": "resources_upsertProcess",
       "module": "resources",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert process",
       "paramCount": 1,
       "serviceParams": [
@@ -34576,9 +36128,9 @@
     {
       "name": "resources_upsertWorkCenter",
       "module": "resources",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert work center",
-      "paramCount": 4,
+      "paramCount": 10,
       "serviceParams": [
         "client",
         "workCenter"
@@ -34601,7 +36153,25 @@
             "type": "string"
           },
           "defaultStandardFactor": {
+            "type": "string"
+          },
+          "departmentId": {
+            "type": "string"
+          },
+          "laborRate": {
             "type": "number"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "machineRate": {
+            "type": "number"
+          },
+          "overheadRate": {
+            "type": "number"
+          },
+          "processes": {
+            "type": "string"
           },
           "_operation": {
             "type": "string",
@@ -34615,6 +36185,8 @@
         "required": [
           "name",
           "description",
+          "defaultStandardFactor",
+          "locationId",
           "_operation"
         ]
       }
@@ -34874,7 +36446,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "create pricing rule",
-      "paramCount": 1,
+      "paramCount": 58,
       "serviceParams": [
         "client",
         "companyId",
@@ -34889,10 +36461,197 @@
       "schema": {
         "type": "object",
         "properties": {
-          "data": {}
+          "id": {
+            "type": "string"
+          },
+          "quoteId": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "salesPersonId": {
+            "type": "string"
+          },
+          "estimatorId": {
+            "type": "string"
+          },
+          "customerId": {
+            "type": "string"
+          },
+          "customerLocationId": {
+            "type": "string"
+          },
+          "customerContactId": {
+            "type": "string"
+          },
+          "customerEngineeringContactId": {
+            "type": "string"
+          },
+          "customerReference": {
+            "type": "string"
+          },
+          "locationId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "notes": {},
+          "dueDate": {
+            "type": "string"
+          },
+          "expirationDate": {
+            "type": "string"
+          },
+          "currencyCode": {
+            "type": "string"
+          },
+          "exchangeRate": {
+            "type": "number"
+          },
+          "exchangeRateUpdatedAt": {
+            "type": "string"
+          },
+          "digitalQuoteAcceptedBy": {
+            "type": "string"
+          },
+          "digitalQuoteAcceptedByEmail": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "amounts": {
+            "type": "number"
+          },
+          "taxable": {
+            "type": "boolean"
+          },
+          "itemType": {
+            "type": "string"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "customerPartId": {
+            "type": "string"
+          },
+          "customerPartRevision": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "noQuoteReason": {
+            "type": "string"
+          },
+          "taxPercent": {
+            "type": "number"
+          },
+          "configuration": {},
+          "invoiceCustomerId": {
+            "type": "string"
+          },
+          "invoiceCustomerLocationId": {
+            "type": "string"
+          },
+          "invoiceCustomerContactId": {
+            "type": "string"
+          },
+          "paymentTermId": {
+            "type": "string"
+          },
+          "shippingMethodId": {
+            "type": "string"
+          },
+          "receiptRequestedDate": {
+            "type": "string"
+          },
+          "shippingCost": {
+            "type": "number"
+          },
+          "incoterm": {
+            "type": "string"
+          },
+          "incotermLocation": {
+            "type": "string"
+          },
+          "salesOrderId": {
+            "type": "string"
+          },
+          "orderDate": {
+            "type": "string"
+          },
+          "requestedDate": {
+            "type": "string"
+          },
+          "promisedDate": {
+            "type": "string"
+          },
+          "paymentComplete": {
+            "type": "string"
+          },
+          "rfqId": {
+            "type": "string"
+          },
+          "externalNotes": {
+            "type": "string"
+          },
+          "internalNotes": {
+            "type": "string"
+          },
+          "rfqDate": {
+            "type": "string"
+          },
+          "is3DModel": {
+            "type": "boolean"
+          },
+          "size": {
+            "type": "number"
+          },
+          "lineId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "salesRfqId": {
+            "type": "string"
+          },
+          "order": {
+            "type": "number"
+          }
         },
         "required": [
-          "data"
+          "customerId",
+          "locationId",
+          "description",
+          "amounts",
+          "quoteId",
+          "itemId",
+          "status",
+          "methodType",
+          "quantity",
+          "id",
+          "paymentComplete",
+          "rfqDate",
+          "customerPartId",
+          "path",
+          "salesRfqId",
+          "unitOfMeasureCode"
         ]
       }
     },
@@ -37714,7 +39473,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "insert customer contact",
-      "paramCount": 2,
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "customerContact"
@@ -37727,13 +39486,19 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "customerId": {
             "type": "string"
           },
+          "contact": {},
           "customerLocationId": {
             "type": "string"
-          }
-        }
+          },
+          "customFields": {}
+        },
+        "required": [
+          "customerId",
+          "contact"
+        ]
       }
     },
     {
@@ -38023,7 +39788,7 @@
     {
       "name": "sales_upsertCustomerItemPriceOverride",
       "module": "sales",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert customer item price override",
       "paramCount": 10,
       "serviceParams": [
@@ -38208,7 +39973,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update customer contact",
-      "paramCount": 2,
+      "paramCount": 4,
       "serviceParams": [
         "client",
         "customerContact"
@@ -38220,13 +39985,19 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
+          "contactId": {
             "type": "string"
           },
+          "contact": {},
           "customerLocationId": {
             "type": "string"
-          }
-        }
+          },
+          "customFields": {}
+        },
+        "required": [
+          "contactId",
+          "contact"
+        ]
       }
     },
     {
@@ -38517,7 +40288,7 @@
     {
       "name": "sales_updateSalesRFQFavorite",
       "module": "sales",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update sales r f q favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -38644,7 +40415,7 @@
     {
       "name": "sales_updateQuoteFavorite",
       "module": "sales",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update quote favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -38715,7 +40486,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote material order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -38727,16 +40498,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -38745,7 +40527,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote operation order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -38757,16 +40539,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "order": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "order"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "order"
+          "updates"
         ]
       }
     },
@@ -39203,7 +40996,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "upsert quote line",
-      "paramCount": 5,
+      "paramCount": 16,
       "serviceParams": [
         "client",
         "quotationLine"
@@ -39230,11 +41023,49 @@
           },
           "status": {
             "type": "string"
-          }
+          },
+          "estimatorId": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "customerPartId": {
+            "type": "string"
+          },
+          "customerPartRevision": {
+            "type": "string"
+          },
+          "unitOfMeasureCode": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "modelUploadId": {
+            "type": "string"
+          },
+          "noQuoteReason": {
+            "type": "string"
+          },
+          "taxPercent": {
+            "type": "number"
+          },
+          "configuration": {}
         },
         "required": [
           "quoteId",
-          "itemId"
+          "itemId",
+          "status",
+          "description",
+          "methodType",
+          "quantity"
         ]
       }
     },
@@ -39243,7 +41074,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update quote line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -39255,16 +41086,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -39309,7 +41151,7 @@
     {
       "name": "sales_upsertQuoteLinePrices",
       "module": "sales",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert quote line prices",
       "paramCount": 3,
       "serviceParams": [
@@ -39334,39 +41176,43 @@
             "type": "string"
           },
           "quoteLinePrices": {
-            "type": "object",
-            "properties": {
-              "quoteLineId": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "quoteLineId": {
+                  "type": "string"
+                },
+                "unitPrice": {
+                  "type": "number"
+                },
+                "quantity": {
+                  "type": "number"
+                },
+                "leadTime": {
+                  "type": "number"
+                },
+                "discountPercent": {
+                  "type": "number"
+                },
+                "shippingCost": {
+                  "type": "number"
+                },
+                "categoryMarkups": {},
+                "priceSource": {
+                  "type": "string",
+                  "enum": [
+                    "system",
+                    "manual"
+                  ]
+                }
               },
-              "unitPrice": {
-                "type": "number"
-              },
-              "leadTime": {
-                "type": "number"
-              },
-              "discountPercent": {
-                "type": "number"
-              },
-              "quantity": {
-                "type": "number"
-              },
-              "categoryMarkups": {},
-              "priceSource": {
-                "type": "string",
-                "enum": [
-                  "system",
-                  "manual"
-                ]
-              }
-            },
-            "required": [
-              "quoteLineId",
-              "unitPrice",
-              "leadTime",
-              "discountPercent",
-              "quantity"
-            ]
+              "required": [
+                "quoteLineId",
+                "unitPrice",
+                "quantity"
+              ]
+            }
           }
         },
         "required": [
@@ -40045,7 +41891,7 @@
     {
       "name": "sales_updateSalesOrderFavorite",
       "module": "sales",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "update sales order favorite",
       "paramCount": 2,
       "serviceParams": [
@@ -40400,7 +42246,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update sales order line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -40412,16 +42258,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -40739,7 +42596,10 @@
             "type": "string"
           },
           "quantity": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
           },
           "unitOfMeasureCode": {
             "type": "string"
@@ -40773,7 +42633,7 @@
       "module": "sales",
       "classification": "WRITE",
       "description": "update sales r f q line order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "db",
         "updates"
@@ -40785,16 +42645,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -43081,7 +44952,7 @@
       "module": "settings",
       "classification": "WRITE",
       "description": "upsert api key",
-      "paramCount": 4,
+      "paramCount": 49,
       "serviceParams": [
         "client",
         "apiKey"
@@ -43094,7 +44965,158 @@
       "schema": {
         "type": "object",
         "properties": {
+          "next": {
+            "type": "string"
+          },
+          "industryId": {
+            "type": "string"
+          },
+          "customIndustryDescription": {
+            "type": "string"
+          },
+          "digitalQuoteEnabled": {
+            "type": "string"
+          },
+          "digitalQuoteNotificationGroup": {
+            "type": "string"
+          },
+          "digitalQuoteIncludesPurchaseOrders": {
+            "type": "string"
+          },
+          "inventoryJobCompletedNotificationGroup": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "salesJobCompletedNotificationGroup": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "kanbanOutput": {
+            "type": "string"
+          },
+          "plmReleaseControl": {
+            "type": "string"
+          },
+          "purchasePriceUpdateTiming": {
+            "type": "string"
+          },
+          "incompletePickingListPolicy": {
+            "type": "string"
+          },
+          "returnPickedMaterialTiming": {
+            "type": "string"
+          },
+          "updateLeadTimesOnReceipt": {
+            "type": "string"
+          },
+          "materialGeneratedIds": {
+            "type": "string"
+          },
+          "useMetric": {
+            "type": "string"
+          },
+          "productLabelSize": {
+            "type": "string"
+          },
+          "rfqReadyNotificationGroup": {
+            "type": "string"
+          },
+          "suggestionNotificationGroup": {
+            "type": "string"
+          },
+          "maintenanceDispatchNotificationGroup": {
+            "type": "string"
+          },
+          "qualityDispatchNotificationGroup": {
+            "type": "string"
+          },
+          "operationsDispatchNotificationGroup": {
+            "type": "string"
+          },
+          "otherDispatchNotificationGroup": {
+            "type": "string"
+          },
+          "supplierQuoteNotificationGroup": {
+            "type": "string"
+          },
+          "accountsPayableEmail": {
+            "type": "string"
+          },
+          "defaultSupplierCc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "accountsReceivableEmail": {
+            "type": "string"
+          },
+          "defaultCustomerCc": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "id": {
+            "type": "string"
+          },
+          "parentCompanyId": {
+            "type": "string"
+          },
+          "table": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "suffix": {
+            "type": "string"
+          },
+          "step": {
+            "type": "number"
+          },
+          "size": {
+            "type": "number"
+          },
+          "itemId": {
+            "type": "string"
+          },
+          "theme": {
+            "type": "string"
+          },
+          "consoleEnabled": {
+            "type": "string"
+          },
+          "intent": {
+            "type": "string"
+          },
+          "ids": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string",
+            "enum": [
+              "Pending",
+              "Skipped"
+            ]
+          },
+          "accountId": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "externalCode": {
+            "type": "string"
+          },
+          "externalName": {
+            "type": "string"
+          },
+          "mappings": {
             "type": "string"
           },
           "name": {
@@ -43116,6 +45138,26 @@
           }
         },
         "required": [
+          "next",
+          "digitalQuoteEnabled",
+          "digitalQuoteIncludesPurchaseOrders",
+          "kanbanOutput",
+          "plmReleaseControl",
+          "purchasePriceUpdateTiming",
+          "updateLeadTimesOnReceipt",
+          "materialGeneratedIds",
+          "useMetric",
+          "productLabelSize",
+          "table",
+          "itemId",
+          "theme",
+          "consoleEnabled",
+          "intent",
+          "ids",
+          "to",
+          "accountId",
+          "externalId",
+          "mappings",
           "name",
           "_operation"
         ]
@@ -44696,7 +46738,7 @@
       "module": "shared",
       "classification": "WRITE",
       "description": "update saved view order",
-      "paramCount": 2,
+      "paramCount": 1,
       "serviceParams": [
         "client",
         "updates"
@@ -44708,16 +46750,27 @@
       "schema": {
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string"
-          },
-          "sortOrder": {
-            "type": "number"
+          "updates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "sortOrder": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "sortOrder"
+              ]
+            }
           }
         },
         "required": [
-          "id",
-          "sortOrder"
+          "updates"
         ]
       }
     },
@@ -45748,20 +47801,20 @@
             "type": "string"
           },
           "permissions": {
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "permission": {}
               },
-              "permission": {
-                "type": "array",
-                "items": {}
-              }
-            },
-            "required": [
-              "name",
-              "permission"
-            ]
+              "required": [
+                "name",
+                "permission"
+              ]
+            }
           }
         },
         "required": [
@@ -45804,7 +47857,7 @@
     {
       "name": "users_upsertGroupMembers",
       "module": "users",
-      "classification": "WRITE",
+      "classification": "DESTRUCTIVE",
       "description": "upsert group members",
       "paramCount": 2,
       "serviceParams": [

--- a/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
@@ -70,6 +70,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   const inserts = unitPricesByQuantity.data.map((unitPrice, index) => {
     const quantity = quantities.data[index];
+    const markups = categoryMarkupsByQuantity.data[quantity];
     return {
       quoteLineId: lineId,
       quantity,
@@ -78,10 +79,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
       // discountPercent / leadTime / shippingCost are intentionally omitted so
       // upsertQuoteLinePrices preserves the user-entered values for each quantity
       // — a recalc only recomputes the unit price.
-      categoryMarkups: categoryMarkupsByQuantity.data[quantity] ?? undefined,
-      // Applying a markup is explicit cost-plus intent: the row goes back to
-      // system pricing so future BOM changes reprice it from these markups.
-      priceSource: "system" as const
+      categoryMarkups: markups ?? undefined,
+      // Applying a markup is explicit cost-plus intent: that row goes back to
+      // system pricing so future BOM changes reprice it. A quantity with no
+      // markup omits priceSource, so a manual row keeps its manual source.
+      ...(markups !== undefined ? { priceSource: "system" as const } : {})
     };
   });
 

--- a/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
@@ -74,9 +74,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
       quoteLineId: lineId,
       quantity,
       unitPrice,
-      discountPercent: 0,
-      leadTime: 0,
       createdBy: userId,
+      // discountPercent / leadTime / shippingCost are intentionally omitted so
+      // upsertQuoteLinePrices preserves the user-entered values for each quantity
+      // — a recalc only recomputes the unit price.
       categoryMarkups: categoryMarkupsByQuantity.data[quantity] ?? undefined,
       // Applying a markup is explicit cost-plus intent: the row goes back to
       // system pricing so future BOM changes reprice it from these markups.

--- a/apps/erp/test/mcp-tool-metadata.test.ts
+++ b/apps/erp/test/mcp-tool-metadata.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import metadata from "../app/routes/api+/mcp+/lib/tool-metadata.json";
+
+// Regression guards for the MCP tool-metadata generator (scripts/generate-mcp.ts).
+// These encode the shape bugs reported against the quote-setup tools AND the
+// general classes they belong to, so a future generator change that reintroduces
+// any of them fails here instead of silently in a customer's MCP session.
+
+type Tool = {
+  name: string;
+  classification: "READ" | "WRITE" | "DESTRUCTIVE";
+  serviceParams: string[];
+  schema: {
+    type?: string;
+    properties?: Record<string, any>;
+    required?: string[];
+  };
+};
+
+const tools = metadata.tools as Tool[];
+const byName = new Map(tools.map((t) => [t.name, t]));
+const get = (name: string): Tool => {
+  const t = byName.get(name);
+  if (!t) throw new Error(`tool ${name} missing from metadata`);
+  return t;
+};
+const props = (t: Tool) => t.schema.properties ?? {};
+
+describe("mcp tool-metadata generator", () => {
+  it("totalTools matches the tools array", () => {
+    expect(metadata.totalTools).toBe(tools.length);
+  });
+
+  // #2 — an array-of-objects service param publishes as an array, not an object.
+  it("upsertQuoteLinePrices exposes quoteLinePrices as an array of rows", () => {
+    const t = get("sales_upsertQuoteLinePrices");
+    const arr = props(t).quoteLinePrices;
+    expect(arr?.type).toBe("array");
+    expect(arr?.items?.type).toBe("object");
+    // createdBy is auth-injected, never a caller field.
+    expect(arr?.items?.properties?.createdBy).toBeUndefined();
+    expect(Object.keys(arr?.items?.properties ?? {})).toContain("unitPrice");
+  });
+
+  // #8 — a delete-and-reinsert write is flagged destructive-by-omission.
+  it("upsertQuoteLinePrices is classified DESTRUCTIVE", () => {
+    expect(get("sales_upsertQuoteLinePrices").classification).toBe("DESTRUCTIVE");
+  });
+
+  // #5 — a validator field after an `errorMap: () => (...)` is not truncated.
+  it("upsertQuoteLine still exposes fields that follow an errorMap arrow", () => {
+    const p = props(get("sales_upsertQuoteLine"));
+    expect(p.quantity?.type).toBe("array");
+    for (const field of ["description", "methodType", "unitOfMeasureCode"]) {
+      expect(Object.keys(p)).toContain(field);
+    }
+  });
+
+  // #9 — a `applyX(baseValidator.merge(z.object({...})))` param resolves to real
+  // fields instead of an opaque {}. Guard the whole item-validator family.
+  it("resolves merge/wrapper validator params to real fields", () => {
+    for (const name of [
+      "items_upsertService",
+      "items_upsertConsumable",
+      "items_upsertPart",
+      "items_upsertMaterial",
+      "items_upsertTool"
+    ]) {
+      const keys = Object.keys(props(get(name)));
+      expect(keys.length).toBeGreaterThan(1);
+      expect(keys).toContain("name");
+    }
+  });
+
+  // General: every array-typed property declares its items shape (no bare arrays
+  // that leave a caller guessing the element type).
+  it("every array-typed schema property has an items definition", () => {
+    for (const t of tools) {
+      for (const [key, value] of Object.entries(props(t))) {
+        if (value && typeof value === "object" && value.type === "array") {
+          expect(value.items, `${t.name}.${key}`).toBeDefined();
+        }
+      }
+    }
+  });
+});

--- a/scripts/generate-mcp.ts
+++ b/scripts/generate-mcp.ts
@@ -147,7 +147,7 @@ function splitAtTopLevel(str: string, delimiter: string): string[] {
   for (let i = 0; i < str.length; i++) {
     const ch = str[i];
     if ("({[<".includes(ch)) depth++;
-    else if (")}]>".includes(ch)) depth--;
+    else if (")}]>".includes(ch) && !isArrowClose(str, i)) depth--;
     if (ch === delimiter && depth === 0) {
       parts.push(current.trim());
       current = "";
@@ -159,12 +159,20 @@ function splitAtTopLevel(str: string, delimiter: string): string[] {
   return parts;
 }
 
+// The `>` in an arrow function (`() => ...`) is not a generic close. Counting it
+// as one drives brace depth negative, so every top-level delimiter after the
+// first arrow (e.g. a validator field after an `errorMap: () => ({...})`) stops
+// splitting — silently truncating a tool's schema to the fields before it.
+function isArrowClose(str: string, i: number): boolean {
+  return str[i] === ">" && str[i - 1] === "=";
+}
+
 function findTopLevelColon(str: string): number {
   let depth = 0;
   for (let i = 0; i < str.length; i++) {
     const ch = str[i];
     if ("({[<".includes(ch)) depth++;
-    else if (")}]>".includes(ch)) depth--;
+    else if (")}]>".includes(ch) && !isArrowClose(str, i)) depth--;
     if (ch === ":" && depth === 0) return i;
   }
   return -1;
@@ -251,8 +259,10 @@ function typeToJsonSchema(typeStr: string): Record<string, unknown> {
   // Json type
   if (t === "Json" || t === "Json | null") return {};
 
-  // (typeof X)[number] — enum array reference
-  if (t.match(/\(typeof\s+\w+\)\s*\[number\]/)) return { type: "string" };
+  // (typeof X)[number] — enum array reference. Anchored: an unanchored match
+  // also fired for any inline object type that merely CONTAINS such a field,
+  // collapsing the whole object to a string.
+  if (/^\(typeof\s+\w+\)\s*\[number\]$/.test(t)) return { type: "string" };
 
   // Inline object: { field: Type; ... }
   if (t.startsWith("{")) {
@@ -338,7 +348,7 @@ function splitObjectFields(inner: string): string[] {
   for (let i = 0; i < inner.length; i++) {
     const ch = inner[i];
     if ("({[<".includes(ch)) depth++;
-    else if (")}]>".includes(ch)) depth--;
+    else if (")}]>".includes(ch) && !isArrowClose(inner, i)) depth--;
 
     if (ch === ";" && depth === 0) {
       fields.push(current.trim());
@@ -357,17 +367,81 @@ function splitObjectFields(inner: string): string[] {
 
 function parseValidatorFields(
   validatorName: string,
-  modelsContent: string
+  modelsContent: string,
+  seen: Set<string> = new Set()
 ): Record<string, unknown> | null {
-  const regex = new RegExp(
-    `export\\s+const\\s+${validatorName}\\s*=\\s*z\\.object\\(\\{`
+  // Cycle guard for mutually-referential validators.
+  if (seen.has(validatorName)) return null;
+  seen = new Set(seen).add(validatorName);
+
+  const rhs = extractValidatorRhs(validatorName, modelsContent);
+  if (rhs === null) return null;
+
+  const properties: Record<string, unknown> = {};
+  const required: string[] = [];
+  const mergeIn = (sub: Record<string, unknown> | null) => {
+    if (!sub) return;
+    Object.assign(properties, sub.properties as Record<string, unknown>);
+    for (const r of (sub.required as string[] | undefined) ?? []) {
+      if (!required.includes(r)) required.push(r);
+    }
+  };
+
+  // Base validators pulled in by `Base.merge(...)` / `Base.extend(...)` — resolve
+  // each referenced `*Validator` (same file) and fold its fields in first, so the
+  // extension below can override. This is what makes
+  // `applyX(itemValidator.merge(z.object({...})))` resolvable instead of opaque.
+  const refs = new Set(
+    (rhs.match(/\b\w+Validator\b/g) ?? []).filter((n) => n !== validatorName)
   );
+  for (const ref of refs) {
+    mergeIn(parseValidatorFields(ref, modelsContent, seen));
+  }
+
+  // This validator's own object literal — for a `.merge(z.object({...}))` /
+  // wrapped chain the FIRST z.object is the extension; for a plain
+  // `z.object({...})` it is the whole thing. Wrappers (`applyX(...)`, `.refine`,
+  // `.superRefine`) are transparent to this scan.
+  mergeIn(parseFirstZObject(rhs));
+
+  if (Object.keys(properties).length === 0) return null;
+  const result: Record<string, unknown> = { type: "object", properties };
+  if (required.length > 0) result.required = required;
+  return result;
+}
+
+// The assignment expression of `export const {name} = <expr>;`, captured to the
+// first top-level `;` (arrow-guarded) so a `*Validator` reference or `z.object`
+// from a later declaration is never pulled in.
+function extractValidatorRhs(
+  validatorName: string,
+  modelsContent: string
+): string | null {
+  const regex = new RegExp(`export\\s+const\\s+${validatorName}\\s*=\\s*`);
   const match = regex.exec(modelsContent);
   if (!match) return null;
+  const start = match.index + match[0].length;
 
-  const braceStart = match.index + match[0].length - 1;
-  const braceEnd = findMatchingBrace(modelsContent, braceStart);
-  const inner = modelsContent.substring(braceStart + 1, braceEnd).trim();
+  let depth = 0;
+  for (let i = start; i < modelsContent.length; i++) {
+    const ch = modelsContent[i];
+    if ("({[<".includes(ch)) depth++;
+    else if (")}]>".includes(ch) && !isArrowClose(modelsContent, i)) depth--;
+    else if (ch === ";" && depth === 0) {
+      return modelsContent.substring(start, i);
+    }
+  }
+  return modelsContent.substring(start);
+}
+
+// Parse the first `z.object({ ... })` in an expression into a JSON-Schema object.
+function parseFirstZObject(expr: string): Record<string, unknown> | null {
+  const idx = expr.indexOf("z.object(");
+  if (idx === -1) return null;
+  const braceStart = expr.indexOf("{", idx);
+  if (braceStart === -1) return null;
+  const braceEnd = findMatchingBrace(expr, braceStart);
+  const inner = expr.substring(braceStart + 1, braceEnd).trim();
 
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
@@ -398,6 +472,7 @@ function parseValidatorFields(
     if (!isOptional) required.push(fieldName);
   }
 
+  if (Object.keys(properties).length === 0) return null;
   const result: Record<string, unknown> = { type: "object", properties };
   if (required.length > 0) result.required = required;
   return result;
@@ -417,7 +492,14 @@ function zodExprToJsonSchema(expr: string): Record<string, unknown> {
     }
   }
 
-  if (e.startsWith("z.array(")) return { type: "array" };
+  if (e.startsWith("z.array(")) {
+    // Resolve the element schema so the array is well-formed rather than a bare
+    // `{type:"array"}` a caller can't fill.
+    const open = e.indexOf("(");
+    const close = findMatchingBrace(e, open);
+    const inner = e.substring(open + 1, close).trim();
+    return { type: "array", items: inner ? zodExprToJsonSchema(inner) : {} };
+  }
   if (e.includes("z.number()")) return { type: "number" };
   if (e.includes("z.boolean()")) return { type: "boolean" };
   if (e.includes("z.string()") || e.startsWith("zfd.text("))
@@ -425,7 +507,10 @@ function zodExprToJsonSchema(expr: string): Record<string, unknown> {
   if (e.includes("z.any()")) return {};
   if (e.startsWith("zfd.numeric(")) return { type: "number" };
   if (e.startsWith("z.preprocess(")) {
-    if (e.includes("z.enum(")) return zodExprToJsonSchema(e);
+    // A preprocessed enum whose values aren't an inline array can't be
+    // enumerated (the top-of-function z.enum check already ran on this same
+    // expr), so treat it as a string. Recursing on `e` here looped forever.
+    if (e.includes("z.enum(")) return { type: "string" };
     if (e.includes("z.number()")) return { type: "number" };
     return { type: "string" };
   }
@@ -438,7 +523,8 @@ function zodExprToJsonSchema(expr: string): Record<string, unknown> {
 // ---------------------------------------------------------------------------
 
 function classifyFunction(
-  name: string
+  name: string,
+  content?: string
 ): "READ" | "WRITE" | "DESTRUCTIVE" {
   if (/^delete/.test(name)) return "DESTRUCTIVE";
   // Require a camelCase boundary after the read prefix so a mutating name that merely starts with
@@ -446,7 +532,39 @@ function classifyFunction(
   // while `isBlocked`/`getJob` ("is"/"get"+uppercase) stay READ.
   if (/^(get|list|fetch|search|find|count|check|is|has|compute)(?![a-z])/.test(name))
     return "READ";
+  // Destructive-by-omission: a write whose body deletes rows (e.g. the
+  // delete-then-reinsert `upsert*Prices` rewrite) can silently drop data the
+  // caller didn't include. Flag it so the client treats it as destructive, even
+  // though its name says `upsert`/`update`. injectAuth stays name-based below, so
+  // the insert branch still gets its createdBy.
+  if (content && functionBodyDeletes(content, name)) return "DESTRUCTIVE";
   return "WRITE";
+}
+
+// True when the function body issues a row delete (supabase `.delete(` or Kysely
+// `.deleteFrom(`). Comment/URL-safe via stripComments.
+function functionBodyDeletes(content: string, funcName: string): boolean {
+  const body = extractFunctionBody(content, funcName);
+  if (body === null) return false;
+  const stripped = stripComments(body);
+  return /\.delete\s*\(/.test(stripped) || /\.deleteFrom\s*\(/.test(stripped);
+}
+
+function extractFunctionBody(content: string, funcName: string): string | null {
+  const regex = new RegExp(
+    `export\\s+(?:async\\s+)?function\\s+${funcName}\\s*\\(`
+  );
+  const match = regex.exec(content);
+  if (!match) return null;
+  const closeParen = findMatchingBrace(
+    content,
+    match.index + match[0].length - 1
+  );
+  const nextExport = content.indexOf("\nexport ", closeParen);
+  return content.substring(
+    closeParen,
+    nextExport === -1 ? content.length : nextExport
+  );
 }
 
 function computeInjectAuth(
@@ -454,7 +572,12 @@ function computeInjectAuth(
   classification: "READ" | "WRITE" | "DESTRUCTIVE"
 ): AuthField[] {
   const lower = funcName.toLowerCase();
-  if (classification === "READ" || classification === "DESTRUCTIVE") {
+  // Only READ tools take no audit fields. A DESTRUCTIVE label is just a caller
+  // hint — a delete-then-reinsert `upsert*` still inserts rows and needs its
+  // createdBy/updatedBy, so audit injection is keyed off the name verb, not the
+  // classification. A genuine `delete*` matches neither verb group and falls
+  // through to companyId-only.
+  if (classification === "READ") {
     return ["companyId"];
   }
   if (
@@ -477,20 +600,8 @@ function usesCreatedByDiscriminator(
   content: string,
   funcName: string
 ): boolean {
-  const regex = new RegExp(
-    `export\\s+(?:async\\s+)?function\\s+${funcName}\\s*\\(`
-  );
-  const match = regex.exec(content);
-  if (!match) return false;
-  const closeParen = findMatchingBrace(
-    content,
-    match.index + match[0].length - 1
-  );
-  const nextExport = content.indexOf("\nexport ", closeParen);
-  const body = content.substring(
-    closeParen,
-    nextExport === -1 ? content.length : nextExport
-  );
+  const body = extractFunctionBody(content, funcName);
+  if (body === null) return false;
   return stripComments(body).includes('"createdBy" in');
 }
 
@@ -540,10 +651,14 @@ function buildToolSchema(
   if (userParams.length === 1) {
     const param = userParams[0];
 
-    // Check for validator reference: z.infer<typeof validatorName>
-    const validatorMatch = param.typeStr.match(
-      /z\.infer<typeof\s+(\w+)>/
-    );
+    // Check for validator reference: z.infer<typeof validatorName>. Skip when the
+    // type is an inline object literal (`{ ... }`) that merely CONTAINS a nested
+    // `z.infer<...>` field — that object should be flattened, not replaced by the
+    // nested schema.
+    const isInlineObject = param.typeStr.trim().startsWith("{");
+    const validatorMatch = isInlineObject
+      ? null
+      : param.typeStr.match(/z\.infer<typeof\s+(\w+)>/);
     if (validatorMatch && modelsContent) {
       const validatorName = validatorMatch[1];
       const resolved = parseValidatorFields(validatorName, modelsContent);
@@ -555,13 +670,23 @@ function buildToolSchema(
       }
     }
 
-    // Inline object type
+    // Inline object type — flatten its fields to the top level. An
+    // array-of-objects (`{...}[]`) can't be flattened, so wrap it under the
+    // param name instead (typeToJsonSchema returns `{type:"array",...}`).
     if (param.typeStr.trim().startsWith("{")) {
-      const schema = parseInlineObjectType(param.typeStr);
+      const resolved = typeToJsonSchema(param.typeStr);
+      if (resolved.type === "array") {
+        const schema: Record<string, unknown> = {
+          type: "object",
+          properties: { [param.name]: resolved },
+          required: param.optional ? undefined : [param.name],
+        };
+        return { schema, paramCount: 1 };
+      }
       const propCount = Object.keys(
-        (schema.properties as Record<string, unknown>) || {}
+        (resolved.properties as Record<string, unknown>) || {}
       ).length;
-      return { schema, paramCount: propCount };
+      return { schema: resolved, paramCount: propCount };
     }
 
     // GenericQueryFilters
@@ -591,12 +716,10 @@ function buildToolSchema(
   const properties: Record<string, unknown> = {};
   const required: string[] = [];
   for (const param of userParams) {
-    if (param.typeStr.trim().startsWith("{")) {
-      // Inline object — wrap under param name
-      properties[param.name] = parseInlineObjectType(param.typeStr);
-    } else {
-      properties[param.name] = typeToJsonSchema(param.typeStr);
-    }
+    // typeToJsonSchema handles inline objects AND arrays-of-objects (`{...}[]`),
+    // checking the `[]` suffix before the `{` prefix. Calling parseInlineObjectType
+    // directly here dropped the suffix, publishing an array param as a bare object.
+    properties[param.name] = typeToJsonSchema(param.typeStr);
     if (!param.optional) required.push(param.name);
   }
 
@@ -671,7 +794,7 @@ export function generateToolMetadata(): void {
       const toolName = `${mod}_${func.name}`;
       if (MCP_BLOCKED_TOOL_NAMES.includes(toolName)) continue;
 
-      const classification = classifyFunction(func.name);
+      const classification = classifyFunction(func.name, content);
       const injectAuth =
         INJECT_AUTH_OVERRIDES[toolName] ||
         computeInjectAuth(func.name, classification);


### PR DESCRIPTION
## What does this PR do?

Fixes a batch of Carbon MCP quote-setup tool bugs reported from real usage, solving each **class** of bug in the metadata generator (`scripts/generate-mcp.ts`) and executor rather than per-tool: array-of-object params now publish as typed arrays; a `=>` arrow in a validator `errorMap`/`refine` no longer truncates the fields after it; `z.infer` params resolve `Base.merge(z.object({...}))` / `applyX(...)` wrappers / referenced `*Validators` into real fields (previously an opaque `{}`); WRITE tools whose body deletes rows are classified `DESTRUCTIVE` (with `injectAuth` decoupled from the label so a delete-and-reinsert `upsert` keeps its `createdBy`); and the executor stamps `createdBy` into array-row payload elements. It also fixes two latent generator bugs surfaced along the way (a `z.preprocess` infinite recursion and an unanchored `(typeof X)[number]` match that collapsed inline objects to strings), and reworks `upsertQuoteLinePrices` to be explicit-wins/omit-preserves for user-entered fields, default new rows' `priceSource` to `manual`, and sync `quoteLine.quantity` (the recalc route now omits the preserved fields so a recalc can't clobber them). `tool-metadata.json` is regenerated (1449 tools, count unchanged; every changed schema is a shape correction).

- Fixes: N/A (reported via internal Slack, no GitHub issue)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- `pnpm exec turbo run typecheck --filter=erp` — clean.
- `cd apps/erp && pnpm exec vitest run app/modules/sales test/mcp-tool-metadata.test.ts` — the new `mcp-tool-metadata.test.ts` pins the reporter's exact bugs (array shape, un-truncated fields, resolved merge-validators, `DESTRUCTIVE` classification, well-formed array items) and `sales.utils.test.ts` covers the price-field merge (explicit-wins / omit-preserves / `manual` default).
- Regenerate with `npx tsx scripts/generate-mcp.ts` and confirm `tool-metadata.json` is unchanged.
- No env vars or seed data required.

## Checklist

- Follows the project's generator/executor conventions; changes are commented in hard-to-follow areas; no new warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Quote-line recalculations now preserve manually entered discounts, lead times, shipping costs, and other pricing details.
  - New quote pricing defaults to a manual price source when no value is provided.
  - Explicit pricing updates synchronize quote-line quantity breaks with submitted quantities.
  - MCP quote tools now provide more accurate schemas, validation, classifications, and authentication handling for array-based pricing data.
  - Destructive MCP operations are identified more accurately.

- **Documentation**
  - Updated guidance for quote pricing behavior and MCP tool capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->