### PR TITLE
fix(accounting): take the refresh rate from the document, not the request

### DIFF
--- a/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getPurchaseInvoice,
   isPurchaseInvoiceLocked,
@@ -44,21 +44,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a confirmed purchase invoice."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = purchaseInvoice.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updatePurchaseInvoiceExchangeRate(client, {
     id: invoiceId,
-    exchangeRate: currency.data.exchangeRate,
+    exchangeRate: resolved.data.exchangeRate,
     updatedBy: userId
   });
 

--- a/apps/erp/app/routes/x+/purchase-order+/$orderId.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/$orderId.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getPurchaseOrder,
   isPurchaseOrderLocked,
@@ -44,21 +44,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a confirmed purchase order."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = purchaseOrder.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updatePurchaseOrderExchangeRate(client, {
     id: orderId,
-    exchangeRate: currency.data.exchangeRate
+    exchangeRate: resolved.data.exchangeRate
   });
 
   if (update.error) {

--- a/apps/erp/app/routes/x+/quote+/$quoteId.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getQuote,
   isQuoteLocked,
@@ -32,21 +32,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a locked quote. Reopen it first."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = quote.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updateQuoteExchangeRate(client, {
     id: quoteId,
-    exchangeRate: currency.data.exchangeRate
+    exchangeRate: resolved.data.exchangeRate
   });
 
   if (update.error) {

--- a/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getSalesInvoice,
   isSalesInvoiceLocked,
@@ -41,21 +41,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a locked sales invoice. Reopen it first."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = invoice.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updateSalesInvoiceExchangeRate(client, {
     id: invoiceId,
-    exchangeRate: currency.data.exchangeRate,
+    exchangeRate: resolved.data.exchangeRate,
     updatedBy: userId
   });
 

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getSalesOrder,
   isSalesOrderLocked,
@@ -28,21 +28,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a locked sales order. Reopen it first."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = salesOrder.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updateSalesOrderExchangeRate(client, {
     id: orderId,
-    exchangeRate: currency.data.exchangeRate
+    exchangeRate: resolved.data.exchangeRate
   });
 
   if (update.error) {

--- a/apps/erp/app/routes/x+/supplier-quote+/$id.exchange-rate.tsx
+++ b/apps/erp/app/routes/x+/supplier-quote+/$id.exchange-rate.tsx
@@ -3,7 +3,7 @@ import { requirePermissions } from "@carbon/auth/auth.server";
 import { flash } from "@carbon/auth/session.server";
 import type { ActionFunctionArgs } from "react-router";
 import { redirect } from "react-router";
-import { getCurrencyByCode } from "~/modules/accounting";
+import { resolveCurrencyAndRate } from "~/modules/accounting";
 import {
   getSupplierQuote,
   isSupplierQuoteLocked,
@@ -32,21 +32,23 @@ export async function action({ request, params }: ActionFunctionArgs) {
     message: "Cannot modify a locked supplier quote. Reopen it first."
   });
 
-  const formData = await request.formData();
-  const currencyCode = formData.get("currencyCode") as string;
-  if (!currencyCode) throw new Error("Could not find currencyCode");
+  // The currency comes from the document, never from the request: this route
+  // refreshes a rate, and trusting a client-supplied code lets a crafted POST
+  // stamp another currency's rate onto a document that keeps its own code.
+  const currencyCode = quote.data?.currencyCode;
+  if (!currencyCode)
+    throw new Error("Document has no currency to refresh a rate for");
 
-  const currency = await getCurrencyByCode(
+  const resolved = await resolveCurrencyAndRate(
     client,
     companyGroupId,
     currencyCode
   );
-  if (currency.error || !currency.data.exchangeRate)
-    throw new Error("Could not find currency");
+  if (resolved.error) throw new Error(resolved.error.message);
 
   const update = await updateSupplierQuoteExchangeRate(client, {
     id: id,
-    exchangeRate: currency.data.exchangeRate
+    exchangeRate: resolved.data.exchangeRate
   });
 
   if (update.error) {


### PR DESCRIPTION
> Stacked on #1526 — it uses `resolveCurrencyAndRate`, introduced there. Base will need retargeting to `main` once #1526 merges.

## Problem

The six `*.exchange-rate` routes read `currencyCode` from the posted form, look up **that** currency's rate, and write only `exchangeRate` — never `currencyCode`. A crafted POST can therefore stamp one currency's rate onto a document that keeps its own code.

Posting `SEK` to a USD invoice left it denominated in USD at SEK's rate of 11.24, which mispriced every line through the `converted*` generated columns. Found while verifying #1527.

The UI always posts the document's own currency (e.g. `QuoteProperties.tsx:438-447`), so this behaves as a refresh in practice. That is what makes it worth closing rather than living with — the parameter carries no information the server does not already have.

## Fix

Every one of these routes already loads its document for the locked check, so the currency is read from there and the form is no longer parsed at all. The lookup goes through `resolveCurrencyAndRate`, so a refresh cannot install a zero or missing rate either.

## Verification

Typecheck and lint clean. The client-supplied value is now ignored by construction — no route calls `request.formData()` any more.

Runtime re-test of the SEK-onto-USD POST is **not** done: the browser extension disconnected mid-verification. The pre-fix reproduction was confirmed on a local stack (USD invoice ended at rate 11.24); the post-fix confirmation is outstanding and I'll add it here once I can drive the app again.