### PR TITLE
fix(production): gate step slide uploads to displayable formats, show model slides in the standard MES view

### DIFF
--- a/apps/erp/app/components/SlidesEditor.tsx
+++ b/apps/erp/app/components/SlidesEditor.tsx
@@ -3,6 +3,7 @@ import type { Database } from "@carbon/database";
 import { Button, cn, IconButton, Label, VStack } from "@carbon/react";
 import {
   isSupportedSlideImagePath,
+  SLIDE_IMAGE_HEADER_BYTES,
   sniffSlideImageType,
   supportedModelTypes,
   supportedSlideImageTypes
@@ -39,23 +40,31 @@ export type SlideImageUploadResult =
   | { path: string; error?: undefined }
   | { path?: undefined; error: MessageDescriptor };
 
-// Upload an image for a step slide. The file is stored byte-for-byte — nothing is
-// decoded, re-encoded or resized — so the gate is up front: the container header
-// must be a format every browser can paint. `accept` alone isn't enough (it's a
-// picker hint, and `file.type` is derived from the extension), so a renamed
-// `.heic` → `.jpg` is caught here and nowhere else.
-//
-// `folder` is the path segment(s) under the company prefix: "parts" for BOP steps,
-// `assembly/{instructionId}` for assembly instructions. The stored extension comes
-// from the sniff, not the filename, so an extension-less upload still serves with
-// the right Content-Type.
+/**
+ * Upload an image for a step slide. The file is stored byte-for-byte — nothing
+ * is decoded, re-encoded or resized — so the gate is up front: the container
+ * header must be a format every browser can paint. `accept` alone isn't enough
+ * (it's a picker hint, and `file.type` is derived from the extension), so a
+ * renamed `.heic` → `.jpg` is caught here and nowhere else.
+ *
+ * @param folder Path segment(s) under the company prefix: "parts" for BOP steps,
+ *   `assembly/{instructionId}` for assembly instructions.
+ * @returns The stored path, or a translatable message describing the rejection.
+ *   The stored extension comes from the sniff, not the filename, so an
+ *   extension-less upload still serves with the right Content-Type.
+ */
 export async function uploadStepSlideImage(
   carbon: SupabaseClient<Database>,
   companyId: string,
   file: File,
   folder: string
 ): Promise<SlideImageUploadResult> {
-  const ext = await sniffSlideImageType(file);
+  // The header read is the upload layer's job — @carbon/utils stays synchronous
+  // and pure, so it gets the bytes rather than the Blob.
+  const header = new Uint8Array(
+    await file.slice(0, SLIDE_IMAGE_HEADER_BYTES).arrayBuffer()
+  );
+  const ext = sniffSlideImageType(header);
   if (!ext) {
     const named = file.name.toLowerCase().split(".").pop() ?? "";
     const isHeic = named === "heic" || named === "heif";
@@ -75,11 +84,15 @@ export async function uploadStepSlideImage(
   return { path: upload.data.path };
 }
 
-// Upload a 3D model file for a step slide: the raw file goes to the private bucket
-// under the models prefix, then the model-upload API registers the modelUpload row —
-// `convert` also starts the assembler's STEP → GLB conversion (best-effort, so the
-// slide still works via client-side parsing when the assembler is unavailable).
-// Returns the new modelUpload id, or null on failure.
+/**
+ * Upload a 3D model file for a step slide: the raw file goes to the private
+ * bucket under the models prefix, then the model-upload API registers the
+ * modelUpload row — `convert` also starts the assembler's STEP → GLB conversion
+ * (best-effort, so the slide still works via client-side parsing when the
+ * assembler is unavailable).
+ *
+ * @returns The new modelUpload id, or null on failure.
+ */
 export async function uploadStepSlideModel(
   carbon: SupabaseClient<Database>,
   companyId: string,

--- a/apps/erp/app/components/SlidesEditor.tsx
+++ b/apps/erp/app/components/SlidesEditor.tsx
@@ -1,12 +1,19 @@
 import { useCarbon } from "@carbon/auth";
 import type { Database } from "@carbon/database";
 import { Button, cn, IconButton, Label, VStack } from "@carbon/react";
-import { supportedModelTypes } from "@carbon/utils";
+import {
+  isSupportedSlideImagePath,
+  sniffSlideImageType,
+  supportedModelTypes,
+  supportedSlideImageTypes
+} from "@carbon/utils";
+import type { MessageDescriptor } from "@lingui/core";
+import { msg } from "@lingui/core/macro";
 import { useLingui } from "@lingui/react/macro";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { nanoid } from "nanoid";
 import { useEffect, useMemo, useState } from "react";
-import { LuBox, LuCirclePlus, LuMapPin, LuX } from "react-icons/lu";
+import { LuBox, LuCirclePlus, LuImageOff, LuMapPin, LuX } from "react-icons/lu";
 import type { SlideAnnotation, SlideSize } from "~/modules/shared";
 import { getPrivateUrl, path } from "~/utils/path";
 import { SlideAnnotator } from "./SlideAnnotator";
@@ -20,6 +27,53 @@ const SLIDE_IMAGE_HEIGHT = "h-28";
 export const MODEL_FILE_ACCEPT = supportedModelTypes
   .map((type) => `.${type}`)
   .join(",");
+
+// File-input accept for image slides. Explicit extensions, NOT `image/*` — the
+// wildcard lets the picker hand us HEIC (the iPhone camera default), which only
+// Safari can decode, and the resulting slide is a grey box on the shop floor.
+export const SLIDE_IMAGE_ACCEPT = supportedSlideImageTypes
+  .map((type) => `.${type}`)
+  .join(",");
+
+export type SlideImageUploadResult =
+  | { path: string; error?: undefined }
+  | { path?: undefined; error: MessageDescriptor };
+
+// Upload an image for a step slide. The file is stored byte-for-byte — nothing is
+// decoded, re-encoded or resized — so the gate is up front: the container header
+// must be a format every browser can paint. `accept` alone isn't enough (it's a
+// picker hint, and `file.type` is derived from the extension), so a renamed
+// `.heic` → `.jpg` is caught here and nowhere else.
+//
+// `folder` is the path segment(s) under the company prefix: "parts" for BOP steps,
+// `assembly/{instructionId}` for assembly instructions. The stored extension comes
+// from the sniff, not the filename, so an extension-less upload still serves with
+// the right Content-Type.
+export async function uploadStepSlideImage(
+  carbon: SupabaseClient<Database>,
+  companyId: string,
+  file: File,
+  folder: string
+): Promise<SlideImageUploadResult> {
+  const ext = await sniffSlideImageType(file);
+  if (!ext) {
+    const named = file.name.toLowerCase().split(".").pop() ?? "";
+    const isHeic = named === "heic" || named === "heif";
+    return {
+      error: isHeic
+        ? msg`HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG.`
+        : msg`That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF.`
+    };
+  }
+
+  const upload = await carbon.storage
+    .from("private")
+    .upload(`${companyId}/${folder}/${nanoid()}.${ext}`, file);
+  if (upload.error || !upload.data) {
+    return { error: msg`Failed to upload image` };
+  }
+  return { path: upload.data.path };
+}
 
 // Upload a 3D model file for a step slide: the raw file goes to the private bucket
 // under the models prefix, then the model-upload API registers the modelUpload row —
@@ -174,7 +228,7 @@ export function SlidesEditor({
             <input
               ref={fileInputRef}
               type="file"
-              accept="image/*"
+              accept={SLIDE_IMAGE_ACCEPT}
               className="hidden"
               onChange={onFileChange}
             />
@@ -258,6 +312,20 @@ export function SlidesEditor({
                         </span>
                       )}
                     </div>
+                  ) : !isSupportedSlideImagePath(slide.imagePath) ? (
+                    // Written before the upload gate existed (or by a client that
+                    // skipped it): say so instead of rendering a broken image.
+                    <div
+                      className={cn(
+                        "flex w-full flex-col items-center justify-center gap-1 rounded-md bg-muted/40 px-2 text-center",
+                        SLIDE_IMAGE_HEIGHT
+                      )}
+                    >
+                      <LuImageOff className="size-5 text-muted-foreground" />
+                      <span className="text-[9px] leading-tight text-muted-foreground">
+                        {t`Format can't be displayed — re-upload as JPEG or PNG`}
+                      </span>
+                    </div>
                   ) : (
                     <>
                       <img
@@ -305,19 +373,21 @@ export function SlidesEditor({
                     {model.name}
                   </p>
                 )}
-                {!isDisabled && !slide.modelUploadId && (
-                  <div className="flex items-center justify-end gap-1">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      className="h-6 px-2 text-[10px]"
-                      leftIcon={<LuMapPin className="size-3" />}
-                      onClick={() => setAnnotatingIndex(index)}
-                    >
-                      {pins.length > 0 ? pins.length : t`Pin`}
-                    </Button>
-                  </div>
-                )}
+                {!isDisabled &&
+                  !slide.modelUploadId &&
+                  isSupportedSlideImagePath(slide.imagePath) && (
+                    <div className="flex items-center justify-end gap-1">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className="h-6 px-2 text-[10px]"
+                        leftIcon={<LuMapPin className="size-3" />}
+                        onClick={() => setAnnotatingIndex(index)}
+                      >
+                        {pins.length > 0 ? pins.length : t`Pin`}
+                      </Button>
+                    </div>
+                  )}
                 <input
                   type="text"
                   aria-label={t`Caption`}
@@ -333,18 +403,20 @@ export function SlidesEditor({
         </div>
       )}
 
-      {annotating?.imagePath && annotatingIndex != null && (
-        <SlideAnnotator
-          open
-          imageUrl={getPrivateUrl(annotating.imagePath)}
-          initial={annotating.annotations ?? []}
-          onSave={(next) => {
-            onAnnotationsChange(annotatingIndex, next);
-            setAnnotatingIndex(null);
-          }}
-          onClose={() => setAnnotatingIndex(null)}
-        />
-      )}
+      {annotating?.imagePath &&
+        isSupportedSlideImagePath(annotating.imagePath) &&
+        annotatingIndex != null && (
+          <SlideAnnotator
+            open
+            imageUrl={getPrivateUrl(annotating.imagePath)}
+            initial={annotating.annotations ?? []}
+            onSave={(next) => {
+              onAnnotationsChange(annotatingIndex, next);
+              setAnnotatingIndex(null);
+            }}
+            onClose={() => setAnnotatingIndex(null)}
+          />
+        )}
     </VStack>
   );
 }

--- a/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
@@ -103,7 +103,11 @@ import { getUnitHint } from "~/components/Form/UnitHint";
 import { useUnitOfMeasure } from "~/components/Form/UnitOfMeasure";
 import { OperationTypeIcon, ProcedureStepTypeIcon } from "~/components/Icons";
 import { ConfirmDelete } from "~/components/Modals";
-import { SlidesEditor, uploadStepSlideModel } from "~/components/SlidesEditor";
+import {
+  SlidesEditor,
+  uploadStepSlideImage,
+  uploadStepSlideModel
+} from "~/components/SlidesEditor";
 import type { Item, SortableItemRenderProps } from "~/components/SortableList";
 import {
   SortableList,
@@ -1879,7 +1883,7 @@ function AttributesForm({
   onConfigure?: (c: Configuration) => void;
   itemMentions: { id: string; label: string }[];
 }) {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const fetcher = useFetcher<typeof newMethodOperationParameterAction>();
   const sortOrderFetcher = useFetcher<{ success: boolean }>();
   const [type, setType] = useState<OperationStep["type"]>("Task");
@@ -2036,20 +2040,21 @@ function AttributesForm({
     if (!file || !carbon) return;
     setDraftUploading(true);
     try {
-      const ext = file.name.split(".").pop();
-      const fileName = `${companyId}/parts/${nanoid()}.${ext}`;
-      const result = await carbon.storage
-        .from("private")
-        .upload(fileName, file);
-      if (result.error || !result.data) {
-        toast.error(t`Failed to upload image`);
+      const result = await uploadStepSlideImage(
+        carbon,
+        companyId,
+        file,
+        "parts"
+      );
+      if (result.error) {
+        toast.error(i18n._(result.error));
         return;
       }
       setDraftSlides((prev) => [
         ...prev,
         {
           id: nanoid(),
-          imagePath: result.data.path,
+          imagePath: result.path,
           modelUploadId: null,
           caption: "",
           size: "medium",
@@ -3095,7 +3100,7 @@ function StepSlides({
   step: OperationStep;
   isDisabled: boolean;
 }) {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const fetcher = useFetcher();
   const captionFetcher = useFetcher();
   const { carbon } = useCarbon();
@@ -3119,18 +3124,19 @@ function StepSlides({
     if (!file || !carbon || !step.id) return;
     setUploading(true);
     try {
-      const ext = file.name.split(".").pop();
-      const fileName = `${companyId}/parts/${nanoid()}.${ext}`;
-      const result = await carbon.storage
-        .from("private")
-        .upload(fileName, file);
-      if (result.error || !result.data) {
-        toast.error(t`Failed to upload image`);
+      const result = await uploadStepSlideImage(
+        carbon,
+        companyId,
+        file,
+        "parts"
+      );
+      if (result.error) {
+        toast.error(i18n._(result.error));
         return;
       }
       const fd = new FormData();
       fd.append("stepId", step.id);
-      fd.append("imagePath", result.data.path);
+      fd.append("imagePath", result.path);
       fd.append("sortOrder", String(nextSortOrder()));
       fetcher.submit(fd, {
         method: "post",

--- a/apps/erp/app/modules/production/ui/Assemblies/AssemblyStepSlides.tsx
+++ b/apps/erp/app/modules/production/ui/Assemblies/AssemblyStepSlides.tsx
@@ -1,9 +1,13 @@
 import { useCarbon } from "@carbon/auth";
 import { toast } from "@carbon/react";
-import { nanoid } from "nanoid";
+import { useLingui } from "@lingui/react/macro";
 import { useRef, useState } from "react";
 import { useFetcher } from "react-router";
-import { SlidesEditor, uploadStepSlideModel } from "~/components/SlidesEditor";
+import {
+  SlidesEditor,
+  uploadStepSlideImage,
+  uploadStepSlideModel
+} from "~/components/SlidesEditor";
 import { useUser } from "~/hooks";
 import type { SlideAnnotation, SlideSize } from "~/modules/shared";
 import { path } from "~/utils/path";
@@ -27,6 +31,7 @@ export default function AssemblyStepSlides({
   slides: slideRows,
   isDisabled
 }: AssemblyStepSlidesProps) {
+  const { i18n } = useLingui();
   const fetcher = useFetcher();
   const captionFetcher = useFetcher();
   const { carbon } = useCarbon();
@@ -50,18 +55,19 @@ export default function AssemblyStepSlides({
     if (!file || !carbon) return;
     setUploading(true);
     try {
-      const ext = file.name.split(".").pop();
-      const fileName = `${companyId}/assembly/${instructionId}/${nanoid()}.${ext}`;
-      const result = await carbon.storage
-        .from("private")
-        .upload(fileName, file);
-      if (result.error || !result.data) {
-        toast.error("Failed to upload image");
+      const result = await uploadStepSlideImage(
+        carbon,
+        companyId,
+        file,
+        `assembly/${instructionId}`
+      );
+      if (result.error) {
+        toast.error(i18n._(result.error));
         return;
       }
       const fd = new FormData();
       fd.append("stepId", stepId);
-      fd.append("imagePath", result.data.path);
+      fd.append("imagePath", result.path);
       fd.append("sortOrder", String(nextSortOrder()));
       fetcher.submit(fd, {
         method: "post",

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -125,7 +125,11 @@ import UnitOfMeasure, {
 import { OperationTypeIcon, ProcedureStepTypeIcon } from "~/components/Icons";
 import InfiniteScroll from "~/components/InfiniteScroll";
 import { ConfirmDelete } from "~/components/Modals";
-import { SlidesEditor, uploadStepSlideModel } from "~/components/SlidesEditor";
+import {
+  SlidesEditor,
+  uploadStepSlideImage,
+  uploadStepSlideModel
+} from "~/components/SlidesEditor";
 import type { Item, SortableItemRenderProps } from "~/components/SortableList";
 import {
   SortableList,
@@ -1139,7 +1143,7 @@ function StepsForm({
   tools: OperationTool[];
 }) {
   const fetcher = useFetcher<typeof newJobOperationParameterAction>();
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const revalidator = useRevalidator();
   const sortOrderFetcher = useFetcher<{ success: boolean }>();
   const [type, setType] = useState<OperationStep["type"]>("Task");
@@ -1316,20 +1320,21 @@ function StepsForm({
     if (!file || !carbon) return;
     setDraftUploading(true);
     try {
-      const ext = file.name.split(".").pop();
-      const fileName = `${companyId}/parts/${nanoid()}.${ext}`;
-      const result = await carbon.storage
-        .from("private")
-        .upload(fileName, file);
-      if (result.error || !result.data) {
-        toast.error(t`Failed to upload image`);
+      const result = await uploadStepSlideImage(
+        carbon,
+        companyId,
+        file,
+        "parts"
+      );
+      if (result.error) {
+        toast.error(i18n._(result.error));
         return;
       }
       setDraftSlides((prev) => [
         ...prev,
         {
           id: nanoid(),
-          imagePath: result.data.path,
+          imagePath: result.path,
           modelUploadId: null,
           caption: "",
           size: "medium",
@@ -1919,7 +1924,7 @@ function JobStepSlides({
   step: JobOperationStep;
   isDisabled: boolean;
 }) {
-  const { t } = useLingui();
+  const { i18n, t } = useLingui();
   const fetcher = useFetcher();
   const captionFetcher = useFetcher();
   const { carbon } = useCarbon();
@@ -1943,18 +1948,19 @@ function JobStepSlides({
     if (!file || !carbon || !step.id) return;
     setUploading(true);
     try {
-      const ext = file.name.split(".").pop();
-      const fileName = `${companyId}/parts/${nanoid()}.${ext}`;
-      const result = await carbon.storage
-        .from("private")
-        .upload(fileName, file);
-      if (result.error || !result.data) {
-        toast.error(t`Failed to upload image`);
+      const result = await uploadStepSlideImage(
+        carbon,
+        companyId,
+        file,
+        "parts"
+      );
+      if (result.error) {
+        toast.error(i18n._(result.error));
         return;
       }
       const fd = new FormData();
       fd.append("stepId", step.id);
-      fd.append("imagePath", result.data.path);
+      fd.append("imagePath", result.path);
       fd.append("sortOrder", String(nextSortOrder()));
       fetcher.submit(fd, {
         method: "post",

--- a/apps/erp/app/modules/shared/shared.models.ts
+++ b/apps/erp/app/modules/shared/shared.models.ts
@@ -1,5 +1,5 @@
 import type { Database } from "@carbon/database";
-import { textToTiptap } from "@carbon/utils";
+import { isSupportedSlideImagePath, textToTiptap } from "@carbon/utils";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
 
@@ -419,6 +419,16 @@ export const operationStepSlideValidator = z
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: "An image or model is required",
+        path: ["imagePath"]
+      });
+    }
+    // The client sniffs the file before uploading, but the storage write is
+    // direct-to-Supabase and this route also serves API-key callers — so the row
+    // gets its own check. A slide the MES can't paint must never be persisted.
+    if (slide.imagePath && !isSupportedSlideImagePath(slide.imagePath)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Unsupported image format. Use JPEG, PNG, WebP, AVIF or GIF.",
         path: ["imagePath"]
       });
     }

--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -138,6 +138,7 @@ import { QualityIssueModal } from "./components/QualityIssueModal";
 import { QuantityModal } from "./components/QuantityModal";
 import { ReworkModal } from "./components/ReworkModal";
 import { SerialSelectorModal } from "./components/SerialSelectorModal";
+import type { StepSlideModel } from "./components/Step";
 import {
   DeleteStepRecordModal,
   RecordModal,
@@ -173,6 +174,7 @@ type JobOperationProps = {
   procedure: Promise<{
     attributes: JobOperationStep[];
     parameters: JobOperationParameter[];
+    slideModels: Record<string, StepSlideModel>;
   }>;
   job: Job;
   thumbnailPath: string | null;
@@ -997,6 +999,9 @@ export const JobOperation = ({
                                       key={`step-${step.id}`}
                                       activeStep={activeStep}
                                       step={step}
+                                      slideModels={
+                                        resolvedProcedure.slideModels
+                                      }
                                       onRecord={onRecordStepRecord}
                                       onDelete={onDeleteStepRecord}
                                       operationId={operationId}
@@ -2112,6 +2117,9 @@ export const JobOperation = ({
                                             key={`step-${step.id}`}
                                             activeStep={activeStep}
                                             step={step}
+                                            slideModels={
+                                              resolvedProcedure.slideModels
+                                            }
                                             compact={true}
                                             onRecord={onRecordStepRecord}
                                             onDelete={onDeleteStepRecord}

--- a/apps/mes/app/components/JobOperation/components/Step.tsx
+++ b/apps/mes/app/components/JobOperation/components/Step.tsx
@@ -107,6 +107,11 @@ function hasStepDescription(
   return documentHasImages(doc);
 }
 
+/**
+ * One step of the operator's procedure: its type icon, name, record/complete
+ * controls, reference slides (images, 3D models, and an explicit placeholder for
+ * an image stored in a format no browser can paint) and its description.
+ */
 export function StepsListItem({
   activeStep,
   step,

--- a/apps/mes/app/components/JobOperation/components/Step.tsx
+++ b/apps/mes/app/components/JobOperation/components/Step.tsx
@@ -35,19 +35,23 @@ import {
 } from "@carbon/react";
 import {
   documentHasImages,
+  isSupportedSlideImagePath,
   parseMentionsFromDocument,
   stripSpecialCharacters,
   tiptapToText
 } from "@carbon/utils";
+import { ModelPreview } from "@carbon/viewer/model-preview";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useNumberFormatter } from "@react-aria/i18n";
 import { nanoid } from "nanoid";
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  LuBox,
   LuChevronDown,
   LuChevronRight,
   LuCircleCheck,
   LuFile,
+  LuImageOff,
   LuPaperclip,
   LuTrash
 } from "react-icons/lu";
@@ -62,6 +66,18 @@ import type { JobOperationStep } from "~/services/types";
 import { useItems, usePeople } from "~/stores";
 import { getPrivateUrl, path } from "~/utils/path";
 import FileDropzone from "../../FileDropzone";
+
+// Render metadata for a 3D model slide, resolved by the loader from modelUpload
+// (same shape the assembly view consumes).
+export type StepSlideModel = {
+  id: string;
+  name: string | null;
+  modelPath: string | null;
+  thumbnailPath: string | null;
+  glbPath: string | null;
+  optimizedModelPath?: string | null;
+  processingStatus?: string | null;
+};
 
 // Reference-image annotation pins (mirrors ImageZoomViewer's Annotation shape). The
 // slide row stores these as JSON, so we cast when passing them to the viewer.
@@ -97,6 +113,7 @@ export function StepsListItem({
   compact = false,
   operationId,
   className,
+  slideModels,
   onRecord,
   onDelete
 }: {
@@ -105,6 +122,7 @@ export function StepsListItem({
   compact?: boolean;
   operationId?: string;
   className: string;
+  slideModels?: Record<string, StepSlideModel> | null;
   onRecord: (step: JobOperationStep) => void;
   onDelete: (step: JobOperationStep) => void;
 }) {
@@ -122,25 +140,68 @@ export function StepsListItem({
     defaultIsOpen: hasDescription
   });
 
-  // Reference images ("slides") attached to this step in the Bill of Process. A slide
-  // is image XOR model; only image slides (imagePath) render here — model slides need a
-  // modelUpload join the standard-view loader doesn't fetch, so they're skipped.
-  const imageSlides = (step.jobOperationStepSlide ?? [])
-    .filter((slide) => !!slide.imagePath)
+  // Reference slides attached to this step in the Bill of Process, in planner order.
+  // A slide is image XOR model, and both render here: an image opens the zoom viewer
+  // with its pins, a model opens the 3D preview. An image whose stored format no
+  // browser can paint (rows written before the upload gate) becomes an explicit
+  // placeholder rather than a broken <img>.
+  const slideTiles = (step.jobOperationStepSlide ?? [])
+    .slice()
     .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
-    .map((slide) => ({
-      id: slide.id,
-      url: getPrivateUrl(slide.imagePath as string),
-      caption: slide.caption,
-      // Slides copied from the method (get-method) can persist annotations as a
-      // non-array JSON value ({}), so normalize before the viewer calls .map().
-      annotations: Array.isArray(slide.annotations)
-        ? (slide.annotations as SlideAnnotation[])
-        : []
-    }));
-  const [viewerIndex, setViewerIndex] = useState<number | null>(null);
+    .map((slide) => {
+      if (slide.modelUploadId) {
+        const model = slideModels?.[slide.modelUploadId] ?? null;
+        return {
+          kind: "model" as const,
+          id: slide.id,
+          caption: slide.caption,
+          name: model?.name ?? null,
+          thumbnailUrl: model?.thumbnailPath
+            ? getPrivateUrl(model.thumbnailPath)
+            : null,
+          // Prefer the assembler-converted GLB, then the optimiser's recorded
+          // artifact. Never guess a path: a non-null glbUrl switches ModelPreview
+          // to its server tier and disables the raw WASM fallback entirely, so a
+          // speculative URL that 404s leaves the operator with "Couldn't load the
+          // 3D model" instead of the model. Null here = parse the raw upload.
+          glbUrl: model?.glbPath
+            ? getPrivateUrl(model.glbPath)
+            : model?.optimizedModelPath
+              ? getPrivateUrl(model.optimizedModelPath)
+              : null,
+          rawUrl: model?.modelPath ? getPrivateUrl(model.modelPath) : null,
+          converting:
+            model?.processingStatus === "Queued" ||
+            model?.processingStatus === "Processing"
+        };
+      }
+      if (!isSupportedSlideImagePath(slide.imagePath)) {
+        return {
+          kind: "unsupported" as const,
+          id: slide.id,
+          caption: slide.caption
+        };
+      }
+      return {
+        kind: "image" as const,
+        id: slide.id,
+        url: getPrivateUrl(slide.imagePath as string),
+        caption: slide.caption,
+        // Slides copied from the method (get-method) can persist annotations as a
+        // non-array JSON value ({}), so normalize before the viewer calls .map().
+        annotations: Array.isArray(slide.annotations)
+          ? (slide.annotations as SlideAnnotation[])
+          : []
+      };
+    });
+  const imageSlides = slideTiles.filter((tile) => tile.kind === "image");
+  const modelSlides = slideTiles.filter((tile) => tile.kind === "model");
+  const [viewerSlideId, setViewerSlideId] = useState<string | null>(null);
+  const [modelSlideId, setModelSlideId] = useState<string | null>(null);
   const activeSlide =
-    viewerIndex !== null ? (imageSlides[viewerIndex] ?? null) : null;
+    imageSlides.find((slide) => slide.id === viewerSlideId) ?? null;
+  const activeModel =
+    modelSlides.find((slide) => slide.id === modelSlideId) ?? null;
 
   if (!operationId) return null;
   const record = step.jobOperationStepRecord.find(
@@ -282,28 +343,79 @@ export function StepsListItem({
           )}
         </div>
       </div>
-      {imageSlides.length > 0 && (
+      {slideTiles.length > 0 && (
         <div className="mt-4 flex flex-wrap gap-2">
-          {imageSlides.map((slide, i) => (
-            <button
-              key={slide.id}
-              type="button"
-              aria-label={slide.caption || `Reference image ${i + 1}`}
-              title={slide.caption ?? undefined}
-              onClick={() => setViewerIndex(i)}
-              className={cn(
-                "relative flex h-24 w-32 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-muted/40",
+          {slideTiles.map((slide, i) => {
+            const tileClass = cn(
+              "relative flex h-24 w-32 shrink-0 items-center justify-center overflow-hidden rounded-lg border bg-muted/40",
+              slide.kind !== "unsupported" &&
                 "transition-transform active:scale-[0.96]"
-              )}
-            >
-              <img
-                src={slide.url}
-                alt={slide.caption || ""}
-                className="h-full w-full object-cover"
-                loading="lazy"
-              />
-            </button>
-          ))}
+            );
+            if (slide.kind === "unsupported") {
+              return (
+                <div
+                  key={slide.id}
+                  title={slide.caption ?? undefined}
+                  className={cn(tileClass, "flex-col gap-1 px-2 text-center")}
+                >
+                  <LuImageOff className="size-5 text-muted-foreground" />
+                  <span className="text-[10px] leading-tight text-muted-foreground">
+                    <Trans>Image format not supported</Trans>
+                  </span>
+                </div>
+              );
+            }
+            if (slide.kind === "model") {
+              return (
+                <button
+                  key={slide.id}
+                  type="button"
+                  aria-label={
+                    slide.caption || slide.name || `Reference model ${i + 1}`
+                  }
+                  title={slide.caption ?? slide.name ?? undefined}
+                  onClick={() => setModelSlideId(slide.id)}
+                  className={tileClass}
+                >
+                  {slide.thumbnailUrl ? (
+                    <img
+                      src={slide.thumbnailUrl}
+                      alt={slide.caption || slide.name || ""}
+                      className="h-full w-full object-contain"
+                      loading="lazy"
+                    />
+                  ) : (
+                    <LuBox className="size-8 text-muted-foreground" />
+                  )}
+                  <span className="pointer-events-none absolute left-1 top-1 rounded bg-muted px-1 text-[10px] font-semibold text-muted-foreground">
+                    3D
+                  </span>
+                  {slide.converting && (
+                    <span className="pointer-events-none absolute bottom-1 left-1 rounded bg-muted px-1 text-[10px] text-muted-foreground">
+                      <Trans>Converting…</Trans>
+                    </span>
+                  )}
+                </button>
+              );
+            }
+            return (
+              <button
+                key={slide.id}
+                type="button"
+                aria-label={slide.caption || `Reference image ${i + 1}`}
+                title={slide.caption ?? undefined}
+                onClick={() => setViewerSlideId(slide.id)}
+                className={tileClass}
+              >
+                <img
+                  src={slide.url}
+                  alt={slide.caption || ""}
+                  className="h-full w-full object-cover"
+                  loading="lazy"
+                />
+              </button>
+            );
+          })}
         </div>
       )}
       {disclosure.isOpen && hasDescription && (
@@ -316,12 +428,41 @@ export function StepsListItem({
       )}
       {mentionIds.length > 0 && <ItemsSummaryTable itemsIds={mentionIds} />}
       <ImageZoomViewer
-        open={viewerIndex !== null}
+        open={activeSlide !== null}
         src={activeSlide?.url ?? null}
         caption={activeSlide?.caption}
         annotations={activeSlide?.annotations ?? []}
-        onClose={() => setViewerIndex(null)}
+        onClose={() => setViewerSlideId(null)}
       />
+      {/* 3D model slides: the same viewer the assembly view uses, in a modal so the
+          step list stays a list. Mounted only while open — the viewer pulls a WASM
+          tier the operator shouldn't pay for on every step. */}
+      <Modal
+        open={activeModel !== null}
+        onOpenChange={(open) => {
+          if (!open) setModelSlideId(null);
+        }}
+      >
+        <ModalContent size="xlarge">
+          <ModalHeader>
+            <ModalTitle>
+              {activeModel?.caption || activeModel?.name || t`3D model`}
+            </ModalTitle>
+          </ModalHeader>
+          <ModalBody>
+            {activeModel && (
+              <div className="h-[60vh] w-full overflow-hidden rounded-lg border">
+                <ModelPreview
+                  key={`slide-model-${activeModel.id}`}
+                  glbUrl={activeModel.glbUrl}
+                  rawUrl={activeModel.rawUrl}
+                  className="rounded-none"
+                />
+              </div>
+            )}
+          </ModalBody>
+        </ModalContent>
+      </Modal>
     </div>
   );
 }

--- a/apps/mes/app/routes/x+/assembly.$operationId.tsx
+++ b/apps/mes/app/routes/x+/assembly.$operationId.tsx
@@ -16,7 +16,6 @@ import {
   getJobOperationById,
   getJobOperationProcedure,
   getKanbanByJobId,
-  getModelUploadsByIds,
   getNcrsByJobOperationId,
   getNonConformanceActions,
   getProductionEventsForJobOperation,
@@ -105,26 +104,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     getAssemblyPlaybackByOperationId(serviceRole, operationId)
   ]);
 
-  // 3D model slides reference modelUpload rows; resolve their render metadata
-  // (glbPath / modelPath / thumbnail) in one query.
-  const slideModelIds = Array.from(
-    new Set(
-      procedure.attributes.flatMap((step) =>
-        (step.jobOperationStepSlide ?? []).map((slide) => slide.modelUploadId)
-      )
-    )
-  ).filter((id): id is string => !!id);
-
-  const [quantities, workCenter, kanban, slideModelUploads] = await Promise.all(
-    [
-      getProductionQuantitiesForJobOperation(serviceRole, operationId),
-      getWorkCenter(serviceRole, op.workCenterId),
-      job.data.id ? getKanbanByJobId(serviceRole, job.data.id) : null,
-      slideModelIds.length > 0
-        ? getModelUploadsByIds(serviceRole, slideModelIds)
-        : null
-    ]
-  );
+  // 3D model slides reference modelUpload rows; getJobOperationProcedure resolves
+  // their render metadata (glbPath / modelPath / thumbnail) in one query, shared
+  // with the standard operation view.
+  const [quantities, workCenter, kanban] = await Promise.all([
+    getProductionQuantitiesForJobOperation(serviceRole, operationId),
+    getWorkCenter(serviceRole, op.workCenterId),
+    job.data.id ? getKanbanByJobId(serviceRole, job.data.id) : null
+  ]);
 
   const productionQuantities = (quantities.data ?? []).reduce(
     (acc, curr) => {
@@ -270,9 +257,7 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       (op as { itemModelPath?: string | null }).itemModelPath ??
       (job.data as { modelPath?: string | null }).modelPath ??
       null,
-    slideModels: Object.fromEntries(
-      (slideModelUploads?.data ?? []).map((model) => [model.id, model])
-    ),
+    slideModels: procedure.slideModels,
     assemblyPlayback
   };
 }

--- a/apps/mes/app/services/operations.service.ts
+++ b/apps/mes/app/services/operations.service.ts
@@ -453,9 +453,31 @@ export async function getJobOperationProcedure(
       .eq("operationId", operationId)
   ]);
 
+  const steps = attributes.data ?? [];
+
+  // 3D model slides carry only a modelUploadId; resolve their render metadata in
+  // one query so BOTH execution views (standard step list and assembly) can paint
+  // them. Without this the standard view silently drops every model slide the
+  // planner attached.
+  const slideModelIds = Array.from(
+    new Set(
+      steps.flatMap((step) =>
+        (step.jobOperationStepSlide ?? []).map((slide) => slide.modelUploadId)
+      )
+    )
+  ).filter((id): id is string => !!id);
+
+  const slideModelUploads =
+    slideModelIds.length > 0
+      ? await getModelUploadsByIds(client, slideModelIds)
+      : null;
+
   return {
-    attributes: attributes.data ?? [],
-    parameters: parameters.data ?? []
+    attributes: steps,
+    parameters: parameters.data ?? [],
+    slideModels: Object.fromEntries(
+      (slideModelUploads?.data ?? []).map((model) => [model.id, model])
+    )
   };
 }
 

--- a/apps/mes/app/services/operations.service.ts
+++ b/apps/mes/app/services/operations.service.ts
@@ -438,6 +438,12 @@ export function getFileType(fileName: string): (typeof documentTypes)[number] {
   return "Other";
 }
 
+/**
+ * A job operation's steps (with their recorded values and reference slides) and
+ * its process parameters, plus the render metadata for any 3D model slides —
+ * resolved here so BOTH execution views (standard step list and assembly) paint
+ * models from the same query.
+ */
 export async function getJobOperationProcedure(
   client: SupabaseClient<Database>,
   operationId: string

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Ausstempeln vergessen?"
 msgid "Format"
 msgstr "Format"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Techniker vor Ort"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Header"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Hilfe"
@@ -15586,6 +15592,9 @@ msgstr "Testwert"
 
 msgid "Text size"
 msgstr "Textgröße"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Dieser Name wird bereits von einem anderen Schritt verwendet."

--- a/packages/locale/locales/de/mes.po
+++ b/packages/locale/locales/de/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} erfasste Fehler werden NICHT abgeschlossen – beheben Sie diese
 msgid "+{overflow} more"
 msgstr "+{overflow} weitere"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "Über"
 
@@ -288,6 +291,9 @@ msgstr "Verbrauchte abgelaufen"
 
 msgid "Continue"
 msgstr "Weiter"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Ideen, Vorschläge oder Probleme?"
 
 msgid "Idle for"
 msgstr "Untätig seit"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Auswirkung"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Forgot to Clock Out?"
 msgid "Format"
 msgstr "Format"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr "Format can't be displayed — re-upload as JPEG or PNG"
+
 msgid "Forward deployed engineer"
 msgstr "Forward deployed engineer"
 
@@ -7690,6 +7693,9 @@ msgstr "Has operations that can't be scheduled"
 
 msgid "Headers"
 msgstr "Headers"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
 
 msgid "Help"
 msgstr "Help"
@@ -15586,6 +15592,9 @@ msgstr "Test Value"
 
 msgid "Text size"
 msgstr "Text size"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
 
 msgid "That name is already used by another step."
 msgstr "That name is already used by another step."

--- a/packages/locale/locales/en/mes.po
+++ b/packages/locale/locales/en/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} sampled failure(s) are recorded and will NOT be completed — re
 msgid "+{overflow} more"
 msgstr "+{overflow} more"
 
+msgid "3D model"
+msgstr "3D model"
+
 msgid "About"
 msgstr "About"
 
@@ -288,6 +291,9 @@ msgstr "Consumed expired"
 
 msgid "Continue"
 msgstr "Continue"
+
+msgid "Converting…"
+msgstr "Converting…"
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Ideas, suggestions or problems?"
 
 msgid "Idle for"
 msgstr "Idle for"
+
+msgid "Image format not supported"
+msgstr "Image format not supported"
 
 msgid "Impact"
 msgstr "Impact"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -7277,6 +7277,9 @@ msgstr "¿Olvidó fichar salida?"
 msgid "Format"
 msgstr "Formato"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Ingeniero desplegado en sitio"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Encabezados"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Ayuda"
@@ -15586,6 +15592,9 @@ msgstr "Valor de Prueba"
 
 msgid "Text size"
 msgstr "Tamaño de texto"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Ese nombre ya está siendo utilizado por otro paso."

--- a/packages/locale/locales/es/mes.po
+++ b/packages/locale/locales/es/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} fallo(s) muestreado(s) registrado(s) y NO serán completado(s) �
 msgid "+{overflow} more"
 msgstr "+{overflow} más"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "Acerca de"
 
@@ -288,6 +291,9 @@ msgstr "Consumido vencido"
 
 msgid "Continue"
 msgstr "Continuar"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "¿Ideas, sugerencias o problemas?"
 
 msgid "Idle for"
 msgstr "Inactivo durante"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impacto"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Avez-vous oublié le pointage fin ?"
 msgid "Format"
 msgstr "Format"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Ingénieur dédié au terrain"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "En-têtes"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Aide"
@@ -15586,6 +15592,9 @@ msgstr "Valeur de test"
 
 msgid "Text size"
 msgstr "Taille du texte"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Ce nom est déjà utilisé par une autre étape."

--- a/packages/locale/locales/fr/mes.po
+++ b/packages/locale/locales/fr/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} défaut(s) échantillonné(s) enregistré(s) et ne seront PAS co
 msgid "+{overflow} more"
 msgstr "+{overflow} autres"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "À propos"
 
@@ -288,6 +291,9 @@ msgstr "Consommé expiré"
 
 msgid "Continue"
 msgstr "Continuer"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Des idées, suggestions ou problèmes ?"
 
 msgid "Idle for"
 msgstr "Inactif depuis"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impact"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -7277,6 +7277,9 @@ msgstr "कार्य समाप्त करना भूल गए?"
 msgid "Format"
 msgstr "प्रारूप"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "अग्रपंक्ति में तैनात इंजीनियर"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "हेडर"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "मदद"
@@ -15586,6 +15592,9 @@ msgstr "परीक्षण मान"
 
 msgid "Text size"
 msgstr "पाठ आकार"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "वह नाम पहले से ही एक अन्य चरण द्वारा उपयोग किया जा रहा है।"

--- a/packages/locale/locales/hi/mes.po
+++ b/packages/locale/locales/hi/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} नमूना विफलता(एं) दर्ज की �
 msgid "+{overflow} more"
 msgstr "+{overflow} अधिक"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "के बारे में"
 
@@ -288,6 +291,9 @@ msgstr "खपत की गई समाप्त"
 
 msgid "Continue"
 msgstr "जारी रखें"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "विचार, सुझाव या समस्याएं?"
 
 msgid "Idle for"
 msgstr "के लिए निष्क्रिय"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "प्रभाव"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Hai dimenticato di timbrare la fine?"
 msgid "Format"
 msgstr "Formato"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Ingegnere dispiegato in prima linea"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Intestazioni"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Aiuto"
@@ -15586,6 +15592,9 @@ msgstr "Valore di Test"
 
 msgid "Text size"
 msgstr "Dimensione testo"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Quel nome è già utilizzato da un altro passaggio."

--- a/packages/locale/locales/it/mes.po
+++ b/packages/locale/locales/it/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} errore(i) campionato(i) registrato(i) e NON sarà(sarranno) comp
 msgid "+{overflow} more"
 msgstr "+{overflow} altri"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "Informazioni"
 
@@ -288,6 +291,9 @@ msgstr "Consumato scaduto"
 
 msgid "Continue"
 msgstr "Continua"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Idee, suggerimenti o problemi?"
 
 msgid "Idle for"
 msgstr "Inattivo per"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impatto"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -7277,6 +7277,9 @@ msgstr "作業終了を忘れましたか？"
 msgid "Format"
 msgstr "フォーマット"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "現地配置エンジニア"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "ヘッダー"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "ヘルプ"
@@ -15586,6 +15592,9 @@ msgstr "テスト値"
 
 msgid "Text size"
 msgstr "テキストサイズ"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "その名前は別のステップで既に使用されています。"

--- a/packages/locale/locales/ja/mes.po
+++ b/packages/locale/locales/ja/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails}件のサンプル不良が記録されており、完了され�
 msgid "+{overflow} more"
 msgstr "+{overflow} その他"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "バージョン情報"
 
@@ -288,6 +291,9 @@ msgstr "消費期限切れ"
 
 msgid "Continue"
 msgstr "続行"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "アイデア、提案、または問題はありますか？"
 
 msgid "Idle for"
 msgstr "待機時間"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "影響"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -7277,6 +7277,9 @@ msgstr "작업 종료를 잊으셨습니까?"
 msgid "Format"
 msgstr "형식"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "현장 배치 엔지니어"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "헤더"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "도움말"
@@ -15586,6 +15592,9 @@ msgstr "테스트 값"
 
 msgid "Text size"
 msgstr "글자 크기"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "해당 이름은 이미 다른 단계에서 사용 중입니다."

--- a/packages/locale/locales/ko/mes.po
+++ b/packages/locale/locales/ko/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails}개의 샘플 불량이 기록되었으며 완료되지 않습니
 msgid "+{overflow} more"
 msgstr "+{overflow} 더 보기"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "정보"
 
@@ -288,6 +291,9 @@ msgstr "소모 만료"
 
 msgid "Continue"
 msgstr "계속"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "아이디어, 제안, 또는 문제가 있으신가요?"
 
 msgid "Idle for"
 msgstr "유휴 상태"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "영향"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Zapomniałeś o zakończeniu pracy?"
 msgid "Format"
 msgstr "Format"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Inżynier wdrażający"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Nagłówki"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Pomoc"
@@ -15586,6 +15592,9 @@ msgstr "Wartość testowa"
 
 msgid "Text size"
 msgstr "Rozmiar tekstu"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Ta nazwa jest już używana przez inny krok."

--- a/packages/locale/locales/pl/mes.po
+++ b/packages/locale/locales/pl/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} zarejestrowanych niepowodzeń będzie NIEUKOŃCZONYCH — rozwi�
 msgid "+{overflow} more"
 msgstr "+{overflow} więcej"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "O programie"
 
@@ -288,6 +291,9 @@ msgstr "Zużyte wygasłe"
 
 msgid "Continue"
 msgstr "Kontynuuj"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Pomysły, sugestie czy problemy?"
 
 msgid "Idle for"
 msgstr "Bezczynny przez"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Wpływ"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Esqueceu de apontar fim?"
 msgid "Format"
 msgstr "Formato"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Engenheiro de campo"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Cabeçalhos"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Ajuda"
@@ -15586,6 +15592,9 @@ msgstr "Valor de Teste"
 
 msgid "Text size"
 msgstr "Tamanho do texto"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Esse nome já está sendo usado por outra etapa."

--- a/packages/locale/locales/pt/mes.po
+++ b/packages/locale/locales/pt/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} falha(s) amostrada(s) registrada(s) e NÃO será(ão) concluída
 msgid "+{overflow} more"
 msgstr "+{overflow} mais"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "Sobre"
 
@@ -288,6 +291,9 @@ msgstr "Consumido vencido"
 
 msgid "Continue"
 msgstr "Continuar"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Ideias, sugestões ou problemas?"
 
 msgid "Idle for"
 msgstr "Inativo por"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Impacto"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -7277,6 +7277,9 @@ msgstr "Забыли завершить окончание работы?"
 msgid "Format"
 msgstr "Формат"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Инженер на месте"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Заголовки"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Справка"
@@ -15586,6 +15592,9 @@ msgstr "Тестовое значение"
 
 msgid "Text size"
 msgstr "Размер текста"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Это имя уже используется другим шагом."

--- a/packages/locale/locales/ru/mes.po
+++ b/packages/locale/locales/ru/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} записанных отказов будут НЕ заверш
 msgid "+{overflow} more"
 msgstr "+{overflow} ещё"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "О системе"
 
@@ -288,6 +291,9 @@ msgstr "Израсходовано - истек срок"
 
 msgid "Continue"
 msgstr "Продолжить"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Идеи, предложения или проблемы?"
 
 msgid "Idle for"
 msgstr "Простой в течение"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Влияние"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -7277,6 +7277,9 @@ msgstr "İş bitişini mi unuttunuz?"
 msgid "Format"
 msgstr "Biçim"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "Sahadaki mühendis"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "Başlıklar"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "Yardım"
@@ -15586,6 +15592,9 @@ msgstr "Test Değeri"
 
 msgid "Text size"
 msgstr "Metin boyutu"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "Bu ad başka bir adım tarafından zaten kullanılıyor."

--- a/packages/locale/locales/tr/mes.po
+++ b/packages/locale/locales/tr/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} örnek hata(ları) kaydedildi ve tamamlanmayacak — bunları i�
 msgid "+{overflow} more"
 msgstr "+{overflow} daha fazla"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "Hakkında"
 
@@ -288,6 +291,9 @@ msgstr "Tüketildi süresi doldu"
 
 msgid "Continue"
 msgstr "Devam Et"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "Fikirler, öneriler veya sorunlar?"
 
 msgid "Idle for"
 msgstr "Boş olma süresi"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "Etki"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -7277,6 +7277,9 @@ msgstr "忘记收工了吗？"
 msgid "Format"
 msgstr "格式"
 
+msgid "Format can't be displayed — re-upload as JPEG or PNG"
+msgstr ""
+
 msgid "Forward deployed engineer"
 msgstr "驻场工程师"
 
@@ -7690,6 +7693,9 @@ msgstr ""
 
 msgid "Headers"
 msgstr "标头"
+
+msgid "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG."
+msgstr ""
 
 msgid "Help"
 msgstr "帮助"
@@ -15586,6 +15592,9 @@ msgstr "测试值"
 
 msgid "Text size"
 msgstr "文本大小"
+
+msgid "That file isn't an image browsers can display. Use JPEG, PNG, WebP, AVIF or GIF."
+msgstr ""
 
 msgid "That name is already used by another step."
 msgstr "该名称已被另一个步骤使用。"

--- a/packages/locale/locales/zh/mes.po
+++ b/packages/locale/locales/zh/mes.po
@@ -63,6 +63,9 @@ msgstr "{fails} 个抽样不合格已被记录，将不会被完成 — 从操�
 msgid "+{overflow} more"
 msgstr "还有 +{overflow} 个"
 
+msgid "3D model"
+msgstr ""
+
 msgid "About"
 msgstr "关于"
 
@@ -288,6 +291,9 @@ msgstr "已消耗已过期"
 
 msgid "Continue"
 msgstr "继续"
+
+msgid "Converting…"
+msgstr ""
 
 #. placeholder {0}: board.unplannedCost.days
 msgid "Cost of unplanned maintenance, last {0} days"
@@ -559,6 +565,9 @@ msgstr "有想法、建议或问题？"
 
 msgid "Idle for"
 msgstr "闲置时间"
+
+msgid "Image format not supported"
+msgstr ""
 
 msgid "Impact"
 msgstr "影响"

--- a/packages/utils/src/file.test.ts
+++ b/packages/utils/src/file.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
-import { isSupportedSlideImagePath, sniffSlideImageType } from "./file";
+import {
+  isSupportedSlideImagePath,
+  SLIDE_IMAGE_HEADER_BYTES,
+  sniffSlideImageType
+} from "./file";
 
 // Minimal container headers — enough bytes for the sniffer to reach a verdict.
 const header = (...bytes: number[]) =>
-  new Blob([new Uint8Array([...bytes, ...new Array(16).fill(0)])]);
+  new Uint8Array([
+    ...bytes,
+    ...new Array(SLIDE_IMAGE_HEADER_BYTES).fill(0)
+  ]).slice(0, SLIDE_IMAGE_HEADER_BYTES);
 const ascii = (text: string) => Array.from(text, (c) => c.charCodeAt(0));
 
 const PNG = header(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
@@ -16,29 +23,27 @@ const AVIF = header(0, 0, 0, 0x20, ...ascii("ftypavif"));
 const HEIC = header(0, 0, 0, 0x20, ...ascii("ftypheic"));
 
 describe("sniffSlideImageType", () => {
-  it("identifies every format a browser can paint", async () => {
-    expect(await sniffSlideImageType(PNG)).toBe("png");
-    expect(await sniffSlideImageType(JPEG)).toBe("jpg");
-    expect(await sniffSlideImageType(GIF)).toBe("gif");
-    expect(await sniffSlideImageType(WEBP)).toBe("webp");
-    expect(await sniffSlideImageType(AVIF)).toBe("avif");
+  it("identifies every format a browser can paint", () => {
+    expect(sniffSlideImageType(PNG)).toBe("png");
+    expect(sniffSlideImageType(JPEG)).toBe("jpg");
+    expect(sniffSlideImageType(GIF)).toBe("gif");
+    expect(sniffSlideImageType(WEBP)).toBe("webp");
+    expect(sniffSlideImageType(AVIF)).toBe("avif");
   });
 
-  it("rejects HEIC even though it shares AVIF's container", async () => {
-    expect(await sniffSlideImageType(HEIC)).toBeNull();
+  it("rejects HEIC even though it shares AVIF's container", () => {
+    expect(sniffSlideImageType(HEIC)).toBeNull();
   });
 
-  it("rejects a file too short to identify", async () => {
-    expect(await sniffSlideImageType(new Blob([new Uint8Array([0xff])]))).toBe(
+  it("rejects a header too short to identify", () => {
+    expect(sniffSlideImageType(new Uint8Array([0xff]))).toBeNull();
+  });
+
+  it("reads only the header, so a renamed file is judged on its bytes", () => {
+    // What the upload layer passes for `fixture-setup.jpg` that is really HEIC.
+    expect(sniffSlideImageType(HEIC.slice(0, SLIDE_IMAGE_HEADER_BYTES))).toBe(
       null
     );
-  });
-
-  it("ignores the filename — a renamed HEIC is still rejected", async () => {
-    const renamed = new File([HEIC], "fixture-setup.jpg", {
-      type: "image/jpeg"
-    });
-    expect(await sniffSlideImageType(renamed)).toBeNull();
   });
 });
 

--- a/packages/utils/src/file.test.ts
+++ b/packages/utils/src/file.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { isSupportedSlideImagePath, sniffSlideImageType } from "./file";
+
+// Minimal container headers — enough bytes for the sniffer to reach a verdict.
+const header = (...bytes: number[]) =>
+  new Blob([new Uint8Array([...bytes, ...new Array(16).fill(0)])]);
+const ascii = (text: string) => Array.from(text, (c) => c.charCodeAt(0));
+
+const PNG = header(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
+const JPEG = header(0xff, 0xd8, 0xff, 0xe0);
+const GIF = header(...ascii("GIF89a"));
+const WEBP = header(...ascii("RIFF"), 0, 0, 0, 0, ...ascii("WEBP"));
+const AVIF = header(0, 0, 0, 0x20, ...ascii("ftypavif"));
+// The iPhone camera default: same ISO-BMFF container as AVIF, different brand —
+// the brand check is the only thing separating them.
+const HEIC = header(0, 0, 0, 0x20, ...ascii("ftypheic"));
+
+describe("sniffSlideImageType", () => {
+  it("identifies every format a browser can paint", async () => {
+    expect(await sniffSlideImageType(PNG)).toBe("png");
+    expect(await sniffSlideImageType(JPEG)).toBe("jpg");
+    expect(await sniffSlideImageType(GIF)).toBe("gif");
+    expect(await sniffSlideImageType(WEBP)).toBe("webp");
+    expect(await sniffSlideImageType(AVIF)).toBe("avif");
+  });
+
+  it("rejects HEIC even though it shares AVIF's container", async () => {
+    expect(await sniffSlideImageType(HEIC)).toBeNull();
+  });
+
+  it("rejects a file too short to identify", async () => {
+    expect(await sniffSlideImageType(new Blob([new Uint8Array([0xff])]))).toBe(
+      null
+    );
+  });
+
+  it("ignores the filename — a renamed HEIC is still rejected", async () => {
+    const renamed = new File([HEIC], "fixture-setup.jpg", {
+      type: "image/jpeg"
+    });
+    expect(await sniffSlideImageType(renamed)).toBeNull();
+  });
+});
+
+describe("isSupportedSlideImagePath", () => {
+  it("accepts stored paths in a displayable format, case-insensitively", () => {
+    expect(isSupportedSlideImagePath("co/parts/abc.png")).toBe(true);
+    expect(isSupportedSlideImagePath("co/parts/abc.JPG")).toBe(true);
+    expect(isSupportedSlideImagePath("co/parts/abc.avif")).toBe(true);
+  });
+
+  it("rejects formats the MES can't paint, and paths with no extension", () => {
+    expect(isSupportedSlideImagePath("co/parts/abc.heic")).toBe(false);
+    expect(isSupportedSlideImagePath("co/parts/abc.tiff")).toBe(false);
+    // svg renders, but the preview route serves it same-origin with no CSP.
+    expect(isSupportedSlideImagePath("co/parts/abc.svg")).toBe(false);
+    expect(isSupportedSlideImagePath("co/parts/abc")).toBe(false);
+    expect(isSupportedSlideImagePath(null)).toBe(false);
+  });
+});

--- a/packages/utils/src/file.ts
+++ b/packages/utils/src/file.ts
@@ -140,9 +140,14 @@ export const supportedSlideImageTypes = [
   "webp"
 ];
 
-// Whether a stored slide path (or a filename) ends in a format the browser can
-// paint. Used at upload time to reject, and at render time to show an explicit
-// "unsupported format" placeholder for rows written before the gate existed.
+/**
+ * Whether a stored slide path (or filename) ends in a format the browser can
+ * paint. Used at upload time to reject, and at render time to show an explicit
+ * "unsupported format" placeholder for rows written before the gate existed.
+ *
+ * @param path Storage path or filename; a missing path is not supported.
+ * @returns True when the extension is in {@link supportedSlideImageTypes}.
+ */
 export function isSupportedSlideImagePath(
   path: string | null | undefined
 ): boolean {
@@ -151,14 +156,19 @@ export function isSupportedSlideImagePath(
   return !!ext && supportedSlideImageTypes.includes(ext);
 }
 
-// Magic-number sniff for the allowed slide formats. `accept` is only a picker
-// filter and the browser's `file.type` is derived from the extension, so a
-// renamed `.heic` → `.jpg` passes both — this reads the container header and is
-// the only check that catches it. Identification only: the bytes are never
-// decoded or rewritten. Returns the canonical extension, or null when the
-// header matches nothing we can serve.
-export async function sniffSlideImageType(file: Blob): Promise<string | null> {
-  const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+/**
+ * Magic-number sniff for the allowed slide formats. `accept` is only a picker
+ * filter and the browser's `file.type` is derived from the extension, so a
+ * renamed `.heic` → `.jpg` passes both — reading the container header is the
+ * only check that catches it. Identification only: the bytes are never decoded
+ * or rewritten, and this stays a synchronous pure function (the caller does the
+ * I/O and passes the header in).
+ *
+ * @param header The file's first bytes — 12 minimum, {@link SLIDE_IMAGE_HEADER_BYTES} covers every case.
+ * @returns The canonical extension to store the file under, or null when the
+ *   header matches nothing a browser can paint.
+ */
+export function sniffSlideImageType(header: Uint8Array): string | null {
   if (header.length < 12) return null;
 
   const startsWith = (...bytes: number[]) =>
@@ -186,3 +196,6 @@ export async function sniffSlideImageType(file: Blob): Promise<string | null> {
   }
   return null;
 }
+
+/** Bytes of a file's head to read before calling {@link sniffSlideImageType}. */
+export const SLIDE_IMAGE_HEADER_BYTES = 16;

--- a/packages/utils/src/file.ts
+++ b/packages/utils/src/file.ts
@@ -115,3 +115,74 @@ export const supportedModelTypes = [
   "stl",
   "stp"
 ];
+
+// Image formats a step slide may use. The gate is decode support in EVERY
+// browser the MES runs on — a slide is served byte-for-byte from storage and
+// painted in an <img>, so anything Chrome/Firefox can't decode is a grey box on
+// the shop floor with no error anywhere in the stack.
+//
+// Deliberately excluded:
+//   heic/heif — Safari-only decoder (the payload is HEVC, which Chrome and
+//     Firefox have never shipped). The iPhone camera default, so this is the
+//     one users actually hit; iOS Safari's own photo picker hands the page a
+//     JPEG, but a desktop upload of the original does not.
+//   tiff, jxl — Safari-only for the same practical reason.
+//   svg    — renders everywhere, but the preview route serves it from the app's
+//     own origin with no CSP or Content-Disposition, so an SVG opened in a tab
+//     executes script with the viewer's session. Not worth the XSS surface for
+//     a reference photo.
+export const supportedSlideImageTypes = [
+  "avif",
+  "gif",
+  "jpeg",
+  "jpg",
+  "png",
+  "webp"
+];
+
+// Whether a stored slide path (or a filename) ends in a format the browser can
+// paint. Used at upload time to reject, and at render time to show an explicit
+// "unsupported format" placeholder for rows written before the gate existed.
+export function isSupportedSlideImagePath(
+  path: string | null | undefined
+): boolean {
+  if (!path) return false;
+  const ext = path.toLowerCase().split(".").pop();
+  return !!ext && supportedSlideImageTypes.includes(ext);
+}
+
+// Magic-number sniff for the allowed slide formats. `accept` is only a picker
+// filter and the browser's `file.type` is derived from the extension, so a
+// renamed `.heic` → `.jpg` passes both — this reads the container header and is
+// the only check that catches it. Identification only: the bytes are never
+// decoded or rewritten. Returns the canonical extension, or null when the
+// header matches nothing we can serve.
+export async function sniffSlideImageType(file: Blob): Promise<string | null> {
+  const header = new Uint8Array(await file.slice(0, 16).arrayBuffer());
+  if (header.length < 12) return null;
+
+  const startsWith = (...bytes: number[]) =>
+    bytes.every((byte, index) => header[index] === byte);
+  const asciiAt = (offset: number, text: string) =>
+    text
+      .split("")
+      .every((char, i) => header[offset + i] === char.charCodeAt(0));
+
+  if (startsWith(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)) return "png";
+  if (startsWith(0xff, 0xd8, 0xff)) return "jpg";
+  if (startsWith(0x47, 0x49, 0x46, 0x38)) return "gif";
+  // RIFF....WEBP
+  if (asciiAt(0, "RIFF") && asciiAt(8, "WEBP")) return "webp";
+  // ISO-BMFF: ....ftyp<brand>. AVIF and HEIC share the container, so the major
+  // brand is what separates a paintable file from a Safari-only one. Only the
+  // major brand is read, never the compatible-brands list, so an AVIF written
+  // with a generic `mif1` major brand is rejected too — erring toward a clear
+  // "unsupported" message is the right failure, since the alternative direction
+  // lets a HEIC through and ends as a grey box on the shop floor.
+  if (asciiAt(4, "ftyp")) {
+    const brand = String.fromCharCode(...header.slice(8, 12)).toLowerCase();
+    if (brand === "avif" || brand === "avis") return "avif";
+    return null;
+  }
+  return null;
+}


### PR DESCRIPTION
## What

A bill-of-process step slide is served byte-for-byte from storage and painted in an `<img>`, so a format the browser cannot decode is a grey box on the operator's step, with no error anywhere in the stack. Three defects, all of which report success in the ERP and fail on the shop floor:

1. **HEIC.** `accept="image/*"` let the picker hand us HEIC — the iPhone camera default, which only Safari decodes. iOS Safari's own photo picker transcodes to JPEG, so this hit the desktop path: the original copied off a phone or camera.
2. **Extension from the filename.** The stored extension came from `file.name.split(".").pop()`, so a renamed `.heic` → `.jpg` and a file with no extension both stored a bogus extension and served as `application/octet-stream`.
3. **Model slides invisible outside the assembly view.** The standard operation loader never resolved `modelUploadId`, so `Step.tsx` skipped them — the ERP offered an "Add model" button whose output never reached the operator.

## Approach

Nothing is transformed. The gate is up front and the bytes are stored exactly as uploaded.

- `supportedSlideImageTypes`, `isSupportedSlideImagePath`, `sniffSlideImageType` in `@carbon/utils`. The allowlist is "formats every browser can decode": png, jpg/jpeg, gif, webp, avif. **svg is excluded deliberately** — it renders, but the preview route serves it same-origin with no CSP or `Content-Disposition`, so an SVG opened in a tab executes script with the viewer's session.
- One `uploadStepSlideImage` helper replaces upload logic that was duplicated across five call sites (item BOP draft + existing, job BOP draft + existing, assembly instructions). It sniffs the container header — the only check that catches a renamed file — and derives the stored extension from the sniff, not the filename.
- `operationStepSlideValidator` rejects an unsupported `imagePath` server-side: the storage write is direct-to-Supabase and the route also serves API-key callers, so the row gets its own check.
- Slides **already** stored in an undisplayable format render an explicit placeholder in both the ERP editor and the MES step, rather than a broken image. Pin/annotate is hidden for those.
- `getJobOperationProcedure` resolves slide model uploads for both execution views. The standard step list renders model tiles that open `ModelPreview` in a modal; the assembly route drops its now-duplicate query.

## Verification

Driven in Chrome against a local stack, on a plain machining operation (not an assembly):

| Input | Result |
|---|---|
| Real macOS HEIC (HEVC, `ftypheic`) | Rejected: "HEIC photos can't be displayed in a browser. On iPhone, Settings → Camera → Formats → Most Compatible saves photos as JPEG." |
| That HEIC renamed `.jpg` (`file.type` = `image/jpeg`) | Rejected by the byte sniff |
| PNG with **no extension** | Accepted, stored as `.png` |
| JPEG | Accepted |

After four attempts, storage held exactly two objects — the rejected files never reached it, so there are no orphans. Both ERP call sites (new-step draft form and saved-step editor) behave identically.

A job created from the method copied all four slides, and the operator's MES step shows two images, a **3D** tile, and the legacy row as "Image format not supported".

`packages/utils/src/file.test.ts` covers the sniffer, including that HEIC and AVIF share the ISO-BMFF container and are separated only by the major brand.

## Notes for review

- The pre-commit hook extracted 58 new ERP strings and 3 MES strings into all 13 locale catalogs — that is most of the file count.
- The AVIF brand check reads only the major brand, so an AVIF written with a generic `mif1` brand is rejected too. Deliberate: that direction fails with a clear message; the other lets a HEIC through to the shop floor.
- Not addressed here, found in the same review: no size cap on slide uploads, slides being job-snapshotted with no "method has newer images" affordance, the item-side routes gating on `parts` while RLS demands `production_*`, orphaned storage objects on slide delete, and hardening the preview route for svg generally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRiSpYjm2czj2pQbm2VNJ9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for viewing 3D model slides alongside image slides in job instructions.
  * Added validation for supported slide image formats, including JPEG, PNG, WebP, AVIF, and GIF.
  * Unsupported images now show a helpful placeholder instead of a broken preview.
  * Added clearer upload guidance and localized error messages.

* **Bug Fixes**
  * Prevented unsupported or renamed image files, including HEIC files, from being uploaded or displayed.
  * Improved image upload handling across bill of process, assembly, and job workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->