### PR TITLE
fix(mes): render an unconverted 3D model slide instead of a load error

### DIFF
--- a/apps/mes/app/components/AssemblyView.tsx
+++ b/apps/mes/app/components/AssemblyView.tsx
@@ -165,6 +165,9 @@ type SlideModel = {
   modelPath: string | null;
   thumbnailPath: string | null;
   glbPath: string | null;
+  // The optimiser's output, recorded by model-optimize. Preferred over deriving
+  // the path, which is only ever a guess.
+  optimizedModelPath?: string | null;
   processingStatus?: string | null;
 };
 
@@ -1021,10 +1024,17 @@ export function AssemblyView({
     if (slide.modelUploadId) {
       const model = slideModels?.[slide.modelUploadId] ?? null;
       // ModelPreview loads the assembler-converted GLB fast tier when present and
-      // falls back to parsing the raw upload client-side (WASM tier).
+      // falls back to parsing the raw upload client-side (WASM tier). Only a REAL
+      // recorded artifact may be passed as glbUrl: a non-null value makes
+      // ModelPreview treat a server model as available and skip the raw tier
+      // entirely (`useRawTier` requires `!hasServerModel`), so guessing the
+      // optimiser's `optimized.glb` path left an unconverted model showing
+      // "Couldn't load the 3D model." instead of rendering from the raw upload.
       const glbUrl = model?.glbPath
         ? getPrivateUrl(model.glbPath)
-        : optimizedModelPreviewUrl(model?.modelPath ?? null);
+        : model?.optimizedModelPath
+          ? getPrivateUrl(model.optimizedModelPath)
+          : null;
       const rawUrl = model?.modelPath ? getPrivateUrl(model.modelPath) : null;
       return {
         kind: "model" as const,

--- a/apps/mes/app/services/operations.service.ts
+++ b/apps/mes/app/services/operations.service.ts
@@ -468,7 +468,9 @@ export async function getModelUploadsByIds(
 ) {
   return client
     .from("modelUpload")
-    .select("id, name, modelPath, thumbnailPath, glbPath, processingStatus")
+    .select(
+      "id, name, modelPath, thumbnailPath, glbPath, processingStatus, optimizedModelPath"
+    )
     .in("id", ids);
 }
 


### PR DESCRIPTION
## What

A 3D model slide whose model the assembler and optimiser have not processed yet renders **"Couldn't load the 3D model."** to the operator instead of the model.

## Why

`ModelPreview` treats a non-null `glbUrl` as "a server artifact exists" and skips its in-browser raw (WASM) tier entirely — `useRawTier` requires `!hasServerModel`. The assembly view was passing a **guessed** `optimized.glb` path for any model without `glbPath`, so an unconverted model requested an artifact that does not exist (503), and the fallback that should have rendered it never ran.

That contradicts `ModelPreview`'s own contract: the raw tier "is ALWAYS the fallback, independent of whether the assembler is running."

## Fix

`modelUpload` already records the optimiser's output in `optimizedModelPath`, so nothing needs guessing. Select that column in `getModelUploadsByIds` and prefer `glbPath → optimizedModelPath → null`. `null` is the signal that hands the raw tier the original upload.

## Verification

Reproduced locally with a GLB uploaded as a step slide (`processingStatus: "Idle"`): before, a 503 on `.../{modelId}/optimized.glb` and the load error; after, the guessed request is gone.

Note: the 3D canvas does not paint in my local dev stack for **any** model, including a converted seeded one on `main` — that is an environment issue, unrelated to this change, and it is why this PR claims the error is gone rather than that the model renders.

Typecheck clean on both apps; MES and `@carbon/utils` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRiSpYjm2czj2pQbm2VNJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved 3D model loading by accurately detecting when an optimized model is available.
  * Added a reliable fallback to render models from their original uploads when optimization has not completed.
  * Prevented unavailable models from incorrectly displaying a “Couldn’t load the 3D model” error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->