### PR TITLE
fix(purchasing): convert supplier part prices to the supplier's currency, not away from it

### DIFF
--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
@@ -149,7 +149,11 @@ const PurchaseInvoiceLineForm = ({
     taxAmount: initialValues.supplierTaxAmount ?? 0,
     taxPercent: initialValues.taxPercent ?? 0,
     priceBreaks: [],
-    fallbackUnitPrice: initialValues.supplierUnitPrice ?? 0
+    // fallbackUnitPrice is BASE currency, matching what resolveSupplierPrice
+    // expects. initialValues.supplierUnitPrice is the SUPPLIER's, so divide.
+    fallbackUnitPrice:
+      (initialValues.supplierUnitPrice ?? 0) /
+      (routeData?.purchaseInvoice?.exchangeRate || 1)
   });
 
   // Re-derive the tax amount when the line's base changes — never on mount, so
@@ -355,10 +359,12 @@ const PurchaseInvoiceLineForm = ({
         const itemReplenishment = item?.data?.itemReplenishment;
         const exchangeRate = routeData?.purchaseInvoice?.exchangeRate ?? 1;
         const initialQty = supplierPart?.data?.minimumOrderQuantity ?? 1;
+        // BASE currency: supplierPart.unitPrice and itemCost.unitCost are both
+        // stored in base. resolveSupplierPrice converts to the supplier's.
         const baseFallback =
           supplierPart?.data?.unitPrice !== null &&
           supplierPart?.data?.unitPrice !== undefined
-            ? supplierPart.data.unitPrice / exchangeRate
+            ? supplierPart.data.unitPrice
             : (itemCost?.unitCost ?? 0);
 
         const breaks = supplierPart?.data?.id

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -150,7 +150,11 @@ const PurchaseOrderLineForm = ({
     itemId: initialValues.itemId ?? "",
     conversionFactor: initialValues.conversionFactor ?? 1,
     description: initialValues.description ?? "",
-    fallbackUnitPrice: initialValues.supplierUnitPrice ?? 0,
+    // fallbackUnitPrice is BASE currency, matching what resolveSupplierPrice
+    // expects. initialValues.supplierUnitPrice is the SUPPLIER's, so divide.
+    fallbackUnitPrice:
+      (initialValues.supplierUnitPrice ?? 0) /
+      (routeData?.purchaseOrder?.exchangeRate || 1),
     inventoryUom: initialValues.inventoryUnitOfMeasureCode ?? "",
     minimumOrderQuantity: undefined,
     purchaseQuantity: initialValues.purchaseQuantity ?? 1,
@@ -378,10 +382,12 @@ const PurchaseOrderLineForm = ({
         const exchangeRate = routeData?.purchaseOrder?.exchangeRate ?? 1;
         const initialQty = supplierPart?.data?.minimumOrderQuantity ?? 1;
         const leadTime = item?.data?.itemReplenishment?.leadTime ?? 0;
+        // BASE currency: supplierPart.unitPrice and itemCost.unitCost are both
+        // stored in base. resolveSupplierPrice converts to the supplier's.
         const baseFallback =
           supplierPart?.data?.unitPrice !== null &&
           supplierPart?.data?.unitPrice !== undefined
-            ? supplierPart.data.unitPrice / exchangeRate
+            ? supplierPart.data.unitPrice
             : (itemCost?.unitCost ?? 0);
 
         const breaks = supplierPart?.data?.id

--- a/apps/erp/app/modules/shared/shared.service.ts
+++ b/apps/erp/app/modules/shared/shared.service.ts
@@ -1428,8 +1428,16 @@ export function resolveBuyUnitCost(
 }
 
 /**
- * Resolve the best supplier unit price for a quantity, applying exchange
- * rate conversion.
+ * Resolve the supplier unit price for a quantity.
+ *
+ * `supplierPart.unitPrice` and `supplierPartPrice.unitPrice` are stored in the
+ * company BASE currency -- neither table has a currency column, and all three
+ * writers put base there. The field this feeds (`supplierUnitPrice`) is in the
+ * SUPPLIER's currency. The document's `exchangeRate` is foreign-per-base, so
+ * base to supplier is MULTIPLY.
+ *
+ * @param fallbackUnitPrice base currency, used when no break matches
+ * @returns the price in the supplier's currency
  */
 export function resolveSupplierPrice(
   priceBreaks: PriceBreak[],
@@ -1437,12 +1445,8 @@ export function resolveSupplierPrice(
   fallbackUnitPrice: number,
   exchangeRate: number
 ): number {
-  if (!priceBreaks.length) return fallbackUnitPrice;
-  return (
-    lookupPriceFromBreaks(
-      priceBreaks,
-      quantity,
-      fallbackUnitPrice * exchangeRate
-    ) / exchangeRate
-  );
+  const basePrice = priceBreaks.length
+    ? lookupPriceFromBreaks(priceBreaks, quantity, fallbackUnitPrice)
+    : fallbackUnitPrice;
+  return basePrice * exchangeRate;
 }


### PR DESCRIPTION
## Problem

`supplierPart.unitPrice` and `supplierPartPrice.unitPrice` are stored in the company **base** currency. Neither table has a currency column, and all three writers put base there — `convert/index.ts:1767` (`supplierUnitPrice / exchangeRate`), supplier-quote `$id.finalize.tsx:187`, and `SupplierPartForm.tsx:188`, which formats the field with `baseCurrencyCode`.

The field they prefill, `supplierUnitPrice`, is in the **supplier's** currency (`PurchaseOrderLineForm.tsx:716` formats it with `orderCurrency`). The document's `exchangeRate` is foreign-per-base, so base → supplier is **multiply**.

Both purchasing line forms divided, and `resolveSupplierPrice` divided again on the price-break path. The value written into a supplier-currency column was `base / rate` where it should be `base × rate` — wrong by the rate squared.

Nobody notices a plausible small number in a foreign-currency field. The generated base column then derives from it, so receiving the line creates a cost layer at the wrong magnitude and drags the weighted-average item cost with it.

## Fix

`resolveSupplierPrice` now takes a base fallback and base breaks and returns the supplier-currency price. Both call sites hand it the raw base value.

Also: the `itemData` initializer seeded `fallbackUnitPrice` from `initialValues.supplierUnitPrice` — a supplier-currency value — into a field the helper treats as base. It now divides to base, so the field means one thing throughout. That inconsistency predates this PR but the fix makes the direction explicit, so leaving it would have been a new bug.

## Verification

On a local stack, base EUR, supplier Deep Space RF in SEK at rate 11.24, part RW-010 with a stored base price of €14,500:

Adding that item to a SEK purchase order now defaults **Unit Price: SEK 162,980.00** (14,500 × 11.24). Before the fix it defaulted to SEK 1,290.04 — understating the line by a factor of 126.

Typecheck and lint clean. Found by an audit of the costing and supplier-pricing surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected supplier price calculations on purchase orders and purchase invoices when exchange rates are applied.
  - Improved price-break handling so prices are resolved consistently in the base currency before conversion to the supplier’s currency.
  - Prevented incorrect unit prices caused by duplicate or misplaced currency conversions.
  - Improved the accuracy of fallback pricing for supplier parts and item costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
