### PR TITLE
fix(inventory): divide receipt header shipping to base, don't multiply

### DIFF
--- a/packages/database/supabase/functions/post-receipt/index.ts
+++ b/packages/database/supabase/functions/post-receipt/index.ts
@@ -620,9 +620,17 @@ serve(async (req: Request) => {
         if (purchaseOrderDelivery.error)
           throw new Error("Failed to fetch purchase order delivery");
 
+        // supplierShippingCost is a supplier-currency amount and the order's
+        // exchangeRate is foreign-units-per-base, so supplier -> base is
+        // DIVIDE. It is mixed into base line costs below and becomes the
+        // cost-ledger layer value, so multiplying inflated every foreign
+        // receipt's capitalised cost by the rate squared. Matches
+        // post-purchase-invoice (supplierShippingCost) and migration
+        // 20260702061504, which fixed the same expression in the
+        // purchaseOrders/purchaseInvoices views.
         const shippingCost =
-          (purchaseOrderDelivery.data?.supplierShippingCost ?? 0) *
-          (purchaseOrder.data?.exchangeRate ?? 1);
+          (purchaseOrderDelivery.data?.supplierShippingCost ?? 0) /
+          (purchaseOrder.data?.exchangeRate || 1);
 
         const totalLinesCost = receiptLines.data.reduce((acc, receiptLine) => {
           const safeReceivedQuantity =


### PR DESCRIPTION
## Problem

`purchaseOrderDelivery.supplierShippingCost` is a supplier-currency amount and the order's `exchangeRate` is foreign-units-per-base, so supplier → base is **divide**. `post-receipt/index.ts:623` multiplied.

This is not only a journal amount. The result is weighted across the receipt lines and mixed with `receiptLine.unitPrice` — already base, seeded from the generated `purchaseOrderLine.unitPrice` at `create/index.ts:896` — to produce the cost-ledger layer value, the per-piece cost, and the Inventory/GR-IR journal. So every foreign-currency receipt carrying header shipping capitalised the wrong number by the rate squared and dragged the weighted-average item cost with it.

## Why this one was missed

The codebase already knows the right answer twice over:

- `post-purchase-invoice/index.ts:559` divides, with a comment explaining that supplier → base is divide.
- Migration `20260702061504` is titled *"Fix supplierShippingCost currency conversion: divide, not multiply"* and fixed exactly this expression in the `purchaseOrders` / `purchaseInvoices` views.

The edge function was the straggler — the views were corrected, the function that writes the cost layers was not.

## Scope note

`post-receipt` falls inside what #1298 would have touched. With that PR set aside this is unowned, and it is worth separating on its own merits: the convention debate there is about GL presentation, whereas this corrupts `costLedger` and inventory valuation, which no later journal correction would repair.

## Verification

One-line change; `deno check` shows the same 71 pre-existing errors before and after, none in this file. Not exercised end to end — that needs a foreign-currency PO receipted with header shipping, which I did not want to post into the shared test instance. The direction is established by the two references above rather than by a run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected purchase receipt shipping cost conversion to apply exchange rates consistently with purchase invoices.
  * Ensured shipping costs are accurately capitalized in the purchase order currency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
