### PR TITLE
fix(accounting): push AR invoice amounts in the currency the payload declares

### DIFF
--- a/packages/ee/src/accounting/core/models.ts
+++ b/packages/ee/src/accounting/core/models.ts
@@ -960,7 +960,12 @@ export const SalesInvoiceLineSchema = z.object({
   itemCode: withNullable(z.string()), // readableIdWithRevision
   description: withNullable(z.string()),
   quantity: z.number(),
+  // BASE currency, matching the stored column.
   unitPrice: z.number(),
+  // The document-currency mirror (unitPrice * exchangeRate). Optional because
+  // not every provider selects it; push this to any payload that declares a
+  // currency code, since unitPrice above is base.
+  convertedUnitPrice: withNullable(z.number()).optional(),
   taxPercent: z.number(),
   lineAmount: z.number()
 });

--- a/packages/ee/src/accounting/providers/rillet/entities/invoice.ts
+++ b/packages/ee/src/accounting/providers/rillet/entities/invoice.ts
@@ -81,7 +81,10 @@ type InvoiceLineRow = {
   itemId: string | null;
   description: string | null;
   quantity: number;
+  /** BASE currency, as stored. */
   unitPrice: number;
+  /** Document-currency mirror (unitPrice * exchangeRate). */
+  convertedUnitPrice: number | null;
   taxPercent: number;
   itemReadableIdWithRevision: string | null;
 };
@@ -133,7 +136,13 @@ export function mapSalesInvoiceToRilletInvoice(args: {
       product_id: productId,
       description: line.description ?? line.itemCode ?? "Invoice line",
       quantity: line.quantity,
-      total_amount: toRilletMoney(line.quantity * line.unitPrice, currency),
+      // `currency` is the DOCUMENT currency, so the amount must be too.
+      // salesInvoiceLine.unitPrice is stored in the company BASE currency;
+      // convertedUnitPrice is the document-currency mirror.
+      total_amount: toRilletMoney(
+        line.quantity * (line.convertedUnitPrice ?? line.unitPrice),
+        currency
+      ),
       // CUSTOMER_CUSTOM satisfies rev-rec validation and carries the line id
       // for audit. NO `carbon` ref here: Rillet counts header + item
       // references together for RESTRICTED types, and organizations that
@@ -244,6 +253,7 @@ export class RilletSalesInvoiceSyncer extends RilletTransactionSyncer<
         "salesInvoiceLine.description",
         "salesInvoiceLine.quantity",
         "salesInvoiceLine.unitPrice",
+        "salesInvoiceLine.convertedUnitPrice",
         "salesInvoiceLine.taxPercent",
         "item.readableIdWithRevision as itemReadableIdWithRevision"
       ])
@@ -286,6 +296,11 @@ export class RilletSalesInvoiceSyncer extends RilletTransactionSyncer<
         lines: lines.map((line) => {
           const quantity = Number(line.quantity) || 0;
           const unitPrice = Number(line.unitPrice) || 0;
+          const convertedUnitPrice =
+            line.convertedUnitPrice === null ||
+            line.convertedUnitPrice === undefined
+              ? null
+              : Number(line.convertedUnitPrice);
           return {
             id: line.id,
             invoiceLineType: line.invoiceLineType,
@@ -294,6 +309,7 @@ export class RilletSalesInvoiceSyncer extends RilletTransactionSyncer<
             description: line.description,
             quantity,
             unitPrice,
+            convertedUnitPrice,
             taxPercent: Number(line.taxPercent) || 0,
             lineAmount: quantity * unitPrice
           };

--- a/packages/ee/src/accounting/providers/xero/entities/__tests__/invoice.test.ts
+++ b/packages/ee/src/accounting/providers/xero/entities/__tests__/invoice.test.ts
@@ -154,3 +154,70 @@ describe("SalesInvoiceSyncer.mapToRemote (item revenue account)", () => {
     });
   });
 });
