### PR TITLE
fix(accounting): resolve quote currency by company group, not dropped companyId

### DIFF
--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -1084,8 +1084,14 @@ serve(async (req: Request) => {
           .from("currency")
           .select("*")
           .eq("code", currencyCode)
-          .eq("companyId", companyId)
+          .eq("companyGroupId", company.data.companyGroupId)
           .single();
+        // A missing rate must not fall through to 1 -- that quotes a
+        // foreign-currency customer at par. The base currency is the only
+        // case where 1 is correct by definition.
+        if (currency.error && currencyCode !== company.data.baseCurrencyCode) {
+          throw currency.error;
+        }
         const exchangeRate = currency.data?.exchangeRate ?? 1;
 
         const {


### PR DESCRIPTION
## Problem

The Sales RFQ → Quote conversion looks the customer's currency up with `.eq("companyId", companyId)`. That column was dropped from `currency` on 2026-02-28 when the table moved to company-group scoping (`20260228023426_company-groups.sql:335`).

PostgREST rejects the filter, `currency.data` is null, the error is never checked, and `?? 1` writes an exchange rate of 1 onto a quote that still carries the customer's foreign currency code. Every RFQ converted for a foreign-currency customer is quoted at par, with no error surfaced.

## Fix

Filter on `companyGroupId`, matching `create/index.ts:541-544`, and throw when the lookup fails so a missing rate can't be defaulted to 1. The base currency is exempt — 1 is correct there by definition.

## Notes

- Swept the other two tables that moved in the same migration (`account`, `accountCategory`) for stale `companyId` filters. None found; this was the only one.
- Verified on a local stack with a EUR-base company: converting an RFQ for a USD customer now produces a quote at rate 1.085 instead of 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sales RFQ-to-quote currency handling by using the company group’s currency configuration.
  * Quotes using the company’s base currency can now be created even when no matching currency record exists; the exchange rate defaults to 1.
  * Missing non-base currency configurations continue to raise an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->