### PR TITLE
fix(jobs): rebase exchange rates once per company group, not once per company

### DIFF
--- a/packages/jobs/src/inngest/functions/scheduled/update-exchange-rates.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/update-exchange-rates.ts
@@ -131,29 +131,61 @@ export const updateExchangeRatesFunction = inngest.createFunction(
         EUR: ratesEUR
       };
 
-      for (const integration of integrations.data) {
-        logger.info("Processing integration for company", {
-          companyId: integration.companyId
-        });
+      // `currency` rows are scoped to a company GROUP, but `companyIntegration`
+      // is scoped to a COMPANY. Rebasing once per company therefore wrote every
+      // company's own base-currency view into the same shared rows, so a group
+      // whose companies use different base currencies had them overwrite each
+      // other and the last one processed won for everybody.
+      //
+      // Resolve the group's base currency first, then rebase and write once.
+      const companies = await serviceRole
+        .from("company")
+        .select("id, companyGroupId, baseCurrencyCode")
+        .in(
+          "id",
+          integrations.data.map((i) => i.companyId)
+        );
 
-        const company = await serviceRole
-          .from("company")
-          .select("*")
-          .eq("id", integration.companyId)
-          .single();
+      if (companies.error) {
+        logger.error("Error fetching companies", { error: companies.error });
+        return;
+      }
 
-        if (company.error) {
-          logger.error("Error fetching company", {
-            companyId: integration.companyId,
-            error: company.error
+      const groups = new Map<string, { code: string; companyId: string }[]>();
+      for (const company of companies.data ?? []) {
+        if (!company.companyGroupId) {
+          logger.warn("Company has no companyGroupId, skipping", {
+            companyId: company.id
           });
           continue;
         }
+        if (!company.baseCurrencyCode) {
+          logger.warn("Company has no baseCurrencyCode, skipping", {
+            companyId: company.id
+          });
+          continue;
+        }
+        const bucket = groups.get(company.companyGroupId) ?? [];
+        bucket.push({ code: company.baseCurrencyCode, companyId: company.id });
+        groups.set(company.companyGroupId, bucket);
+      }
 
-        const baseCurrencyCode = company.data.baseCurrencyCode as CurrencyCode;
-        let rates: Rates | undefined;
-        rates = cachedRates[baseCurrencyCode];
-        // Check if the rates for this base currency are cached, and if not compute them
+      for (const [companyGroupId, members] of groups) {
+        const bases = [...new Set(members.map((m) => m.code))];
+
+        // One shared rate set cannot express two base currencies at once, and
+        // nothing in the schema records a group-level base. Refuse rather than
+        // let one member silently rebase the other's rates.
+        if (bases.length > 1) {
+          logger.error(
+            "Company group has members with different base currencies; refusing to rebase shared rates",
+            { companyGroupId, baseCurrencyCodes: bases }
+          );
+          continue;
+        }
+
+        const baseCurrencyCode = bases[0] as CurrencyCode;
+        let rates = cachedRates[baseCurrencyCode];
         if (rates) {
           logger.info("Using cached rates", { baseCurrencyCode });
         } else {
@@ -168,30 +200,35 @@ export const updateExchangeRatesFunction = inngest.createFunction(
         const updatedAt = new Date().toISOString();
 
         try {
-          if (!company.data.companyGroupId) {
-            logger.warn("Company has no companyGroupId, skipping", {
-              companyId: integration.companyId
-            });
-            continue;
-          }
           const { data, error } = await serviceRole
             .from("currency")
             .select("*")
-            .eq("companyGroupId", company.data.companyGroupId);
+            .eq("companyGroupId", companyGroupId);
 
           if (error) {
-            logger.error("Error fetching currencies for company", {
-              companyId: integration.companyId,
+            logger.error("Error fetching currencies for group", {
+              companyGroupId,
               error
             });
             continue;
           }
 
           if (!data || data.length === 0) {
-            logger.info("No currencies found for company", {
-              companyId: integration.companyId
-            });
+            logger.info("No currencies found for group", { companyGroupId });
             continue;
+          }
+
+          // A currency the feed omits keeps whatever rate it already had. That
+          // is silent staleness, so name them rather than dropping them quietly.
+          const missing = data
+            .filter((currency) => !rates[currency.code as CurrencyCode])
+            .map((currency) => currency.code);
+          if (missing.length > 0) {
+            logger.warn("No rate returned for these currencies; leaving them stale", {
+              companyGroupId,
+              baseCurrencyCode,
+              currencyCodes: missing
+            });
           }
 
           const updates = data
@@ -201,37 +238,38 @@ export const updateExchangeRatesFunction = inngest.createFunction(
               // decimals, which zeroed every 0-decimal currency's fraction and
               // silently froze rates that rounded to 0
               exchangeRate: round(Number(rates[currency.code as CurrencyCode])),
+              updatedBy: "system",
               updatedAt
             }))
             .filter((currency) => currency.exchangeRate);
 
           if (updates.length === 0) {
-            logger.info("No currency updates needed for company", {
-              companyId: integration.companyId
+            logger.info("No currency updates needed for group", {
+              companyGroupId
             });
             continue;
           }
 
-          logger.info("Updating currencies for company", {
+          logger.info("Updating currencies for group", {
             count: updates.length,
-            companyId: integration.companyId
+            companyGroupId
           });
           const { error: upsertError } = await serviceRole
             .from("currency")
             .upsert(updates);
           if (upsertError) {
-            logger.error("Error updating currencies for company", {
-              companyId: integration.companyId,
+            logger.error("Error updating currencies for group", {
+              companyGroupId,
               error: upsertError
             });
           } else {
-            logger.info("Successfully updated currencies for company", {
-              companyId: integration.companyId
+            logger.info("Successfully updated currencies for group", {
+              companyGroupId
             });
           }
         } catch (err) {
-          logger.error("Unexpected error processing company", {
-            companyId: integration.companyId,
+          logger.error("Unexpected error processing group", {
+            companyGroupId,
             error: err
           });
         }

--- a/packages/jobs/src/inngest/functions/scheduled/update-exchange-rates.ts
+++ b/packages/jobs/src/inngest/functions/scheduled/update-exchange-rates.ts
@@ -170,6 +170,11 @@ export const updateExchangeRatesFunction = inngest.createFunction(
         groups.set(company.companyGroupId, bucket);
       }
 
+      // Collected so one misconfigured group cannot stop the others from being
+      // updated, while the step still ends in a visible failure.
+      const conflictingGroups: { companyGroupId: string; bases: string[] }[] =
+        [];
+
       for (const [companyGroupId, members] of groups) {
         const bases = [...new Set(members.map((m) => m.code))];
 
@@ -181,6 +186,7 @@ export const updateExchangeRatesFunction = inngest.createFunction(
             "Company group has members with different base currencies; refusing to rebase shared rates",
             { companyGroupId, baseCurrencyCodes: bases }
           );
+          conflictingGroups.push({ companyGroupId, bases });
           continue;
         }
 
@@ -224,11 +230,14 @@ export const updateExchangeRatesFunction = inngest.createFunction(
             .filter((currency) => !rates[currency.code as CurrencyCode])
             .map((currency) => currency.code);
           if (missing.length > 0) {
-            logger.warn("No rate returned for these currencies; leaving them stale", {
-              companyGroupId,
-              baseCurrencyCode,
-              currencyCodes: missing
-            });
+            logger.warn(
+              "No rate returned for these currencies; leaving them stale",
+              {
+                companyGroupId,
+                baseCurrencyCode,
+                currencyCodes: missing
+              }
+            );
           }
 
           const updates = data
@@ -276,6 +285,19 @@ export const updateExchangeRatesFunction = inngest.createFunction(
       }
 
       logger.info("Exchange rates task completed");
+
+      // Throw AFTER every healthy group has been updated. Returning normally
+      // would let Inngest record a success, so a group whose members disagree
+      // on base currency would sit un-rebased indefinitely with nothing but a
+      // log line to show for it.
+      if (conflictingGroups.length > 0) {
+        throw new Error(
+          `Refused to rebase ${conflictingGroups.length} company group(s) whose members disagree on base currency: ` +
+            conflictingGroups
+              .map((g) => `${g.companyGroupId} (${g.bases.join(", ")})`)
+              .join("; ")
+        );
+      }
     });
   }
 );


### PR DESCRIPTION
## Problem

`currency` rows are scoped to a company **group** (`20260228023426`), but `companyIntegration` is keyed `(id, companyId)` — per **company** (`20240119095150:34`). The job iterated integrations, rebased the EUR feed to each company's own `baseCurrencyCode`, and upserted into the group's shared rows.

So a group whose companies use different base currencies had them overwrite each other, and whichever ran last won for everybody. With both integrations active the rows flip on every nightly run and the same document's converted totals change day to day.

Nothing in the schema records a group-level base currency, and `getBaseCurrency` (`accounting.ee.service.ts:1813`) resolves a company's base against the group's shared rows — so the model already assumes one base per group. That assumption was just never enforced where the rates are written.

## Fix

Group the active integrations by `companyGroupId`, resolve the base once, rebase once, write once.

When a group's members disagree on base currency, refuse with an error naming the group and the conflicting codes. One shared rate set cannot express two bases at once, and silently picking a winner is what produced the bug.

Two smaller fixes in the same loop: a currency the feed omits kept its old rate with no signal, so the omitted codes are now named in a warning; and `updatedBy` was never set on the upsert.

## Verification

Not executed end to end — the job requires `EXCHANGE_RATES_API_KEY` and calls the live rates provider, which isn't something to fire for a test.

The decision logic was exercised against the real schema instead. With one company in the group: `rebase once as EUR`, same as before. After adding a second company to the same group with a SEK base, the same query reports `REFUSE + log error` where the old code would have issued `2 competing upserts (last wins)`. The temporary company and its intercompany records were removed afterwards; the instance is back to one company and zero integrations.

Typecheck clean (the one error in `packages/documents/src/pdf/fonts.data` is a generated file missing from an `--ignore-scripts` install, unrelated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exchange rates are now updated consistently for each company group using its configured base currency.
  * Groups with conflicting base-currency settings are skipped, while other groups continue processing normally.
  * Missing currencies from the rate feed are reported and retain their previous rates instead of being removed.
  * Processing now clearly reports groups requiring configuration correction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->