### PR TITLE
fix(accounting): never write a document currency without its exchange rate

### DIFF
--- a/apps/erp/app/modules/accounting/accounting.ee.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.ee.service.ts
@@ -1950,6 +1950,40 @@ export async function getCurrencyByCode(
     .single();
 }
 
+/**
+ * A document's `currencyCode` and `exchangeRate` are ONE VALUE PAIR. A document
+ * denominated in a currency we hold no rate for cannot be priced, and a rate
+ * fabricated as 1 silently quotes a foreign-currency party at par. Resolve the
+ * two together, or refuse -- never write the code and leave the rate behind.
+ *
+ * A rate of 0 is refused for the same reason: the sales `converted*` generated
+ * columns have no zero-guard, so it would zero every line on the document.
+ */
+export async function resolveCurrencyAndRate(
+  client: SupabaseClient<Database>,
+  companyGroupId: string,
+  currencyCode: string
+): Promise<
+  | { data: { currencyCode: string; exchangeRate: number }; error: null }
+  | { data: null; error: { message: string } }
+> {
+  const currency = await getCurrencyByCode(
+    client,
+    companyGroupId,
+    currencyCode
+  );
+  const exchangeRate = currency.data?.exchangeRate;
+  if (currency.error || !exchangeRate) {
+    return {
+      data: null,
+      error: {
+        message: `No exchange rate is configured for ${currencyCode}. Set one under Accounting > Exchange Rates before using it on a document.`
+      }
+    };
+  }
+  return { data: { currencyCode, exchangeRate }, error: null };
+}
+
 export async function getCurrencies(
   client: SupabaseClient<Database>,
   companyGroupId: string,

--- a/apps/erp/app/modules/accounting/accounting.ee.service.ts
+++ b/apps/erp/app/modules/accounting/accounting.ee.service.ts
@@ -1973,7 +1973,14 @@ export async function resolveCurrencyAndRate(
     currencyCode
   );
   const exchangeRate = currency.data?.exchangeRate;
-  if (currency.error || !exchangeRate) {
+  // `!exchangeRate` alone would let a negative or Infinity through -- both are
+  // truthy, and both silently misprice every line they reach.
+  if (
+    currency.error ||
+    typeof exchangeRate !== "number" ||
+    !Number.isFinite(exchangeRate) ||
+    exchangeRate <= 0
+  ) {
     return {
       data: null,
       error: {

--- a/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
@@ -42,9 +42,30 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   switch (field) {
+    case "exchangeRate": {
+      // A rate written directly still has to be usable: 0 zeroes every sales
+      // `converted*` column (they carry no zero-guard) and a null violates the
+      // NOT NULL on the invoice tables.
+      const rate = Number(value);
+      if (!Number.isFinite(rate) || rate <= 0) {
+        return {
+          error: { message: "Exchange rate must be greater than zero" },
+          data: null
+        };
+      }
+      return await client
+        .from("purchaseInvoice")
+        .update({
+          exchangeRate: rate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "invoiceSupplierId":
       let currencyCode: string | undefined;
-      if (value && ids.length === 1) {
+      if (value) {
         const supplier = await client
           ?.from("supplier")
           .select("currencyCode")
@@ -160,7 +181,6 @@ export async function action({ request }: ActionFunctionArgs) {
     case "invoiceSupplierLocationId":
     case "locationId":
     case "supplierReference":
-    case "exchangeRate":
     case "dateDue":
     case "datePaid":
       return await client

--- a/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { datetime } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
@@ -57,9 +58,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .from("purchaseInvoice")
         .update({
           exchangeRate: rate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }
@@ -88,9 +89,9 @@ export async function action({ request }: ActionFunctionArgs) {
               invoiceSupplierLocationId: null,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -170,9 +171,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }

--- a/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/update.tsx
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   computeInvoiceDateDue,
   isPurchaseInvoiceLocked
@@ -53,19 +53,21 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (supplier.data?.currencyCode) {
           currencyCode = supplier.data.currencyCode;
-          const currency = await getCurrencyByCode(
+          const resolved = await resolveCurrencyAndRate(
             client,
             companyGroupId,
             currencyCode
           );
+          if (resolved.error) return resolved;
           return await client
             .from("purchaseInvoice")
             .update({
               invoiceSupplierId: value ?? undefined,
               invoiceSupplierContactId: null,
               invoiceSupplierLocationId: null,
-              currencyCode: currencyCode ?? undefined,
-              exchangeRate: currency.data?.exchangeRate ?? 1,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -132,26 +134,27 @@ export async function action({ request }: ActionFunctionArgs) {
       }
       break;
     // don't break -- just let it catch the next case
-    case "currencyCode":
-      if (value) {
-        const currency = await getCurrencyByCode(
-          client,
-          companyGroupId,
-          value as string
-        );
-        if (currency.data) {
-          return await client
-            .from("purchaseInvoice")
-            .update({
-              currencyCode: value as string,
-              exchangeRate: currency.data.exchangeRate ?? 1,
-              updatedBy: userId,
-              updatedAt: new Date().toISOString()
-            })
-            .in("id", ids as string[]);
-        }
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
       }
-    // don't break -- just let it catch the next case
+      const resolved = await resolveCurrencyAndRate(
+        client,
+        companyGroupId,
+        value as string
+      );
+      if (resolved.error) return resolved;
+      return await client
+        .from("purchaseInvoice")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "supplierId":
     case "invoiceSupplierContactId":
     case "invoiceSupplierLocationId":

--- a/apps/erp/app/routes/x+/purchase-order+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/update.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { datetime } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isPurchaseOrderLocked } from "~/modules/purchasing";
@@ -61,9 +62,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .from("purchaseOrder")
         .update({
           exchangeRate: rate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }
@@ -90,9 +91,9 @@ export async function action({ request }: ActionFunctionArgs) {
               supplierId: value ?? undefined,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -155,9 +156,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }

--- a/apps/erp/app/routes/x+/purchase-order+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/update.tsx
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isPurchaseOrderLocked } from "~/modules/purchasing";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 
@@ -57,17 +57,19 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (supplier.data?.currencyCode) {
           currencyCode = supplier.data.currencyCode;
-          const currency = await getCurrencyByCode(
+          const resolved = await resolveCurrencyAndRate(
             client,
             companyGroupId,
             currencyCode
           );
+          if (resolved.error) return resolved;
           return await client
             .from("purchaseOrder")
             .update({
               supplierId: value ?? undefined,
-              currencyCode: currencyCode ?? undefined,
-              exchangeRate: currency.data?.exchangeRate ?? 1,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -117,26 +119,27 @@ export async function action({ request }: ActionFunctionArgs) {
           updatedAt: new Date().toISOString()
         })
         .in("id", ids as string[]);
-    case "currencyCode":
-      if (value) {
-        const currency = await getCurrencyByCode(
-          client,
-          companyGroupId,
-          value as string
-        );
-        if (currency.data) {
-          return await client
-            .from("purchaseOrder")
-            .update({
-              currencyCode: value as string,
-              exchangeRate: currency.data.exchangeRate,
-              updatedBy: userId,
-              updatedAt: new Date().toISOString()
-            })
-            .in("id", ids as string[]);
-        }
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
       }
-    // don't break -- just let it catch the next case
+      const resolved = await resolveCurrencyAndRate(
+        client,
+        companyGroupId,
+        value as string
+      );
+      if (resolved.error) return resolved;
+      return await client
+        .from("purchaseOrder")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "supplierContactId":
     case "supplierLocationId":
     case "supplierReference":

--- a/apps/erp/app/routes/x+/purchase-order+/update.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/update.tsx
@@ -46,9 +46,30 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   switch (field) {
+    case "exchangeRate": {
+      // A rate written directly still has to be usable: 0 zeroes every sales
+      // `converted*` column (they carry no zero-guard) and a null violates the
+      // NOT NULL on the invoice tables.
+      const rate = Number(value);
+      if (!Number.isFinite(rate) || rate <= 0) {
+        return {
+          error: { message: "Exchange rate must be greater than zero" },
+          data: null
+        };
+      }
+      return await client
+        .from("purchaseOrder")
+        .update({
+          exchangeRate: rate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "supplierId":
       let currencyCode: string | undefined;
-      if (value && ids.length === 1) {
+      if (value) {
         const supplier = await client
           ?.from("supplier")
           .select("currencyCode")
@@ -143,7 +164,6 @@ export async function action({ request }: ActionFunctionArgs) {
     case "supplierContactId":
     case "supplierLocationId":
     case "supplierReference":
-    case "exchangeRate":
     case "orderDate":
       return await client
         .from("purchaseOrder")

--- a/apps/erp/app/routes/x+/quote+/update.tsx
+++ b/apps/erp/app/routes/x+/quote+/update.tsx
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isQuoteLocked } from "~/modules/sales";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 
@@ -36,7 +36,6 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (field) {
     case "customerId":
-      let currencyCode: string | undefined;
       if (value && ids.length === 1) {
         const customer = await client
           ?.from("customer")
@@ -45,12 +44,19 @@ export async function action({ request }: ActionFunctionArgs) {
           .single();
 
         if (customer.data?.currencyCode) {
-          currencyCode = customer.data.currencyCode;
+          const resolved = await resolveCurrencyAndRate(
+            client,
+            companyGroupId,
+            customer.data.currencyCode
+          );
+          if (resolved.error) return resolved;
           return await client
             .from("quote")
             .update({
               customerId: value ?? undefined,
-              currencyCode: currencyCode ? currencyCode : undefined,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -66,24 +72,27 @@ export async function action({ request }: ActionFunctionArgs) {
           updatedAt: new Date().toISOString()
         })
         .in("id", ids as string[]);
-    case "currencyCode":
-      const currency = await getCurrencyByCode(
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
+      }
+      const resolved = await resolveCurrencyAndRate(
         client,
         companyGroupId,
         value as string
       );
-      if (currency.data) {
-        return await client
-          .from("quote")
-          .update({
-            currencyCode: value,
-            exchangeRate: currency.data.exchangeRate,
-            updatedBy: userId,
-            updatedAt: new Date().toISOString()
-          })
-          .in("id", ids as string[]);
-      }
-    // don't break -- just let it catch the next case
+      if (resolved.error) return resolved;
+      return await client
+        .from("quote")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
 
     case "customerContactId":
     case "customerEngineeringContactId":

--- a/apps/erp/app/routes/x+/quote+/update.tsx
+++ b/apps/erp/app/routes/x+/quote+/update.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { datetime } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isQuoteLocked } from "~/modules/sales";
@@ -56,9 +57,9 @@ export async function action({ request }: ActionFunctionArgs) {
               customerId: value ?? undefined,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -87,9 +88,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }

--- a/apps/erp/app/routes/x+/quote+/update.tsx
+++ b/apps/erp/app/routes/x+/quote+/update.tsx
@@ -36,7 +36,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (field) {
     case "customerId":
-      if (value && ids.length === 1) {
+      if (value) {
         const customer = await client
           ?.from("customer")
           .select("currencyCode")

--- a/apps/erp/app/routes/x+/sales-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/update.tsx
@@ -41,9 +41,30 @@ export async function action({ request }: ActionFunctionArgs) {
   }
 
   switch (field) {
+    case "exchangeRate": {
+      // A rate written directly still has to be usable: 0 zeroes every sales
+      // `converted*` column (they carry no zero-guard) and a null violates the
+      // NOT NULL on the invoice tables.
+      const rate = Number(value);
+      if (!Number.isFinite(rate) || rate <= 0) {
+        return {
+          error: { message: "Exchange rate must be greater than zero" },
+          data: null
+        };
+      }
+      return await client
+        .from("salesInvoice")
+        .update({
+          exchangeRate: rate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "invoiceCustomerId":
       let currencyCode: string | undefined;
-      if (value && ids.length === 1) {
+      if (value) {
         const customer = await client
           ?.from("customer")
           .select("currencyCode")
@@ -159,7 +180,6 @@ export async function action({ request }: ActionFunctionArgs) {
     case "invoiceCustomerLocationId":
     case "locationId":
     case "customerReference":
-    case "exchangeRate":
     case "dateDue":
     case "datePaid":
       return await client

--- a/apps/erp/app/routes/x+/sales-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/update.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { datetime } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
@@ -56,9 +57,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .from("salesInvoice")
         .update({
           exchangeRate: rate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }
@@ -87,9 +88,9 @@ export async function action({ request }: ActionFunctionArgs) {
               invoiceCustomerLocationId: null,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -169,9 +170,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }

--- a/apps/erp/app/routes/x+/sales-invoice+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/update.tsx
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   computeInvoiceDateDue,
   isSalesInvoiceLocked
@@ -52,19 +52,21 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (customer.data?.currencyCode) {
           currencyCode = customer.data.currencyCode;
-          const currency = await getCurrencyByCode(
+          const resolved = await resolveCurrencyAndRate(
             client,
             companyGroupId,
             currencyCode
           );
+          if (resolved.error) return resolved;
           return await client
             .from("salesInvoice")
             .update({
               invoiceCustomerId: value ?? undefined,
               invoiceCustomerContactId: null,
               invoiceCustomerLocationId: null,
-              currencyCode: currencyCode ?? undefined,
-              exchangeRate: currency.data?.exchangeRate ?? 1,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -131,26 +133,27 @@ export async function action({ request }: ActionFunctionArgs) {
       }
       break;
     // don't break -- just let it catch the next case
-    case "currencyCode":
-      if (value) {
-        const currency = await getCurrencyByCode(
-          client,
-          companyGroupId,
-          value as string
-        );
-        if (currency.data) {
-          return await client
-            .from("salesInvoice")
-            .update({
-              currencyCode: value as string,
-              exchangeRate: currency.data.exchangeRate ?? 1,
-              updatedBy: userId,
-              updatedAt: new Date().toISOString()
-            })
-            .in("id", ids as string[]);
-        }
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
       }
-    // don't break -- just let it catch the next case
+      const resolved = await resolveCurrencyAndRate(
+        client,
+        companyGroupId,
+        value as string
+      );
+      if (resolved.error) return resolved;
+      return await client
+        .from("salesInvoice")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "customerId":
     case "invoiceCustomerContactId":
     case "invoiceCustomerLocationId":

--- a/apps/erp/app/routes/x+/sales-order+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/update.tsx
@@ -1,6 +1,6 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isSalesOrderLocked } from "~/modules/sales";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 
@@ -46,17 +46,19 @@ export async function action({ request }: ActionFunctionArgs) {
 
         if (customer.data?.currencyCode) {
           currencyCode = customer.data.currencyCode;
-          const currency = await getCurrencyByCode(
+          const resolved = await resolveCurrencyAndRate(
             client,
             companyGroupId,
             currencyCode
           );
+          if (resolved.error) return resolved;
           return await client
             .from("salesOrder")
             .update({
               customerId: value ?? undefined,
-              currencyCode: currencyCode ?? undefined,
-              exchangeRate: currency.data?.exchangeRate ?? 1,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -72,26 +74,27 @@ export async function action({ request }: ActionFunctionArgs) {
           updatedAt: new Date().toISOString()
         })
         .in("id", ids as string[]);
-    case "currencyCode":
-      if (value) {
-        const currency = await getCurrencyByCode(
-          client,
-          companyGroupId,
-          value as string
-        );
-        if (currency.data) {
-          return await client
-            .from("salesOrder")
-            .update({
-              currencyCode: value as string,
-              exchangeRate: currency.data.exchangeRate,
-              updatedBy: userId,
-              updatedAt: new Date().toISOString()
-            })
-            .in("id", ids as string[]);
-        }
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
       }
-    // don't break -- just let it catch the next case
+      const resolved = await resolveCurrencyAndRate(
+        client,
+        companyGroupId,
+        value as string
+      );
+      if (resolved.error) return resolved;
+      return await client
+        .from("salesOrder")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "customerContactId":
     case "customerEngineeringContactId":
     case "customerLocationId":

--- a/apps/erp/app/routes/x+/sales-order+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/update.tsx
@@ -35,9 +35,30 @@ export async function action({ request }: ActionFunctionArgs) {
   if (lockedError) return lockedError;
 
   switch (field) {
+    case "exchangeRate": {
+      // A rate written directly still has to be usable: 0 zeroes every sales
+      // `converted*` column (they carry no zero-guard) and a null violates the
+      // NOT NULL on the invoice tables.
+      const rate = Number(value);
+      if (!Number.isFinite(rate) || rate <= 0) {
+        return {
+          error: { message: "Exchange rate must be greater than zero" },
+          data: null
+        };
+      }
+      return await client
+        .from("salesOrder")
+        .update({
+          exchangeRate: rate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
     case "customerId":
       let currencyCode: string | undefined;
-      if (value && ids.length === 1) {
+      if (value) {
         const customer = await client
           ?.from("customer")
           .select("currencyCode")
@@ -100,7 +121,6 @@ export async function action({ request }: ActionFunctionArgs) {
     case "customerLocationId":
     case "customerReference":
 
-    case "exchangeRate":
     case "expirationDate":
     case "locationId":
     case "orderDate":

--- a/apps/erp/app/routes/x+/sales-order+/update.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/update.tsx
@@ -1,4 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { datetime } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isSalesOrderLocked } from "~/modules/sales";
@@ -50,9 +51,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .from("salesOrder")
         .update({
           exchangeRate: rate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }
@@ -79,9 +80,9 @@ export async function action({ request }: ActionFunctionArgs) {
               customerId: value ?? undefined,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -110,9 +111,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }

--- a/apps/erp/app/routes/x+/supplier-quote+/update.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/update.tsx
@@ -3,7 +3,7 @@ import { datetime } from "@carbon/utils";
 import type { CalendarDate } from "@internationalized/date";
 import { parseDate } from "@internationalized/date";
 import type { ActionFunctionArgs } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import { isSupplierQuoteLocked } from "~/modules/purchasing";
 import { getCompanyTimeZone } from "~/modules/shared/timezone.server";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
@@ -39,7 +39,6 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (field) {
     case "supplierId":
-      let currencyCode: string | undefined;
       if (value && ids.length === 1) {
         const supplier = await client
           ?.from("supplier")
@@ -48,12 +47,19 @@ export async function action({ request }: ActionFunctionArgs) {
           .single();
 
         if (supplier.data?.currencyCode) {
-          currencyCode = supplier.data.currencyCode;
+          const resolved = await resolveCurrencyAndRate(
+            client,
+            companyGroupId,
+            supplier.data.currencyCode
+          );
+          if (resolved.error) return resolved;
           return await client
             .from("supplierQuote")
             .update({
               supplierId: value ?? undefined,
-              currencyCode: currencyCode ? currencyCode : undefined,
+              currencyCode: resolved.data.currencyCode,
+              exchangeRate: resolved.data.exchangeRate,
+              exchangeRateUpdatedAt: new Date().toISOString(),
               updatedBy: userId,
               updatedAt: new Date().toISOString()
             })
@@ -69,24 +75,27 @@ export async function action({ request }: ActionFunctionArgs) {
           updatedAt: new Date().toISOString()
         })
         .in("id", ids as string[]);
-    case "currencyCode":
-      const currency = await getCurrencyByCode(
+    case "currencyCode": {
+      if (!value) {
+        return { error: { message: "A currency is required" }, data: null };
+      }
+      const resolved = await resolveCurrencyAndRate(
         client,
         companyGroupId,
         value as string
       );
-      if (currency.data) {
-        return await client
-          .from("supplierQuote")
-          .update({
-            currencyCode: value,
-            exchangeRate: currency.data.exchangeRate,
-            updatedBy: userId,
-            updatedAt: new Date().toISOString()
-          })
-          .in("id", ids as string[]);
-      }
-    // don't break -- just let it catch the next case
+      if (resolved.error) return resolved;
+      return await client
+        .from("supplierQuote")
+        .update({
+          currencyCode: resolved.data.currencyCode,
+          exchangeRate: resolved.data.exchangeRate,
+          exchangeRateUpdatedAt: new Date().toISOString(),
+          updatedBy: userId,
+          updatedAt: new Date().toISOString()
+        })
+        .in("id", ids as string[]);
+    }
 
     case "supplierContactId":
     case "supplierLocationId":

--- a/apps/erp/app/routes/x+/supplier-quote+/update.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/update.tsx
@@ -39,7 +39,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   switch (field) {
     case "supplierId":
-      if (value && ids.length === 1) {
+      if (value) {
         const supplier = await client
           ?.from("supplier")
           .select("currencyCode")

--- a/apps/erp/app/routes/x+/supplier-quote+/update.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/update.tsx
@@ -59,9 +59,9 @@ export async function action({ request }: ActionFunctionArgs) {
               supplierId: value ?? undefined,
               currencyCode: resolved.data.currencyCode,
               exchangeRate: resolved.data.exchangeRate,
-              exchangeRateUpdatedAt: new Date().toISOString(),
+              exchangeRateUpdatedAt: datetime.timestamp(),
               updatedBy: userId,
-              updatedAt: new Date().toISOString()
+              updatedAt: datetime.timestamp()
             })
             .in("id", ids as string[]);
         }
@@ -90,9 +90,9 @@ export async function action({ request }: ActionFunctionArgs) {
         .update({
           currencyCode: resolved.data.currencyCode,
           exchangeRate: resolved.data.exchangeRate,
-          exchangeRateUpdatedAt: new Date().toISOString(),
+          exchangeRateUpdatedAt: datetime.timestamp(),
           updatedBy: userId,
-          updatedAt: new Date().toISOString()
+          updatedAt: datetime.timestamp()
         })
         .in("id", ids as string[]);
     }


### PR DESCRIPTION
## Problem

A document's `currencyCode` and `exchangeRate` are one value pair. Six bulk-update routes could set the code and leave the rate behind, denominating the document in one currency while pricing it at another's rate.

Two ways it happened:

1. **Party reassignment.** Quote and supplier quote adopted the customer's or supplier's `currencyCode` and never touched `exchangeRate`. A quote drafted for a base-currency customer and then reassigned to a foreign-currency one kept rate 1, so every line stayed at the base price. Because the rate never changed value, the header→line cascade's `IS DISTINCT FROM` guard never fired either. The four sibling routes already re-fetched the rate here.

2. **The `currencyCode` case falling through.** All six routes ran the lookup and, when it returned nothing, fell through — deliberately, per the comment — to the generic `[field]: value` setter. Same defect, every document type.

## Fix

Both paths resolve the pair together through a new `resolveCurrencyAndRate`, which refuses a currency it has no usable rate for rather than substituting 1, and stamps `exchangeRateUpdatedAt` so a set rate is distinguishable from one never set. It also refuses rate 0, since the sales `converted*` generated columns have no zero-guard and would zero every line.

## Behaviour changes

Setting a currency with no configured rate now returns an error instead of writing rate 1 or no rate; so does clearing a document's currency outright. Neither is reachable through the UI — the `Currency` picker, including on the customer and supplier forms, only offers currencies that have a row — so this is a guard for CSV/API-created records.

## Verification

On a local stack with a EUR-base company: reassigning a draft quote to a JPY customer set the header to rate 162.5, stamped the timestamp, and cascaded all six price rows (1,950,000 → ¥316,875,000). Same path with a GBP customer gave 0.842. Typecheck and lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Currency and exchange rates are now resolved together when updating purchase, sales, and quote documents.
  * Currency and exchange-rate updates support bulk-selected documents.
  * Exchange-rate update timestamps are recorded automatically.
* **Bug Fixes**
  * Exchange rates must be finite and greater than zero.
  * Invalid or missing exchange rates no longer default silently.
  * Missing or unresolved currencies are rejected with clear errors.
  * Invalid currency lookups no longer trigger unrelated update actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->