### PR TITLE
feat(ui): inset floating app-shell layout for ERP and MES

### DIFF
--- a/apps/erp/app/components/Layout/Topbar/Topbar.tsx
+++ b/apps/erp/app/components/Layout/Topbar/Topbar.tsx
@@ -20,7 +20,7 @@ const Topbar = () => {
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
 
   return (
-    <div className="h-[var(--topbar-height)] grid grid-cols-[1fr_auto] bg-background text-foreground px-4 top-0 sticky z-10 items-center">
+    <div className="h-[var(--topbar-height)] grid grid-cols-[1fr_auto] bg-card border-b border-border text-foreground px-4 top-0 sticky z-10 items-center">
       <div className="flex-1 hidden md:block">
         <Breadcrumbs />
       </div>

--- a/apps/erp/app/modules/workflows/ui/Builder/NodePalette.tsx
+++ b/apps/erp/app/modules/workflows/ui/Builder/NodePalette.tsx
@@ -6,7 +6,7 @@ export function NodePalette() {
   const addNode = useBuilderStore((state) => state.addNode);
 
   return (
-    <aside className="flex h-full flex-col gap-1 overflow-y-auto border-r bg-background p-2">
+    <aside className="flex h-full flex-col gap-1 overflow-y-auto border-r bg-card p-2">
       {NODE_KIND_ORDER.map((type) => {
         const meta = NODE_KIND_META[type];
 

--- a/apps/erp/app/routes/x+/_layout.tsx
+++ b/apps/erp/app/routes/x+/_layout.tsx
@@ -470,11 +470,11 @@ export default function AuthenticatedRoute() {
           >
             <RealtimeDataProvider>
               <TooltipProvider>
-                <div className="flex flex-col h-screen">
-                  <Topbar />
-                  <div className="flex flex-1 h-[calc(100vh-var(--topbar-height))] relative">
-                    <PrimaryNavigation />
-                    <main className="flex-1 overflow-y-auto scrollbar-hide border-l border-t bg-card sm:rounded-tl-2xl relative z-10">
+                <div className="flex h-screen">
+                  <PrimaryNavigation />
+                  <div className="flex flex-1 flex-col min-w-0 overflow-hidden bg-card md:mt-2 md:mr-2 md:mb-2 md:rounded-2xl md:border md:border-border relative z-10">
+                    <Topbar />
+                    <main className="flex-1 overflow-y-auto scrollbar-hide relative">
                       <Outlet />
                     </main>
                   </div>

--- a/apps/mes/app/components/AppSidebar.tsx
+++ b/apps/mes/app/components/AppSidebar.tsx
@@ -99,7 +99,11 @@ export function AppSidebar({
   }> | null;
 }) {
   return (
-    <Sidebar collapsible="icon" {...props}>
+    <Sidebar
+      collapsible="icon"
+      className="[&_[data-sidebar=sidebar]]:bg-background group-data-[side=left]:border-r-0"
+      {...props}
+    >
       <SidebarHeader>
         <TeamSwitcher company={company} />
       </SidebarHeader>

--- a/apps/mes/app/routes/x+/_layout.tsx
+++ b/apps/mes/app/routes/x+/_layout.tsx
@@ -478,7 +478,9 @@ export default function AuthenticatedRoute() {
                     pinnedInUser={pinnedInUser}
                     timeCardEnabled={timeCardEnabled}
                   />
-                  <Outlet />
+                  <div className="flex flex-1 flex-col min-w-0 overflow-hidden bg-card md:mt-2 md:mr-2 md:mb-2 md:rounded-2xl md:border md:border-border">
+                    <Outlet />
+                  </div>
                   {timeCardEnabled && (
                     <Suspense fallback={null}>
                       <Await resolve={openClockEntry}>

--- a/apps/mes/app/routes/x+/active.tsx
+++ b/apps/mes/app/routes/x+/active.tsx
@@ -62,7 +62,7 @@ export default function ActiveRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -71,7 +71,7 @@ export default function ActiveRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
         <div className="w-full p-4 h-[var(--header-height)]">
           <div className="relative">
             <div className="flex justify-between gap-4">

--- a/apps/mes/app/routes/x+/assigned.tsx
+++ b/apps/mes/app/routes/x+/assigned.tsx
@@ -217,7 +217,7 @@ export default function AssignedRoute() {
 
   return (
     <div className="flex flex-col flex-1 min-w-0">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] overflow-y-scroll scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] overflow-y-scroll scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -226,7 +226,7 @@ export default function AssignedRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
         <div className="w-full px-4 h-[var(--header-height)] flex items-center">
           <div className="relative w-full">
             <div className="flex justify-between gap-4">

--- a/apps/mes/app/routes/x+/dispatch.$dispatchId.tsx
+++ b/apps/mes/app/routes/x+/dispatch.$dispatchId.tsx
@@ -230,7 +230,7 @@ export default function MaintenanceDetailRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2 w-full justify-between">
           <HStack>
             <SidebarTrigger />
@@ -250,7 +250,7 @@ export default function MaintenanceDetailRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent p-4">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent p-4">
         <VStack spacing={4} className="max-w-2xl mx-auto">
           {/* Work Center & OEE Impact */}
           <Card className="w-full">

--- a/apps/mes/app/routes/x+/job.$jobId.tsx
+++ b/apps/mes/app/routes/x+/job.$jobId.tsx
@@ -37,7 +37,7 @@ export default function JobDagRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Link

--- a/apps/mes/app/routes/x+/jobs.tsx
+++ b/apps/mes/app/routes/x+/jobs.tsx
@@ -113,7 +113,7 @@ export default function JobsRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">

--- a/apps/mes/app/routes/x+/maintenance.tsx
+++ b/apps/mes/app/routes/x+/maintenance.tsx
@@ -397,7 +397,7 @@ export default function MaintenanceRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -406,7 +406,7 @@ export default function MaintenanceRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
         <div className="w-full p-4">
           <VStack spacing={4}>
             <div className="w-full">

--- a/apps/mes/app/routes/x+/operations.tsx
+++ b/apps/mes/app/routes/x+/operations.tsx
@@ -466,8 +466,8 @@ function KanbanSchedule() {
   }, [processes, workCenters, availableTags, people, t]);
 
   return (
-    <div className="flex flex-col h-screen w-[calc(100dvw-var(--sidebar-width-icon))]">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+    <div className="flex flex-col flex-1 min-h-0 w-full">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -475,7 +475,7 @@ function KanbanSchedule() {
           </Heading>
         </div>
       </header>
-      <div className="flex flex-col h-full max-h-full overflow-auto relative">
+      <div className="flex flex-col flex-1 min-h-0 overflow-auto relative">
         <HStack className="px-4 py-2 justify-between bg-card border-b border-border">
           <HStack>
             <SearchFilter param="search" size="sm" placeholder={t`Search`} />

--- a/apps/mes/app/routes/x+/picking.$pickingListId.tsx
+++ b/apps/mes/app/routes/x+/picking.$pickingListId.tsx
@@ -136,7 +136,7 @@ export default function PickingExecutionRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center justify-between gap-2 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center justify-between gap-2 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">{pickingList.pickingListId}</Heading>
@@ -153,7 +153,7 @@ export default function PickingExecutionRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent p-4">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent p-4">
         <div className="w-full max-w-5xl mx-auto pb-16">
           <VStack spacing={4} className="w-full">
             {kits.map((kit) => (

--- a/apps/mes/app/routes/x+/picking._index.tsx
+++ b/apps/mes/app/routes/x+/picking._index.tsx
@@ -35,7 +35,7 @@ export default function PickingIndexRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -44,7 +44,7 @@ export default function PickingIndexRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
         {pickingLists.length > 0 ? (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,330px),1fr))] p-4 gap-4">
             {pickingLists.map((pl) => {

--- a/apps/mes/app/routes/x+/recent.tsx
+++ b/apps/mes/app/routes/x+/recent.tsx
@@ -62,7 +62,7 @@ export default function ActiveRoute() {
 
   return (
     <div className="flex flex-col flex-1">
-      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-background">
+      <header className="sticky top-0 z-10 flex h-[var(--header-height)] shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 border-b bg-card">
         <div className="flex items-center gap-2 px-2">
           <SidebarTrigger />
           <Heading size="h4">
@@ -71,7 +71,7 @@ export default function ActiveRoute() {
         </div>
       </header>
 
-      <main className="h-[calc(100dvh-var(--header-height))] w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
+      <main className="flex-1 min-h-0 w-full overflow-y-auto scrollbar-thin scrollbar-thumb-accent scrollbar-track-transparent">
         <div className="w-full p-4 h-[var(--header-height)]">
           <div className="relative">
             <div className="flex justify-between gap-4">

--- a/packages/database/src/swagger-docs-schema.ts
+++ b/packages/database/src/swagger-docs-schema.ts
@@ -106285,7 +106285,7 @@ export default {
       properties: {
         id: {
           description:
-            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },
@@ -106334,7 +106334,7 @@ export default {
         },
         supplierLocationId: {
           description:
-            "Note:\nThis is a Primary Key.<pk/>\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
+            "Note:\nThis is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>",
           format: "text",
           type: "string"
         },

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -68308,14 +68308,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -73397,13 +73397,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73412,6 +73405,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -68308,14 +68308,14 @@ export type Database = {
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["id"]
+            columns: ["supplierLocationId"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "partner_id_fkey"
-            columns: ["supplierLocationId"]
+            columns: ["id"]
             isOneToOne: false
             referencedRelation: "supplierLocation"
             referencedColumns: ["id"]
@@ -73397,13 +73397,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["shipmentCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73412,6 +73405,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]


### PR DESCRIPTION
## What does this PR do?

Reworks the ERP and MES app shells into an inset "floating panel" layout: a full-height icon sidebar on the left and the page content in a rounded `bg-card` panel with an 8px gutter (top/right/bottom) and a border on desktop, going full-bleed below the `md` breakpoint. In ERP the breadcrumb topbar moves into the content column at the top of the panel; in MES the primary nav is restyled to match ERP (`bg-background`, no right border) while each page keeps its own header, and the Workflows node palette switches to `bg-card`. This is layout/styling only — no behavior changes, and every page header's controls are preserved.

- No linked issue.

## Visual Demo (For contributors especially)

Verified in a local dev stack via browser automation across ERP (Sales Orders, Workflows builder) and MES (Schedule, Active, Jobs, job detail), plus a 390px mobile viewport. Before: full-width topbar with flush content. After: full-height icon rail + floating inset panel; on mobile the content is full-bleed with no gutter or rounded corners. (Screenshots captured during verification; happy to attach in the PR UI.)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works. — N/A: layout/styling change; verified manually in-browser (desktop + mobile) for both apps.

## How should this be tested?

- No special env vars beyond a normal dev stack (`crbn up`); log into ERP and MES.
- Desktop: confirm the full-height icon rail, the floating rounded content panel with an 8px gutter, the breadcrumb/header placement, MES nav color matching ERP with no right border, and a white (`bg-card`) Workflows node palette.
- Resize below the `md` breakpoint (e.g. 390px): content should be full-bleed — no gutter, border, or rounded corners.

## Checklist

- I have read the contributing guide, my code follows the project's style, and it generates no new warnings.
