### PR TITLE
fix(react): honor `disabled` on Combobox fields + tune theme background lightness

### DIFF
--- a/apps/erp/app/components/Layout/Topbar/AskDocs.tsx
+++ b/apps/erp/app/components/Layout/Topbar/AskDocs.tsx
@@ -18,7 +18,7 @@ export default function AskDocs() {
   return (
     <Button
       aria-label="Question (⌘L)"
-      variant="secondary"
+      variant="outline"
       leftIcon={<LuCircleHelp />}
       className="hover:scale-100"
       onClick={() => toggleAgent()}

--- a/apps/erp/app/components/Layout/Topbar/Suggestion.tsx
+++ b/apps/erp/app/components/Layout/Topbar/Suggestion.tsx
@@ -138,7 +138,7 @@ const Suggestion = () => {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          variant="secondary"
+          variant="outline"
           className="hover:scale-100"
           leftIcon={<LuMegaphone />}
         >

--- a/apps/erp/app/components/OnshapeSync.tsx
+++ b/apps/erp/app/components/OnshapeSync.tsx
@@ -262,7 +262,7 @@ export const OnshapeSync = ({
                 <Combobox
                   isLoading={documentsFetcher.state === "loading"}
                   options={documentOptions}
-                  disabled={isDisabled}
+                  isReadOnly={isDisabled}
                   onChange={(value) => {
                     setVersionId(null);
                     setElementId(null);
@@ -282,7 +282,7 @@ export const OnshapeSync = ({
               <div className="w-[180px]">
                 <Combobox
                   isLoading={versionsFetcher.state === "loading"}
-                  disabled={isDisabled}
+                  isReadOnly={isDisabled}
                   options={versionOptions}
                   onChange={(value) => {
                     setVersionId(value);
@@ -303,7 +303,7 @@ export const OnshapeSync = ({
                 <Combobox
                   isLoading={elementsFetcher.state === "loading"}
                   options={elementOptions}
-                  disabled={isDisabled}
+                  isReadOnly={isDisabled}
                   onChange={(value) => {
                     setElementId(value);
                   }}

--- a/apps/erp/app/modules/production/ui/Schedule/People/PeopleMatrix.tsx
+++ b/apps/erp/app/modules/production/ui/Schedule/People/PeopleMatrix.tsx
@@ -69,6 +69,10 @@ type PeopleMatrixProps = {
   weekDates: string[];
   locationTimeZone?: string;
   employees: { id: string; name: string | null; avatarUrl: string | null }[];
+  /** selected department filter — floats its people to the top, hides no one */
+  departmentId: string | null;
+  /** employeeId → their department, for the department-first ordering */
+  employeeDepartments: Record<string, string | null>;
   workCenters: MatrixWorkCenter[];
   assignments: MatrixAssignment[];
   absences: { id: string; employeeId: string; date: string }[];
@@ -92,6 +96,8 @@ export function PeopleMatrix({
   weekDates,
   locationTimeZone,
   employees,
+  departmentId,
+  employeeDepartments,
   workCenters,
   assignments,
   absences,
@@ -165,12 +171,19 @@ export function PeopleMatrix({
     [absences]
   );
 
-  // department scoping happens at the page level (workCenters/employees
-  // arrive pre-filtered); rows are just the employees, sorted
+  // The roster shows everyone; the department filter only reorders — its people
+  // float to the top, everyone else follows, each group alphabetical by name.
   const rows = useMemo(
     () =>
-      [...employees].sort((a, b) => (a.name ?? "").localeCompare(b.name ?? "")),
-    [employees]
+      [...employees].sort((a, b) => {
+        if (departmentId) {
+          const aInDept = employeeDepartments[a.id] === departmentId ? 0 : 1;
+          const bInDept = employeeDepartments[b.id] === departmentId ? 0 : 1;
+          if (aInDept !== bInDept) return aInDept - bInDept;
+        }
+        return (a.name ?? "").localeCompare(b.name ?? "");
+      }),
+    [employees, departmentId, employeeDepartments]
   );
 
   const hoursLadder = { shiftHoursById, employeeShiftHours, defaultShiftHours };

--- a/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQProperties.tsx
@@ -242,7 +242,6 @@ const PurchasingRFQProperties = () => {
           value={currentSupplierIds}
           inline={renderSuppliersInlinePreview}
           isReadOnly={isDisabled}
-          disabled={isDisabled}
           onChange={(selected) => {
             onUpdateSuppliers(selected);
           }}

--- a/apps/erp/app/modules/purchasing/ui/Supplier/SupplierForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/Supplier/SupplierForm.tsx
@@ -176,7 +176,7 @@ const SupplierForm = ({
                     name="supplierStatus"
                     label={t`Supplier Status`}
                     placeholder={t`Select Supplier Status`}
-                    disabled={supplierApprovalRequired}
+                    isReadOnly={supplierApprovalRequired}
                     termId="supplier-status"
                   />
                   <SupplierType

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderForm.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderForm.tsx
@@ -248,7 +248,7 @@ const SalesOrderForm = ({ initialValues }: SalesOrderFormProps) => {
                     }));
                   }
                 }}
-                disabled={initialValues.originatedFromQuote}
+                isReadOnly={initialValues.originatedFromQuote}
               />
 
               {isEditing &&

--- a/apps/erp/app/modules/settings/ui/Company/CompanyForm.tsx
+++ b/apps/erp/app/modules/settings/ui/Company/CompanyForm.tsx
@@ -79,7 +79,7 @@ const CompanyForm = ({ company }: CompanyFormProps) => {
             <Currency
               name="baseCurrencyCode"
               label={t`Base Currency`}
-              disabled={true}
+              isReadOnly
             />
             <Timezone name="timezone" label={t`Timezone`} />
             <PhoneInput

--- a/apps/erp/app/routes/x+/priority+/people.tsx
+++ b/apps/erp/app/routes/x+/priority+/people.tsx
@@ -12,7 +12,7 @@ import {
 } from "@internationalized/date";
 import { msg } from "@lingui/core/macro";
 import { useLocale } from "@react-aria/i18n";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { redirect, useLoaderData } from "react-router";
 import {
@@ -590,43 +590,45 @@ export default function SchedulePeopleRoute() {
     [weekAssignments, departmentId, displayedWorkCenterIds]
   );
 
-  // the department's own people (employeeJob) and the shift's own people
-  // (employeeShift), plus anyone already assigned — so a filter can never hide
-  // someone you actually scheduled
+  // The department filter never HIDES people from the roster — it floats the
+  // department's own people (employeeJob) to the top of the list and leaves
+  // everyone else in place below them (a stable partition), so the whole roster
+  // stays draggable. Only the shift filter still narrows the roster, and even
+  // then anyone already assigned stays visible so a filter can't hide someone
+  // you actually scheduled.
+  const orderDepartmentFirst = useCallback(
+    (list: typeof employees) =>
+      departmentId
+        ? [
+            ...list.filter(
+              (employee) => employeeDepartments[employee.id] === departmentId
+            ),
+            ...list.filter(
+              (employee) => employeeDepartments[employee.id] !== departmentId
+            )
+          ]
+        : list,
+    [departmentId, employeeDepartments]
+  );
+  const filterByShift = useCallback(
+    (list: typeof employees, assigned: Set<string>) =>
+      shiftId
+        ? list.filter(
+            (employee) =>
+              assigned.has(employee.id) ||
+              fitsShiftFilter(employee.id, shiftId, employeeShiftId)
+          )
+        : list,
+    [shiftId, employeeShiftId]
+  );
   const employeesForBoard = useMemo(() => {
-    if (!departmentId && !shiftId) return employees;
     const assigned = new Set(boardAssignments.map((a) => a.employeeId));
-    return employees.filter(
-      (employee) =>
-        assigned.has(employee.id) ||
-        ((!departmentId || employeeDepartments[employee.id] === departmentId) &&
-          fitsShiftFilter(employee.id, shiftId, employeeShiftId))
-    );
-  }, [
-    employees,
-    departmentId,
-    employeeDepartments,
-    boardAssignments,
-    shiftId,
-    employeeShiftId
-  ]);
+    return orderDepartmentFirst(filterByShift(employees, assigned));
+  }, [employees, boardAssignments, filterByShift, orderDepartmentFirst]);
   const employeesForMatrix = useMemo(() => {
-    if (!departmentId && !shiftId) return employees;
     const assigned = new Set(matrixAssignments.map((a) => a.employeeId));
-    return employees.filter(
-      (employee) =>
-        assigned.has(employee.id) ||
-        ((!departmentId || employeeDepartments[employee.id] === departmentId) &&
-          fitsShiftFilter(employee.id, shiftId, employeeShiftId))
-    );
-  }, [
-    employees,
-    departmentId,
-    employeeDepartments,
-    matrixAssignments,
-    shiftId,
-    employeeShiftId
-  ]);
+    return orderDepartmentFirst(filterByShift(employees, assigned));
+  }, [employees, matrixAssignments, filterByShift, orderDepartmentFirst]);
 
   const shortDate = (value: string) =>
     formatDate(value, { month: "short", day: "numeric" }, locale);
@@ -728,6 +730,8 @@ export default function SchedulePeopleRoute() {
             weekDates={weekDates}
             locationTimeZone={locationTimeZone}
             employees={employeesForMatrix}
+            departmentId={departmentId}
+            employeeDepartments={employeeDepartments}
             workCenters={displayedWorkCenters}
             assignments={matrixAssignments}
             absences={weekAbsences}

--- a/packages/react/src/Combobox.tsx
+++ b/packages/react/src/Combobox.tsx
@@ -67,7 +67,8 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
       filter,
       isClearable,
       isLoading,
-      isReadOnly,
+      isReadOnly: isReadOnlyProp,
+      disabled,
       placeholder,
       emptyMessage,
       onChange,
@@ -78,6 +79,10 @@ const Combobox = forwardRef<HTMLButtonElement, ComboboxProps>(
     ref
   ) => {
     const { t } = useLingui();
+    // Treat the native `disabled` prop as equivalent to `isReadOnly`. The type
+    // accepts `disabled` (it extends button props), so callers reasonably pass
+    // it — honor it instead of silently overwriting it below.
+    const isReadOnly = isReadOnlyProp || disabled;
     const [open, setOpen] = useState(false);
     const isInlinePreview = !!inline;
     const selectedOption = useMemo(

--- a/packages/react/src/CreateableCombobox.tsx
+++ b/packages/react/src/CreateableCombobox.tsx
@@ -119,7 +119,12 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
           </span>
         )}
 
-        <Popover open={open} onOpenChange={setOpen}>
+        {/* In inline mode the trigger is a non-button HStack, so its `disabled`
+            is inert — guard onOpenChange so no surface can open while read-only. */}
+        <Popover
+          open={open}
+          onOpenChange={(next) => setOpen(isReadOnly ? false : next)}
+        >
           <PopoverTrigger disabled={isReadOnly} asChild>
             {inline ? (
               <HStack>

--- a/packages/react/src/CreateableCombobox.tsx
+++ b/packages/react/src/CreateableCombobox.tsx
@@ -53,7 +53,8 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
       options,
       selected,
       isClearable,
-      isReadOnly,
+      isReadOnly: isReadOnlyProp,
+      disabled,
       placeholder,
       emptyMessage,
       onChange,
@@ -67,6 +68,9 @@ const CreatableCombobox = forwardRef<HTMLButtonElement, CreatableComboboxProps>(
     ref
   ) => {
     const { t } = useLingui();
+    // Treat the native `disabled` prop as equivalent to `isReadOnly` — the type
+    // accepts it (extends button props), so honor it rather than swallow it.
+    const isReadOnly = isReadOnlyProp || disabled;
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
 

--- a/packages/react/src/CreateableMultiSelect.tsx
+++ b/packages/react/src/CreateableMultiSelect.tsx
@@ -59,7 +59,8 @@ const CreatableMultiSelect = forwardRef<
       value,
       options,
       selected,
-      isReadOnly,
+      isReadOnly: isReadOnlyProp,
+      disabled,
       placeholder,
       emptyMessage,
       label,
@@ -77,6 +78,9 @@ const CreatableMultiSelect = forwardRef<
     ref
   ) => {
     const { t } = useLingui();
+    // Treat the native `disabled` prop as equivalent to `isReadOnly` — the type
+    // accepts it (extends button props), so honor it rather than swallow it.
+    const isReadOnly = isReadOnlyProp || disabled;
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
 

--- a/packages/react/src/CreateableMultiSelect.tsx
+++ b/packages/react/src/CreateableMultiSelect.tsx
@@ -111,14 +111,20 @@ const CreatableMultiSelect = forwardRef<
       >
         {isInlinePreview && Array.isArray(value) && value.length > 0 && (
           <span
-            className="flex flex-grow line-clamp-1 items-center cursor-pointer"
-            onClick={() => setOpen(true)}
+            className={cn(
+              "flex flex-grow line-clamp-1 items-center cursor-pointer",
+              isReadOnly && "cursor-default opacity-50"
+            )}
+            onClick={isReadOnly ? undefined : () => setOpen(true)}
           >
             {inline(value, options, maxPreview)}
           </span>
         )}
 
-        <Popover open={open} onOpenChange={setOpen}>
+        <Popover
+          open={open}
+          onOpenChange={(next) => setOpen(isReadOnly ? false : next)}
+        >
           <PopoverTrigger asChild>
             {inline ? (
               <IconButton
@@ -136,7 +142,9 @@ const CreatableMultiSelect = forwardRef<
                 }
                 ref={ref}
                 isDisabled={isReadOnly}
-                onClick={() => setOpen(true)}
+                onClick={() => {
+                  if (!isReadOnly) setOpen(true);
+                }}
               />
             ) : (
               <CommandTrigger

--- a/packages/react/src/MultiSelect.tsx
+++ b/packages/react/src/MultiSelect.tsx
@@ -51,7 +51,8 @@ const MultiSelect = forwardRef<HTMLButtonElement, MultiSelectProps>(
       size,
       value,
       options,
-      isReadOnly,
+      isReadOnly: isReadOnlyProp,
+      disabled,
       isClearable,
       placeholder,
       emptyMessage,
@@ -66,6 +67,9 @@ const MultiSelect = forwardRef<HTMLButtonElement, MultiSelectProps>(
     ref
   ) => {
     const { t } = useLingui();
+    // Treat the native `disabled` prop as equivalent to `isReadOnly` — the type
+    // accepts it (extends button props), so honor it rather than swallow it.
+    const isReadOnly = isReadOnlyProp || disabled;
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
 

--- a/packages/utils/src/themes.ts
+++ b/packages/utils/src/themes.ts
@@ -10,7 +10,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "220 4% 97%",
+        background: "220 4% 95%",
         foreground: "220 10% 3.9%",
         card: "0 0% 100%",
         "card-foreground": "220 10% 3.9%",
@@ -36,7 +36,7 @@ export const themes = [
       },
       dark: {
         // Vercel/Geist-inspired dark mode - pure black base
-        background: "0 6.8% 6.1%",
+        background: "0 6.8% 8.1%",
         foreground: "0 0% 93%",
         card: "0 10% 3.9%",
         "card-foreground": "0 0% 93%",
@@ -71,7 +71,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "0 4% 97%",
+        background: "0 4% 95%",
         foreground: "0 0% 3.9%",
         card: "0 0% 93%",
         "card-foreground": "0 0% 3.9%",
@@ -96,7 +96,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "20 6.8% 6.1%",
+        background: "20 6.8% 8.1%",
         foreground: "0 0% 98%",
         card: "0 10% 3.9%",
         "card-foreground": "0 0% 98%",
@@ -131,7 +131,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "0 4% 97%",
+        background: "0 4% 95%",
         foreground: "0 0% 3.9%",
         card: "0 0% 100%",
         "card-foreground": "0 0% 3.9%",
@@ -156,7 +156,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "0 6.8% 6.1%",
+        background: "0 6.8% 8.1%",
         foreground: "0 0% 98%",
         card: "0 10% 3.9%",
         "card-foreground": "0 0% 98%",
@@ -191,7 +191,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "17 4% 97%",
+        background: "17 4% 95%",
         foreground: "20 14.3% 4.1%",
         card: "0 0% 100%",
         "card-foreground": "20 14.3% 4.1%",
@@ -216,7 +216,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "20 6.8% 6.1%",
+        background: "20 6.8% 8.1%",
         foreground: "20 9.1% 97.8%",
         card: "20 10% 3.9%",
         "card-foreground": "60 9.1% 97.8%",
@@ -251,7 +251,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "47.9 4% 97%",
+        background: "47.9 4% 95%",
         foreground: "20 14.3% 4.1%",
         card: "0 0% 100%",
         "card-foreground": "20 14.3% 4.1%",
@@ -276,7 +276,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "61 6.8% 6.1%",
+        background: "61 6.8% 8.1%",
         foreground: "61 9.1% 97.8%",
         card: "61 10% 3.9%",
         "card-foreground": "61 9.1% 97.8%",
@@ -313,7 +313,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "171 4% 97%",
+        background: "171 4% 95%",
         foreground: "171 10% 3.9%",
         card: "0 0% 100%",
         "card-foreground": "171 10% 3.9%",
@@ -338,7 +338,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "171 6.8% 6.1%",
+        background: "171 6.8% 8.1%",
         foreground: "0 0% 95%",
         popover: "171 0% 9%",
         "popover-foreground": "171 0% 95%",
@@ -373,7 +373,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "237 4% 97%",
+        background: "237 4% 95%",
         foreground: "237 98% 4.9%",
         card: "0 0% 100%",
         "card-foreground": "237 98% 4.9%",
@@ -398,7 +398,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "220 6.8% 6.1%",
+        background: "220 6.8% 8.1%",
         foreground: "220 0% 95%",
         popover: "216 0% 9%",
         "popover-foreground": "220 0% 95%",
@@ -433,7 +433,7 @@ export const themes = [
     },
     cssVars: {
       light: {
-        background: "238 4% 97%",
+        background: "238 4% 95%",
         foreground: "224 71.4% 4.1%",
         card: "0 0% 100%",
         "card-foreground": "224 71.4% 4.1%",
@@ -458,7 +458,7 @@ export const themes = [
         "success-foreground": "0 0% 98%"
       },
       dark: {
-        background: "263 6.8% 3.1%",
+        background: "263 6.8% 8.1%",
         foreground: "263 20% 98%",
         card: "263 41.4 5%",
         "card-foreground": "210 20% 98%",


### PR DESCRIPTION
## What does this PR do?

Fixes a regression (from #741) where the base `Combobox`/`MultiSelect`/`CreatableCombobox`/`CreatableMultiSelect` overwrote any incoming `disabled` prop with `disabled={isReadOnly}` after spreading props, making per-field `disabled={...}` — and every form-selector wrapper that relied on it (e.g. `Currency`, `SupplierStatus`) — a silent no-op; the base layer now folds `disabled` into the read-only flag so it's honored for all callers, and the affected call sites (CompanyForm base currency, SalesOrderForm currency, SupplierForm status, PurchasingRFQ suppliers, OnShape pickers) were swapped to the idiomatic `isReadOnly`. Separately, it adjusts the `--background` lightness across all eight themes to 95% in light mode and 8.1% in dark mode, preserving each theme's hue and saturation.

- Fixes #XXXX (GitHub issue number)

## Visual Demo (For contributors especially)

_N/A — behavioral fix (fields that should be locked now actually lock) plus a small theme value change._

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Open **Settings → Company** and confirm the Base Currency field is now read-only; on a Sales Order originated from a quote confirm the currency is locked; on a Supplier requiring approval confirm the status field is locked. Toggle light/dark mode and confirm the app background reads at the new lightness across themes. `@carbon/react`, `@carbon/form`, `@carbon/utils`, and `erp` typecheck clean.

## Checklist

- My code doesn't follow the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Selection, multi-select, and read-only fields now consistently prevent unintended editing, clearing, or popover opening across purchasing, sales, supplier, company settings, and Onshape workflows.
  - Disabled controls now retain expected non-interactive behavior.

- **Improvements**
  - Production scheduling rosters now keep all employees visible while prioritizing people from the selected department; shift filters continue to narrow results.

- **Style**
  - Updated light and dark theme background colors across available themes.
  - Updated top-bar action buttons with a clearer outlined appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->