### PR TITLE
fix(build): stub rhino3dm's Node-only `ws` require so the ERP and MES builds resolve

### DIFF
--- a/apps/erp/app/ssr-shims/ws-stub.cjs
+++ b/apps/erp/app/ssr-shims/ws-stub.cjs
@@ -1,0 +1,37 @@
+/**
+ * Stub for the `ws` package. rhino3dm's Emscripten runtime does
+ * `require("ws")` inside its `ENVIRONMENT_IS_NODE` socket branches — dead code
+ * for us, since the viewer only ever loads `.3dm` geometry in the browser — but
+ * the bundler still has to resolve the specifier. rhino3dm declares no
+ * dependency on `ws`, so resolution only ever worked by accident when some
+ * other package hoisted a copy to the workspace root; the `ws@8` override in
+ * #1515 ended that and broke both app builds.
+ *
+ * Aliased rather than installed: adding `ws` as a real dependency would ship a
+ * Node WebSocket implementation to satisfy a branch that never runs. Throws if
+ * anything actually reaches for it, so a genuine need surfaces loudly instead
+ * of failing strangely at runtime.
+ */
+"use strict";
+
+function unavailable() {
+  throw new Error(
+    "`ws` is stubbed in this app: rhino3dm's Node socket path is not supported. If you need a real WebSocket client, add `ws` as an explicit dependency and drop this alias."
+  );
+}
+
+class WebSocketStub {
+  constructor() {
+    unavailable();
+  }
+}
+
+WebSocketStub.Server = class WebSocketServerStub {
+  constructor() {
+    unavailable();
+  }
+};
+
+module.exports = WebSocketStub;
+module.exports.default = WebSocketStub;
+module.exports.WebSocket = WebSocketStub;

--- a/apps/erp/vite.config.ts
+++ b/apps/erp/vite.config.ts
@@ -69,6 +69,12 @@ export default defineConfig(({ isSsrBuild, mode }) => {
          * whole `konva` package — react-konva imports `konva/lib/Core.js`, etc.).
          */
         canvas: path.resolve(__dirname, "app/ssr-shims/canvas-stub.cjs"),
+        /**
+         * rhino3dm's Emscripten runtime requires `ws` in its Node-only socket
+         * branches, without declaring it as a dependency. Nothing in the viewer
+         * takes that path, but the bundler must still resolve the specifier.
+         */
+        ws: path.resolve(__dirname, "app/ssr-shims/ws-stub.cjs"),
         // Directory (not index.ts) so subpath imports like
         // `@carbon/utils/favicon` resolve to `src/favicon.ts`.
         "@carbon/utils": path.resolve(__dirname, "../../packages/utils/src"),

--- a/apps/mes/app/ssr-shims/ws-stub.cjs
+++ b/apps/mes/app/ssr-shims/ws-stub.cjs
@@ -1,0 +1,37 @@
+/**
+ * Stub for the `ws` package. rhino3dm's Emscripten runtime does
+ * `require("ws")` inside its `ENVIRONMENT_IS_NODE` socket branches — dead code
+ * for us, since the viewer only ever loads `.3dm` geometry in the browser — but
+ * the bundler still has to resolve the specifier. rhino3dm declares no
+ * dependency on `ws`, so resolution only ever worked by accident when some
+ * other package hoisted a copy to the workspace root; the `ws@8` override in
+ * #1515 ended that and broke both app builds.
+ *
+ * Aliased rather than installed: adding `ws` as a real dependency would ship a
+ * Node WebSocket implementation to satisfy a branch that never runs. Throws if
+ * anything actually reaches for it, so a genuine need surfaces loudly instead
+ * of failing strangely at runtime.
+ */
+"use strict";
+
+function unavailable() {
+  throw new Error(
+    "`ws` is stubbed in this app: rhino3dm's Node socket path is not supported. If you need a real WebSocket client, add `ws` as an explicit dependency and drop this alias."
+  );
+}
+
+class WebSocketStub {
+  constructor() {
+    unavailable();
+  }
+}
+
+WebSocketStub.Server = class WebSocketServerStub {
+  constructor() {
+    unavailable();
+  }
+};
+
+module.exports = WebSocketStub;
+module.exports.default = WebSocketStub;
+module.exports.WebSocket = WebSocketStub;

--- a/apps/mes/vite.config.ts
+++ b/apps/mes/vite.config.ts
@@ -62,6 +62,12 @@ export default defineConfig(({ mode, isSsrBuild }) => {
          * konva entry itself — the drawing pane needs the real browser build).
          */
         canvas: path.resolve(__dirname, "app/ssr-shims/canvas-stub.cjs"),
+        /**
+         * rhino3dm's Emscripten runtime requires `ws` in its Node-only socket
+         * branches, without declaring it as a dependency. Nothing in the viewer
+         * takes that path, but the bundler must still resolve the specifier.
+         */
+        ws: path.resolve(__dirname, "app/ssr-shims/ws-stub.cjs"),
         // Directory (not index.ts) so subpath imports like
         // `@carbon/utils/favicon` resolve to `src/favicon.ts`.
         "@carbon/utils": path.resolve(__dirname, "../../packages/utils/src"),


### PR DESCRIPTION
## The failure

Every commit since #1515 has failed the `Vercel – carbon` and `Vercel – mes` deployments, **including `main` itself**. `docs` and `academy` pass, because they don't bundle the viewer.

```
[vite]: Rolldown failed to resolve import "ws" from
node_modules/.pnpm/rhino3dm@8.17.0/node_modules/rhino3dm/rhino3dm.js
```

## Why

rhino3dm's Emscripten runtime calls `require("ws")` inside its `ENVIRONMENT_IS_NODE` socket branches. That code never runs for us — the viewer only loads `.3dm` geometry in the browser — but the bundler still has to resolve the specifier.

rhino3dm declares **no dependencies at all**, so `ws` only ever resolved because some other package happened to hoist a copy to the workspace root. #1515's `"ws@8": 8.21.0` override (from 8.20.0) changed that layout and the specifier stopped resolving. Nothing is wrong with the override itself — it exposed a latent fragility.

Local builds kept passing on stale `node_modules`; `pnpm install --frozen-lockfile` reproduces it immediately.

## The fix

Alias `ws` to a stub in both apps, the same shape as the `canvas` alias sitting next to it (which handles Konva's Node entry for exactly the same reason).

Aliased rather than installed on purpose: adding `ws` as a real dependency would ship a Node WebSocket implementation to satisfy a branch that never executes. The stub throws if anything actually reaches for it, so a genuine need surfaces loudly instead of failing strangely at runtime.

## Verification

`turbo run build --filter=erp --filter=mes --force` fails on the parent commit and passes here. Both apps, both client and SSR bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRiSpYjm2czj2pQbm2VNJ9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering and build reliability for the ERP and MES applications.
  * Prevented browser-only viewers from incorrectly attempting to use unsupported Node.js WebSocket functionality.
  * Added clear runtime errors if an unsupported WebSocket connection is attempted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->