### PR TITLE
fix(invoicing): don't set datePaid when a purchase invoice is posted

### DIFF
--- a/packages/database/supabase/functions/post-purchase-invoice/index.ts
+++ b/packages/database/supabase/functions/post-purchase-invoice/index.ts
@@ -2261,7 +2261,6 @@ serve(async (req: Request) => {
       await trx
         .updateTable("purchaseInvoice")
         .set({
-          datePaid: today, // TODO: remove this once we have payments working
           ...(dateDue ? { dateDue } : {}),
           postingDate: today,
           status: "Open",


### PR DESCRIPTION
## What does this PR do?

Posting a purchase invoice was stamping `datePaid` with today's date while also setting `status` to `"Open"` — a contradiction, since a posted invoice is an open payable, not a paid one. This removes that write (the original author had already flagged it with `// TODO: remove this once we have payments working`), so `datePaid` stays null until an actual payment lands. Paid status and balance are unaffected: they're already derived from real `invoiceSettlement`/`payment` rows in the `purchaseInvoices` view, not from `datePaid`.

## Visual Demo (For contributors especially)

N/A — one-line edge-function logic change with no UI surface.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Post a purchase invoice via the ERP.
- Expected: the invoice moves to status `Open` with `postingDate` set to today and `datePaid` left empty (previously `datePaid` was incorrectly set to today).
- Applying a payment against it should be what sets paid status/balance (derived in the `purchaseInvoices` view).

## Checklist

- My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase invoices no longer receive an automatic payment date when posted.
  * Due date, posting date, and status handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->