### PR TITLE
style(auth): remove card container from login/auth screens

### DIFF
--- a/apps/academy/app/routes/_auth+/callback.tsx
+++ b/apps/academy/app/routes/_auth+/callback.tsx
@@ -146,7 +146,7 @@ export default function AuthCallback() {
         <img src="/carbon-mark-light.svg" alt="Carbon Logo" className="w-24" />
       </div>
       {error ? (
-        <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 mt-8 w-[380px]">
+        <div className="rounded-lg p-8 mt-8 w-[380px]">
           <VStack spacing={4}>
             <Alert variant="destructive">
               <LuTriangleAlert className="h-4 w-4" />

--- a/apps/academy/app/routes/_auth+/login.tsx
+++ b/apps/academy/app/routes/_auth+/login.tsx
@@ -146,7 +146,7 @@ export default function LoginRoute() {
       <div className="flex justify-center mb-8">
         <img src="/carbon-mark-light.svg" alt="Carbon Logo" className="w-24" />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         {fetcher.data?.success === true ? (
           <>
             <VStack spacing={4} className="items-center justify-center">

--- a/apps/academy/app/routes/_auth+/mfa.tsx
+++ b/apps/academy/app/routes/_auth+/mfa.tsx
@@ -156,7 +156,7 @@ export default function MfaRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
           <Hidden name="redirectTo" value={redirectTo} />
           <VStack spacing={4} className="items-center">

--- a/apps/erp/app/routes/_public+/callback.tsx
+++ b/apps/erp/app/routes/_public+/callback.tsx
@@ -448,7 +448,7 @@ export default function AuthCallback() {
   return (
     <div className="flex flex-col items-center justify-center">
       {error ? (
-        <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 mt-8 w-[380px]">
+        <div className="rounded-lg p-8 mt-8 w-[380px]">
           <VStack spacing={4}>
             <Alert variant="destructive">
               <LuTriangleAlert className="h-4 w-4" />

--- a/apps/erp/app/routes/_public+/login.tsx
+++ b/apps/erp/app/routes/_public+/login.tsx
@@ -526,7 +526,7 @@ export default function LoginRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         {fetcher.data?.success === true && fetcher.data?.mode === "login" ? (
           <>
             <VStack spacing={4} className="items-center justify-center">

--- a/apps/erp/app/routes/_public+/magic-link.tsx
+++ b/apps/erp/app/routes/_public+/magic-link.tsx
@@ -32,7 +32,7 @@ export default function ConfirmMagicLink() {
           alt={t`Carbon Logo`}
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <div className="flex flex-col items-center text-center">
           <Heading size="h3" className="tracking-tight">
             <Trans>Sign in to Carbon</Trans>

--- a/apps/erp/app/routes/_public+/mfa.tsx
+++ b/apps/erp/app/routes/_public+/mfa.tsx
@@ -178,7 +178,7 @@ export default function MfaRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
           <Hidden name="redirectTo" value={redirectTo} />
           <VStack spacing={4} className="items-center">

--- a/apps/erp/app/routes/_public+/unlock.tsx
+++ b/apps/erp/app/routes/_public+/unlock.tsx
@@ -404,7 +404,7 @@ export default function UnlockRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <VStack spacing={4} className="items-center">
           <LuLock className="w-8 h-8 text-muted-foreground" />
           <Heading size="h3">

--- a/apps/erp/app/routes/_public+/verify.tsx
+++ b/apps/erp/app/routes/_public+/verify.tsx
@@ -153,7 +153,7 @@ export default function VerifyRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <ValidatedForm
           fetcher={fetcher}
           validator={verifyValidator}

--- a/apps/mes/app/root.tsx
+++ b/apps/mes/app/root.tsx
@@ -193,7 +193,7 @@ function Document({
   // Combine the styles with proper selectors
   const themeStyle = {
     ...(mode === "dark" ? darkVars : lightVars),
-    "--radius": "0.675rem"
+    "--radius": "0.4375rem"
   } as React.CSSProperties;
 
   return (

--- a/apps/mes/app/routes/_public+/callback.tsx
+++ b/apps/mes/app/routes/_public+/callback.tsx
@@ -271,7 +271,7 @@ export default function AuthCallback() {
   return (
     <div className="flex flex-col items-center justify-center">
       {error ? (
-        <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 mt-8 w-[380px]">
+        <div className="rounded-lg p-8 mt-8 w-[380px]">
           <VStack spacing={4}>
             <Alert variant="destructive">
               <LuTriangleAlert className="h-4 w-4" />

--- a/apps/mes/app/routes/_public+/login.tsx
+++ b/apps/mes/app/routes/_public+/login.tsx
@@ -416,7 +416,7 @@ export default function LoginRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         {fetcher.data?.success === true ? (
           <>
             <VStack spacing={4} className="items-center justify-center">

--- a/apps/mes/app/routes/_public+/mfa.tsx
+++ b/apps/mes/app/routes/_public+/mfa.tsx
@@ -166,7 +166,7 @@ export default function MfaRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
           <Hidden name="redirectTo" value={redirectTo} />
           <VStack spacing={4} className="items-center">

--- a/apps/mes/app/routes/_public+/setup-required.tsx
+++ b/apps/mes/app/routes/_public+/setup-required.tsx
@@ -40,7 +40,7 @@ export default function SetupRequiredRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <VStack spacing={4} className="items-center justify-center text-center">
           <Heading size="h3">
             <Trans>Finish setting up your account</Trans>

--- a/apps/mes/app/routes/_public+/unlock.tsx
+++ b/apps/mes/app/routes/_public+/unlock.tsx
@@ -410,7 +410,7 @@ export default function UnlockRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <VStack spacing={4} className="items-center">
           <LuLock className="w-8 h-8 text-muted-foreground" />
           <Heading size="h3">

--- a/apps/starter/app/routes/_public+/callback.tsx
+++ b/apps/starter/app/routes/_public+/callback.tsx
@@ -160,7 +160,7 @@ export default function AuthCallback() {
         />
       </div>
       {error ? (
-        <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 mt-8 w-[380px]">
+        <div className="rounded-lg p-8 mt-8 w-[380px]">
           <VStack spacing={4}>
             <Alert variant="destructive">
               <LuTriangleAlert className="h-4 w-4" />

--- a/apps/starter/app/routes/_public+/login.tsx
+++ b/apps/starter/app/routes/_public+/login.tsx
@@ -155,7 +155,7 @@ export default function LoginRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         {fetcher.data?.success === true ? (
           <>
             <VStack spacing={4} className="items-center justify-center">

--- a/apps/starter/app/routes/_public+/mfa.tsx
+++ b/apps/starter/app/routes/_public+/mfa.tsx
@@ -159,7 +159,7 @@ export default function MfaRoute() {
           className="w-24 hidden dark:block"
         />
       </div>
-      <div className="rounded-lg md:bg-card md:border md:border-border md:shadow-lg p-8 w-[380px]">
+      <div className="rounded-lg p-8 w-[380px]">
         <ValidatedForm fetcher={fetcher} validator={mfaValidator} method="post">
           <Hidden name="redirectTo" value={redirectTo} />
           <VStack spacing={4} className="items-center">


### PR DESCRIPTION
## What does this PR do?

Removes the card container styling (`md:bg-card`, `md:border`, `md:border-border`, `md:shadow-lg`) from all auth and login screens across the erp, mes, academy, and starter apps. The forms now render directly on the page background without a card background, border, or shadow at any breakpoint.

## Visual Demo (For contributors especially)

#### Image Demo (if applicable):

- Before: auth forms sit inside a bordered, shadowed card on `md+` screens.
- After: auth forms render on the plain page background — no card, border, or shadow.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- No environment variables or test data required.
- Load any auth screen (login, mfa, callback, unlock, verify, magic-link, setup-required) in the erp, mes, academy, or starter apps at a `md+` viewport width.
- Expected: the form renders without a card background, border, or shadow.

## Checklist

- (none apply)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Simplified authentication screen styling across the Academy, ERP, MES, and Starter apps.
  - Removed responsive card backgrounds, borders, and shadows from login, MFA, callback, verification, unlock, magic-link, and setup-required containers.
  - Preserved existing spacing, rounded corners, sizing, and layout behavior.
  - Reduced the default theme corner radius for a slightly more compact visual style.
  - Updated screens now present a cleaner, less card-like appearance on medium and larger displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->