### PR TITLE
style(production): replace amber behind-target text with a red badge

### DIFF
--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -318,10 +318,10 @@ function makeItem(
           {projectedDate &&
             (behindDays > 0 ? (
               <Tooltip>
-                <TooltipTrigger>
-                  <span className="text-xs text-amber-500 whitespace-nowrap">
+                <TooltipTrigger asChild>
+                  <Badge variant="red">
                     <Trans>Projected {formatDate(projectedDate)}</Trans>
-                  </span>
+                  </Badge>
                 </TooltipTrigger>
                 <TooltipContent>
                   <span>

--- a/apps/erp/app/modules/production/ui/Schedule/Kanban/components/ItemCard.tsx
+++ b/apps/erp/app/modules/production/ui/Schedule/Kanban/components/ItemCard.tsx
@@ -384,17 +384,13 @@ export function ItemCard({ item, isOverlay, progressByItemId }: ItemCardProps) {
         )}
         {displaySettings.showDueDate && projectedCompletionDate && (
           <HStack className="justify-start space-x-2">
-            <LuCalendarClock
-              className={
-                isBehindTarget ? "text-amber-500" : "text-muted-foreground"
-              }
-            />
+            <LuCalendarClock className="text-muted-foreground" />
             {isBehindTarget ? (
               <Tooltip>
-                <TooltipTrigger>
-                  <span className="text-sm text-amber-500">
+                <TooltipTrigger asChild>
+                  <Badge variant="red">
                     {t`Proj. ${formatDate(projectedCompletionDate)}`}
-                  </span>
+                  </Badge>
                 </TooltipTrigger>
                 <TooltipContent side="right">
                   {t`Behind target by ${daysBehindTarget} day(s)`}

--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -770,12 +770,12 @@ export const JobOperation = ({
                       {projectedCompletionDate &&
                         (isBehindTarget ? (
                           <Tooltip>
-                            <TooltipTrigger>
-                              <span className="text-sm text-amber-500">
+                            <TooltipTrigger asChild>
+                              <Badge variant="red">
                                 {t`Proj. ${formatDate(
                                   projectedCompletionDate
                                 )}`}
-                              </span>
+                              </Badge>
                             </TooltipTrigger>
                             <TooltipContent>
                               {t`Behind target by ${daysBehindTarget} day(s)`}


### PR DESCRIPTION
## What does this PR do?

The "Projected [date]" behind-target indicator rendered as amber/yellow text, which isn't part of the design system's palette. This swaps it for a small `Badge variant="red"` — the built-in attention color — keeping the existing "Behind target by N day(s)" tooltip. The on-target case stays muted plain text, so the badge only draws the eye when an operation is projected past its due date. Applied consistently in the three places this state renders: the Bill of Process rows, the ops-board `ItemCard`, and the MES operation detail.

## Visual Demo (For contributors especially)

N/A — a self-contained styling swap (`<span className="text-amber-500">` → `<Badge variant="red">`). Reproducing the state needs an operation whose projected finish is past its due date.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Open a job with an operation projected to finish after its due date (behind target).
- Expected: the "Projected …" / "Proj. …" indicator now shows as a small red badge (not amber text) in the Bill of Process, the schedule board card, and the MES operation view; hovering still shows "Behind target by N day(s)". On-target operations remain muted plain text.

## Checklist

- My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated behind-schedule projected dates to display as prominent red badges.
  - Added consistent tooltip behavior explaining how many days an operation is behind target.
  - Standardized calendar icon styling in kanban schedule cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->