### PR TITLE
fix(settings): hide SSO section in Settings → Security for now

### DIFF
--- a/apps/erp/app/routes/x+/settings+/security.tsx
+++ b/apps/erp/app/routes/x+/settings+/security.tsx
@@ -338,6 +338,10 @@ function SsoDomainRow({
   );
 }
 
+// Temporarily hide the Single Sign-On section from Settings → Security.
+// Set to true to restore it — the loader, action, and SSO UI remain intact.
+const SHOW_SSO_SETTINGS = false;
+
 export default function Security() {
   const { ssoEnabled, connection, domains, acsUrl, metadataUrl } =
     useLoaderData<typeof loader>();
@@ -450,7 +454,7 @@ export default function Security() {
           twoFactorCard
         )}
 
-        {ssoEnabled && (
+        {SHOW_SSO_SETTINGS && ssoEnabled && (
           <>
             <div className="flex items-end justify-between gap-4 w-full">
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
## What does this PR do?

Hides the Single Sign-On (SAML SSO) section from **Settings → Security** for now by gating its render behind a `SHOW_SSO_SETTINGS` flag (currently `false`) in `apps/erp/app/routes/x+/settings+/security.tsx`. The loader, action, and all SSO UI remain intact, so restoring the section is a one-line flip of the flag back to `true`. No behavior other than visibility changes.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

- Before: Settings → Security shows the "Single Sign-On" section (Service Provider Details, Identity Provider form, Email Domains) below Two-Factor Authentication.
- After: only the Two-Factor Authentication section renders; the SSO section is hidden.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open **Settings → Security** as an employee in an Enterprise deployment with `sso` in `AUTH_PROVIDERS` (where the section previously rendered).
- Expected: the Single Sign-On section no longer appears; Two-Factor Authentication is unaffected.

## Checklist

- I haven't checked if my changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Temporarily hid the Single Sign-On settings section in **Settings → Security**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->