### PR TITLE
fix(invoicing): stop converting the base-currency shipping on the invoice summary

### DIFF
--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceSummary.tsx
@@ -413,9 +413,11 @@ const SalesInvoiceSummary = ({
       return acc + lineTaxAmount;
     }, 0) ?? 0;
 
-  const shippingCost =
-    (routeData?.salesInvoiceShipment?.shippingCost ?? 0) *
-    (routeData?.salesInvoice?.exchangeRate ?? 1);
+  // `salesInvoiceShipment.shippingCost` is stored in BASE currency, like every
+  // other raw column on this side -- the `salesInvoices` view adds it straight
+  // onto a base subtotal built from `unitPrice`. So the base figure is the
+  // stored value and only the customer-facing one converts.
+  const shippingCost = routeData?.salesInvoiceShipment?.shippingCost ?? 0;
 
   const customerShippingCost =
     (routeData?.salesInvoiceShipment?.shippingCost ?? 0) *


### PR DESCRIPTION
## Problem

`SalesInvoiceSummary` keeps two parallel families: a base one built from the raw columns (`unitPrice`, `addOnCost`, `shippingCost`) and a customer-facing one built from the `converted*` columns. Header shipping was the one value computed identically in both — multiplied by the exchange rate — so the base figure, and the base total, carried a document-currency amount (`:416-422`).

`salesInvoiceShipment.shippingCost` is stored in base currency: the `salesInvoices` view adds it straight onto a subtotal built from the base `unitPrice` column (`20260604120000`), and the PDF multiplies it by the rate to reach the customer figure. So the base value is the stored one and only the customer figure converts.

The purchasing siblings already get this right in the opposite direction — `PurchaseInvoiceSummary:419` divides `supplierShippingCost` to base and leaves the supplier figure raw.

## Fix

One line: the base figure is the stored value, unconverted. `customerShippingCost` is unchanged.

## Verification

On a local stack with a EUR base and a SEK invoice at rate 11.24, stored header shipping of 1,000:

| | Base (€) | Document (SEK) |
|---|---|---|
| Subtotal | 5,400,000.00 | 60,696,000.00 |
| Shipping | 1,000.00 | 11,240.00 |
| Total | 5,401,000.00 | 60,707,240.00 |

Before the fix the base shipping rendered as €11,240.00 and the base total as €5,411,240.00 — overstated by 10,240. Confirmed in the running app; typecheck and lint clean.

Found while verifying #1527. Independent of it and of the other currency PRs — no shared files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected sales invoice shipping cost calculations to use the stored base-currency amount without applying the exchange rate a second time.
  - Customer-facing shipping costs continue to reflect the applicable exchange rate, ensuring displayed amounts remain accurate for customers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->