### PR TITLE
fix(erp): inline react-csv in SSR build only; dev server broke on its…

### DIFF
--- a/apps/erp/vite.config.ts
+++ b/apps/erp/vite.config.ts
@@ -42,8 +42,15 @@ export default defineConfig(({ isSsrBuild, mode }) => {
          * crashes on cold start with "Cannot find module 'react'". Bundling it
          * inline resolves react/prop-types against the app's copies at build
          * time, the same reason the react-* packages above are inlined.
+         *
+         * Build-only: react-csv also declares `"jsnext:main": "src/index.js"`,
+         * so when inlined in the dev server Vite picks the untranspiled ESM
+         * source, whose `import { func } from "prop-types"` fails under Node's
+         * CJS interop ("Named export 'func' not found"). In dev the CJS entry is
+         * externalized and `require`d directly, which works via pnpm's store.
          */
-        "react-csv",
+
+        ...(isSsrBuild ? ["react-csv"] : []),
         /**
          * @react-three/fiber v8 (inlined via @carbon/viewer) default-imports
          * its nested zustand v3, while the app uses zustand v5 (no default
@@ -93,7 +100,7 @@ export default defineConfig(({ isSsrBuild, mode }) => {
         "@carbon/utils": path.resolve(__dirname, "../../packages/utils/src"),
         "@carbon/form": path.resolve(
           __dirname,
-          "../../packages/form/src/index.tsx",
+          "../../packages/form/src/index.tsx"
         ),
       },
     },


### PR DESCRIPTION
## What does this PR do?

- Fixes the ERP dev server failing on any page that uses the CSV export link, with the error "Named export 'func' not found. The requested module 'prop-types' is a CommonJS module".
- The bundling is now applied only to the production server build, so the Vercel fix from #1535 is unchanged and the dev server goes back to loading the library the way it did before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server-side rendering compatibility for CSV-related functionality.
  * Resolved a development-mode module loading issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->