### PR TITLE
fix(items): show the stored conversion factor when units of measure match

### DIFF
--- a/apps/erp/app/components/Form/ConversionFactor.tsx
+++ b/apps/erp/app/components/Form/ConversionFactor.tsx
@@ -171,12 +171,18 @@ const ConversionFactor = forwardRef<
       t
     ]);
 
+    // Equal codes force the factor to 1 only when a unit of measure CHANGES
+    // into equality — never on mount, where the codes can already be equal
+    // and the stored factor must be displayed (and submitted) as stored.
+    const wasEqual = useRef(inventoryCode === purchasingCode);
     useEffect(() => {
-      if (inventoryCode === purchasingCode) {
+      const isEqual = inventoryCode === purchasingCode;
+      if (isEqual && !wasEqual.current) {
         setConversionFactor(1);
         setControlValue(1);
         initialValue.current = 1;
       }
+      wasEqual.current = isEqual;
     }, [inventoryCode, purchasingCode, setControlValue]);
 
     const onPurchaseUnitChange = (v: number) => {


### PR DESCRIPTION
## Problem

Opening the **Edit Supplier Part** drawer for a row whose supplier unit of measure matches the item's inventory unit of measure showed **Conversion Factor: 1**, even though the Supplier Parts table (and the database) held a different stored factor (e.g. 10). Worse, saving the untouched drawer silently persisted the `1`, destroying the stored factor.

## Cause

The `ConversionFactor` form field reset its value to `1` whenever the inventory and purchasing unit-of-measure codes compared equal — including on **mount**, over a stored value. The reset is a legitimate derivation when the user *changes* a unit of measure into equality ("no conversion is required"), but running it unconditionally meant merely opening an edit form rewrote stored data.

## Fix

The reset now fires only when a unit of measure **changes into equality** during the session ([ConversionFactor.tsx](https://github.com/crbnos/carbon/blob/sid/fix-supplier-part-conversion-factor-display/apps/erp/app/components/Form/ConversionFactor.tsx)). On mount, the stored factor is displayed — and submitted — as stored. This applies to every consumer of the field (supplier part drawer, item purchasing card, PO / supplier quote / RFQ / invoice line forms, kanban form).

## Testing evidence

Verified end-to-end on a local dev environment with a part stocked in `EA` and a supplier part with a stored conversion factor of `2`.

**Before** — drawer shows `1` instead of the stored factor when the units of measure match:

![before](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/supplier-part-conversion-factor/before.png)

**After** — drawer shows the stored factor:

![after](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/supplier-part-conversion-factor/after.png)

Also verified:
- Changing the unit of measure to a different code makes the factor editable and keeps showing the stored value.
- Changing the unit of measure back into equality still resets the factor to `1` (the intended derivation is preserved).
- `pnpm exec turbo run typecheck --filter=erp` and Biome pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the stored conversion factor when purchasing and inventory codes are already equal.
  * Reset the conversion factor to 1 only when the codes newly become equal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->