### PR TITLE
fix(scheduling): never reopen finished operations on a location regen

### DIFF
--- a/.github/workflows/supabase.yml
+++ b/.github/workflows/supabase.yml
@@ -22,10 +22,10 @@ jobs:
       SUPABASE_AUTH_EXTERNAL_AZURE_REDIRECT_URI: ${{ secrets.SUPABASE_AUTH_EXTERNAL_AZURE_REDIRECT_URI }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: pnpm

--- a/packages/ee/src/planning/scheduling/master-data-provider.ts
+++ b/packages/ee/src/planning/scheduling/master-data-provider.ts
@@ -263,6 +263,7 @@ export class KyselyMasterDataProvider implements MasterDataProvider {
       .leftJoin("location", "location.id", "job.locationId")
       .select([
         "job.id",
+        "job.status",
         "job.dueDate",
         "job.deadlineType",
         "job.locationId",

--- a/packages/ee/src/planning/scheduling/scheduling-engine.ts
+++ b/packages/ee/src/planning/scheduling/scheduling-engine.ts
@@ -69,6 +69,7 @@ import type {
   SchedulingOptions,
   SchedulingResult
 } from "./types.ts";
+import { capacityHoldingJobStatuses } from "./types.ts";
 import {
   applyWorkCenterSelections,
   type FiniteSchedulingContext,
@@ -469,15 +470,40 @@ export class SchedulingEngine {
         }
       });
 
-      // Update operations with no dependencies to Ready status (outside the
-      // rebuild txn so the advisory lock is held only for the delete/insert).
-      for (const [opId, deps] of allDependencies) {
-        if (deps.size === 0) {
-          await this.db
-            .updateTable("jobOperation")
-            .set({ status: "Ready" })
-            .where("id", "=", opId)
-            .execute();
+      // Unblock dependency-free operations to Ready (outside the rebuild txn so
+      // the advisory lock is held only for the delete/insert). Two guards keep
+      // this from RE-OPENING work that is already finished or in flight:
+      //
+      //  1. Only OPEN jobs. A terminal job (Completed/Closed/Cancelled) or a
+      //     pre-release Draft/Planned job is never re-opened by a regen. Open
+      //     work is `capacityHoldingJobStatuses`; the batch loader already
+      //     filters to these, so this is defense-in-depth for any direct caller.
+      //  2. Only resettable operation statuses. Never overwrite an operation
+      //     that is Done/Canceled (finished) or In Progress/Paused (running) —
+      //     only Ready/Waiting/Todo become Ready. Without this, a first op that
+      //     an operator already completed was flipped back to Ready, and because
+      //     `is_last_job_operation` requires EVERY op Done, the finished job
+      //     could then never auto-complete (it sat stuck as open work).
+      const jobIsOpen =
+        this.job?.status != null &&
+        (capacityHoldingJobStatuses as readonly string[]).includes(
+          this.job.status
+        );
+      if (jobIsOpen) {
+        for (const [opId, deps] of allDependencies) {
+          if (deps.size === 0) {
+            await this.db
+              .updateTable("jobOperation")
+              .set({ status: "Ready" })
+              .where("id", "=", opId)
+              .where("status", "not in", [
+                "Done",
+                "Canceled",
+                "In Progress",
+                "Paused"
+              ])
+              .execute();
+          }
         }
       }
     }

--- a/packages/ee/src/planning/scheduling/types.ts
+++ b/packages/ee/src/planning/scheduling/types.ts
@@ -88,6 +88,11 @@ export type Operation = Omit<
 
 export type Job = {
   id?: string;
+  /**
+   * Job header status. Governs whether a scheduling run may (re)set this job's
+   * operation statuses — only `capacityHoldingJobStatuses` jobs are open work.
+   */
+  status?: Database["public"]["Enums"]["jobStatus"];
   dueDate?: string | null;
   deadlineType?: DeadlineType;
   locationId?: string;


### PR DESCRIPTION
## What does this PR do?

The whole-location schedule regen reset **every** dependency-free operation to `Ready` inside `createDependencies`, with no guard — so an operation an operator had already finished (`Done`) was flipped back to `Ready` on the next regen. Because `is_last_job_operation` requires *every* operation to be `Done`, a finished job whose first op was reset could no longer auto-complete and sat stuck as open work with a reopened operation. This guards the reset two ways: it only runs for **open** jobs (`capacityHoldingJobStatuses`), and it never overwrites an operation that is `Done`/`Canceled` or `In Progress`/`Paused` — only `Ready`/`Waiting`/`Todo` are unblocked. `job.status` is now selected in `getJob` so the engine can see it.

- Fixes the "old jobs with incomplete operations get reopened" report

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Release a job, complete its first operation, then trigger a whole-location regen (drag a due date on the Dates board, or let the replan wave run). Before: the finished first operation reverts to `Ready` and the job can't auto-complete. After: `Done`/running operations are left untouched and the job completes normally. Scoped checks: `pnpm --filter @carbon/ee typecheck` and `pnpm --filter @carbon/ee test` both pass.

## Checklist

- (n/a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduling behavior by preventing completed, canceled, in-progress, or paused operations from being reset.
  - Dependency-free operations are now reset only for open jobs and eligible operation statuses.
  - Job status is now available to scheduling logic for more accurate planning decisions.

- **Chores**
  - Updated deployment workflow tooling to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->