### PR TITLE
fix(mes): show item revision in operation header

### DIFF
--- a/apps/mes/app/components/JobOperation/JobOperation.tsx
+++ b/apps/mes/app/components/JobOperation/JobOperation.tsx
@@ -676,7 +676,7 @@ export const JobOperation = ({
                     {operation.reworkId && <Badge variant="red">Rework</Badge>}
                   </HStack>
                   <p className="text-muted-foreground line-clamp-1">
-                    {operation.itemDescription}{" "}
+                    {operation.itemReadableId}
                   </p>
                 </div>
               </HStack>


### PR DESCRIPTION
## Problem

The MES operation header showed the item name under the operation title, which omits the revision. An operator working an operation on a revised part (e.g. `VF900.V4`) couldn't tell which rev they were building without checking the Item panel — which is hidden on shorter screens.

## Fix

Render the item's readable ID with revision in the header subtitle — the same value the Item panel shows — so the two can never disagree and the revision is always visible.

`get_job_operation_by_id` already returns `itemReadableId` as `item.readableIdWithRevision`, so this is a one-line change in `JobOperation.tsx`.

## Before

![before](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-operation-header-revision/before.png)

## After

![after](https://raw.githubusercontent.com/crbnos/carbon/pr-assets/mes-operation-header-revision/after.png)

## Verification

- `pnpm exec turbo run typecheck --filter=mes` passes
- Verified in the MES operation view on a part with a named revision (screenshots above)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job operation details now display the item’s readable ID beneath the operation description for clearer identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->