### PR TITLE
build(docker): add un-hardened ops image for migrate + seed Jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,19 @@ ARG NODE_OPTIONS="--max-old-space-size=8024"
 ENV NODE_OPTIONS=${NODE_OPTIONS}
 RUN pnpm run build:${APP}
 
+# --- Ops image (DB migrations + first-boot seed) --------------------------
+# The migrate Job (supabase migration up) and the seed Helm hook (tsx src/seed.ts)
+# repurpose the app build to run one-off ops tasks. They need the supabase CLI
+# and tsx/esbuild — exactly the build tooling the `runner` stage strips for its
+# CVE posture. Rather than un-harden the served image, publish a separate
+# un-stripped ops image from the `deps` stage for those short-lived Jobs. It is
+# never exposed and is scanned report-only (it intentionally carries build-tool
+# CVEs). migrate.yml and charts/apps seed-job point at carbon/ops:<same-tag>.
+# Kept BEFORE `runner` so `runner` remains the default (no --target) build stage.
+FROM deps AS ops
+WORKDIR /repo/packages/database
+CMD ["bash"]
+
 FROM node:22-slim AS runner
 ARG APP
 WORKDIR /repo
@@ -59,15 +72,3 @@ RUN find node_modules/.pnpm -maxdepth 1 -type d \( \
 EXPOSE 3000
 WORKDIR /repo/apps/${APP}
 CMD ["pnpm","run","start"]
-
-# --- Ops image (DB migrations + first-boot seed) --------------------------
-# The migrate Job (supabase migration up) and the seed Helm hook (tsx src/seed.ts)
-# repurpose the app build to run one-off ops tasks. They need the supabase CLI
-# and tsx/esbuild — exactly the build tooling the `runner` stage strips for its
-# CVE posture. Rather than un-harden the served image, publish a separate
-# un-stripped ops image from the `deps` stage for those short-lived Jobs. It is
-# never exposed and is scanned report-only (it intentionally carries build-tool
-# CVEs). migrate.yml and charts/apps seed-job point at carbon/ops:<same-tag>.
-FROM deps AS ops
-WORKDIR /repo/packages/database
-CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,3 +59,15 @@ RUN find node_modules/.pnpm -maxdepth 1 -type d \( \
 EXPOSE 3000
 WORKDIR /repo/apps/${APP}
 CMD ["pnpm","run","start"]
+
+# --- Ops image (DB migrations + first-boot seed) --------------------------
+# The migrate Job (supabase migration up) and the seed Helm hook (tsx src/seed.ts)
+# repurpose the app build to run one-off ops tasks. They need the supabase CLI
+# and tsx/esbuild — exactly the build tooling the `runner` stage strips for its
+# CVE posture. Rather than un-harden the served image, publish a separate
+# un-stripped ops image from the `deps` stage for those short-lived Jobs. It is
+# never exposed and is scanned report-only (it intentionally carries build-tool
+# CVEs). migrate.yml and charts/apps seed-job point at carbon/ops:<same-tag>.
+FROM deps AS ops
+WORKDIR /repo/packages/database
+CMD ["bash"]


### PR DESCRIPTION
The runtime-image hardening (stripping supabase CLI / esbuild / npm to pass the CVE gate) broke the migrate Job and the seed Helm hook, which repurpose the app image to run `supabase migration up` and `tsx src/seed.ts`. This adds a separate un-stripped `ops` target (from `deps`) for those short-lived, never-exposed Jobs. Infra builds+pushes `carbon/ops:<same-tag>` alongside erp/mes (scanned report-only), and migrate.yml + charts/apps seed-job point at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an operations container stage for running short-lived database migrations and seed jobs.
  * Preserved the standard application container as the default Docker build target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->