### PR TITLE
fix(documents): email the line unit price in the currency the email is formatted in

### DIFF
--- a/packages/documents/src/email/PurchaseOrderEmail.tsx
+++ b/packages/documents/src/email/PurchaseOrderEmail.tsx
@@ -268,8 +268,12 @@ const PurchaseOrderEmail = ({
                   <Text className="text-xs font-semibold">
                     {line.purchaseOrderLineType === "Comment"
                       ? "-"
-                      : line.unitPrice
-                        ? formatter.format(line.unitPrice)
+                      : // `formatter` is the SUPPLIER's currency (above), and
+                        // purchaseOrderLine.unitPrice is the GENERATED BASE
+                        // column -- supplierUnitPrice is what the supplier
+                        // quoted, and it is what getLineTotal already sums.
+                        line.supplierUnitPrice
+                        ? formatter.format(line.supplierUnitPrice)
                         : "-"}
                   </Text>
                 </Column>

--- a/packages/documents/src/email/PurchaseOrderEmail.tsx
+++ b/packages/documents/src/email/PurchaseOrderEmail.tsx
@@ -280,7 +280,10 @@ const PurchaseOrderEmail = ({
                         // purchaseOrderLine.unitPrice is the GENERATED BASE
                         // column -- supplierUnitPrice is what the supplier
                         // quoted, and it is what getLineTotal already sums.
-                        line.supplierUnitPrice
+                        // A zero unit price is a real price (a no-charge
+                        // line), not a missing one, and getLineTotal already
+                        // sums it as 0 -- so test for absence, not falsiness.
+                        line.supplierUnitPrice != null
                         ? rateFormatter.format(line.supplierUnitPrice)
                         : "-"}
                   </Text>

--- a/packages/documents/src/email/PurchaseOrderEmail.tsx
+++ b/packages/documents/src/email/PurchaseOrderEmail.tsx
@@ -18,7 +18,7 @@ import {
   getPurchaseOrderDisplayId,
   getTotal
 } from "../utils/purchase-order";
-import { getMoneyFormatter } from "../utils/shared";
+import { getMoneyFormatter, getRateFormatter } from "../utils/shared";
 import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
@@ -67,6 +67,14 @@ const PurchaseOrderEmail = ({
   // The DOCUMENT's currency, not the company's — a supplier priced in JPY must
   // not be emailed as "$20.00". Decimals come from that currency's row.
   const formatter = getMoneyFormatter(
+    locale,
+    currencyDecimals,
+    purchaseOrder.currencyCode ?? company.baseCurrencyCode ?? "USD"
+  );
+  // A unit price is a RATE, not a settlement amount: the currency's
+  // decimals are its FLOOR, not its ceiling, so a sub-cent price does not
+  // print as 0.00. The PDFs already split these two kinds.
+  const rateFormatter = getRateFormatter(
     locale,
     currencyDecimals,
     purchaseOrder.currencyCode ?? company.baseCurrencyCode ?? "USD"
@@ -273,7 +281,7 @@ const PurchaseOrderEmail = ({
                         // column -- supplierUnitPrice is what the supplier
                         // quoted, and it is what getLineTotal already sums.
                         line.supplierUnitPrice
-                        ? formatter.format(line.supplierUnitPrice)
+                        ? rateFormatter.format(line.supplierUnitPrice)
                         : "-"}
                   </Text>
                 </Column>

--- a/packages/documents/src/email/SalesInvoiceEmail.tsx
+++ b/packages/documents/src/email/SalesInvoiceEmail.tsx
@@ -18,7 +18,7 @@ import {
   getLineTotal,
   getTotal
 } from "../utils/sales-invoice";
-import { getMoneyFormatter } from "../utils/shared";
+import { getMoneyFormatter, getRateFormatter } from "../utils/shared";
 import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
@@ -60,6 +60,14 @@ const SalesInvoiceEmail = ({
 
   const currencyCode = salesInvoice.currencyCode ?? company.baseCurrencyCode;
   const formatter = getMoneyFormatter(locale, currencyDecimals, currencyCode);
+  // A unit price is a RATE, not a settlement amount: the currency's
+  // decimals are its FLOOR, not its ceiling, so a sub-cent price does not
+  // print as 0.00. The PDFs already split these two kinds.
+  const rateFormatter = getRateFormatter(
+    locale,
+    currencyDecimals,
+    currencyCode
+  );
   const preview = (
     <Preview>{`${salesInvoice.invoiceId} from ${company.name}`}</Preview>
   );
@@ -253,7 +261,7 @@ const SalesInvoiceEmail = ({
                   <Text className="text-xs font-semibold">
                     {line.invoiceLineType === "Comment"
                       ? "-"
-                      : formatter.format(line.convertedUnitPrice ?? 0)}
+                      : rateFormatter.format(line.convertedUnitPrice ?? 0)}
                   </Text>
                 </Column>
                 <Column className="text-right pr-5 align-top w-[100px]">

--- a/packages/documents/src/email/SalesOrderEmail.tsx
+++ b/packages/documents/src/email/SalesOrderEmail.tsx
@@ -266,7 +266,11 @@ const SalesOrderEmail = ({
                   <Text className="text-xs font-semibold">
                     {line.salesOrderLineType === "Comment"
                       ? "-"
-                      : formatter.format(line.unitPrice ?? 0)}
+                      : // `formatter` is the DOCUMENT currency (above), and
+                        // salesOrderLine.unitPrice is stored in BASE --
+                        // convertedUnitPrice is the document-currency mirror,
+                        // and it is what getLineTotal already sums.
+                        formatter.format(line.convertedUnitPrice ?? 0)}
                   </Text>
                 </Column>
                 <Column className="text-right pr-5 align-top w-[100px]">

--- a/packages/documents/src/email/SalesOrderEmail.tsx
+++ b/packages/documents/src/email/SalesOrderEmail.tsx
@@ -18,7 +18,7 @@ import {
   getLineTotal,
   getTotal
 } from "../utils/sales-order";
-import { getMoneyFormatter } from "../utils/shared";
+import { getMoneyFormatter, getRateFormatter } from "../utils/shared";
 import ExternalNotes from "./components/ExternalNotes";
 import {
   EmailThemeProvider,
@@ -66,6 +66,14 @@ const SalesOrderEmail = ({
   // The DOCUMENT's currency, not the company's — a supplier priced in JPY must
   // not be emailed as "$20.00". Decimals come from that currency's row.
   const formatter = getMoneyFormatter(
+    locale,
+    currencyDecimals,
+    salesOrder.currencyCode ?? company.baseCurrencyCode ?? "USD"
+  );
+  // A unit price is a RATE, not a settlement amount: the currency's
+  // decimals are its FLOOR, not its ceiling, so a sub-cent price does not
+  // print as 0.00. The PDFs already split these two kinds.
+  const rateFormatter = getRateFormatter(
     locale,
     currencyDecimals,
     salesOrder.currencyCode ?? company.baseCurrencyCode ?? "USD"
@@ -270,7 +278,7 @@ const SalesOrderEmail = ({
                         // salesOrderLine.unitPrice is stored in BASE --
                         // convertedUnitPrice is the document-currency mirror,
                         // and it is what getLineTotal already sums.
-                        formatter.format(line.convertedUnitPrice ?? 0)}
+                        rateFormatter.format(line.convertedUnitPrice ?? 0)}
                   </Text>
                 </Column>
                 <Column className="text-right pr-5 align-top w-[100px]">


### PR DESCRIPTION
## Problem

Both order emails build their money formatter from the **document's** currency — each carries a comment saying exactly why (`PurchaseOrderEmail.tsx:67`, `SalesOrderEmail.tsx:66`: *"a supplier priced in JPY must not be emailed as `$20.00`"*) — and then format a **base-currency** column with it.

- `SalesOrderEmail.tsx:269` printed `salesOrderLine.unitPrice`, stored in BASE, while the line total beside it comes from `getLineTotal` → `getLineSubtotal`, which sums `convertedUnitPrice` (`utils/sales-order.ts:47`). The customer saw a base unit price labelled with their currency next to a correctly converted total — quantity × unit price did not equal the total on the same row.
- `PurchaseOrderEmail.tsx:272` printed `purchaseOrderLine.unitPrice`, the **generated base** column, under the supplier's currency, while its `getLineTotal` sums `supplierUnitPrice` (`utils/purchase-order.ts:49`). The PO **PDF** has always used `supplierUnitPrice` for this column (`pdf/blocks/purchaseOrder/LineItemsBlock.tsx:163`).

`SalesInvoiceEmail.tsx:256` already used `convertedUnitPrice`. Its two siblings were missed — the formatter's currency was corrected in all three, the amount column in only one.

These go to customers and suppliers, so the wrong number left the building.

## Fix

Each email now formats the same column its own total helper sums: `convertedUnitPrice` for the sales order, `supplierUnitPrice` for the purchase order.

## Verification

`tsc` on `packages/documents`: 104 pre-existing errors before and after, none in either changed file. There are no tests over the email templates, and no snapshot fixtures to extend.

Not exercised end to end — sending an order email from the test instance would email a real address. The claim rests on the column families, which are established by each file's own total helper doing it the other way.

Found by an audit of the document layer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Purchase order emails now display supplier-quoted unit prices, including valid zero-priced items.
  * Sales order emails now show unit prices in the document’s currency.
  * Sales invoice emails now show document-currency unit prices.
  * Sales order comment lines continue to display “-”.
  * Low-value unit prices are now displayed accurately without rounding to zero.
  * Settlement subtotals and totals continue to use standard money formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->