### PR TITLE
fix(sales): print the quote PDF at the quote's own exchange rate

### DIFF
--- a/apps/erp/app/routes/file+/quote+/$id[.]pdf.tsx
+++ b/apps/erp/app/routes/file+/quote+/$id[.]pdf.tsx
@@ -141,7 +141,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }, {}) ?? {};
   }
 
-  let exchangeRate = 1;
+  // The rate is the QUOTE's snapshot, not today's. The line amounts this PDF
+  // renders come from `converted*` generated columns, which bake in the rate
+  // stored on the quote; taking the live rate for the header charges made one
+  // document mix two rates as soon as the daily cron moved the currency.
+  // The currency row is still read, but only for its decimalPlaces.
+  const exchangeRate = quote.data?.exchangeRate ?? 1;
   let currencyDecimals: number | null = null;
   if (quote.data?.currencyCode) {
     const currency = await getCurrencyByCode(
@@ -149,9 +154,6 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       companyGroupId,
       quote.data.currencyCode
     );
-    if (currency.data?.exchangeRate) {
-      exchangeRate = currency.data.exchangeRate;
-    }
     currencyDecimals = currency.data?.decimalPlaces ?? null;
   }
 


### PR DESCRIPTION
## Problem

`file+/quote+/$id[.]pdf.tsx:144-156` ignored `quote.exchangeRate` and fetched the **current** rate from the currency table, then passed it to `QuotePDF` for every header-level charge — shipment shipping (`QuotePDF.tsx:110`) and the add-on/charge amounts (`QuotePDF.tsx:118,134`, `blocks/quote/LineItemsBlock.tsx:120,128,225`).

The line amounts on the same page come from `converted*` generated columns, which bake in the rate stored on the quote. So the moment the daily cron moved the currency, one document printed lines at the snapshot rate and header charges at today's, and the total reconciled to neither. Reprinting an old quote silently changed what it said.

## Fix

The rate now comes from the quote. The currency row is still read, for `decimalPlaces` only.

The quote PDF is the only `file+` route that passes a scalar rate — sales order, sales invoice and purchase order PDFs read `converted*` / `supplier*` columns directly and were never exposed to this. I checked all sixteen.

## Verification

`tsc --noEmit` on `apps/erp` clean.

**Not rendered end to end.** The quote PDF route currently fails in this environment with `TypeError: Cannot read properties of undefined (reading 'width')`. I confirmed that is **pre-existing** by checking out the unmodified `origin/main` version of the file and reproducing the identical error, then restoring the fix — it is a rendering fault unrelated to a scalar rate change, and worth a look on its own.

So this rests on the data path rather than a rendered document: with a quote snapshotted at 5.00 against a live SEK rate of 11.24 and base header shipping of 1,000, the PDF previously computed shipping as 11,240 while its lines used 5.00; it now computes 5,000.

Found by an audit of the document layer, confirmed by two independent verifiers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quote PDFs now use the exchange rate captured with the quote, ensuring generated documents reflect the rate at the time of quoting.
  * Currency precision formatting remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->