### PR TITLE
fix(items): stop the CSV import route dropping Revision and MPN

### DIFF
--- a/.claude/rules/csv-import-system.md
+++ b/.claude/rules/csv-import-system.md
@@ -59,7 +59,7 @@ Three exported maps, all keyed by table name:
 
 Other exports: `creatableLookups`, and types `CreatableLookup`, `CreatableForm`.
 
-> **`fieldMappings[table]` and `importSchemas[table]` must declare the same fields.**
+> **Every field in `fieldMappings[table]` must also be declared in `importSchemas[table]`.**
 > The route builds `columnMappings` from the zod parse result, and a zod object strips
 > keys it does not declare — so a field the wizard offers but the schema omits is mapped
 > by the user, submitted, and silently dropped before the edge function sees it. That is

--- a/.claude/rules/csv-import-system.md
+++ b/.claude/rules/csv-import-system.md
@@ -30,8 +30,9 @@ a transaction. Imports are idempotent via the `externalIntegrationMapping` table
   `useCreateLookup.ts` creates missing lookup values inline.
 - `useCsvContext.tsx` — shared state (`file`, `filePath`, `fileColumns`, `firstRows`).
 
-Used from `apps/erp/app/components/Table/components/TableHeader.tsx` (table import button)
-and `apps/erp/app/modules/items/ui/Item/BoMExplorer.tsx`.
+Mounted from exactly one place: `apps/erp/app/components/Table/components/TableHeader.tsx`
+(the Bulk Import dropdown). A list page opts in by passing `importCSV={[{ table, label }]}`
+to `<Table>` — that prop is the whole UI-side registration.
 
 ## Models (`apps/erp/app/modules/shared/imports.models.ts`)
 
@@ -58,10 +59,18 @@ Three exported maps, all keyed by table name:
 
 Other exports: `creatableLookups`, and types `CreatableLookup`, `CreatableForm`.
 
+> **`fieldMappings[table]` and `importSchemas[table]` must declare the same fields.**
+> The route builds `columnMappings` from the zod parse result, and a zod object strips
+> keys it does not declare — so a field the wizard offers but the schema omits is mapped
+> by the user, submitted, and silently dropped before the edge function sees it. That is
+> what made every CSV-imported item land at revision `"0"` while the wizard marked the
+> Revision column required. `apps/erp/app/modules/shared/imports.models.test.ts` asserts
+> the invariant per table; add the field to BOTH maps when adding one.
+
 ### Tables & permissions
 
 `customer`, `customerContact` → `sales`; `supplier`, `supplierContact` → `purchasing`;
-`part`, `material`, `tool`, `fixture`, `consumable`, `methodMaterial`, `bom`,
+`part`, `material`, `tool`, `fixture`, `consumable`, `bom`,
 `operations`, `partWithMethod`, `materialSubstance`, `materialForm`, `materialFinish`,
 `materialGrade`, `materialType`, `materialDimension` → `parts`;
 `workCenter`, `process` → `production`; `storageUnit` → `inventory`;
@@ -72,7 +81,7 @@ The edge function's own `table` enum (`import-csv/index.ts`) accepts: `consumabl
 `partWithMethod`, `part`, `supplier`, `supplierContact`, `tool`, `workCenter`,
 `process`, `storageUnit`, `materialSubstance`, `materialForm`, `materialFinish`,
 `materialGrade`, `materialType`, `materialDimension`. Note it does **not** list
-`fixedAsset` or `methodMaterial` (see Gotchas).
+`fixedAsset` (see Gotchas).
 
 ### Storage-unit import (natural-key match + two-pass parent linking)
 