+
+/**
+ * Foreign-currency AR. `salesInvoiceLine.unitPrice` is stored in the company
+ * BASE currency (`convertedUnitPrice` is the document mirror), so a payload
+ * declaring `CurrencyCode: "EUR"` must carry EUR amounts, not the base ones.
+ *
+ * Xero's `CurrencyRate` is base-per-foreign — the rate that converts the
+ * invoice's currency INTO the organisation's base. Carbon's
+ * `currency.exchangeRate` is foreign-per-base, so the two are reciprocal.
+ */
+const fxInvoice = (): Accounting.SalesInvoice =>
+  ({
+    ...invoice(),
+    currencyCode: "EUR",
+    // 0.80 EUR per 1 USD of base
+    exchangeRate: 0.8,
+    subtotal: 100,
+    totalAmount: 100,
+    balance: 100,
+    lines: [
+      {
+        id: "sil-1",
+        invoiceLineType: "Part",
+        itemId: "item-1",
+        itemCode: "WIDGET-1",
+        description: "Widget",
+        quantity: 2,
+        // base currency: 2 x 50 = 100 base, i.e. 80 EUR
+        unitPrice: 50,
+        convertedUnitPrice: 40,
+        taxPercent: 0,
+        lineAmount: 100
+      }
+    ]
+  }) as unknown as Accounting.SalesInvoice;
+
+describe("SalesInvoiceSyncer.mapToRemote (foreign currency)", () => {
+  const db = () =>
+    makeInvoiceDb({
+      accountDefault: { salesAccount: "acct_sales" },
+      accountMappings: [
+        {
+          id: "m-1",
+          accountId: "acct_sales",
+          externalId: "sales-remote",
+          metadata: { externalCode: "4000" },
+          lastSyncedAt: null,
+          accountNumber: "4000",
+          accountName: "Sales Revenue"
+        }
+      ]
+    });
+
+  it("pushes line amounts in the currency the payload declares", async () => {
+    const payload = await makeInvoiceSyncer(db()).mapToRemote(fxInvoice());
+    expect(payload.CurrencyCode).toBe("EUR");
+    // 40 EUR/ea, not the 50 base
+    expect(payload.LineItems[0]?.UnitAmount).toBe(40);
+    expect(payload.LineItems[0]?.LineAmount).toBe(80);
+  });
+
+  it("sends CurrencyRate in Xero's direction (base per foreign)", async () => {
+    const payload = await makeInvoiceSyncer(db()).mapToRemote(fxInvoice());
+    // Carbon stores 0.8 EUR per USD; Xero wants USD per EUR = 1.25
+    expect(payload.CurrencyRate).toBeCloseTo(1.25, 6);
+  });
+});

