### PR TITLE
fix(dev): allow portless origins through react-router 7.18 CSRF action guard

### DIFF
--- a/apps/erp/react-router.config.ts
+++ b/apps/erp/react-router.config.ts
@@ -6,4 +6,8 @@ export default {
   ssr: true,
   presets: process.env.VERCEL ? [vercelPreset()] : undefined,
   future: { unstable_optimizeDeps: true, v8_middleware: true },
+  allowedActionOrigins:
+    process.env.NODE_ENV === "development"
+      ? ["erp.*.dev", "**.localhost"]
+      : undefined,
 } satisfies Config;

--- a/apps/mes/react-router.config.ts
+++ b/apps/mes/react-router.config.ts
@@ -5,4 +5,8 @@ export default {
   ssr: true,
   presets: process.env.VERCEL ? [vercelPreset()] : undefined,
   future: { unstable_optimizeDeps: true, v8_middleware: true },
+  allowedActionOrigins:
+    process.env.NODE_ENV === "development"
+      ? ["mes.*.dev", "**.localhost"]
+      : undefined,
 } satisfies Config;


### PR DESCRIPTION
## Symptom

With the dev stack running behind the portless proxy, login fails. Every attempt logs

```
erp | ERR carbon·erp: Unhandled error in 'POST' '/callback.data': 'Bad Request'
```

and the client surfaces `Bad Request` from `singleFetchAction`. Pages load fine — only action POSTs fail, and `/callback` is the first POST in the auth flow, so login is where it shows up.

## Root cause

react-router has shipped a CSRF guard (`throwIfPotentialCSRFAttack`) since 7.12.0: an action request whose `Origin` host differs from the request's own host is rejected with 400 unless the origin is in `allowedActionOrigins`, which defaults to deny-all and is set nowhere in this repo.

