### PR TITLE
fix(erp): keep the home page reachable when an implementation hub is active

### DIFF
--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -13,11 +13,6 @@ import {
   stateMap,
   type Tier
 } from "@carbon/onboarding";
-import {
-  detectImplementationSignals,
-  getImplementationCheckStates,
-  getImplementationHub
-} from "@carbon/onboarding/server";
 import { OnboardingHubSummary } from "@carbon/onboarding/ui";
 import {
   Button,
@@ -33,7 +28,7 @@ import {
   useOperatingSystem,
   useRouteData
 } from "@carbon/react";
-import { datetime, formatRelativeTime, isInternalEmail } from "@carbon/utils";
+import { datetime, formatRelativeTime } from "@carbon/utils";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocale } from "@react-aria/i18n";
 import * as cookie from "cookie";
@@ -49,7 +44,7 @@ import {
 } from "react-icons/lu";
 import { RxMagnifyingGlass } from "react-icons/rx";
 import type { LoaderFunctionArgs } from "react-router";
-import { Link, redirect, useFetcher, useLoaderData } from "react-router";
+import { Link, useFetcher, useLoaderData } from "react-router";
 import {
   ClaudeIcon,
   CodexIcon,
@@ -76,25 +71,11 @@ import { copyToClipboard } from "~/utils/string";
 // cookie so the loader can read it server-side and SSR renders the final state.
 const AGENT_WIDGET_COOKIE = "onboardAgentDismissed";
 
-// While a hub is active (not yet finished) it replaces the home page for
-// internal users, who land straight in it until every checkpoint is done.
-// Customers keep the normal home page (with the hub summary card) — only the
-// auto-redirect is internal-only.
+// The home page is always accessible. When a hub is active (enrolled and not yet
+// finished) it surfaces as a primary-nav item (`useImplementationNavItem`) and a
+// summary card below — it never replaces the home page for anyone.
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId, email } = await requirePermissions(request, {});
-  if (isInternalEmail(email)) {
-    const hub = await getImplementationHub(client, companyId);
-    const status = hub.data?.status;
-    if (hub.data && status !== "complete" && status !== "archived") {
-      const [states, signals] = await Promise.all([
-        getImplementationCheckStates(client, companyId),
-        detectImplementationSignals(client, companyId)
-      ]);
-      const spine = spineForTier(SPINE, hub.data.tier);
-      const done = gatesDone(spine, stateMap(states.data ?? []), signals);
-      if (done < spine.length) throw redirect(path.to.getStarted);
-    }
-  }
+  const { client, companyId } = await requirePermissions(request, {});
 
   // Compute the greeting on the server so SSR and hydration render the SAME
   // line — no client-side randomness, so no flash on refresh. `pick` is the

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -68308,14 +68308,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -73397,13 +73397,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73412,6 +73405,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -68308,14 +68308,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -73397,13 +73397,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73412,6 +73405,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]


### PR DESCRIPTION
## What does this PR do?

Keeps the ERP home page reachable when a company is enrolled in the Implementation Hub. The home-page loader previously auto-redirected internal (Carbon-staff) users straight into `/x/get-started` whenever a hub was still in progress, so they could never land on the home page. This removes that internal-only redirect (and the imports it required) — the hub is already surfaced as a primary-nav item (`useImplementationNavItem`) and a home-page summary card, so it now augments the home page for everyone instead of replacing it.

## Visual Demo (For contributors especially)

#### Image Demo:

Home page with an active hub — reachable, showing the "Get Started" summary card and Modules grid (previously this redirected away for internal users):

<!-- Attach: Screenshot 2026-08-31 at 9.12.13 AM.jpg -->

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No env vars or special data required beyond an enrolled Implementation Hub (`implementationHub` row present, status not `complete`/`archived`).
- Sign in as an internal-email user with an in-progress hub and navigate to `/x`. Expected: the home page renders (greeting, search, hub summary card, module grid) rather than redirecting to `/x/get-started`.
- The hub stays reachable via the "Get Started" rail item and the summary card's "Open" button.

## Checklist

- My code follows the style guidelines of this project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * The ERP home page now opens directly for internal users instead of automatically redirecting to the implementation hub.
  * The implementation hub remains accessible from the primary navigation and is highlighted through a summary card.
  * Home page navigation is now more consistent, allowing users to access key ERP content before choosing whether to enter the implementation hub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->