### PR TITLE
fix(invoicing): cascade the sales invoice exchange rate to its lines

### DIFF
--- a/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
+++ b/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
@@ -1,0 +1,61 @@
+-- salesInvoice was the only rate-bearing document header with no cascade to its
+-- lines. quote and salesOrder propagate via event interceptors; purchaseOrder,
+-- purchaseInvoice and supplierQuote via AFTER UPDATE OF triggers. salesInvoice
+-- had neither, so refreshing the rate or changing the currency moved the header
+-- alone and left salesInvoiceLine -- and every converted* column generated off
+-- it -- at whatever rate was current when each line was created.
+--
+-- The invoice then carries two rates for one currency: the PDF sums lines at the
+-- line rate and header shipping at the header rate, printing a total that exists
+-- at no exchange rate.
+--
+-- This mirrors the purchaseInvoice pair exactly (20241210214820, 20260616061244)
+-- so the two invoice sides behave identically.
+
+-- 1. Backfill lines that have already drifted from their header.
+UPDATE "salesInvoiceLine" sl
+SET "exchangeRate" = si."exchangeRate",
+    "updatedBy" = COALESCE(si."updatedBy", 'system'),
+    "updatedAt" = NOW()
+FROM "salesInvoice" si
+WHERE sl."invoiceId" = si."id"
+  AND (sl."exchangeRate" IS DISTINCT FROM si."exchangeRate" OR sl."exchangeRate" IS NULL);
+
+-- 2. Cascade a header rate change down to the lines.
+CREATE OR REPLACE FUNCTION update_sales_invoice_line_exchange_rate()
+RETURNS TRIGGER AS $$
+BEGIN
+  UPDATE "salesInvoiceLine"
+  SET "exchangeRate" = NEW."exchangeRate"
+  WHERE "invoiceId" = NEW."id";
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS update_sales_invoice_line_exchange_rate_trigger ON "salesInvoice";
+CREATE TRIGGER update_sales_invoice_line_exchange_rate_trigger
+AFTER UPDATE OF "exchangeRate" ON "salesInvoice"
+FOR EACH ROW
+WHEN (OLD."exchangeRate" IS DISTINCT FROM NEW."exchangeRate")
+EXECUTE FUNCTION update_sales_invoice_line_exchange_rate();
+
+-- 3. A new line inherits the header's rate, so it cannot be stranded at the
+--    DEFAULT of 1 when the client fails to pass one.
+CREATE OR REPLACE FUNCTION sync_sales_invoice_line_exchange_rate_on_insert()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW."exchangeRate" IS NULL OR NEW."exchangeRate" = 1 THEN
+    SELECT "exchangeRate" INTO NEW."exchangeRate"
+    FROM "salesInvoice"
+    WHERE "id" = NEW."invoiceId";
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+DROP TRIGGER IF EXISTS sales_invoice_line_exchange_rate_insert_trigger ON "salesInvoiceLine";
+CREATE TRIGGER sales_invoice_line_exchange_rate_insert_trigger
+BEFORE INSERT ON "salesInvoiceLine"
+FOR EACH ROW
+EXECUTE FUNCTION sync_sales_invoice_line_exchange_rate_on_insert();

--- a/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
+++ b/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
@@ -31,7 +31,7 @@ BEGIN
 
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
 
 DROP TRIGGER IF EXISTS update_sales_invoice_line_exchange_rate_trigger ON "salesInvoice";
 CREATE TRIGGER update_sales_invoice_line_exchange_rate_trigger
@@ -52,7 +52,7 @@ BEGIN
   END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
 
 DROP TRIGGER IF EXISTS sales_invoice_line_exchange_rate_insert_trigger ON "salesInvoiceLine";
 CREATE TRIGGER sales_invoice_line_exchange_rate_insert_trigger

--- a/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
+++ b/packages/database/supabase/migrations/20260901134416_sales-invoice-rate-cascade.sql
@@ -31,7 +31,7 @@ BEGIN
 
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 DROP TRIGGER IF EXISTS update_sales_invoice_line_exchange_rate_trigger ON "salesInvoice";
 CREATE TRIGGER update_sales_invoice_line_exchange_rate_trigger
@@ -52,7 +52,7 @@ BEGIN
   END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;
 
 DROP TRIGGER IF EXISTS sales_invoice_line_exchange_rate_insert_trigger ON "salesInvoiceLine";
 CREATE TRIGGER sales_invoice_line_exchange_rate_insert_trigger


### PR DESCRIPTION
## Problem

`salesInvoice` is the only rate-bearing document header with no cascade to its lines. `quote` and `salesOrder` propagate via event interceptors (`20260410031804`); `purchaseOrder`, `purchaseInvoice` and `supplierQuote` via `AFTER UPDATE OF` triggers (`20241210214820`, recreated in `20260811123616`). `salesInvoice` has neither.

So refreshing the rate or changing the currency updates the header alone and leaves `salesInvoiceLine` — and every `converted*` column generated off it — at whatever rate was current when each line was created. The invoice then carries two rates for one currency: `SummaryBlock` sums lines at the line rate (`:43-47`) and header shipping at the header rate (`:87-89`), so the PDF prints a total that exists at no exchange rate. A line added after a rate change is stranded at the `DEFAULT` of 1.

## Fix

Mirrors the `purchaseInvoice` pair exactly so the two invoice sides behave identically:

1. Backfill lines that have already drifted from their header.
2. `AFTER UPDATE OF "exchangeRate" ON "salesInvoice"` — cascade to the lines.
3. `BEFORE INSERT ON "salesInvoiceLine"` — a new line inherits the header's rate.

Migration only; no app changes. `updateSalesInvoiceExchangeRate` already writes the header, and the trigger now does the rest.

## Known tradeoff

The `BEFORE INSERT` treats a rate of 1 as unset, so a line cannot deliberately be held at 1 on a document whose header rate differs. That is purchasing's existing behaviour (`20260616061244:27-41`), inherited on purpose rather than letting the two sides diverge.

## Verification

On a local stack with a EUR-base company:

- Changing the header from rate 1 to 162.5 cascaded to the line and recomputed `convertedUnitPrice` from 1,800,000 to 292,500,000.
- Inserting a line with no rate inherited 162.5; inserting one with an explicit 999 was left alone.
- Driving the app's own rate-refresh route moved header and line together to 11.24, with `convertedUnitPrice` at 20,232,000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sales invoice line exchange rates are now synchronized with their invoice header rates.
  * Existing invoice lines are backfilled, updated lines reflect header rate changes, and new lines inherit the header rate when no specific rate is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->