What changed in **7.18.0** is *which host the origin is compared against* (remix-run/react-router#15185, "Use the constructed request URL host when validating action request origins"). Before 7.18 the guard compared `Origin` against `x-forwarded-host`/`host` headers — which the portless proxy forwards, so origin and host matched and the guard passed. 7.18 removed that header parsing and compares against `new URL(request.url).host`, delegating proxy-aware host construction to adapter layers. The vite dev server behind the portless proxy sees `localhost:<PORT_ERP>` while the browser sends `Origin: https://erp.<branch>.dev`; hosts differ, the allowlist is empty, and every action 400s.

### Why the default dev script masks it

The root `package.json` dev script is `crbn up --no-portless`, which serves at `http://localhost:<port>` — origin equals host, so the guard never fires. Portless is opt-in (`crbn up`, or `CARBON_PORTLESS=1`). And the 7.15.1 → 7.18.0 bump arrived in the Trivy CVE sweep (0233084fc4, #1535), not as a deliberate framework upgrade, so there was no migration pass over it. It's a latent bug for every portless user.

## Fix

Set `allowedActionOrigins` in `apps/erp/react-router.config.ts` and `apps/mes/react-router.config.ts` (the two apps served through portless — `ERP_URL`/`MES_URL` are the only portless app URLs `crbn` generates, and both apps have a `_public+/callback.tsx`):

```ts
// erp:
allowedActionOrigins:
  process.env.NODE_ENV === "development"
    ? ["erp.*.dev", "**.localhost"]   // mes: ["mes.*.dev", "**.localhost"]
    : undefined,
```

Each app allows only its own portless hostname shape: the branch prefix is sanitized to a single DNS label (`branchToPrefix` in `@carbon/dev` strips everything but `[a-z0-9-]`), so `erp.*.dev` (one wildcard label) matches every possible `erp.<branch>.dev` and nothing else — an attacker-registered `evil.dev`, a sub-subdomain, or the other app's origin all fail. `.localhost` is a loopback-reserved TLD and not publicly registrable.

### Production is provably unchanged

- `react-router.config.ts` is evaluated by vite's `resolveConfig`, which assigns `process.env.NODE_ENV = defaultNodeEnv` **before** plugin hooks load the config — `"development"` for `react-router dev`, `"production"` for `react-router build`.
- For any `NODE_ENV !== "development"` — including unset — the ternary yields `undefined`, and the runtime does `Array.isArray(build.allowedActionOrigins) ? ... : []`, i.e. the framework's default deny-all.
- The built ERP/MES server bundles contain no dev allowlist (verified by grepping the production build output).

## Evidence the guard is narrowed, not disabled

No live repro was possible in this worktree (no running stack), so the guard functions (`throwIfPotentialCSRFAttack` / `isAllowedOrigin` / `matchWildcardDomain`) were extracted verbatim from the installed `react-router@7.18.0` bundle and driven with the acceptance-criteria origins against the exact allowlist above:

| Origin | Result |
|---|---|
| `http://localhost:3000` (same host, `--no-portless`) | allowed |
| `https://erp.<branch>.dev` (erp) / `https://mes.<branch>.dev` (mes) | **allowed** ✅ |
| `https://evil.dev` (registrable .dev domain) | **rejected (400)** |
| `https://mes.<branch>.dev` against the ERP allowlist (cross-app) | **rejected (400)** |
| `https://evil.com` | **rejected (400)** |
| `https://erp.<branch>.dev.evil.com` (suffix attack) | **rejected (400)** |
| `http://attacker.example.org` | **rejected (400)** |
| `https://dev` (bare TLD) | rejected (400) |
| portless origin with `allowedActionOrigins: undefined` (non-dev NODE_ENV) | rejected (400) |

(The matcher is react-router's own domain-segment wildcard, not micromatch-on-strings: `erp.*.dev` requires a literal `erp` label, exactly one wildcard label, and a literal final `dev` label, so a `.evil.com` suffix, a registered `.dev` domain, or the bare TLD can never match.)

Live repro for anyone with a portless stack up:

```bash
PORT=$(grep '^PORT_ERP=' .env.local | cut -d= -f2)
HOST=$(grep '^ERP_URL='  .env.local | cut -d= -f2)

# matching origin -> passes the guard (was already fine)
curl -s -o /dev/null -w "%{http_code}\n" -X POST "http://localhost:$PORT/callback.data" \
  -H "Origin: http://localhost:$PORT" \
  -H "Content-Type: application/x-www-form-urlencoded" --data "refreshToken=x&userId=y"

# portless origin (what the browser sends) -> was 400 before this fix
curl -s -o /dev/null -w "%{http_code}\n" -X POST "http://localhost:$PORT/callback.data" \
  -H "Origin: $HOST" \
  -H "Content-Type: application/x-www-form-urlencoded" --data "refreshToken=x&userId=y"
```

## Notes on the alternatives considered

- **Shared helper vs duplication** — only `erp` and `mes` run behind portless (`APP_CHOICES` in `@carbon/dev` is erp/mes/assembler/email; only `ERP_URL`/`MES_URL` get `*.{branch}.dev` hostnames). `academy` and `starter` are not served through `crbn` and have no exposure. Two five-line config entries don't justify a workspace-package import inside build-time config files.
- **Fix the proxy instead** — making the proxy preserve the forwarded host would remove the need for an allowlist, but `portless` is an external globally-installed CLI (not a repo dependency), so that fix can't ship from this repo. The config allowlist is also the approach react-router's own docs prescribe for proxied setups.
- **Other 7.15.1 → 7.18.0 changes** — reviewed the changelog: 7.16 stabilized `future.v8_trailingSlashAwareDataRequests` (opt-in, not enabled here), 7.17 bundled docs into the package, and the remaining 7.18 patches (nonce-aware SSR, turbo-stream hydration errors, RSC redirect protocol validation) don't touch any pattern this repo uses. #15185 is the only behavior change that needed a migration pass.

## Verification

- `pnpm exec turbo run typecheck --filter=erp --filter=mes` — green
- `pnpm --filter mes test` — 52/52 (erp has no test script)
- `pnpm exec turbo run build --filter=erp --filter=mes` — green; production bundles contain no allowlist
- Guard behavior matrix above, run against the shipped 7.18.0 code

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-mode compatibility for ERP and MES applications accessed through local or development proxy domains.
  * Prevented development-only origin checks from blocking valid form actions, while production security behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->