### PR TITLE
docs: land on Architecture reference instead of Guides

### DIFF
--- a/docs/components/main-header.tsx
+++ b/docs/components/main-header.tsx
@@ -5,8 +5,8 @@ import { SearchCommand } from "./search/search-command";
 import { SiteLogo } from "./site-logo";
 
 const NAV = [
-  { key: "guides", label: "Guides", href: "/guides/order" },
   { key: "reference", label: "Reference", href: "/docs" },
+  { key: "guides", label: "Guides", href: "/guides/order" },
   { key: "api", label: "API", href: "/api-reference" },
   { key: "mcp", label: "MCP", href: "/mcp" },
 ] as const;

--- a/docs/components/mobile-nav.tsx
+++ b/docs/components/mobile-nav.tsx
@@ -25,8 +25,8 @@ import {
 import { createPortal } from "react-dom";
 
 const NAV = [
-  { key: "guides", label: "Guides", href: "/guides/order" },
   { key: "reference", label: "Reference", href: "/docs" },
+  { key: "guides", label: "Guides", href: "/guides/order" },
   { key: "api", label: "API", href: "/api-reference" },
   { key: "mcp", label: "MCP", href: "/mcp" },
 ] as const;

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -31,12 +31,12 @@ const config = {
     "*.ngrok.app",
     "*.ngrok.io",
   ],
-  // Serve the first guide at "/" without changing the URL — a server-side rewrite,
-  // not a client/redirect bounce. `beforeFiles` runs ahead of the app router so it
-  // takes precedence (app/page.tsx is removed).
+  // Serve the Architecture reference at "/" without changing the URL — a server-side
+  // rewrite, not a client/redirect bounce. `beforeFiles` runs ahead of the app router
+  // so it takes precedence (app/page.tsx is removed).
   async rewrites() {
     return {
-      beforeFiles: [{ source: "/", destination: "/guides/order" }],
+      beforeFiles: [{ source: "/", destination: "/docs/platform/architecture" }],
     };
   },
   // Deployment moved under Self-hosting as the "AWS with SST" recipe; keep the old


### PR DESCRIPTION
## What does this PR do?

Repoints the docs site's `/` server-side rewrite from `/guides/order` to `/docs/platform/architecture`, so the initial page a visitor lands on is the Architecture reference rather than the Guides. This is a rewrite (not a redirect), so the URL stays `/` while serving the Architecture content.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Run the docs app (`docs`) and visit `/` — it should render the Architecture reference page (`content/docs/platform/architecture.mdx`) with the URL remaining `/`.

## Checklist

- My code follows the style guidelines of this project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Navigation**
  - Reordered desktop and mobile navigation links so **Reference** appears before **Guides**.
  - Updated the site’s root page to open the **Architecture reference** instead of the first guide.

- **Documentation**
  - Improved the default documentation entry point, making Architecture content immediately accessible from the homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->