### PR TITLE
feat(settings): restore Single Sign-On section in Settings → Security

### DIFF
--- a/apps/erp/app/routes/x+/settings+/security.tsx
+++ b/apps/erp/app/routes/x+/settings+/security.tsx
@@ -338,10 +338,6 @@ function SsoDomainRow({
   );
 }
 
-// Temporarily hide the Single Sign-On section from Settings → Security.
-// Set to true to restore it — the loader, action, and SSO UI remain intact.
-const SHOW_SSO_SETTINGS = false;
-
 export default function Security() {
   const { ssoEnabled, connection, domains, acsUrl, metadataUrl } =
     useLoaderData<typeof loader>();
@@ -465,7 +461,7 @@ export default function Security() {
           twoFactorCard
         )}
 
-        {SHOW_SSO_SETTINGS && ssoEnabled && (
+        {ssoEnabled && (
           <>
             <div className="flex items-end justify-between gap-4 w-full">
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary

Removes the `SHOW_SSO_SETTINGS = false` flag added in #1507, which temporarily hid the Single Sign-On section from **Settings → Security**. The section now renders again whenever SSO is enabled (`{ssoEnabled && (...)}`).

This is a clean reversal of #1507 — the loader, action, and SSO UI were already left intact behind the flag, so only the gate is removed.

## Changes

- Delete the `SHOW_SSO_SETTINGS` constant and its comment
- Restore the render condition to `{ssoEnabled && (` in `apps/erp/app/routes/x+/settings+/security.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Single Sign-On settings now appear in **Settings → Security** whenever SSO is enabled.
  * Removed the temporary restriction that could hide the SSO configuration section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->