--- a/packages/ee/src/accounting/providers/xero/entities/__tests__/invoice.test.ts
+++ b/packages/ee/src/accounting/providers/xero/entities/__tests__/invoice.test.ts
@@ -160,15 +160,19 @@ describe("SalesInvoiceSyncer.mapToRemote (item revenue account)", () => {
  * BASE currency (`convertedUnitPrice` is the document mirror), so a payload
  * declaring `CurrencyCode: "EUR"` must carry EUR amounts, not the base ones.
  *
- * Xero's `CurrencyRate` is base-per-foreign — the rate that converts the
- * invoice's currency INTO the organisation's base. Carbon's
- * `currency.exchangeRate` is foreign-per-base, so the two are reciprocal.
+ * Xero's `CurrencyRate` runs the SAME direction as Carbon's
+ * `currency.exchangeRate`: foreign per base. Xero's multicurrency guide is
+ * explicit — "The units of CurrencyRate are always [Foreign Currency] PER
+ * [Base Currency] ... A CurrencyRate of 1.10 for a EUR invoice against a
+ * GBP-base-currency organisation says that 1 GBP = 1.1 EUR." So the rate is
+ * passed through unchanged; inverting it triggers Xero's "inverse rate"
+ * warning and books base amounts wrong.
  */
 const fxInvoice = (): Accounting.SalesInvoice =>
   ({
     ...invoice(),
     currencyCode: "EUR",
-    // 0.80 EUR per 1 USD of base
+    // 0.80 EUR per 1 USD of base -- Xero's units exactly
     exchangeRate: 0.8,
     subtotal: 100,
     totalAmount: 100,
@@ -215,9 +219,16 @@ describe("SalesInvoiceSyncer.mapToRemote (foreign currency)", () => {
     expect(payload.LineItems[0]?.LineAmount).toBe(80);
   });
 
-  it("sends CurrencyRate in Xero's direction (base per foreign)", async () => {
+  it("passes CurrencyRate through unchanged (foreign per base, both sides)", async () => {
     const payload = await makeInvoiceSyncer(db()).mapToRemote(fxInvoice());
-    // Carbon stores 0.8 EUR per USD; Xero wants USD per EUR = 1.25
-    expect(payload.CurrencyRate).toBeCloseTo(1.25, 6);
+    // Xero wants EUR per USD, which is what Carbon already stores. Sending the
+    // reciprocal (1.25) is the documented "inverse rate" mistake.
+    expect(payload.CurrencyRate).toBeCloseTo(0.8, 6);
+  });
+
+  it("omits CurrencyRate on a base-currency invoice rather than sending 1", async () => {
+    const payload = await makeInvoiceSyncer(db()).mapToRemote(invoice());
+    // Xero: "Setting a CurrencyRate of 1 is redundant and considered incorrect."
+    expect(payload.CurrencyRate).toBeUndefined();
   });
 });

--- a/packages/ee/src/accounting/providers/xero/entities/invoice.ts
+++ b/packages/ee/src/accounting/providers/xero/entities/invoice.ts
@@ -461,13 +461,13 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
       AmountDue: local.balance,
       AmountPaid: local.totalAmount - local.balance,
       CurrencyCode: local.currencyCode,
-      // Xero's CurrencyRate converts the invoice currency INTO the org's base
-      // (base per foreign). Carbon's exchangeRate is foreign per base, so the
-      // two are reciprocal -- passing ours through inverted the rate.
-      CurrencyRate:
-        local.exchangeRate !== 1 && local.exchangeRate > 0
-          ? 1 / local.exchangeRate
-          : undefined
+      // Xero's CurrencyRate is [invoice currency] PER [base currency] -- the
+      // same direction Carbon stores exchangeRate in, so it passes through
+      // unchanged. Inverting it earns Xero's "inverse rate" warning and books
+      // the base amounts wrong. Omit it on base-currency invoices: Xero calls
+      // an explicit rate of 1 redundant and warns on a 1 that reaches an FX
+      // document.
+      CurrencyRate: local.exchangeRate !== 1 ? local.exchangeRate : undefined
     };
   }
 

--- a/packages/ee/src/accounting/providers/xero/entities/invoice.ts
+++ b/packages/ee/src/accounting/providers/xero/entities/invoice.ts
@@ -54,7 +54,10 @@ type InvoiceLineRow = {
   itemId: string | null;
   description: string | null;
   quantity: number;
+  /** BASE currency, as stored. */
   unitPrice: number;
+  /** Document-currency mirror (unitPrice * exchangeRate). */
+  convertedUnitPrice: number | null;
   taxPercent: number;
   // For item code lookup
   itemReadableIdWithRevision: string | null;
@@ -264,6 +267,7 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
         "salesInvoiceLine.description",
         "salesInvoiceLine.quantity",
         "salesInvoiceLine.unitPrice",
+        "salesInvoiceLine.convertedUnitPrice",
         "salesInvoiceLine.taxPercent",
         "item.readableIdWithRevision as itemReadableIdWithRevision"
       ])
@@ -309,6 +313,11 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
           const quantity = Number(line.quantity) || 0;
           const unitPrice = Number(line.unitPrice) || 0;
           const taxPercent = Number(line.taxPercent) || 0;
+          const convertedUnitPrice =
+            line.convertedUnitPrice === null ||
+            line.convertedUnitPrice === undefined
+              ? null
+              : Number(line.convertedUnitPrice);
           return {
             id: line.id,
             invoiceLineType: line.invoiceLineType,
@@ -317,6 +326,7 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
             description: line.description,
             quantity,
             unitPrice,
+            convertedUnitPrice,
             taxPercent,
             lineAmount: quantity * unitPrice
           };
@@ -388,15 +398,18 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
     // Build line items, resolving item dependencies
     const lineItems: Xero.InvoiceLineItem[] = [];
     for (const line of local.lines) {
-      const taxAmount =
-        (line.quantity * line.unitPrice * line.taxPercent) / 100;
+      // The payload declares CurrencyCode below, so every amount on it must be
+      // in THAT currency. salesInvoiceLine.unitPrice is stored in the company
+      // BASE currency; convertedUnitPrice is the document-currency mirror.
+      const unitAmount = line.convertedUnitPrice ?? line.unitPrice;
+      const taxAmount = (line.quantity * unitAmount * line.taxPercent) / 100;
 
       const lineItem: Xero.InvoiceLineItem = {
         Description: line.description ?? undefined,
         Quantity: line.quantity,
-        UnitAmount: line.unitPrice,
+        UnitAmount: unitAmount,
         TaxAmount: taxAmount,
-        LineAmount: line.quantity * line.unitPrice,
+        LineAmount: line.quantity * unitAmount,
         // The item's mapped revenue account (item-referenced AR).
         AccountCode: salesAccountCode,
         // TaxType is required by Xero: OUTPUT for sales tax, NONE for zero tax
@@ -448,7 +461,13 @@ export class SalesInvoiceSyncer extends BaseEntitySyncer<
       AmountDue: local.balance,
       AmountPaid: local.totalAmount - local.balance,
       CurrencyCode: local.currencyCode,
-      CurrencyRate: local.exchangeRate !== 1 ? local.exchangeRate : undefined
+      // Xero's CurrencyRate converts the invoice currency INTO the org's base
+      // (base per foreign). Carbon's exchangeRate is foreign per base, so the
+      // two are reciprocal -- passing ours through inverted the rate.
+      CurrencyRate:
+        local.exchangeRate !== 1 && local.exchangeRate > 0
+          ? 1 / local.exchangeRate
+          : undefined
     };
   }
 


### PR DESCRIPTION
## The problem

`salesInvoiceLine.unitPrice` is stored in the company **base** currency; `convertedUnitPrice` (generated as `unitPrice * exchangeRate`) is the document-currency mirror.

Both the Xero and Rillet AR invoice syncers built their line amounts from `unitPrice`, then declared the document's `CurrencyCode` on the payload. A EUR invoice on a USD-base company therefore shipped USD numbers labelled EUR — the provider records the base amount as if it were the foreign amount, and every downstream figure (revenue, AR balance, realised FX) is wrong by the exchange rate.

## The fix

Select and push `convertedUnitPrice`, falling back to `unitPrice` when it is null (base-currency invoices, where the two are equal).

## Correction to an earlier commit on this branch

An earlier commit here also inverted `CurrencyRate`, on the premise that Xero's rate runs the opposite direction to Carbon's. **That was wrong and has been reverted** (deee8198a).

Xero's [multicurrency guide](https://developer.xero.com/documentation/best-practices/data-integrity/multicurrency) states it verbatim:

> The units of CurrencyRate are always [Foreign Currency] PER [Base Currency] ... A CurrencyRate of 1.10 for a EUR invoice against a GBP-base-currency organisation says that 1 GBP = 1.1 EUR.

That is Carbon's own convention, so the rate passes through unchanged. Xero returns a dedicated "inverse rate" warning for that exact transform and states it "will cause base currency amounts to be significantly wrong". The rate handling on this branch is now identical to `origin/main`; only the line amounts change.

## Verification

`packages/ee` tests pass (6/6 in the Xero invoice suite), including two new cases: the rate passes through as 0.8 rather than 1.25, and a base-currency invoice omits `CurrencyRate` rather than sending a redundant 1.

**Not verified against a live Xero organisation.** There is no sandbox connection available here, so this rests on the documented contract and unit tests. Given that this branch already shipped one wrong reading of that contract, a round-trip against a Xero demo org before merge would be worth it.

## Related, not fixed here

An audit of the other provider entities found the same base-vs-document-currency confusion in the Xero sales-order and purchase-order pushes, the QuickBooks invoice, bill, purchase-order and payment mappings, and Rillet's bill. QuickBooks' `ExchangeRate` genuinely *is* base-per-foreign and is currently written un-inverted. Those are separate PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected foreign-currency invoice amounts when syncing with Rillet and Xero.
  * Invoice line totals, unit amounts, and tax calculations now reflect the document currency.
  * Currency-rate handling now remains accurate for foreign-currency invoices.
  * Base-currency invoices no longer send an unnecessary currency rate.
* **Tests**
  * Added coverage for foreign-currency amounts, currency rates, and base-currency invoices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->