@@ -172,7 +181,9 @@ See `.claude/rules/accounting-sync-handlers.md` for the full `externalIntegratio
 
 ## Gotchas
 
-- **`methodMaterial` is not implemented** — its edge-function case `throw new Error("Not implemented")`.
+- **`fixture` is orphaned** — registered in `fieldMappings`, `importPermissions` and the edge
+  function's enum, but `Fixture` was dropped from the app's item-type enum
+  (`items.models.ts`) and there is no Fixtures list page, so nothing surfaces it.
 - **`fixedAsset`** has models/permissions (`fieldMappings`, `importPermissions`) but is
   **confirmed absent** from the edge function's `table` enum, so the edge function
   **rejects it** — the zod `table` enum fails to parse and it errors out (effectively

--- a/apps/erp/app/modules/shared/imports.models.test.ts
+++ b/apps/erp/app/modules/shared/imports.models.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { fieldMappings, importSchemas } from "./imports.models";
+
+// The import route builds `columnMappings` from `validator(importSchemas[table]
+// .extend({...})).validate(formData)`, and a zod object strips keys it does not
+// declare. So a field the wizard offers but the schema omits is mapped by the
+// user, submitted, and silently dropped before the edge function ever sees it —
+// which is how every CSV-imported item landed at revision "0" while the wizard
+// marked the Revision column required.
+//
+// Only this direction is asserted. A schema key with no `fieldMappings` entry is
+// inert (nothing submits it), whereas a `fieldMappings` entry with no schema key
+// loses data.
+describe("importSchemas covers every mappable field", () => {
+  const tables = Object.keys(fieldMappings) as (keyof typeof fieldMappings)[];
+
+  it.each(tables)("%s", (table) => {
+    const mappable = Object.keys(fieldMappings[table]);
+    const declared = new Set(Object.keys(importSchemas[table].shape));
+    const dropped = mappable.filter((field) => !declared.has(field));
+
+    expect(dropped).toEqual([]);
+  });
+});
+
+describe("item revision survives route validation", () => {
+  const itemTables = [
+    "part",
+    "tool",
+    "fixture",
+    "consumable",
+    "material"
+  ] as const;
+
+  it.each(itemTables)("%s keeps the mapped Revision column", (table) => {
+    const parsed = importSchemas[table].parse({
+      id: "EXT-1",
+      readableId: "PN-1",
+      revision: "B",
+      name: "Widget"
+    });
+
+    expect(parsed).toHaveProperty("revision", "B");
+  });
+});

--- a/apps/erp/app/modules/shared/imports.models.ts
+++ b/apps/erp/app/modules/shared/imports.models.ts
@@ -1867,6 +1867,7 @@ const methodPartSchema = {
   readableId: z.string().optional(),
   revision: z.string().optional(),
   name: z.string().optional(),
+  mpn: z.string().optional(),
   active: z.string().optional(),
   replenishmentSystem: z.string().optional(),
   defaultMethodType: z.string().optional(),
@@ -2079,6 +2080,12 @@ export const importSchemas: Record<
       .describe(
         "The readable id of the part. Usually a number or set of alphanumeric characters."
       ),
+    revision: z
+      .string()
+      .optional()
+      .describe(
+        'The revision of the part. Defaults to "0" when the column is absent.'
+      ),
     name: z
       .string()
       .min(1, { message: "Name is required" })
@@ -2123,6 +2130,12 @@ export const importSchemas: Record<
       .min(1, { message: "Part Number is required" })
       .describe(
         "The readable id of the tool. Usually a number or set of alphanumeric characters."
+      ),
+    revision: z
+      .string()
+      .optional()
+      .describe(
+        'The revision of the tool. Defaults to "0" when the column is absent.'
       ),
     name: z
       .string()
@@ -2172,6 +2185,12 @@ export const importSchemas: Record<
       .describe(
         "The readable id of the fixture. Usually a number or set of alphanumeric characters."
       ),
+    revision: z
+      .string()
+      .optional()
+      .describe(
+        'The revision of the fixture. Defaults to "0" when the column is absent.'
+      ),
     name: z
       .string()
       .min(1, { message: "Name is required" })
@@ -2220,6 +2239,12 @@ export const importSchemas: Record<
       .describe(
         "The readable id of the part. Usually a number or set of alphanumeric characters."
       ),
+    revision: z
+      .string()
+      .optional()
+      .describe(
+        'The revision of the consumable. Defaults to "0" when the column is absent.'
+      ),
     name: z
       .string()
       .min(1, { message: "Name is required" })
@@ -2264,6 +2289,12 @@ export const importSchemas: Record<
       .min(1, { message: "Part Number is required" })
       .describe(
         "The readable id of the material. Usually a number or set of alphanumeric characters."
+      ),
+    revision: z
+      .string()
+      .optional()
+      .describe(
+        'The revision of the material. Defaults to "0" when the column is absent.'
       ),
     name: z
       .string()

--- a/packages/database/supabase/functions/import-csv/method-import.ts
+++ b/packages/database/supabase/functions/import-csv/method-import.ts
@@ -561,6 +561,7 @@ async function writeGroup(
             readableId: g.readableId,
             revision: g.revision || "0",
             name: text(r.name) || g.readableId,
+            mpn: text(r.mpn) || undefined,
             type: "Part",
             companyId,
             active: text(r.active).toLowerCase() !== "false",


### PR DESCRIPTION
## Problem

The import route builds `columnMappings` from the `importSchemas[table]` parse result, and a zod object strips keys it does not declare. A field present in `fieldMappings` but missing from `importSchemas` is offered in the mapping wizard, mapped by the user, submitted — and discarded before the edge function sees it.

Two fields were affected:

- **`revision`** on `part`, `tool`, `fixture`, `consumable`, `material`. Every CSV-imported item landed at revision `"0"`, while the wizard marked the Revision column required. The edge function was always revision-aware (`import-csv/index.ts:1688,1787`); it just never received the value.
- **`mpn`** on `partWithMethod`. Missing from the schema, and `method-import.ts` never wrote it either — so the combined importer silently dropped a manufacturer part number the plain Parts importer handles fine.

## Change

- Add `revision` to the five item schemas and `mpn` to `methodPartSchema`.
- Write `mpn` on the `method-import.ts` item insert.
- Add `imports.models.test.ts` asserting `fieldMappings[table] ⊆ importSchemas[table]` for all 22 tables, plus a direct assertion that a mapped Revision survives the route's parse.
- Update `.claude/rules/csv-import-system.md`: document the two-map invariant, drop the `methodMaterial` claims (gone from the code), correct the modal's mount point, note the orphaned `fixture` entry.

## Verification

Against `origin/main`'s `imports.models.ts`: 11 failed, 16 passed. With the fix: 27 passed. `biome check` clean, `tsgo --noEmit` clean, `deno check` reports no errors in `method-import.ts`.

Not yet exercised in a browser — worth one import on a file with a Revision column before merge.

## Notes

- No schema change. `pnpm db:check:datasets` was skipped at commit time (`CARBON_SKIP_DATASET_CHECK=1`) — it needs a local database, and this touches no migration, tier, or dataset.
- `revision` is optional in the schema rather than required, so a file without the column keeps the edge function's `"0"` default and no existing import breaks.
- `packages/database/supabase/functions/**` changed, so merging also triggers `functions.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDq21LnZKoN6dAWGvhJQDL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CSV imports now support optional part numbers for method-related part records.
  * Imported parts, tools, fixtures, consumables, and materials retain their revision values, defaulting to “0” when not provided.

* **Bug Fixes**
  * Fixed imported method parts losing their part number.
  * Added validation safeguards to prevent supported import fields from being silently discarded.
  * Improved import reliability for revision and part-number fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->