### PR TITLE
fix(accounting): refuse a non-positive exchange rate at every layer

### DIFF
--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -424,7 +424,10 @@ export const currencyValidator = z.object({
     z.number().positive({ message: "Rate must be greater than zero" })
   ),
   historicalExchangeRate: zfd.numeric(
-    z.number().positive({ message: "Rate must be greater than zero" }).optional()
+    z
+      .number()
+      .positive({ message: "Rate must be greater than zero" })
+      .optional()
   )
 });
 

--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -417,9 +417,14 @@ export const currencyValidator = z.object({
   id: zfd.text(z.string().optional()),
   code: z.string().trim().min(1, { message: "Code is required" }),
   decimalPlaces: zfd.numeric(z.number().min(0).max(4)),
-  exchangeRate: zfd.numeric(z.number().min(0, { message: "Rate is required" })),
+  // Zero is not a rate. It is refused at the database too
+  // (`currency_exchangeRate_check`), so accepting it here only produces a
+  // constraint violation the user cannot act on.
+  exchangeRate: zfd.numeric(
+    z.number().positive({ message: "Rate must be greater than zero" })
+  ),
   historicalExchangeRate: zfd.numeric(
-    z.number().min(0, { message: "Rate must be positive" }).optional()
+    z.number().positive({ message: "Rate must be greater than zero" }).optional()
   )
 });
 

