### PR TITLE
style(erp): soften Properties side-panel background to bg-background/30

### DIFF
--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceProperties.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceProperties.tsx
@@ -114,7 +114,7 @@ const PurchaseInvoiceProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceProperties.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceProperties.tsx
@@ -108,7 +108,7 @@ const SalesInvoiceProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeProperties.tsx
+++ b/apps/erp/app/modules/items/ui/ChangeNotice/ChangeNoticeProperties.tsx
@@ -135,7 +135,7 @@ const ChangeNoticeProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 flex-shrink-0 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 pt-2 pb-12 text-sm"
+      className="w-96 flex-shrink-0 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 pt-2 pb-12 text-sm"
     >
       {/* Release is triggered from the header button (opens this confirmation
           dialog via releaseDialogOpenAtom). The dialog is mounted here — headless

--- a/apps/erp/app/modules/items/ui/Consumables/ConsumableProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Consumables/ConsumableProperties.tsx
@@ -193,7 +193,7 @@ const ConsumableProperties = ({ data }: ConsumablePropertiesProps) => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/items/ui/Item/SelectedItemProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Item/SelectedItemProperties.tsx
@@ -70,7 +70,7 @@ export function SelectedItemProperties({
   const ready = d && d.itemId === selectedItemId;
   if (!ready || fetcher.state === "loading") {
     return (
-      <div className="flex w-96 items-center justify-center bg-background h-full border-l border-border">
+      <div className="flex w-96 items-center justify-center bg-background/30 h-full border-l border-border">
         <Spinner className="h-6 w-6" />
       </div>
     );

--- a/apps/erp/app/modules/items/ui/Materials/MaterialProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Materials/MaterialProperties.tsx
@@ -296,7 +296,7 @@ const MaterialProperties = ({ data }: MaterialPropertiesProps) => {
     <>
       <VStack
         spacing={4}
-        className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+        className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
       >
         <VStack spacing={2}>
           <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/items/ui/Parts/PartProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Parts/PartProperties.tsx
@@ -367,7 +367,7 @@ const PartProperties = ({
           : "flex flex-col items-start space-y-4",
         embedded
           ? "px-1 py-2"
-          : "w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2"
+          : "w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2"
       )}
     >
       {formLayout ? (

--- a/apps/erp/app/modules/items/ui/Services/ServiceProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Services/ServiceProperties.tsx
@@ -155,7 +155,7 @@ const ServiceProperties = ({ data }: ServicePropertiesProps) => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/items/ui/Tools/ToolProperties.tsx
+++ b/apps/erp/app/modules/items/ui/Tools/ToolProperties.tsx
@@ -206,7 +206,7 @@ const ToolProperties = ({ data }: ToolPropertiesProps) => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionProperties.tsx
+++ b/apps/erp/app/modules/production/ui/Assemblies/AssemblyInstructionProperties.tsx
@@ -145,7 +145,7 @@ const AssemblyInstructionProperties = ({
   return (
     <VStack
       spacing={0}
-      className="w-[450px] bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border text-sm"
+      className="w-[450px] bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border text-sm"
     >
       {/* Sticky panel header: which step you're editing, its status, and a
           one-glance summary (component count, flagged). */}

--- a/apps/erp/app/modules/production/ui/Jobs/JobProperties.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobProperties.tsx
@@ -186,7 +186,7 @@ const JobProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/production/ui/Procedures/ProcedureProperties.tsx
+++ b/apps/erp/app/modules/production/ui/Procedures/ProcedureProperties.tsx
@@ -75,7 +75,7 @@ const ProcedureProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-[450px] bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-[450px] bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderProperties.tsx
@@ -129,7 +129,7 @@ const PurchaseOrderProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchasingRfq/PurchasingRFQProperties.tsx
@@ -166,7 +166,7 @@ const PurchasingRFQProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteProperties.tsx
+++ b/apps/erp/app/modules/purchasing/ui/SupplierQuote/SupplierQuoteProperties.tsx
@@ -107,7 +107,7 @@ const SupplierQuoteProperties = () => {
     <VStack
       key={routeData?.quote?.id}
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/quality/ui/Documents/QualityDocumentProperties.tsx
+++ b/apps/erp/app/modules/quality/ui/Documents/QualityDocumentProperties.tsx
@@ -104,7 +104,7 @@ const QualityDocumentProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-[450px] bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-[450px] bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx
+++ b/apps/erp/app/modules/quality/ui/Issue/IssueProperties.tsx
@@ -156,7 +156,7 @@ const IssueProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchProperties.tsx
+++ b/apps/erp/app/modules/resources/ui/Maintenance/MaintenanceDispatchProperties.tsx
@@ -121,7 +121,7 @@ const MaintenanceDispatchProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/resources/ui/Training/TrainingProperties.tsx
+++ b/apps/erp/app/modules/resources/ui/Training/TrainingProperties.tsx
@@ -93,7 +93,7 @@ const TrainingProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-[450px] bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-[450px] bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={2}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteProperties.tsx
@@ -114,7 +114,7 @@ const QuoteProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesOrder/SalesOrderProperties.tsx
@@ -116,7 +116,7 @@ const SalesOrderProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">

--- a/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
+++ b/apps/erp/app/modules/sales/ui/SalesRFQ/SalesRFQProperties.tsx
@@ -102,7 +102,7 @@ const SalesRFQProperties = () => {
   return (
     <VStack
       spacing={4}
-      className="w-96 bg-background h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
+      className="w-96 bg-background/30 h-full overflow-y-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-accent border-l border-border px-4 py-2 text-sm"
     >
       <VStack spacing={4}>
         <HStack className="w-full justify-between">


### PR DESCRIPTION
## What does this PR do?

Softens the background of every entity Properties side panel in the ERP from the solid `bg-background` to `bg-background/30`, so the panel reads as a subtly recessed surface against the page rather than a flat opaque block. The change is applied consistently across all 22 Properties panels (Parts, Materials, Tools, Services, Consumables, Change Notices, Items, Jobs, Procedures, Assembly Instructions, Purchase/Sales Invoices, Purchase Orders, Purchasing/Supplier/Sales RFQs & Quotes, Sales Orders, Issues, Quality Documents, Training, and Maintenance Dispatch). The sticky-header backdrop in `AssemblyInstructionProperties` (`bg-background/95`) and the no-background embedded branch of `PartProperties` are intentionally left as-is.

## Visual Demo (For contributors especially)

CSS-only opacity tweak; no functional change.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Open any entity detail screen (e.g. a Part) and confirm the right-hand Properties panel renders with a lighter, semi-transparent background while remaining legible in both light and dark themes.

## Checklist

- My code follows the style guidelines of this project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated properties panels across invoicing, items, production, purchasing, quality, resources, and sales to use semi-transparent backgrounds.
  * Improved visual consistency and layering by allowing underlying content to show through panel backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->