--- a/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
+++ b/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
@@ -178,7 +178,9 @@ const CurrencyForm = ({
                   name="historicalExchangeRate"
                   label={t`Historical Rate (Equity)`}
                   termId="historical-exchange-rate"
-                  minValue={0}
+                  // Same reasoning as exchangeRate above: a floor CLAMPS on blur, so a
+                  // typed 0 would commit as the step and pass .positive().
+                  minValue={undefined}
                   step={INPUT_STEP.exchangeRate}
                   formatOptions={INPUT_FORMAT.exchangeRate}
                   helperText="Rate used for equity account translation in consolidation (IAS 21). Leave blank to use the current exchange rate."

--- a/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
+++ b/apps/erp/app/modules/accounting/ui/ExchangeRates/ExchangeRateForm.tsx
@@ -163,7 +163,11 @@ const CurrencyForm = ({
                 name="exchangeRate"
                 label={t`Exchange Rate`}
                 termId="exchange-rate"
-                minValue={isBaseCurrency ? 1 : 0}
+                // No floor for a foreign currency: a minValue CLAMPS on blur,
+                // so a typed 0 would silently commit as the step (0.00001)
+                // instead of being refused. Let the schema reject it with a
+                // message the user can act on.
+                minValue={isBaseCurrency ? 1 : undefined}
                 maxValue={isBaseCurrency ? 1 : undefined}
                 step={INPUT_STEP.exchangeRate}
                 formatOptions={INPUT_FORMAT.exchangeRate}

--- a/packages/database/supabase/migrations/20260901161207_exchange-rate-positive-constraint.sql
+++ b/packages/database/supabase/migrations/20260901161207_exchange-rate-positive-constraint.sql
@@ -1,0 +1,65 @@
+-- An exchange rate of zero or below is never meaningful, and zero is actively
+-- destructive: the sales `converted*` generated columns multiply by the rate
+-- with no guard, so a single zero silently zeroes every priced line on the
+-- document. The purchasing columns substitute 1 for a zero rate instead, which
+-- is quieter but just as wrong -- it prices a foreign document at par.
+--
+-- `currency` has carried CHECK ("exchangeRate" > 0) since 20230330024715, and
+-- `payment`/`memo` since 20260630093809. Every document table was missed.
+--
+-- NULL is left alone deliberately. It means "no rate set", which is a different
+-- condition from a bad rate and one that real rows still carry; deciding what a
+-- historical NULL should become is a data decision, not a schema one.
+--
+-- With zero unrepresentable, the purchasing generated columns' zero-guard
+-- becomes unreachable rather than load-bearing. It is left in place: removing it
+-- would mean dropping and rebuilding stored generated columns on the largest
+-- transactional tables in the schema, for no behavioural gain.
+
+ALTER TABLE "quote"
+  ADD CONSTRAINT "quote_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "quoteLinePrice"
+  ADD CONSTRAINT "quoteLinePrice_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "salesOrder"
+  ADD CONSTRAINT "salesOrder_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "salesOrderLine"
+  ADD CONSTRAINT "salesOrderLine_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "salesInvoice"
+  ADD CONSTRAINT "salesInvoice_exchangeRate_check"
+  CHECK ("exchangeRate" > 0);
+
+ALTER TABLE "salesInvoiceLine"
+  ADD CONSTRAINT "salesInvoiceLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0);
+
+ALTER TABLE "purchaseOrder"
+  ADD CONSTRAINT "purchaseOrder_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "purchaseOrderLine"
+  ADD CONSTRAINT "purchaseOrderLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0);
+
+ALTER TABLE "purchaseInvoice"
+  ADD CONSTRAINT "purchaseInvoice_exchangeRate_check"
+  CHECK ("exchangeRate" > 0);
+
+ALTER TABLE "purchaseInvoiceLine"
+  ADD CONSTRAINT "purchaseInvoiceLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0);
+
+ALTER TABLE "supplierQuote"
+  ADD CONSTRAINT "supplierQuote_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+
+ALTER TABLE "supplierQuoteLinePrice"
+  ADD CONSTRAINT "supplierQuoteLinePrice_exchangeRate_check"
+  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);

--- a/packages/database/supabase/migrations/20260901161207_exchange-rate-positive-constraint.sql
+++ b/packages/database/supabase/migrations/20260901161207_exchange-rate-positive-constraint.sql
@@ -1,15 +1,25 @@
 -- An exchange rate of zero or below is never meaningful, and zero is actively
 -- destructive: the sales `converted*` generated columns multiply by the rate
--- with no guard, so a single zero silently zeroes every priced line on the
--- document. The purchasing columns substitute 1 for a zero rate instead, which
--- is quieter but just as wrong -- it prices a foreign document at par.
+-- with no guard, so one zero silently zeroes every priced line on the document.
+-- The purchasing columns substitute 1 for a zero rate instead, which is quieter
+-- but just as wrong -- it prices a foreign document at par.
 --
 -- `currency` has carried CHECK ("exchangeRate" > 0) since 20230330024715, and
 -- `payment`/`memo` since 20260630093809. Every document table was missed.
 --
+-- NaN is excluded explicitly. PostgreSQL orders NaN ABOVE all finite values, so
+-- `'NaN'::numeric > 0` is TRUE and a bare `> 0` check would accept it -- after
+-- which every converted* column on the document becomes NaN.
+--
 -- NULL is left alone deliberately. It means "no rate set", which is a different
 -- condition from a bad rate and one that real rows still carry; deciding what a
 -- historical NULL should become is a data decision, not a schema one.
+--
+-- Added NOT VALID then validated separately: a plain ADD CONSTRAINT ... CHECK
+-- holds ACCESS EXCLUSIVE while it scans, which across twelve transactional
+-- tables can block writes or time the migration out. NOT VALID takes only a
+-- brief lock, and VALIDATE CONSTRAINT runs under SHARE UPDATE EXCLUSIVE, which
+-- does not block reads or writes.
 --
 -- With zero unrepresentable, the purchasing generated columns' zero-guard
 -- becomes unreachable rather than load-bearing. It is left in place: removing it
@@ -18,48 +28,74 @@
 
 ALTER TABLE "quote"
   ADD CONSTRAINT "quote_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "quoteLinePrice"
   ADD CONSTRAINT "quoteLinePrice_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "salesOrder"
   ADD CONSTRAINT "salesOrder_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "salesOrderLine"
   ADD CONSTRAINT "salesOrderLine_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
-
-ALTER TABLE "salesInvoice"
-  ADD CONSTRAINT "salesInvoice_exchangeRate_check"
-  CHECK ("exchangeRate" > 0);
-
-ALTER TABLE "salesInvoiceLine"
-  ADD CONSTRAINT "salesInvoiceLine_exchangeRate_check"
-  CHECK ("exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "purchaseOrder"
   ADD CONSTRAINT "purchaseOrder_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
-
-ALTER TABLE "purchaseOrderLine"
-  ADD CONSTRAINT "purchaseOrderLine_exchangeRate_check"
-  CHECK ("exchangeRate" > 0);
-
-ALTER TABLE "purchaseInvoice"
-  ADD CONSTRAINT "purchaseInvoice_exchangeRate_check"
-  CHECK ("exchangeRate" > 0);
-
-ALTER TABLE "purchaseInvoiceLine"
-  ADD CONSTRAINT "purchaseInvoiceLine_exchangeRate_check"
-  CHECK ("exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "supplierQuote"
   ADD CONSTRAINT "supplierQuote_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
 
 ALTER TABLE "supplierQuoteLinePrice"
   ADD CONSTRAINT "supplierQuoteLinePrice_exchangeRate_check"
-  CHECK ("exchangeRate" IS NULL OR "exchangeRate" > 0);
+  CHECK ("exchangeRate" IS NULL OR ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN'))
+  NOT VALID;
+
+ALTER TABLE "salesInvoice"
+  ADD CONSTRAINT "salesInvoice_exchangeRate_check"
+  CHECK ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN')
+  NOT VALID;
+
+ALTER TABLE "salesInvoiceLine"
+  ADD CONSTRAINT "salesInvoiceLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN')
+  NOT VALID;
+
+ALTER TABLE "purchaseOrderLine"
+  ADD CONSTRAINT "purchaseOrderLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN')
+  NOT VALID;
+
+ALTER TABLE "purchaseInvoice"
+  ADD CONSTRAINT "purchaseInvoice_exchangeRate_check"
+  CHECK ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN')
+  NOT VALID;
+
+ALTER TABLE "purchaseInvoiceLine"
+  ADD CONSTRAINT "purchaseInvoiceLine_exchangeRate_check"
+  CHECK ("exchangeRate" > 0 AND "exchangeRate" <> 'NaN')
+  NOT VALID;
+
+-- Validate separately: no write-blocking lock.
+ALTER TABLE "quote" VALIDATE CONSTRAINT "quote_exchangeRate_check";
+ALTER TABLE "quoteLinePrice" VALIDATE CONSTRAINT "quoteLinePrice_exchangeRate_check";
+ALTER TABLE "salesOrder" VALIDATE CONSTRAINT "salesOrder_exchangeRate_check";
+ALTER TABLE "salesOrderLine" VALIDATE CONSTRAINT "salesOrderLine_exchangeRate_check";
+ALTER TABLE "purchaseOrder" VALIDATE CONSTRAINT "purchaseOrder_exchangeRate_check";
+ALTER TABLE "supplierQuote" VALIDATE CONSTRAINT "supplierQuote_exchangeRate_check";
+ALTER TABLE "supplierQuoteLinePrice" VALIDATE CONSTRAINT "supplierQuoteLinePrice_exchangeRate_check";
+ALTER TABLE "salesInvoice" VALIDATE CONSTRAINT "salesInvoice_exchangeRate_check";
+ALTER TABLE "salesInvoiceLine" VALIDATE CONSTRAINT "salesInvoiceLine_exchangeRate_check";
+ALTER TABLE "purchaseOrderLine" VALIDATE CONSTRAINT "purchaseOrderLine_exchangeRate_check";
+ALTER TABLE "purchaseInvoice" VALIDATE CONSTRAINT "purchaseInvoice_exchangeRate_check";
+ALTER TABLE "purchaseInvoiceLine" VALIDATE CONSTRAINT "purchaseInvoiceLine_exchangeRate_check";


### PR DESCRIPTION
## Problem

An exchange rate of zero or below is never meaningful, and zero is actively destructive: the sales `converted*` generated columns multiply by the rate with no guard, so one zero silently zeroes every priced line on the document. The purchasing columns substitute 1 instead, which is quieter but just as wrong — it prices a foreign document at par.

`currency` has carried `CHECK ("exchangeRate" > 0)` since `20230330024715`, and `payment`/`memo` since `20260630093809`. Every document table was missed.

Two places also let a zero be typed: the zod schema said `.min(0)` with the message "Rate is required", and the rate field's `minValue` was `0` for any non-base currency.

## Fix

`CHECK` on all twelve document tables — bare `> 0` where the column is `NOT NULL`, `IS NULL OR > 0` where it is nullable. Plus `.positive()` in the schema with a message that says what is wrong.

The form's `minValue` is now unset for foreign currencies rather than `0`. A `minValue` **clamps** on blur, so a typed 0 committed as the step (0.00001) instead of being refused — I hit exactly that while testing, and a nonsense rate saved silently is worse than an error.

## Deliberate omissions

**NULL is left alone.** It means "no rate set", a different condition from a bad rate, and real rows still carry it. Deciding what a historical NULL should become is a data decision, not a schema one.

**The purchasing zero-guard stays.** With zero unrepresentable it is unreachable rather than load-bearing, but removing it would mean dropping and rebuilding stored generated columns on the largest transactional tables for no behavioural gain.

## Verification

Applied against a populated local database — no existing row violated it (12 tables audited: 12 NULLs across `quote`/`salesOrder`, zero non-positives).

Directly exercised: `exchangeRate = 0` on `salesInvoice` and `-1` on `quote` are both refused by the constraint; NULL on a nullable header is still accepted; legitimate rates still save. Attempting to save 0 through the currency form no longer persists.

Not isolated: I could not prove the zod layer rejects independently of the database constraint. `currency` has had its own `CHECK` since 2023, so 0 was already impossible there, and a temporary unit test could not import the module — an unrelated lingui macro transform failure in `packages/glossary`. The schema change stands on reading, not on a test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange rates must now be greater than zero; zero, negative, and invalid values are rejected with clear validation.
  * Foreign-currency rate fields no longer silently convert a typed zero into a small step value.
  * Added safeguards to prevent invalid exchange rates from being saved across sales and purchasing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->