### PR TITLE
feat(accounting): import a chart of accounts from CSV with a review step

### DIFF
--- a/.ai/specs/2026-09-04-chart-of-accounts-import.md
+++ b/.ai/specs/2026-09-04-chart-of-accounts-import.md
@@ -162,7 +162,7 @@ type (`integration = xero | quickbooks | rillet`).
 - [x] The two system roots are never written; a file "Balance Sheet" adopts the root. (Planner test.)
 - [x] Deactivating an account referenced by `accountDefault` is refused per row. (Planner test.)
 - [x] The dry run and the commit produce the same plan. (Same planner call; browser counts matched.)
-- [x] Planner unit tests cover every structure mode, adoption, promotion, conflicts, cycles, class agreement, and resolutions. (`import-csv/account-import.test.ts`, 14 tests.)
+- [x] Planner unit tests cover every structure mode, adoption, promotion, conflicts, cycles, class agreement, and resolutions. (`import-csv/account-import.test.ts`, 17 tests.)
 
 ## Out of Scope
 
@@ -170,3 +170,64 @@ type (`integration = xero | quickbooks | rillet`).
 - Re-pointing `accountDefault` after an import (the review lists the seeded leaves still referenced; the Default Accounts page changes them).
 - Pulling a chart from a connected provider (Xero / QuickBooks / Rillet); the planner is written so a provider read can feed it later.
 - Excel files, non-comma delimiters, header rows below row 1 (wizard limits).
+
+## Feedback from the 2026-09-04 walkthrough
+
+Two lists: what applies to the shared CSV import wizard (noted, not
+implemented), and what is specific to the chart-of-accounts review step
+(implemented the same day).
+
+### General CSV upload feedback
+
+- Closing the wizard should ask for confirmation. The close (×), Escape and
+  the dev-server reload all discard the uploaded file, the column and value
+  mappings and, on the review step, every resolution the user has entered,
+  with no prompt. A "Discard this import?" confirmation once a file has been
+  uploaded, and ideally state that survives a reload, would stop work being
+  lost by a mis-click.
+- The modal has no vertical constraint. `ModalContent` sizes to its content
+  and `AnimatedSizeContainer` animates height with `overflow-hidden`, so a
+  tall step (an enum step with many values, the review table) pushes the
+  modal flush against the top of the viewport and the primary action
+  (Next / Confirm Import) below the fold; the page scrolls instead of the
+  modal body. Predates this branch. Candidate fix: cap `ModalContent` at
+  `max-h-[calc(100vh-4rem)]` with `ModalBody` as the scroll region, and stop
+  animating height when the content exceeds it.
+- Check that the modal's resize animation matches origin/main's import
+  window and the rest of the UI. Inherited from main: `ImportCSVModal`
+  already wrapped the wizard in `AnimatedSizeContainer height` (spring,
+  0.3 s), so the height animation between steps is not new. New on this
+  branch: the modal switches `size` from `medium` to `xxlarge` on entering a
+  review step and back on leaving it — a width jump main never does, and
+  `ModalContent`'s `max-w-*` change is not animated. Verify on main
+  (Customers → Bulk Import) and decide whether the width change should
+  animate, be a fixed wide modal for the whole wizard, or be dropped.
+- Horizontal scroll inside a modal should not be the design. The review
+  table (and `ImportResultsModal`, which uses the same `w-max min-w-full`
+  pattern) scrolls sideways when its columns exceed the modal width. In the
+  results modal it is tolerable because the columns are the user's own CSV;
+  in a review it hides the part that matters.
+- On first load the chart tree is blank for a few seconds: `window.env` is
+  injected differently on server and client (`root.tsx`), React reports a
+  hydration mismatch and re-renders the document on the client. Unrelated to
+  the import; noted because a click in that window hits an element that is
+  about to be replaced.
+
+### Chart of accounts specific feedback (implemented 2026-09-04)
+
+- Details clipping: each plan row is two lines — the account on the first,
+  the reason / changes and the resolution on the second, spanning the
+  table. The table is `table-fixed` at the modal's width, so nothing scrolls
+  sideways.
+- Batched resolutions: picks accumulate in the review's local state and
+  show as Pending; an "Update plan" action re-runs the dry run once with all
+  of them, and Confirm sends the same set. A Resolved / Pending badge and
+  Undo sit under each row.
+- Bulk number choice: "Use the file's numbers for N matching accounts" and
+  "Keep Carbon's numbers" act on every linkable conflict and every matched
+  row at once, and each reverses the other. Per row, an update that
+  renumbers offers "Keep Carbon's number" and "Leave this account as it is".
+  The planner gained the `keepNumber` resolution (also honoured as a
+  name-only match for a numbered row) and reports the matched account's
+  number and name so the badge can name it. Verified in the browser: keep →
+  27 updates / 7 unchanged / 0 attention; file's numbers → 34 updates.

--- a/.ai/specs/2026-09-04-chart-of-accounts-import.md
+++ b/.ai/specs/2026-09-04-chart-of-accounts-import.md
@@ -1,0 +1,172 @@
+# Chart of Accounts Import
+
+> Status: in-progress
+> Author: Raul Soonawala
+> Date: 2026-09-04
+
+## TLDR
+
+Bulk-load a chart of accounts from a CSV exported by another accounting system
+(QuickBooks, Xero, NetSuite, Sage, Business Central, Odoo, Rillet, or a
+hand-written sheet) through the existing CSV import wizard, mounted on the
+Chart of Accounts page. One new importer case (`account`) in the `import-csv`
+edge function builds the tree, matches each row to the existing chart, and
+either previews the plan (dry run) or commits it in one transaction. The wizard
+gains a per-table review step that runs the dry run, shows the resulting tree
+and every conflict, and lets the user resolve conflicts before committing.
+Additive only: the importer creates and updates accounts, never deletes.
+
+## Problem Statement
+
+Every company arrives with a chart of accounts. Today the only ways to get it
+into Carbon are one account at a time through the New Account / New Group
+forms, or a seeded default chart that rarely matches the customer's numbering.
+The CSV import system covers 21 tables but not `account`, and the Chart of
+Accounts page is a tree, not a `<Table>`, so it has no Bulk Import menu.
+
+What makes accounts harder than the existing imports:
+
+- `account` is scoped by `companyGroupId`, not `companyId`; the import payload
+  carries only `companyId`.
+- The chart is a tree. Parents may be referenced by number, by name, by a
+  colon-delimited path in the name (QuickBooks), or implied by Begin-Total /
+  End-Total rows (Business Central, Sage 50 Canada). Some exports have no
+  hierarchy at all (Xero, Sage 50 US, Odoo).
+- Leaves are keyed by `number` (unique per group); groups have `number = NULL`
+  and are keyed by `(name, isGroup)`. Nothing today keys on a number column.
+- `class` and `incomeBalance` are derived, not mapped, and must agree with the
+  parent; `accountType` is required on leaves only.
+- Two `isSystem` roots are frozen by trigger; a seeded chart already exists
+  and `accountDefault` points at ~45 of its leaves with RESTRICT foreign keys.
+- No DB guard exists for parent-is-group, same-group parent, or cycles.
+
+## Proposed Solution
+
+Reuse the whole import pipeline (upload, column mapping, enum mapping, route,
+service, edge dispatch, results modal) and add:
+
+1. `account` registration in `fieldMappings` / `importSchemas` /
+   `importPermissions` and the edge function's table enum.
+2. A pure planner (`import-csv/account-import.ts`) that turns mapped rows plus
+   the existing chart into a plan: one node per row (and per synthesized
+   group), each with an action `create | update | link | unchanged | skip |
+   error`, its resolved parent, class, type, and the reason for any refusal.
+3. A writer that applies a plan inside one Kysely transaction, parents first.
+4. A `dryRun` flag and an `options` object on the import payload; the account
+   case returns the plan when `dryRun` is set.
+5. A per-table review step in the wizard that runs the dry run, renders the
+   tree and the conflicts, and serialises structure choices and per-row
+   resolutions into the final submit.
+6. An Import action on the Chart of Accounts toolbar, gated on
+   `create: accounting` and on the current company being the root of its group.
+
+### Fields
+
+| Field | Label | Type | Notes |
+|---|---|---|---|
+| `number` | Account Number | string | optional; leaves without a number are keyed by name |
+| `name` | Account Name | string | required; may carry a path (`Parent:Child`) |
+| `accountType` | Account Type | enum (21) | required; aliases cover the source-system vocabularies |
+| `class` | Class | enum (5) | optional; derived from the type when absent; validated when present |
+| `parent` | Parent Account | string | number, `number name`, group name, or a grouping label |
+| `isGroup` | Is Group | boolean | Summary / header flag |
+| `rowKind` | Row Kind | enum | Account, Group, Total, Heading, Ignore — for Begin/End-Total exports |
+| `indent` | Indentation | number | places Heading rows |
+| `active` | Active | boolean | inverted automatically when the mapped column is named Inactive / Hidden / Deprecated / Blocked / Archived |
+| `externalId` | Source ID | string | stored in `externalIntegrationMapping` with `integration = "csv"` for re-import |
+
+`incomeBalance` and `consolidatedRate` are never mapped: `incomeBalance` follows
+`class`; `consolidatedRate` is Historical for Equity, Current for other
+balance-sheet accounts, Average for income-statement accounts (the seed rule).
+
+### Structure
+
+`options.structure` is `auto` (default), `file`, or `carbon`.
+
+- `file`: the hierarchy comes from the file. The signal used, in priority
+  order: Row Kind (stack of open groups), Parent Account (resolved by number,
+  `number name`, group name in the file or in Carbon, else a synthesized group
+  named by the label), path in the name split on `options.pathSeparator`
+  (default `:`). A row referenced as a parent is promoted to a group.
+- `carbon`: file hierarchy is ignored; each leaf is placed under the
+  shallowest active Carbon group with the same `accountType`, else the
+  class group (Expense prefers the group whose type matches the leaf, then
+  Operating Expenses), else the system root for its `incomeBalance`.
+- `auto`: `file` when any signal is present, else `carbon`.
+
+Top-level file groups adopt a Carbon group with the same name when the classes
+agree (a file "Assets" becomes Carbon's "Assets"); otherwise they hang under
+the class anchor.
+
+### Identity
+
+In order: an explicit `link` resolution, `externalId` via the csv mapping,
+`number` for leaves, `(name, isGroup)` for groups and for numberless leaves.
+A number match is an update even when the name differs. A name that is held
+by a different account of the same kind is a conflict.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Home | the shared CSV wizard, new `account` case | one import system; the wizard's enum step replaces a synonym table |
+| Scope | additive: create, update, link; never delete | delete is blocked by RESTRICT FKs, the posted-journal trigger and PO/invoice CHECKs for anything referenced |
+| companyGroupId | resolved in the edge function from `company.companyGroupId` | the payload contract stays `companyId`; matches `post-memo` |
+| Root company | required; edge function throws otherwise | RLS lets only root-company users write the chart; Kysely bypasses RLS |
+| Transaction | one, parents inserted by depth | the plan orders nodes, so no second pass is needed; uniques and roots are pre-checked per row so DB errors are not expected |
+| Class change | only when the account has no journal lines | stored amounts are sign-interpreted by class |
+| Cross-class re-parent | same rule as class change | it is a class change |
+| Deactivate | refused when referenced by `accountDefault`, `fixedAssetClass`, or a journal line | balances vanish from every RPC while postings continue; no reactivate UI exists |
+| Preview | `dryRun` on the same edge function; same planner | the plan the user reviews is the plan that commits |
+| Hierarchy parsing | edge function, not the wizard | the wizard maps one column to one field; a provider pull can reuse the normaliser |
+| Type vocabulary | option aliases on the 21 account types | auto-match stays exact-after-normalise and user-visible |
+| Group class | from the group's own class column, else the majority of its leaves; minority leaves error | Carbon requires class agreement with the parent |
+
+## Data Model Changes
+
+None. `externalIntegrationMapping` gains rows with `entityType = "account"`,
+`integration = "csv"`, alongside the accounting-sync rows for the same entity
+type (`integration = xero | quickbooks | rillet`).
+
+## API / Service Changes
+
+- `importCsvValidator` (edge): `dryRun?: boolean`, `options?: Record<string, unknown>`.
+- `importCsv` service: same two optional args; `enumMappings` type corrected to
+  `Record<string, Record<string, string>>`.
+- Route `x/shared/import/$tableId`: accepts `dryRun` and `options` (JSON string)
+  form fields; returns `plan` when the edge function returns one.
+- Edge response for `account`: `{ inserted, updated, errors, skipped, plan? }`.
+- `CsvEntityType` gains `"account"`; `fetchLiveEntityIds` gains its case.
+
+## UI Changes
+
+- `imports.models.ts`: field `aliases` (column-name aliases used by the exact
+  match before the LLM), `enumData.optionAliases`, `enumData.skipStepWhenUnmapped`.
+- `FieldMappings.tsx`: honours the three additions; renders a per-table review
+  step from `importReviewSteps` after the enum steps; widens the modal on it.
+- New `ImportCSVModal/ChartOfAccountsReview.tsx`: structure choice, dry-run
+  fetcher, tree preview, conflict table with per-row resolution
+  (skip / rename / renumber / use existing), hidden `options` input.
+- `ChartOfAccountsTableFilters.tsx` / `charts.tsx`: Import button opening
+  `ImportCSVModal` for `account`; clears the accounts query cache on close.
+- `UploadCSV.tsx`: template hint for `number` fields (was testing `"numeric"`).
+
+## Acceptance Criteria
+
+- [x] A Rillet-style export (Account Number, Account Name, Account Type, Account Subtype, Parent Grouping) imports with groups synthesized from Parent Grouping under the seeded class groups. (Browser, 2026-09-04: 4 groups + 15 accounts created, 1 renumbered in place.)
+- [ ] A QuickBooks Account List export (`Parent:Child` names, Type, Detail type) imports with the path split into groups.
+- [ ] A Xero export (Code, Name, Type) imports flat under Carbon's groups by type.
+- [ ] A Business Central export (No., Name, Account Type Begin-Total/End-Total, Indentation) imports with the stack hierarchy.
+- [x] Re-importing the same file reports every row unchanged. (Planner test; browser dry run.)
+- [x] A number that already exists updates the name; a name held by a different account of the same kind is reported with a resolution. (Planner test; browser: link and rename resolutions re-plan.)
+- [x] The two system roots are never written; a file "Balance Sheet" adopts the root. (Planner test.)
+- [x] Deactivating an account referenced by `accountDefault` is refused per row. (Planner test.)
+- [x] The dry run and the commit produce the same plan. (Same planner call; browser counts matched.)
+- [x] Planner unit tests cover every structure mode, adoption, promotion, conflicts, cycles, class agreement, and resolutions. (`import-csv/account-import.test.ts`, 14 tests.)
+
+## Out of Scope
+
+- Deleting accounts.
+- Re-pointing `accountDefault` after an import (the review lists the seeded leaves still referenced; the Default Accounts page changes them).
+- Pulling a chart from a connected provider (Xero / QuickBooks / Rillet); the planner is written so a provider read can feed it later.
+- Excel files, non-comma delimiters, header rows below row 1 (wizard limits).

--- a/.ai/specs/2026-09-04-chart-of-accounts-import.md
+++ b/.ai/specs/2026-09-04-chart-of-accounts-import.md
@@ -231,3 +231,13 @@ implemented), and what is specific to the chart-of-accounts review step
   name-only match for a numbered row) and reports the matched account's
   number and name so the badge can name it. Verified in the browser: keep →
   27 updates / 7 unchanged / 0 attention; file's numbers → 34 updates.
+- One screen at a time (afternoon follow-up): the step is either Preparing
+  (spinner, Confirm disabled — shown on entry and after every "Update
+  plan"), the hierarchy question (asked once when the file has none, or via
+  a "Change" link), or the plan. The plan screen is a one-line summary, the
+  hierarchy sentence, one decision box for matching accounts (the two bulk
+  buttons, the current choice shown active), the pending banner, the
+  attention rows, and a collapsed "Show all N rows". The structure radios,
+  count badges and All rows / Needs attention tabs are gone. "Loading" is
+  keyed on the plan inputs, not the fetcher, so the stale plan never shows
+  between a change and its request.

--- a/.claude/rules/csv-import-system.md
+++ b/.claude/rules/csv-import-system.md
@@ -26,13 +26,25 @@ a transaction. Imports are idempotent via the `externalIntegrationMapping` table
 
 - `ImportCSVModal.tsx` — modal orchestrating the wizard.
 - `UploadCSV.tsx` — drag-drop upload; PapaParse; uploads to `private` bucket (see path above).
-- `FieldMappings.tsx` — column/enum mapping UI; `enumMatch.ts` does fuzzy enum matching;
+- `FieldMappings.tsx` — column/enum mapping UI; `enumMatch.ts` matches enum values exactly
+  after lower-casing/trimming against each option's label and `aliases` (not fuzzy);
   `useCreateLookup.ts` creates missing lookup values inline.
+- `reviewSteps.ts` — per-table review steps rendered after the enum steps and inside the
+  import form (`account` → `ChartOfAccountsReview.tsx`); any hidden input a step renders
+  (e.g. `options`) travels with the final submit.
 - `useCsvContext.tsx` — shared state (`file`, `filePath`, `fileColumns`, `firstRows`).
 
-Mounted from exactly one place: `apps/erp/app/components/Table/components/TableHeader.tsx`
-(the Bulk Import dropdown). A list page opts in by passing `importCSV={[{ table, label }]}`
-to `<Table>` — that prop is the whole UI-side registration.
+Column matching runs in this order per field, first hit wins and a header is never
+claimed twice: `preferredAliases` (a finer column that should beat the label, e.g.
+QuickBooks "Detail type" over "Type"), the label, the field name, then `aliases`. Headers
+are lower-cased, trimmed and stripped of a leading `*` (Xero templates). Exact/alias
+matches survive the LLM pass — the model only fills fields left unmatched.
+
+Mounted from `apps/erp/app/components/Table/components/TableHeader.tsx` (the Bulk Import
+dropdown; a list page opts in by passing `importCSV={[{ table, label }]}` to `<Table>`) and
+from the Chart of Accounts toolbar (`ChartOfAccountsTableFilters.tsx` → `charts.tsx`), which
+is a tree, not a `<Table>`. `ImportCSVModal` takes only `{ table, onClose }`, so any page can
+mount it.
 
 ## Models (`apps/erp/app/modules/shared/imports.models.ts`)
 
@@ -45,12 +57,16 @@ Three exported maps, all keyed by table name:
     required: boolean;
     type: "string" | "boolean" | "number" | "enum";
     default?: string | number;
+    aliases?: string[];            // other systems' header names for this column
+    preferredAliases?: string[];   // headers that beat the label when both are present
     enumData?: {
       description?: string;
       fetcher?: (client, companyId) => Promise<...>;   // dynamic options
       creatableLookup?: "supplierType" | "customerType" | "customerStatus";
       creatableForm?: "paymentTerm" | "shippingMethod";
       options?: readonly string[];                      // static options
+      optionAliases?: Record<string, string[]>;         // other systems' names per option
+      skipStepWhenUnmapped?: boolean;                   // no wizard step if the column is unmapped
     };
   }
   ```
@@ -74,14 +90,58 @@ Other exports: `creatableLookups`, and types `CreatableLookup`, `CreatableForm`.
 `operations`, `partWithMethod`, `materialSubstance`, `materialForm`, `materialFinish`,
 `materialGrade`, `materialType`, `materialDimension` → `parts`;
 `workCenter`, `process` → `production`; `storageUnit` → `inventory`;
-`fixedAsset` → `accounting`.
+`fixedAsset`, `account` → `accounting`.
 
 The edge function's own `table` enum (`import-csv/index.ts`) accepts: `consumable`,
 `customer`, `customerContact`, `fixture`, `material`, `bom`, `operations`,
 `partWithMethod`, `part`, `supplier`, `supplierContact`, `tool`, `workCenter`,
 `process`, `storageUnit`, `materialSubstance`, `materialForm`, `materialFinish`,
-`materialGrade`, `materialType`, `materialDimension`. Note it does **not** list
+`materialGrade`, `materialType`, `materialDimension`, `account`. Note it does **not** list
 `fixedAsset` (see Gotchas).
+
+### Chart-of-accounts import (planner + review step)
+
+`account` is the only import whose target is a tree scoped by `companyGroupId`. It is
+handled by a pure planner (`import-csv/account-import.ts`, unit-tested with `deno test`)
+plus a writer (`account-import-writer.ts`), and the wizard gains a review step
+(`ChartOfAccountsReview.tsx`) that runs the same edge function with `dryRun: true` and
+renders the returned `plan` before the real submit. Spec:
+`.ai/specs/2026-09-04-chart-of-accounts-import.md`.
+
+- **Scope / auth.** The edge function resolves `companyGroupId` from `company` and
+  throws unless `company.parentCompanyId IS NULL` (RLS only lets a root company write the
+  chart; the Kysely path bypasses RLS). The toolbar button is gated the same way.
+- **Fields.** `number`, `name` (required), `accountType` (required enum, aliases for the
+  QuickBooks / Xero / NetSuite / Sage / Business Central / Odoo / Rillet vocabularies),
+  `class` (optional enum, derived from the type when absent), `parent`, `isGroup`,
+  `rowKind` (Account / Group / Total / Heading / Ignore, for Begin-Total / End-Total
+  exports), `indent`, `active` (inverted when the mapped header is Inactive / Hidden /
+  Deprecated / Blocked / Archived), `externalId`. `incomeBalance` and `consolidatedRate`
+  are derived from the class, never mapped.
+- **Structure** (`options.structure`: `auto` | `file` | `carbon`). `file` builds the tree
+  from, in priority order, Row Kind (a stack of open groups), the Parent column (number,
+  `number name`, group name in the file or in Carbon, else a synthesized group named by the
+  label), or a path in the name split on `options.pathSeparator` (`:`). A row referenced
+  as a parent is promoted to a group. `carbon` ignores file groups and places each leaf
+  under the shallowest active Carbon group with the same `accountType`, else the class
+  group (Expense prefers the group typed like the leaf, then Operating Expenses), else the
+  system root for its `incomeBalance`. A top-level file group named like a Carbon group of
+  the same class links to it instead of creating one.
+- **Identity**, in order: a `link` resolution, `externalId` via the csv mapping, `number`
+  for leaves, `(name, isGroup)` for groups and numberless leaves. A number match updates
+  (rename allowed); a name held by another account of the same kind is a conflict with a
+  `PlanConflict` the review turns into skip / rename / renumber / "same as existing".
+- **Refusals**, per row, never a 500: system roots (adopted as parents only), class change
+  or deactivation on an account with journal lines, deactivation of an
+  `accountDefault` / `fixedAssetClass` account, class disagreeing with the parent, a
+  parent that is not a group, cycles, in-file duplicates. Uniques are pre-checked so the
+  single transaction does not trip `account_number_key` / `account_name_key`.
+- **Write.** One transaction, nodes in plan order (parents first, ids generated up front),
+  then `upsertCsvMappings` for rows with a Source ID. Nothing is ever deleted.
+- **Payload additions** (all importers): `dryRun?: boolean` and
+  `options?: Record<string, unknown>` on `importCsvValidator`, the `importCsv` service and
+  the route (`dryRun` / `options` form fields, `options` as a JSON string); the route
+  returns `plan` when the edge function does.
 
 ### Storage-unit import (natural-key match + two-pass parent linking)
 
@@ -198,3 +258,6 @@ See `.claude/rules/accounting-sync-handlers.md` for the full `externalIntegratio
   is the only authorization gate.
 - Row-level failures are returned in `errors[]` with `{ row, reason }`; only a thrown
   exception produces a 500.
+- The wizard's modal widens (`xxlarge`) while a review step is showing; the wrapper div in
+  `ImportCSVModal.tsx` carries `min-w-0` so a wide table scrolls inside the modal instead
+  of pushing past it.

--- a/.claude/rules/csv-import-system.md
+++ b/.claude/rules/csv-import-system.md
@@ -137,6 +137,11 @@ renders the returned `plan` before the real submit. Spec:
   "Update plan" (or the final submit, which sends the pending set as `options`) re-runs the
   dry run. The two bulk buttons set `link` / `link + keepNumber` on every linkable conflict
   and toggle `keepNumber` on every matched row without dropping the row's link.
+- **Review screens.** `ChartOfAccountsReview` shows one screen at a time: preparing (the
+  dry run is running, or the plan on hand is for stale inputs — `plannedKey !== inputsKey`),
+  the hierarchy question (`StructureScreen`, once when `plan.structure === "carbon"` under
+  `auto`, or via "Change"), or the plan. `ReviewStepProps.onReadyChange` tells `FieldMappings`
+  to disable Confirm while the step is not on the plan screen.
 - **Refusals**, per row, never a 500: system roots (adopted as parents only), class change
   or deactivation on an account with journal lines, deactivation of an
   `accountDefault` / `fixedAssetClass` account, class disagreeing with the parent, a

--- a/.claude/rules/csv-import-system.md
+++ b/.claude/rules/csv-import-system.md
@@ -128,9 +128,15 @@ renders the returned `plan` before the real submit. Spec:
   system root for its `incomeBalance`. A top-level file group named like a Carbon group of
   the same class links to it instead of creating one.
 - **Identity**, in order: a `link` resolution, `externalId` via the csv mapping, `number`
-  for leaves, `(name, isGroup)` for groups and numberless leaves. A number match updates
-  (rename allowed); a name held by another account of the same kind is a conflict with a
-  `PlanConflict` the review turns into skip / rename / renumber / "same as existing".
+  for leaves, `(name, isGroup)` for groups, numberless leaves, and leaves whose resolution
+  is `keepNumber`. A number match updates (rename allowed); a name held by another account
+  of the same kind is a conflict with a `PlanConflict` the review turns into skip / rename /
+  renumber / `link` ("same as existing", `keepNumber` to leave Carbon's number). A resolved
+  node reports `existingId` / `existingNumber` / `existingName`.
+- **Review batching.** Resolutions accumulate in the review's `pending` state; only
+  "Update plan" (or the final submit, which sends the pending set as `options`) re-runs the
+  dry run. The two bulk buttons set `link` / `link + keepNumber` on every linkable conflict
+  and toggle `keepNumber` on every matched row without dropping the row's link.
 - **Refusals**, per row, never a 500: system roots (adopted as parents only), class change
   or deactivation on an account with journal lines, deactivation of an
   `accountDefault` / `fixedAssetClass` account, class disagreeing with the parent, a

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -148,6 +148,28 @@ export function ChartOfAccountsReview({
 
   const attention = plan?.nodes.filter((n) => n.action === "error") ?? [];
   const rows = bucket === "attention" ? attention : (plan?.nodes ?? []);
+  // Rows whose only problem is a name already used by a same-kind account in
+  // Carbon — usually the same account (Accounts Receivable, Retained Earnings,
+  // the variance accounts) under the customer's own number.
+  const mergeable = attention.filter(
+    (n) =>
+      n.row !== null &&
+      n.conflict?.linkable &&
+      resolutions[String(n.row)] === undefined
+  );
+  const mergeAll = () =>
+    setResolutions((prev) => {
+      const next = { ...prev };
+      for (const n of mergeable) {
+        if (n.row !== null && n.conflict) {
+          next[String(n.row)] = {
+            action: "link",
+            accountId: n.conflict.existingId
+          };
+        }
+      }
+      return next;
+    });
 
   const setResolution = (row: number, resolution: Resolution | null) => {
     setResolutions((prev) => {
@@ -267,12 +289,21 @@ export function ChartOfAccountsReview({
       )}
 
       {plan && plan.summary.errors > 0 && (
-        <p className="text-sm text-muted-foreground">
-          <Trans>
-            Rows that need attention are not imported. Resolve them here, fix
-            the file, or import the rest now and the remainder later.
-          </Trans>
-        </p>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">
+            <Trans>
+              Rows that need attention are not imported. Resolve them here, fix
+              the file, or import the rest now and the remainder later.
+            </Trans>
+          </p>
+          {mergeable.length > 0 && (
+            <Button variant="secondary" size="sm" onClick={mergeAll}>
+              <Trans>
+                Treat {mergeable.length} same-name matches as the same account
+              </Trans>
+            </Button>
+          )}
+        </div>
       )}
 
       {plan && (

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -10,10 +10,7 @@ import {
   Input,
   RadioGroup,
   RadioGroupItem,
-  Spinner,
-  Tabs,
-  TabsList,
-  TabsTrigger
+  Spinner
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
@@ -86,6 +83,8 @@ type Resolutions = Record<string, Resolution>;
 
 type Structure = "auto" | "file" | "carbon";
 
+type MatchedNode = PlanNode & { row: number };
+
 const actionVariant: Record<
   PlanAction,
   "green" | "blue" | "gray" | "outline" | "yellow" | "red"
@@ -101,12 +100,19 @@ const actionVariant: Record<
 const changesNumber = (node: PlanNode) =>
   node.changes?.some((c) => c.startsWith("number:")) ?? false;
 
+const keepsNumber = (r: Resolution | undefined) =>
+  r?.action === "keepNumber" || (r?.action === "link" && !!r.keepNumber);
+
+// The step shows one screen at a time: the plan being built, the hierarchy
+// question (asked once when the file has none, or on request), or the plan.
+type Screen = "preparing" | "structure" | "review";
+
 export function ChartOfAccountsReview({
   table,
   columnMappings,
-  enumMappings
+  enumMappings,
+  onReadyChange
 }: ReviewStepProps) {
-  const { t } = useLingui();
   const { filePath } = useCsvContext();
   const fetcher = useFetcher<typeof action>();
   const fetcherRef = useRef(fetcher);
@@ -120,7 +126,9 @@ export function ChartOfAccountsReview({
   // always carries `pending`.
   const [pending, setPending] = useState<Resolutions>({});
   const [applied, setApplied] = useState<Resolutions>({});
-  const [bucket, setBucket] = useState<"attention" | "all">("all");
+  const [asking, setAsking] = useState(false);
+  const [askedOnce, setAskedOnce] = useState(false);
+  const [showAll, setShowAll] = useState(false);
 
   const pendingJson = JSON.stringify(pending);
   const appliedJson = JSON.stringify(applied);
@@ -131,6 +139,19 @@ export function ChartOfAccountsReview({
   );
   const columnMappingsJson = JSON.stringify(columnMappings);
   const enumMappingsJson = JSON.stringify(enumMappings);
+  // Everything the plan depends on. The plan on screen is stale until the
+  // fetcher has answered for the current key, which is what "loading" means
+  // here — not merely whether a request is in flight.
+  const inputsKey = JSON.stringify([
+    filePath,
+    columnMappingsJson,
+    enumMappingsJson,
+    structure,
+    pathSeparator,
+    appliedJson
+  ]);
+  const submittedKey = useRef<string | null>(null);
+  const [plannedKey, setPlannedKey] = useState<string | null>(null);
 
   // Plan on entry, when the structure choice changes, and when the user
   // applies their pending resolutions. Same route and edge function as the
@@ -138,6 +159,7 @@ export function ChartOfAccountsReview({
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the serialised inputs
   useEffect(() => {
     if (!filePath) return;
+    submittedKey.current = inputsKey;
     const formData = new FormData();
     formData.set("filePath", filePath);
     for (const [field, column] of Object.entries(columnMappings)) {
@@ -153,15 +175,13 @@ export function ChartOfAccountsReview({
       method: "post",
       action: path.to.import(table)
     });
-  }, [
-    filePath,
-    columnMappingsJson,
-    enumMappingsJson,
-    structure,
-    pathSeparator,
-    appliedJson,
-    table
-  ]);
+  }, [inputsKey, table]);
+
+  useEffect(() => {
+    if (fetcher.state === "idle" && fetcher.data) {
+      setPlannedKey(submittedKey.current);
+    }
+  }, [fetcher.state, fetcher.data]);
 
   const plan =
     fetcher.data?.success && "plan" in fetcher.data
@@ -171,29 +191,52 @@ export function ChartOfAccountsReview({
     fetcher.data && fetcher.data.success === false
       ? fetcher.data.message
       : undefined;
-  const loading = fetcher.state !== "idle";
+  const loading =
+    fetcher.state !== "idle" || (!!filePath && plannedKey !== inputsKey);
+
+  // A file with no hierarchy is placed under Carbon's groups; say so once and
+  // let the user override before they see the plan.
+  const noHierarchy =
+    !!plan && structure === "auto" && plan.structure === "carbon";
+  const screen: Screen = loading
+    ? "preparing"
+    : asking || (noHierarchy && !askedOnce)
+      ? "structure"
+      : "review";
+
+  useEffect(() => {
+    onReadyChange?.(screen === "review" && !!plan);
+  }, [screen, plan, onReadyChange]);
+
+  const commitStructure = (next: Structure, separator: string) => {
+    setAsking(false);
+    setAskedOnce(true);
+    // Choosing Carbon's groups for a file that has no hierarchy is what the
+    // current plan already did; no need to build it again.
+    if (next === "carbon" && noHierarchy) return;
+    setStructure(next);
+    setPathSeparator(separator);
+  };
 
   const attention = plan?.nodes.filter((n) => n.action === "error") ?? [];
-  const rows = bucket === "attention" ? attention : (plan?.nodes ?? []);
 
   // Rows whose only problem is a name already used by a same-kind account in
   // Carbon — usually the same account (Accounts Receivable, Retained Earnings,
   // the variance accounts) under the customer's own number.
   const linkable = attention.filter(
-    (n): n is PlanNode & { row: number; conflict: PlanConflict } =>
+    (n): n is MatchedNode & { conflict: PlanConflict } =>
       n.row !== null && !!n.conflict?.linkable
   );
   // Matched accounts the plan would renumber to the file's number, plus those
   // already told to keep Carbon's, so either bulk choice can be reversed.
-  const keepsNumber = (r: Resolution | undefined) =>
-    r?.action === "keepNumber" || (r?.action === "link" && !!r.keepNumber);
   const renumbering = (plan?.nodes ?? []).filter(
-    (n): n is PlanNode & { row: number } =>
+    (n): n is MatchedNode =>
       n.row !== null &&
       n.action !== "error" &&
       n.action !== "skip" &&
       (changesNumber(n) || keepsNumber(applied[String(n.row)]))
   );
+  const matching: MatchedNode[] = [...linkable, ...renumbering];
 
   const setResolution = (row: number, resolution: Resolution | null) =>
     setPending((prev) => {
@@ -238,23 +281,393 @@ export function ChartOfAccountsReview({
       }
       return next;
     });
-  const useFileNumbers = () => setNumbers(false);
-  const keepCarbonNumbers = () => setNumbers(true);
-  const matchingCount = linkable.length + renumbering.length;
+
+  // What the pending choices say about each matching account.
+  const choice = (n: MatchedNode) => {
+    const r = pending[String(n.row)];
+    if (keepsNumber(r)) return "keep";
+    if (r?.action === "link" || (!r && changesNumber(n))) return "file";
+    return null;
+  };
+  const keepCount = matching.filter((n) => choice(n) === "keep").length;
+  const fileCount = matching.filter((n) => choice(n) === "file").length;
+  const undecided = linkable.filter((n) => !pending[String(n.row)]).length;
 
   const pendingCount = Object.keys(pending).filter(
     (row) => JSON.stringify(pending[row]) !== JSON.stringify(applied[row])
   ).length;
   const updatePlan = () => setApplied(pending);
 
-  // Attention rows get a Tabs default once the first plan arrives.
-  const firstPlan = useRef(true);
-  useEffect(() => {
-    if (plan && firstPlan.current) {
-      firstPlan.current = false;
-      if (plan.summary.errors > 0) setBucket("attention");
-    }
-  }, [plan]);
+  const summary = useSummary(plan);
+
+  return (
+    <div className="flex min-w-0 flex-col gap-4">
+      <input type="hidden" name="options" value={submitOptionsJson} />
+
+      {screen === "preparing" && (
+        <div className="flex flex-col items-center justify-center gap-3 py-16 text-sm text-muted-foreground">
+          <Spinner className="h-6 w-6" />
+          <span>
+            {plan ? (
+              <Trans>Updating the plan…</Trans>
+            ) : (
+              <Trans>Checking the file against your chart of accounts…</Trans>
+            )}
+          </span>
+        </div>
+      )}
+
+      {screen === "structure" && (
+        <StructureScreen
+          structure={structure}
+          pathSeparator={pathSeparator}
+          noHierarchy={noHierarchy}
+          canCancel={asking}
+          onCancel={() => setAsking(false)}
+          onContinue={commitStructure}
+        />
+      )}
+
+      {screen === "review" && (
+        <>
+          {failure && (
+            <Alert variant="destructive">
+              <LuTriangleAlert className="h-4 w-4" />
+              <AlertTitle>
+                <Trans>The plan could not be built</Trans>
+              </AlertTitle>
+              <AlertDescription>{failure}</AlertDescription>
+            </Alert>
+          )}
+
+          {plan && (
+            <>
+              <div className="flex flex-col gap-1 text-sm">
+                <p>
+                  {summary.length > 0 ? (
+                    summary.join(" · ")
+                  ) : (
+                    <Trans>Nothing to import.</Trans>
+                  )}
+                </p>
+                <p className="text-muted-foreground">
+                  {plan.structure === "file" ? (
+                    plan.signal === "path" ? (
+                      <Trans>
+                        Hierarchy taken from the paths in the account names.
+                      </Trans>
+                    ) : plan.signal === "parent" ? (
+                      <Trans>
+                        Hierarchy taken from the file's parent column.
+                      </Trans>
+                    ) : (
+                      <Trans>
+                        Hierarchy taken from the file's Begin-Total / End-Total
+                        rows.
+                      </Trans>
+                    )
+                  ) : (
+                    <Trans>
+                      No hierarchy in the file: accounts are placed under
+                      Carbon's existing groups by account type.
+                    </Trans>
+                  )}{" "}
+                  <Button
+                    variant="link"
+                    size="sm"
+                    className="h-auto px-0"
+                    onClick={() => setAsking(true)}
+                  >
+                    <Trans>Change</Trans>
+                  </Button>
+                </p>
+              </div>
+
+              {plan.warnings.map((warning) => (
+                <Alert key={warning} variant="warning">
+                  <LuTriangleAlert className="h-4 w-4" />
+                  <AlertDescription>{warning}</AlertDescription>
+                </Alert>
+              ))}
+
+              {matching.length > 0 && (
+                <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-muted/40 p-3 text-sm">
+                  <span className="text-pretty">
+                    {undecided > 0 ? (
+                      <Trans>
+                        {undecided} accounts already exist in Carbon under other
+                        numbers.
+                      </Trans>
+                    ) : keepCount === matching.length ? (
+                      <Trans>
+                        {keepCount} matching accounts keep their Carbon numbers.
+                      </Trans>
+                    ) : fileCount === matching.length ? (
+                      <Trans>
+                        {fileCount} matching accounts take the file's numbers.
+                      </Trans>
+                    ) : (
+                      <Trans>
+                        {matching.length} matching accounts: {fileCount} take
+                        the file's numbers, {keepCount} keep Carbon's.
+                      </Trans>
+                    )}
+                  </span>
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      variant={
+                        fileCount === matching.length ? "active" : "secondary"
+                      }
+                      size="sm"
+                      onClick={() => setNumbers(false)}
+                    >
+                      <Trans>Use the file's numbers</Trans>
+                    </Button>
+                    <Button
+                      variant={
+                        keepCount === matching.length ? "active" : "secondary"
+                      }
+                      size="sm"
+                      onClick={() => setNumbers(true)}
+                    >
+                      <Trans>Keep Carbon's numbers</Trans>
+                    </Button>
+                  </div>
+                </div>
+              )}
+
+              {dirty && (
+                <Alert variant="info">
+                  <LuRefreshCw className="h-4 w-4" />
+                  <AlertTitle>
+                    <Trans>
+                      {pendingCount} decision(s) not in the plan yet
+                    </Trans>
+                  </AlertTitle>
+                  <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+                    <span>
+                      <Trans>
+                        Update the plan to see the result. Confirming the import
+                        applies them all.
+                      </Trans>
+                    </span>
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      leftIcon={<LuRefreshCw />}
+                      onClick={updatePlan}
+                    >
+                      <Trans>Update plan</Trans>
+                    </Button>
+                  </AlertDescription>
+                </Alert>
+              )}
+
+              {attention.length > 0 && (
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Trans>Needs attention</Trans>
+                    <Count count={attention.length} />
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    <Trans>
+                      These rows are not imported until they are resolved;
+                      everything else imports on confirm.
+                    </Trans>
+                  </p>
+                  <PlanTable
+                    rows={attention}
+                    pending={pending}
+                    applied={applied}
+                    onResolve={setResolution}
+                  />
+                </div>
+              )}
+
+              <div className="flex flex-col gap-2">
+                <Button
+                  variant="link"
+                  size="sm"
+                  className="h-auto self-start px-0"
+                  onClick={() => setShowAll((v) => !v)}
+                >
+                  {showAll ? (
+                    <Trans>Hide the full list</Trans>
+                  ) : (
+                    <Trans>Show all {plan.nodes.length} rows</Trans>
+                  )}
+                </Button>
+                {showAll && (
+                  <PlanTable
+                    rows={plan.nodes}
+                    pending={pending}
+                    applied={applied}
+                    onResolve={setResolution}
+                  />
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// One phrase per non-zero count. A hook so the Lingui macro sees `t` from
+// useLingui() in the same scope.
+function useSummary(plan: ImportPlan | undefined): string[] {
+  const { t } = useLingui();
+  if (!plan) return [];
+  const s = plan.summary;
+  const parts: string[] = [];
+  if (s.groupsToCreate > 0 || s.accountsToCreate > 0) {
+    parts.push(
+      s.groupsToCreate > 0
+        ? t`${s.groupsToCreate} groups and ${s.accountsToCreate} accounts to create`
+        : t`${s.accountsToCreate} accounts to create`
+    );
+  }
+  if (s.updates > 0) parts.push(t`${s.updates} to update`);
+  if (s.linked > 0) parts.push(t`${s.linked} merged into existing`);
+  if (s.unchanged > 0) parts.push(t`${s.unchanged} unchanged`);
+  if (s.skipped > 0) parts.push(t`${s.skipped} skipped`);
+  if (s.errors > 0) parts.push(t`${s.errors} need attention`);
+  return parts;
+}
+
+// Asks how the accounts should be organised. Local draft; committed on
+// Continue so a look at the options never rebuilds the plan by itself.
+function StructureScreen({
+  structure,
+  pathSeparator,
+  noHierarchy,
+  canCancel,
+  onCancel,
+  onContinue
+}: {
+  structure: Structure;
+  pathSeparator: string;
+  noHierarchy: boolean;
+  canCancel: boolean;
+  onCancel: () => void;
+  onContinue: (structure: Structure, pathSeparator: string) => void;
+}) {
+  const { t } = useLingui();
+  const [draft, setDraft] = useState<Structure>(
+    noHierarchy && structure === "auto" ? "carbon" : structure
+  );
+  const [separator, setSeparator] = useState(pathSeparator);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <div className="text-sm font-medium">
+          <Trans>How should the accounts be organised?</Trans>
+        </div>
+        {noHierarchy && (
+          <p className="text-sm text-muted-foreground">
+            <Trans>
+              No parent column, row kinds, or paths in the names were found in
+              the file.
+            </Trans>
+          </p>
+        )}
+      </div>
+      <RadioGroup
+        value={draft}
+        onValueChange={(value) => setDraft(value as Structure)}
+        className="flex flex-col gap-3"
+      >
+        {!noHierarchy && (
+          <StructureOption
+            value="auto"
+            label={t`Detect from the file`}
+            description={t`Use the file's parent column, name paths, or total rows when present.`}
+          />
+        )}
+        <StructureOption
+          value="file"
+          label={t`Use the hierarchy in the file`}
+          description={
+            noHierarchy
+              ? t`Split the account names on a separator, e.g. Parent:Child.`
+              : t`Groups come from the file. A top-level group with the same name as a Carbon group is merged into it.`
+          }
+        />
+        <StructureOption
+          value="carbon"
+          label={t`Place accounts under Carbon's existing groups`}
+          description={t`Ignore the file's groups; each account goes under the Carbon group that matches its account type.`}
+        />
+      </RadioGroup>
+      {draft !== "carbon" && (
+        <label className="flex items-center gap-3 text-sm text-muted-foreground">
+          <span>
+            <Trans>Path separator in account names</Trans>
+          </span>
+          <Input
+            size="sm"
+            className="w-16"
+            value={separator}
+            onChange={(e) => setSeparator(e.target.value)}
+          />
+        </label>
+      )}
+      <div className="flex gap-2">
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => onContinue(draft, separator)}
+        >
+          <Trans>Continue</Trans>
+        </Button>
+        {canCancel && (
+          <Button variant="secondary" size="sm" onClick={onCancel}>
+            <Trans>Cancel</Trans>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StructureOption({
+  value,
+  label,
+  description
+}: {
+  value: Structure;
+  label: string;
+  description: string;
+}) {
+  const id = `coa-structure-${value}`;
+  return (
+    <div className="flex items-start gap-3">
+      <RadioGroupItem value={value} id={id} className="mt-0.5" />
+      <label htmlFor={id} className="flex cursor-pointer flex-col">
+        <span className="text-sm">{label}</span>
+        <span className="text-xs text-muted-foreground">{description}</span>
+      </label>
+    </div>
+  );
+}
+
+// The plan rows. Each node is a main row plus, when there is something to
+// say, a detail row under the account name holding the reason / changes and
+// the resolution, full width, so nothing needs a sideways scroll.
+function PlanTable({
+  rows,
+  pending,
+  applied,
+  onResolve
+}: {
+  rows: PlanNode[];
+  pending: Resolutions;
+  applied: Resolutions;
+  onResolve: (row: number, resolution: Resolution | null) => void;
+}) {
+  const { t } = useLingui();
 
   const describe = (node: PlanNode, resolution: Resolution): string => {
     switch (resolution.action) {
@@ -282,399 +695,205 @@ export function ChartOfAccountsReview({
   };
 
   return (
-    <div className="flex min-w-0 flex-col gap-4">
-      <input type="hidden" name="options" value={submitOptionsJson} />
-
-      <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/40 p-4">
-        <div className="text-sm font-medium">
-          <Trans>How should the accounts be organised?</Trans>
-        </div>
-        <RadioGroup
-          value={structure}
-          onValueChange={(value) => setStructure(value as Structure)}
-          className="flex flex-col gap-2"
-        >
-          <StructureOption
-            value="auto"
-            label={t`Detect from the file`}
-            description={
-              plan
-                ? plan.structure === "file"
-                  ? plan.signal === "path"
-                    ? t`Found a path in the account names, e.g. Parent:Child.`
-                    : plan.signal === "parent"
-                      ? t`Found a parent column.`
-                      : t`Found Begin-Total / End-Total rows.`
-                  : t`No hierarchy in the file; accounts go under Carbon's existing groups by account type.`
-                : t`Use the file's parent column, name paths, or total rows when present.`
-            }
-          />
-          <StructureOption
-            value="file"
-            label={t`Use the hierarchy in the file`}
-            description={t`Groups come from the file. A top-level group with the same name as a Carbon group is merged into it.`}
-          />
-          <StructureOption
-            value="carbon"
-            label={t`Place accounts under Carbon's existing groups`}
-            description={t`Ignore the file's groups; each account goes under the Carbon group that matches its account type.`}
-          />
-        </RadioGroup>
-        {structure !== "carbon" && (
-          <label className="flex items-center gap-3 text-sm text-muted-foreground">
-            <span>
-              <Trans>Path separator in account names</Trans>
-            </span>
-            <Input
-              size="sm"
-              className="w-16"
-              value={pathSeparator}
-              onChange={(e) => setPathSeparator(e.target.value)}
-            />
-          </label>
-        )}
-      </div>
-
-      {failure && (
-        <Alert variant="destructive">
-          <LuTriangleAlert className="h-4 w-4" />
-          <AlertTitle>
-            <Trans>The plan could not be built</Trans>
-          </AlertTitle>
-          <AlertDescription>{failure}</AlertDescription>
-        </Alert>
-      )}
-
-      {plan?.warnings.map((warning) => (
-        <Alert key={warning} variant="warning">
-          <LuTriangleAlert className="h-4 w-4" />
-          <AlertDescription>{warning}</AlertDescription>
-        </Alert>
-      ))}
-
-      {plan && (
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <Badge variant="green">
-            <Trans>
-              {plan.summary.groupsToCreate} groups,{" "}
-              {plan.summary.accountsToCreate} accounts to create
-            </Trans>
-          </Badge>
-          <Badge variant="blue">
-            <Trans>{plan.summary.updates} to update</Trans>
-          </Badge>
-          <Badge variant="outline">
-            <Trans>{plan.summary.linked} merged into existing</Trans>
-          </Badge>
-          <Badge variant="gray">
-            <Trans>
-              {plan.summary.unchanged} unchanged, {plan.summary.skipped} skipped
-            </Trans>
-          </Badge>
-          {plan.summary.errors > 0 && (
-            <Badge variant="red">
-              <Trans>{plan.summary.errors} need attention</Trans>
-            </Badge>
-          )}
-          {loading && <Spinner className="h-4 w-4" />}
-        </div>
-      )}
-
-      {plan && (matchingCount > 0 || plan.summary.errors > 0) && (
-        <div className="flex flex-wrap items-start justify-between gap-3">
-          <p className="max-w-prose text-sm text-muted-foreground">
-            {plan.summary.errors > 0 ? (
-              <Trans>
-                Rows that need attention are not imported. Resolve them here,
-                fix the file, or import the rest now and the remainder later.
-              </Trans>
-            ) : (
-              <Trans>
-                Matching accounts are updated in place; choose whose numbers
-                they keep.
-              </Trans>
-            )}
-          </p>
-          {matchingCount > 0 && (
-            <div className="flex flex-wrap gap-2">
-              <Button variant="secondary" size="sm" onClick={useFileNumbers}>
-                <Trans>
-                  Use the file's numbers for {matchingCount} matching accounts
-                </Trans>
-              </Button>
-              <Button variant="secondary" size="sm" onClick={keepCarbonNumbers}>
-                <Trans>Keep Carbon's numbers</Trans>
-              </Button>
-            </div>
-          )}
-        </div>
-      )}
-
-      {dirty && (
-        <Alert variant="info">
-          <LuRefreshCw className="h-4 w-4" />
-          <AlertTitle>
-            <Trans>{pendingCount} change(s) not yet in the plan</Trans>
-          </AlertTitle>
-          <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
-            <span>
-              <Trans>
-                Keep resolving rows, then update the plan to see the result.
-                Confirming the import applies them all.
-              </Trans>
-            </span>
-            <Button
-              variant="primary"
-              size="sm"
-              leftIcon={<LuRefreshCw />}
-              isLoading={loading}
-              onClick={updatePlan}
-            >
-              <Trans>Update plan</Trans>
-            </Button>
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {plan && (
-        <>
-          <Tabs
-            value={bucket}
-            onValueChange={(value) => setBucket(value as "attention" | "all")}
-          >
-            <TabsList>
-              <TabsTrigger value="all" className="gap-1.5">
-                <Trans>All rows</Trans>
-                <Count count={plan.nodes.length} />
-              </TabsTrigger>
-              <TabsTrigger value="attention" className="gap-1.5">
-                <Trans>Needs attention</Trans>
-                <Count count={attention.length} />
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
-
-          <div
-            className={cn(
-              "w-full min-w-0 max-h-[420px] overflow-y-auto rounded-md border border-border",
-              loading && "opacity-60"
-            )}
-          >
-            <table className="w-full table-fixed border-collapse text-sm">
-              <colgroup>
-                <col className="w-14" />
-                <col className="w-28" />
-                <col className="w-24" />
-                <col />
-                <col className="w-48" />
-                <col className="w-44" />
-              </colgroup>
-              <thead className="sticky top-0 z-20 bg-card">
-                <tr className="border-b border-border text-left text-muted-foreground">
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Line</Trans>
-                  </th>
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Action</Trans>
-                  </th>
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Number</Trans>
-                  </th>
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Account</Trans>
-                  </th>
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Under</Trans>
-                  </th>
-                  <th className="whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Type</Trans>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((node) => {
-                  const resolution =
-                    node.row === null ? undefined : pending[String(node.row)];
-                  const resolutionDirty =
-                    node.row !== null &&
-                    JSON.stringify(pending[String(node.row)]) !==
-                      JSON.stringify(applied[String(node.row)]);
-                  const detail =
-                    node.action === "error" || node.action === "skip"
-                      ? node.reason
-                      : node.changes?.join("; ");
-                  const hasDetail =
-                    !!detail || node.action === "update" || !!resolution;
-                  return (
-                    <Fragment key={node.key}>
-                      <tr
-                        className={cn(
-                          hasDetail ? "border-0" : "border-b border-border",
-                          node.action === "error" && "bg-destructive/5"
-                        )}
-                      >
-                        <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
-                          {node.row === null ? "—" : node.row + 2}
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-2 align-top">
-                          <ActionBadge action={node.action} />
-                        </td>
-                        <td className="whitespace-nowrap px-3 py-2 align-top">
-                          {node.number ?? ""}
-                        </td>
-                        <td className="min-w-0 px-3 py-2 align-top">
-                          <div
-                            className="flex min-w-0 items-center gap-1.5"
-                            style={{ paddingLeft: `${node.depth * 16}px` }}
-                          >
-                            {node.kind === "group" && (
-                              <LuFolder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                            )}
-                            <span className="truncate" title={node.name}>
-                              {node.name}
-                            </span>
-                            {node.promoted && (
-                              <span className="shrink-0 text-xs text-muted-foreground">
-                                <Trans>(group)</Trans>
-                              </span>
-                            )}
-                          </div>
-                        </td>
-                        <td
-                          className="truncate px-3 py-2 align-top text-muted-foreground"
-                          title={node.parentLabel ?? node.anchorLabel ?? ""}
-                        >
-                          {node.parentLabel ?? node.anchorLabel ?? ""}
-                        </td>
-                        <td
-                          className="truncate px-3 py-2 align-top text-muted-foreground"
-                          title={node.accountType ?? node.class ?? ""}
-                        >
-                          {node.accountType ?? node.class ?? ""}
-                        </td>
-                      </tr>
-                      {hasDetail && (
-                        <tr
-                          className={cn(
-                            "border-b border-border",
-                            node.action === "error" && "bg-destructive/5"
-                          )}
-                        >
-                          <td colSpan={2} />
-                          {/* The reason and the resolution sit under the
-                              account name, full width, so nothing needs a
-                              sideways scroll. */}
-                          <td colSpan={4} className="px-3 pb-3 pt-0 align-top">
-                            <div className="flex flex-col gap-2">
-                              {detail && (
-                                <p
-                                  className={cn(
-                                    "text-pretty text-sm",
-                                    node.action === "error"
-                                      ? "text-destructive"
-                                      : "text-muted-foreground"
-                                  )}
-                                >
-                                  {detail}
-                                </p>
-                              )}
-                              {resolution && (
-                                <div className="flex flex-wrap items-center gap-2 text-sm">
-                                  <Badge
-                                    variant={
-                                      resolutionDirty ? "yellow" : "outline"
-                                    }
-                                  >
-                                    {resolutionDirty ? (
-                                      <Trans>Pending</Trans>
-                                    ) : (
-                                      <Trans>Resolved</Trans>
-                                    )}
-                                  </Badge>
-                                  <span>{describe(node, resolution)}</span>
-                                  <Button
-                                    variant="link"
-                                    size="sm"
-                                    className="h-auto px-0"
-                                    onClick={() =>
-                                      setResolution(node.row as number, null)
-                                    }
-                                  >
-                                    <Trans>Undo</Trans>
-                                  </Button>
-                                </div>
-                              )}
-                              {!resolution &&
-                                node.action === "error" &&
-                                node.row !== null && (
-                                  <ResolutionPicker
-                                    node={node}
-                                    onChange={(r) =>
-                                      setResolution(node.row as number, r)
-                                    }
-                                  />
-                                )}
-                              {!resolution &&
-                                node.action === "update" &&
-                                node.row !== null && (
-                                  <div className="flex flex-wrap gap-3">
-                                    {changesNumber(node) && (
-                                      <Button
-                                        variant="link"
-                                        size="sm"
-                                        className="h-auto px-0"
-                                        onClick={() =>
-                                          setResolution(node.row as number, {
-                                            action: "keepNumber"
-                                          })
-                                        }
-                                      >
-                                        <Trans>Keep Carbon's number</Trans>
-                                      </Button>
-                                    )}
-                                    <Button
-                                      variant="link"
-                                      size="sm"
-                                      className="h-auto px-0"
-                                      onClick={() =>
-                                        setResolution(node.row as number, {
-                                          action: "skip"
-                                        })
-                                      }
-                                    >
-                                      <Trans>Leave this account as it is</Trans>
-                                    </Button>
-                                  </div>
-                                )}
-                            </div>
-                          </td>
-                        </tr>
-                      )}
-                    </Fragment>
-                  );
-                })}
-                {rows.length === 0 && (
-                  <tr>
-                    <td
-                      colSpan={6}
-                      className="px-3 py-8 text-center text-muted-foreground"
+    <div className="w-full min-w-0 max-h-[420px] overflow-y-auto rounded-md border border-border">
+      <table className="w-full table-fixed border-collapse text-sm">
+        <colgroup>
+          <col className="w-14" />
+          <col className="w-28" />
+          <col className="w-24" />
+          <col />
+          <col className="w-48" />
+          <col className="w-44" />
+        </colgroup>
+        <thead className="sticky top-0 z-20 bg-card">
+          <tr className="border-b border-border text-left text-muted-foreground">
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Line</Trans>
+            </th>
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Action</Trans>
+            </th>
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Number</Trans>
+            </th>
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Account</Trans>
+            </th>
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Under</Trans>
+            </th>
+            <th className="whitespace-nowrap px-3 py-2 font-medium">
+              <Trans>Type</Trans>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((node) => {
+            const resolution =
+              node.row === null ? undefined : pending[String(node.row)];
+            const resolutionDirty =
+              node.row !== null &&
+              JSON.stringify(pending[String(node.row)]) !==
+                JSON.stringify(applied[String(node.row)]);
+            const detail =
+              node.action === "error" || node.action === "skip"
+                ? node.reason
+                : node.changes?.join("; ");
+            const hasDetail =
+              !!detail || node.action === "update" || !!resolution;
+            return (
+              <Fragment key={node.key}>
+                <tr
+                  className={cn(
+                    hasDetail ? "border-0" : "border-b border-border",
+                    node.action === "error" && "bg-destructive/5"
+                  )}
+                >
+                  <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                    {node.row === null ? "—" : node.row + 2}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 align-top">
+                    <ActionBadge action={node.action} />
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2 align-top">
+                    {node.number ?? ""}
+                  </td>
+                  <td className="min-w-0 px-3 py-2 align-top">
+                    <div
+                      className="flex min-w-0 items-center gap-1.5"
+                      style={{ paddingLeft: `${node.depth * 16}px` }}
                     >
-                      <Trans>No rows here.</Trans>
+                      {node.kind === "group" && (
+                        <LuFolder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      )}
+                      <span className="truncate" title={node.name}>
+                        {node.name}
+                      </span>
+                      {node.promoted && (
+                        <span className="shrink-0 text-xs text-muted-foreground">
+                          <Trans>(group)</Trans>
+                        </span>
+                      )}
+                    </div>
+                  </td>
+                  <td
+                    className="truncate px-3 py-2 align-top text-muted-foreground"
+                    title={node.parentLabel ?? node.anchorLabel ?? ""}
+                  >
+                    {node.parentLabel ?? node.anchorLabel ?? ""}
+                  </td>
+                  <td
+                    className="truncate px-3 py-2 align-top text-muted-foreground"
+                    title={node.accountType ?? node.class ?? ""}
+                  >
+                    {node.accountType ?? node.class ?? ""}
+                  </td>
+                </tr>
+                {hasDetail && (
+                  <tr
+                    className={cn(
+                      "border-b border-border",
+                      node.action === "error" && "bg-destructive/5"
+                    )}
+                  >
+                    <td colSpan={2} />
+                    <td colSpan={4} className="px-3 pb-3 pt-0 align-top">
+                      <div className="flex flex-col gap-2">
+                        {detail && (
+                          <p
+                            className={cn(
+                              "text-pretty text-sm",
+                              node.action === "error"
+                                ? "text-destructive"
+                                : "text-muted-foreground"
+                            )}
+                          >
+                            {detail}
+                          </p>
+                        )}
+                        {resolution && (
+                          <div className="flex flex-wrap items-center gap-2 text-sm">
+                            <Badge
+                              variant={resolutionDirty ? "yellow" : "outline"}
+                            >
+                              {resolutionDirty ? (
+                                <Trans>Pending</Trans>
+                              ) : (
+                                <Trans>Resolved</Trans>
+                              )}
+                            </Badge>
+                            <span>{describe(node, resolution)}</span>
+                            <Button
+                              variant="link"
+                              size="sm"
+                              className="h-auto px-0"
+                              onClick={() =>
+                                onResolve(node.row as number, null)
+                              }
+                            >
+                              <Trans>Undo</Trans>
+                            </Button>
+                          </div>
+                        )}
+                        {!resolution &&
+                          node.action === "error" &&
+                          node.row !== null && (
+                            <ResolutionPicker
+                              node={node}
+                              onChange={(r) => onResolve(node.row as number, r)}
+                            />
+                          )}
+                        {!resolution &&
+                          node.action === "update" &&
+                          node.row !== null && (
+                            <div className="flex flex-wrap gap-3">
+                              {changesNumber(node) && (
+                                <Button
+                                  variant="link"
+                                  size="sm"
+                                  className="h-auto px-0"
+                                  onClick={() =>
+                                    onResolve(node.row as number, {
+                                      action: "keepNumber"
+                                    })
+                                  }
+                                >
+                                  <Trans>Keep Carbon's number</Trans>
+                                </Button>
+                              )}
+                              <Button
+                                variant="link"
+                                size="sm"
+                                className="h-auto px-0"
+                                onClick={() =>
+                                  onResolve(node.row as number, {
+                                    action: "skip"
+                                  })
+                                }
+                              >
+                                <Trans>Leave this account as it is</Trans>
+                              </Button>
+                            </div>
+                          )}
+                      </div>
                     </td>
                   </tr>
                 )}
-              </tbody>
-            </table>
-          </div>
-        </>
-      )}
-
-      {!plan && !failure && (
-        <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
-          <Spinner className="h-4 w-4" />
-          <Trans>Building the plan…</Trans>
-        </div>
-      )}
+              </Fragment>
+            );
+          })}
+          {rows.length === 0 && (
+            <tr>
+              <td
+                colSpan={6}
+                className="px-3 py-8 text-center text-muted-foreground"
+              >
+                <Trans>No rows here.</Trans>
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
     </div>
   );
 }
@@ -692,27 +911,6 @@ function ActionBadge({ action }: { action: PlanAction }) {
     error: t`Attention`
   };
   return <Badge variant={actionVariant[action]}>{label[action]}</Badge>;
-}
-
-function StructureOption({
-  value,
-  label,
-  description
-}: {
-  value: Structure;
-  label: string;
-  description: string;
-}) {
-  const id = `coa-structure-${value}`;
-  return (
-    <div className="flex items-start gap-3">
-      <RadioGroupItem value={value} id={id} className="mt-0.5" />
-      <label htmlFor={id} className="flex cursor-pointer flex-col">
-        <span className="text-sm">{label}</span>
-        <span className="text-xs text-muted-foreground">{description}</span>
-      </label>
-    </div>
-  );
 }
 
 // Picks a resolution for a flagged row. The choice is recorded as pending;

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -429,8 +429,8 @@ export function ChartOfAccountsReview({
                       />
                     ) : (
                       <Trans>
-                        {matching.length} matching accounts: {fileCount} take
-                        the file's numbers, {keepCount} keep Carbon's.
+                        Matching accounts: {matching.length}. File's numbers:{" "}
+                        {fileCount}, Carbon's numbers: {keepCount}.
                       </Trans>
                     )}
                   </span>

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -356,7 +356,6 @@ export function ChartOfAccountsReview({
                 <p>
                   {summary.length > 0 ? (
                     summary.map((part, i) => (
-                      // biome-ignore lint/suspicious/noArrayIndexKey: fixed order
                       <Fragment key={i}>
                         {i > 0 && " · "}
                         {part}

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -12,8 +12,15 @@ import {
   RadioGroupItem,
   Spinner
 } from "@carbon/react";
-import { Trans, useLingui } from "@lingui/react/macro";
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Plural, Trans, useLingui } from "@lingui/react/macro";
+import {
+  Fragment,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import { LuFolder, LuRefreshCw, LuTriangleAlert } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import type { action } from "~/routes/x+/shared+/import.$tableId";
@@ -293,12 +300,15 @@ export function ChartOfAccountsReview({
   const fileCount = matching.filter((n) => choice(n) === "file").length;
   const undecided = linkable.filter((n) => !pending[String(n.row)]).length;
 
-  const pendingCount = Object.keys(pending).filter(
+  // Keys from both sides: an undone resolution is a change too.
+  const pendingCount = [
+    ...new Set([...Object.keys(pending), ...Object.keys(applied)])
+  ].filter(
     (row) => JSON.stringify(pending[row]) !== JSON.stringify(applied[row])
   ).length;
   const updatePlan = () => setApplied(pending);
 
-  const summary = useSummary(plan);
+  const summary = plan ? summarise(plan) : [];
 
   return (
     <div className="flex min-w-0 flex-col gap-4">
@@ -345,7 +355,13 @@ export function ChartOfAccountsReview({
               <div className="flex flex-col gap-1 text-sm">
                 <p>
                   {summary.length > 0 ? (
-                    summary.join(" · ")
+                    summary.map((part, i) => (
+                      // biome-ignore lint/suspicious/noArrayIndexKey: fixed order
+                      <Fragment key={i}>
+                        {i > 0 && " · "}
+                        {part}
+                      </Fragment>
+                    ))
                   ) : (
                     <Trans>Nothing to import.</Trans>
                   )}
@@ -394,18 +410,23 @@ export function ChartOfAccountsReview({
                 <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-muted/40 p-3 text-sm">
                   <span className="text-pretty">
                     {undecided > 0 ? (
-                      <Trans>
-                        {undecided} accounts already exist in Carbon under other
-                        numbers.
-                      </Trans>
+                      <Plural
+                        value={undecided}
+                        one="# account already exists in Carbon under another number."
+                        other="# accounts already exist in Carbon under other numbers."
+                      />
                     ) : keepCount === matching.length ? (
-                      <Trans>
-                        {keepCount} matching accounts keep their Carbon numbers.
-                      </Trans>
+                      <Plural
+                        value={keepCount}
+                        one="# matching account keeps its Carbon number."
+                        other="# matching accounts keep their Carbon numbers."
+                      />
                     ) : fileCount === matching.length ? (
-                      <Trans>
-                        {fileCount} matching accounts take the file's numbers.
-                      </Trans>
+                      <Plural
+                        value={fileCount}
+                        one="# matching account takes the file's number."
+                        other="# matching accounts take the file's numbers."
+                      />
                     ) : (
                       <Trans>
                         {matching.length} matching accounts: {fileCount} take
@@ -440,9 +461,11 @@ export function ChartOfAccountsReview({
                 <Alert variant="info">
                   <LuRefreshCw className="h-4 w-4" />
                   <AlertTitle>
-                    <Trans>
-                      {pendingCount} decision(s) not in the plan yet
-                    </Trans>
+                    <Plural
+                      value={pendingCount}
+                      one="# decision not in the plan yet"
+                      other="# decisions not in the plan yet"
+                    />
                   </AlertTitle>
                   <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
                     <span>
@@ -494,7 +517,11 @@ export function ChartOfAccountsReview({
                   {showAll ? (
                     <Trans>Hide the full list</Trans>
                   ) : (
-                    <Trans>Show all {plan.nodes.length} rows</Trans>
+                    <Plural
+                      value={plan.nodes.length}
+                      one="Show the only row"
+                      other="Show all # rows"
+                    />
                   )}
                 </Button>
                 {showAll && (
@@ -514,25 +541,68 @@ export function ChartOfAccountsReview({
   );
 }
 
-// One phrase per non-zero count. A hook so the Lingui macro sees `t` from
-// useLingui() in the same scope.
-function useSummary(plan: ImportPlan | undefined): string[] {
-  const { t } = useLingui();
-  if (!plan) return [];
+// One phrase per non-zero count, each with its own plural form.
+function summarise(plan: ImportPlan): ReactNode[] {
   const s = plan.summary;
-  const parts: string[] = [];
-  if (s.groupsToCreate > 0 || s.accountsToCreate > 0) {
+  const parts: ReactNode[] = [];
+  if (s.groupsToCreate > 0) {
     parts.push(
-      s.groupsToCreate > 0
-        ? t`${s.groupsToCreate} groups and ${s.accountsToCreate} accounts to create`
-        : t`${s.accountsToCreate} accounts to create`
+      <Trans>
+        <Plural value={s.groupsToCreate} one="# group" other="# groups" /> and{" "}
+        <Plural value={s.accountsToCreate} one="# account" other="# accounts" />{" "}
+        to create
+      </Trans>
+    );
+  } else if (s.accountsToCreate > 0) {
+    parts.push(
+      <Plural
+        value={s.accountsToCreate}
+        one="# account to create"
+        other="# accounts to create"
+      />
     );
   }
-  if (s.updates > 0) parts.push(t`${s.updates} to update`);
-  if (s.linked > 0) parts.push(t`${s.linked} merged into existing`);
-  if (s.unchanged > 0) parts.push(t`${s.unchanged} unchanged`);
-  if (s.skipped > 0) parts.push(t`${s.skipped} skipped`);
-  if (s.errors > 0) parts.push(t`${s.errors} need attention`);
+  if (s.updates > 0) {
+    parts.push(
+      <Plural
+        value={s.updates}
+        one="# account to update"
+        other="# accounts to update"
+      />
+    );
+  }
+  if (s.linked > 0) {
+    parts.push(
+      <Plural
+        value={s.linked}
+        one="# account merged into an existing one"
+        other="# accounts merged into existing ones"
+      />
+    );
+  }
+  if (s.unchanged > 0) {
+    parts.push(
+      <Plural
+        value={s.unchanged}
+        one="# account unchanged"
+        other="# accounts unchanged"
+      />
+    );
+  }
+  if (s.skipped > 0) {
+    parts.push(
+      <Plural value={s.skipped} one="# row skipped" other="# rows skipped" />
+    );
+  }
+  if (s.errors > 0) {
+    parts.push(
+      <Plural
+        value={s.errors}
+        one="# row needs attention"
+        other="# rows need attention"
+      />
+    );
+  }
   return parts;
 }
 

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -1,0 +1,579 @@
+import { Combobox } from "@carbon/form";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Badge,
+  Button,
+  Count,
+  cn,
+  Input,
+  RadioGroup,
+  RadioGroupItem,
+  Spinner,
+  Tabs,
+  TabsList,
+  TabsTrigger
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { LuFolder, LuTriangleAlert } from "react-icons/lu";
+import { useFetcher } from "react-router";
+import type { action } from "~/routes/x+/shared+/import.$tableId";
+import { path } from "~/utils/path";
+import type { ReviewStepProps } from "./reviewSteps";
+import { useCsvContext } from "./useCsvContext";
+
+// Mirrors the plan the import-csv edge function returns for `account`
+// (packages/database/supabase/functions/import-csv/account-import.ts).
+type PlanAction = "create" | "update" | "link" | "unchanged" | "skip" | "error";
+
+type PlanConflict = {
+  existingId: string;
+  number: string | null;
+  name: string;
+  kind: "group" | "account";
+  linkable: boolean;
+};
+
+type PlanNode = {
+  key: string;
+  row: number | null;
+  reportRow: number;
+  kind: "group" | "account";
+  action: PlanAction;
+  reason?: string;
+  changes?: string[];
+  number: string | null;
+  name: string;
+  class: string | null;
+  accountType: string | null;
+  parentLabel: string | null;
+  anchorLabel: string | null;
+  depth: number;
+  conflict?: PlanConflict;
+  promoted?: boolean;
+  synthesized?: boolean;
+};
+
+type ImportPlan = {
+  structure: "file" | "carbon";
+  signal: "rowKind" | "parent" | "path" | null;
+  nodes: PlanNode[];
+  warnings: string[];
+  summary: {
+    groupsToCreate: number;
+    accountsToCreate: number;
+    updates: number;
+    linked: number;
+    unchanged: number;
+    skipped: number;
+    errors: number;
+  };
+};
+
+type Resolution =
+  | { action: "skip" }
+  | { action: "rename"; name: string }
+  | { action: "renumber"; number: string }
+  | { action: "link"; accountId: string };
+
+type Structure = "auto" | "file" | "carbon";
+
+const actionVariant: Record<
+  PlanAction,
+  "green" | "blue" | "gray" | "outline" | "yellow" | "red"
+> = {
+  create: "green",
+  update: "blue",
+  link: "outline",
+  unchanged: "gray",
+  skip: "gray",
+  error: "red"
+};
+
+export function ChartOfAccountsReview({
+  table,
+  columnMappings,
+  enumMappings
+}: ReviewStepProps) {
+  const { t } = useLingui();
+  const { filePath } = useCsvContext();
+  const fetcher = useFetcher<typeof action>();
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const [structure, setStructure] = useState<Structure>("auto");
+  const [pathSeparator, setPathSeparator] = useState(":");
+  const [resolutions, setResolutions] = useState<Record<string, Resolution>>(
+    {}
+  );
+  const [bucket, setBucket] = useState<"attention" | "all">("all");
+
+  const optionsJson = useMemo(
+    () => JSON.stringify({ structure, pathSeparator, resolutions }),
+    [structure, pathSeparator, resolutions]
+  );
+  const columnMappingsJson = JSON.stringify(columnMappings);
+  const enumMappingsJson = JSON.stringify(enumMappings);
+
+  // Re-plan whenever the inputs change. The dry run goes through the same
+  // route and edge function as the real import, minus the write.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the serialised inputs
+  useEffect(() => {
+    if (!filePath) return;
+    const formData = new FormData();
+    formData.set("filePath", filePath);
+    for (const [field, column] of Object.entries(columnMappings)) {
+      formData.set(field, column);
+    }
+    formData.set("enumMappings", enumMappingsJson);
+    formData.set("dryRun", "true");
+    formData.set("options", optionsJson);
+    fetcherRef.current.submit(formData, {
+      method: "post",
+      action: path.to.import(table)
+    });
+  }, [filePath, columnMappingsJson, enumMappingsJson, optionsJson, table]);
+
+  const plan =
+    fetcher.data?.success && "plan" in fetcher.data
+      ? (fetcher.data.plan as ImportPlan | undefined)
+      : undefined;
+  const failure =
+    fetcher.data && fetcher.data.success === false
+      ? fetcher.data.message
+      : undefined;
+  const loading = fetcher.state !== "idle";
+
+  const attention = plan?.nodes.filter((n) => n.action === "error") ?? [];
+  const rows = bucket === "attention" ? attention : (plan?.nodes ?? []);
+
+  const setResolution = (row: number, resolution: Resolution | null) => {
+    setResolutions((prev) => {
+      const next = { ...prev };
+      if (resolution) next[String(row)] = resolution;
+      else delete next[String(row)];
+      return next;
+    });
+  };
+
+  // Attention rows get a Tabs default once the first plan arrives.
+  const firstPlan = useRef(true);
+  useEffect(() => {
+    if (plan && firstPlan.current) {
+      firstPlan.current = false;
+      if (plan.summary.errors > 0) setBucket("attention");
+    }
+  }, [plan]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input type="hidden" name="options" value={optionsJson} />
+
+      <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/40 p-4">
+        <div className="text-sm font-medium">
+          <Trans>How should the accounts be organised?</Trans>
+        </div>
+        <RadioGroup
+          value={structure}
+          onValueChange={(value) => setStructure(value as Structure)}
+          className="flex flex-col gap-2"
+        >
+          <StructureOption
+            value="auto"
+            label={t`Detect from the file`}
+            description={
+              plan
+                ? plan.structure === "file"
+                  ? plan.signal === "path"
+                    ? t`Found a path in the account names, e.g. Parent:Child.`
+                    : plan.signal === "parent"
+                      ? t`Found a parent column.`
+                      : t`Found Begin-Total / End-Total rows.`
+                  : t`No hierarchy in the file; accounts go under Carbon's existing groups by account type.`
+                : t`Use the file's parent column, name paths, or total rows when present.`
+            }
+          />
+          <StructureOption
+            value="file"
+            label={t`Use the hierarchy in the file`}
+            description={t`Groups come from the file. A top-level group with the same name as a Carbon group is merged into it.`}
+          />
+          <StructureOption
+            value="carbon"
+            label={t`Place accounts under Carbon's existing groups`}
+            description={t`Ignore the file's groups; each account goes under the Carbon group that matches its account type.`}
+          />
+        </RadioGroup>
+        {structure !== "carbon" && (
+          <label className="flex items-center gap-3 text-sm text-muted-foreground">
+            <span>
+              <Trans>Path separator in account names</Trans>
+            </span>
+            <Input
+              size="sm"
+              className="w-16"
+              value={pathSeparator}
+              onChange={(e) => setPathSeparator(e.target.value)}
+            />
+          </label>
+        )}
+      </div>
+
+      {failure && (
+        <Alert variant="destructive">
+          <LuTriangleAlert className="h-4 w-4" />
+          <AlertTitle>
+            <Trans>The plan could not be built</Trans>
+          </AlertTitle>
+          <AlertDescription>{failure}</AlertDescription>
+        </Alert>
+      )}
+
+      {plan?.warnings.map((warning) => (
+        <Alert key={warning} variant="warning">
+          <LuTriangleAlert className="h-4 w-4" />
+          <AlertDescription>{warning}</AlertDescription>
+        </Alert>
+      ))}
+
+      {plan && (
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <Badge variant="green">
+            <Trans>
+              {plan.summary.groupsToCreate} groups,{" "}
+              {plan.summary.accountsToCreate} accounts to create
+            </Trans>
+          </Badge>
+          <Badge variant="blue">
+            <Trans>{plan.summary.updates} to update</Trans>
+          </Badge>
+          <Badge variant="outline">
+            <Trans>{plan.summary.linked} merged into existing</Trans>
+          </Badge>
+          <Badge variant="gray">
+            <Trans>
+              {plan.summary.unchanged} unchanged, {plan.summary.skipped} skipped
+            </Trans>
+          </Badge>
+          {plan.summary.errors > 0 && (
+            <Badge variant="red">
+              <Trans>{plan.summary.errors} need attention</Trans>
+            </Badge>
+          )}
+          {loading && <Spinner className="h-4 w-4" />}
+        </div>
+      )}
+
+      {plan && plan.summary.errors > 0 && (
+        <p className="text-sm text-muted-foreground">
+          <Trans>
+            Rows that need attention are not imported. Resolve them here, fix
+            the file, or import the rest now and the remainder later.
+          </Trans>
+        </p>
+      )}
+
+      {plan && (
+        <>
+          <Tabs
+            value={bucket}
+            onValueChange={(value) => setBucket(value as "attention" | "all")}
+          >
+            <TabsList>
+              <TabsTrigger value="all" className="gap-1.5">
+                <Trans>All rows</Trans>
+                <Count count={plan.nodes.length} />
+              </TabsTrigger>
+              <TabsTrigger value="attention" className="gap-1.5">
+                <Trans>Needs attention</Trans>
+                <Count count={attention.length} />
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <div
+            className={cn(
+              "w-full min-w-0 max-h-[420px] overflow-auto rounded-md border border-border",
+              loading && "opacity-60"
+            )}
+          >
+            <table className="w-max min-w-full border-collapse text-sm">
+              <thead className="sticky top-0 z-20 bg-card">
+                <tr className="border-b border-border text-left text-muted-foreground">
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Line</Trans>
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Action</Trans>
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Number</Trans>
+                  </th>
+                  <th className="min-w-[240px] whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Account</Trans>
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Under</Trans>
+                  </th>
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Type</Trans>
+                  </th>
+                  <th className="min-w-[320px] whitespace-nowrap px-3 py-2 font-medium">
+                    <Trans>Details</Trans>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((node) => (
+                  <tr
+                    key={node.key}
+                    className={cn(
+                      "border-b border-border last:border-0",
+                      node.action === "error" && "bg-destructive/5"
+                    )}
+                  >
+                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                      {node.row === null ? "—" : node.row + 2}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 align-top">
+                      <ActionBadge action={node.action} />
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 align-top">
+                      {node.number ?? ""}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <div
+                        className="flex items-center gap-1.5"
+                        style={{ paddingLeft: `${node.depth * 16}px` }}
+                      >
+                        {node.kind === "group" && (
+                          <LuFolder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                        )}
+                        <span className="truncate" title={node.name}>
+                          {node.name}
+                        </span>
+                        {node.promoted && (
+                          <span className="text-xs text-muted-foreground">
+                            <Trans>(group)</Trans>
+                          </span>
+                        )}
+                      </div>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                      {node.parentLabel ?? node.anchorLabel ?? ""}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                      {node.accountType ?? node.class ?? ""}
+                    </td>
+                    <td
+                      className={cn(
+                        "max-w-[460px] px-3 py-2 align-top",
+                        node.action === "error"
+                          ? "text-destructive"
+                          : "text-muted-foreground"
+                      )}
+                    >
+                      {node.action === "error" || node.action === "skip"
+                        ? node.reason
+                        : (node.changes?.join("; ") ?? "")}
+                      {node.action === "error" && node.row !== null && (
+                        <div className="mt-2">
+                          <ResolutionPicker
+                            node={node}
+                            resolution={resolutions[String(node.row)]}
+                            onChange={(resolution) =>
+                              setResolution(node.row as number, resolution)
+                            }
+                          />
+                        </div>
+                      )}
+                      {/* An update rewrites an account that matched by
+                          number; the reviewer can leave it as it is. */}
+                      {node.action === "update" && node.row !== null && (
+                        <div>
+                          <Button
+                            variant="link"
+                            size="sm"
+                            className="h-auto px-0"
+                            onClick={() =>
+                              setResolution(node.row as number, {
+                                action: "skip"
+                              })
+                            }
+                          >
+                            <Trans>Leave this account as it is</Trans>
+                          </Button>
+                        </div>
+                      )}
+                      {node.action === "skip" &&
+                        node.row !== null &&
+                        resolutions[String(node.row)]?.action === "skip" && (
+                          <div>
+                            <Button
+                              variant="link"
+                              size="sm"
+                              className="h-auto px-0"
+                              onClick={() =>
+                                setResolution(node.row as number, null)
+                              }
+                            >
+                              <Trans>Include this row again</Trans>
+                            </Button>
+                          </div>
+                        )}
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td
+                      colSpan={7}
+                      className="px-3 py-8 text-center text-muted-foreground"
+                    >
+                      <Trans>No rows here.</Trans>
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+
+      {!plan && !failure && (
+        <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+          <Spinner className="h-4 w-4" />
+          <Trans>Building the plan…</Trans>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// A component rather than a helper taking `t`: the Lingui macro only
+// transforms `t` obtained from useLingui() in the same scope.
+function ActionBadge({ action }: { action: PlanAction }) {
+  const { t } = useLingui();
+  const label: Record<PlanAction, string> = {
+    create: t`Create`,
+    update: t`Update`,
+    link: t`Existing`,
+    unchanged: t`Unchanged`,
+    skip: t`Skip`,
+    error: t`Attention`
+  };
+  return <Badge variant={actionVariant[action]}>{label[action]}</Badge>;
+}
+
+function StructureOption({
+  value,
+  label,
+  description
+}: {
+  value: Structure;
+  label: string;
+  description: string;
+}) {
+  const id = `coa-structure-${value}`;
+  return (
+    <div className="flex items-start gap-3">
+      <RadioGroupItem value={value} id={id} className="mt-0.5" />
+      <label htmlFor={id} className="flex cursor-pointer flex-col">
+        <span className="text-sm">{label}</span>
+        <span className="text-xs text-muted-foreground">{description}</span>
+      </label>
+    </div>
+  );
+}
+
+function ResolutionPicker({
+  node,
+  resolution,
+  onChange
+}: {
+  node: PlanNode;
+  resolution: Resolution | undefined;
+  onChange: (resolution: Resolution | null) => void;
+}) {
+  const { t } = useLingui();
+  const kind = resolution?.action ?? "";
+  const [text, setText] = useState(
+    resolution?.action === "rename"
+      ? resolution.name
+      : resolution?.action === "renumber"
+        ? resolution.number
+        : ""
+  );
+
+  const options = [
+    { value: "skip", label: t`Skip this row` },
+    { value: "rename", label: t`Import under a different name` },
+    { value: "renumber", label: t`Import under a different number` },
+    ...(node.conflict?.linkable
+      ? [
+          {
+            value: "link",
+            label: t`Same as ${[node.conflict.number, node.conflict.name].filter(Boolean).join(" ")}`
+          }
+        ]
+      : [])
+  ];
+
+  const suggestion = (action: string) =>
+    action === "rename"
+      ? node.number
+        ? `${node.name} (${node.number})`
+        : `${node.name} (imported)`
+      : action === "renumber" && node.number
+        ? `${node.number}-1`
+        : "";
+
+  const commit = (action: string, value: string) => {
+    if (action === "rename" && value.trim())
+      onChange({ action: "rename", name: value.trim() });
+    else if (action === "renumber" && value.trim())
+      onChange({ action: "renumber", number: value.trim() });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Combobox
+        name={`resolution-${node.row}`}
+        value={kind}
+        options={options}
+        isOptional
+        onChange={(option) => {
+          const action = option?.value ?? "";
+          if (!action) {
+            onChange(null);
+            setText("");
+          } else if (action === "skip") {
+            onChange({ action: "skip" });
+          } else if (action === "link" && node.conflict) {
+            onChange({ action: "link", accountId: node.conflict.existingId });
+          } else {
+            const initial = suggestion(action);
+            setText(initial);
+            commit(action, initial);
+          }
+        }}
+      />
+      {(kind === "rename" || kind === "renumber") && (
+        <Input
+          size="sm"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onBlur={() => commit(kind, text)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commit(kind, text);
+            }
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ChartOfAccountsReview.tsx
@@ -16,8 +16,8 @@ import {
   TabsTrigger
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { useEffect, useMemo, useRef, useState } from "react";
-import { LuFolder, LuTriangleAlert } from "react-icons/lu";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { LuFolder, LuRefreshCw, LuTriangleAlert } from "react-icons/lu";
 import { useFetcher } from "react-router";
 import type { action } from "~/routes/x+/shared+/import.$tableId";
 import { path } from "~/utils/path";
@@ -50,6 +50,9 @@ type PlanNode = {
   accountType: string | null;
   parentLabel: string | null;
   anchorLabel: string | null;
+  existingId: string | null;
+  existingNumber: string | null;
+  existingName: string | null;
   depth: number;
   conflict?: PlanConflict;
   promoted?: boolean;
@@ -76,7 +79,10 @@ type Resolution =
   | { action: "skip" }
   | { action: "rename"; name: string }
   | { action: "renumber"; number: string }
-  | { action: "link"; accountId: string };
+  | { action: "link"; accountId: string; keepNumber?: boolean }
+  | { action: "keepNumber" };
+
+type Resolutions = Record<string, Resolution>;
 
 type Structure = "auto" | "file" | "carbon";
 
@@ -92,6 +98,9 @@ const actionVariant: Record<
   error: "red"
 };
 
+const changesNumber = (node: PlanNode) =>
+  node.changes?.some((c) => c.startsWith("number:")) ?? false;
+
 export function ChartOfAccountsReview({
   table,
   columnMappings,
@@ -105,20 +114,27 @@ export function ChartOfAccountsReview({
 
   const [structure, setStructure] = useState<Structure>("auto");
   const [pathSeparator, setPathSeparator] = useState(":");
-  const [resolutions, setResolutions] = useState<Record<string, Resolution>>(
-    {}
-  );
+  // Resolutions are edited locally (`pending`) and only sent to the planner
+  // when the user asks for an updated plan (`applied`), so working through a
+  // list of conflicts is not a round-trip per decision. The final submit
+  // always carries `pending`.
+  const [pending, setPending] = useState<Resolutions>({});
+  const [applied, setApplied] = useState<Resolutions>({});
   const [bucket, setBucket] = useState<"attention" | "all">("all");
 
-  const optionsJson = useMemo(
-    () => JSON.stringify({ structure, pathSeparator, resolutions }),
-    [structure, pathSeparator, resolutions]
+  const pendingJson = JSON.stringify(pending);
+  const appliedJson = JSON.stringify(applied);
+  const dirty = pendingJson !== appliedJson;
+  const submitOptionsJson = useMemo(
+    () => JSON.stringify({ structure, pathSeparator, resolutions: pending }),
+    [structure, pathSeparator, pending]
   );
   const columnMappingsJson = JSON.stringify(columnMappings);
   const enumMappingsJson = JSON.stringify(enumMappings);
 
-  // Re-plan whenever the inputs change. The dry run goes through the same
-  // route and edge function as the real import, minus the write.
+  // Plan on entry, when the structure choice changes, and when the user
+  // applies their pending resolutions. Same route and edge function as the
+  // real import, minus the write.
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the serialised inputs
   useEffect(() => {
     if (!filePath) return;
@@ -129,12 +145,23 @@ export function ChartOfAccountsReview({
     }
     formData.set("enumMappings", enumMappingsJson);
     formData.set("dryRun", "true");
-    formData.set("options", optionsJson);
+    formData.set(
+      "options",
+      JSON.stringify({ structure, pathSeparator, resolutions: applied })
+    );
     fetcherRef.current.submit(formData, {
       method: "post",
       action: path.to.import(table)
     });
-  }, [filePath, columnMappingsJson, enumMappingsJson, optionsJson, table]);
+  }, [
+    filePath,
+    columnMappingsJson,
+    enumMappingsJson,
+    structure,
+    pathSeparator,
+    appliedJson,
+    table
+  ]);
 
   const plan =
     fetcher.data?.success && "plan" in fetcher.data
@@ -148,37 +175,77 @@ export function ChartOfAccountsReview({
 
   const attention = plan?.nodes.filter((n) => n.action === "error") ?? [];
   const rows = bucket === "attention" ? attention : (plan?.nodes ?? []);
+
   // Rows whose only problem is a name already used by a same-kind account in
   // Carbon — usually the same account (Accounts Receivable, Retained Earnings,
   // the variance accounts) under the customer's own number.
-  const mergeable = attention.filter(
-    (n) =>
-      n.row !== null &&
-      n.conflict?.linkable &&
-      resolutions[String(n.row)] === undefined
+  const linkable = attention.filter(
+    (n): n is PlanNode & { row: number; conflict: PlanConflict } =>
+      n.row !== null && !!n.conflict?.linkable
   );
-  const mergeAll = () =>
-    setResolutions((prev) => {
-      const next = { ...prev };
-      for (const n of mergeable) {
-        if (n.row !== null && n.conflict) {
-          next[String(n.row)] = {
-            action: "link",
-            accountId: n.conflict.existingId
-          };
-        }
-      }
-      return next;
-    });
+  // Matched accounts the plan would renumber to the file's number, plus those
+  // already told to keep Carbon's, so either bulk choice can be reversed.
+  const keepsNumber = (r: Resolution | undefined) =>
+    r?.action === "keepNumber" || (r?.action === "link" && !!r.keepNumber);
+  const renumbering = (plan?.nodes ?? []).filter(
+    (n): n is PlanNode & { row: number } =>
+      n.row !== null &&
+      n.action !== "error" &&
+      n.action !== "skip" &&
+      (changesNumber(n) || keepsNumber(applied[String(n.row)]))
+  );
 
-  const setResolution = (row: number, resolution: Resolution | null) => {
-    setResolutions((prev) => {
+  const setResolution = (row: number, resolution: Resolution | null) =>
+    setPending((prev) => {
       const next = { ...prev };
       if (resolution) next[String(row)] = resolution;
       else delete next[String(row)];
       return next;
     });
+
+  // Sets or clears "keep Carbon's number" on a row without losing the
+  // account it is linked to.
+  const withKeepNumber = (
+    current: Resolution | undefined,
+    keep: boolean
+  ): Resolution | null => {
+    if (current?.action === "link") {
+      return keep
+        ? { ...current, keepNumber: true }
+        : { action: "link", accountId: current.accountId };
+    }
+    if (keep) return { action: "keepNumber" };
+    return current?.action === "keepNumber" ? null : (current ?? null);
   };
+  // Every matching account takes the file's number (keep = false) or keeps
+  // the one it has in Carbon (keep = true).
+  const setNumbers = (keep: boolean) =>
+    setPending((prev) => {
+      const next = { ...prev };
+      for (const n of linkable) {
+        next[String(n.row)] = keep
+          ? {
+              action: "link",
+              accountId: n.conflict.existingId,
+              keepNumber: true
+            }
+          : { action: "link", accountId: n.conflict.existingId };
+      }
+      for (const n of renumbering) {
+        const r = withKeepNumber(next[String(n.row)], keep);
+        if (r) next[String(n.row)] = r;
+        else delete next[String(n.row)];
+      }
+      return next;
+    });
+  const useFileNumbers = () => setNumbers(false);
+  const keepCarbonNumbers = () => setNumbers(true);
+  const matchingCount = linkable.length + renumbering.length;
+
+  const pendingCount = Object.keys(pending).filter(
+    (row) => JSON.stringify(pending[row]) !== JSON.stringify(applied[row])
+  ).length;
+  const updatePlan = () => setApplied(pending);
 
   // Attention rows get a Tabs default once the first plan arrives.
   const firstPlan = useRef(true);
@@ -189,9 +256,34 @@ export function ChartOfAccountsReview({
     }
   }, [plan]);
 
+  const describe = (node: PlanNode, resolution: Resolution): string => {
+    switch (resolution.action) {
+      case "skip":
+        return t`Skip`;
+      case "rename":
+        return t`Import as "${resolution.name}"`;
+      case "renumber":
+        return t`Import as ${resolution.number}`;
+      case "link": {
+        const named = node.conflict ?? {
+          number: node.existingNumber,
+          name: node.existingName
+        };
+        const target =
+          [named.number, named.name].filter(Boolean).join(" ") ||
+          resolution.accountId;
+        return resolution.keepNumber
+          ? t`Same as ${target}, keeping its number`
+          : t`Same as ${target}`;
+      }
+      case "keepNumber":
+        return t`Keep Carbon's number`;
+    }
+  };
+
   return (
-    <div className="flex flex-col gap-4">
-      <input type="hidden" name="options" value={optionsJson} />
+    <div className="flex min-w-0 flex-col gap-4">
+      <input type="hidden" name="options" value={submitOptionsJson} />
 
       <div className="flex flex-col gap-3 rounded-md border border-border bg-muted/40 p-4">
         <div className="text-sm font-medium">
@@ -288,22 +380,60 @@ export function ChartOfAccountsReview({
         </div>
       )}
 
-      {plan && plan.summary.errors > 0 && (
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">
-            <Trans>
-              Rows that need attention are not imported. Resolve them here, fix
-              the file, or import the rest now and the remainder later.
-            </Trans>
-          </p>
-          {mergeable.length > 0 && (
-            <Button variant="secondary" size="sm" onClick={mergeAll}>
+      {plan && (matchingCount > 0 || plan.summary.errors > 0) && (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <p className="max-w-prose text-sm text-muted-foreground">
+            {plan.summary.errors > 0 ? (
               <Trans>
-                Treat {mergeable.length} same-name matches as the same account
+                Rows that need attention are not imported. Resolve them here,
+                fix the file, or import the rest now and the remainder later.
               </Trans>
-            </Button>
+            ) : (
+              <Trans>
+                Matching accounts are updated in place; choose whose numbers
+                they keep.
+              </Trans>
+            )}
+          </p>
+          {matchingCount > 0 && (
+            <div className="flex flex-wrap gap-2">
+              <Button variant="secondary" size="sm" onClick={useFileNumbers}>
+                <Trans>
+                  Use the file's numbers for {matchingCount} matching accounts
+                </Trans>
+              </Button>
+              <Button variant="secondary" size="sm" onClick={keepCarbonNumbers}>
+                <Trans>Keep Carbon's numbers</Trans>
+              </Button>
+            </div>
           )}
         </div>
+      )}
+
+      {dirty && (
+        <Alert variant="info">
+          <LuRefreshCw className="h-4 w-4" />
+          <AlertTitle>
+            <Trans>{pendingCount} change(s) not yet in the plan</Trans>
+          </AlertTitle>
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-3">
+            <span>
+              <Trans>
+                Keep resolving rows, then update the plan to see the result.
+                Confirming the import applies them all.
+              </Trans>
+            </span>
+            <Button
+              variant="primary"
+              size="sm"
+              leftIcon={<LuRefreshCw />}
+              isLoading={loading}
+              onClick={updatePlan}
+            >
+              <Trans>Update plan</Trans>
+            </Button>
+          </AlertDescription>
+        </Alert>
       )}
 
       {plan && (
@@ -326,11 +456,19 @@ export function ChartOfAccountsReview({
 
           <div
             className={cn(
-              "w-full min-w-0 max-h-[420px] overflow-auto rounded-md border border-border",
+              "w-full min-w-0 max-h-[420px] overflow-y-auto rounded-md border border-border",
               loading && "opacity-60"
             )}
           >
-            <table className="w-max min-w-full border-collapse text-sm">
+            <table className="w-full table-fixed border-collapse text-sm">
+              <colgroup>
+                <col className="w-14" />
+                <col className="w-28" />
+                <col className="w-24" />
+                <col />
+                <col className="w-48" />
+                <col className="w-44" />
+              </colgroup>
               <thead className="sticky top-0 z-20 bg-card">
                 <tr className="border-b border-border text-left text-muted-foreground">
                   <th className="whitespace-nowrap px-3 py-2 font-medium">
@@ -342,7 +480,7 @@ export function ChartOfAccountsReview({
                   <th className="whitespace-nowrap px-3 py-2 font-medium">
                     <Trans>Number</Trans>
                   </th>
-                  <th className="min-w-[240px] whitespace-nowrap px-3 py-2 font-medium">
+                  <th className="whitespace-nowrap px-3 py-2 font-medium">
                     <Trans>Account</Trans>
                   </th>
                   <th className="whitespace-nowrap px-3 py-2 font-medium">
@@ -351,116 +489,174 @@ export function ChartOfAccountsReview({
                   <th className="whitespace-nowrap px-3 py-2 font-medium">
                     <Trans>Type</Trans>
                   </th>
-                  <th className="min-w-[320px] whitespace-nowrap px-3 py-2 font-medium">
-                    <Trans>Details</Trans>
-                  </th>
                 </tr>
               </thead>
               <tbody>
-                {rows.map((node) => (
-                  <tr
-                    key={node.key}
-                    className={cn(
-                      "border-b border-border last:border-0",
-                      node.action === "error" && "bg-destructive/5"
-                    )}
-                  >
-                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
-                      {node.row === null ? "—" : node.row + 2}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top">
-                      <ActionBadge action={node.action} />
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top">
-                      {node.number ?? ""}
-                    </td>
-                    <td className="px-3 py-2 align-top">
-                      <div
-                        className="flex items-center gap-1.5"
-                        style={{ paddingLeft: `${node.depth * 16}px` }}
+                {rows.map((node) => {
+                  const resolution =
+                    node.row === null ? undefined : pending[String(node.row)];
+                  const resolutionDirty =
+                    node.row !== null &&
+                    JSON.stringify(pending[String(node.row)]) !==
+                      JSON.stringify(applied[String(node.row)]);
+                  const detail =
+                    node.action === "error" || node.action === "skip"
+                      ? node.reason
+                      : node.changes?.join("; ");
+                  const hasDetail =
+                    !!detail || node.action === "update" || !!resolution;
+                  return (
+                    <Fragment key={node.key}>
+                      <tr
+                        className={cn(
+                          hasDetail ? "border-0" : "border-b border-border",
+                          node.action === "error" && "bg-destructive/5"
+                        )}
                       >
-                        {node.kind === "group" && (
-                          <LuFolder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                        )}
-                        <span className="truncate" title={node.name}>
-                          {node.name}
-                        </span>
-                        {node.promoted && (
-                          <span className="text-xs text-muted-foreground">
-                            <Trans>(group)</Trans>
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
-                      {node.parentLabel ?? node.anchorLabel ?? ""}
-                    </td>
-                    <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
-                      {node.accountType ?? node.class ?? ""}
-                    </td>
-                    <td
-                      className={cn(
-                        "max-w-[460px] px-3 py-2 align-top",
-                        node.action === "error"
-                          ? "text-destructive"
-                          : "text-muted-foreground"
-                      )}
-                    >
-                      {node.action === "error" || node.action === "skip"
-                        ? node.reason
-                        : (node.changes?.join("; ") ?? "")}
-                      {node.action === "error" && node.row !== null && (
-                        <div className="mt-2">
-                          <ResolutionPicker
-                            node={node}
-                            resolution={resolutions[String(node.row)]}
-                            onChange={(resolution) =>
-                              setResolution(node.row as number, resolution)
-                            }
-                          />
-                        </div>
-                      )}
-                      {/* An update rewrites an account that matched by
-                          number; the reviewer can leave it as it is. */}
-                      {node.action === "update" && node.row !== null && (
-                        <div>
-                          <Button
-                            variant="link"
-                            size="sm"
-                            className="h-auto px-0"
-                            onClick={() =>
-                              setResolution(node.row as number, {
-                                action: "skip"
-                              })
-                            }
+                        <td className="whitespace-nowrap px-3 py-2 align-top text-muted-foreground">
+                          {node.row === null ? "—" : node.row + 2}
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 align-top">
+                          <ActionBadge action={node.action} />
+                        </td>
+                        <td className="whitespace-nowrap px-3 py-2 align-top">
+                          {node.number ?? ""}
+                        </td>
+                        <td className="min-w-0 px-3 py-2 align-top">
+                          <div
+                            className="flex min-w-0 items-center gap-1.5"
+                            style={{ paddingLeft: `${node.depth * 16}px` }}
                           >
-                            <Trans>Leave this account as it is</Trans>
-                          </Button>
-                        </div>
-                      )}
-                      {node.action === "skip" &&
-                        node.row !== null &&
-                        resolutions[String(node.row)]?.action === "skip" && (
-                          <div>
-                            <Button
-                              variant="link"
-                              size="sm"
-                              className="h-auto px-0"
-                              onClick={() =>
-                                setResolution(node.row as number, null)
-                              }
-                            >
-                              <Trans>Include this row again</Trans>
-                            </Button>
+                            {node.kind === "group" && (
+                              <LuFolder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                            )}
+                            <span className="truncate" title={node.name}>
+                              {node.name}
+                            </span>
+                            {node.promoted && (
+                              <span className="shrink-0 text-xs text-muted-foreground">
+                                <Trans>(group)</Trans>
+                              </span>
+                            )}
                           </div>
-                        )}
-                    </td>
-                  </tr>
-                ))}
+                        </td>
+                        <td
+                          className="truncate px-3 py-2 align-top text-muted-foreground"
+                          title={node.parentLabel ?? node.anchorLabel ?? ""}
+                        >
+                          {node.parentLabel ?? node.anchorLabel ?? ""}
+                        </td>
+                        <td
+                          className="truncate px-3 py-2 align-top text-muted-foreground"
+                          title={node.accountType ?? node.class ?? ""}
+                        >
+                          {node.accountType ?? node.class ?? ""}
+                        </td>
+                      </tr>
+                      {hasDetail && (
+                        <tr
+                          className={cn(
+                            "border-b border-border",
+                            node.action === "error" && "bg-destructive/5"
+                          )}
+                        >
+                          <td colSpan={2} />
+                          {/* The reason and the resolution sit under the
+                              account name, full width, so nothing needs a
+                              sideways scroll. */}
+                          <td colSpan={4} className="px-3 pb-3 pt-0 align-top">
+                            <div className="flex flex-col gap-2">
+                              {detail && (
+                                <p
+                                  className={cn(
+                                    "text-pretty text-sm",
+                                    node.action === "error"
+                                      ? "text-destructive"
+                                      : "text-muted-foreground"
+                                  )}
+                                >
+                                  {detail}
+                                </p>
+                              )}
+                              {resolution && (
+                                <div className="flex flex-wrap items-center gap-2 text-sm">
+                                  <Badge
+                                    variant={
+                                      resolutionDirty ? "yellow" : "outline"
+                                    }
+                                  >
+                                    {resolutionDirty ? (
+                                      <Trans>Pending</Trans>
+                                    ) : (
+                                      <Trans>Resolved</Trans>
+                                    )}
+                                  </Badge>
+                                  <span>{describe(node, resolution)}</span>
+                                  <Button
+                                    variant="link"
+                                    size="sm"
+                                    className="h-auto px-0"
+                                    onClick={() =>
+                                      setResolution(node.row as number, null)
+                                    }
+                                  >
+                                    <Trans>Undo</Trans>
+                                  </Button>
+                                </div>
+                              )}
+                              {!resolution &&
+                                node.action === "error" &&
+                                node.row !== null && (
+                                  <ResolutionPicker
+                                    node={node}
+                                    onChange={(r) =>
+                                      setResolution(node.row as number, r)
+                                    }
+                                  />
+                                )}
+                              {!resolution &&
+                                node.action === "update" &&
+                                node.row !== null && (
+                                  <div className="flex flex-wrap gap-3">
+                                    {changesNumber(node) && (
+                                      <Button
+                                        variant="link"
+                                        size="sm"
+                                        className="h-auto px-0"
+                                        onClick={() =>
+                                          setResolution(node.row as number, {
+                                            action: "keepNumber"
+                                          })
+                                        }
+                                      >
+                                        <Trans>Keep Carbon's number</Trans>
+                                      </Button>
+                                    )}
+                                    <Button
+                                      variant="link"
+                                      size="sm"
+                                      className="h-auto px-0"
+                                      onClick={() =>
+                                        setResolution(node.row as number, {
+                                          action: "skip"
+                                        })
+                                      }
+                                    >
+                                      <Trans>Leave this account as it is</Trans>
+                                    </Button>
+                                  </div>
+                                )}
+                            </div>
+                          </td>
+                        </tr>
+                      )}
+                    </Fragment>
+                  );
+                })}
                 {rows.length === 0 && (
                   <tr>
                     <td
-                      colSpan={7}
+                      colSpan={6}
                       className="px-3 py-8 text-center text-muted-foreground"
                     >
                       <Trans>No rows here.</Trans>
@@ -519,25 +715,22 @@ function StructureOption({
   );
 }
 
+// Picks a resolution for a flagged row. The choice is recorded as pending;
+// rename / renumber ask for the value first and commit on Enter or Apply.
 function ResolutionPicker({
   node,
-  resolution,
   onChange
 }: {
   node: PlanNode;
-  resolution: Resolution | undefined;
-  onChange: (resolution: Resolution | null) => void;
+  onChange: (resolution: Resolution) => void;
 }) {
   const { t } = useLingui();
-  const kind = resolution?.action ?? "";
-  const [text, setText] = useState(
-    resolution?.action === "rename"
-      ? resolution.name
-      : resolution?.action === "renumber"
-        ? resolution.number
-        : ""
-  );
+  const [kind, setKind] = useState("");
+  const [text, setText] = useState("");
 
+  const target = node.conflict
+    ? [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+    : "";
   const options = [
     { value: "skip", label: t`Skip this row` },
     { value: "rename", label: t`Import under a different name` },
@@ -546,7 +739,11 @@ function ResolutionPicker({
       ? [
           {
             value: "link",
-            label: t`Same as ${[node.conflict.number, node.conflict.name].filter(Boolean).join(" ")}`
+            label: t`Same as ${target} (use this file's number)`
+          },
+          {
+            value: "link-keep",
+            label: t`Same as ${target} (keep its number)`
           }
         ]
       : [])
@@ -569,7 +766,7 @@ function ResolutionPicker({
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex max-w-md flex-col gap-2">
       <Combobox
         name={`resolution-${node.row}`}
         value={kind}
@@ -577,33 +774,43 @@ function ResolutionPicker({
         isOptional
         onChange={(option) => {
           const action = option?.value ?? "";
-          if (!action) {
-            onChange(null);
-            setText("");
-          } else if (action === "skip") {
+          setKind(action);
+          if (action === "skip") {
             onChange({ action: "skip" });
           } else if (action === "link" && node.conflict) {
             onChange({ action: "link", accountId: node.conflict.existingId });
-          } else {
-            const initial = suggestion(action);
-            setText(initial);
-            commit(action, initial);
+          } else if (action === "link-keep" && node.conflict) {
+            onChange({
+              action: "link",
+              accountId: node.conflict.existingId,
+              keepNumber: true
+            });
+          } else if (action === "rename" || action === "renumber") {
+            setText(suggestion(action));
           }
         }}
       />
       {(kind === "rename" || kind === "renumber") && (
-        <Input
-          size="sm"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          onBlur={() => commit(kind, text)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              commit(kind, text);
-            }
-          }}
-        />
+        <div className="flex items-center gap-2">
+          <Input
+            size="sm"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                commit(kind, text);
+              }
+            }}
+          />
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => commit(kind, text)}
+          >
+            <Trans>Apply</Trans>
+          </Button>
+        </div>
       )}
     </div>
   );

--- a/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
+++ b/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
@@ -248,6 +248,7 @@ export function FieldMapping({
   // A per-table review step (e.g. the chart-of-accounts plan) sits after the
   // enum steps and before the submit.
   const ReviewStep = importReviewSteps[table];
+  const [reviewReady, setReviewReady] = useState(true);
   const steps = enumFields.length + 1 + (ReviewStep ? 1 : 0);
   const isReviewStep = !!ReviewStep && currentStep === steps - 1;
   const enumStepIndex = currentStep - 1;
@@ -369,6 +370,7 @@ export function FieldMapping({
               table={table}
               columnMappings={columnMappings}
               enumMappings={enumMappings}
+              onReadyChange={setReviewReady}
             />
           )}
         </div>
@@ -376,7 +378,11 @@ export function FieldMapping({
         <div className="flex flex-col w-full gap-2 mt-4">
           {currentStep === steps - 1 && (
             <Submit
-              isDisabled={!filePath || fetcher.state !== "idle"}
+              isDisabled={
+                !filePath ||
+                fetcher.state !== "idle" ||
+                (isReviewStep && !reviewReady)
+              }
               type="submit"
             >
               <Trans>Confirm Import</Trans>

--- a/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
+++ b/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
@@ -158,13 +158,18 @@ export function FieldMapping({
         continue;
       }
       // Match by label (e.g., "Process Type" === "Process Type")
-      const labelIdx = fileColumnsLower.indexOf(fieldDef.label.toLowerCase());
+      const labelIdx = fileColumnsLower.findIndex(
+        (header, idx) =>
+          header === fieldDef.label.toLowerCase() && !claimed.has(idx)
+      );
       if (labelIdx !== -1) {
         claim(fieldName, labelIdx);
         continue;
       }
       // Match by field name (e.g., "processType" === "processtype")
-      const nameIdx = fileColumnsLower.indexOf(fieldName.toLowerCase());
+      const nameIdx = fileColumnsLower.findIndex(
+        (header, idx) => header === fieldName.toLowerCase() && !claimed.has(idx)
+      );
       if (nameIdx !== -1) {
         claim(fieldName, nameIdx);
         continue;

--- a/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
+++ b/apps/erp/app/components/ImportCSVModal/FieldMappings.tsx
@@ -54,6 +54,7 @@ import {
   matchCsvValue,
   toMatchableOption
 } from "./enumMatch";
+import { importReviewSteps } from "./reviewSteps";
 import { useCreateLookup } from "./useCreateLookup";
 import { useCsvContext } from "./useCsvContext";
 
@@ -64,29 +65,49 @@ type EnumData =
       creatableLookup?: CreatableLookup;
       creatableForm?: CreatableForm;
       options: readonly string[];
+      // Other systems' names for each option, matched exactly after
+      // normalisation (see enumMatch.ts).
+      optionAliases?: Record<string, readonly string[]>;
+      // Omit this enum's wizard step when its column is not mapped, for
+      // fields that are optional refinements rather than requirements.
+      skipStepWhenUnmapped?: boolean;
     }
   | {
       default: string;
       description: string;
       creatableLookup?: CreatableLookup;
       creatableForm?: CreatableForm;
+      skipStepWhenUnmapped?: boolean;
       fetcher: (
         client: SupabaseClient<Database>,
         companyId: string
       ) => Promise<PostgrestResponse<ListItem>>;
     };
 
+// Header text as compared for the exact column match: lower-cased, trimmed,
+// and without the leading asterisk some templates use to mark required
+// columns (Xero: *Code, *Name, *Type).
+const normalizeHeader = (header: string) =>
+  header.trim().replace(/^\*+/, "").trim().toLowerCase();
+
 export function FieldMapping({
   formId,
   table,
-  onReset
+  onReset,
+  onReviewStepChange
 }: {
   formId: string;
   table: keyof typeof importSchemas;
   onReset: () => void;
+  // Fires when the wizard enters or leaves a per-table review step, so the
+  // modal can widen for it.
+  onReviewStepChange?: (isReviewStep: boolean) => void;
 }) {
   const { t } = useLingui();
   const initialized = useRef(false);
+  // The client's exact/alias column matches. Kept so they survive the LLM
+  // pass, which only needs to fill in what did not match.
+  const exactMatchesRef = useRef<Record<string, string>>({});
   const { validate } = useFormContext(formId);
   const { fileColumns, filePath, firstRows } = useCsvContext();
   const fetcher = useFetcher<typeof action>();
@@ -112,30 +133,63 @@ export function FieldMapping({
   useEffect(() => {
     if (!fileColumns || !firstRows || initialized.current) return;
 
-    // Try exact matching by label and field name before calling the LLM
-    const fileColumnsLower = fileColumns.map((c) => c.toLowerCase().trim());
+    // Try exact matching by label, field name and aliases before calling the LLM
+    const fileColumnsLower = fileColumns.map(normalizeHeader);
     const exactMatches: Record<string, string> = {};
+    const claimed = new Set<number>();
+    const claim = (fieldName: string, idx: number) => {
+      exactMatches[fieldName] = fileColumns[idx];
+      claimed.add(idx);
+    };
 
     for (const [fieldName, fieldDef] of Object.entries(mappableFields)) {
+      // A more specific column beats the label when both are present (e.g.
+      // QuickBooks "Detail type" over "Type", Rillet "Account Subtype" over
+      // "Account Type"), so a coarse column stays free for another field.
+      const preferred: readonly string[] =
+        "preferredAliases" in fieldDef
+          ? (fieldDef.preferredAliases as readonly string[])
+          : [];
+      const preferredIdx = preferred
+        .map((alias) => fileColumnsLower.indexOf(normalizeHeader(alias)))
+        .find((idx) => idx !== -1 && !claimed.has(idx));
+      if (preferredIdx !== undefined) {
+        claim(fieldName, preferredIdx);
+        continue;
+      }
       // Match by label (e.g., "Process Type" === "Process Type")
       const labelIdx = fileColumnsLower.indexOf(fieldDef.label.toLowerCase());
       if (labelIdx !== -1) {
-        exactMatches[fieldName] = fileColumns[labelIdx];
+        claim(fieldName, labelIdx);
         continue;
       }
       // Match by field name (e.g., "processType" === "processtype")
       const nameIdx = fileColumnsLower.indexOf(fieldName.toLowerCase());
       if (nameIdx !== -1) {
-        exactMatches[fieldName] = fileColumns[nameIdx];
+        claim(fieldName, nameIdx);
+        continue;
+      }
+      // Match by alias (e.g., "Subaccount of" → parent). A header already
+      // claimed by a label/name match is never reassigned to an alias.
+      const aliases: readonly string[] =
+        "aliases" in fieldDef ? (fieldDef.aliases as readonly string[]) : [];
+      for (const alias of aliases) {
+        const aliasIdx = fileColumnsLower.indexOf(normalizeHeader(alias));
+        if (aliasIdx !== -1 && !claimed.has(aliasIdx)) {
+          claim(fieldName, aliasIdx);
+          break;
+        }
       }
     }
+
+    exactMatchesRef.current = exactMatches;
+    setColumnMappings(exactMatches);
 
     // If all fields matched exactly, skip the LLM call
     if (
       Object.keys(exactMatches).length === Object.keys(mappableFields).length
     ) {
       initialized.current = true;
-      setColumnMappings(exactMatches);
       return;
     }
 
@@ -162,7 +216,7 @@ export function FieldMapping({
       setColumnMappings((prevMappings) => {
         if (!fetcher.data || !fileColumns) return prevMappings;
 
-        return Object.entries(fetcher.data).reduce(
+        const fromModel = Object.entries(fetcher.data).reduce(
           (acc, [key, value]) => {
             if (fileColumns.includes(value)) {
               acc[key] = value;
@@ -171,6 +225,8 @@ export function FieldMapping({
           },
           {} as Record<string, string>
         );
+        // An exact or alias match beats the model's guess for the same field.
+        return { ...fromModel, ...exactMatchesRef.current };
       });
     }
   }, [fetcher.data]);
@@ -181,11 +237,27 @@ export function FieldMapping({
       label: string;
       enumData: EnumData;
     }
-  ][] = Object.entries(mappableFields).filter(
-    ([_, { type }]) => type === "enum"
-  );
+  ][] = Object.entries(mappableFields).filter(([name, field]) => {
+    if (field.type !== "enum") return false;
+    const enumData = (field as { enumData: EnumData }).enumData;
+    if (!enumData.skipStepWhenUnmapped) return true;
+    const mapped = columnMappings[name];
+    return !!mapped && mapped !== "None" && mapped !== "N/A";
+  });
 
-  const steps = enumFields.length > 0 ? enumFields.length + 1 : 1;
+  // A per-table review step (e.g. the chart-of-accounts plan) sits after the
+  // enum steps and before the submit.
+  const ReviewStep = importReviewSteps[table];
+  const steps = enumFields.length + 1 + (ReviewStep ? 1 : 0);
+  const isReviewStep = !!ReviewStep && currentStep === steps - 1;
+  const enumStepIndex = currentStep - 1;
+  const enumStep =
+    !isReviewStep && enumStepIndex >= 0 ? enumFields[enumStepIndex] : undefined;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: notify only on change
+  useEffect(() => {
+    onReviewStepChange?.(isReviewStep);
+  }, [isReviewStep]);
 
   const onNext = () => {
     if (currentStep < steps - 1) {
@@ -221,7 +293,9 @@ export function FieldMapping({
           <ModalTitle className="m-0 p-0">
             {currentStep === 0
               ? t`Field Mapping`
-              : enumFields[currentStep - 1][1].label}
+              : isReviewStep
+                ? t`Review`
+                : enumStep?.[1].label}
           </ModalTitle>
           {steps > 1 && (
             <span className="ml-auto text-sm text-muted-foreground whitespace-nowrap">
@@ -233,7 +307,9 @@ export function FieldMapping({
         <ModalDescription>
           {currentStep === 0
             ? t`We auto-matched each column. Review the values below before continuing.`
-            : enumFields[currentStep - 1][1].enumData.description}
+            : isReviewStep
+              ? t`Check what will be created and changed before importing. Nothing is written until you confirm.`
+              : enumStep?.[1].enumData.description}
         </ModalDescription>
       </ModalHeader>
       <ModalBody>
@@ -275,6 +351,7 @@ export function FieldMapping({
           )}
           {enumFields.map(
             ([name, { enumData }], index) =>
+              !isReviewStep &&
               currentStep === index + 1 && (
                 <EnumMappingStep
                   key={name}
@@ -286,6 +363,13 @@ export function FieldMapping({
                   onEnumMappingChange={onEnumMappingChange}
                 />
               )
+          )}
+          {isReviewStep && ReviewStep && (
+            <ReviewStep
+              table={table}
+              columnMappings={columnMappings}
+              enumMappings={enumMappings}
+            />
           )}
         </div>
 
@@ -445,7 +529,10 @@ function EnumMappingStep({
       return (
         enumData.options.map((option) => ({
           label: option,
-          value: option
+          value: option,
+          aliases: enumData.optionAliases?.[option]
+            ? [...enumData.optionAliases[option]]
+            : undefined
         })) || []
       );
     } else {

--- a/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
@@ -40,6 +40,9 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
   const [firstRows, setFirstRows] = useState<Record<string, string>[] | null>(
     null
   );
+  // A per-table review step (see FieldMappings) renders a plan table that
+  // needs the wide modal.
+  const [wide, setWide] = useState(false);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   useEffect(() => {
@@ -99,8 +102,14 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
         }
       }}
     >
-      <ModalContent onInteractOutside={(e) => e.preventDefault()}>
-        <div className="relative">
+      <ModalContent
+        size={wide ? "xxlarge" : "medium"}
+        className={wide ? "min-w-0" : undefined}
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        {/* min-w-0: a grid item otherwise grows to its content's width, and a
+            wide review table would push the wizard past the modal's edge. */}
+        <div className="relative min-w-0">
           <AnimatedSizeContainer height>
             <ImportCsvContext.Provider
               value={{
@@ -124,7 +133,9 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
                     filePath: z
                       .string()
                       .min(1, { message: "Path is required" }),
-                    enumMappings: z.string().optional()
+                    enumMappings: z.string().optional(),
+                    dryRun: z.string().optional(),
+                    options: z.string().optional()
                   })}
                   id={formId}
                   onSubmit={() => {
@@ -132,6 +143,7 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
                   }}
                 >
                   <Hidden name="filePath" value={filePath ?? ""} />
+                  <Hidden name="dryRun" value="false" />
                   {page === ImportCSVPage.UploadCSV && (
                     <UploadCSV table={table} />
                   )}
@@ -139,6 +151,7 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
                     <FieldMapping
                       formId={formId}
                       table={table}
+                      onReviewStepChange={setWide}
                       onReset={() => {
                         flushSync(() => {
                           setFile(null);

--- a/apps/erp/app/components/ImportCSVModal/UploadCSV.tsx
+++ b/apps/erp/app/components/ImportCSVModal/UploadCSV.tsx
@@ -35,7 +35,7 @@ export const UploadCSV = ({ table }: { table: keyof typeof importSchemas }) => {
     const fields = Object.values(mapping) as Array<{
       label: string;
       required?: boolean;
-      type: "string" | "boolean" | "enum" | "numeric";
+      type: "string" | "boolean" | "enum" | "number";
       enumData?: {
         description?: string;
         options?: readonly string[];
@@ -55,7 +55,7 @@ export const UploadCSV = ({ table }: { table: keyof typeof importSchemas }) => {
         return `${prefix} — ${f.enumData.description ?? "see your configured options"}`;
       }
       if (f.type === "boolean") return `${prefix} — true | false`;
-      if (f.type === "numeric") return `${prefix} — number`;
+      if (f.type === "number") return `${prefix} — number`;
       return prefix;
     });
     const csv = Papa.unparse({ fields: headers, data: [hints] });

--- a/apps/erp/app/components/ImportCSVModal/reviewSteps.ts
+++ b/apps/erp/app/components/ImportCSVModal/reviewSteps.ts
@@ -6,6 +6,9 @@ export type ReviewStepProps = {
   table: keyof typeof fieldMappings;
   columnMappings: Record<string, string>;
   enumMappings: Record<string, Record<string, string>>;
+  // Whether the step is showing something the user can confirm; the wizard
+  // disables Confirm while it is false (e.g. while a plan is being built).
+  onReadyChange?: (ready: boolean) => void;
 };
 
 // Per-table review steps. A table listed here gets one extra wizard page after

--- a/apps/erp/app/components/ImportCSVModal/reviewSteps.ts
+++ b/apps/erp/app/components/ImportCSVModal/reviewSteps.ts
@@ -1,0 +1,18 @@
+import type { ComponentType } from "react";
+import type { fieldMappings } from "~/modules/shared";
+import { ChartOfAccountsReview } from "./ChartOfAccountsReview";
+
+export type ReviewStepProps = {
+  table: keyof typeof fieldMappings;
+  columnMappings: Record<string, string>;
+  enumMappings: Record<string, Record<string, string>>;
+};
+
+// Per-table review steps. A table listed here gets one extra wizard page after
+// the enum steps, rendered inside the import form so any hidden inputs it
+// renders (e.g. `options`) travel with the final submit.
+export const importReviewSteps: Partial<
+  Record<keyof typeof fieldMappings, ComponentType<ReviewStepProps>>
+> = {
+  account: ChartOfAccountsReview
+};

--- a/apps/erp/app/modules/accounting/ui/ChartOfAccounts/ChartOfAccountsTableFilters.tsx
+++ b/apps/erp/app/modules/accounting/ui/ChartOfAccounts/ChartOfAccountsTableFilters.tsx
@@ -6,7 +6,13 @@ import {
   InputLeftElement
 } from "@carbon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { LuCheckCheck, LuSearch, LuWallet, LuX } from "react-icons/lu";
+import {
+  LuCheckCheck,
+  LuSearch,
+  LuUpload,
+  LuWallet,
+  LuX
+} from "react-icons/lu";
 import { New, PeriodSelector } from "~/components";
 import { usePermissions, useUrlParams } from "~/hooks";
 
@@ -20,6 +26,9 @@ type ChartOfAccountsTableFiltersProps = {
   onEnterOpeningBalances: () => void;
   onCancelOpeningBalances: () => void;
   onPostOpeningBalances: () => void;
+  // Present only when the current company may bulk-import the chart (root
+  // company of its group); opens the CSV import wizard for `account`.
+  onImport?: () => void;
 };
 
 const ChartOfAccountsTableFilters = ({
@@ -31,7 +40,8 @@ const ChartOfAccountsTableFilters = ({
   hasOpeningBalanceEntries,
   onEnterOpeningBalances,
   onCancelOpeningBalances,
-  onPostOpeningBalances
+  onPostOpeningBalances,
+  onImport
 }: ChartOfAccountsTableFiltersProps) => {
   const { t } = useLingui();
   const [params, setParams] = useUrlParams();
@@ -85,6 +95,15 @@ const ChartOfAccountsTableFilters = ({
           </>
         ) : (
           <>
+            {permissions.can("create", "accounting") && onImport && (
+              <Button
+                variant="secondary"
+                leftIcon={<LuUpload />}
+                onClick={onImport}
+              >
+                <Trans>Import</Trans>
+              </Button>
+            )}
             {permissions.can("create", "accounting") && (
               <>
                 <New label={t`Group`} to={`new-group?${params.toString()}`} />

--- a/apps/erp/app/modules/shared/imports.models.ts
+++ b/apps/erp/app/modules/shared/imports.models.ts
@@ -32,6 +32,475 @@ const supplierStatusTypes = [
   "Rejected"
 ] as const;
 
+// Chart-of-accounts vocabulary. Mirrors accounting.models.ts; inlined here (like
+// methodType above) because that module imports ~/modules/shared and would
+// otherwise form a cycle.
+const accountTypes = [
+  "Bank",
+  "Cash",
+  "Accounts Receivable",
+  "Accounts Payable",
+  "Inventory",
+  "Fixed Asset",
+  "Accumulated Depreciation",
+  "Other Current Asset",
+  "Other Asset",
+  "Other Current Liability",
+  "Long Term Liability",
+  "Equity - No Close",
+  "Equity - Close",
+  "Retained Earnings",
+  "Income",
+  "Cost of Goods Sold",
+  "Expense",
+  "Other Income",
+  "Other Expense",
+  "Tax",
+  "Investments"
+] as const;
+const accountClasses = [
+  "Asset",
+  "Liability",
+  "Equity",
+  "Revenue",
+  "Expense"
+] as const;
+const accountRowKinds = [
+  "Account",
+  "Group",
+  "Total",
+  "Heading",
+  "Ignore"
+] as const;
+
+// How other accounting systems name Carbon's account types, so the enum step
+// auto-matches a QuickBooks, Xero, NetSuite, Sage, Business Central, Odoo or
+// Rillet export without the user re-mapping every value. Matching is exact
+// after lower-casing and trimming (enumMatch.ts); the first option to claim an
+// alias wins, so nothing below may appear under two types. Values that are
+// genuinely ambiguous in the source system (Xero LIABILITY, an Intacct
+// balance-sheet credit account) are left for the user.
+const accountTypeAliases: Record<(typeof accountTypes)[number], string[]> = {
+  Bank: [
+    "BANK",
+    "Bank Accounts",
+    "Bank Account",
+    "Checking",
+    "Savings",
+    "Money Market",
+    "Bank and Cash",
+    "Bank & Cash",
+    "asset_cash"
+  ],
+  Cash: [
+    "Cash on Hand",
+    "CashOnHand",
+    "Petty Cash",
+    "Cash in Transit",
+    "Cash and Cash Equivalents",
+    "Undeposited Funds"
+  ],
+  "Accounts Receivable": [
+    "AR",
+    "A/R",
+    "AccountsReceivable",
+    "Accounts receivable (A/R)",
+    "Receivable",
+    "Receivables",
+    "Trade Receivables",
+    "Trade Debtors",
+    "Debtors",
+    "asset_receivable"
+  ],
+  "Accounts Payable": [
+    "AP",
+    "A/P",
+    "AccountsPayable",
+    "Accounts payable (A/P)",
+    "Payable",
+    "Payables",
+    "Trade Payables",
+    "Trade Creditors",
+    "Creditors",
+    "liability_payable"
+  ],
+  Inventory: [
+    "INVENTORY",
+    "Inventory Asset",
+    "Stock",
+    "Stock on Hand",
+    "Raw Materials",
+    "Work in Progress",
+    "Work in Process",
+    "WIP",
+    "Finished Goods",
+    "Inventory Reserve"
+  ],
+  "Fixed Asset": [
+    "Fixed Assets",
+    "FixedAsset",
+    "FIXASSET",
+    "FIXED",
+    "asset_fixed",
+    "Property, Plant and Equipment",
+    "Property Plant and Equipment",
+    "PP&E",
+    "PPE",
+    "Machinery and Equipment",
+    "Machinery & Equipment",
+    "MachineryAndEquipment",
+    "Furniture and Fixtures",
+    "Furniture & Fixtures",
+    "Property, Plant & Equipment",
+    "Leasehold Improvements",
+    "Vehicles",
+    "Buildings",
+    "Land",
+    "Right of Use Asset",
+    "Capital Assets"
+  ],
+  "Accumulated Depreciation": [
+    "AccumulatedDepreciation",
+    "Accumulated Amortization",
+    "AccumulatedAmortization",
+    "Accumulated Amortisation",
+    "Accumulated Depreciation and Amortization",
+    "Less Accumulated Depreciation"
+  ],
+  "Other Current Asset": [
+    "Other Current Assets",
+    "OtherCurrentAsset",
+    "OCASSET",
+    "Current Asset",
+    "Current Assets",
+    "CURRENT",
+    "asset_current",
+    "Prepayment",
+    "Prepayments",
+    "PREPAYMENT",
+    "asset_prepayments",
+    "Prepaid Expense",
+    "Prepaid Expenses",
+    "PrepaidExpenses",
+    "Unbilled Revenue",
+    "Unbilled Receivable",
+    "Accrued Revenue",
+    "Contract Asset",
+    "Restricted Cash",
+    "Allowance for Doubtful Accounts",
+    "Deferred Expense",
+    "Employee Cash Advances",
+    "Deposits Paid",
+    "Receivable Retainage"
+  ],
+  "Other Asset": [
+    "Other Assets",
+    "OtherAsset",
+    "OASSET",
+    "NONCURRENT",
+    "Non-current Asset",
+    "Non-current Assets",
+    "Noncurrent Asset",
+    "Other Non Current Assets",
+    "asset_non_current",
+    "Intangible Assets",
+    "Goodwill",
+    "Security Deposits",
+    "Deferred Commissions",
+    "Long-term Assets",
+    "Long Term Assets",
+    "Long-term Asset"
+  ],
+  "Other Current Liability": [
+    "Other Current Liabilities",
+    "OtherCurrentLiability",
+    "OCLIAB",
+    "CURRLIAB",
+    "Current Liability",
+    "Current Liabilities",
+    "liability_current",
+    "Credit Card",
+    "Credit Cards",
+    "CreditCard",
+    "CCARD",
+    "liability_credit_card",
+    "Deferred Revenue",
+    "Unearned Revenue",
+    "Deferred Income",
+    "Contract Liability",
+    "Accrued Expense",
+    "Accrued Expenses",
+    "Accrued Liabilities",
+    "Accruals",
+    "Accrued Payroll",
+    "Customer Deposits",
+    "Customer Deposit",
+    "Customer Credit",
+    "Payroll Liabilities",
+    "Wages Payable",
+    "Due to Related Party",
+    "Payable Retainage"
+  ],
+  "Long Term Liability": [
+    "Long Term Liabilities",
+    "Long-term Liability",
+    "Long-term Liabilities",
+    "LongTermLiability",
+    "LTLIAB",
+    "TERMLIAB",
+    "Non-current Liability",
+    "Non-current Liabilities",
+    "liability_non_current",
+    "Debt",
+    "Loans Payable",
+    "Notes Payable",
+    "Long Term Debt",
+    "Line of Credit",
+    "Term Loan",
+    "Borrowings",
+    "Convertible Notes",
+    "Lease Liability",
+    "Lease Liabilities",
+    "Operating Lease Liability",
+    "Finance Lease Liability"
+  ],
+  Tax: [
+    "Taxes",
+    "Sales Tax",
+    "Sales Tax Payable",
+    "Sales Tax Liability",
+    "SalesTaxPayable",
+    "GlobalTaxPayable",
+    "PayrollTaxPayable",
+    "Tax Payable",
+    "Tax Liabilities",
+    "VAT",
+    "VAT Payable",
+    "GST Payable",
+    "HST Payable",
+    "PAYG Liability",
+    "PAYGLIABILITY",
+    "Income Tax Payable",
+    "Tax Expense"
+  ],
+  "Equity - No Close": [
+    "Equity",
+    "EQUITY",
+    "Capital",
+    "Owners Equity",
+    "Owner's Equity",
+    "Shareholders Equity",
+    "Shareholders' Equity",
+    "Common Stock",
+    "Share Capital",
+    "Preferred Stock",
+    "Capital Stock",
+    "Members Equity",
+    "Partners Equity",
+    "Treasury Stock",
+    "Additional Paid in Capital",
+    "APIC",
+    "Paid in Capital",
+    "Share Premium",
+    "Opening Balance Equity",
+    "OpeningBalanceEquity",
+    "Equity-doesn't close"
+  ],
+  "Equity - Close": [
+    "Equity Close",
+    "Equity-gets closed",
+    "Closing Account",
+    "Accumulated Other Comprehensive Income",
+    "AOCI",
+    "Other Comprehensive Income",
+    "Cumulative Translation Adjustment",
+    "Dividends",
+    "Distributions",
+    "Distributions to Shareholders",
+    "PartnerDistributions",
+    "Owner Draw",
+    "Owner's Draw",
+    "Drawings"
+  ],
+  "Retained Earnings": [
+    "RetainedEarnings",
+    "RETEARNINGS",
+    "Equity-Retained Earnings",
+    "Accumulated Deficit",
+    "Accumulated Earnings",
+    "Net Income Prior Years",
+    "Current Year Earnings",
+    "equity_unaffected"
+  ],
+  Income: [
+    "INC",
+    "Revenue",
+    "REVENUE",
+    "Revenues",
+    "Sales",
+    "SALES",
+    "Sales of Product Income",
+    "Income, Product Sales",
+    "Income Product Sales",
+    "Product Sales",
+    "Income, Service",
+    "Income Service",
+    "Income, Jobs",
+    "Income Jobs",
+    "Service Revenue",
+    "Service Income",
+    "Service/Fee Income",
+    "Product Revenue",
+    "Turnover",
+    "Subscription Revenue",
+    "Operating Revenue",
+    "Sales Revenue",
+    "income"
+  ],
+  "Cost of Goods Sold": [
+    "COGS",
+    "CostofGoodsSold",
+    "Cost of Sales",
+    "Cost of Revenue",
+    "Direct Costs",
+    "DIRECTCOSTS",
+    "Direct Labor",
+    "Direct Labour",
+    "Materials Cost",
+    "Cost of Materials",
+    "Cost of Labor",
+    "Cost of Capacities",
+    "Jobs Cost",
+    "Manufacturing Overhead",
+    "Subcontractor Costs",
+    "Freight In",
+    "Supplies & Materials - COGS",
+    "expense_direct_cost"
+  ],
+  Expense: [
+    "Expenses",
+    "EXP",
+    "EXPENSE",
+    "Operating Expense",
+    "Operating Expenses",
+    "Opex",
+    "Overhead",
+    "Overheads",
+    "OVERHEADS",
+    "General and Administrative",
+    "G&A",
+    "Administrative Expense",
+    "Payroll Expense",
+    "Payroll Expenses",
+    "Salaries",
+    "Salaries and Wages",
+    "Wages",
+    "Wages Expense",
+    "WAGESEXPENSE",
+    "Personnel",
+    "Employee Benefits",
+    "Payroll Taxes",
+    "Compensation",
+    "Office Expenses",
+    "Office Supplies",
+    "Rent Expense",
+    "Rent or Lease",
+    "Rent or Lease of Buildings",
+    "Insurance",
+    "Utilities",
+    "Professional Fees",
+    "Legal and Professional Fees",
+    "Legal & Professional Fees",
+    "Bank Charges",
+    "Software Subscriptions",
+    "Dues and Subscriptions",
+    "Repairs and Maintenance",
+    "Repairs & Maintenance",
+    "Repair & Maintenance",
+    "Repairs and Maintenance Expense",
+    "Advertising",
+    "Advertising Expense",
+    "Advertising and Promotion",
+    "Advertising & Promotion",
+    "Advertising/Promotional",
+    "Marketing",
+    "Sales and Marketing",
+    "Sales & Marketing",
+    "Commissions",
+    "Research and Development",
+    "Research & Development",
+    "Product Development",
+    "Recruiting",
+    "Travel",
+    "Travel Expense",
+    "Travel Meals",
+    "Travel Meals and Entertainment",
+    "Travel, Meals & Entertainment",
+    "Vehicle Expenses",
+    "Fees Expense",
+    "Insurance Expense",
+    "Benefits Expense",
+    "Utilities Expense",
+    "Salaries Expense",
+    "Dues & Subscriptions",
+    "Bad Debt Expense",
+    "Superannuation Expense",
+    "SUPERANNUATIONEXPENSE",
+    "expense"
+  ],
+  "Other Income": [
+    "OtherIncome",
+    "EXINC",
+    "OTHERINCOME",
+    "income_other",
+    "Non Operating Income",
+    "Non-operating Income",
+    "Interest Income",
+    "Interest Earned",
+    "Foreign Exchange Gain",
+    "Gain on Disposal",
+    "Dividend Income",
+    "Other Miscellaneous Income"
+  ],
+  "Other Expense": [
+    "Other Expenses",
+    "OtherExpense",
+    "EXEXP",
+    "OTHEREXPENSE",
+    "Non Operating Expense",
+    "Non-operating Expense",
+    "Interest Expense",
+    "Foreign Exchange Loss",
+    "Loss on Disposal",
+    "Extraordinary Expense",
+    "Depreciation",
+    "DEPRECIATN",
+    "expense_depreciation",
+    "Depreciation Expense",
+    "Amortization",
+    "Amortization Expense",
+    "Penalties & Settlements"
+  ],
+  Investments: ["Investment", "Marketable Securities", "Equity Investments"]
+};
+const accountClassAliases: Record<(typeof accountClasses)[number], string[]> = {
+  Asset: ["Assets", "ASSET"],
+  Liability: ["Liabilities", "LIABILITY"],
+  Equity: ["Capital", "EQUITY"],
+  Revenue: ["Income", "INCOME", "Revenues", "Sales"],
+  Expense: ["Expenses", "EXPENSE", "Cost", "Cost of Goods Sold"]
+};
+const accountRowKindAliases: Record<
+  (typeof accountRowKinds)[number],
+  string[]
+> = {
+  Account: ["Posting", "Detail", "Leaf", "G", "A", "X"],
+  Group: ["Begin-Total", "Begin Total", "H", "Header"],
+  Total: ["End-Total", "End Total", "T"],
+  Heading: [],
+  Ignore: ["S", "Subtotal", "Sub-Total"]
+};
+
 // Name-only lookups that may be created inline during a CSV import. The value
 // doubles as the lookup's table name; the create-lookup route's zod enum, its
 // permission map, and the import modal's types all derive from this list.
@@ -1786,6 +2255,164 @@ export const fieldMappings = {
       required: false,
       type: "boolean"
     }
+  },
+  account: {
+    number: {
+      label: "Account Number",
+      required: false,
+      type: "string",
+      aliases: [
+        "Number",
+        "No.",
+        "No",
+        "Code",
+        "Account Code",
+        "Account No",
+        "Account No.",
+        "Account #",
+        "Acct No",
+        "Acct No.",
+        "Acct",
+        "AcctNum",
+        "ACCNUM",
+        "ACCOUNTNO",
+        "GL Account",
+        "GL Code",
+        "Nominal Code",
+        "Account ID"
+      ]
+    },
+    name: {
+      label: "Account Name",
+      required: true,
+      type: "string",
+      aliases: [
+        "Name",
+        "Account",
+        "Title",
+        "Description",
+        "Account Description",
+        "Account Title",
+        "Full Name",
+        "Account Full Name",
+        "NAME",
+        "TITLE"
+      ]
+    },
+    accountType: {
+      label: "Account Type",
+      required: true,
+      type: "enum",
+      // A finer column wins over "Account Type" when the file has both.
+      preferredAliases: [
+        "Detail Type",
+        "Account Subtype",
+        "Subtype",
+        "Sub Type",
+        "Account Subcategory Descript.",
+        "Account Subcategory"
+      ],
+      aliases: ["Type", "ACCNTTYPE"],
+      enumData: {
+        description:
+          "Map each account type in your file to one of Carbon's account types. Most systems' types match automatically; check anything left blank.",
+        options: accountTypes,
+        optionAliases: accountTypeAliases,
+        default: ""
+      }
+    },
+    class: {
+      label: "Class",
+      required: false,
+      type: "enum",
+      aliases: [
+        "Classification",
+        "Account Class",
+        "Account Category",
+        "Category",
+        "Section",
+        "Account Type"
+      ],
+      enumData: {
+        description:
+          "Optional. Asset, Liability, Equity, Revenue or Expense. Derived from the account type when the file has no class column.",
+        options: accountClasses,
+        optionAliases: accountClassAliases,
+        default: "",
+        skipStepWhenUnmapped: true
+      }
+    },
+    parent: {
+      label: "Parent Account",
+      required: false,
+      type: "string",
+      aliases: [
+        "Parent",
+        "Parent Grouping",
+        "Parent Group",
+        "Parent Name",
+        "Subaccount of",
+        "Sub-account of",
+        "Group",
+        "Group Name",
+        "Grouping",
+        "Account Group",
+        "Rollup"
+      ]
+    },
+    isGroup: {
+      label: "Is Group",
+      required: false,
+      type: "boolean",
+      aliases: ["Summary", "Is Summary", "Header", "Is Header", "Group Account"]
+    },
+    rowKind: {
+      label: "Row Kind",
+      required: false,
+      type: "enum",
+      aliases: [
+        "Row Type",
+        "Line Type",
+        "Account Kind",
+        "Entry Type",
+        "Account Type"
+      ],
+      enumData: {
+        description:
+          "For exports with Begin-Total / End-Total or heading rows (Business Central, Sage 50 Canada): which rows are accounts, which open a group, and which close one.",
+        options: accountRowKinds,
+        optionAliases: accountRowKindAliases,
+        default: "Account",
+        skipStepWhenUnmapped: true
+      }
+    },
+    indent: {
+      label: "Indentation",
+      required: false,
+      type: "number",
+      aliases: ["Indent", "Level", "Depth"]
+    },
+    active: {
+      label: "Active",
+      required: false,
+      type: "boolean",
+      aliases: [
+        "Is Active",
+        "Status",
+        "Inactive",
+        "Is Inactive",
+        "Hidden",
+        "Deprecated",
+        "Blocked",
+        "Archived"
+      ]
+    },
+    externalId: {
+      label: "Source ID",
+      required: false,
+      type: "string",
+      aliases: ["Id", "ID", "External ID", "External Id", "Internal ID"]
+    }
   }
 } as const;
 
@@ -1811,7 +2438,8 @@ export const importPermissions: Record<keyof typeof fieldMappings, string> = {
   materialFinish: "parts",
   materialGrade: "parts",
   materialType: "parts",
-  materialDimension: "parts"
+  materialDimension: "parts",
+  account: "accounting"
 };
 
 // Zod fragments for the method imports. Every method cell is an optional string at
@@ -2582,5 +3210,65 @@ export const importSchemas: Record<
       .string()
       .optional()
       .describe("Whether the dimension is metric (true/false)")
+  }),
+  account: z.object({
+    number: z
+      .string()
+      .optional()
+      .describe(
+        "The account number or code (e.g. 1010). Unique within the chart. Optional for group accounts."
+      ),
+    name: z
+      .string()
+      .min(1, { message: "Account name is required" })
+      .describe(
+        "The account name. May contain a colon-delimited path (Parent:Child) for sub-accounts."
+      ),
+    accountType: z
+      .string()
+      .min(1, { message: "Account type is required" })
+      .describe(
+        "The account type or detail type (e.g. Bank, Accounts Receivable, Cost of Goods Sold, Expense)."
+      ),
+    class: z
+      .string()
+      .optional()
+      .describe(
+        "The account class: Asset, Liability, Equity, Revenue or Expense."
+      ),
+    parent: z
+      .string()
+      .optional()
+      .describe(
+        "The parent account or grouping this account sits under — a number, a 'number name', a group name, or a grouping label."
+      ),
+    isGroup: z
+      .string()
+      .optional()
+      .describe(
+        "Whether the row is a group / summary / header account rather than a posting account (true/false)."
+      ),
+    rowKind: z
+      .string()
+      .optional()
+      .describe(
+        "For Begin-Total / End-Total style exports: Posting, Begin-Total, End-Total, Heading or Total."
+      ),
+    indent: z
+      .string()
+      .optional()
+      .describe("The indentation level of the row in a hierarchical export."),
+    active: z
+      .string()
+      .optional()
+      .describe(
+        "Whether the account is active (true/false), or an inactive/hidden flag."
+      ),
+    externalId: z
+      .string()
+      .optional()
+      .describe(
+        "The account's id in the source system, used to match on re-import."
+      )
   })
 } as const;

--- a/apps/erp/app/modules/shared/shared.service.ts
+++ b/apps/erp/app/modules/shared/shared.service.ts
@@ -998,9 +998,13 @@ export async function importCsv(
     table: string;
     filePath: string;
     columnMappings: Record<string, string>;
-    enumMappings?: Record<string, string[]>;
+    enumMappings?: Record<string, Record<string, string>>;
     companyId: string;
     userId: string;
+    // Plan without writing (importers that plan return `plan`).
+    dryRun?: boolean;
+    // Importer-specific options from the wizard's review step.
+    options?: Record<string, unknown>;
   }
 ) {
   return client.functions.invoke("import-csv", {

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-09-03T15:31:57.926Z",
+  "generated": "2026-09-04T09:16:17.244Z",
   "totalTools": 1495,
   "modules": 15,
   "tools": [
@@ -47692,7 +47692,7 @@
       "module": "shared",
       "classification": "WRITE",
       "description": "import csv",
-      "paramCount": 4,
+      "paramCount": 6,
       "serviceParams": [
         "client",
         "args"
@@ -47710,7 +47710,11 @@
             "type": "string"
           },
           "columnMappings": {},
-          "enumMappings": {}
+          "enumMappings": {},
+          "dryRun": {
+            "type": "boolean"
+          },
+          "options": {}
         },
         "required": [
           "table",

--- a/apps/erp/app/routes/x+/accounting+/charts.tsx
+++ b/apps/erp/app/routes/x+/accounting+/charts.tsx
@@ -7,6 +7,7 @@ import { msg } from "@lingui/core/macro";
 import { useMemo, useState } from "react";
 import type { ActionFunctionArgs, LoaderFunctionArgs } from "react-router";
 import { data, Outlet, redirect, useLoaderData } from "react-router";
+import { ImportCSVModal } from "~/components/ImportCSVModal";
 import { usePermissions, useSettings } from "~/hooks";
 import type { Chart } from "~/modules/accounting";
 import {
@@ -22,6 +23,7 @@ import OpeningBalancePostModal from "~/modules/accounting/ui/ChartOfAccounts/Ope
 import { months } from "~/modules/shared";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
+import { accountsQuery, getCompanyId } from "~/utils/react-query";
 import { revalidateIgnoringOffset } from "~/utils/revalidate";
 
 export const handle: Handle = {
@@ -47,7 +49,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const startDate = searchParams.get("startDate") || null;
   const endDate = searchParams.get("endDate") || null;
 
-  const [chartOfAccounts, fiscalYearSettings, existingOpeningBalance] =
+  const [chartOfAccounts, fiscalYearSettings, existingOpeningBalance, company] =
     await Promise.all([
       getChartOfAccounts(client, companyGroupId, {
         incomeBalance: null,
@@ -55,7 +57,15 @@ export async function loader({ request }: LoaderFunctionArgs) {
         endDate
       }),
       getFiscalYearSettings(client, companyId),
-      getExistingOpeningBalanceEntry(client, companyId)
+      getExistingOpeningBalanceEntry(client, companyId),
+      // The chart is shared by the company group and only its root company
+      // may write it (RLS: get_company_groups_for_root_permission), so the
+      // import action is offered only there.
+      client
+        .from("company")
+        .select("parentCompanyId")
+        .eq("id", companyId)
+        .single()
     ]);
 
   if (chartOfAccounts.error) {
@@ -72,7 +82,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
     chartOfAccounts: (chartOfAccounts.data ?? []) as Chart[],
     fiscalStartMonth:
       months.indexOf(fiscalYearSettings.data?.startMonth ?? "January") + 1,
-    hasOpeningBalance: existingOpeningBalance.data !== null
+    hasOpeningBalance: existingOpeningBalance.data !== null,
+    canImport: company.data?.parentCompanyId === null
   };
 }
 
@@ -120,7 +131,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function ChartOfAccountsRoute() {
-  const { chartOfAccounts, fiscalStartMonth, hasOpeningBalance } =
+  const { chartOfAccounts, fiscalStartMonth, hasOpeningBalance, canImport } =
     useLoaderData<typeof loader>();
   const permissions = usePermissions();
   const settings = useSettings();
@@ -131,6 +142,7 @@ export default function ChartOfAccountsRoute() {
   const [openingBalanceMode, setOpeningBalanceMode] = useState(false);
   const [amounts, setAmounts] = useState<Record<string, number>>({});
   const [postModalOpen, setPostModalOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   const canEnterOpeningBalances =
     Boolean(accountingEnabled) &&
@@ -170,6 +182,11 @@ export default function ChartOfAccountsRoute() {
         onEnterOpeningBalances={() => setOpeningBalanceMode(true)}
         onCancelOpeningBalances={exitOpeningBalanceMode}
         onPostOpeningBalances={() => setPostModalOpen(true)}
+        onImport={
+          canImport && !openingBalanceMode
+            ? () => setImportOpen(true)
+            : undefined
+        }
       />
       <ChartOfAccountsTree
         data={chartOfAccounts}
@@ -187,6 +204,20 @@ export default function ChartOfAccountsRoute() {
         linesJson={linesJson}
         count={enteredCount}
       />
+      {importOpen && (
+        <ImportCSVModal
+          table="account"
+          onClose={() => {
+            setImportOpen(false);
+            // Account pickers cache the chart; the loader revalidates on its
+            // own after the import's POST.
+            window.clientCache?.setQueryData(
+              accountsQuery(getCompanyId()).queryKey,
+              null
+            );
+          }}
+        />
+      )}
     </VStack>
   );
 }

--- a/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
+++ b/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
@@ -23,7 +23,11 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   const schema = importSchemas[table].extend({
     filePath: z.string().min(1, { message: "Path is required" }),
-    enumMappings: z.string().optional()
+    enumMappings: z.string().optional(),
+    // "true" plans without writing; importers that plan (account) return it.
+    dryRun: z.string().optional(),
+    // JSON from a per-table review step (structure choice, conflict resolutions).
+    options: z.string().optional()
   });
 
   const validation = await validator(schema).validate(await request.formData());
@@ -35,7 +39,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
     };
   }
 
-  const { filePath, enumMappings, ...columnMappings } = validation.data;
+  const { filePath, enumMappings, dryRun, options, ...columnMappings } =
+    validation.data;
+
+  let parsedOptions: Record<string, unknown> | undefined;
+  if (options) {
+    try {
+      parsedOptions = JSON.parse(options as string);
+    } catch {
+      return { success: false, message: "Invalid import options" };
+    }
+  }
 
   const serviceRole = getCarbonServiceRole();
   const importResult = await importCsv(serviceRole, {
@@ -44,7 +58,9 @@ export async function action({ request, params }: ActionFunctionArgs) {
     columnMappings,
     enumMappings: enumMappings ? JSON.parse(enumMappings as string) : undefined,
     companyId,
-    userId
+    userId,
+    dryRun: dryRun === "true",
+    options: parsedOptions
   });
 
   if (importResult.error) {
@@ -64,14 +80,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
     updated?: number;
     errors?: RowIssue[];
     skipped?: RowIssue[];
+    plan?: unknown;
   };
 
   return {
     success: true,
-    message: "Import successful",
+    dryRun: dryRun === "true",
+    message: dryRun === "true" ? "Plan ready" : "Import successful",
     inserted: data.inserted ?? 0,
     updated: data.updated ?? 0,
     errors: data.errors ?? [],
-    skipped: data.skipped ?? []
+    skipped: data.skipped ?? [],
+    plan: data.plan
   };
 }

--- a/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
+++ b/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
@@ -25,7 +25,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     filePath: z.string().min(1, { message: "Path is required" }),
     enumMappings: z.string().optional(),
     // "true" plans without writing; importers that plan (account) return it.
-    dryRun: z.string().optional(),
+    dryRun: z.enum(["true", "false"]).optional(),
     // JSON from a per-table review step (structure choice, conflict resolutions).
     options: z.string().optional()
   });

--- a/docs/content/docs/reference/import-export.mdx
+++ b/docs/content/docs/reference/import-export.mdx
@@ -33,12 +33,27 @@ Bulk import is deliberately scoped. A **Bulk Import** menu appears in the table 
   <Field name="Parts, Materials, Tools, Consumables, Fixtures">From each item type's list. A single row can optionally create a supplier-part link, set purchasing lead time, and seed unit cost alongside the item.</Field>
   <Field name="Work Centers">From the work centers list, including labor, machine, and overhead rates and a location.</Field>
   <Field name="Processes">From the processes list.</Field>
+  <Field name="Chart of accounts">From Accounting → Chart of Accounts (the **Import** button), for the root company of a company group. Accepts the chart-of-accounts export of QuickBooks, Xero, NetSuite, Sage, Business Central, Odoo, Rillet or a hand-written sheet; see below.</Field>
 </FieldTable>
 
 Beyond these table buttons, the importer also understands three **method** formats used to load bills of materials and operations against parts: a focused BOM file, a focused Operations file, and a combined part-with-method file that creates parts and their full BOM and routing together. These are richer, row-typed CSVs (each row is tagged `PART`, `BOM`, `BOP`, `STEP`, `TOOL`, or `PARAM`) driven from the method-building UI rather than a plain list screen.
 
 <Callout type="warn" title="Fixed assets and BOM components aren't importable here">
 The models list a `fixedAsset` import shape, but the import function's own table list omits it, so a fixed-asset CSV is rejected. Individual BOM material lines (`methodMaterial`) are likewise not wired up. Import the entities above; create assets and one-off BOM lines in the app.
+</Callout>
+
+## Importing a chart of accounts
+
+The chart of accounts is a tree and is shared by every company in a company group, so its import has two extra steps and a few rules of its own.
+
+- Map at least an **Account Name** and an **Account Type** column. Most exports match automatically: QuickBooks (`Account`, `Type`, `Detail type`), Xero (`*Code`, `*Name`, `*Type`), NetSuite (`Number`, `Name`, `Type`, `Subaccount of`), Sage 50 (`Account ID`, `Account Description`, `Account Type`), Business Central (`No.`, `Name`, `Account Type`, `Account Category`, `Account Subcategory Descript.`, `Indentation`), Odoo (`Code`, `Account Name`, `Type`) and Rillet (`Account Number`, `Account Name`, `Account Type`, `Account Subtype`, `Parent Grouping`).
+- On the **Account Type** step, each type in your file is matched to one of Carbon's 21 account types. The class (Asset, Liability, Equity, Revenue, Expense) and the balance-sheet / income-statement placement follow from the type; a **Class** column is only needed to disambiguate (a `Tax` account can be a liability or an expense).
+- The **Review** step shows what will happen before anything is written. Choose how the tree is built — from the file's own hierarchy (a parent column, `Parent:Child` names, or Begin-Total / End-Total rows) or by placing every account under Carbon's existing groups by type — then read the plan: rows are created, updated, merged into an existing account, unchanged, or flagged for attention.
+- A row is flagged when its name is already used by a different account of the same kind, when it would change the class of an account that has journal lines, when it would deactivate a posting-default account, or when its parent cannot be resolved. Resolve it in place — skip it, import it under another name or number, or say it is the same account as the existing one (Carbon's account is then renumbered to yours) — or import the rest now and fix the file for the remainder.
+- Re-importing the same file reports every row unchanged. Accounts are matched by **Source ID** when your file has one, else by number, else by name. Nothing is ever deleted by an import.
+
+<Callout type="note" title="The seeded chart stays">
+Every company starts with Carbon's default chart, and the posting defaults under Accounting → Default Accounts point at it. Importing adds your accounts beside it. After the import, point the defaults at your own accounts where they differ; the review lists collisions with the seeded numbers and names so you can merge or rename them.
 </Callout>
 
 ## The import flow

--- a/packages/database/supabase/functions/import-csv/account-import-writer.ts
+++ b/packages/database/supabase/functions/import-csv/account-import-writer.ts
@@ -1,0 +1,118 @@
+// Applies an account ImportPlan inside a Kysely transaction. Kept apart from
+// the planner so the planner and its tests import nothing from lib/.
+
+import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
+import type { Transaction } from "npm:kysely@0.27.6";
+import type { DB } from "../lib/database.ts";
+import type { ImportPlan, PlanNode } from "./account-import.ts";
+
+// ---------------------------------------------------------------------------
+
+export type ApplyResult = {
+  inserted: number;
+  updated: number;
+  // key → account id, for every node that now exists
+  idByKey: Map<string, string>;
+  csvMappings: Array<{ entityId: string; externalId: string }>;
+};
+
+// Applies a plan inside `trx`. Parents are inserted before children by walking
+// the plan in its own (depth-first) order, so a single transaction suffices.
+// Any DB error propagates and rolls back the whole import — the planner has
+// already pre-checked uniques and system rows, so one here is a genuine bug or
+// a concurrent edit, and the caller turns it into a 500.
+export async function applyAccountPlan(
+  trx: Transaction<DB>,
+  plan: ImportPlan,
+  args: {
+    companyGroupId: string;
+    userId: string;
+    alreadyMappedEntityIds: Set<string>;
+  }
+): Promise<ApplyResult> {
+  const now = new Date().toISOString();
+  const idByKey = new Map<string, string>();
+  const csvMappings: Array<{ entityId: string; externalId: string }> = [];
+  let inserted = 0;
+  let updated = 0;
+
+  for (const node of plan.nodes) {
+    if (node.existingId) idByKey.set(node.key, node.existingId);
+  }
+
+  const parentIdFor = (node: PlanNode): string | null => {
+    if (node.parentKey) return idByKey.get(node.parentKey) ?? null;
+    return node.parentId;
+  };
+
+  for (const node of plan.nodes) {
+    if (node.action === "create") {
+      const id = nanoid();
+      const parentId = parentIdFor(node);
+      if (node.parentKey && !parentId) {
+        throw new Error(`Parent for "${node.name}" was not created`);
+      }
+      // The planner never emits a create without a resolved class; this guard
+      // narrows the types for the NOT NULL columns.
+      if (!node.class || !node.incomeBalance || !node.consolidatedRate) {
+        throw new Error(`"${node.name}" has no class and cannot be created`);
+      }
+      await trx
+        .insertInto("account")
+        .values({
+          id,
+          name: node.name,
+          number: node.number,
+          class: node.class,
+          incomeBalance: node.incomeBalance,
+          accountType: node.accountType,
+          consolidatedRate: node.consolidatedRate,
+          isGroup: node.kind === "group",
+          parentId,
+          companyGroupId: args.companyGroupId,
+          active: node.active,
+          customFields: {},
+          createdBy: args.userId,
+          createdAt: now,
+        })
+        .execute();
+      idByKey.set(node.key, id);
+      inserted += 1;
+      if (node.externalId) csvMappings.push({ entityId: id, externalId: node.externalId });
+    } else if (node.action === "update" && node.existingId) {
+      const set: Record<string, unknown> = { updatedBy: args.userId, updatedAt: now };
+      for (const change of node.changes ?? []) {
+        if (change.startsWith("name:")) set.name = node.name;
+        else if (change.startsWith("number:")) set.number = node.number;
+        else if (change.startsWith("type:")) set.accountType = node.accountType;
+        else if (change.startsWith("class:")) {
+          set.class = node.class;
+          set.incomeBalance = node.incomeBalance;
+          set.consolidatedRate = node.consolidatedRate;
+        } else if (change.startsWith("parent:")) set.parentId = parentIdFor(node);
+        else if (change === "deactivate") set.active = false;
+        else if (change === "reactivate") set.active = true;
+      }
+      await trx
+        .updateTable("account")
+        .set(set)
+        .where("id", "=", node.existingId)
+        .execute();
+      updated += 1;
+      if (node.externalId && !args.alreadyMappedEntityIds.has(node.existingId)) {
+        csvMappings.push({ entityId: node.existingId, externalId: node.externalId });
+        args.alreadyMappedEntityIds.add(node.existingId);
+      }
+    } else if (
+      (node.action === "unchanged" || node.action === "link") &&
+      node.existingId &&
+      node.externalId &&
+      !args.alreadyMappedEntityIds.has(node.existingId)
+    ) {
+      csvMappings.push({ entityId: node.existingId, externalId: node.externalId });
+      args.alreadyMappedEntityIds.add(node.existingId);
+    }
+  }
+
+  return { inserted, updated, idByKey, csvMappings };
+}

--- a/packages/database/supabase/functions/import-csv/account-import.test.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.test.ts
@@ -335,6 +335,40 @@ Deno.test("keepNumber keeps Carbon's number on a linked or matched account", () 
   assertEquals(namedAr.action, "unchanged");
 });
 
+Deno.test("a parent chain that loops back on itself fails those rows instead of recursing", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "100", name: "A", accountType: "Cash", parent: "200" },
+      { number: "200", name: "B", accountType: "Cash", parent: "100" },
+      { number: "300", name: "C", accountType: "Cash", parent: "100" },
+      { number: "1015", name: "Petty Cash", accountType: "Cash" }
+    ),
+    ctx()
+  );
+  for (const name of ["A", "B"]) {
+    const n = byName(plan, name);
+    assertEquals(n.action, "error");
+    assert(n.reason?.includes("loops back"), n.reason);
+  }
+  // Under the loop, so not importable either; the rest of the file is.
+  assertEquals(byName(plan, "C").action, "error");
+  assertEquals(byName(plan, "Petty Cash").action, "create");
+  assertEquals(plan.summary.errors, 3);
+});
+
+Deno.test("a blank cell in a mapped Active column leaves the account's status alone", () => {
+  const inactive = seed().map((a) => (a.id === "1010" ? { ...a, active: false } : a));
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1010", name: "Bank - Cash", accountType: "Bank", active: "" },
+      { number: "1110", name: "Accounts Receivable", accountType: "Accounts Receivable", active: "true" }
+    ),
+    ctx({ existing: inactive })
+  );
+  assertEquals(byName(plan, "Bank - Cash").action, "unchanged");
+  assertEquals(byName(plan, "Accounts Receivable").action, "unchanged");
+});
+
 Deno.test("system roots are adopted, never written", () => {
   const plan = planChartOfAccounts(
     rows(

--- a/packages/database/supabase/functions/import-csv/account-import.test.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.test.ts
@@ -306,6 +306,35 @@ Deno.test("a number match renames; a name held by another account is a conflict 
   assertEquals(byName(third, "Accounts Receivable (11000)").action, "create");
 });
 
+Deno.test("keepNumber keeps Carbon's number on a linked or matched account", () => {
+  const linked = planChartOfAccounts(
+    rows({ number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable" }),
+    ctx(),
+    { resolutions: { "0": { action: "link", accountId: "1110", keepNumber: true } } }
+  );
+  const ar = byName(linked, "Accounts Receivable");
+  assertEquals(ar.existingId, "1110");
+  assertEquals(ar.action, "unchanged");
+
+  const matched = planChartOfAccounts(
+    rows({ number: "1015", name: "Bank - Cash", accountType: "Bank", externalId: "ext-1" }),
+    ctx({ externalIdMap: new Map([["ext-1", "1010"]]) }),
+    { resolutions: { "0": { action: "keepNumber" } } }
+  );
+  assertEquals(byName(matched, "Bank - Cash").action, "unchanged");
+
+  // A numbered row told to keep Carbon's number is the account of that name.
+  const named = planChartOfAccounts(
+    rows({ number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable" }),
+    ctx(),
+    { resolutions: { "0": { action: "keepNumber" } } }
+  );
+  const namedAr = byName(named, "Accounts Receivable");
+  assertEquals(namedAr.existingId, "1110");
+  assertEquals(namedAr.existingNumber, "1110");
+  assertEquals(namedAr.action, "unchanged");
+});
+
 Deno.test("system roots are adopted, never written", () => {
   const plan = planChartOfAccounts(
     rows(

--- a/packages/database/supabase/functions/import-csv/account-import.test.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.test.ts
@@ -58,7 +58,7 @@ const seed = (): ExistingAccount[] => {
     a("1010", "1010", "Bank - Cash", false, "cash", "Asset", "Bank"),
     a("1110", "1110", "Accounts Receivable", false, "recv", "Asset", "Accounts Receivable"),
     a("4010", "4010", "Sales", false, "rev", "Revenue", "Income"),
-    a("5010", "5010", "Cost of Goods Sold", false, "cogs", "Expense", "Cost of Goods Sold"),
+    a("5010", "5010", "Cost of Goods Sold - Direct", false, "cogs", "Expense", "Cost of Goods Sold"),
     a("6010", "6010", "Maintenance", false, "opex", "Expense", "Expense"),
   ];
 };
@@ -112,6 +112,58 @@ Deno.test("grouping labels synthesize groups under the class anchor; a label mat
   assertEquals(plan.summary.errors, 0);
   assertEquals(plan.summary.groupsToCreate, 2);
   assertEquals(plan.summary.accountsToCreate, 4);
+});
+
+Deno.test("a grouping label equal to the row's own name is a group, not a self-reference", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable", parent: "Accounts Receivable" },
+      { number: "22000", name: "Deferred Revenue", accountType: "Other Current Liability", parent: "Deferred Revenue" }
+    ),
+    ctx()
+  );
+  // No Carbon group is named "Accounts Receivable" (the seed has "Receivables"), so
+  // a group is synthesized and anchored by type; the leaf collides with 1110.
+  const arGroup = plan.nodes.find((n) => n.kind === "group" && n.name === "Accounts Receivable");
+  assert(arGroup);
+  assertEquals(arGroup.action, "create");
+  assertEquals(arGroup.parentId, "recv");
+  const ar = plan.nodes.find((n) => n.kind === "account" && n.name === "Accounts Receivable");
+  assertEquals(ar?.parentKey, arGroup.key);
+  assertEquals(ar?.conflict?.existingId, "1110");
+  const dr = byName(plan, "Deferred Revenue");
+  assertEquals(dr.action, "create");
+  assert(plan.nodes.every((n) => !(n.reason ?? "").includes("own parent")));
+});
+
+Deno.test("a grouping label that is also a member account's name resolves to Carbon's group, not the member", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "50000", name: "Cost of Goods Sold", accountType: "Cost of Goods Sold", parent: "Cost of Goods Sold" },
+      { number: "50100", name: "Absorption (MFG)", accountType: "Cost of Goods Sold", parent: "Cost of Goods Sold" }
+    ),
+    ctx()
+  );
+  const cogs = plan.nodes.find((n) => n.number === "50000");
+  assertEquals(cogs?.kind, "account");
+  assertEquals(cogs?.action, "create");
+  assertEquals(cogs?.parentId, "cogs");
+  assertEquals(plan.nodes.find((n) => n.number === "50100")?.parentId, "cogs");
+  assertEquals(plan.summary.errors, 0);
+
+  // Without a Carbon group of that name, a file posting account named like
+  // the label is still promoted (QuickBooks-style sub-accounts).
+  const promotedPlan = planChartOfAccounts(
+    rows(
+      { number: "1000", name: "Bank Accounts", accountType: "Bank" },
+      { number: "1010", name: "Operating", accountType: "Bank", parent: "Bank Accounts" }
+    ),
+    ctx()
+  );
+  const bank = byName(promotedPlan, "Bank Accounts");
+  assertEquals(bank.kind, "group");
+  assertEquals(bank.promoted, true);
+  assertEquals(byName(promotedPlan, "Operating").parentKey, bank.key);
 });
 
 Deno.test("colon paths split into groups; a parent that is also a row is promoted", () => {

--- a/packages/database/supabase/functions/import-csv/account-import.test.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.test.ts
@@ -1,0 +1,440 @@
+import {
+  assert,
+  assertEquals,
+  assertStringIncludes,
+} from "https://deno.land/std@0.175.0/testing/asserts.ts";
+import {
+  type ExistingAccount,
+  type ImportPlan,
+  isInvertedActiveHeader,
+  type PlanContext,
+  planChartOfAccounts,
+} from "./account-import.ts";
+
+// A miniature of the seeded chart: two system roots, class groups, a few
+// typed sub-groups and posting accounts.
+const seed = (): ExistingAccount[] => {
+  const a = (
+    id: string,
+    number: string | null,
+    name: string,
+    isGroup: boolean,
+    parentId: string | null,
+    cls: ExistingAccount["class"],
+    type: ExistingAccount["accountType"],
+    extra: Partial<ExistingAccount> = {}
+  ): ExistingAccount => ({
+    id,
+    number,
+    name,
+    isGroup,
+    isSystem: false,
+    parentId,
+    class: cls,
+    accountType: type,
+    incomeBalance:
+      cls === null
+        ? name === "Balance Sheet"
+          ? "Balance Sheet"
+          : "Income Statement"
+        : ["Asset", "Liability", "Equity"].includes(cls)
+        ? "Balance Sheet"
+        : "Income Statement",
+    active: true,
+    ...extra,
+  });
+  return [
+    a("bs", null, "Balance Sheet", true, null, null, null, { isSystem: true }),
+    a("is", null, "Income Statement", true, null, null, null, { isSystem: true }),
+    a("assets", null, "Assets", true, "bs", "Asset", "Other Current Asset"),
+    a("cash", null, "Cash & Bank", true, "assets", "Asset", "Bank"),
+    a("recv", null, "Receivables", true, "assets", "Asset", "Accounts Receivable"),
+    a("liab", null, "Liabilities", true, "bs", "Liability", "Other Current Liability"),
+    a("equity", null, "Equity", true, "bs", "Equity", "Equity - No Close"),
+    a("rev", null, "Revenue", true, "is", "Revenue", "Income"),
+    a("cogs", null, "Cost of Goods Sold", true, "is", "Expense", "Cost of Goods Sold"),
+    a("opex", null, "Operating Expenses", true, "is", "Expense", "Expense"),
+    a("othexp", null, "Other Expenses", true, "is", "Expense", "Other Expense"),
+    a("1010", "1010", "Bank - Cash", false, "cash", "Asset", "Bank"),
+    a("1110", "1110", "Accounts Receivable", false, "recv", "Asset", "Accounts Receivable"),
+    a("4010", "4010", "Sales", false, "rev", "Revenue", "Income"),
+    a("5010", "5010", "Cost of Goods Sold", false, "cogs", "Expense", "Cost of Goods Sold"),
+    a("6010", "6010", "Maintenance", false, "opex", "Expense", "Expense"),
+  ];
+};
+
+const ctx = (overrides: Partial<PlanContext> = {}): PlanContext => ({
+  existing: seed(),
+  externalIdMap: new Map(),
+  postedAccountIds: new Set(),
+  protectedAccountIds: new Set(["1110", "4010"]),
+  ...overrides,
+});
+
+const byName = (plan: ImportPlan, name: string) => {
+  const node = plan.nodes.find((n) => n.name === name);
+  assert(node, `no node named ${name}`);
+  return node;
+};
+
+const rows = (...list: Record<string, string>[]) => list;
+
+Deno.test("grouping labels synthesize groups under the class anchor; a label matching a Carbon group adopts it", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "10000", name: "Checking - Mercury", accountType: "Bank", parent: "Cash Accounts" },
+      { number: "10010", name: "Savings", accountType: "Bank", parent: "Cash Accounts" },
+      { number: "12000", name: "Trade Debtors", accountType: "Accounts Receivable", parent: "Assets" },
+      { number: "50000", name: "Materials", accountType: "Cost of Goods Sold", parent: "Direct Costs" }
+    ),
+    ctx()
+  );
+  assertEquals(plan.structure, "file");
+  assertEquals(plan.signal, "parent");
+
+  const cashGroup = byName(plan, "Cash Accounts");
+  assertEquals(cashGroup.action, "create");
+  assertEquals(cashGroup.kind, "group");
+  assertEquals(cashGroup.class, "Asset");
+  // Anchored under the shallowest group with the same accountType (Bank).
+  assertEquals(cashGroup.parentId, "cash");
+  assertEquals(cashGroup.anchorLabel, "Cash & Bank");
+
+  // A label that names a Carbon group resolves straight to it: no node.
+  assert(!plan.nodes.some((n) => n.name === "Assets"));
+  const debtors = byName(plan, "Trade Debtors");
+  assertEquals(debtors.parentId, "assets");
+  assertEquals(debtors.action, "create");
+
+  const direct = byName(plan, "Direct Costs");
+  assertEquals(direct.parentId, "cogs");
+
+  assertEquals(plan.summary.errors, 0);
+  assertEquals(plan.summary.groupsToCreate, 2);
+  assertEquals(plan.summary.accountsToCreate, 4);
+});
+
+Deno.test("colon paths split into groups; a parent that is also a row is promoted", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1000", name: "Current Assets", accountType: "Other Current Asset" },
+      { number: "1001", name: "Current Assets:Petty Cash", accountType: "Cash" },
+      { number: "1002", name: "Current Assets:Bank:Operating", accountType: "Bank" }
+    ),
+    ctx()
+  );
+  assertEquals(plan.signal, "path");
+  const current = byName(plan, "Current Assets");
+  assertEquals(current.kind, "group");
+  assertEquals(current.promoted, true);
+  assertEquals(current.number, "1000");
+  assertEquals(current.parentId, "assets");
+
+  const petty = byName(plan, "Petty Cash");
+  assertEquals(petty.parentKey, current.key);
+
+  const bank = byName(plan, "Bank");
+  assertEquals(bank.synthesized, true);
+  assertEquals(bank.parentKey, current.key);
+  const operating = byName(plan, "Operating");
+  assertEquals(operating.parentKey, bank.key);
+  assertEquals(plan.summary.errors, 0);
+
+  // Parents precede children in plan order.
+  const idx = (name: string) => plan.nodes.findIndex((n) => n.name === name);
+  assert(idx("Current Assets") < idx("Petty Cash"));
+  assert(idx("Bank") < idx("Operating"));
+});
+
+Deno.test("a flat file places leaves under Carbon's groups by account type, then by class", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "200", name: "Business Savings", accountType: "Bank" },
+      { number: "820", name: "GST Payable", accountType: "Tax" },
+      { number: "310", name: "Cost of Sales", accountType: "Cost of Goods Sold" },
+      { number: "404", name: "Bank Fees", accountType: "Expense" },
+      { number: "900", name: "Owner Draw", accountType: "Equity - Close" }
+    ),
+    ctx()
+  );
+  assertEquals(plan.structure, "carbon");
+  assertEquals(byName(plan, "Business Savings").parentId, "cash");
+  // Tax → Liability class by default; no Tax-typed group → the class anchor.
+  assertEquals(byName(plan, "GST Payable").parentId, "liab");
+  assertEquals(byName(plan, "Cost of Sales").parentId, "cogs");
+  assertEquals(byName(plan, "Bank Fees").parentId, "opex");
+  assertEquals(byName(plan, "Owner Draw").parentId, "equity");
+  assertEquals(plan.summary.errors, 0);
+});
+
+Deno.test("Begin-Total / End-Total rows build the tree; headings use indentation; totals are skipped", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1000", name: "ASSETS", rowKind: "Heading", indent: "0", class: "Asset" },
+      { number: "1100", name: "Liquid Assets", rowKind: "Group", indent: "1" },
+      { number: "1110", name: "Cash", accountType: "Cash", rowKind: "Account", indent: "2" },
+      { number: "1120", name: "Bank, Checking", accountType: "Bank", rowKind: "Account", indent: "2" },
+      { number: "1199", name: "Liquid Assets, Total", rowKind: "Total", indent: "1" },
+      { number: "1200", name: "Inventory", accountType: "Inventory", rowKind: "Account", indent: "1" },
+      { number: "2000", name: "LIABILITIES", rowKind: "Heading", indent: "0", class: "Liability" },
+      { number: "2100", name: "Vendors", accountType: "Accounts Payable", rowKind: "Account", indent: "1" }
+    ),
+    ctx()
+  );
+  assertEquals(plan.signal, "rowKind");
+  // A heading named like a Carbon group adopts it (case-insensitive).
+  const assetsHeading = byName(plan, "ASSETS");
+  assertEquals(assetsHeading.kind, "group");
+  assertEquals(assetsHeading.action, "link");
+  assertEquals(assetsHeading.existingId, "assets");
+  const liquid = byName(plan, "Liquid Assets");
+  assertEquals(liquid.parentKey, assetsHeading.key);
+  assertEquals(byName(plan, "Cash").parentKey, liquid.key);
+  assertEquals(byName(plan, "Liquid Assets, Total").action, "skip");
+  // After the total, Inventory hangs off the heading again.
+  assertEquals(byName(plan, "Inventory").parentKey, assetsHeading.key);
+  // A new heading at indent 0 closes the previous one.
+  const liabHeading = byName(plan, "LIABILITIES");
+  assertEquals(liabHeading.action, "link");
+  assertEquals(liabHeading.existingId, "liab");
+  assertEquals(byName(plan, "Vendors").parentKey, liabHeading.key);
+  assertEquals(plan.summary.errors, 0);
+});
+
+Deno.test("re-importing what Carbon already has reports every row unchanged", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1010", name: "Bank - Cash", accountType: "Bank" },
+      { number: "4010", name: "Sales", accountType: "Income" }
+    ),
+    ctx()
+  );
+  assertEquals(plan.summary.unchanged, 2);
+  assertEquals(plan.summary.accountsToCreate, 0);
+});
+
+Deno.test("a number match renames; a name held by another account is a conflict with a link resolution", () => {
+  const first = planChartOfAccounts(
+    rows(
+      { number: "1010", name: "Operating Account", accountType: "Bank" },
+      { number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable" }
+    ),
+    ctx()
+  );
+  const renamed = byName(first, "Operating Account");
+  assertEquals(renamed.action, "update");
+  assertEquals(renamed.existingId, "1010");
+  assertStringIncludes(renamed.changes?.[0] ?? "", "name:");
+
+  const conflict = byName(first, "Accounts Receivable");
+  assertEquals(conflict.action, "error");
+  assertEquals(conflict.conflict?.existingId, "1110");
+  assertEquals(conflict.conflict?.linkable, true);
+
+  // Resolve by linking: Carbon's 1110 becomes the customer's 11000.
+  const second = planChartOfAccounts(
+    rows(
+      { number: "1010", name: "Operating Account", accountType: "Bank" },
+      { number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable" }
+    ),
+    ctx(),
+    { resolutions: { "1": { action: "link", accountId: "1110" } } }
+  );
+  const linked = byName(second, "Accounts Receivable");
+  assertEquals(linked.action, "update");
+  assertEquals(linked.existingId, "1110");
+  assert(linked.changes?.some((c) => c.startsWith("number: 1110 → 11000")));
+
+  // Or by renaming.
+  const third = planChartOfAccounts(
+    rows({ number: "11000", name: "Accounts Receivable", accountType: "Accounts Receivable" }),
+    ctx(),
+    { resolutions: { "0": { action: "rename", name: "Accounts Receivable (11000)" } } }
+  );
+  assertEquals(byName(third, "Accounts Receivable (11000)").action, "create");
+});
+
+Deno.test("system roots are adopted, never written", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { name: "Balance Sheet", isGroup: "true", class: "Liability" },
+      { number: "1500", name: "Deposits", accountType: "Other Current Asset", parent: "Balance Sheet" },
+      { number: "9999", name: "Income Statement", accountType: "Income" }
+    ),
+    ctx()
+  );
+  // A group row named like the root links to it whatever its class column
+  // says, and rows naming it as their parent hang off that link.
+  const root = byName(plan, "Balance Sheet");
+  assertEquals(root.action, "link");
+  assertEquals(root.existingId, "bs");
+  assertEquals(byName(plan, "Deposits").parentKey, root.key);
+  // A posting account may share a root's name (uniqueness is per kind).
+  assertEquals(plan.nodes.find((n) => n.number === "9999")?.action, "create");
+
+  // A numbered heading named like a root (Business Central exports number
+  // their headings) links to the root; the file's number is not applied.
+  const numbered = planChartOfAccounts(
+    rows(
+      { number: "10000", name: "BALANCE SHEET", rowKind: "Heading", indent: "0" },
+      { number: "10001", name: "ASSETS", rowKind: "Group", indent: "1", class: "Asset" },
+      { number: "10100", name: "Cash", accountType: "Cash", rowKind: "Account", indent: "2" }
+    ),
+    ctx()
+  );
+  const heading = byName(numbered, "BALANCE SHEET");
+  assertEquals(heading.action, "link");
+  assertEquals(heading.existingId, "bs");
+  // A numbered group named like a Carbon group links to it the same way.
+  const assetsGroup = byName(numbered, "ASSETS");
+  assertEquals(assetsGroup.action, "link");
+  assertEquals(assetsGroup.existingId, "assets");
+  assertEquals(byName(numbered, "Cash").parentKey, assetsGroup.key);
+  assertEquals(numbered.summary.errors, 0);
+
+  // A link resolution pointing a posting row at a root is refused.
+  const forced = planChartOfAccounts(
+    rows({ number: "9999", name: "Income Statement", accountType: "Income" }),
+    ctx(),
+    { resolutions: { "0": { action: "link", accountId: "is" } } }
+  );
+  assertStringIncludes(forced.nodes[0].reason ?? "", "system account");
+});
+
+Deno.test("deactivating a posting default or a posted account is refused; an unmapped Active column changes nothing", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1110", name: "Accounts Receivable", accountType: "Accounts Receivable", active: "false" },
+      { number: "6010", name: "Maintenance", accountType: "Expense", active: "No" },
+      { number: "1010", name: "Bank - Cash", accountType: "Bank" }
+    ),
+    ctx({ postedAccountIds: new Set(["6010"]) })
+  );
+  assertStringIncludes(byName(plan, "Accounts Receivable").reason ?? "", "posting default");
+  assertStringIncludes(byName(plan, "Maintenance").reason ?? "", "journal lines");
+  assertEquals(byName(plan, "Bank - Cash").action, "unchanged");
+
+  const inactiveExisting = seed().map((a) => (a.id === "1010" ? { ...a, active: false } : a));
+  const untouched = planChartOfAccounts(
+    rows({ number: "1010", name: "Bank - Cash", accountType: "Bank" }),
+    ctx({ existing: inactiveExisting })
+  );
+  assertEquals(byName(untouched, "Bank - Cash").action, "unchanged");
+  const reactivated = planChartOfAccounts(
+    rows({ number: "1010", name: "Bank - Cash", accountType: "Bank", active: "true" }),
+    ctx({ existing: inactiveExisting })
+  );
+  assertEquals(byName(reactivated, "Bank - Cash").changes, ["reactivate"]);
+});
+
+Deno.test("an inverted Active header flips the meaning", () => {
+  assert(isInvertedActiveHeader("Inactive"));
+  assert(isInvertedActiveHeader("Is Hidden"));
+  assert(!isInvertedActiveHeader("Active"));
+  const plan = planChartOfAccounts(
+    rows({ number: "1500", name: "Deposits", accountType: "Other Current Asset", active: "Yes" }),
+    ctx(),
+    { activeInverted: true }
+  );
+  assertEquals(byName(plan, "Deposits").active, false);
+});
+
+Deno.test("class changes on a posted account are refused; class mismatch with the parent errors the leaf", () => {
+  const posted = planChartOfAccounts(
+    rows({ number: "4010", name: "Sales", accountType: "Other Current Liability" }),
+    ctx({ postedAccountIds: new Set(["4010"]) })
+  );
+  assertStringIncludes(byName(posted, "Sales").reason ?? "", "journal lines");
+
+  const mixed = planChartOfAccounts(
+    rows(
+      { number: "7000", name: "Alpha", accountType: "Expense", parent: "Misc" },
+      { number: "7001", name: "Beta", accountType: "Expense", parent: "Misc" },
+      { number: "7002", name: "Gamma", accountType: "Other Income", parent: "Misc" }
+    ),
+    ctx()
+  );
+  assertEquals(byName(mixed, "Misc").class, "Expense");
+  const gamma = byName(mixed, "Gamma");
+  assertEquals(gamma.action, "error");
+  assertStringIncludes(gamma.reason ?? "", "does not match the parent group");
+});
+
+Deno.test("moving an existing group under its own descendant is a cycle", () => {
+  const existing = seed().concat([
+    {
+      id: "sub",
+      number: null,
+      name: "Sub Cash",
+      isGroup: true,
+      isSystem: false,
+      parentId: "cash",
+      class: "Asset",
+      accountType: "Bank",
+      incomeBalance: "Balance Sheet",
+      active: true,
+    },
+  ]);
+  const plan = planChartOfAccounts(
+    rows(
+      { name: "Cash & Bank", isGroup: "true", parent: "Sub Cash" },
+      { name: "Sub Cash", isGroup: "true" }
+    ),
+    ctx({ existing })
+  );
+  const moved = byName(plan, "Cash & Bank");
+  assertEquals(moved.action, "error");
+  assertStringIncludes(moved.reason ?? "", "cycle");
+});
+
+Deno.test("in-file duplicates, missing names, unmapped types and skips are reported per row", () => {
+  const plan = planChartOfAccounts(
+    rows(
+      { number: "1500", name: "Deposits", accountType: "Other Current Asset" },
+      { number: "1500", name: "Deposits Again", accountType: "Other Current Asset" },
+      { number: "1600", name: "", accountType: "Other Current Asset" },
+      { number: "1700", name: "Mystery", accountType: "" },
+      { number: "1800", name: "Skip me", accountType: "Cash" }
+    ),
+    ctx(),
+    { resolutions: { "4": { action: "skip" } } }
+  );
+  assertStringIncludes(byName(plan, "Deposits Again").reason ?? "", "Duplicate account number");
+  assertEquals(plan.nodes[2].action, "error");
+  assertStringIncludes(byName(plan, "Mystery").reason ?? "", "Account type is required");
+  assertEquals(byName(plan, "Skip me").action, "skip");
+  assertEquals(plan.summary.errors, 3);
+  assertEquals(plan.summary.skipped, 1);
+});
+
+Deno.test("a Source ID matches through the csv mapping and allows renumbering", () => {
+  const plan = planChartOfAccounts(
+    rows({ number: "1015", name: "Bank - Cash", accountType: "Bank", externalId: "ext-1" }),
+    ctx({ externalIdMap: new Map([["ext-1", "1010"]]) })
+  );
+  const node = byName(plan, "Bank - Cash");
+  assertEquals(node.action, "update");
+  assertEquals(node.existingId, "1010");
+  assertEquals(node.changes, ["number: 1010 → 1015"]);
+});
+
+Deno.test("structure=carbon drops file groups; structure=file without signals falls back with a warning", () => {
+  const dropped = planChartOfAccounts(
+    rows(
+      { name: "My Group", isGroup: "true" },
+      { number: "1500", name: "Deposits", accountType: "Other Current Asset", parent: "My Group" }
+    ),
+    ctx(),
+    { structure: "carbon" }
+  );
+  assertEquals(byName(dropped, "My Group").action, "skip");
+  assertEquals(byName(dropped, "Deposits").parentId, "assets");
+
+  const fallback = planChartOfAccounts(
+    rows({ number: "1500", name: "Deposits", accountType: "Other Current Asset" }),
+    ctx(),
+    { structure: "file" }
+  );
+  assertEquals(fallback.structure, "carbon");
+  assertEquals(fallback.warnings.length, 1);
+});

--- a/packages/database/supabase/functions/import-csv/account-import.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.ts
@@ -1,0 +1,1206 @@
+// Chart-of-accounts import: the pure planner. The writer that applies a plan
+// lives in account-import-writer.ts so this module (and its tests) stay free of
+// database imports.
+//
+// The planner turns mapped CSV rows and the company group's existing chart into
+// an ImportPlan — one node per source row (plus one per synthesized group), each
+// with an action and, for refusals, a reason. The same plan is returned to the
+// wizard for review (dryRun) and applied by `applyAccountPlan` on commit, so what
+// the user reviews is exactly what gets written.
+//
+// Why accounts need their own planner rather than `classifyImportRow`:
+//   - `account` is scoped by companyGroupId, and its natural keys are `number`
+//     for leaves and `(name, isGroup)` for groups (`account_number_key`,
+//     `account_name_key`).
+//   - The chart is a tree. Parents arrive as a number, a "number name" string, a
+//     group name, a grouping label that is not an account, a colon-delimited
+//     path inside the name (QuickBooks), or Begin-Total / End-Total rows
+//     (Business Central, Sage 50 Canada). Nothing in the DB guards
+//     parent-is-group, class agreement with the parent, or cycles, so the
+//     planner does.
+//   - `class` / `incomeBalance` / `consolidatedRate` are derived, never mapped.
+//   - The two isSystem roots are frozen by trigger and must only ever be adopted
+//     as parents.
+//
+// Spec: .ai/specs/2026-09-04-chart-of-accounts-import.md
+
+// ---------------------------------------------------------------------------
+// Carbon's vocabulary (mirrors apps/erp/app/modules/accounting/accounting.models.ts)
+// ---------------------------------------------------------------------------
+
+export const ACCOUNT_TYPES = [
+  "Bank",
+  "Cash",
+  "Accounts Receivable",
+  "Accounts Payable",
+  "Inventory",
+  "Fixed Asset",
+  "Accumulated Depreciation",
+  "Other Current Asset",
+  "Other Asset",
+  "Other Current Liability",
+  "Long Term Liability",
+  "Equity - No Close",
+  "Equity - Close",
+  "Retained Earnings",
+  "Income",
+  "Cost of Goods Sold",
+  "Expense",
+  "Other Income",
+  "Other Expense",
+  "Tax",
+  "Investments",
+] as const;
+export type AccountType = (typeof ACCOUNT_TYPES)[number];
+
+export const ACCOUNT_CLASSES = [
+  "Asset",
+  "Liability",
+  "Equity",
+  "Revenue",
+  "Expense",
+] as const;
+export type AccountClass = (typeof ACCOUNT_CLASSES)[number];
+export type IncomeBalance = "Balance Sheet" | "Income Statement";
+export type ConsolidatedRate = "Average" | "Current" | "Historical";
+
+export const TYPES_BY_CLASS: Record<AccountClass, readonly AccountType[]> = {
+  Asset: [
+    "Bank",
+    "Cash",
+    "Accounts Receivable",
+    "Inventory",
+    "Fixed Asset",
+    "Accumulated Depreciation",
+    "Other Current Asset",
+    "Other Asset",
+    "Investments",
+  ],
+  Liability: [
+    "Accounts Payable",
+    "Other Current Liability",
+    "Long Term Liability",
+    "Tax",
+  ],
+  Equity: ["Equity - No Close", "Equity - Close", "Retained Earnings"],
+  Revenue: ["Income", "Other Income"],
+  Expense: ["Cost of Goods Sold", "Expense", "Other Expense", "Tax"],
+};
+
+// Tax is legal under Liability and Expense; Liability wins when the file gives
+// no class column, which matches the seeded 2210-2230 tax payable accounts.
+export const CLASS_OF_TYPE: Record<AccountType, AccountClass> = (() => {
+  const out = {} as Record<AccountType, AccountClass>;
+  for (const cls of ACCOUNT_CLASSES) {
+    for (const type of TYPES_BY_CLASS[cls]) {
+      if (!(type in out)) out[type] = cls;
+    }
+  }
+  return out;
+})();
+
+export const INCOME_BALANCE_BY_CLASS: Record<AccountClass, IncomeBalance> = {
+  Asset: "Balance Sheet",
+  Liability: "Balance Sheet",
+  Equity: "Balance Sheet",
+  Revenue: "Income Statement",
+  Expense: "Income Statement",
+};
+
+// The seed rule (20260315000002_exchange-rate-history.sql): equity translates
+// at the historical rate, other balance-sheet lines at the closing rate, the
+// income statement at the average rate.
+export const CONSOLIDATED_RATE_BY_CLASS: Record<AccountClass, ConsolidatedRate> =
+  {
+    Asset: "Current",
+    Liability: "Current",
+    Equity: "Historical",
+    Revenue: "Average",
+    Expense: "Average",
+  };
+
+// When a class has several top-level groups (Expense: Cost of Goods Sold,
+// Operating Expenses, Other Expenses) and the leaf's own type matches none of
+// them, prefer the group with this type.
+const DEFAULT_ANCHOR_TYPE: Record<AccountClass, AccountType> = {
+  Asset: "Other Current Asset",
+  Liability: "Other Current Liability",
+  Equity: "Equity - No Close",
+  Revenue: "Income",
+  Expense: "Expense",
+};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ExistingAccount = {
+  id: string;
+  number: string | null;
+  name: string;
+  isGroup: boolean;
+  isSystem: boolean;
+  parentId: string | null;
+  class: AccountClass | null;
+  accountType: AccountType | null;
+  incomeBalance: IncomeBalance;
+  active: boolean;
+};
+
+export type Resolution =
+  | { action: "skip" }
+  | { action: "rename"; name: string }
+  | { action: "renumber"; number: string }
+  | { action: "link"; accountId: string };
+
+export type AccountImportOptions = {
+  structure?: "auto" | "file" | "carbon";
+  pathSeparator?: string;
+  resolutions?: Record<string, Resolution>;
+  // True when the mapped Active column is named Inactive / Hidden / Deprecated
+  // / Blocked / Archived, so its truthy values mean inactive.
+  activeInverted?: boolean;
+};
+
+export type PlanContext = {
+  existing: ExistingAccount[];
+  // csv externalId → account id (externalIntegrationMapping, integration "csv")
+  externalIdMap: Map<string, string>;
+  // accounts that have journal lines — class may not change, may not deactivate
+  postedAccountIds: Set<string>;
+  // accounts referenced by accountDefault / fixedAssetClass — may not deactivate
+  protectedAccountIds: Set<string>;
+};
+
+export type PlanAction =
+  | "create"
+  | "update"
+  | "link"
+  | "unchanged"
+  | "skip"
+  | "error";
+
+export type PlanConflict = {
+  existingId: string;
+  number: string | null;
+  name: string;
+  kind: "group" | "account";
+  // The "use existing" resolution is only offered when the kinds agree.
+  linkable: boolean;
+};
+
+export type PlanNode = {
+  key: string;
+  row: number | null;
+  // The row used to attribute a synthesized group's issue in the results UI.
+  reportRow: number;
+  kind: "group" | "account";
+  action: PlanAction;
+  reason?: string;
+  changes?: string[];
+  number: string | null;
+  name: string;
+  class: AccountClass | null;
+  accountType: AccountType | null;
+  incomeBalance: IncomeBalance | null;
+  consolidatedRate: ConsolidatedRate | null;
+  active: boolean;
+  externalId: string | null;
+  // Exactly one of parentKey (a plan node) / parentId (an existing account) is
+  // set for a node that will be written; both null means a new root.
+  parentKey: string | null;
+  parentId: string | null;
+  parentLabel: string | null;
+  // Existing account this node resolves to (update / link / unchanged).
+  existingId: string | null;
+  depth: number;
+  // Name of the existing account the top of this node's subtree hangs under.
+  anchorLabel: string | null;
+  conflict?: PlanConflict;
+  promoted?: boolean;
+  synthesized?: boolean;
+};
+
+export type ImportPlan = {
+  structure: "file" | "carbon";
+  signal: "rowKind" | "parent" | "path" | null;
+  nodes: PlanNode[];
+  warnings: string[];
+  summary: {
+    groupsToCreate: number;
+    accountsToCreate: number;
+    updates: number;
+    linked: number;
+    unchanged: number;
+    skipped: number;
+    errors: number;
+  };
+};
+
+type SourceRow = {
+  index: number;
+  number: string | null;
+  name: string;
+  displayName: string;
+  accountType: AccountType | null;
+  rawAccountType: string;
+  class: AccountClass | null;
+  rawClass: string;
+  parentRef: string | null;
+  isGroup: boolean;
+  rowKind: "Account" | "Group" | "Total" | "Heading" | "Ignore";
+  indent: number | null;
+  active: boolean;
+  // False when the file has no Active column: updates then leave `active` alone.
+  activeSpecified: boolean;
+  externalId: string | null;
+  linkAccountId: string | null;
+  skipReason: string | null;
+  errorReason: string | null;
+};
+
+type NodeRef =
+  | { kind: "row"; index: number }
+  | { kind: "synth"; key: string }
+  | { kind: "existing"; id: string };
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+const norm = (value: string | null | undefined): string =>
+  (value ?? "").trim().toLowerCase();
+
+const isAccountType = (value: string): value is AccountType =>
+  (ACCOUNT_TYPES as readonly string[]).includes(value);
+
+const isAccountClass = (value: string): value is AccountClass =>
+  (ACCOUNT_CLASSES as readonly string[]).includes(value);
+
+export function parseBoolean(
+  value: string | undefined,
+  fallback: boolean
+): boolean {
+  const v = norm(value);
+  if (v === "") return fallback;
+  if (["true", "yes", "y", "1", "t", "x", "active", "on"].includes(v))
+    return true;
+  if (
+    [
+      "false",
+      "no",
+      "n",
+      "0",
+      "f",
+      "inactive",
+      "off",
+      "archived",
+      "deleted",
+      "blocked",
+      "hidden",
+      "deprecated",
+    ].includes(v)
+  )
+    return false;
+  return fallback;
+}
+
+// A mapped column whose header says the opposite of "active".
+export function isInvertedActiveHeader(header: string | undefined): boolean {
+  const h = norm(header);
+  return ["inactive", "hidden", "deprecated", "blocked", "archived"].some(
+    (word) => h === word || h === `is ${word}`
+  );
+}
+
+function majority<T extends string>(values: T[]): T | null {
+  if (values.length === 0) return null;
+  const counts = new Map<T, number>();
+  for (const v of values) counts.set(v, (counts.get(v) ?? 0) + 1);
+  let best: T | null = null;
+  let bestCount = 0;
+  for (const [v, c] of counts) {
+    if (c > bestCount) {
+      best = v;
+      bestCount = c;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// Planner
+// ---------------------------------------------------------------------------
+
+export function planChartOfAccounts(
+  records: Record<string, string>[],
+  ctx: PlanContext,
+  options: AccountImportOptions = {}
+): ImportPlan {
+  const warnings: string[] = [];
+  const resolutions = options.resolutions ?? {};
+  const separator = (options.pathSeparator ?? ":").trim() || ":";
+
+  // -- existing chart indexes ------------------------------------------------
+  const existingById = new Map(ctx.existing.map((a) => [a.id, a]));
+  const existingByNumber = new Map<string, ExistingAccount>();
+  const existingByNumberName = new Map<string, ExistingAccount>();
+  const existingGroupByName = new Map<string, ExistingAccount>();
+  const existingLeafByName = new Map<string, ExistingAccount>();
+  for (const a of ctx.existing) {
+    if (a.number) {
+      existingByNumber.set(norm(a.number), a);
+      existingByNumberName.set(`${norm(a.number)} ${norm(a.name)}`, a);
+    }
+    (a.isGroup ? existingGroupByName : existingLeafByName).set(norm(a.name), a);
+  }
+  const existingDepth = (a: ExistingAccount): number => {
+    let depth = 0;
+    const seen = new Set<string>();
+    let cur: ExistingAccount | undefined = a;
+    while (cur?.parentId && !seen.has(cur.parentId)) {
+      seen.add(cur.parentId);
+      cur = existingById.get(cur.parentId);
+      if (!cur) break;
+      depth += 1;
+    }
+    return depth;
+  };
+  const existingGroups = ctx.existing
+    .filter((a) => a.isGroup && a.active)
+    .map((a) => ({ account: a, depth: existingDepth(a) }))
+    .sort(
+      (x, y) => x.depth - y.depth || x.account.name.localeCompare(y.account.name)
+    );
+  const systemRootFor = (incomeBalance: IncomeBalance) =>
+    ctx.existing.find(
+      (a) => a.isSystem && a.parentId === null && a.incomeBalance === incomeBalance
+    ) ?? null;
+
+  // Shallowest active, non-system group for a class, preferring one whose
+  // accountType matches the node's type, then the class's default anchor type.
+  const findAnchor = (
+    cls: AccountClass,
+    type: AccountType | null
+  ): ExistingAccount | null => {
+    const candidates = existingGroups.filter(
+      (g) => !g.account.isSystem && g.account.class === cls
+    );
+    if (type) {
+      const byType = candidates.find((g) => g.account.accountType === type);
+      if (byType) return byType.account;
+    }
+    const preferred = candidates.find(
+      (g) => g.account.accountType === DEFAULT_ANCHOR_TYPE[cls]
+    );
+    if (preferred) return preferred.account;
+    if (candidates.length > 0) return candidates[0].account;
+    return systemRootFor(INCOME_BALANCE_BY_CLASS[cls]);
+  };
+
+  // -- 1. normalise rows -------------------------------------------------------
+  const rows: SourceRow[] = records.map((record, index) => {
+    const rawKind = (record.rowKind ?? "").trim();
+    const rowKind = (
+      ["Account", "Group", "Total", "Heading", "Ignore"].includes(rawKind)
+        ? rawKind
+        : "Account"
+    ) as SourceRow["rowKind"];
+    const rawType = (record.accountType ?? "").trim();
+    const rawClass = (record.class ?? "").trim();
+    const indentRaw = (record.indent ?? "").trim();
+    const indent = indentRaw === "" ? null : Number.parseInt(indentRaw, 10);
+    const activeFromFile = parseBoolean(record.active, true);
+    const row: SourceRow = {
+      index,
+      number: (record.number ?? "").trim() || null,
+      name: (record.name ?? "").trim(),
+      displayName: (record.name ?? "").trim(),
+      accountType: isAccountType(rawType) ? rawType : null,
+      rawAccountType: rawType,
+      class: isAccountClass(rawClass) ? rawClass : null,
+      rawClass,
+      parentRef: (record.parent ?? "").trim() || null,
+      isGroup:
+        rowKind === "Group" ||
+        rowKind === "Heading" ||
+        parseBoolean(record.isGroup, false),
+      rowKind,
+      indent: indent === null || Number.isNaN(indent) ? null : indent,
+      active:
+        options.activeInverted && (record.active ?? "").trim() !== ""
+          ? !parseBoolean(record.active, false)
+          : activeFromFile,
+      activeSpecified: record.active !== undefined,
+      externalId: (record.externalId ?? "").trim() || null,
+      linkAccountId: null,
+      skipReason: null,
+      errorReason: null,
+    };
+
+    const resolution = resolutions[String(index)];
+    if (resolution) {
+      switch (resolution.action) {
+        case "skip":
+          row.skipReason = "Skipped by user";
+          break;
+        case "rename":
+          if (resolution.name.trim()) {
+            row.name = resolution.name.trim();
+            row.displayName = row.name;
+          }
+          break;
+        case "renumber":
+          if (resolution.number.trim()) row.number = resolution.number.trim();
+          break;
+        case "link":
+          row.linkAccountId = resolution.accountId;
+          break;
+      }
+    }
+
+    if (rowKind === "Total") row.skipReason ??= "Total row";
+    if (rowKind === "Ignore") row.skipReason ??= "Ignored row kind";
+    if (!row.skipReason && row.name === "") {
+      row.errorReason = "Missing required Account Name";
+    }
+    return row;
+  });
+
+  // -- 2. structure ------------------------------------------------------------
+  const live = rows.filter((r) => !r.skipReason && !r.errorReason);
+  const hasRowKind = rows.some((r) =>
+    ["Group", "Total", "Heading"].includes(r.rowKind)
+  );
+  const hasParent = live.some((r) => r.parentRef !== null);
+  const hasPath = live.some((r) => r.name.includes(separator));
+  let signal: ImportPlan["signal"] = hasRowKind
+    ? "rowKind"
+    : hasParent
+    ? "parent"
+    : hasPath
+    ? "path"
+    : null;
+  let structure: ImportPlan["structure"] =
+    options.structure === "carbon"
+      ? "carbon"
+      : options.structure === "file"
+      ? "file"
+      : signal
+      ? "file"
+      : "carbon";
+  if (structure === "file" && !signal) {
+    warnings.push(
+      "No hierarchy was found in the file (no Parent Account, Row Kind, or path in the name); accounts are placed under Carbon's existing groups by account type."
+    );
+    structure = "carbon";
+  }
+  if (structure === "carbon") signal = null;
+
+  // -- 3. parents ----------------------------------------------------------------
+  const parentRefOf = new Map<number, NodeRef | null>();
+  const synth = new Map<
+    string,
+    { key: string; name: string; parentRef: NodeRef | null; firstRow: number }
+  >();
+  const promoted = new Set<number>();
+  const rowByNumber = new Map<string, SourceRow>();
+  const rowByNumberName = new Map<string, SourceRow>();
+  const rowByName = new Map<string, SourceRow>();
+  for (const r of live) {
+    if (r.number && !rowByNumber.has(norm(r.number))) {
+      rowByNumber.set(norm(r.number), r);
+      rowByNumberName.set(`${norm(r.number)} ${norm(r.name)}`, r);
+    }
+    // Groups win the name slot so "Assets" resolves to the group row when a
+    // leaf shares the name.
+    const key = norm(r.name);
+    const prior = rowByName.get(key);
+    if (!prior || (!prior.isGroup && r.isGroup)) rowByName.set(key, r);
+  }
+
+  const synthKeyFor = (label: string) => `synth:${norm(label)}`;
+  const ensureSynth = (
+    label: string,
+    parentRef: NodeRef | null,
+    firstRow: number,
+    keyOverride?: string
+  ): NodeRef => {
+    const key = keyOverride ?? synthKeyFor(label);
+    if (!synth.has(key)) {
+      synth.set(key, { key, name: label.trim(), parentRef, firstRow });
+    }
+    return { kind: "synth", key };
+  };
+
+  if (structure === "file" && signal === "rowKind") {
+    const stack: Array<{
+      ref: NodeRef;
+      indent: number | null;
+      kind: "group" | "heading";
+    }> = [];
+    const hasIndent = rows.some((r) => r.indent !== null);
+    for (const r of rows) {
+      const top = () => (stack.length ? stack[stack.length - 1].ref : null);
+      if (hasIndent && r.indent !== null) {
+        while (
+          stack.length &&
+          stack[stack.length - 1].kind === "heading" &&
+          (stack[stack.length - 1].indent ?? 0) >= r.indent
+        ) {
+          stack.pop();
+        }
+      }
+      switch (r.rowKind) {
+        case "Total": {
+          // Close the nearest open group, discarding any headings above it.
+          let idx = stack.length - 1;
+          while (idx >= 0 && stack[idx].kind !== "group") idx -= 1;
+          if (idx < 0) {
+            warnings.push(
+              `Row ${r.index + 1}: a Total row closes a group that was never opened; ignored.`
+            );
+          } else {
+            stack.length = idx;
+          }
+          break;
+        }
+        case "Group": {
+          if (r.skipReason || r.errorReason) break;
+          parentRefOf.set(r.index, top());
+          stack.push({ ref: { kind: "row", index: r.index }, indent: r.indent, kind: "group" });
+          break;
+        }
+        case "Heading": {
+          if (r.skipReason || r.errorReason) break;
+          if (!hasIndent) {
+            r.skipReason =
+              "Heading rows need an Indentation column to be placed; ignored";
+            break;
+          }
+          parentRefOf.set(r.index, top());
+          stack.push({ ref: { kind: "row", index: r.index }, indent: r.indent, kind: "heading" });
+          break;
+        }
+        case "Ignore":
+          break;
+        default: {
+          if (r.skipReason || r.errorReason) break;
+          parentRefOf.set(r.index, top());
+        }
+      }
+    }
+  } else if (structure === "file" && signal === "parent") {
+    const resolveParent = (r: SourceRow): NodeRef | null => {
+      const ref = r.parentRef;
+      if (!ref) return null;
+      const key = norm(ref);
+      const byRow =
+        rowByNumber.get(key) ??
+        rowByNumberName.get(key) ??
+        rowByName.get(key);
+      if (byRow) {
+        if (byRow.index === r.index) {
+          r.errorReason = "An account cannot be its own parent";
+          return null;
+        }
+        if (!byRow.isGroup) promoted.add(byRow.index);
+        return { kind: "row", index: byRow.index };
+      }
+      const byExisting =
+        existingByNumber.get(key) ??
+        existingByNumberName.get(key) ??
+        existingGroupByName.get(key);
+      if (byExisting) {
+        if (!byExisting.isGroup) {
+          r.errorReason = `Parent "${ref}" is a posting account in Carbon, not a group`;
+          return null;
+        }
+        return { kind: "existing", id: byExisting.id };
+      }
+      return ensureSynth(ref, null, r.index);
+    };
+    for (const r of live) parentRefOf.set(r.index, resolveParent(r));
+  } else if (structure === "file" && signal === "path") {
+    const rowByPath = new Map<string, SourceRow>();
+    for (const r of live) rowByPath.set(norm(r.name), r);
+    for (const r of live) {
+      const segments = r.name
+        .split(separator)
+        .map((s) => s.trim())
+        .filter((s) => s !== "");
+      if (segments.length <= 1) {
+        parentRefOf.set(r.index, null);
+        continue;
+      }
+      r.displayName = segments[segments.length - 1];
+      let parentRef: NodeRef | null = null;
+      for (let depth = 1; depth < segments.length; depth += 1) {
+        const prefix = segments.slice(0, depth).join(separator);
+        const matched = rowByPath.get(norm(prefix));
+        if (matched && matched.index !== r.index) {
+          if (!matched.isGroup) promoted.add(matched.index);
+          parentRef = { kind: "row", index: matched.index };
+        } else {
+          parentRef = ensureSynth(
+            segments[depth - 1],
+            parentRef,
+            r.index,
+            `synth:path:${norm(prefix)}`
+          );
+        }
+      }
+      parentRefOf.set(r.index, parentRef);
+    }
+  } else {
+    // carbon: file groups are dropped, leaves hang under Carbon's groups.
+    for (const r of live) {
+      if (r.isGroup) {
+        r.skipReason =
+          "Group rows are not imported when accounts are placed under Carbon's existing groups";
+        continue;
+      }
+      parentRefOf.set(r.index, null);
+    }
+  }
+  for (const index of promoted) {
+    const r = rows[index];
+    if (r && !r.skipReason && !r.errorReason) r.isGroup = true;
+  }
+
+  // -- 4. nodes ----------------------------------------------------------------
+  const nodes = new Map<string, PlanNode>();
+  const refKey = (ref: NodeRef | null): string | null =>
+    ref === null
+      ? null
+      : ref.kind === "row"
+      ? `row:${ref.index}`
+      : ref.kind === "synth"
+      ? ref.key
+      : `existing:${ref.id}`;
+
+  for (const s of synth.values()) {
+    nodes.set(s.key, {
+      key: s.key,
+      row: null,
+      reportRow: s.firstRow,
+      kind: "group",
+      action: "create",
+      number: null,
+      name: s.name,
+      class: null,
+      accountType: null,
+      incomeBalance: null,
+      consolidatedRate: null,
+      active: true,
+      externalId: null,
+      parentKey: null,
+      parentId: null,
+      parentLabel: null,
+      existingId: null,
+      depth: 0,
+      anchorLabel: null,
+      synthesized: true,
+    });
+  }
+  for (const r of rows) {
+    const key = `row:${r.index}`;
+    const node: PlanNode = {
+      key,
+      row: r.index,
+      reportRow: r.index,
+      kind: r.isGroup ? "group" : "account",
+      action: r.skipReason ? "skip" : r.errorReason ? "error" : "create",
+      reason: r.skipReason ?? r.errorReason ?? undefined,
+      number: r.number,
+      name: r.displayName,
+      class: r.class,
+      accountType: r.accountType,
+      incomeBalance: null,
+      consolidatedRate: null,
+      active: r.active,
+      externalId: r.externalId,
+      parentKey: null,
+      parentId: null,
+      parentLabel: null,
+      existingId: null,
+      depth: 0,
+      anchorLabel: null,
+      promoted: promoted.has(r.index) || undefined,
+    };
+    nodes.set(key, node);
+  }
+
+  // Wire parents. A parent that is itself a plan node is referenced by key; an
+  // existing account by id.
+  const parentRefByKey = new Map<string, NodeRef | null>();
+  for (const s of synth.values()) parentRefByKey.set(s.key, s.parentRef);
+  for (const r of rows) parentRefByKey.set(`row:${r.index}`, parentRefOf.get(r.index) ?? null);
+  for (const node of nodes.values()) {
+    const ref = parentRefByKey.get(node.key) ?? null;
+    if (ref === null) continue;
+    if (ref.kind === "existing") {
+      node.parentId = ref.id;
+      node.parentLabel = existingById.get(ref.id)?.name ?? null;
+    } else {
+      node.parentKey = refKey(ref);
+      node.parentLabel = nodes.get(node.parentKey!)?.name ?? null;
+    }
+  }
+  const children = new Map<string, PlanNode[]>();
+  for (const node of nodes.values()) {
+    if (node.parentKey) {
+      const list = children.get(node.parentKey) ?? [];
+      list.push(node);
+      children.set(node.parentKey, list);
+    }
+  }
+
+  const fail = (node: PlanNode, reason: string) => {
+    if (node.action === "error" || node.action === "skip") return;
+    node.action = "error";
+    node.reason = reason;
+  };
+
+  // -- 5. leaf typing --------------------------------------------------------------
+  for (const node of nodes.values()) {
+    if (node.action === "skip" || node.action === "error") continue;
+    const r = node.row === null ? null : rows[node.row];
+    if (node.kind === "account") {
+      if (!node.accountType) {
+        fail(
+          node,
+          r?.rawAccountType
+            ? `Account type "${r.rawAccountType}" is not mapped to a Carbon account type`
+            : "Account type is required for a posting account"
+        );
+        continue;
+      }
+      if (node.class) {
+        if (!TYPES_BY_CLASS[node.class].includes(node.accountType)) {
+          fail(
+            node,
+            `Account type "${node.accountType}" is not valid for class ${node.class}`
+          );
+          continue;
+        }
+      } else {
+        node.class = CLASS_OF_TYPE[node.accountType];
+      }
+    } else if (node.kind === "group" && r && r.rawClass && !node.class) {
+      fail(node, `Class "${r.rawClass}" is not one of Carbon's classes`);
+    }
+  }
+
+  // -- 6. group class: own column, else majority of descendant leaves, else parent -----
+  const descendantLeafClasses = (node: PlanNode): AccountClass[] => {
+    const out: AccountClass[] = [];
+    for (const child of children.get(node.key) ?? []) {
+      if (child.action === "skip" || child.action === "error") continue;
+      if (child.kind === "account") {
+        if (child.class) out.push(child.class);
+      } else {
+        out.push(...descendantLeafClasses(child));
+      }
+    }
+    return out;
+  };
+  const descendantLeafTypes = (node: PlanNode): AccountType[] => {
+    const out: AccountType[] = [];
+    for (const child of children.get(node.key) ?? []) {
+      if (child.action === "skip" || child.action === "error") continue;
+      if (child.kind === "account") {
+        if (child.accountType) out.push(child.accountType);
+      } else {
+        out.push(...descendantLeafTypes(child));
+      }
+    }
+    return out;
+  };
+  for (const node of nodes.values()) {
+    if (node.kind !== "group" || node.action === "skip" || node.action === "error")
+      continue;
+    if (!node.class) node.class = majority(descendantLeafClasses(node));
+    if (!node.accountType) {
+      const t = majority(descendantLeafTypes(node));
+      node.accountType = t && node.class && TYPES_BY_CLASS[node.class].includes(t) ? t : null;
+    }
+  }
+
+  // Top-down: inherit a missing class from the parent, then resolve anchors and
+  // adoption for top-level nodes. Order by depth in the plan tree so parents
+  // are settled first.
+  const planDepth = (node: PlanNode): number => {
+    let depth = 0;
+    let cur: PlanNode | undefined = node;
+    const seen = new Set<string>();
+    while (cur?.parentKey && !seen.has(cur.parentKey)) {
+      seen.add(cur.parentKey);
+      cur = nodes.get(cur.parentKey);
+      depth += 1;
+    }
+    return depth;
+  };
+  const ordered = [...nodes.values()].sort(
+    (a, b) => planDepth(a) - planDepth(b) || a.reportRow - b.reportRow
+  );
+  for (const node of ordered) {
+    node.depth = planDepth(node);
+    if (node.action === "skip" || node.action === "error") continue;
+    const parentNode = node.parentKey ? nodes.get(node.parentKey) : undefined;
+    const parentExisting = node.parentId ? existingById.get(node.parentId) : undefined;
+    if (!node.class && node.kind === "group") {
+      // A group with no class column and no leaves under it takes the class
+      // of the Carbon group it names (the one it will adopt or update).
+      node.class = existingGroupByName.get(norm(node.name))?.class ?? null;
+    }
+    if (!node.class) {
+      node.class = parentNode?.class ?? parentExisting?.class ?? null;
+    }
+    if (!node.class) {
+      fail(
+        node,
+        node.kind === "group"
+          ? "Group has no accounts to derive a class from; add a Class column or an account under it"
+          : "Class could not be determined"
+      );
+      continue;
+    }
+    node.incomeBalance = INCOME_BALANCE_BY_CLASS[node.class];
+    node.consolidatedRate = CONSOLIDATED_RATE_BY_CLASS[node.class];
+
+    if (!node.parentKey && !node.parentId) {
+      // Top of a subtree. A group adopts Carbon's group of the same name when
+      // the classes agree (or the existing is a root); otherwise it hangs
+      // under the class anchor. Leaves always hang under the anchor.
+      if (node.kind === "group" && !node.existingId) {
+        const adopt = existingGroupByName.get(norm(node.name));
+        if (adopt && (adopt.class === null || adopt.class === node.class)) {
+          node.existingId = adopt.id;
+          node.action = "link";
+          node.anchorLabel = adopt.name;
+          node.parentId = adopt.parentId;
+          node.parentLabel = adopt.parentId ? existingById.get(adopt.parentId)?.name ?? null : null;
+          continue;
+        }
+      }
+      const anchor = findAnchor(node.class, node.accountType);
+      if (!anchor) {
+        fail(node, `No group exists in Carbon to place a ${node.class} account under`);
+        continue;
+      }
+      node.parentId = anchor.id;
+      node.parentLabel = anchor.name;
+      node.anchorLabel = anchor.name;
+    } else {
+      node.anchorLabel = parentNode?.anchorLabel ?? parentExisting?.name ?? null;
+    }
+  }
+
+  // -- 7. identity -------------------------------------------------------------------
+  const seenNumbers = new Map<string, PlanNode>();
+  const seenNames = new Map<string, PlanNode>();
+  const claimed = new Map<string, PlanNode>(); // existing id → node
+  const nameKey = (node: PlanNode) => `${node.kind}:${norm(node.name)}`;
+  const isPosted = (id: string) => ctx.postedAccountIds.has(id);
+
+  for (const node of ordered) {
+    if (node.action === "skip" || node.action === "error") continue;
+    const r = node.row === null ? null : rows[node.row];
+
+    // In-file duplicates.
+    if (node.number) {
+      const dup = seenNumbers.get(norm(node.number));
+      if (dup) {
+        fail(node, `Duplicate account number "${node.number}" in file (also row ${dup.reportRow + 1})`);
+        continue;
+      }
+    }
+    const dupName = seenNames.get(nameKey(node));
+    if (dupName) {
+      fail(
+        node,
+        `Duplicate ${node.kind === "group" ? "group" : "account"} name "${node.name}" in file (also row ${dupName.reportRow + 1})`
+      );
+      continue;
+    }
+
+    // Match an existing account.
+    let existing: ExistingAccount | undefined;
+    let matchedBy: "link" | "externalId" | "number" | "name" | "adopt" | null = null;
+    if (node.existingId) {
+      existing = existingById.get(node.existingId);
+      matchedBy = "adopt";
+    } else if (r?.linkAccountId) {
+      existing = existingById.get(r.linkAccountId);
+      if (!existing) {
+        fail(node, "The account chosen in the resolution no longer exists");
+        continue;
+      }
+      matchedBy = "link";
+    } else if (node.externalId && ctx.externalIdMap.has(node.externalId)) {
+      existing = existingById.get(ctx.externalIdMap.get(node.externalId)!);
+      matchedBy = existing ? "externalId" : null;
+    }
+    if (!existing && node.number) {
+      const byNumber = existingByNumber.get(norm(node.number));
+      if (byNumber) {
+        if (byNumber.isGroup !== (node.kind === "group")) {
+          node.conflict = {
+            existingId: byNumber.id,
+            number: byNumber.number,
+            name: byNumber.name,
+            kind: byNumber.isGroup ? "group" : "account",
+            linkable: false,
+          };
+          fail(
+            node,
+            `Number "${node.number}" belongs to the ${byNumber.isGroup ? "group" : "posting account"} "${byNumber.name}" in Carbon`
+          );
+          continue;
+        }
+        existing = byNumber;
+        matchedBy = "number";
+      }
+    }
+    // Groups are keyed by name (their numbers are cosmetic); leaves only
+    // when the file gives no number, since number is a leaf's identity.
+    if (!existing && (node.kind === "group" || !node.number)) {
+      const byName = (node.kind === "group" ? existingGroupByName : existingLeafByName).get(norm(node.name));
+      if (byName) {
+        existing = byName;
+        matchedBy = "name";
+      }
+    }
+
+    if (existing && existing.isSystem && node.kind === "account") {
+      fail(node, `"${existing.name}" is a system account and cannot be changed`);
+      continue;
+    }
+    if (existing && claimed.has(existing.id)) {
+      const other = claimed.get(existing.id)!;
+      fail(node, `Also matches Carbon's "${existing.name}" (row ${other.reportRow + 1})`);
+      continue;
+    }
+    // A group that adopts a Carbon group (or a system root) only links to it:
+    // the file's number and name are not applied, so they cannot collide.
+    if (existing && (matchedBy === "adopt" || existing.isSystem)) {
+      claimed.set(existing.id, node);
+      node.existingId = existing.id;
+      node.action = "link";
+      seenNames.set(nameKey(node), node);
+      continue;
+    }
+
+    // Name / number held by a different account of the same kind.
+    const nameOwner = (node.kind === "group" ? existingGroupByName : existingLeafByName).get(norm(node.name));
+    if (nameOwner && nameOwner.id !== existing?.id) {
+      node.conflict = {
+        existingId: nameOwner.id,
+        number: nameOwner.number,
+        name: nameOwner.name,
+        kind: nameOwner.isGroup ? "group" : "account",
+        linkable: !existing,
+      };
+      fail(
+        node,
+        existing
+          ? `Renaming to "${node.name}" collides with ${nameOwner.number ? `${nameOwner.number} ` : ""}"${nameOwner.name}"`
+          : `A different ${node.kind === "group" ? "group" : "account"} named "${node.name}"${nameOwner.number ? ` (${nameOwner.number})` : ""} already exists in Carbon`
+      );
+      continue;
+    }
+    if (node.number && existing && norm(existing.number) !== norm(node.number)) {
+      const numberOwner = existingByNumber.get(norm(node.number));
+      if (numberOwner && numberOwner.id !== existing.id) {
+        node.conflict = {
+          existingId: numberOwner.id,
+          number: numberOwner.number,
+          name: numberOwner.name,
+          kind: numberOwner.isGroup ? "group" : "account",
+          linkable: false,
+        };
+        fail(node, `Renumbering to "${node.number}" collides with "${numberOwner.name}"`);
+        continue;
+      }
+    }
+
+    if (node.number) seenNumbers.set(norm(node.number), node);
+    seenNames.set(nameKey(node), node);
+
+    if (!existing) continue; // create
+
+    claimed.set(existing.id, node);
+    node.existingId = existing.id;
+
+    // A group matched by name keeps Carbon's number and name; only a move
+    // (and its class consequences) counts as a change.
+    const groupByName = node.kind === "group" && matchedBy === "name";
+    if (groupByName && node.class && existing.class && existing.class !== node.class) {
+      fail(
+        node,
+        `Carbon's group "${existing.name}" is ${existing.class}, but the accounts under it in the file are ${node.class}`
+      );
+      continue;
+    }
+
+    // Changes for an update.
+    const changes: string[] = [];
+    if (!groupByName && existing.name !== node.name) changes.push(`name: "${existing.name}" → "${node.name}"`);
+    if (node.number && !groupByName && (matchedBy === "externalId" || matchedBy === "link" || matchedBy === "name") && norm(existing.number) !== norm(node.number)) {
+      changes.push(`number: ${existing.number ?? "—"} → ${node.number}`);
+    }
+    if (node.kind === "account" && node.accountType && existing.accountType !== node.accountType) {
+      changes.push(`type: ${existing.accountType ?? "—"} → ${node.accountType}`);
+    }
+    if (node.kind === "group" && node.accountType && existing.accountType !== node.accountType && r?.rawAccountType) {
+      changes.push(`type: ${existing.accountType ?? "—"} → ${node.accountType}`);
+    }
+    if (!groupByName && node.class && existing.class !== node.class) {
+      if (isPosted(existing.id)) {
+        fail(
+          node,
+          `Class would change from ${existing.class ?? "none"} to ${node.class}, but "${existing.name}" has journal lines; change it in Carbon after reviewing the postings`
+        );
+        continue;
+      }
+      changes.push(`class: ${existing.class ?? "—"} → ${node.class}`);
+    }
+    // Re-parent: intended parent differs from the current one.
+    const intendedParentId = node.parentId ?? null;
+    const intendedParentKey = node.parentKey ?? null;
+    if (intendedParentKey) {
+      const parentNode = nodes.get(intendedParentKey);
+      if (parentNode?.existingId) {
+        if (parentNode.existingId !== existing.parentId) changes.push(`parent: → "${parentNode.name}"`);
+      } else {
+        changes.push(`parent: → "${parentNode?.name ?? "new group"}"`);
+      }
+    } else if (intendedParentId && intendedParentId !== existing.parentId) {
+      changes.push(`parent: → "${existingById.get(intendedParentId)?.name ?? intendedParentId}"`);
+    }
+    if (r?.activeSpecified && existing.active !== node.active) {
+      if (!node.active) {
+        if (ctx.protectedAccountIds.has(existing.id)) {
+          fail(node, `"${existing.name}" is a posting default or asset-class account and cannot be deactivated`);
+          continue;
+        }
+        if (isPosted(existing.id)) {
+          fail(node, `"${existing.name}" has journal lines and cannot be deactivated by import`);
+          continue;
+        }
+      }
+      changes.push(node.active ? "reactivate" : "deactivate");
+    }
+    node.changes = changes;
+    node.action = changes.length ? "update" : groupByName ? "link" : "unchanged";
+  }
+
+  // -- 8. parent validity, class agreement, cycles -----------------------------------
+  const resolvedParentClass = (node: PlanNode): { cls: AccountClass | null; ok: boolean; reason?: string } => {
+    if (node.parentKey) {
+      const p = nodes.get(node.parentKey);
+      if (!p) return { cls: null, ok: false, reason: "Parent could not be resolved" };
+      if (p.action === "error" || p.action === "skip") {
+        return { cls: null, ok: false, reason: `Parent "${p.name}" (row ${p.reportRow + 1}) could not be imported` };
+      }
+      if (p.kind !== "group") {
+        return { cls: null, ok: false, reason: `Parent "${p.name}" is a posting account, not a group` };
+      }
+      return { cls: p.class, ok: true };
+    }
+    if (node.parentId) {
+      const p = existingById.get(node.parentId);
+      if (!p) return { cls: null, ok: false, reason: "Parent account not found in Carbon" };
+      if (!p.isGroup) return { cls: null, ok: false, reason: `Parent "${p.name}" is a posting account, not a group` };
+      return { cls: p.class, ok: true };
+    }
+    return { cls: null, ok: true };
+  };
+  for (const node of ordered) {
+    if (node.action === "skip" || node.action === "error" || node.action === "link") continue;
+    const parent = resolvedParentClass(node);
+    if (!parent.ok) {
+      fail(node, parent.reason ?? "Parent could not be imported");
+      continue;
+    }
+    if (parent.cls && node.class && parent.cls !== node.class) {
+      fail(
+        node,
+        `Class ${node.class} does not match the parent group "${node.parentLabel ?? ""}" (${parent.cls})`
+      );
+      continue;
+    }
+    // Cycle: an existing account moved under one of its own descendants.
+    if (node.existingId && (node.action === "update" || node.action === "unchanged")) {
+      const walk = (startKey: string | null, startId: string | null): boolean => {
+        let key = startKey;
+        let id = startId;
+        const seen = new Set<string>();
+        while (key || id) {
+          if (id === node.existingId) return true;
+          if (key) {
+            if (seen.has(key)) return false;
+            seen.add(key);
+            const p = nodes.get(key);
+            if (!p) return false;
+            if (p.existingId === node.existingId) return true;
+            key = p.parentKey;
+            id = p.parentId;
+          } else if (id) {
+            if (seen.has(id)) return false;
+            seen.add(id);
+            const p = existingById.get(id);
+            if (!p) return false;
+            key = null;
+            id = p.parentId;
+          }
+        }
+        return false;
+      };
+      if (walk(node.parentKey, node.parentId)) {
+        fail(node, `Moving "${node.name}" under "${node.parentLabel}" would create a cycle`);
+        continue;
+      }
+    }
+  }
+  // A failed parent fails its subtree; iterate until stable.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const node of ordered) {
+      if (node.action === "skip" || node.action === "error" || node.action === "link") continue;
+      if (!node.parentKey) continue;
+      const p = nodes.get(node.parentKey);
+      if (p && (p.action === "error" || p.action === "skip")) {
+        fail(node, `Parent "${p.name}" (row ${p.reportRow + 1}) could not be imported`);
+        changed = true;
+      }
+    }
+  }
+
+  // -- 9. order: depth-first so parents precede children and siblings keep file order --
+  const output: PlanNode[] = [];
+  const visit = (node: PlanNode) => {
+    output.push(node);
+    const kids = (children.get(node.key) ?? []).sort((a, b) => a.reportRow - b.reportRow);
+    for (const kid of kids) visit(kid);
+  };
+  for (const node of ordered) {
+    if (!node.parentKey) visit(node);
+  }
+  // Nodes whose parent chain was broken (parentKey to a missing node) — append.
+  for (const node of ordered) if (!output.includes(node)) output.push(node);
+
+  const summary = {
+    groupsToCreate: output.filter((n) => n.action === "create" && n.kind === "group").length,
+    accountsToCreate: output.filter((n) => n.action === "create" && n.kind === "account").length,
+    updates: output.filter((n) => n.action === "update").length,
+    linked: output.filter((n) => n.action === "link").length,
+    unchanged: output.filter((n) => n.action === "unchanged").length,
+    skipped: output.filter((n) => n.action === "skip").length,
+    errors: output.filter((n) => n.action === "error").length,
+  };
+
+  return { structure, signal, nodes: output, warnings, summary };
+}

--- a/packages/database/supabase/functions/import-csv/account-import.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.ts
@@ -151,7 +151,10 @@ export type Resolution =
   | { action: "skip" }
   | { action: "rename"; name: string }
   | { action: "renumber"; number: string }
-  | { action: "link"; accountId: string };
+  // Carbon's account IS this row; with keepNumber the file's number is not applied.
+  | { action: "link"; accountId: string; keepNumber?: boolean }
+  // For a row that already matches an account: apply everything but the number.
+  | { action: "keepNumber" };
 
 export type AccountImportOptions = {
   structure?: "auto" | "file" | "carbon";
@@ -213,6 +216,8 @@ export type PlanNode = {
   parentLabel: string | null;
   // Existing account this node resolves to (update / link / unchanged).
   existingId: string | null;
+  existingNumber: string | null;
+  existingName: string | null;
   depth: number;
   // Name of the existing account the top of this node's subtree hangs under.
   anchorLabel: string | null;
@@ -255,6 +260,7 @@ type SourceRow = {
   activeSpecified: boolean;
   externalId: string | null;
   linkAccountId: string | null;
+  keepNumber: boolean;
   skipReason: string | null;
   errorReason: string | null;
 };
@@ -434,6 +440,7 @@ export function planChartOfAccounts(
       activeSpecified: record.active !== undefined,
       externalId: (record.externalId ?? "").trim() || null,
       linkAccountId: null,
+      keepNumber: false,
       skipReason: null,
       errorReason: null,
     };
@@ -455,6 +462,10 @@ export function planChartOfAccounts(
           break;
         case "link":
           row.linkAccountId = resolution.accountId;
+          row.keepNumber = !!resolution.keepNumber;
+          break;
+        case "keepNumber":
+          row.keepNumber = true;
           break;
       }
     }
@@ -706,6 +717,8 @@ export function planChartOfAccounts(
       parentId: null,
       parentLabel: null,
       existingId: null,
+      existingNumber: null,
+      existingName: null,
       depth: 0,
       anchorLabel: null,
       synthesized: true,
@@ -732,6 +745,8 @@ export function planChartOfAccounts(
       parentId: null,
       parentLabel: null,
       existingId: null,
+      existingNumber: null,
+      existingName: null,
       depth: 0,
       anchorLabel: null,
       promoted: promoted.has(r.index) || undefined,
@@ -885,6 +900,8 @@ export function planChartOfAccounts(
         const adopt = existingGroupByName.get(norm(node.name));
         if (adopt && (adopt.class === null || adopt.class === node.class)) {
           node.existingId = adopt.id;
+          node.existingNumber = adopt.number;
+          node.existingName = adopt.name;
           node.action = "link";
           node.anchorLabel = adopt.name;
           node.parentId = adopt.parentId;
@@ -972,8 +989,10 @@ export function planChartOfAccounts(
       }
     }
     // Groups are keyed by name (their numbers are cosmetic); leaves only
-    // when the file gives no number, since number is a leaf's identity.
-    if (!existing && (node.kind === "group" || !node.number)) {
+    // when the file gives no number, since number is a leaf's identity — or
+    // when the row is told to keep Carbon's number, which can only mean the
+    // account of that name.
+    if (!existing && (node.kind === "group" || !node.number || r?.keepNumber)) {
       const byName = (node.kind === "group" ? existingGroupByName : existingLeafByName).get(norm(node.name));
       if (byName) {
         existing = byName;
@@ -995,6 +1014,8 @@ export function planChartOfAccounts(
     if (existing && (matchedBy === "adopt" || existing.isSystem)) {
       claimed.set(existing.id, node);
       node.existingId = existing.id;
+      node.existingNumber = existing.number;
+      node.existingName = existing.name;
       node.action = "link";
       seenNames.set(nameKey(node), node);
       continue;
@@ -1018,7 +1039,7 @@ export function planChartOfAccounts(
       );
       continue;
     }
-    if (node.number && existing && norm(existing.number) !== norm(node.number)) {
+    if (node.number && existing && !r?.keepNumber && norm(existing.number) !== norm(node.number)) {
       const numberOwner = existingByNumber.get(norm(node.number));
       if (numberOwner && numberOwner.id !== existing.id) {
         node.conflict = {
@@ -1040,6 +1061,8 @@ export function planChartOfAccounts(
 
     claimed.set(existing.id, node);
     node.existingId = existing.id;
+    node.existingNumber = existing.number;
+    node.existingName = existing.name;
 
     // A group matched by name keeps Carbon's number and name; only a move
     // (and its class consequences) counts as a change.
@@ -1055,7 +1078,7 @@ export function planChartOfAccounts(
     // Changes for an update.
     const changes: string[] = [];
     if (!groupByName && existing.name !== node.name) changes.push(`name: "${existing.name}" → "${node.name}"`);
-    if (node.number && !groupByName && (matchedBy === "externalId" || matchedBy === "link" || matchedBy === "name") && norm(existing.number) !== norm(node.number)) {
+    if (node.number && !groupByName && !r?.keepNumber && (matchedBy === "externalId" || matchedBy === "link" || matchedBy === "name") && norm(existing.number) !== norm(node.number)) {
       changes.push(`number: ${existing.number ?? "—"} → ${node.number}`);
     }
     if (node.kind === "account" && node.accountType && existing.accountType !== node.accountType) {

--- a/packages/database/supabase/functions/import-csv/account-import.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.ts
@@ -595,28 +595,36 @@ export function planChartOfAccounts(
       const ref = r.parentRef;
       if (!ref) return null;
       const key = norm(ref);
-      const byRow =
-        rowByNumber.get(key) ??
-        rowByNumberName.get(key) ??
-        rowByName.get(key);
-      if (byRow) {
-        if (byRow.index === r.index) {
-          r.errorReason = "An account cannot be its own parent";
-          return null;
-        }
-        if (!byRow.isGroup) promoted.add(byRow.index);
-        return { kind: "row", index: byRow.index };
+      // A number or "number name" reference names an account: a file row
+      // first, then Carbon.
+      const byNumber = rowByNumber.get(key) ?? rowByNumberName.get(key);
+      if (byNumber && byNumber.index !== r.index) {
+        if (!byNumber.isGroup) promoted.add(byNumber.index);
+        return { kind: "row", index: byNumber.index };
       }
-      const byExisting =
-        existingByNumber.get(key) ??
-        existingByNumberName.get(key) ??
-        existingGroupByName.get(key);
-      if (byExisting) {
-        if (!byExisting.isGroup) {
+      const existingByNum =
+        existingByNumber.get(key) ?? existingByNumberName.get(key);
+      if (!byNumber && existingByNum) {
+        if (!existingByNum.isGroup) {
           r.errorReason = `Parent "${ref}" is a posting account in Carbon, not a group`;
           return null;
         }
-        return { kind: "existing", id: byExisting.id };
+        return { kind: "existing", id: existingByNum.id };
+      }
+      // A name-only reference is a grouping label. A file row that is itself
+      // a group wins, then a Carbon group of that name, and only then a file
+      // posting account of that name (promoted to a group, as QuickBooks
+      // sub-accounts need). A label equal to the row's own name is never a
+      // self-reference: a source group often holds one account named after it.
+      const byName = rowByName.get(key);
+      if (byName && byName.index !== r.index && byName.isGroup) {
+        return { kind: "row", index: byName.index };
+      }
+      const existingGroup = existingGroupByName.get(key);
+      if (existingGroup) return { kind: "existing", id: existingGroup.id };
+      if (byName && byName.index !== r.index) {
+        promoted.add(byName.index);
+        return { kind: "row", index: byName.index };
       }
       return ensureSynth(ref, null, r.index);
     };

--- a/packages/database/supabase/functions/import-csv/account-import.ts
+++ b/packages/database/supabase/functions/import-csv/account-import.ts
@@ -437,7 +437,8 @@ export function planChartOfAccounts(
         options.activeInverted && (record.active ?? "").trim() !== ""
           ? !parseBoolean(record.active, false)
           : activeFromFile,
-      activeSpecified: record.active !== undefined,
+      // A blank cell in a mapped Active column says nothing about the account.
+      activeSpecified: (record.active ?? "").trim() !== "",
       externalId: (record.externalId ?? "").trim() || null,
       linkAccountId: null,
       keepNumber: false,
@@ -785,6 +786,27 @@ export function planChartOfAccounts(
     node.reason = reason;
   };
 
+  // A parent chain that comes back to itself (row A under B, B under A) can
+  // only be written by the file. Fail every row on the loop here, before any
+  // walk below follows `children` into it.
+  for (const node of nodes.values()) {
+    const seen = new Set<string>();
+    let cur: PlanNode | undefined = node;
+    while (cur?.parentKey && !seen.has(cur.key)) {
+      seen.add(cur.key);
+      cur = nodes.get(cur.parentKey);
+    }
+    if (!cur?.parentKey || !seen.has(cur.key)) continue;
+    const loop: PlanNode[] = [];
+    let member: PlanNode | undefined = cur;
+    do {
+      loop.push(member);
+      member = member.parentKey ? nodes.get(member.parentKey) : undefined;
+    } while (member && member !== cur && loop.length <= seen.size);
+    const chain = [...loop, cur].map((n) => `"${n.name}"`).join(" → ");
+    for (const n of loop) fail(n, `Parent chain loops back on itself: ${chain}`);
+  }
+
   // -- 5. leaf typing --------------------------------------------------------------
   for (const node of nodes.values()) {
     if (node.action === "skip" || node.action === "error") continue;
@@ -816,26 +838,30 @@ export function planChartOfAccounts(
   }
 
   // -- 6. group class: own column, else majority of descendant leaves, else parent -----
-  const descendantLeafClasses = (node: PlanNode): AccountClass[] => {
+  const descendantLeafClasses = (node: PlanNode, seen = new Set<string>()): AccountClass[] => {
     const out: AccountClass[] = [];
+    if (seen.has(node.key)) return out;
+    seen.add(node.key);
     for (const child of children.get(node.key) ?? []) {
       if (child.action === "skip" || child.action === "error") continue;
       if (child.kind === "account") {
         if (child.class) out.push(child.class);
       } else {
-        out.push(...descendantLeafClasses(child));
+        out.push(...descendantLeafClasses(child, seen));
       }
     }
     return out;
   };
-  const descendantLeafTypes = (node: PlanNode): AccountType[] => {
+  const descendantLeafTypes = (node: PlanNode, seen = new Set<string>()): AccountType[] => {
     const out: AccountType[] = [];
+    if (seen.has(node.key)) return out;
+    seen.add(node.key);
     for (const child of children.get(node.key) ?? []) {
       if (child.action === "skip" || child.action === "error") continue;
       if (child.kind === "account") {
         if (child.accountType) out.push(child.accountType);
       } else {
-        out.push(...descendantLeafTypes(child));
+        out.push(...descendantLeafTypes(child, seen));
       }
     }
     return out;
@@ -1212,7 +1238,10 @@ export function planChartOfAccounts(
 
   // -- 9. order: depth-first so parents precede children and siblings keep file order --
   const output: PlanNode[] = [];
+  const emitted = new Set<string>();
   const visit = (node: PlanNode) => {
+    if (emitted.has(node.key)) return;
+    emitted.add(node.key);
     output.push(node);
     const kids = (children.get(node.key) ?? []).sort((a, b) => a.reportRow - b.reportRow);
     for (const kid of kids) visit(kid);
@@ -1221,7 +1250,7 @@ export function planChartOfAccounts(
     if (!node.parentKey) visit(node);
   }
   // Nodes whose parent chain was broken (parentKey to a missing node) — append.
-  for (const node of ordered) if (!output.includes(node)) output.push(node);
+  for (const node of ordered) if (!emitted.has(node.key)) output.push(node);
 
   const summary = {
     groupsToCreate: output.filter((n) => n.action === "create" && n.kind === "group").length,

--- a/packages/database/supabase/functions/import-csv/index.ts
+++ b/packages/database/supabase/functions/import-csv/index.ts
@@ -23,6 +23,21 @@ import { importMethods } from "./method-import.ts";
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
 
+// What the chart-of-accounts review may send back for a row; the planner
+// reads these fields without further checks.
+const accountResolutionValidator = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("skip") }),
+  z.object({ action: z.literal("rename"), name: z.string() }),
+  z.object({ action: z.literal("renumber"), number: z.string() }),
+  z.object({
+    action: z.literal("link"),
+    accountId: z.string(),
+    keepNumber: z.boolean().optional(),
+  }),
+  z.object({ action: z.literal("keepNumber") }),
+]);
+const accountResolutionsValidator = z.record(accountResolutionValidator);
+
 const importCsvValidator = z.object({
   table: z.enum([
     "consumable",
@@ -3043,15 +3058,18 @@ serve(async (req: Request) => {
 
         const opts = (options ?? {}) as Record<string, unknown>;
         const structure = String(opts.structure ?? "auto");
+        const resolutions = accountResolutionsValidator.safeParse(
+          opts.resolutions ?? {}
+        );
+        if (!resolutions.success) {
+          throw new Error("Invalid resolutions in the import options");
+        }
         const planOptions: AccountImportOptions = {
           structure:
             structure === "file" || structure === "carbon" ? structure : "auto",
           pathSeparator:
             typeof opts.pathSeparator === "string" ? opts.pathSeparator : ":",
-          resolutions:
-            opts.resolutions && typeof opts.resolutions === "object"
-              ? (opts.resolutions as AccountImportOptions["resolutions"])
-              : {},
+          resolutions: resolutions.data,
           activeInverted: isInvertedActiveHeader(columnMappings.active),
         };
 

--- a/packages/database/supabase/functions/import-csv/index.ts
+++ b/packages/database/supabase/functions/import-csv/index.ts
@@ -8,6 +8,14 @@ import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
 import { getReadableIdWithRevision } from "../lib/utils.ts";
+import {
+  type AccountImportOptions,
+  type ExistingAccount,
+  type ImportPlan,
+  isInvertedActiveHeader,
+  planChartOfAccounts,
+} from "./account-import.ts";
+import { applyAccountPlan } from "./account-import-writer.ts";
 import { classifyImportRow } from "./classify-import-row.ts";
 import { importMaterialProperties } from "./material-property-import.ts";
 import { importMethods } from "./method-import.ts";
@@ -38,12 +46,18 @@ const importCsvValidator = z.object({
     "materialGrade",
     "materialType",
     "materialDimension",
+    "account",
   ]),
   filePath: z.string(),
   columnMappings: z.record(z.string()),
   enumMappings: z.record(z.record(z.string())).optional(),
   companyId: z.string(),
   userId: z.string(),
+  // Plan without writing; only the importers that build a plan honour it
+  // (account). The response then carries `plan`.
+  dryRun: z.boolean().optional(),
+  // Importer-specific options gathered by the wizard's review step.
+  options: z.record(z.unknown()).optional(),
 });
 
 const EXTERNAL_ID_KEY = "csv";
@@ -115,7 +129,8 @@ type CsvEntityType =
   | "contact"
   | "workCenter"
   | "process"
-  | "storageUnit";
+  | "storageUnit"
+  | "account";
 
 /**
  * Look up the ids that still exist in the entity table. Done as a typed
@@ -174,6 +189,13 @@ async function fetchLiveEntityIds(
     case "storageUnit":
       rows = await db
         .selectFrom("storageUnit")
+        .select(["id"])
+        .where("id", "in", ids)
+        .execute();
+      break;
+    case "account":
+      rows = await db
+        .selectFrom("account")
         .select(["id"])
         .where("id", "in", ids)
         .execute();
@@ -951,6 +973,8 @@ serve(async (req: Request) => {
       enumMappings = {},
       companyId,
       userId,
+      dryRun = false,
+      options,
     } = importCsvValidator.parse(payload);
 
     console.log({
@@ -1002,9 +1026,12 @@ serve(async (req: Request) => {
       return record;
     });
 
-    const missingEnumKeys = Object.keys(enumMappings).filter(
-      (key) => !(key in mappedRecords[0])
-    );
+    const missingEnumKeys =
+      mappedRecords.length === 0
+        ? []
+        : Object.keys(enumMappings).filter(
+            (key) => !(key in mappedRecords[0])
+          );
 
     if (missingEnumKeys.length > 0) {
       mappedRecords = mappedRecords.map((record) => {
@@ -1026,6 +1053,9 @@ serve(async (req: Request) => {
       // Rows intentionally not written (duplicates, already-existing) — informational.
       skipped: [] as Array<{ row: number; reason: string }>,
     };
+    // Set by importers that plan before they write (account). Returned to
+    // the wizard so the user can review it; on a dry run nothing is written.
+    let plan: ImportPlan | undefined;
 
     switch (table) {
       case "customer": {
@@ -2903,6 +2933,188 @@ serve(async (req: Request) => {
         });
         break;
       }
+      case "account": {
+        // The chart is scoped by companyGroupId and shared by every company in
+        // the group; RLS only lets the group's ROOT company write it, and this
+        // Kysely path bypasses RLS, so the same rule is enforced here.
+        const company = await db
+          .selectFrom("company")
+          .select(["companyGroupId", "parentCompanyId"])
+          .where("id", "=", companyId)
+          .executeTakeFirst();
+        if (!company?.companyGroupId) {
+          throw new Error("This company does not belong to a company group");
+        }
+        if (company.parentCompanyId) {
+          throw new Error(
+            "The chart of accounts is shared across the company group and can only be imported from the group's root company"
+          );
+        }
+        const companyGroupId = company.companyGroupId;
+
+        const existingRows = await db
+          .selectFrom("account")
+          .select([
+            "id",
+            "number",
+            "name",
+            "isGroup",
+            "isSystem",
+            "parentId",
+            "class",
+            "accountType",
+            "incomeBalance",
+            "active",
+          ])
+          .where("companyGroupId", "=", companyGroupId)
+          .execute();
+        const existing: ExistingAccount[] = existingRows.map((a) => ({
+          id: a.id,
+          number: a.number ?? null,
+          name: a.name,
+          isGroup: !!a.isGroup,
+          isSystem: !!a.isSystem,
+          parentId: a.parentId ?? null,
+          class: (a.class ?? null) as ExistingAccount["class"],
+          accountType: (a.accountType ?? null) as ExistingAccount["accountType"],
+          incomeBalance: a.incomeBalance as ExistingAccount["incomeBalance"],
+          active: a.active ?? true,
+        }));
+        const existingIds = existing.map((a) => a.id);
+
+        const externalIdMap = await getCsvExternalIdMap("account", companyId);
+        const alreadyMappedEntityIds = new Set(externalIdMap.values());
+
+        // Accounts with journal lines: class may not change, may not deactivate.
+        const postedAccountIds = new Set<string>();
+        for (let i = 0; i < existingIds.length; i += 500) {
+          const chunk = existingIds.slice(i, i + 500);
+          const posted = await db
+            .selectFrom("journalLine")
+            .select(["accountId"])
+            .distinct()
+            .where("accountId", "in", chunk)
+            .execute();
+          for (const p of posted) if (p.accountId) postedAccountIds.add(p.accountId);
+        }
+
+        // Accounts the group's posting defaults and asset classes point at:
+        // RESTRICT foreign keys, and deactivating one hides its balance while
+        // postings continue.
+        const protectedAccountIds = new Set<string>();
+        const groupCompanies = await db
+          .selectFrom("company")
+          .select(["id"])
+          .where("companyGroupId", "=", companyGroupId)
+          .execute();
+        const groupCompanyIds = groupCompanies.map((c) => c.id);
+        if (groupCompanyIds.length > 0) {
+          const defaults = await db
+            .selectFrom("accountDefault")
+            .selectAll()
+            .where("companyId", "in", groupCompanyIds)
+            .execute();
+          for (const row of defaults) {
+            for (const [column, value] of Object.entries(row)) {
+              if (/Account(Id)?$/.test(column) && typeof value === "string") {
+                protectedAccountIds.add(value);
+              }
+            }
+          }
+          const assetClasses = await db
+            .selectFrom("fixedAssetClass")
+            .select([
+              "assetAccountId",
+              "accumulatedDepreciationAccountId",
+              "depreciationExpenseAccountId",
+              "gainOnDisposalAccountId",
+              "lossOnDisposalAccountId",
+              "writeDownAccountId",
+              "writeOffAccountId",
+            ])
+            .where("companyId", "in", groupCompanyIds)
+            .execute();
+          for (const row of assetClasses) {
+            for (const value of Object.values(row)) {
+              if (typeof value === "string") protectedAccountIds.add(value);
+            }
+          }
+        }
+
+        const opts = (options ?? {}) as Record<string, unknown>;
+        const structure = String(opts.structure ?? "auto");
+        const planOptions: AccountImportOptions = {
+          structure:
+            structure === "file" || structure === "carbon" ? structure : "auto",
+          pathSeparator:
+            typeof opts.pathSeparator === "string" ? opts.pathSeparator : ":",
+          resolutions:
+            opts.resolutions && typeof opts.resolutions === "object"
+              ? (opts.resolutions as AccountImportOptions["resolutions"])
+              : {},
+          activeInverted: isInvertedActiveHeader(columnMappings.active),
+        };
+
+        const accountPlan = planChartOfAccounts(
+          mappedRecords,
+          { existing, externalIdMap, postedAccountIds, protectedAccountIds },
+          planOptions
+        );
+        plan = accountPlan;
+
+        for (const node of accountPlan.nodes) {
+          if (node.action === "error") {
+            summary.errors.push({
+              row: node.reportRow,
+              reason: node.reason ?? "Could not be imported",
+            });
+          } else if (node.action === "skip") {
+            summary.skipped.push({
+              row: node.reportRow,
+              reason: node.reason ?? "Skipped",
+            });
+          } else if (node.action === "unchanged") {
+            summary.skipped.push({
+              row: node.reportRow,
+              reason: "Already in Carbon, unchanged",
+            });
+          }
+        }
+
+        console.log({
+          totalRecords: mappedRecords.length,
+          dryRun,
+          ...accountPlan.summary,
+        });
+
+        if (dryRun) {
+          summary.inserted =
+            accountPlan.summary.groupsToCreate +
+            accountPlan.summary.accountsToCreate;
+          summary.updated = accountPlan.summary.updates;
+          break;
+        }
+
+        await db.transaction().execute(async (trx) => {
+          const result = await applyAccountPlan(trx, accountPlan, {
+            companyGroupId,
+            userId,
+            alreadyMappedEntityIds,
+          });
+          summary.inserted += result.inserted;
+          summary.updated += result.updated;
+          if (result.csvMappings.length > 0) {
+            await upsertCsvMappings(
+              trx,
+              "account",
+              result.csvMappings,
+              companyId,
+              userId
+            );
+          }
+        });
+        break;
+      }
       default: {
         throw new Error(`Invalid table: ${table}`);
       }
@@ -2921,6 +3133,7 @@ serve(async (req: Request) => {
       updated: summary.updated,
       errors: withValues(summary.errors),
       skipped: withValues(summary.skipped),
+      ...(plan ? { plan } : {}),
     });
   } catch (err) {
     return errorResponse(err, 500);

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Übertragung zu"
 msgid "Trash"
 msgstr "Papierkorb"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Rohbilanz"
 

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -51,6 +51,27 @@ msgstr "(für diesen Kunden ausgeschlossen)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# Zeile verweist auf Daten außerhalb dieses Unternehmens, daher kann keine Sicherungskopie Ihrer aktuellen Daten erstellt werden.} other {# Zeilen verweisen auf Daten außerhalb dieses Unternehmens, daher kann keine Sicherungskopie Ihrer aktuellen Daten erstellt werden.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# Zeile verweist auf Daten außerhalb dieses Unternehme
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# Zeile verweist auf Daten außerhalb dieses Unternehmens, daher kann sie nicht gesichert werden. Wenn Sie sie überspringen, wird alles andere gesichert.} other {# Zeilen verweisen auf Daten außerhalb dieses Unternehmens, daher können sie nicht gesichert werden. Wenn Sie sie überspringen, wird alles andere gesichert.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Dieser Artikel ist auf 1 offener Änderungsmitteilung} other {Dieser Artikel ist auf # offenen Änderungsmitteilungen}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Dieser Artikel ist auf 1 offener Änderungsmitteilung} 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} Konten"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} erfolgreich gelöscht"
 msgid "{0} draft journal entries"
 msgstr "{0} Entwurfs-Buchungszeilen"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} Fertigungsaufträge erstellt"
@@ -111,14 +135,6 @@ msgstr "{0} Zeilen zum Zuordnen"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} registriert"
 msgid "{0} rows"
 msgstr "{0} Zeilen"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} Lieferanten mit einem Saldo"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nicht beprobte Entitäten werden freigegeben. Beprobte Annahmen bleiben verfügbar und beprobte Fehler bleiben abgelehnt."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} von {total} Phasen abgeschlossen"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# Zeile ausgeschlossen} other {# Zeilen ausgeschlossen}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} weitere: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eingefügt, {updated} aktualisiert, {0} benötigen Behebung, {1} übersprungen."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} Teile übersprungen — es gibt nichts zu produziere
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} wird zur Bearbeitung erneut geöffnet als Revision {0}. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# Einheit} other {# Einheiten}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Zeigen Sie eine lesbare Kundennummern-Spalte in der Kundenliste, Kundenf
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Zeigen Sie eine lesbare Lieferanten-ID-Spalte in der Lieferantenliste, Lieferantenformularen und Dropdowns an. Lieferanten werden intern in jedem Fall identifiziert."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Kundenkennung anzeigen"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(für diesen Kunden ausgeschlossen)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(Gruppe)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# Konto mit einem bestehenden zusammengeführt} other {# Konten mit bestehenden zusammengeführt}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# Konto anzulegen} other {# Konten anzulegen}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# Konto zu aktualisieren} other {# Konten zu aktualisieren}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# Konto unverändert} other {# Konten unverändert}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# Gruppe} other {# Gruppen}} und {1, plural, one {# Konto} other {# Konten}} anzulegen"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# Zeile verweist auf Daten außerhalb dieses Unternehme
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# Zeile erfordert Aufmerksamkeit} other {# Zeilen erfordern Aufmerksamkeit}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# Zeile übersprungen} other {# Zeilen übersprungen}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Die einzige Zeile anzeigen} other {Alle # Zeilen anzeigen}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} Zeilen zum Zuordnen"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} übereinstimmende Konten: {fileCount} übernehmen die Nummern aus der Datei, {keepCount} behalten die Nummern aus Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# Zeile ausgeschlossen} other {# Zeilen ausgeschlossen}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# übereinstimmendes Konto übernimmt die Nummer aus der Datei.} other {# übereinstimmende Konten übernehmen die Nummern aus der Datei.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} von {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eingefügt, {updated} aktualisiert, {0} benötigen Behebung, {1} übersprungen."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# übereinstimmendes Konto behält seine Nummer aus Carbon.} other {# übereinstimmende Konten behalten ihre Nummern aus Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# Zeile} other {# Zeilen}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} wird zur Bearbeitung erneut geöffnet als Revision {0}. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# Entscheidung noch nicht im Plan} other {# Entscheidungen noch nicht im Plan}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# Zeile dauerhaft löschen?} other {# Zeilen dauerhaft löschen?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# Konto existiert in Carbon bereits unter einer anderen Nummer.} other {# Konten existieren in Carbon bereits unter anderen Nummern.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} können nicht eingeplant werden"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Versuche"
 
 msgid "Attention"
-msgstr ""
+msgstr "Achtung"
 
 msgid "Attribute"
 msgstr "Attribut"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Überprüfen Sie das Artikelledger auf Artikel mit negativer Bestandsmenge am Periodenende – normalerweise ein fehlender Wareneingang oder eine fehlerhafte Buchung, die den Bestandswert und die Umsatzkosten verzerrt. Markieren Sie es als erledigt, nachdem es überprüft wurde, oder überspringen Sie es mit einem Grund."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Prüfen Sie vor dem Import, was angelegt und geändert wird. Bis zur Bestätigung wird nichts geschrieben."
 
 msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Überprüfung von Stripe für diesen Kunden…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Datei wird mit Ihrem Kontenplan abgeglichen…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Details"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Aus der Datei erkennen"
 
 msgid "Developer"
 msgstr "Entwickler"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Ausnahmegrunde"
 
 msgid "Existing"
-msgstr ""
+msgstr "Vorhanden"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Vorhandene Zuordnungen. Wählen Sie eine andere Provider-Option zum Neu-Zuordnen."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Gruppen"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Die Gruppen stammen aus der Datei. Eine oberste Gruppe mit demselben Namen wie eine Carbon-Gruppe wird mit dieser zusammengeführt."
 
 msgid "Guided"
 msgstr "Geführt"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Systemmengen bis zum Überprüfungsschritt ausblenden"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Vollständige Liste ausblenden"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Spalten ausblenden, fixieren und neu anordnen"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Hierarchie aus den Begin-Total-/End-Total-Zeilen der Datei übernommen."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Hierarchie aus der Spalte für das übergeordnete Konto der Datei übernommen."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Hierarchie aus den Pfaden in den Kontonamen übernommen."
 
 msgid "High"
 msgstr "Hoch"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Wie oft diese Instandhaltung wiederkehrt — Täglich, Wöchentlich, Monatlich, Bei Permanenter Inventur; Täglich zeigt die Wähler für Wochentage an, die anderen verwenden einfachere Intervallberechnung."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Wie sollen die Konten gegliedert werden?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Wie der Fertigungsauftrag eingestuft wird, wenn der Planer Kapazität verteilt — ASAP beansprucht zuerst, dann Hard Deadline, Soft Deadline und No Deadline zuletzt. Nur ein Ranking-Signal; kein Deadline-Typ blockiert oder sperrt die Platzierung."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Wenn Sie die Teilenummern ändern möchten, klicken Sie bitte Abbrechen und weisen Sie manuell die Teile für jede Position zu, bevor Sie konvertieren."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Die Gruppen der Datei ignorieren; jedes Konto wird unter die Carbon-Gruppe eingeordnet, die seinem Kontotyp entspricht."
 
 msgid "II (normal default)"
 msgstr "II (normalstandard)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Umsetzungsleiter"
 
 msgid "Import"
-msgstr ""
+msgstr "Importieren"
 
 msgid "Import {label} CSV"
 msgstr "Importiere {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Als „{0}“ importieren"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Als {0} importieren"
 
 msgid "Import results"
 msgstr "Importergebnisse"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Unter einem anderen Namen importieren"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Unter einer anderen Nummer importieren"
 
 msgid "Import your BOM"
 msgstr "Importieren Sie Ihre BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Behalten"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Nummer aus Carbon behalten"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Nummern aus Carbon behalten"
 
 msgid "Keep Current"
 msgstr "Aktuell behalten"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Leer lassen für exakte Übereinstimmung"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Dieses Konto unverändert lassen"
 
 msgid "Leave this page"
 msgstr "Diese Seite verlassen"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Wahrscheinlichkeit"
 
 msgid "Line"
-msgstr ""
+msgstr "Zeile"
 
 msgid "Line description (optional)"
 msgstr "Zeilenbeschreibung (optional)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Benötigt einen Business- oder Partner-Plan."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Erfordert Aufmerksamkeit"
 
 msgid "Needs fixing"
 msgstr "Muss behoben werden"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Keine Gruppen zugewiesen"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Keine Hierarchie in der Datei: Die Konten werden nach Kontotyp unter die bestehenden Carbon-Gruppen eingeordnet."
 
 msgid "No image"
 msgstr "Kein Bild"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Keine Überstunden geplant"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "In der Datei wurden weder eine Spalte für das übergeordnete Konto noch Zeilenarten oder Pfade in den Namen gefunden."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Noch keine übergeordneten Quellen aufgezeichnet. Klicken Sie auf der Planungsseite auf Neu berechnen, um die Zuordnung zu aktualisieren."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Nichts eingeplant – fügen Sie unten eine Station hinzu."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Nichts zu importieren."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Noch nichts. Ein Schritt bietet Werte erst nach der Konfiguration an."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Pfad"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Pfadtrennzeichen in Kontonamen"
 
 msgid "Pay Rate"
 msgstr "Zahlungskurs"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Angeheftet"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Konten unter die bestehenden Carbon-Gruppen einordnen"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Lösen Sie diese auf, bevor Sie die NCR abschließen: Jede Zeile muss einen nicht-ausstehenden Verwendungsentscheid haben, und ihre verknüpften Entitätsmengen müssen der Zeilenmenge entsprechen."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Gelöst"
 
 msgid "Resolved Price"
 msgstr "Aufgelöster Preis"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Verkaufsvertreter"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "Identisch mit {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "Identisch mit {target} (dessen Nummer behalten)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "Identisch mit {target} (Nummer aus dieser Datei verwenden)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "Identisch mit {target}, Nummer wird beibehalten"
 
 msgid "Same as Book"
 msgstr "Gleich wie Buch"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Überspringen Sie den freigegebenen, aber nicht gestarteten Zustand – der Auftrag startet sofort beim Scannen."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Diese Zeile überspringen"
 
 msgid "Skipped"
 msgstr "Übersprungen"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Lieferposition teilen"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Kontonamen an einem Trennzeichen aufteilen, z. B. Übergeordnet:Untergeordnet."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "Der Berechtigungssatz, den neue Mitarbeiter dieses Typs automatisch erhalten; durch die Bearbeitung hier wird nur die Vorlage für zukünftige Mitarbeiter geändert – vorhandene Mitarbeiter behalten das, was sie haben, es sei denn, es wird explizit in großen Mengen aktualisiert."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Der Plan konnte nicht erstellt werden"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Die Fabriken, Lagerhäuser und Standorte, an denen sich Ihre Arbeit und Bestände befinden"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Diese Buchungssätze sind noch Entwurf, sodass ihre Sollposten und Habenposten nicht im Sachkonto für diesen Zeitraum enthalten sind. Buchen Sie jeden einzelnen oder ändern Sie das Datum zu einem späteren offenen Zeitraum."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Diese Zeilen werden erst importiert, wenn sie gelöst sind; alles andere wird bei der Bestätigung importiert."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Diese Zeilen verlinken auf Daten außerhalb dieses Unternehmens. Daher kann keine Sicherheitskopie Ihrer aktuellen Daten erstellt werden. Das Löschen kann nicht rückgängig gemacht werden. Sollten diese sich als gemeinsam mit anderen Unternehmen in dieser Gruppe herausstellen, wird nichts gelöscht und die Wiederherstellung wird nicht gestartet."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Ballon entfernen"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Unverändert"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Nicht gezählte Zeilen bleiben beim Buchen unverändert — sie werden nicht auf Null gesetzt."
 
 msgid "Under"
-msgstr ""
+msgstr "Unter"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Unter Demand-Based Reorder summiert die Planung den Bedarf in diesem rollierenden Fenster beim Berechnen einer Auffüllungsmenge."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Berechtigungen aktualisieren"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Plan aktualisieren"
 
 msgid "Update Quantity"
 msgstr "Menge aktualisieren"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Aktualisieren Sie die Kanban-Informationen für die scanbasierte Auffüllung."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Aktualisieren Sie den Plan, um das Ergebnis zu sehen. Mit der Bestätigung des Imports werden alle übernommen."
 
 msgid "Update the purchase order quantities"
 msgstr "Bestellmengen aktualisieren"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Erfolgreich aktualisiert"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Plan wird aktualisiert…"
 
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Metrisches System für Standard-Materialdimensionen verwenden."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Nummern aus der Datei verwenden"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Spalte für das übergeordnete Konto, Namenspfade oder Summenzeilen der Datei verwenden, sofern vorhanden."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Hierarchie aus der Datei verwenden"
 
 msgid "Used In"
 msgstr "Verwendet in"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -48,6 +48,9 @@ msgstr "„{taskName}\" ist erledigt – alle {0} seiner Setup-Map-Elemente sind
 msgid "(excluded for this customer)"
 msgstr "(für diesen Kunden ausgeschlossen)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# Zeile verweist auf Daten außerhalb dieses Unternehmens, daher kann keine Sicherungskopie Ihrer aktuellen Daten erstellt werden.} other {# Zeilen verweisen auf Daten außerhalb dieses Unternehmens, daher kann keine Sicherungskopie Ihrer aktuellen Daten erstellt werden.}}"
@@ -89,6 +92,11 @@ msgstr "{0} erfolgreich gelöscht"
 msgid "{0} draft journal entries"
 msgstr "{0} Entwurfs-Buchungszeilen"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} Fertigungsaufträge erstellt"
@@ -96,6 +104,14 @@ msgstr "{0} Fertigungsaufträge erstellt"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} Zeilen zum Zuordnen"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} Zeilen"
 msgid "{0} suppliers with a balance"
 msgstr "{0} Lieferanten mit einem Saldo"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nicht beprobte Entitäten werden freigegeben. Beprobte Annahmen bleiben verfügbar und beprobte Fehler bleiben abgelehnt."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Alle Standorte"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Alle Mitglieder der ausgewählten Gruppen und ausgewählten Personen können Anfragen genehmigen"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Alle Zeilen importiert — {inserted} eingefügt, {updated} aktualisiert."
 
@@ -2431,6 +2459,9 @@ msgstr "Anhänge"
 msgid "Attempts"
 msgstr "Versuche"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Attribut"
 
@@ -2829,6 +2860,9 @@ msgstr "Erstellen Sie rollenbasierte Schulungsmaterialien"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Erstellen Sie maßgeschneiderte, rollenbasierte Schulungsmaterialien"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Als eigene Methode aufgebaut und kalkuliert"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Überprüfen Sie das Artikelledger auf Artikel mit negativer Bestandsmenge am Periodenende – normalerweise ein fehlender Wareneingang oder eine fehlerhafte Buchung, die den Bestandswert und die Umsatzkosten verzerrt. Markieren Sie es als erledigt, nachdem es überprüft wurde, oder überspringen Sie es mit einem Grund."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Überprüfen Sie Ihre E-Mail"
@@ -5417,6 +5454,9 @@ msgstr "Detail"
 msgid "Details"
 msgstr "Details"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Entwickler"
 
@@ -6571,6 +6611,9 @@ msgstr "Ausnahmezertifikat"
 msgid "Exemption Reason"
 msgstr "Ausnahmegrunde"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Vorhandene Zuordnungen. Wählen Sie eine andere Provider-Option zum Neu-Zuordnen."
 
@@ -7328,6 +7371,15 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Techniker vor Ort"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Grundlagen"
 
@@ -7712,6 +7764,9 @@ msgstr "Gruppenname"
 msgid "Groups"
 msgstr "Gruppen"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Geführt"
 
@@ -7892,6 +7947,9 @@ msgstr "Wie oft dieses Prüfmittel kalibriert werden muss; kombiniert mit dem le
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Wie oft diese Instandhaltung wiederkehrt — Täglich, Wöchentlich, Monatlich, Bei Permanenter Inventur; Täglich zeigt die Wähler für Wochentage an, die anderen verwenden einfachere Intervallberechnung."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Wie der Fertigungsauftrag eingestuft wird, wenn der Planer Kapazität verteilt — ASAP beansprucht zuerst, dann Hard Deadline, Soft Deadline und No Deadline zuletzt. Nur ein Ranking-Signal; kein Deadline-Typ blockiert oder sperrt die Platzierung."
 
@@ -8012,6 +8070,9 @@ msgstr "Wenn etwas aus dem Ruder läuft"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Wenn Sie die Teilenummern ändern möchten, klicken Sie bitte Abbrechen und weisen Sie manuell die Teile für jede Position zu, bevor Sie konvertieren."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normalstandard)"
 
@@ -8033,11 +8094,20 @@ msgstr "Umsetzungs-Hub"
 msgid "Implementation Lead"
 msgstr "Umsetzungsleiter"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importiere {label} CSV"
 
 msgid "Import results"
 msgstr "Importergebnisse"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Importieren Sie Ihre BOM"
@@ -8117,6 +8187,9 @@ msgstr "Zusätzliche Teile zur Lieferung hinzufügen"
 
 msgid "Include Inactive"
 msgstr "Inaktive einschließen"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Enthalten"
@@ -8897,6 +8970,9 @@ msgstr "Lassen Sie das Feld leer, um die nächste Revision automatisch zu verwen
 msgid "Leave empty for exact match"
 msgstr "Leer lassen für exakte Übereinstimmung"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Diese Seite verlassen"
 
@@ -8974,6 +9050,9 @@ msgstr "Lichter aus (24/7)"
 
 msgid "Likelihood"
 msgstr "Wahrscheinlichkeit"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Zeilenbeschreibung (optional)"
@@ -9901,6 +9980,9 @@ msgstr "Erforderlich sind die für diesen Tag fälligen Arbeitsstunden dividiert
 msgid "Needs a Business or Partner plan."
 msgstr "Benötigt einen Business- oder Partner-Plan."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Muss behoben werden"
 
@@ -10459,6 +10541,9 @@ msgstr "Keine gruppierten Benachrichtigungen"
 
 msgid "No groups assigned"
 msgstr "Keine Gruppen zugewiesen"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Kein Bild"
@@ -11565,6 +11650,9 @@ msgstr "Fügen Sie die Metadaten-XML ein, wenn Ihr Identitätsanbieter keine Met
 msgid "Path"
 msgstr "Pfad"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Zahlungskurs"
 
@@ -11794,6 +11882,9 @@ msgstr "Anheften {0}"
 
 msgid "Pinned"
 msgstr "Angeheftet"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "Zeilen"
 msgid "Rows left out of this backup"
 msgstr "Zeilen, die aus dieser Sicherung ausgelassen wurden"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Regel"
 
@@ -13791,6 +13885,10 @@ msgstr "Vertrieb, Angebote und Konfigurieren nach Bestellung"
 
 msgid "Salesperson"
 msgstr "Verkaufsvertreter"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Gleich wie Buch"
@@ -14815,6 +14913,9 @@ msgstr "Geplante Instandhaltung an Betriebsferien überspringen"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Überspringen Sie den freigegebenen, aber nicht gestarteten Zustand – der Auftrag startet sofort beim Scannen."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Übersprungen"
@@ -16217,6 +16318,9 @@ msgstr "Der Prozentsatz des Kassenrabatts. Verwenden Sie 0 für keinen Rabatt."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Der Berechtigungssatz, den neue Mitarbeiter dieses Typs automatisch erhalten; durch die Bearbeitung hier wird nur die Vorlage für zukünftige Mitarbeiter geändert – vorhandene Mitarbeiter behalten das, was sie haben, es sei denn, es wird explizit in großen Mengen aktualisiert."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Die Fabriken, Lagerhäuser und Standorte, an denen sich Ihre Arbeit und Bestände befinden"
 
@@ -17259,8 +17363,14 @@ msgstr "Nicht zugewiesen"
 msgid "Unballoon"
 msgstr "Ballon entfernen"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Nicht gezählte Zeilen bleiben beim Buchen unverändert — sie werden nicht auf Null gesetzt."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Unter Demand-Based Reorder summiert die Planung den Bedarf in diesem rollierenden Fenster beim Berechnen einer Auffüllungsmenge."
@@ -17600,6 +17710,12 @@ msgstr "Verwenden Sie eine andere E-Mail"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Metrisches System für Standard-Materialdimensionen verwenden."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Verwendet in"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} Fertigungsaufträge erstellt"
 msgid "{0} lines to map"
 msgstr "{0} Zeilen zum Zuordnen"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} übereinstimmende Konten: {fileCount} übernehmen die Nummern aus der Datei, {keepCount} behalten die Nummern aus Carbon."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Abgestimmt"
 
 msgid "matches"
 msgstr "entspricht"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Übereinstimmende Konten: {0}. Nummern aus der Datei: {fileCount}, Nummern aus Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Zuordnungspaare"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} Teile übersprungen — es gibt nichts zu produziere
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} wird zur Bearbeitung erneut geöffnet als Revision {0}. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# Zeile dauerhaft löschen?} other {# Zeilen dauerhaft löschen?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importiere {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Importergebnisse"
 
@@ -8187,9 +8198,6 @@ msgstr "Zusätzliche Teile zur Lieferung hinzufügen"
 
 msgid "Include Inactive"
 msgstr "Inaktive einschließen"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Enthalten"
@@ -8792,6 +8800,12 @@ msgstr "Kanbans"
 msgid "Keep"
 msgstr "Behalten"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Aktuell behalten"
 
@@ -8809,6 +8823,9 @@ msgstr "Offen halten"
 
 msgid "Keep picking"
 msgstr "Weiter kommissionieren"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Schützt Bestellungen, Angebote und Einstellungen durch eine zweite Überprüfung"
@@ -9548,6 +9565,9 @@ msgstr "Abgestimmt"
 
 msgid "matches"
 msgstr "entspricht"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Zuordnungspaare"
@@ -13412,6 +13432,9 @@ msgstr "Restwert %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Lösen Sie diese auf, bevor Sie die NCR abschließen: Jede Zeile muss einen nicht-ausstehenden Verwendungsentscheid haben, und ihre verknüpften Entitätsmengen müssen der Zeilenmenge entsprechen."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Aufgelöster Preis"
 
@@ -13886,8 +13909,16 @@ msgstr "Vertrieb, Angebote und Konfigurieren nach Bestellung"
 msgid "Salesperson"
 msgstr "Verkaufsvertreter"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Übertragung zu"
 msgid "Trash"
 msgstr "Papierkorb"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Rohbilanz"
 
@@ -17598,6 +17625,9 @@ msgstr "Passwort aktualisieren"
 msgid "Update Permissions"
 msgstr "Berechtigungen aktualisieren"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Menge aktualisieren"
 
@@ -17714,6 +17744,9 @@ msgstr "Verwenden Sie eine andere E-Mail"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Metrisches System für Standard-Materialdimensionen verwenden."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Dieser Artikel ist auf 1 offener Änderungsmitteilung} 
 msgid "{0} accounts"
 msgstr "{0} Konten"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "vor {0}"
@@ -92,9 +96,9 @@ msgstr "{0} erfolgreich gelöscht"
 msgid "{0} draft journal entries"
 msgstr "{0} Entwurfs-Buchungszeilen"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} Fertigungsaufträge erstellt"
 msgid "{0} lines to map"
 msgstr "{0} Zeilen zum Zuordnen"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} registriert"
 msgid "{0} rows"
 msgstr "{0} Zeilen"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} Lieferanten mit einem Saldo"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nicht beprobte Entitäten werden freigegeben. Beprobte Annahmen bleiben verfügbar und beprobte Fehler bleiben abgelehnt."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} von {total} Phasen abgeschlossen"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# Zeile ausgeschlossen} other {# Zeilen ausgeschlossen}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} von {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} weitere: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eingefügt, {updated} aktualisiert, {0} benötigen Behebung, {1} übersprungen."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# Zeile} other {# Zeilen}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} Teile übersprungen — es gibt nichts zu produziere
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} wird zur Bearbeitung erneut geöffnet als Revision {0}. Das bereits an den Lieferanten gesendete Dokument bleibt unverändert, bis Sie die Bestellung abschließen und erneut senden."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# Einheit} other {# Einheiten}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# nicht gezählte Zeile} other {# nicht gezählte Zeilen}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} können nicht eingeplant werden"
@@ -1496,9 +1516,6 @@ msgstr "Alle Standorte"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Alle Mitglieder der ausgewählten Gruppen und ausgewählten Personen können Anfragen genehmigen"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Alle Zeilen importiert — {inserted} eingefügt, {updated} aktualisiert."
@@ -2864,9 +2881,6 @@ msgstr "Erstellen Sie rollenbasierte Schulungsmaterialien"
 msgid "Build tailored, role-based training materials"
 msgstr "Erstellen Sie maßgeschneiderte, rollenbasierte Schulungsmaterialien"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Als eigene Methode aufgebaut und kalkuliert"
 
@@ -3278,6 +3292,9 @@ msgstr "Überprüfen Sie Ihre E-Mail"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Überprüfung von Stripe für diesen Kunden…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -7374,15 +7391,6 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Techniker vor Ort"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Grundlagen"
 
@@ -7809,8 +7817,20 @@ msgstr "Roh ausblenden"
 msgid "Hide system quantities until the review step"
 msgstr "Systemmengen bis zum Überprüfungsschritt ausblenden"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Spalten ausblenden, fixieren und neu anordnen"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Hoch"
@@ -8824,9 +8844,6 @@ msgstr "Offen halten"
 msgid "Keep picking"
 msgstr "Weiter kommissionieren"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Schützt Bestellungen, Angebote und Einstellungen durch eine zweite Überprüfung"
 
@@ -9565,9 +9582,6 @@ msgstr "Abgestimmt"
 
 msgid "matches"
 msgstr "entspricht"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Zuordnungspaare"
@@ -10562,7 +10576,7 @@ msgstr "Keine gruppierten Benachrichtigungen"
 msgid "No groups assigned"
 msgstr "Keine Gruppen zugewiesen"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Keine ausstehenden Schulungen"
 
 msgid "No overtime scheduled"
 msgstr "Keine Überstunden geplant"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Noch keine übergeordneten Quellen aufgezeichnet. Klicken Sie auf der Planungsseite auf Neu berechnen, um die Zuordnung zu aktualisieren."
@@ -10946,6 +10963,9 @@ msgstr "Nichts im Archiv"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Nichts eingeplant – fügen Sie unten eine Station hinzu."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Noch nichts. Ein Schritt bietet Werte erst nach der Konfiguration an."
@@ -13689,9 +13709,6 @@ msgstr "Zeilen"
 msgid "Rows left out of this backup"
 msgstr "Zeilen, die aus dieser Sicherung ausgelassen wurden"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Regel"
 
@@ -14815,6 +14832,10 @@ msgstr "Zeigen Sie eine lesbare Kundennummern-Spalte in der Kundenliste, Kundenf
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Zeigen Sie eine lesbare Lieferanten-ID-Spalte in der Lieferantenliste, Lieferantenformularen und Dropdowns an. Lieferanten werden intern in jedem Fall identifiziert."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Kundenkennung anzeigen"
 
@@ -15091,6 +15112,9 @@ msgstr "Beleg-Position aufteilen"
 
 msgid "Split shipment line"
 msgstr "Lieferposition teilen"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Diese Fertigungsaufträge haben diesem Arbeitsplatz zugewiesene Arbeitsg
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Diese Buchungssätze sind noch Entwurf, sodass ihre Sollposten und Habenposten nicht im Sachkonto für diesen Zeitraum enthalten sind. Buchen Sie jeden einzelnen oder ändern Sie das Datum zu einem späteren offenen Zeitraum."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Diese Zeilen verlinken auf Daten außerhalb dieses Unternehmens. Daher kann keine Sicherheitskopie Ihrer aktuellen Daten erstellt werden. Das Löschen kann nicht rückgängig gemacht werden. Sollten diese sich als gemeinsam mit anderen Unternehmen in dieser Gruppe herausstellen, wird nichts gelöscht und die Wiederherstellung wird nicht gestartet."
 
@@ -17640,6 +17667,9 @@ msgstr "Aktualisieren Sie Ursprungsbeleg-Mengen"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Aktualisieren Sie die Kanban-Informationen für die scanbasierte Auffüllung."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Bestellmengen aktualisieren"
 
@@ -17657,6 +17687,9 @@ msgstr "Aktualisiert von"
 
 msgid "Updated successfully"
 msgstr "Erfolgreich aktualisiert"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -17745,7 +17778,7 @@ msgstr "Verwenden Sie eine andere E-Mail"
 msgid "Use metric system for default material dimensions."
 msgstr "Metrisches System für Standard-Materialdimensionen verwenden."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Transfer To"
 msgid "Trash"
 msgstr "Trash"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr "Treat {0} same-name matches as the same account"
+
 msgid "Trial Balance"
 msgstr "Trial Balance"
 

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {This item is on 1 open change notice} other {This item 
 msgid "{0} accounts"
 msgstr "{0} accounts"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr "{0} accounts to create"
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} ago"
@@ -92,10 +96,10 @@ msgstr "{0} deleted successfully"
 msgid "{0} draft journal entries"
 msgstr "{0} draft journal entries"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
-msgstr "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
+msgstr "{0} groups and {1} accounts to create"
 
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
@@ -105,11 +109,15 @@ msgstr "{0} jobs created"
 msgid "{0} lines to map"
 msgstr "{0} lines to map"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr "{0} merged into existing"
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr "{0} need attention"
 
@@ -142,11 +150,15 @@ msgstr "{0} registered"
 msgid "{0} rows"
 msgstr "{0} rows"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr "{0} skipped"
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} suppliers with a balance"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr "{0} to update"
 
@@ -154,10 +166,9 @@ msgstr "{0} to update"
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
-msgstr "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
+msgstr "{0} unchanged"
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -238,6 +249,9 @@ msgstr "{done} of {total} phases complete"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr "{fileCount} matching accounts take the file's numbers."
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} of {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} more: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr "{keepCount} matching accounts keep their Carbon numbers."
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# line} other {# lines}}"
@@ -280,8 +297,8 @@ msgstr "{noDemandItemCount} parts skipped — nothing to make"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 
-msgid "{pendingCount} change(s) not yet in the plan"
-msgstr "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
+msgstr "{pendingCount} decision(s) not in the plan yet"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# unit} other {# units}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr "{undecided} accounts already exist in Carbon under other numbers."
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} can't be scheduled"
@@ -1496,9 +1516,6 @@ msgstr "All Locations"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "All members of selected groups and selected individuals will be able to approve requests"
-
-msgid "All rows"
-msgstr "All rows"
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "All rows imported — {inserted} inserted, {updated} updated."
@@ -2864,9 +2881,6 @@ msgstr "Build role-based training materials"
 msgid "Build tailored, role-based training materials"
 msgstr "Build tailored, role-based training materials"
 
-msgid "Building the plan…"
-msgstr "Building the plan…"
-
 msgid "Built and costed as its own method"
 msgstr "Built and costed as its own method"
 
@@ -3278,6 +3292,9 @@ msgstr "Check your email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Checking Stripe for this customer…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr "Checking the file against your chart of accounts…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -7374,15 +7391,6 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Forward deployed engineer"
 
-msgid "Found a parent column."
-msgstr "Found a parent column."
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr "Found a path in the account names, e.g. Parent:Child."
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr "Found Begin-Total / End-Total rows."
-
 msgid "Foundation"
 msgstr "Foundation"
 
@@ -7809,8 +7817,20 @@ msgstr "Hide raw"
 msgid "Hide system quantities until the review step"
 msgstr "Hide system quantities until the review step"
 
+msgid "Hide the full list"
+msgstr "Hide the full list"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Hide, pin and reorder columns"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr "Hierarchy taken from the file's Begin-Total / End-Total rows."
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr "Hierarchy taken from the file's parent column."
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr "Hierarchy taken from the paths in the account names."
 
 msgid "High"
 msgstr "High"
@@ -8824,9 +8844,6 @@ msgstr "Keep Open"
 msgid "Keep picking"
 msgstr "Keep picking"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Keeps orders, quotes, and settings behind a second check"
 
@@ -9565,9 +9582,6 @@ msgstr "Matched"
 
 msgid "matches"
 msgstr "matches"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr "Matching accounts are updated in place; choose whose numbers they keep."
 
 msgid "Matching Pairs"
 msgstr "Matching Pairs"
@@ -10562,8 +10576,8 @@ msgstr "No grouped notifications"
 msgid "No groups assigned"
 msgstr "No groups assigned"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
-msgstr "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
+msgstr "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 
 msgid "No image"
 msgstr "No image"
@@ -10663,6 +10677,9 @@ msgstr "No outstanding trainings"
 
 msgid "No overtime scheduled"
 msgstr "No overtime scheduled"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr "No parent column, row kinds, or paths in the names were found in the file."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
@@ -10946,6 +10963,9 @@ msgstr "Nothing in the archive"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Nothing scheduled — add a station below."
+
+msgid "Nothing to import."
+msgstr "Nothing to import."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Nothing yet. A step only offers values once it is configured."
@@ -13689,9 +13709,6 @@ msgstr "rows"
 msgid "Rows left out of this backup"
 msgstr "Rows left out of this backup"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-
 msgid "Rule"
 msgstr "Rule"
 
@@ -14815,6 +14832,10 @@ msgstr "Show a readable Customer ID column on the customer list, customer forms,
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr "Show all {0} rows"
+
 msgid "Show Customer IDs"
 msgstr "Show Customer IDs"
 
@@ -15091,6 +15112,9 @@ msgstr "Split receipt line"
 
 msgid "Split shipment line"
 msgstr "Split shipment line"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr "Split the account names on a separator, e.g. Parent:Child."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "These jobs have operations assigned to this work center:"
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr "These rows are not imported until they are resolved; everything else imports on confirm."
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 
@@ -17640,6 +17667,9 @@ msgstr "Update source document quantities"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Update the kanban information for scan-based replenishment."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr "Update the plan to see the result. Confirming the import applies them all."
+
 msgid "Update the purchase order quantities"
 msgstr "Update the purchase order quantities"
 
@@ -17657,6 +17687,9 @@ msgstr "Updated By"
 
 msgid "Updated successfully"
 msgstr "Updated successfully"
+
+msgid "Updating the plan…"
+msgstr "Updating the plan…"
 
 msgid "Upgrade"
 msgstr "Upgrade"
@@ -17745,8 +17778,8 @@ msgstr "Use a different email"
 msgid "Use metric system for default material dimensions."
 msgstr "Use metric system for default material dimensions."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
-msgstr "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
+msgstr "Use the file's numbers"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} parts skipped — nothing to make"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr "{pendingCount} change(s) not yet in the plan"
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 
@@ -8100,6 +8103,14 @@ msgstr "Import"
 msgid "Import {label} CSV"
 msgstr "Import {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr "Import as \"{0}\""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr "Import as {0}"
+
 msgid "Import results"
 msgstr "Import results"
 
@@ -8187,9 +8198,6 @@ msgstr "Include extra parts in shipment"
 
 msgid "Include Inactive"
 msgstr "Include Inactive"
-
-msgid "Include this row again"
-msgstr "Include this row again"
 
 msgid "Included"
 msgstr "Included"
@@ -8792,6 +8800,12 @@ msgstr "Kanbans"
 msgid "Keep"
 msgstr "Keep"
 
+msgid "Keep Carbon's number"
+msgstr "Keep Carbon's number"
+
+msgid "Keep Carbon's numbers"
+msgstr "Keep Carbon's numbers"
+
 msgid "Keep Current"
 msgstr "Keep Current"
 
@@ -8809,6 +8823,9 @@ msgstr "Keep Open"
 
 msgid "Keep picking"
 msgstr "Keep picking"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Keeps orders, quotes, and settings behind a second check"
@@ -9548,6 +9565,9 @@ msgstr "Matched"
 
 msgid "matches"
 msgstr "matches"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr "Matching accounts are updated in place; choose whose numbers they keep."
 
 msgid "Matching Pairs"
 msgstr "Matching Pairs"
@@ -13412,6 +13432,9 @@ msgstr "Residual Value %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 
+msgid "Resolved"
+msgstr "Resolved"
+
 msgid "Resolved Price"
 msgstr "Resolved Price"
 
@@ -13886,9 +13909,17 @@ msgstr "Sales, quoting, and configure-to-order"
 msgid "Salesperson"
 msgstr "Salesperson"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
-msgstr "Same as {0}"
+msgid "Same as {target}"
+msgstr "Same as {target}"
+
+msgid "Same as {target} (keep its number)"
+msgstr "Same as {target} (keep its number)"
+
+msgid "Same as {target} (use this file's number)"
+msgstr "Same as {target} (use this file's number)"
+
+msgid "Same as {target}, keeping its number"
+msgstr "Same as {target}, keeping its number"
 
 msgid "Same as Book"
 msgstr "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Transfer To"
 msgid "Trash"
 msgstr "Trash"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr "Treat {0} same-name matches as the same account"
-
 msgid "Trial Balance"
 msgstr "Trial Balance"
 
@@ -17598,6 +17625,9 @@ msgstr "Update Password"
 msgid "Update Permissions"
 msgstr "Update Permissions"
 
+msgid "Update plan"
+msgstr "Update plan"
+
 msgid "Update Quantity"
 msgstr "Update Quantity"
 
@@ -17714,6 +17744,9 @@ msgstr "Use a different email"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Use metric system for default material dimensions."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr "Use the file's numbers for {matchingCount} matching accounts"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} jobs created"
 msgid "{0} lines to map"
 msgstr "{0} lines to map"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Matched"
 
 msgid "matches"
 msgstr "matches"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Matching Pairs"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -51,6 +51,27 @@ msgstr "(excluded for this customer)"
 msgid "(group)"
 msgstr "(group)"
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr "{0, plural, one {# account to create} other {# accounts to create}}"
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr "{0, plural, one {# account to update} other {# accounts to update}}"
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# row links to data outside this company, so a safety c
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr "{0, plural, one {# row needs attention} other {# rows need attention}}"
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr "{0, plural, one {# row skipped} other {# rows skipped}}"
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr "{0, plural, one {Show the only row} other {Show all # rows}}"
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {This item is on 1 open change notice} other {This item 
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} accounts"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr "{0} accounts to create"
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} deleted successfully"
 msgid "{0} draft journal entries"
 msgstr "{0} draft journal entries"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr "{0} groups and {1} accounts to create"
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} jobs created"
@@ -112,14 +136,6 @@ msgstr "{0} lines to map"
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
 msgstr "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr "{0} merged into existing"
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
-msgstr "{0} need attention"
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -150,25 +166,13 @@ msgstr "{0} registered"
 msgid "{0} rows"
 msgstr "{0} rows"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr "{0} skipped"
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} suppliers with a balance"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr "{0} to update"
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr "{0} unchanged"
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,8 +253,8 @@ msgstr "{done} of {total} phases complete"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
-msgstr "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
+msgstr "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} of {count}"
@@ -266,8 +270,8 @@ msgstr "{hiddenCount} more: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
-msgstr "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
+msgstr "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,8 +301,8 @@ msgstr "{noDemandItemCount} parts skipped — nothing to make"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
-msgstr "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
+msgstr "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,8 +328,8 @@ msgstr "{totalQuantity, plural, one {# unit} other {# units}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
-msgstr "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
+msgstr "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Show a readable Customer ID column on the customer list, customer forms,
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr "Show all {0} rows"
 
 msgid "Show Customer IDs"
 msgstr "Show Customer IDs"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" is done — all {0} of its Setup Map items are configured
 msgid "(excluded for this customer)"
 msgstr "(excluded for this customer)"
 
+msgid "(group)"
+msgstr "(group)"
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -89,6 +92,11 @@ msgstr "{0} deleted successfully"
 msgid "{0} draft journal entries"
 msgstr "{0} draft journal entries"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr "{0} groups, {1} accounts to create"
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} jobs created"
@@ -96,6 +104,14 @@ msgstr "{0} jobs created"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} lines to map"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr "{0} merged into existing"
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr "{0} need attention"
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} rows"
 msgid "{0} suppliers with a balance"
 msgstr "{0} suppliers with a balance"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr "{0} to update"
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr "{0} unchanged, {1} skipped"
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "All Locations"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "All members of selected groups and selected individuals will be able to approve requests"
 
+msgid "All rows"
+msgstr "All rows"
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "All rows imported — {inserted} inserted, {updated} updated."
 
@@ -2431,6 +2459,9 @@ msgstr "Attachments"
 msgid "Attempts"
 msgstr "Attempts"
 
+msgid "Attention"
+msgstr "Attention"
+
 msgid "Attribute"
 msgstr "Attribute"
 
@@ -2829,6 +2860,9 @@ msgstr "Build role-based training materials"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Build tailored, role-based training materials"
+
+msgid "Building the plan…"
+msgstr "Building the plan…"
 
 msgid "Built and costed as its own method"
 msgstr "Built and costed as its own method"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr "Check what will be created and changed before importing. Nothing is written until you confirm."
 
 msgid "Check your email"
 msgstr "Check your email"
@@ -5417,6 +5454,9 @@ msgstr "Detail"
 msgid "Details"
 msgstr "Details"
 
+msgid "Detect from the file"
+msgstr "Detect from the file"
+
 msgid "Developer"
 msgstr "Developer"
 
@@ -6571,6 +6611,9 @@ msgstr "Exemption Certificate"
 msgid "Exemption Reason"
 msgstr "Exemption Reason"
 
+msgid "Existing"
+msgstr "Existing"
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Existing mappings. Pick a different provider option to re-map."
 
@@ -7328,6 +7371,15 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Forward deployed engineer"
 
+msgid "Found a parent column."
+msgstr "Found a parent column."
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr "Found a path in the account names, e.g. Parent:Child."
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr "Found Begin-Total / End-Total rows."
+
 msgid "Foundation"
 msgstr "Foundation"
 
@@ -7712,6 +7764,9 @@ msgstr "Group Name"
 msgid "Groups"
 msgstr "Groups"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+
 msgid "Guided"
 msgstr "Guided"
 
@@ -7892,6 +7947,9 @@ msgstr "How often this gauge must be recalibrated; combined with Last Calibratio
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 
+msgid "How should the accounts be organised?"
+msgstr "How should the accounts be organised?"
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 
@@ -8012,6 +8070,9 @@ msgstr "If something is off track"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+
 msgid "II (normal default)"
 msgstr "II (normal default)"
 
@@ -8033,11 +8094,20 @@ msgstr "Implementation Hub"
 msgid "Implementation Lead"
 msgstr "Implementation Lead"
 
+msgid "Import"
+msgstr "Import"
+
 msgid "Import {label} CSV"
 msgstr "Import {label} CSV"
 
 msgid "Import results"
 msgstr "Import results"
+
+msgid "Import under a different name"
+msgstr "Import under a different name"
+
+msgid "Import under a different number"
+msgstr "Import under a different number"
 
 msgid "Import your BOM"
 msgstr "Import your BOM"
@@ -8117,6 +8187,9 @@ msgstr "Include extra parts in shipment"
 
 msgid "Include Inactive"
 msgstr "Include Inactive"
+
+msgid "Include this row again"
+msgstr "Include this row again"
 
 msgid "Included"
 msgstr "Included"
@@ -8897,6 +8970,9 @@ msgstr "Leave blank to use the next revision automatically"
 msgid "Leave empty for exact match"
 msgstr "Leave empty for exact match"
 
+msgid "Leave this account as it is"
+msgstr "Leave this account as it is"
+
 msgid "Leave this page"
 msgstr "Leave this page"
 
@@ -8974,6 +9050,9 @@ msgstr "Lights-out (24/7)"
 
 msgid "Likelihood"
 msgstr "Likelihood"
+
+msgid "Line"
+msgstr "Line"
 
 msgid "Line description (optional)"
 msgstr "Line description (optional)"
@@ -9901,6 +9980,9 @@ msgstr "Needed is the job hours due that day divided by {personDayHours}h, round
 msgid "Needs a Business or Partner plan."
 msgstr "Needs a Business or Partner plan."
 
+msgid "Needs attention"
+msgstr "Needs attention"
+
 msgid "Needs fixing"
 msgstr "Needs fixing"
 
@@ -10459,6 +10541,9 @@ msgstr "No grouped notifications"
 
 msgid "No groups assigned"
 msgstr "No groups assigned"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
 
 msgid "No image"
 msgstr "No image"
@@ -11565,6 +11650,9 @@ msgstr "Paste the metadata XML if your identity provider does not publish a meta
 msgid "Path"
 msgstr "Path"
 
+msgid "Path separator in account names"
+msgstr "Path separator in account names"
+
 msgid "Pay Rate"
 msgstr "Pay Rate"
 
@@ -11794,6 +11882,9 @@ msgstr "Pin {0}"
 
 msgid "Pinned"
 msgstr "Pinned"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr "Place accounts under Carbon's existing groups"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "rows"
 msgid "Rows left out of this backup"
 msgstr "Rows left out of this backup"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+
 msgid "Rule"
 msgstr "Rule"
 
@@ -13791,6 +13885,10 @@ msgstr "Sales, quoting, and configure-to-order"
 
 msgid "Salesperson"
 msgstr "Salesperson"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr "Same as {0}"
 
 msgid "Same as Book"
 msgstr "Same as Book"
@@ -14815,6 +14913,9 @@ msgstr "Skip scheduled maintenance on company holidays"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Skip the released-but-not-started state — the job starts immediately on scan."
+
+msgid "Skip this row"
+msgstr "Skip this row"
 
 msgid "Skipped"
 msgstr "Skipped"
@@ -16217,6 +16318,9 @@ msgstr "The percentage of the cash discount. Use 0 for no discount."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 
+msgid "The plan could not be built"
+msgstr "The plan could not be built"
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "The plants, warehouses, and sites where your work and stock live"
 
@@ -17259,8 +17363,14 @@ msgstr "Unassigned"
 msgid "Unballoon"
 msgstr "Unballoon"
 
+msgid "Unchanged"
+msgstr "Unchanged"
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Uncounted lines are left unchanged at post — they are not zeroed."
+
+msgid "Under"
+msgstr "Under"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
@@ -17600,6 +17710,12 @@ msgstr "Use a different email"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Use metric system for default material dimensions."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr "Use the file's parent column, name paths, or total rows when present."
+
+msgid "Use the hierarchy in the file"
+msgstr "Use the hierarchy in the file"
 
 msgid "Used In"
 msgstr "Used In"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" está hecho — todos los {0} elementos de su Mapa de Con
 msgid "(excluded for this customer)"
 msgstr "(excluido para este cliente)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# fila vincula a datos fuera de esta empresa, por lo que no se puede hacer una copia de seguridad de sus datos actuales.} other {# filas vinculan a datos fuera de esta empresa, por lo que no se puede hacer una copia de seguridad de sus datos actuales.}}"
@@ -89,6 +92,11 @@ msgstr "{0} eliminado correctamente"
 msgid "{0} draft journal entries"
 msgstr "{0} asientos de diario en borrador"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} órdenes de trabajo creadas"
@@ -96,6 +104,14 @@ msgstr "{0} órdenes de trabajo creadas"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} líneas para mapear"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} filas"
 msgid "{0} suppliers with a balance"
 msgstr "{0} proveedores con saldo"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades no muestreadas serán liberadas a Disponible. Los pases muestreados permanecen Disponibles y los fallos muestreados permanecen Rechazados."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Todas las Ubicaciones"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Todos los miembros de los grupos seleccionados e individuos seleccionados podrán aprobar solicitudes"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas las filas importadas — {inserted} insertadas, {updated} actualizadas."
 
@@ -2431,6 +2459,9 @@ msgstr "Adjuntos"
 msgid "Attempts"
 msgstr "Intentos"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Atributo"
 
@@ -2829,6 +2860,9 @@ msgstr "Crear materiales de capacitación basados en roles"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Crear materiales de capacitación personalizados basados en roles"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Construido y calculado como su propio método"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Verifique el libro mayor de artículos para cualquier artículo con cantidad negativa en existencias a fin de período — generalmente una recepción faltante o una contabilización fuera de orden que distorsiona el valor del inventario y el costo de ventas. Márquelo como completado una vez revisado, o omítalo con un motivo."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Revisa tu correo electrónico"
@@ -5417,6 +5454,9 @@ msgstr "Detalle"
 msgid "Details"
 msgstr "Detalles"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Desarrollador"
 
@@ -6571,6 +6611,9 @@ msgstr "Certificado de Exención"
 msgid "Exemption Reason"
 msgstr "Motivo de Exención"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeos existentes. Elige una opción de proveedor diferente para remapear."
 
@@ -7328,6 +7371,15 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Ingeniero desplegado en sitio"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Fundación"
 
@@ -7712,6 +7764,9 @@ msgstr "Nombre del Grupo"
 msgid "Groups"
 msgstr "Grupos"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Guiado"
 
@@ -7892,6 +7947,9 @@ msgstr "Con qué frecuencia debe recalibrarse este Instrumento de medición; com
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Con qué frecuencia se repite este Mantenimiento — Diario, Semanal, Mensual, En Conteo cíclico; Diario revela el selector de día de la semana, los otros usan matemática de intervalo más simple."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Cómo se clasifica la orden de trabajo cuando el programador asigna capacidad — ASAP va primero, luego Plazo firme, Plazo flexible, y Sin plazo al final. Solo una señal de clasificación; ningún tipo de plazo bloquea o restringe la colocación."
 
@@ -8012,6 +8070,9 @@ msgstr "Si algo se desvía del plan"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Si desea cambiar los números de pieza, haga clic en Cancelar y Asigne manualmente las Piezas para cada Línea de Artículo antes de convertir."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normal predeterminado)"
 
@@ -8033,11 +8094,20 @@ msgstr "Centro de Implementación"
 msgid "Implementation Lead"
 msgstr "Líder de Implementación"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
 msgid "Import results"
 msgstr "Resultados de Importación"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Importa tu BOM"
@@ -8117,6 +8187,9 @@ msgstr "Incluir piezas adicionales en el envío"
 
 msgid "Include Inactive"
 msgstr "Incluir Inactivos"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Incluido"
@@ -8897,6 +8970,9 @@ msgstr "Dejar en blanco para usar la siguiente revisión automáticamente"
 msgid "Leave empty for exact match"
 msgstr "Dejar vacío para coincidencia exacta"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Salir de esta página"
 
@@ -8974,6 +9050,9 @@ msgstr "Sin luces (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilidad"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Descripción de línea (opcional)"
@@ -9901,6 +9980,9 @@ msgstr "Lo necesario son las horas de trabajo vencidas ese día divididas por {p
 msgid "Needs a Business or Partner plan."
 msgstr "Requiere un plan Business o Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Necesita reparación"
 
@@ -10459,6 +10541,9 @@ msgstr "Sin notificaciones agrupadas"
 
 msgid "No groups assigned"
 msgstr "No hay grupos asignados"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Sin imagen"
@@ -11565,6 +11650,9 @@ msgstr "Pegue el XML de metadatos si su proveedor de identidad no publica una UR
 msgid "Path"
 msgstr "Ruta"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Tasa de Pago"
 
@@ -11794,6 +11882,9 @@ msgstr "Fijar {0}"
 
 msgid "Pinned"
 msgstr "Fijado"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "filas"
 msgid "Rows left out of this backup"
 msgstr "Filas excluidas de esta copia de seguridad"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Regla"
 
@@ -13791,6 +13885,10 @@ msgstr "Ventas, cotización y configuración a pedido"
 
 msgid "Salesperson"
 msgstr "Vendedor"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Igual que el libro"
@@ -14815,6 +14913,9 @@ msgstr "Omitir mantenimiento programado en días festivos de la empresa"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Omita el estado liberado pero no iniciado: el trabajo comienza inmediatamente al escanear."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Omitido"
@@ -16217,6 +16318,9 @@ msgstr "El porcentaje del descuento en efectivo. Utiliza 0 para sin descuento."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "El conjunto de permisos que reciben automáticamente los nuevos empleados de este tipo; editar aquí cambia la plantilla solo para futuras contrataciones - los empleados existentes conservan lo que tienen a menos que se actualicen explícitamente en masa."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Las plantas, almacenes y sitios donde viven tu trabajo e inventario"
 
@@ -17259,8 +17363,14 @@ msgstr "Sin asignar"
 msgid "Unballoon"
 msgstr "Desvinculación"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Las líneas no contadas se dejan sin cambios al publicar — no se ponen a cero."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Bajo Reorden Basado en Demanda, la planificación suma la demanda dentro de esta ventana móvil al calcular una cantidad de reabastecimiento."
@@ -17600,6 +17710,12 @@ msgstr "Usar un correo electrónico diferente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizar el sistema métrico para las dimensiones predeterminadas del material."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Utilizado en"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} piezas omitidas — no hay nada que fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} se reabrirá para edición como revisión {0}. El documento ya enviado al proveedor permanece sin cambios hasta que finalices y reenvíes la orden."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {¿Eliminar permanentemente # fila?} other {¿Eliminar permanentemente # filas?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Resultados de Importación"
 
@@ -8187,9 +8198,6 @@ msgstr "Incluir piezas adicionales en el envío"
 
 msgid "Include Inactive"
 msgstr "Incluir Inactivos"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Incluido"
@@ -8792,6 +8800,12 @@ msgstr "Kanbans"
 msgid "Keep"
 msgstr "Mantener"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Mantener Actual"
 
@@ -8809,6 +8823,9 @@ msgstr "Mantener Abierto"
 
 msgid "Keep picking"
 msgstr "Continuar picking"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantiene órdenes, cotizaciones y configuración tras una segunda verificación"
@@ -9548,6 +9565,9 @@ msgstr "Emparejado"
 
 msgid "matches"
 msgstr "coincide"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pares de coincidencia"
@@ -13412,6 +13432,9 @@ msgstr "Valor residual %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Resuelve estos antes de completar la NCR: cada fila debe tener una disposición que no sea Pendiente, y sus cantidades de entidades vinculadas deben coincidir con la cantidad de la fila."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Precio Resuelto"
 
@@ -13886,8 +13909,16 @@ msgstr "Ventas, cotización y configuración a pedido"
 msgid "Salesperson"
 msgstr "Vendedor"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Transferir a"
 msgid "Trash"
 msgstr "Papelera"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Balance de prueba"
 
@@ -17598,6 +17625,9 @@ msgstr "Actualizar Contraseña"
 msgid "Update Permissions"
 msgstr "Actualizar Permisos"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Actualizar Cantidad"
 
@@ -17714,6 +17744,9 @@ msgstr "Usar un correo electrónico diferente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizar el sistema métrico para las dimensiones predeterminadas del material."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(excluido para este cliente)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(grupo)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# cuenta fusionada con una existente} other {# cuentas fusionadas con existentes}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# cuenta por crear} other {# cuentas por crear}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# cuenta por actualizar} other {# cuentas por actualizar}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# cuenta sin cambios} other {# cuentas sin cambios}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# grupo} other {# grupos}} y {1, plural, one {# cuenta} other {# cuentas}} por crear"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# fila vincula a datos fuera de esta empresa, por lo qu
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# fila requiere atención} other {# filas requieren atención}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# fila omitida} other {# filas omitidas}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Mostrar la única fila} other {Mostrar las # filas}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} líneas para mapear"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} cuentas coincidentes: {fileCount} toman los números del archivo, {keepCount} conservan los de Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# fila excluida} other {# filas excluidas}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# cuenta coincidente toma el número del archivo.} other {# cuentas coincidentes toman los números del archivo.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} de {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insertados, {updated} actualizados, {0} necesitan corrección, {1} omitidos."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# cuenta coincidente conserva su número de Carbon.} other {# cuentas coincidentes conservan sus números de Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# línea} other {# líneas}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} se reabrirá para edición como revisión {0}. El documento ya enviado al proveedor permanece sin cambios hasta que finalices y reenvíes la orden."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# decisión aún no está en el plan} other {# decisiones aún no están en el plan}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {¿Eliminar permanentemente # fila?} other {¿Eliminar permanentemente # filas?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# cuenta ya existe en Carbon con otro número.} other {# cuentas ya existen en Carbon con otros números.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} no puede ser programado"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Intentos"
 
 msgid "Attention"
-msgstr ""
+msgstr "Atención"
 
 msgid "Attribute"
 msgstr "Atributo"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Verifique el libro mayor de artículos para cualquier artículo con cantidad negativa en existencias a fin de período — generalmente una recepción faltante o una contabilización fuera de orden que distorsiona el valor del inventario y el costo de ventas. Márquelo como completado una vez revisado, o omítalo con un motivo."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Revise lo que se creará y cambiará antes de importar. No se escribe nada hasta que confirme."
 
 msgid "Check your email"
 msgstr "Revisa tu correo electrónico"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Comparando el archivo con su plan de cuentas…"
 
 msgid "Checkpoint ·"
 msgstr "Punto de control ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Detalles"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Detectar desde el archivo"
 
 msgid "Developer"
 msgstr "Desarrollador"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Motivo de Exención"
 
 msgid "Existing"
-msgstr ""
+msgstr "Existente"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeos existentes. Elige una opción de proveedor diferente para remapear."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Grupos"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Los grupos provienen del archivo. Un grupo de nivel superior con el mismo nombre que un grupo de Carbon se fusiona con él."
 
 msgid "Guided"
 msgstr "Guiado"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Ocultar cantidades del sistema hasta el paso de revisión"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Ocultar la lista completa"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, anclar y reordenar columnas"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Jerarquía tomada de las filas Begin-Total / End-Total del archivo."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Jerarquía tomada de la columna de cuenta principal del archivo."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Jerarquía tomada de las rutas en los nombres de las cuentas."
 
 msgid "High"
 msgstr "Alto"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Con qué frecuencia se repite este Mantenimiento — Diario, Semanal, Mensual, En Conteo cíclico; Diario revela el selector de día de la semana, los otros usan matemática de intervalo más simple."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "¿Cómo se deben organizar las cuentas?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Cómo se clasifica la orden de trabajo cuando el programador asigna capacidad — ASAP va primero, luego Plazo firme, Plazo flexible, y Sin plazo al final. Solo una señal de clasificación; ningún tipo de plazo bloquea o restringe la colocación."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Si desea cambiar los números de pieza, haga clic en Cancelar y Asigne manualmente las Piezas para cada Línea de Artículo antes de convertir."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Ignorar los grupos del archivo; cada cuenta se coloca bajo el grupo de Carbon que corresponde a su tipo de cuenta."
 
 msgid "II (normal default)"
 msgstr "II (normal predeterminado)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Líder de Implementación"
 
 msgid "Import"
-msgstr ""
+msgstr "Importar"
 
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Importar como «{0}»"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Importar como {0}"
 
 msgid "Import results"
 msgstr "Resultados de Importación"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Importar con otro nombre"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Importar con otro número"
 
 msgid "Import your BOM"
 msgstr "Importa tu BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Mantener"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Conservar el número de Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Conservar los números de Carbon"
 
 msgid "Keep Current"
 msgstr "Mantener Actual"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Dejar vacío para coincidencia exacta"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Dejar esta cuenta como está"
 
 msgid "Leave this page"
 msgstr "Salir de esta página"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Probabilidad"
 
 msgid "Line"
-msgstr ""
+msgstr "Línea"
 
 msgid "Line description (optional)"
 msgstr "Descripción de línea (opcional)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Requiere un plan Business o Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Requiere atención"
 
 msgid "Needs fixing"
 msgstr "Necesita reparación"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "No hay grupos asignados"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "El archivo no tiene jerarquía: las cuentas se colocan bajo los grupos existentes de Carbon según su tipo de cuenta."
 
 msgid "No image"
 msgstr "Sin imagen"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Sin horas extra programadas"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "No se encontró en el archivo una columna de cuenta principal, tipos de fila ni rutas en los nombres."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "No hay fuentes principales registradas aún. Haz clic en Recalcular en la página de planificación para actualizar la atribución."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Nada programado — añade una estación abajo."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Nada que importar."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Aún no hay nada. Un paso solo ofrece valores una vez que está configurado."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Ruta"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Separador de ruta en los nombres de cuenta"
 
 msgid "Pay Rate"
 msgstr "Tasa de Pago"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Fijado"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Colocar las cuentas bajo los grupos existentes de Carbon"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Resuelve estos antes de completar la NCR: cada fila debe tener una disposición que no sea Pendiente, y sus cantidades de entidades vinculadas deben coincidir con la cantidad de la fila."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Resuelto"
 
 msgid "Resolved Price"
 msgstr "Precio Resuelto"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Vendedor"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "Igual que {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "Igual que {target} (conservar su número)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "Igual que {target} (usar el número de este archivo)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "Igual que {target}, conservando su número"
 
 msgid "Same as Book"
 msgstr "Igual que el libro"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Omita el estado liberado pero no iniciado: el trabajo comienza inmediatamente al escanear."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Omitir esta fila"
 
 msgid "Skipped"
 msgstr "Omitido"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Dividir línea de envío"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Dividir los nombres de cuenta por un separador, p. ej. Principal:Secundaria."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "El conjunto de permisos que reciben automáticamente los nuevos empleados de este tipo; editar aquí cambia la plantilla solo para futuras contrataciones - los empleados existentes conservan lo que tienen a menos que se actualicen explícitamente en masa."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "No se pudo generar el plan"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Las plantas, almacenes y sitios donde viven tu trabajo e inventario"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Estos asientos aún están en Borrador, por lo que sus debe y haber no están en el libro mayor para este período. Contabiliza cada uno, o cambia su fecha a un período abierto posterior."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Estas filas no se importan hasta que se resuelvan; todo lo demás se importa al confirmar."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Estas filas contienen referencias a datos fuera de esta empresa, por lo que no se puede crear una copia de seguridad de los datos actuales. La eliminación de estas filas no se puede deshacer. Si se encuentran compartidas con otras empresas del grupo, nada se eliminará y la restauración no se iniciará."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Desvinculación"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Sin cambios"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Las líneas no contadas se dejan sin cambios al publicar — no se ponen a cero."
 
 msgid "Under"
-msgstr ""
+msgstr "Bajo"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Bajo Reorden Basado en Demanda, la planificación suma la demanda dentro de esta ventana móvil al calcular una cantidad de reabastecimiento."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Actualizar Permisos"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Actualizar plan"
 
 msgid "Update Quantity"
 msgstr "Actualizar Cantidad"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Actualizar la información del kanban para reabastecimiento basado en escaneo."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Actualice el plan para ver el resultado. Al confirmar la importación se aplican todas."
 
 msgid "Update the purchase order quantities"
 msgstr "Actualizar las cantidades de la orden de compra"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Actualizado exitosamente"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Actualizando el plan…"
 
 msgid "Upgrade"
 msgstr "Actualizar"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Utilizar el sistema métrico para las dimensiones predeterminadas del material."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Usar los números del archivo"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Usar la columna de cuenta principal, las rutas en los nombres o las filas de totales del archivo cuando existan."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Usar la jerarquía del archivo"
 
 msgid "Used In"
 msgstr "Utilizado en"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Transferir a"
 msgid "Trash"
 msgstr "Papelera"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Balance de prueba"
 

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -51,6 +51,27 @@ msgstr "(excluido para este cliente)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# fila vincula a datos fuera de esta empresa, por lo que no se puede hacer una copia de seguridad de sus datos actuales.} other {# filas vinculan a datos fuera de esta empresa, por lo que no se puede hacer una copia de seguridad de sus datos actuales.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# fila vincula a datos fuera de esta empresa, por lo qu
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# fila vincula a datos fuera de esta empresa, por lo que no se puede hacer backup. Omitirla permite hacer backup del resto.} other {# filas vinculan a datos fuera de esta empresa, por lo que no se pueden hacer backup. Omitirlas permite hacer backup del resto.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Este artículo está en 1 aviso de cambio abierto} other {Este artículo está en # avisos de cambio abiertos}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Este artículo está en 1 aviso de cambio abierto} othe
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} cuentas"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} eliminado correctamente"
 msgid "{0} draft journal entries"
 msgstr "{0} asientos de diario en borrador"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} órdenes de trabajo creadas"
@@ -111,14 +135,6 @@ msgstr "{0} líneas para mapear"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} registrado"
 msgid "{0} rows"
 msgstr "{0} filas"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} proveedores con saldo"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades no muestreadas serán liberadas a Disponible. Los pases muestreados permanecen Disponibles y los fallos muestreados permanecen Rechazados."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} de {total} fases completadas"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# fila excluida} other {# filas excluidas}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} más: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insertados, {updated} actualizados, {0} necesitan corrección, {1} omitidos."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} piezas omitidas — no hay nada que fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} se reabrirá para edición como revisión {0}. El documento ya enviado al proveedor permanece sin cambios hasta que finalices y reenvíes la orden."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# unidad} other {# unidades}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Mostrar una columna de ID de cliente legible en la lista de clientes, fo
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostrar una columna de ID de Proveedor legible en la lista de proveedores, formularios de proveedores y menús desplegables. Los proveedores se identifican internamente de cualquier forma."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Mostrar IDs de Cliente"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Este artículo está en 1 aviso de cambio abierto} othe
 msgid "{0} accounts"
 msgstr "{0} cuentas"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} hace"
@@ -92,9 +96,9 @@ msgstr "{0} eliminado correctamente"
 msgid "{0} draft journal entries"
 msgstr "{0} asientos de diario en borrador"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} órdenes de trabajo creadas"
 msgid "{0} lines to map"
 msgstr "{0} líneas para mapear"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} registrado"
 msgid "{0} rows"
 msgstr "{0} filas"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} proveedores con saldo"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades no muestreadas serán liberadas a Disponible. Los pases muestreados permanecen Disponibles y los fallos muestreados permanecen Rechazados."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} de {total} fases completadas"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# fila excluida} other {# filas excluidas}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} de {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} más: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insertados, {updated} actualizados, {0} necesitan corrección, {1} omitidos."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# línea} other {# líneas}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} piezas omitidas — no hay nada que fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} se reabrirá para edición como revisión {0}. El documento ya enviado al proveedor permanece sin cambios hasta que finalices y reenvíes la orden."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# unidad} other {# unidades}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# línea sin contar} other {# líneas sin contar}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} no puede ser programado"
@@ -1496,9 +1516,6 @@ msgstr "Todas las Ubicaciones"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Todos los miembros de los grupos seleccionados e individuos seleccionados podrán aprobar solicitudes"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas las filas importadas — {inserted} insertadas, {updated} actualizadas."
@@ -2864,9 +2881,6 @@ msgstr "Crear materiales de capacitación basados en roles"
 msgid "Build tailored, role-based training materials"
 msgstr "Crear materiales de capacitación personalizados basados en roles"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Construido y calculado como su propio método"
 
@@ -3278,6 +3292,9 @@ msgstr "Revisa tu correo electrónico"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Punto de control ·"
@@ -7374,15 +7391,6 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Ingeniero desplegado en sitio"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Fundación"
 
@@ -7809,8 +7817,20 @@ msgstr "Ocultar sin procesar"
 msgid "Hide system quantities until the review step"
 msgstr "Ocultar cantidades del sistema hasta el paso de revisión"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, anclar y reordenar columnas"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Alto"
@@ -8824,9 +8844,6 @@ msgstr "Mantener Abierto"
 msgid "Keep picking"
 msgstr "Continuar picking"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantiene órdenes, cotizaciones y configuración tras una segunda verificación"
 
@@ -9565,9 +9582,6 @@ msgstr "Emparejado"
 
 msgid "matches"
 msgstr "coincide"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pares de coincidencia"
@@ -10562,7 +10576,7 @@ msgstr "Sin notificaciones agrupadas"
 msgid "No groups assigned"
 msgstr "No hay grupos asignados"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "No hay capacitaciones pendientes"
 
 msgid "No overtime scheduled"
 msgstr "Sin horas extra programadas"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "No hay fuentes principales registradas aún. Haz clic en Recalcular en la página de planificación para actualizar la atribución."
@@ -10946,6 +10963,9 @@ msgstr "Nada en el archivo"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Nada programado — añade una estación abajo."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Aún no hay nada. Un paso solo ofrece valores una vez que está configurado."
@@ -13689,9 +13709,6 @@ msgstr "filas"
 msgid "Rows left out of this backup"
 msgstr "Filas excluidas de esta copia de seguridad"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Regla"
 
@@ -14815,6 +14832,10 @@ msgstr "Mostrar una columna de ID de cliente legible en la lista de clientes, fo
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostrar una columna de ID de Proveedor legible en la lista de proveedores, formularios de proveedores y menús desplegables. Los proveedores se identifican internamente de cualquier forma."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Mostrar IDs de Cliente"
 
@@ -15091,6 +15112,9 @@ msgstr "Dividir línea de recepción"
 
 msgid "Split shipment line"
 msgstr "Dividir línea de envío"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Estas órdenes de trabajo tienen operaciones asignadas a este centro de 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Estos asientos aún están en Borrador, por lo que sus debe y haber no están en el libro mayor para este período. Contabiliza cada uno, o cambia su fecha a un período abierto posterior."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Estas filas contienen referencias a datos fuera de esta empresa, por lo que no se puede crear una copia de seguridad de los datos actuales. La eliminación de estas filas no se puede deshacer. Si se encuentran compartidas con otras empresas del grupo, nada se eliminará y la restauración no se iniciará."
 
@@ -17640,6 +17667,9 @@ msgstr "Actualizar cantidades del documento de origen"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Actualizar la información del kanban para reabastecimiento basado en escaneo."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Actualizar las cantidades de la orden de compra"
 
@@ -17657,6 +17687,9 @@ msgstr "Actualizado por"
 
 msgid "Updated successfully"
 msgstr "Actualizado exitosamente"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Actualizar"
@@ -17745,7 +17778,7 @@ msgstr "Usar un correo electrónico diferente"
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizar el sistema métrico para las dimensiones predeterminadas del material."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -53,7 +53,7 @@ msgstr "(grupo)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr "{0, plural, one {# cuenta fusionada con una existente} other {# cuentas fusionadas con existentes}}"
+msgstr "{0, plural, one {# cuenta fusionada con una existente} other {# cuentas fusionadas con cuentas existentes}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
@@ -132,10 +132,6 @@ msgstr "{0} órdenes de trabajo creadas"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} líneas para mapear"
-
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} cuentas coincidentes: {fileCount} toman los números del archivo, {keepCount} conservan los de Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -9586,6 +9582,10 @@ msgstr "Emparejado"
 
 msgid "matches"
 msgstr "coincide"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Cuentas coincidentes: {0}. Números del archivo: {fileCount}, números de Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Pares de coincidencia"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} ordres de fabrication créés"
 msgid "{0} lines to map"
 msgstr "{0} lignes à mapper"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} comptes correspondants : {fileCount} prennent les numéros du fichier, {keepCount} conservent ceux de Carbon."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Rapproché"
 
 msgid "matches"
 msgstr "correspond"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Comptes correspondants : {0}. Numéros du fichier : {fileCount}, numéros Carbon : {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Paires d'appariement"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -51,6 +51,27 @@ msgstr "(exclu pour ce client)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# ligne se connecte à des données en dehors de cette Société, donc une copie de sécurité de vos données actuelles ne peut pas être créée.} other {# lignes se connectent à des données en dehors de cette Société, donc une copie de sécurité de vos données actuelles ne peut pas être créée.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# ligne se connecte à des données en dehors de cette 
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# ligne se connecte à des données en dehors de cette Société, donc elle ne peut pas être sauvegardée. L'ignorer sauvegarde tout le reste.} other {# lignes se connectent à des données en dehors de cette Société, donc elles ne peuvent pas être sauvegardées. Les ignorer sauvegarde tout le reste.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Cet article est sur 1 avis de modification ouvert} other {Cet article est sur # avis de modification ouverts}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Cet article est sur 1 avis de modification ouvert} othe
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} comptes"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} supprimé avec succès"
 msgid "{0} draft journal entries"
 msgstr "{0} écritures de journal brouillon"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordres de fabrication créés"
@@ -111,14 +135,6 @@ msgstr "{0} lignes à mapper"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} enregistré"
 msgid "{0} rows"
 msgstr "{0} lignes"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fournisseurs avec un solde"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entités non échantillonnées seront libérées en Disponible. Les passes échantillonnées restent Disponible et les défaillances échantillonnées restent Rejetées."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} sur {total} phases terminées"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# ligne exclue} other {# lignes exclues}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} autres : {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insérés, {updated} mis à jour, {0} nécessitent correction, {1} ignorés."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} pièces ignorées — rien à fabriquer"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} sera rouvert pour modification en tant que révision {0}. Le document déjà envoyé au fournisseur reste inchangé jusqu'à ce que vous le finalisiez et le renvoiez."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# unité} other {# unités}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Afficher une colonne ID client lisible sur la liste des clients, les for
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Afficher une colonne ID Fournisseur lisible sur la liste des fournisseurs, les formulaires de fournisseur et les listes déroulantes. Les fournisseurs sont toujours identifiés en interne de toute façon."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Afficher les ID clients"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Cet article est sur 1 avis de modification ouvert} othe
 msgid "{0} accounts"
 msgstr "{0} comptes"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} il y a"
@@ -92,9 +96,9 @@ msgstr "{0} supprimé avec succès"
 msgid "{0} draft journal entries"
 msgstr "{0} écritures de journal brouillon"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} ordres de fabrication créés"
 msgid "{0} lines to map"
 msgstr "{0} lignes à mapper"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} enregistré"
 msgid "{0} rows"
 msgstr "{0} lignes"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fournisseurs avec un solde"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entités non échantillonnées seront libérées en Disponible. Les passes échantillonnées restent Disponible et les défaillances échantillonnées restent Rejetées."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} sur {total} phases terminées"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# ligne exclue} other {# lignes exclues}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} sur {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} autres : {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insérés, {updated} mis à jour, {0} nécessitent correction, {1} ignorés."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# ligne} other {# lignes}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} pièces ignorées — rien à fabriquer"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} sera rouvert pour modification en tant que révision {0}. Le document déjà envoyé au fournisseur reste inchangé jusqu'à ce que vous le finalisiez et le renvoiez."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# unité} other {# unités}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} ne peuvent pas être planifiés"
@@ -1496,9 +1516,6 @@ msgstr "Tous les Emplacements"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Tous les membres des groupes sélectionnés et les individus sélectionnés pourront approuver les demandes"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Toutes les lignes importées — {inserted} insérées, {updated} mises à jour."
@@ -2864,9 +2881,6 @@ msgstr "Créer des matériels de formation basés sur les rôles"
 msgid "Build tailored, role-based training materials"
 msgstr "Créer des matériels de formation personnalisés et basés sur les rôles"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Construit et chiffré comme sa propre méthode"
 
@@ -3278,6 +3292,9 @@ msgstr "Vérifiez votre email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Vérification de Stripe pour ce client…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Point de contrôle ·"
@@ -7374,15 +7391,6 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Ingénieur dédié au terrain"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Fondation"
 
@@ -7809,8 +7817,20 @@ msgstr "Masquer le brut"
 msgid "Hide system quantities until the review step"
 msgstr "Masquer les quantités système jusqu'à l'étape de revue"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Masquer, épingler et réorganiser les colonnes"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Élevé"
@@ -8824,9 +8844,6 @@ msgstr "Garder ouvert"
 msgid "Keep picking"
 msgstr "Continuer le prélèvement"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Garde les commandes, les devis et les paramètres derrière une deuxième vérification"
 
@@ -9565,9 +9582,6 @@ msgstr "Rapproché"
 
 msgid "matches"
 msgstr "correspond"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Paires d'appariement"
@@ -10562,7 +10576,7 @@ msgstr "Aucune notification groupée"
 msgid "No groups assigned"
 msgstr "Aucun groupe assigné"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Aucune formation en attente"
 
 msgid "No overtime scheduled"
 msgstr "Aucune heure supplémentaire prévue"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Aucune source parent enregistrée pour le moment. Cliquez sur Recalculer sur la page de planification pour actualiser l'attribution."
@@ -10946,6 +10963,9 @@ msgstr "Rien dans l'archive"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Rien de programmé — ajoutez une station ci-dessous."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Rien pour le moment. Une étape n'offre des valeurs qu'une fois configurée."
@@ -13689,9 +13709,6 @@ msgstr "lignes"
 msgid "Rows left out of this backup"
 msgstr "Lignes exclues de cette sauvegarde"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Règle"
 
@@ -14815,6 +14832,10 @@ msgstr "Afficher une colonne ID client lisible sur la liste des clients, les for
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Afficher une colonne ID Fournisseur lisible sur la liste des fournisseurs, les formulaires de fournisseur et les listes déroulantes. Les fournisseurs sont toujours identifiés en interne de toute façon."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Afficher les ID clients"
 
@@ -15091,6 +15112,9 @@ msgstr "Diviser la ligne de reçu"
 
 msgid "Split shipment line"
 msgstr "Diviser la ligne d'expédition"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Ces ordres de fabrication ont des opérations assignées à ce poste de 
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Ces écritures de journal sont encore Brouillon, de sorte que leurs débits et crédits ne se trouvent pas dans le grand livre pour cette période. Comptabilisez chacune ou redatez-la à une période ouverte ultérieure."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Ces lignes sont liées à des données en dehors de cette Société, c'est pourquoi une copie de sécurité de vos données actuelles ne peut pas être créée. La suppression de ces lignes ne peut pas être annulée. S'il s'avère qu'elles sont partagées avec d'autres Sociétés de ce groupe, rien n'est supprimé et la restauration ne démarre pas."
 
@@ -17640,6 +17667,9 @@ msgstr "Mettre à jour les quantités du document d'origine"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Mettez à jour les informations du kanban pour le réapprovisionnement basé sur le scan."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Mettre à jour les quantités du bon de commande"
 
@@ -17657,6 +17687,9 @@ msgstr "Mis à jour par"
 
 msgid "Updated successfully"
 msgstr "Mise à jour réussie"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Mettre à niveau"
@@ -17745,7 +17778,7 @@ msgstr "Utiliser une adresse e-mail différente"
 msgid "Use metric system for default material dimensions."
 msgstr "Utiliser le système métrique pour les dimensions de matière par défaut."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} pièces ignorées — rien à fabriquer"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} sera rouvert pour modification en tant que révision {0}. Le document déjà envoyé au fournisseur reste inchangé jusqu'à ce que vous le finalisiez et le renvoiez."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Supprimer définitivement # ligne ?} other {Supprimer définitivement # lignes ?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importer {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Résultats d'Importation"
 
@@ -8187,9 +8198,6 @@ msgstr "Inclure les pièces supplémentaires dans l'expédition"
 
 msgid "Include Inactive"
 msgstr "Inclure les inactifs"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Inclus"
@@ -8792,6 +8800,12 @@ msgstr "Kanbans"
 msgid "Keep"
 msgstr "Conserver"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Conserver les paramètres actuels"
 
@@ -8809,6 +8823,9 @@ msgstr "Garder ouvert"
 
 msgid "Keep picking"
 msgstr "Continuer le prélèvement"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Garde les commandes, les devis et les paramètres derrière une deuxième vérification"
@@ -9548,6 +9565,9 @@ msgstr "Rapproché"
 
 msgid "matches"
 msgstr "correspond"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Paires d'appariement"
@@ -13412,6 +13432,9 @@ msgstr "Valeur résiduelle %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Résolvez ceci avant de terminer le NCR : chaque ligne doit avoir un traitement non-Pending, et les quantités d'entités liées doivent correspondre à la quantité de la ligne."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Prix résolu"
 
@@ -13886,8 +13909,16 @@ msgstr "Ventes, devis et configuration à la commande"
 msgid "Salesperson"
 msgstr "Représentant commercial"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Transférer vers"
 msgid "Trash"
 msgstr "Corbeille"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Balance de vérification"
 
@@ -17598,6 +17625,9 @@ msgstr "Mettre à jour le mot de passe"
 msgid "Update Permissions"
 msgstr "Mettre à jour les autorisations"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Mettre à jour la quantité"
 
@@ -17714,6 +17744,9 @@ msgstr "Utiliser une adresse e-mail différente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utiliser le système métrique pour les dimensions de matière par défaut."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Transférer vers"
 msgid "Trash"
 msgstr "Corbeille"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Balance de vérification"
 

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(exclu pour ce client)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(groupe)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# compte fusionné avec un compte existant} other {# comptes fusionnés avec des comptes existants}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# compte à créer} other {# comptes à créer}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# compte à mettre à jour} other {# comptes à mettre à jour}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# compte inchangé} other {# comptes inchangés}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# groupe} other {# groupes}} et {1, plural, one {# compte} other {# comptes}} à créer"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# ligne se connecte à des données en dehors de cette 
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# ligne requiert votre attention} other {# lignes requièrent votre attention}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# ligne ignorée} other {# lignes ignorées}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Afficher la seule ligne} other {Afficher les # lignes}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} lignes à mapper"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} comptes correspondants : {fileCount} prennent les numéros du fichier, {keepCount} conservent ceux de Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# ligne exclue} other {# lignes exclues}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# compte correspondant prend le numéro du fichier.} other {# comptes correspondants prennent les numéros du fichier.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} sur {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} insérés, {updated} mis à jour, {0} nécessitent correction, {1} ignorés."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# compte correspondant conserve son numéro Carbon.} other {# comptes correspondants conservent leurs numéros Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# ligne} other {# lignes}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} sera rouvert pour modification en tant que révision {0}. Le document déjà envoyé au fournisseur reste inchangé jusqu'à ce que vous le finalisiez et le renvoiez."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# décision pas encore dans le plan} other {# décisions pas encore dans le plan}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Supprimer définitivement # ligne ?} other {Supprimer définitivement # lignes ?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# ligne non comptabilisée} other {# lignes non comptabilisées}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# compte existe déjà dans Carbon sous un autre numéro.} other {# comptes existent déjà dans Carbon sous d'autres numéros.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} ne peuvent pas être planifiés"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Tentatives"
 
 msgid "Attention"
-msgstr ""
+msgstr "Attention"
 
 msgid "Attribute"
 msgstr "Attribut"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Vérifiez le registre des articles pour tous les articles ayant une quantité disponible négative à la fin de la période — généralement un reçu manquant ou une comptabilisation désordonnée qui fausse la valeur des stocks et le coût des marchandises vendues. Marquez comme fait une fois examiné, ou ignorez avec une raison."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Vérifiez ce qui sera créé et modifié avant l'import. Rien n'est écrit tant que vous n'avez pas confirmé."
 
 msgid "Check your email"
 msgstr "Vérifiez votre email"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Vérification de Stripe pour ce client…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Comparaison du fichier avec votre plan comptable…"
 
 msgid "Checkpoint ·"
 msgstr "Point de contrôle ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Détails"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Détecter à partir du fichier"
 
 msgid "Developer"
 msgstr "Développeur"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Motif d'Exonération"
 
 msgid "Existing"
-msgstr ""
+msgstr "Existant"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mappages existants. Choisissez une option de fournisseur différente pour remapper."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Groupes"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Les groupes proviennent du fichier. Un groupe de premier niveau portant le même nom qu'un groupe Carbon y est fusionné."
 
 msgid "Guided"
 msgstr "Guidé"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Masquer les quantités système jusqu'à l'étape de revue"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Masquer la liste complète"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Masquer, épingler et réorganiser les colonnes"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Hiérarchie issue des lignes Begin-Total / End-Total du fichier."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Hiérarchie issue de la colonne de compte parent du fichier."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Hiérarchie issue des chemins dans les noms de compte."
 
 msgid "High"
 msgstr "Élevé"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Fréquence de récurrence de cette maintenance — Quotidien, Hebdomadaire, Mensuel, À chaque inventaire tournant ; Quotidien affiche le sélecteur de jour de la semaine, les autres utilisent une arithmétique d'intervalle plus simple."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Comment organiser les comptes ?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Comment l'ordre de fabrication est classé lors de l'allocation de capacité par le planificateur — Dès que possible d'abord, puis Délai critique, Délai souple et Sans délai en dernier. Un signal de classement uniquement ; aucun type de délai ne bloque ou ne contrôle le placement."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Si vous souhaitez modifier les numéros de pièce, veuillez cliquer sur Annuler et attribuer manuellement les pièces pour chaque ligne avant la conversion."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Ignorer les groupes du fichier ; chaque compte est placé sous le groupe Carbon correspondant à son type de compte."
 
 msgid "II (normal default)"
 msgstr "II (normal par défaut)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Chef de mise en œuvre"
 
 msgid "Import"
-msgstr ""
+msgstr "Importer"
 
 msgid "Import {label} CSV"
 msgstr "Importer {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Importer sous le nom « {0} »"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Importer sous le numéro {0}"
 
 msgid "Import results"
 msgstr "Résultats d'Importation"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Importer sous un autre nom"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Importer sous un autre numéro"
 
 msgid "Import your BOM"
 msgstr "Importer votre BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Conserver"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Conserver le numéro Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Conserver les numéros Carbon"
 
 msgid "Keep Current"
 msgstr "Conserver les paramètres actuels"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Laisser vide pour une correspondance exacte"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Laisser ce compte tel quel"
 
 msgid "Leave this page"
 msgstr "Quitter cette page"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Probabilité"
 
 msgid "Line"
-msgstr ""
+msgstr "Ligne"
 
 msgid "Line description (optional)"
 msgstr "Description de la ligne (optionnel)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Nécessite un plan Business ou Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Requiert votre attention"
 
 msgid "Needs fixing"
 msgstr "Doit être réparé"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Aucun groupe assigné"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Aucune hiérarchie dans le fichier : les comptes sont placés sous les groupes Carbon existants selon leur type de compte."
 
 msgid "No image"
 msgstr "Aucune image"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Aucune heure supplémentaire prévue"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "Aucune colonne de compte parent, aucun type de ligne ni aucun chemin dans les noms n'a été trouvé dans le fichier."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Aucune source parent enregistrée pour le moment. Cliquez sur Recalculer sur la page de planification pour actualiser l'attribution."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Rien de programmé — ajoutez une station ci-dessous."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Rien à importer."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Rien pour le moment. Une étape n'offre des valeurs qu'une fois configurée."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Chemin"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Séparateur de chemin dans les noms de compte"
 
 msgid "Pay Rate"
 msgstr "Taux de paiement"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Épinglé"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Placer les comptes sous les groupes Carbon existants"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Résolvez ceci avant de terminer le NCR : chaque ligne doit avoir un traitement non-Pending, et les quantités d'entités liées doivent correspondre à la quantité de la ligne."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Résolu"
 
 msgid "Resolved Price"
 msgstr "Prix résolu"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Représentant commercial"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "Identique à {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "Identique à {target} (conserver son numéro)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "Identique à {target} (utiliser le numéro de ce fichier)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "Identique à {target}, en conservant son numéro"
 
 msgid "Same as Book"
 msgstr "Identique à la comptabilité"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Ignorer l'état libéré mais non démarré — l'ordre de fabrication démarre immédiatement lors du scan."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Ignorer cette ligne"
 
 msgid "Skipped"
 msgstr "Ignoré"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Diviser la ligne d'expédition"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Scinder les noms de compte sur un séparateur, p. ex. Parent:Enfant."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "L'ensemble d'autorisations que les nouveaux employés de ce type reçoivent automatiquement; la modification ici change uniquement le modèle pour les embauches futures - les employés existants conservent ce qu'ils ont sauf s'ils sont explicitement mis à jour en masse."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Le plan n'a pas pu être établi"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Les usines, entrepôts et sites où se trouvent votre travail et vos stocks"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Ces écritures de journal sont encore Brouillon, de sorte que leurs débits et crédits ne se trouvent pas dans le grand livre pour cette période. Comptabilisez chacune ou redatez-la à une période ouverte ultérieure."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Ces lignes ne sont pas importées tant qu'elles ne sont pas résolues ; tout le reste est importé à la confirmation."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Ces lignes sont liées à des données en dehors de cette Société, c'est pourquoi une copie de sécurité de vos données actuelles ne peut pas être créée. La suppression de ces lignes ne peut pas être annulée. S'il s'avère qu'elles sont partagées avec d'autres Sociétés de ce groupe, rien n'est supprimé et la restauration ne démarre pas."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Retirer le ballon"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Inchangé"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Les lignes non comptabilisées restent inchangées à la publication — elles ne sont pas mises à zéro."
 
 msgid "Under"
-msgstr ""
+msgstr "Sous"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Sous le réapprovisionnement basé sur la demande, la planification additionne la demande dans cette fenêtre mobile lors du calcul d'une quantité de réapprovisionnement."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Mettre à jour les autorisations"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Mettre à jour le plan"
 
 msgid "Update Quantity"
 msgstr "Mettre à jour la quantité"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Mettez à jour les informations du kanban pour le réapprovisionnement basé sur le scan."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Mettez à jour le plan pour voir le résultat. La confirmation de l'import les applique toutes."
 
 msgid "Update the purchase order quantities"
 msgstr "Mettre à jour les quantités du bon de commande"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Mise à jour réussie"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Mise à jour du plan…"
 
 msgid "Upgrade"
 msgstr "Mettre à niveau"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Utiliser le système métrique pour les dimensions de matière par défaut."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Utiliser les numéros du fichier"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Utiliser la colonne de compte parent, les chemins dans les noms ou les lignes de totaux du fichier lorsqu'ils existent."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Utiliser la hiérarchie du fichier"
 
 msgid "Used In"
 msgstr "Utilisé dans"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -48,6 +48,9 @@ msgstr "« {taskName} » est fait – tous les {0} éléments de sa carte de mis
 msgid "(excluded for this customer)"
 msgstr "(exclu pour ce client)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# ligne se connecte à des données en dehors de cette Société, donc une copie de sécurité de vos données actuelles ne peut pas être créée.} other {# lignes se connectent à des données en dehors de cette Société, donc une copie de sécurité de vos données actuelles ne peut pas être créée.}}"
@@ -89,6 +92,11 @@ msgstr "{0} supprimé avec succès"
 msgid "{0} draft journal entries"
 msgstr "{0} écritures de journal brouillon"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordres de fabrication créés"
@@ -96,6 +104,14 @@ msgstr "{0} ordres de fabrication créés"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} lignes à mapper"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} lignes"
 msgid "{0} suppliers with a balance"
 msgstr "{0} fournisseurs avec un solde"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entités non échantillonnées seront libérées en Disponible. Les passes échantillonnées restent Disponible et les défaillances échantillonnées restent Rejetées."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Tous les Emplacements"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Tous les membres des groupes sélectionnés et les individus sélectionnés pourront approuver les demandes"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Toutes les lignes importées — {inserted} insérées, {updated} mises à jour."
 
@@ -2431,6 +2459,9 @@ msgstr "Pièces jointes"
 msgid "Attempts"
 msgstr "Tentatives"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Attribut"
 
@@ -2829,6 +2860,9 @@ msgstr "Créer des matériels de formation basés sur les rôles"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Créer des matériels de formation personnalisés et basés sur les rôles"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Construit et chiffré comme sa propre méthode"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Vérifiez le registre des articles pour tous les articles ayant une quantité disponible négative à la fin de la période — généralement un reçu manquant ou une comptabilisation désordonnée qui fausse la valeur des stocks et le coût des marchandises vendues. Marquez comme fait une fois examiné, ou ignorez avec une raison."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Vérifiez votre email"
@@ -5417,6 +5454,9 @@ msgstr "Détail"
 msgid "Details"
 msgstr "Détails"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Développeur"
 
@@ -6571,6 +6611,9 @@ msgstr "Certificat d'Exonération"
 msgid "Exemption Reason"
 msgstr "Motif d'Exonération"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mappages existants. Choisissez une option de fournisseur différente pour remapper."
 
@@ -7328,6 +7371,15 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Ingénieur dédié au terrain"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Fondation"
 
@@ -7712,6 +7764,9 @@ msgstr "Nom du groupe"
 msgid "Groups"
 msgstr "Groupes"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Guidé"
 
@@ -7892,6 +7947,9 @@ msgstr "Fréquence d'étalonnage de cet instrument de mesure ; combinée avec la
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Fréquence de récurrence de cette maintenance — Quotidien, Hebdomadaire, Mensuel, À chaque inventaire tournant ; Quotidien affiche le sélecteur de jour de la semaine, les autres utilisent une arithmétique d'intervalle plus simple."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Comment l'ordre de fabrication est classé lors de l'allocation de capacité par le planificateur — Dès que possible d'abord, puis Délai critique, Délai souple et Sans délai en dernier. Un signal de classement uniquement ; aucun type de délai ne bloque ou ne contrôle le placement."
 
@@ -8012,6 +8070,9 @@ msgstr "Si quelque chose déraille"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Si vous souhaitez modifier les numéros de pièce, veuillez cliquer sur Annuler et attribuer manuellement les pièces pour chaque ligne avant la conversion."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normal par défaut)"
 
@@ -8033,11 +8094,20 @@ msgstr "Centre de mise en œuvre"
 msgid "Implementation Lead"
 msgstr "Chef de mise en œuvre"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importer {label} CSV"
 
 msgid "Import results"
 msgstr "Résultats d'Importation"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Importer votre BOM"
@@ -8117,6 +8187,9 @@ msgstr "Inclure les pièces supplémentaires dans l'expédition"
 
 msgid "Include Inactive"
 msgstr "Inclure les inactifs"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Inclus"
@@ -8897,6 +8970,9 @@ msgstr "Laisser vide pour utiliser automatiquement la prochaine révision"
 msgid "Leave empty for exact match"
 msgstr "Laisser vide pour une correspondance exacte"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Quitter cette page"
 
@@ -8974,6 +9050,9 @@ msgstr "Lumières éteintes (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilité"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Description de la ligne (optionnel)"
@@ -9901,6 +9980,9 @@ msgstr "Nécessaire = les heures de travail dues ce jour divisées par {personDa
 msgid "Needs a Business or Partner plan."
 msgstr "Nécessite un plan Business ou Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Doit être réparé"
 
@@ -10459,6 +10541,9 @@ msgstr "Aucune notification groupée"
 
 msgid "No groups assigned"
 msgstr "Aucun groupe assigné"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Aucune image"
@@ -11565,6 +11650,9 @@ msgstr "Collez le XML de métadonnées si votre fournisseur d'identité ne publi
 msgid "Path"
 msgstr "Chemin"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Taux de paiement"
 
@@ -11794,6 +11882,9 @@ msgstr "Épingler {0}"
 
 msgid "Pinned"
 msgstr "Épinglé"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "lignes"
 msgid "Rows left out of this backup"
 msgstr "Lignes exclues de cette sauvegarde"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Règle"
 
@@ -13791,6 +13885,10 @@ msgstr "Ventes, devis et configuration à la commande"
 
 msgid "Salesperson"
 msgstr "Représentant commercial"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Identique à la comptabilité"
@@ -14815,6 +14913,9 @@ msgstr "Ignorer la maintenance programmée lors des jours fériés de l'entrepri
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Ignorer l'état libéré mais non démarré — l'ordre de fabrication démarre immédiatement lors du scan."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Ignoré"
@@ -16217,6 +16318,9 @@ msgstr "Le pourcentage de remise en trésorerie. Utilisez 0 pour aucune remise."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "L'ensemble d'autorisations que les nouveaux employés de ce type reçoivent automatiquement; la modification ici change uniquement le modèle pour les embauches futures - les employés existants conservent ce qu'ils ont sauf s'ils sont explicitement mis à jour en masse."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Les usines, entrepôts et sites où se trouvent votre travail et vos stocks"
 
@@ -17259,8 +17363,14 @@ msgstr "Non assigné"
 msgid "Unballoon"
 msgstr "Retirer le ballon"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Les lignes non comptabilisées restent inchangées à la publication — elles ne sont pas mises à zéro."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Sous le réapprovisionnement basé sur la demande, la planification additionne la demande dans cette fenêtre mobile lors du calcul d'une quantité de réapprovisionnement."
@@ -17600,6 +17710,12 @@ msgstr "Utiliser une adresse e-mail différente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utiliser le système métrique pour les dimensions de matière par défaut."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Utilisé dans"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {यह आइटम 1 खुली परिवर्�
 msgid "{0} accounts"
 msgstr "{0} खाते"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} पहले"
@@ -92,9 +96,9 @@ msgstr "{0} सफलतापूर्वक हटाया गया"
 msgid "{0} draft journal entries"
 msgstr "{0} ड्राफ्ट जर्नल प्रविष्टियाँ"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} जॉब बनाए गए"
 msgid "{0} lines to map"
 msgstr "{0} लाइनें मैप करने के लिए"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} पंजीकृत"
 msgid "{0} rows"
 msgstr "{0} पंक्तियाँ"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} आपूर्तिकर्ता शेष राशि के साथ"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} नमूना न किए गए इकाइयों को उपलब्ध में जारी किया जाएगा। नमूना किए गए पास उपलब्ध रहेंगे और नमूना किए गए विफलताएं अस्वीकृत रहेंगी।"
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} में से {total} चरण पूर्ण"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# पंक्ति बाहर रखी गई} other {# पंक्तियाँ बाहर रखी गईं}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} में से {count}"
 
@@ -251,6 +265,9 @@ msgstr "और {hiddenCount}: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} जोड़े गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# लाइन} other {# लाइनें}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} पार्ट्स छोड़ दिए गए 
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} को रिवीजन {0} के रूप में संपादन के लिए फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ अपरिवर्तित रहेगा जब तक आप क्रय आदेश को अंतिम रूप न दें और पुनः न भेजें।"
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# इकाई} other {# इकाइया
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} को शेड्यूल नहीं किया जा सकता"
@@ -1496,9 +1516,6 @@ msgstr "सभी स्थान"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "सभी चुने गए समूहों के सदस्य और चुने गए व्यक्ति अनुरोधों को अनुमोदित कर सकेंगे"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "सभी पंक्तियाँ आयात की गईं — {inserted} डाली गईं, {updated} अपडेट की गईं।"
@@ -2864,9 +2881,6 @@ msgstr "भूमिका-आधारित प्रशिक्षण सा
 msgid "Build tailored, role-based training materials"
 msgstr "अनुकूलित, भूमिका-आधारित प्रशिक्षण सामग्री बनाएं"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "अपनी स्वयं की विधि के रूप में निर्मित और लागत निर्धारित"
 
@@ -3278,6 +3292,9 @@ msgstr "अपना ईमेल जांचें"
 
 msgid "Checking Stripe for this customer…"
 msgstr "इस ग्राहक के लिए Stripe की जांच की जा रही है…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "चेकपॉइंट ·"
@@ -7374,15 +7391,6 @@ msgstr "प्रारूप"
 msgid "Forward deployed engineer"
 msgstr "अग्रपंक्ति में तैनात इंजीनियर"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "आधार"
 
@@ -7809,8 +7817,20 @@ msgstr "कच्चे को छुपाएं"
 msgid "Hide system quantities until the review step"
 msgstr "समीक्षा चरण तक सिस्टम मात्रा को छिपाएं"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "कॉलम को छिपाएं, पिन करें और पुनः क्रमित करें"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "उच्च"
@@ -8824,9 +8844,6 @@ msgstr "खुला रखें"
 msgid "Keep picking"
 msgstr "पिकिंग जारी रखें"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "ऑर्डर, कोट्स और सेटिंग्स को एक दूसरी जांच के पीछे रखता है"
 
@@ -9565,9 +9582,6 @@ msgstr "मेल खाया"
 
 msgid "matches"
 msgstr "मेल खाता है"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "मिलान जोड़े"
@@ -10562,7 +10576,7 @@ msgstr "कोई समूहीकृत सूचनाएं नहीं"
 msgid "No groups assigned"
 msgstr "कोई समूह असाइन नहीं किया गया"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "कोई बकाया प्रशिक्षण नहीं"
 
 msgid "No overtime scheduled"
 msgstr "कोई ओवरटाइम शेड्यूल नहीं है"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "अभी तक कोई मूल स्रोत दर्ज नहीं किया गया है। एट्रिब्यूशन को रीफ्रेश करने के लिए योजना पृष्ठ पर पुनः गणना करें पर क्लिक करें।"
@@ -10946,6 +10963,9 @@ msgstr "आर्काइव में कुछ नहीं है"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "कुछ भी शेड्यूल नहीं किया गया — नीचे एक स्टेशन जोड़ें।"
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "अभी कुछ नहीं। एक चरण केवल तभी मान प्रदान करता है जब इसे कॉन्फ़िगर किया जाता है।"
@@ -13689,9 +13709,6 @@ msgstr "पंक्तियाँ"
 msgid "Rows left out of this backup"
 msgstr "इस बैकअप से छोड़ी गई पंक्तियां"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "नियम"
 
@@ -14815,6 +14832,10 @@ msgstr "ग्राहक सूची, ग्राहक फॉर्म औ�
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "आपूर्तिकर्ता सूची, आपूर्तिकर्ता फॉर्म और ड्रॉपडाउन पर एक पठनीय आपूर्तिकर्ता ID कॉलम दिखाएं। आपूर्तिकर्ता अभी भी किसी भी तरह से आंतरिक रूप से पहचाने जाते हैं।"
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "ग्राहक आईडी दिखाएं"
 
@@ -15091,6 +15112,9 @@ msgstr "रसीद लाइन को विभाजित करें"
 
 msgid "Split shipment line"
 msgstr "शिपमेंट पंक्ति को विभाजित करें"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "ये जॉब इस वर्क सेंटर को असाइ
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "ये जर्नल प्रविष्टियां अभी भी ड्राफ्ट हैं, इसलिए उनके नामे और जमा इस अवधि के लिए खाता बही में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में फिर से दिनांकित करें।"
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "ये पंक्तियां इस कंपनी के बाहर के डेटा से जुड़ी हुई हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती। उन्हें हटाना पूर्ववत नहीं किया जा सकता। यदि वे इस समूह की अन्य कंपनियों के साथ साझा की जाती हैं, तो कुछ भी हटाया नहीं जाता है और पुनर्स्थापन शुरू नहीं होता है।"
 
@@ -17640,6 +17667,9 @@ msgstr "स्रोत दस्तावेज़ मात्रा अपड
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "स्कैन-आधारित पुनः भरण के लिए कानबान जानकारी को अपडेट करें।"
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "क्रय आदेश मात्रा अपडेट करें"
 
@@ -17657,6 +17687,9 @@ msgstr "अपडेट किया गया"
 
 msgid "Updated successfully"
 msgstr "सफलतापूर्वक अपडेट किया गया"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "अपग्रेड करें"
@@ -17745,7 +17778,7 @@ msgstr "एक अलग ईमेल का उपयोग करें"
 msgid "Use metric system for default material dimensions."
 msgstr "डिफ़ॉल्ट सामग्री आयामों के लिए मीट्रिक सिस्टम का उपयोग करें।"
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -17270,6 +17270,10 @@ msgstr "को स्थानांतरित करें"
 msgid "Trash"
 msgstr "ट्रैश"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "परीक्षण शेष"
 

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" पूरा हो गया — इसके सभी 
 msgid "(excluded for this customer)"
 msgstr "(इस ग्राहक के लिए बाहर रखा गया)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# पंक्ति इस कंपनी के बाहर डेटा से जुड़ी है, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती।} other {# पंक्तियाँ इस कंपनी के बाहर डेटा से जुड़ी हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती।}}"
@@ -89,6 +92,11 @@ msgstr "{0} सफलतापूर्वक हटाया गया"
 msgid "{0} draft journal entries"
 msgstr "{0} ड्राफ्ट जर्नल प्रविष्टियाँ"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} जॉब बनाए गए"
@@ -96,6 +104,14 @@ msgstr "{0} जॉब बनाए गए"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} लाइनें मैप करने के लिए"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} पंक्तियाँ"
 msgid "{0} suppliers with a balance"
 msgstr "{0} आपूर्तिकर्ता शेष राशि के साथ"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} नमूना न किए गए इकाइयों को उपलब्ध में जारी किया जाएगा। नमूना किए गए पास उपलब्ध रहेंगे और नमूना किए गए विफलताएं अस्वीकृत रहेंगी।"
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "सभी स्थान"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "सभी चुने गए समूहों के सदस्य और चुने गए व्यक्ति अनुरोधों को अनुमोदित कर सकेंगे"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "सभी पंक्तियाँ आयात की गईं — {inserted} डाली गईं, {updated} अपडेट की गईं।"
 
@@ -2431,6 +2459,9 @@ msgstr "अनुलग्नक"
 msgid "Attempts"
 msgstr "प्रयास"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "विशेषता"
 
@@ -2829,6 +2860,9 @@ msgstr "भूमिका-आधारित प्रशिक्षण सा
 
 msgid "Build tailored, role-based training materials"
 msgstr "अनुकूलित, भूमिका-आधारित प्रशिक्षण सामग्री बनाएं"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "अपनी स्वयं की विधि के रूप में निर्मित और लागत निर्धारित"
@@ -3232,6 +3266,9 @@ msgstr "चैट"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "अवधि के अंत तक किसी भी आइटम के लिए आइटम लेजर की जांच करें जिसमें नकारात्मक ऑन-हैंड मात्रा है — आमतौर पर एक लापता प्राप्ति या एक गलत क्रम में पोस्टिंग जो इन्वेंटरी मूल्य और बेचे गए माल की लागत को विकृत करती है। एक बार समीक्षा के बाद इसे हो गया के रूप में चिह्नित करें, या कारण के साथ छोड़ दें।"
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "अपना ईमेल जांचें"
@@ -5417,6 +5454,9 @@ msgstr "विवरण"
 msgid "Details"
 msgstr "विवरण"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "डेवलपर"
 
@@ -6571,6 +6611,9 @@ msgstr "छूट प्रमाणपत्र"
 msgid "Exemption Reason"
 msgstr "छूट कारण"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "मौजूदा मैपिंग। पुनः-मैप करने के लिए एक अलग प्रदाता विकल्प चुनें।"
 
@@ -7328,6 +7371,15 @@ msgstr "प्रारूप"
 msgid "Forward deployed engineer"
 msgstr "अग्रपंक्ति में तैनात इंजीनियर"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "आधार"
 
@@ -7712,6 +7764,9 @@ msgstr "समूह का नाम"
 msgid "Groups"
 msgstr "समूह"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "निर्देशित"
 
@@ -7892,6 +7947,9 @@ msgstr "यह गेज कितनी बार पुनः-अंशां�
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "यह रखरखाव कितनी बार दोहराया जाता है — दैनिक, साप्ताहिक, मासिक, चक्रीय गणना पर; दैनिक सप्ताह-की-दिन चयनकर्ता को प्रकट करता है, अन्य सरल अंतराल गणित का उपयोग करते हैं।"
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "जब शेड्यूलर क्षमता देता है तो जॉब कैसे रैंक करता है — ASAP पहले दावे करता है, फिर कठोर समय सीमा, नरम समय सीमा, और कोई समय सीमा नहीं अंतिम। केवल एक रैंकिंग संकेत; कोई समय सीमा प्रकार प्लेसमेंट को रोकता या प्रतिबंधित नहीं करता है।"
 
@@ -8012,6 +8070,9 @@ msgstr "अगर कुछ गलत रास्ते पर है"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "यदि आप पार्ट नंबर बदलना चाहते हैं, तो कृपया रद्द करें पर क्लिक करें और परिवर्तित करने से पहले प्रत्येक पंक्ति आइटम के लिए पार्ट्स को मैन्युअल रूप से असाइन करें।"
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (सामान्य डिफ़ॉल्ट)"
 
@@ -8033,11 +8094,20 @@ msgstr "कार्यान्वयन हब"
 msgid "Implementation Lead"
 msgstr "कार्यान्वयन नेता"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "{label} CSV आयात करें"
 
 msgid "Import results"
 msgstr "आयात परिणाम"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "अपना BOM आयात करें"
@@ -8117,6 +8187,9 @@ msgstr "शिपमेंट में अतिरिक्त पार्ट
 
 msgid "Include Inactive"
 msgstr "निष्क्रिय शामिल करें"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "शामिल"
@@ -8897,6 +8970,9 @@ msgstr "अगले रिवीजन को स्वचालित रू�
 msgid "Leave empty for exact match"
 msgstr "सटीक मिलान के लिए खाली छोड़ें"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "इस पृष्ठ को छोड़ें"
 
@@ -8974,6 +9050,9 @@ msgstr "लाइट्स आउट (24/7)"
 
 msgid "Likelihood"
 msgstr "संभावना"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "पंक्ति विवरण (वैकल्पिक)"
@@ -9901,6 +9980,9 @@ msgstr "आवश्यक उस दिन के कारण काम के
 msgid "Needs a Business or Partner plan."
 msgstr "एक बिजनेस या पार्टनर प्लान की आवश्यकता है।"
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "मरम्मत की आवश्यकता है"
 
@@ -10459,6 +10541,9 @@ msgstr "कोई समूहीकृत सूचनाएं नहीं"
 
 msgid "No groups assigned"
 msgstr "कोई समूह असाइन नहीं किया गया"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "कोई छवि नहीं"
@@ -11565,6 +11650,9 @@ msgstr "मेटाडेटा XML को पेस्ट करें यद�
 msgid "Path"
 msgstr "पथ"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "भुगतान दर"
 
@@ -11794,6 +11882,9 @@ msgstr "{0} को पिन करें"
 
 msgid "Pinned"
 msgstr "पिन किया गया"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "योजना"
@@ -13575,6 +13666,9 @@ msgstr "पंक्तियाँ"
 msgid "Rows left out of this backup"
 msgstr "इस बैकअप से छोड़ी गई पंक्तियां"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "नियम"
 
@@ -13791,6 +13885,10 @@ msgstr "बिक्रय, उद्धरण, और कॉन्फ़िग�
 
 msgid "Salesperson"
 msgstr "विक्रयकर्ता"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "किताब के समान"
@@ -14815,6 +14913,9 @@ msgstr "कंपनी की छुट्टियों पर निर्�
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "रिलीज़ किए गए लेकिन शुरू न किए गए स्थिति को छोड़ दें — जॉब स्कैन पर तुरंत शुरू हो जाता है।"
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "छोड़ा गया"
@@ -16217,6 +16318,9 @@ msgstr "नकद छूट का प्रतिशत। कोई छूट 
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "अनुमति सेट जो इस प्रकार के नए कर्मचारी स्वचालित रूप से प्राप्त करते हैं; यहाँ संपादन केवल भविष्य की भर्ती के लिए टेम्पलेट को बदलता है - मौजूदा कर्मचारी जो उनके पास है वह रखते हैं जब तक कि स्पष्ट रूप से बड़े पैमाने पर अद्यतन नहीं किया जाता।"
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "वह संयंत्र, गोदाम, और साइटें जहां आपका काम और स्टॉक रहता है"
 
@@ -17259,8 +17363,14 @@ msgstr "अनुत्तरित"
 msgid "Unballoon"
 msgstr "गुब्बारा हटाएं"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "गिनती न किए गए लाइनें पोस्ट पर अपरिवर्तित रहती हैं — उन्हें शून्य नहीं किया जाता है।"
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Demand-आधारित पुनः आदेश के तहत, योजना एक पुनः भरण मात्रा की गणना करते समय इस रोलिंग विंडो के भीतर मांग को जोड़ता है।"
@@ -17600,6 +17710,12 @@ msgstr "एक अलग ईमेल का उपयोग करें"
 
 msgid "Use metric system for default material dimensions."
 msgstr "डिफ़ॉल्ट सामग्री आयामों के लिए मीट्रिक सिस्टम का उपयोग करें।"
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "में उपयोग किया गया"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} पार्ट्स छोड़ दिए गए 
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} को रिवीजन {0} के रूप में संपादन के लिए फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ अपरिवर्तित रहेगा जब तक आप क्रय आदेश को अंतिम रूप न दें और पुनः न भेजें।"
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# पंक्ति को स्थायी रूप से हटाएँ?} other {# पंक्तियों को स्थायी रूप से हटाएँ?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "{label} CSV आयात करें"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "आयात परिणाम"
 
@@ -8187,9 +8198,6 @@ msgstr "शिपमेंट में अतिरिक्त पार्ट
 
 msgid "Include Inactive"
 msgstr "निष्क्रिय शामिल करें"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "शामिल"
@@ -8792,6 +8800,12 @@ msgstr "कानबान"
 msgid "Keep"
 msgstr "रखें"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "वर्तमान रखें"
 
@@ -8809,6 +8823,9 @@ msgstr "खुला रखें"
 
 msgid "Keep picking"
 msgstr "पिकिंग जारी रखें"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "ऑर्डर, कोट्स और सेटिंग्स को एक दूसरी जांच के पीछे रखता है"
@@ -9548,6 +9565,9 @@ msgstr "मेल खाया"
 
 msgid "matches"
 msgstr "मेल खाता है"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "मिलान जोड़े"
@@ -13412,6 +13432,9 @@ msgstr "अवशिष्ट मूल्य %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "इसे NCR पूरा करने से पहले हल करें: प्रत्येक पंक्ति के पास एक गैर-लंबित निपटान होना चाहिए, और इसकी जुड़ी हुई इकाई मात्रा पंक्ति मात्रा से मेल खानी चाहिए।"
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "समाधान की गई कीमत"
 
@@ -13886,8 +13909,16 @@ msgstr "बिक्रय, उद्धरण, और कॉन्फ़िग�
 msgid "Salesperson"
 msgstr "विक्रयकर्ता"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "को स्थानांतरित करें"
 msgid "Trash"
 msgstr "ट्रैश"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "परीक्षण शेष"
 
@@ -17598,6 +17625,9 @@ msgstr "पासवर्ड अपडेट करें"
 msgid "Update Permissions"
 msgstr "अनुमतियों को अपडेट करें"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "मात्रा अपडेट करें"
 
@@ -17714,6 +17744,9 @@ msgstr "एक अलग ईमेल का उपयोग करें"
 
 msgid "Use metric system for default material dimensions."
 msgstr "डिफ़ॉल्ट सामग्री आयामों के लिए मीट्रिक सिस्टम का उपयोग करें।"
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(इस ग्राहक के लिए बाहर रखा गया)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(समूह)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# खाता मौजूदा खाते में मिलाया गया} other {# खाते मौजूदा खातों में मिलाए गए}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# खाता बनाया जाएगा} other {# खाते बनाए जाएंगे}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# खाता अपडेट किया जाएगा} other {# खाते अपडेट किए जाएंगे}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# खाता अपरिवर्तित} other {# खाते अपरिवर्तित}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# समूह} other {# समूह}} और {1, plural, one {# खाता} other {# खाते}} बनाए जाएंगे"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# पंक्ति इस कंपनी के ब�
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# पंक्ति पर ध्यान देना आवश्यक है} other {# पंक्तियों पर ध्यान देना आवश्यक है}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# पंक्ति छोड़ी गई} other {# पंक्तियाँ छोड़ी गईं}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {एकमात्र पंक्ति दिखाएँ} other {सभी # पंक्तियाँ दिखाएँ}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} लाइनें मैप करने के लिए"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} मिलते-जुलते खाते: {fileCount} फ़ाइल की संख्याएँ लेंगे, {keepCount} Carbon की संख्याएँ रखेंगे।"
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# पंक्ति बाहर रखी गई} other {# पंक्तियाँ बाहर रखी गईं}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# मिलता-जुलता खाता फ़ाइल की संख्या लेगा।} other {# मिलते-जुलते खाते फ़ाइल की संख्याएँ लेंगे।}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} में से {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} जोड़े गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# मिलता-जुलता खाता अपनी Carbon संख्या रखेगा।} other {# मिलते-जुलते खाते अपनी Carbon संख्याएँ रखेंगे।}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# लाइन} other {# लाइनें}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} को रिवीजन {0} के रूप में संपादन के लिए फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ अपरिवर्तित रहेगा जब तक आप क्रय आदेश को अंतिम रूप न दें और पुनः न भेजें।"
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# निर्णय अभी योजना में नहीं है} other {# निर्णय अभी योजना में नहीं हैं}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# पंक्ति को स्थायी रूप से हटाएँ?} other {# पंक्तियों को स्थायी रूप से हटाएँ?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# खाता Carbon में पहले से किसी अन्य संख्या के साथ मौजूद है।} other {# खाते Carbon में पहले से अन्य संख्याओं के साथ मौजूद हैं।}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} को शेड्यूल नहीं किया जा सकता"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "प्रयास"
 
 msgid "Attention"
-msgstr ""
+msgstr "ध्यान दें"
 
 msgid "Attribute"
 msgstr "विशेषता"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "अवधि के अंत तक किसी भी आइटम के लिए आइटम लेजर की जांच करें जिसमें नकारात्मक ऑन-हैंड मात्रा है — आमतौर पर एक लापता प्राप्ति या एक गलत क्रम में पोस्टिंग जो इन्वेंटरी मूल्य और बेचे गए माल की लागत को विकृत करती है। एक बार समीक्षा के बाद इसे हो गया के रूप में चिह्नित करें, या कारण के साथ छोड़ दें।"
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "आयात करने से पहले जाँचें कि क्या बनाया और बदला जाएगा। आपकी पुष्टि तक कुछ भी लिखा नहीं जाता।"
 
 msgid "Check your email"
 msgstr "अपना ईमेल जांचें"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "इस ग्राहक के लिए Stripe की जांच की जा रही है…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "फ़ाइल की आपके खातों के चार्ट से जाँच की जा रही है…"
 
 msgid "Checkpoint ·"
 msgstr "चेकपॉइंट ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "विवरण"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "फ़ाइल से पहचानें"
 
 msgid "Developer"
 msgstr "डेवलपर"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "छूट कारण"
 
 msgid "Existing"
-msgstr ""
+msgstr "मौजूदा"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "मौजूदा मैपिंग। पुनः-मैप करने के लिए एक अलग प्रदाता विकल्प चुनें।"
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "समूह"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "समूह फ़ाइल से आते हैं। Carbon के किसी समूह के समान नाम वाला शीर्ष-स्तरीय समूह उसमें मिला दिया जाता है।"
 
 msgid "Guided"
 msgstr "निर्देशित"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "समीक्षा चरण तक सिस्टम मात्रा को छिपाएं"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "पूरी सूची छिपाएँ"
 
 msgid "Hide, pin and reorder columns"
 msgstr "कॉलम को छिपाएं, पिन करें और पुनः क्रमित करें"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "पदानुक्रम फ़ाइल की Begin-Total / End-Total पंक्तियों से लिया गया।"
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "पदानुक्रम फ़ाइल के मूल खाता स्तंभ से लिया गया।"
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "पदानुक्रम खाता नामों में मौजूद पथों से लिया गया।"
 
 msgid "High"
 msgstr "उच्च"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "यह रखरखाव कितनी बार दोहराया जाता है — दैनिक, साप्ताहिक, मासिक, चक्रीय गणना पर; दैनिक सप्ताह-की-दिन चयनकर्ता को प्रकट करता है, अन्य सरल अंतराल गणित का उपयोग करते हैं।"
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "खातों को कैसे व्यवस्थित किया जाए?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "जब शेड्यूलर क्षमता देता है तो जॉब कैसे रैंक करता है — ASAP पहले दावे करता है, फिर कठोर समय सीमा, नरम समय सीमा, और कोई समय सीमा नहीं अंतिम। केवल एक रैंकिंग संकेत; कोई समय सीमा प्रकार प्लेसमेंट को रोकता या प्रतिबंधित नहीं करता है।"
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "यदि आप पार्ट नंबर बदलना चाहते हैं, तो कृपया रद्द करें पर क्लिक करें और परिवर्तित करने से पहले प्रत्येक पंक्ति आइटम के लिए पार्ट्स को मैन्युअल रूप से असाइन करें।"
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "फ़ाइल के समूहों को अनदेखा करें; प्रत्येक खाता उसके खाता प्रकार से मेल खाने वाले Carbon समूह के अंतर्गत जाएगा।"
 
 msgid "II (normal default)"
 msgstr "II (सामान्य डिफ़ॉल्ट)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "कार्यान्वयन नेता"
 
 msgid "Import"
-msgstr ""
+msgstr "आयात करें"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV आयात करें"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "“{0}” के रूप में आयात करें"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "{0} के रूप में आयात करें"
 
 msgid "Import results"
 msgstr "आयात परिणाम"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "किसी अन्य नाम से आयात करें"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "किसी अन्य संख्या से आयात करें"
 
 msgid "Import your BOM"
 msgstr "अपना BOM आयात करें"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "रखें"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Carbon की संख्या रखें"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Carbon की संख्याएँ रखें"
 
 msgid "Keep Current"
 msgstr "वर्तमान रखें"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "सटीक मिलान के लिए खाली छोड़ें"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "इस खाते को वैसा ही रहने दें"
 
 msgid "Leave this page"
 msgstr "इस पृष्ठ को छोड़ें"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "संभावना"
 
 msgid "Line"
-msgstr ""
+msgstr "पंक्ति"
 
 msgid "Line description (optional)"
 msgstr "पंक्ति विवरण (वैकल्पिक)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "एक बिजनेस या पार्टनर प्लान की आवश्यकता है।"
 
 msgid "Needs attention"
-msgstr ""
+msgstr "ध्यान देना आवश्यक"
 
 msgid "Needs fixing"
 msgstr "मरम्मत की आवश्यकता है"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "कोई समूह असाइन नहीं किया गया"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "फ़ाइल में कोई पदानुक्रम नहीं: खाते खाता प्रकार के अनुसार Carbon के मौजूदा समूहों के अंतर्गत रखे जाते हैं।"
 
 msgid "No image"
 msgstr "कोई छवि नहीं"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "कोई ओवरटाइम शेड्यूल नहीं है"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "फ़ाइल में मूल खाता स्तंभ, पंक्ति प्रकार या नामों में पथ नहीं मिले।"
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "अभी तक कोई मूल स्रोत दर्ज नहीं किया गया है। एट्रिब्यूशन को रीफ्रेश करने के लिए योजना पृष्ठ पर पुनः गणना करें पर क्लिक करें।"
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "कुछ भी शेड्यूल नहीं किया गया — नीचे एक स्टेशन जोड़ें।"
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "आयात करने के लिए कुछ नहीं।"
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "अभी कुछ नहीं। एक चरण केवल तभी मान प्रदान करता है जब इसे कॉन्फ़िगर किया जाता है।"
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "पथ"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "खाता नामों में पथ विभाजक"
 
 msgid "Pay Rate"
 msgstr "भुगतान दर"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "पिन किया गया"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "खातों को Carbon के मौजूदा समूहों के अंतर्गत रखें"
 
 msgid "Plan"
 msgstr "योजना"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "इसे NCR पूरा करने से पहले हल करें: प्रत्येक पंक्ति के पास एक गैर-लंबित निपटान होना चाहिए, और इसकी जुड़ी हुई इकाई मात्रा पंक्ति मात्रा से मेल खानी चाहिए।"
 
 msgid "Resolved"
-msgstr ""
+msgstr "हल किया गया"
 
 msgid "Resolved Price"
 msgstr "समाधान की गई कीमत"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "विक्रयकर्ता"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "{target} के समान"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "{target} के समान (उसकी संख्या रखें)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "{target} के समान (इस फ़ाइल की संख्या उपयोग करें)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "{target} के समान, उसकी संख्या रखते हुए"
 
 msgid "Same as Book"
 msgstr "किताब के समान"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "रिलीज़ किए गए लेकिन शुरू न किए गए स्थिति को छोड़ दें — जॉब स्कैन पर तुरंत शुरू हो जाता है।"
 
 msgid "Skip this row"
-msgstr ""
+msgstr "इस पंक्ति को छोड़ें"
 
 msgid "Skipped"
 msgstr "छोड़ा गया"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "शिपमेंट पंक्ति को विभाजित करें"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "खाता नामों को विभाजक से विभाजित करें, जैसे मूल:उप।"
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "अनुमति सेट जो इस प्रकार के नए कर्मचारी स्वचालित रूप से प्राप्त करते हैं; यहाँ संपादन केवल भविष्य की भर्ती के लिए टेम्पलेट को बदलता है - मौजूदा कर्मचारी जो उनके पास है वह रखते हैं जब तक कि स्पष्ट रूप से बड़े पैमाने पर अद्यतन नहीं किया जाता।"
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "योजना नहीं बनाई जा सकी"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "वह संयंत्र, गोदाम, और साइटें जहां आपका काम और स्टॉक रहता है"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "ये जर्नल प्रविष्टियां अभी भी ड्राफ्ट हैं, इसलिए उनके नामे और जमा इस अवधि के लिए खाता बही में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में फिर से दिनांकित करें।"
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "ये पंक्तियाँ हल होने तक आयात नहीं होंगी; बाकी सब पुष्टि पर आयात हो जाएगा।"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "ये पंक्तियां इस कंपनी के बाहर के डेटा से जुड़ी हुई हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती। उन्हें हटाना पूर्ववत नहीं किया जा सकता। यदि वे इस समूह की अन्य कंपनियों के साथ साझा की जाती हैं, तो कुछ भी हटाया नहीं जाता है और पुनर्स्थापन शुरू नहीं होता है।"
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "गुब्बारा हटाएं"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "अपरिवर्तित"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "गिनती न किए गए लाइनें पोस्ट पर अपरिवर्तित रहती हैं — उन्हें शून्य नहीं किया जाता है।"
 
 msgid "Under"
-msgstr ""
+msgstr "के अंतर्गत"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Demand-आधारित पुनः आदेश के तहत, योजना एक पुनः भरण मात्रा की गणना करते समय इस रोलिंग विंडो के भीतर मांग को जोड़ता है।"
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "अनुमतियों को अपडेट करें"
 
 msgid "Update plan"
-msgstr ""
+msgstr "योजना अपडेट करें"
 
 msgid "Update Quantity"
 msgstr "मात्रा अपडेट करें"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "स्कैन-आधारित पुनः भरण के लिए कानबान जानकारी को अपडेट करें।"
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "परिणाम देखने के लिए योजना अपडेट करें। आयात की पुष्टि करने पर सभी लागू हो जाएंगे।"
 
 msgid "Update the purchase order quantities"
 msgstr "क्रय आदेश मात्रा अपडेट करें"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "सफलतापूर्वक अपडेट किया गया"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "योजना अपडेट की जा रही है…"
 
 msgid "Upgrade"
 msgstr "अपग्रेड करें"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "डिफ़ॉल्ट सामग्री आयामों के लिए मीट्रिक सिस्टम का उपयोग करें।"
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "फ़ाइल की संख्याएँ उपयोग करें"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "मौजूद होने पर फ़ाइल के मूल खाता स्तंभ, नाम पथ या योग पंक्तियों का उपयोग करें।"
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "फ़ाइल के पदानुक्रम का उपयोग करें"
 
 msgid "Used In"
 msgstr "में उपयोग किया गया"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -51,6 +51,27 @@ msgstr "(इस ग्राहक के लिए बाहर रखा ग�
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# पंक्ति इस कंपनी के बाहर डेटा से जुड़ी है, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती।} other {# पंक्तियाँ इस कंपनी के बाहर डेटा से जुड़ी हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती।}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# पंक्ति इस कंपनी के ब�
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# पंक्ति इस कंपनी के बाहर डेटा से जुड़ी है, इसलिए इसे बैकअप नहीं किया जा सकता। इसे छोड़ने से सब कुछ और बैकअप हो जाता है।} other {# पंक्तियाँ इस कंपनी के बाहर डेटा से जुड़ी हैं, इसलिए उन्हें बैकअप नहीं किया जा सकता। उन्हें छोड़ने से सब कुछ और बैकअप हो जाता है।}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {यह आइटम 1 खुली परिवर्तन सूचना पर है} other {यह आइटम # खुली परिवर्तन सूचनाओं पर है}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {यह आइटम 1 खुली परिवर्�
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} खाते"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} सफलतापूर्वक हटाया गया"
 msgid "{0} draft journal entries"
 msgstr "{0} ड्राफ्ट जर्नल प्रविष्टियाँ"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} जॉब बनाए गए"
@@ -111,14 +135,6 @@ msgstr "{0} लाइनें मैप करने के लिए"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} पंजीकृत"
 msgid "{0} rows"
 msgstr "{0} पंक्तियाँ"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} आपूर्तिकर्ता शेष राशि के साथ"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} नमूना न किए गए इकाइयों को उपलब्ध में जारी किया जाएगा। नमूना किए गए पास उपलब्ध रहेंगे और नमूना किए गए विफलताएं अस्वीकृत रहेंगी।"
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} में से {total} चरण पूर्ण"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# पंक्ति बाहर रखी गई} other {# पंक्तियाँ बाहर रखी गईं}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "और {hiddenCount}: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} जोड़े गए, {updated} अपडेट किए गए, {0} को ठीक करने की आवश्यकता है, {1} छोड़ दिए गए।"
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} पार्ट्स छोड़ दिए गए 
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} को रिवीजन {0} के रूप में संपादन के लिए फिर से खोला जाएगा। आपूर्तिकर्ता को भेजा गया दस्तावेज़ अपरिवर्तित रहेगा जब तक आप क्रय आदेश को अंतिम रूप न दें और पुनः न भेजें।"
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# इकाई} other {# इकाइया
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# अनगिनती लाइन} other {# अनगिनती लाइनें}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "ग्राहक सूची, ग्राहक फॉर्म औ�
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "आपूर्तिकर्ता सूची, आपूर्तिकर्ता फॉर्म और ड्रॉपडाउन पर एक पठनीय आपूर्तिकर्ता ID कॉलम दिखाएं। आपूर्तिकर्ता अभी भी किसी भी तरह से आंतरिक रूप से पहचाने जाते हैं।"
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "ग्राहक आईडी दिखाएं"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} जॉब बनाए गए"
 msgid "{0} lines to map"
 msgstr "{0} लाइनें मैप करने के लिए"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} मिलते-जुलते खाते: {fileCount} फ़ाइल की संख्याएँ लेंगे, {keepCount} Carbon की संख्याएँ रखेंगे।"
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "मेल खाया"
 
 msgid "matches"
 msgstr "मेल खाता है"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "मिलते-जुलते खाते: {0}। फ़ाइल की संख्याएँ: {fileCount}, Carbon की संख्याएँ: {keepCount}।"
 
 msgid "Matching Pairs"
 msgstr "मिलान जोड़े"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -51,6 +51,27 @@ msgstr "(escluso per questo cliente)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# riga si collega ai dati al di fuori di questa Azienda, quindi non è possibile fare una copia di sicurezza dei dati attuali.} other {# righe si collegano ai dati al di fuori di questa Azienda, quindi non è possibile fare una copia di sicurezza dei dati attuali.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# riga si collega ai dati al di fuori di questa Azienda
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# riga si collega ai dati al di fuori di questa Azienda, quindi non può essere sottoposta a backup. Ignorarla fa il backup di tutto il resto.} other {# righe si collegano ai dati al di fuori di questa Azienda, quindi non possono essere sottoposte a backup. Ignorarle fa il backup di tutto il resto.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Questo articolo è in 1 avviso di modifica aperto} other {Questo articolo è in # avvisi di modifica aperti}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Questo articolo è in 1 avviso di modifica aperto} othe
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} conti"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} eliminato con successo"
 msgid "{0} draft journal entries"
 msgstr "{0} righe di registrazione in bozza"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordini di produzione creati"
@@ -111,14 +135,6 @@ msgstr "{0} righe da mappare"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} registrato"
 msgid "{0} rows"
 msgstr "{0} righe"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornitori con un saldo"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entità non campionate verranno rilasciate a Disponibile. I campioni approvati rimangono Disponibili e i campioni rifiutati rimangono Rifiutati."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} di {total} fasi completate"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# riga esclusa} other {# righe escluse}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} altri: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseriti, {updated} aggiornati, {0} richiedono correzione, {1} saltati."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} componenti saltati — nulla da produrre"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} verrà riaperto per la modifica come revisione {0}. Il documento già inviato al fornitore rimane invariato fino a quando non si finalizza e si rinvia l'ordine."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# unità} other {# unità}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Mostra una colonna ID Cliente leggibile nell'elenco clienti, nei moduli 
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostra una colonna ID Fornitore leggibile nell'elenco dei fornitori, nei moduli fornitori e nei menu a discesa. I fornitori sono comunque identificati internamente in entrambi i casi."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Mostra ID Cliente"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} ordini di produzione creati"
 msgid "{0} lines to map"
 msgstr "{0} righe da mappare"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} conti corrispondenti: {fileCount} prendono i numeri del file, {keepCount} mantengono quelli di Carbon."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Abbinato"
 
 msgid "matches"
 msgstr "corrisponde"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Conti corrispondenti: {0}. Numeri del file: {fileCount}, numeri di Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Coppie di corrispondenza"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} componenti saltati — nulla da produrre"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} verrà riaperto per la modifica come revisione {0}. Il documento già inviato al fornitore rimane invariato fino a quando non si finalizza e si rinvia l'ordine."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Eliminare definitivamente # riga?} other {Eliminare definitivamente # righe?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importa {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Risultati dell'Importazione"
 
@@ -8187,9 +8198,6 @@ msgstr "Includi componenti aggiuntivi nella spedizione"
 
 msgid "Include Inactive"
 msgstr "Includi Inattivi"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Incluso"
@@ -8792,6 +8800,12 @@ msgstr "Kanban"
 msgid "Keep"
 msgstr "Mantieni"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Mantieni Attuale"
 
@@ -8809,6 +8823,9 @@ msgstr "Mantieni Aperto"
 
 msgid "Keep picking"
 msgstr "Continua il prelievo"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantiene ordini, offerte e impostazioni dietro un secondo controllo"
@@ -9548,6 +9565,9 @@ msgstr "Abbinato"
 
 msgid "matches"
 msgstr "corrisponde"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Coppie di corrispondenza"
@@ -13412,6 +13432,9 @@ msgstr "Valore residuo %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Risolvi questi prima di completare l'NCR: ogni riga deve avere una disposizione non in sospeso e le quantità delle entità collegate devono corrispondere alla quantità della riga."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Prezzo Risolto"
 
@@ -13886,8 +13909,16 @@ msgstr "Vendite, preventivi e configurazione su ordinazione"
 msgid "Salesperson"
 msgstr "Addetto alle vendite"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Trasferisci A"
 msgid "Trash"
 msgstr "Cestino"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Bilancio di verifica"
 
@@ -17598,6 +17625,9 @@ msgstr "Aggiorna Password"
 msgid "Update Permissions"
 msgstr "Aggiorna Autorizzazioni"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Aggiorna Quantità"
 
@@ -17714,6 +17744,9 @@ msgstr "Usa un'email diversa"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizza il sistema metrico per le dimensioni predefinite dei materiali."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Trasferisci A"
 msgid "Trash"
 msgstr "Cestino"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Bilancio di verifica"
 

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(escluso per questo cliente)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(gruppo)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# conto unito a uno esistente} other {# conti uniti a conti esistenti}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# conto da creare} other {# conti da creare}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# conto da aggiornare} other {# conti da aggiornare}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# conto invariato} other {# conti invariati}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# gruppo} other {# gruppi}} e {1, plural, one {# conto} other {# conti}} da creare"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# riga si collega ai dati al di fuori di questa Azienda
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# riga richiede attenzione} other {# righe richiedono attenzione}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# riga saltata} other {# righe saltate}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Mostra l'unica riga} other {Mostra tutte le # righe}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} righe da mappare"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} conti corrispondenti: {fileCount} prendono i numeri del file, {keepCount} mantengono quelli di Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# riga esclusa} other {# righe escluse}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# conto corrispondente prende il numero del file.} other {# conti corrispondenti prendono i numeri del file.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} di {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseriti, {updated} aggiornati, {0} richiedono correzione, {1} saltati."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# conto corrispondente mantiene il suo numero di Carbon.} other {# conti corrispondenti mantengono i loro numeri di Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# riga} other {# righe}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} verrà riaperto per la modifica come revisione {0}. Il documento già inviato al fornitore rimane invariato fino a quando non si finalizza e si rinvia l'ordine."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# decisione non ancora nel piano} other {# decisioni non ancora nel piano}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Eliminare definitivamente # riga?} other {Eliminare definitivamente # righe?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# conto esiste già in Carbon con un altro numero.} other {# conti esistono già in Carbon con altri numeri.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} non può essere programmato"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Tentativi"
 
 msgid "Attention"
-msgstr ""
+msgstr "Attenzione"
 
 msgid "Attribute"
 msgstr "Attributo"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Verifica il registro articoli per eventuali articoli con quantità disponibile negativa al termine del periodo — solitamente un'entrata merci mancante o una registrazione fuori ordine che distorce il valore del magazzino e il costo del venduto. Segna come fatto una volta revisionato, o salta con un motivo."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Controlla cosa verrà creato e modificato prima di importare. Nulla viene scritto finché non confermi."
 
 msgid "Check your email"
 msgstr "Controlla la tua email"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Verifica di Stripe per questo cliente…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Confronto del file con il piano dei conti…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Dettagli"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Rileva dal file"
 
 msgid "Developer"
 msgstr "Sviluppatore"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Motivo dell'Esenzione"
 
 msgid "Existing"
-msgstr ""
+msgstr "Esistente"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapping esistenti. Scegli un'opzione provider diversa per rimappare."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Gruppi"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "I gruppi provengono dal file. Un gruppo di primo livello con lo stesso nome di un gruppo Carbon viene unito a esso."
 
 msgid "Guided"
 msgstr "Guidato"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Nascondi le quantità di sistema fino al passaggio di revisione"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Nascondi l'elenco completo"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Nascondi, fissa e riordina le colonne"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Gerarchia ricavata dalle righe Begin-Total / End-Total del file."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Gerarchia ricavata dalla colonna del conto padre del file."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Gerarchia ricavata dai percorsi nei nomi dei conti."
 
 msgid "High"
 msgstr "Alto"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Ogni quanto questa manutenzione ricorre — Giornaliero, Settimanale, Mensile, Su conteggio ciclico; Giornaliero mostra il selettore del giorno della settimana, gli altri usano semplice aritmetica di intervalli."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Come devono essere organizzati i conti?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Come si classifica l'ordine di produzione quando il scheduler distribuisce la capacità — i claim ASAP vanno per primo, quindi Scadenza rigida, Scadenza flessibile e Nessuna scadenza per ultimo. Solo un segnale di classificazione; nessun tipo di scadenza blocca o limita il posizionamento."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Se desideri modificare i numeri dei componenti, fai clic su Annulla e assegna manualmente i componenti per ogni riga prima della conversione."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Ignora i gruppi del file; ogni conto viene collocato sotto il gruppo Carbon corrispondente al suo tipo di conto."
 
 msgid "II (normal default)"
 msgstr "II (normale predefinito)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Responsabile dell'Implementazione"
 
 msgid "Import"
-msgstr ""
+msgstr "Importa"
 
 msgid "Import {label} CSV"
 msgstr "Importa {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Importa come «{0}»"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Importa come {0}"
 
 msgid "Import results"
 msgstr "Risultati dell'Importazione"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Importa con un nome diverso"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Importa con un numero diverso"
 
 msgid "Import your BOM"
 msgstr "Importa il tuo BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Mantieni"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Mantieni il numero di Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Mantieni i numeri di Carbon"
 
 msgid "Keep Current"
 msgstr "Mantieni Attuale"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Lascia vuoto per una corrispondenza esatta"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Lascia questo conto com'è"
 
 msgid "Leave this page"
 msgstr "Lascia questa pagina"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Probabilità"
 
 msgid "Line"
-msgstr ""
+msgstr "Riga"
 
 msgid "Line description (optional)"
 msgstr "Descrizione riga (facoltativa)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Richiede un piano Business o Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Richiede attenzione"
 
 msgid "Needs fixing"
 msgstr "Necessita correzione"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Nessun gruppo assegnato"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Nessuna gerarchia nel file: i conti vengono collocati sotto i gruppi esistenti di Carbon in base al tipo di conto."
 
 msgid "No image"
 msgstr "Nessuna immagine"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Nessun straordinario programmato"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "Nel file non sono stati trovati una colonna del conto padre, tipi di riga o percorsi nei nomi."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Nessuna fonte padre registrata ancora. Fai clic su Ricalcola nella pagina di pianificazione per aggiornare l'attribuzione."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Niente programmato — aggiungi una stazione di seguito."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Niente da importare."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Non c'è ancora nulla. Un passaggio offre valori solo dopo essere stato configurato."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Percorso"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Separatore di percorso nei nomi dei conti"
 
 msgid "Pay Rate"
 msgstr "Tasso di Pagamento"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Fissato"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Colloca i conti sotto i gruppi esistenti di Carbon"
 
 msgid "Plan"
 msgstr "Piano"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Risolvi questi prima di completare l'NCR: ogni riga deve avere una disposizione non in sospeso e le quantità delle entità collegate devono corrispondere alla quantità della riga."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Risolto"
 
 msgid "Resolved Price"
 msgstr "Prezzo Risolto"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Addetto alle vendite"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "Uguale a {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "Uguale a {target} (mantieni il suo numero)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "Uguale a {target} (usa il numero di questo file)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "Uguale a {target}, mantenendo il suo numero"
 
 msgid "Same as Book"
 msgstr "Uguale al registro"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Ignora lo stato rilasciato ma non avviato: il lavoro inizia immediatamente alla scansione."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Salta questa riga"
 
 msgid "Skipped"
 msgstr "Saltato"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Dividi riga spedizione"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Dividi i nomi dei conti in base a un separatore, ad es. Padre:Figlio."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "Il set di autorizzazioni che i nuovi dipendenti di questo tipo ricevono automaticamente; la modifica qui cambia il modello solo per i futuri assunti - i dipendenti esistenti mantengono quello che hanno a meno che non vengono esplicitamente aggiornati in massa."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Impossibile creare il piano"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Gli impianti, i depositi e i siti dove vivono il tuo lavoro e le tue giacenze"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Queste voci di prima nota sono ancora Bozza, quindi i loro dare e avere non sono nel registro per questo periodo. Registra ognuno, o ri-datalo in un periodo aperto successivo."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Queste righe non vengono importate finché non sono risolte; tutto il resto viene importato alla conferma."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Queste righe sono collegate a dati esterni a questa azienda, pertanto non è possibile effettuare una copia di sicurezza dei dati attuali. La loro eliminazione non può essere annullata. Se risultano condivise con altre aziende del gruppo, nulla viene eliminato e il ripristino non si avvierà."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Rimuovi palloncino"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Invariato"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Le righe non conteggiate rimangono invariate al post — non vengono azzerate."
 
 msgid "Under"
-msgstr ""
+msgstr "Sotto"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Nel riordino basato sul fabbisogno, la pianificazione somma il fabbisogno entro questa finestra mobile durante il calcolo di una quantità di rifornimento."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Aggiorna Autorizzazioni"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Aggiorna piano"
 
 msgid "Update Quantity"
 msgstr "Aggiorna Quantità"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Aggiorna le informazioni del kanban per il rifornimento basato su scansione."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Aggiorna il piano per vedere il risultato. Confermando l'importazione vengono applicate tutte."
 
 msgid "Update the purchase order quantities"
 msgstr "Aggiorna le quantità dell'ordine di acquisto"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Aggiornato con successo"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Aggiornamento del piano…"
 
 msgid "Upgrade"
 msgstr "Aggiorna"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Utilizza il sistema metrico per le dimensioni predefinite dei materiali."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Usa i numeri del file"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Usa la colonna del conto padre, i percorsi nei nomi o le righe dei totali del file, se presenti."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Usa la gerarchia del file"
 
 msgid "Used In"
 msgstr "Utilizzato in"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Questo articolo è in 1 avviso di modifica aperto} othe
 msgid "{0} accounts"
 msgstr "{0} conti"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} fa"
@@ -92,9 +96,9 @@ msgstr "{0} eliminato con successo"
 msgid "{0} draft journal entries"
 msgstr "{0} righe di registrazione in bozza"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} ordini di produzione creati"
 msgid "{0} lines to map"
 msgstr "{0} righe da mappare"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} registrato"
 msgid "{0} rows"
 msgstr "{0} righe"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornitori con un saldo"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entità non campionate verranno rilasciate a Disponibile. I campioni approvati rimangono Disponibili e i campioni rifiutati rimangono Rifiutati."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} di {total} fasi completate"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# riga esclusa} other {# righe escluse}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} di {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} altri: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseriti, {updated} aggiornati, {0} richiedono correzione, {1} saltati."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# riga} other {# righe}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} componenti saltati — nulla da produrre"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} verrà riaperto per la modifica come revisione {0}. Il documento già inviato al fornitore rimane invariato fino a quando non si finalizza e si rinvia l'ordine."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# unità} other {# unità}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# riga non conteggiata} other {# righe non conteggiate}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} non può essere programmato"
@@ -1496,9 +1516,6 @@ msgstr "Tutte le Ubicazioni"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Tutti i membri dei gruppi selezionati e gli individui selezionati potranno approvare le richieste"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Tutte le righe importate — {inserted} inserite, {updated} aggiornate."
@@ -2864,9 +2881,6 @@ msgstr "Crea materiali di formazione basati sui ruoli"
 msgid "Build tailored, role-based training materials"
 msgstr "Crea materiali di formazione personalizzati basati sui ruoli"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Costruito e calcolato come proprio metodo"
 
@@ -3278,6 +3292,9 @@ msgstr "Controlla la tua email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verifica di Stripe per questo cliente…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -7374,15 +7391,6 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Ingegnere dispiegato in prima linea"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Fondamenti"
 
@@ -7809,8 +7817,20 @@ msgstr "Nascondi raw"
 msgid "Hide system quantities until the review step"
 msgstr "Nascondi le quantità di sistema fino al passaggio di revisione"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Nascondi, fissa e riordina le colonne"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Alto"
@@ -8824,9 +8844,6 @@ msgstr "Mantieni Aperto"
 msgid "Keep picking"
 msgstr "Continua il prelievo"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantiene ordini, offerte e impostazioni dietro un secondo controllo"
 
@@ -9565,9 +9582,6 @@ msgstr "Abbinato"
 
 msgid "matches"
 msgstr "corrisponde"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Coppie di corrispondenza"
@@ -10562,7 +10576,7 @@ msgstr "Nessuna notifica raggruppata"
 msgid "No groups assigned"
 msgstr "Nessun gruppo assegnato"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Nessun corso di formazione in sospeso"
 
 msgid "No overtime scheduled"
 msgstr "Nessun straordinario programmato"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Nessuna fonte padre registrata ancora. Fai clic su Ricalcola nella pagina di pianificazione per aggiornare l'attribuzione."
@@ -10946,6 +10963,9 @@ msgstr "Niente nell'archivio"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Niente programmato — aggiungi una stazione di seguito."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Non c'è ancora nulla. Un passaggio offre valori solo dopo essere stato configurato."
@@ -13689,9 +13709,6 @@ msgstr "righe"
 msgid "Rows left out of this backup"
 msgstr "Righe escluse da questo backup"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Regola"
 
@@ -14815,6 +14832,10 @@ msgstr "Mostra una colonna ID Cliente leggibile nell'elenco clienti, nei moduli 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostra una colonna ID Fornitore leggibile nell'elenco dei fornitori, nei moduli fornitori e nei menu a discesa. I fornitori sono comunque identificati internamente in entrambi i casi."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Mostra ID Cliente"
 
@@ -15091,6 +15112,9 @@ msgstr "Dividi riga ricevuta"
 
 msgid "Split shipment line"
 msgstr "Dividi riga spedizione"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Questi ordini di produzione hanno operazioni assegnate a questo centro d
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Queste voci di prima nota sono ancora Bozza, quindi i loro dare e avere non sono nel registro per questo periodo. Registra ognuno, o ri-datalo in un periodo aperto successivo."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Queste righe sono collegate a dati esterni a questa azienda, pertanto non è possibile effettuare una copia di sicurezza dei dati attuali. La loro eliminazione non può essere annullata. Se risultano condivise con altre aziende del gruppo, nulla viene eliminato e il ripristino non si avvierà."
 
@@ -17640,6 +17667,9 @@ msgstr "Aggiorna le quantità del documento di origine"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Aggiorna le informazioni del kanban per il rifornimento basato su scansione."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Aggiorna le quantità dell'ordine di acquisto"
 
@@ -17657,6 +17687,9 @@ msgstr "Aggiornato da"
 
 msgid "Updated successfully"
 msgstr "Aggiornato con successo"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Aggiorna"
@@ -17745,7 +17778,7 @@ msgstr "Usa un'email diversa"
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizza il sistema metrico per le dimensioni predefinite dei materiali."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" è completato — tutti i {0} articoli della sua Mappa di
 msgid "(excluded for this customer)"
 msgstr "(escluso per questo cliente)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# riga si collega ai dati al di fuori di questa Azienda, quindi non è possibile fare una copia di sicurezza dei dati attuali.} other {# righe si collegano ai dati al di fuori di questa Azienda, quindi non è possibile fare una copia di sicurezza dei dati attuali.}}"
@@ -89,6 +92,11 @@ msgstr "{0} eliminato con successo"
 msgid "{0} draft journal entries"
 msgstr "{0} righe di registrazione in bozza"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordini di produzione creati"
@@ -96,6 +104,14 @@ msgstr "{0} ordini di produzione creati"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} righe da mappare"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} righe"
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornitori con un saldo"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entità non campionate verranno rilasciate a Disponibile. I campioni approvati rimangono Disponibili e i campioni rifiutati rimangono Rifiutati."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Tutte le Ubicazioni"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Tutti i membri dei gruppi selezionati e gli individui selezionati potranno approvare le richieste"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Tutte le righe importate — {inserted} inserite, {updated} aggiornate."
 
@@ -2431,6 +2459,9 @@ msgstr "Allegati"
 msgid "Attempts"
 msgstr "Tentativi"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Attributo"
 
@@ -2829,6 +2860,9 @@ msgstr "Crea materiali di formazione basati sui ruoli"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Crea materiali di formazione personalizzati basati sui ruoli"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Costruito e calcolato come proprio metodo"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Verifica il registro articoli per eventuali articoli con quantità disponibile negativa al termine del periodo — solitamente un'entrata merci mancante o una registrazione fuori ordine che distorce il valore del magazzino e il costo del venduto. Segna come fatto una volta revisionato, o salta con un motivo."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Controlla la tua email"
@@ -5417,6 +5454,9 @@ msgstr "Dettagli"
 msgid "Details"
 msgstr "Dettagli"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Sviluppatore"
 
@@ -6571,6 +6611,9 @@ msgstr "Certificato di Esenzione"
 msgid "Exemption Reason"
 msgstr "Motivo dell'Esenzione"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapping esistenti. Scegli un'opzione provider diversa per rimappare."
 
@@ -7328,6 +7371,15 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Ingegnere dispiegato in prima linea"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Fondamenti"
 
@@ -7712,6 +7764,9 @@ msgstr "Nome Gruppo"
 msgid "Groups"
 msgstr "Gruppi"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Guidato"
 
@@ -7892,6 +7947,9 @@ msgstr "Ogni quanto questo strumento di misura deve essere ritarato; combinato c
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Ogni quanto questa manutenzione ricorre — Giornaliero, Settimanale, Mensile, Su conteggio ciclico; Giornaliero mostra il selettore del giorno della settimana, gli altri usano semplice aritmetica di intervalli."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Come si classifica l'ordine di produzione quando il scheduler distribuisce la capacità — i claim ASAP vanno per primo, quindi Scadenza rigida, Scadenza flessibile e Nessuna scadenza per ultimo. Solo un segnale di classificazione; nessun tipo di scadenza blocca o limita il posizionamento."
 
@@ -8012,6 +8070,9 @@ msgstr "Se qualcosa non è in linea"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Se desideri modificare i numeri dei componenti, fai clic su Annulla e assegna manualmente i componenti per ogni riga prima della conversione."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normale predefinito)"
 
@@ -8033,11 +8094,20 @@ msgstr "Hub di implementazione"
 msgid "Implementation Lead"
 msgstr "Responsabile dell'Implementazione"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importa {label} CSV"
 
 msgid "Import results"
 msgstr "Risultati dell'Importazione"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Importa il tuo BOM"
@@ -8117,6 +8187,9 @@ msgstr "Includi componenti aggiuntivi nella spedizione"
 
 msgid "Include Inactive"
 msgstr "Includi Inattivi"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Incluso"
@@ -8897,6 +8970,9 @@ msgstr "Lascia vuoto per usare la prossima revisione automaticamente"
 msgid "Leave empty for exact match"
 msgstr "Lascia vuoto per una corrispondenza esatta"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Lascia questa pagina"
 
@@ -8974,6 +9050,9 @@ msgstr "Spento (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilità"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Descrizione riga (facoltativa)"
@@ -9901,6 +9980,9 @@ msgstr "Necessario sono le ore di lavoro dovute quel giorno divise per {personDa
 msgid "Needs a Business or Partner plan."
 msgstr "Richiede un piano Business o Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Necessita correzione"
 
@@ -10459,6 +10541,9 @@ msgstr "Nessuna notifica raggruppata"
 
 msgid "No groups assigned"
 msgstr "Nessun gruppo assegnato"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Nessuna immagine"
@@ -11565,6 +11650,9 @@ msgstr "Incolla l'XML dei metadati se il tuo provider di identità non pubblica 
 msgid "Path"
 msgstr "Percorso"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Tasso di Pagamento"
 
@@ -11794,6 +11882,9 @@ msgstr "Fissa {0}"
 
 msgid "Pinned"
 msgstr "Fissato"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Piano"
@@ -13575,6 +13666,9 @@ msgstr "righe"
 msgid "Rows left out of this backup"
 msgstr "Righe escluse da questo backup"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Regola"
 
@@ -13791,6 +13885,10 @@ msgstr "Vendite, preventivi e configurazione su ordinazione"
 
 msgid "Salesperson"
 msgstr "Addetto alle vendite"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Uguale al registro"
@@ -14815,6 +14913,9 @@ msgstr "Salta la manutenzione programmata durante le festività aziendali"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Ignora lo stato rilasciato ma non avviato: il lavoro inizia immediatamente alla scansione."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Saltato"
@@ -16217,6 +16318,9 @@ msgstr "La percentuale dello sconto di cassa. Utilizza 0 per nessuno sconto."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Il set di autorizzazioni che i nuovi dipendenti di questo tipo ricevono automaticamente; la modifica qui cambia il modello solo per i futuri assunti - i dipendenti esistenti mantengono quello che hanno a meno che non vengono esplicitamente aggiornati in massa."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Gli impianti, i depositi e i siti dove vivono il tuo lavoro e le tue giacenze"
 
@@ -17259,8 +17363,14 @@ msgstr "Non assegnato"
 msgid "Unballoon"
 msgstr "Rimuovi palloncino"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Le righe non conteggiate rimangono invariate al post — non vengono azzerate."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Nel riordino basato sul fabbisogno, la pianificazione somma il fabbisogno entro questa finestra mobile durante il calcolo di una quantità di rifornimento."
@@ -17600,6 +17710,12 @@ msgstr "Usa un'email diversa"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilizza il sistema metrico per le dimensioni predefinite dei materiali."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Utilizzato in"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -17270,6 +17270,10 @@ msgstr "転送先"
 msgid "Trash"
 msgstr "ゴミ箱"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "試算表"
 

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -48,6 +48,9 @@ msgstr "「{taskName}」は完了しました — セットアップマップの
 msgid "(excluded for this customer)"
 msgstr "（このお客様向けに除外されています）"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 行はこの会社の外部のデータにリンクしているため、現在のデータの安全なコピーを作成できません。} other {# 行はこの会社の外部のデータにリンクしているため、現在のデータの安全なコピーを作成できません。}}"
@@ -89,6 +92,11 @@ msgstr "{0}が正常に削除されました"
 msgid "{0} draft journal entries"
 msgstr "{0}件の下書き仕訳"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} 件の製造指図が作成されました"
@@ -96,6 +104,14 @@ msgstr "{0} 件の製造指図が作成されました"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0}件のラインをマップします"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} 行"
 msgid "{0} suppliers with a balance"
 msgstr "{0}件の残高のある仕入先"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}個の未サンプリングエンティティが利用可能にリリースされます。サンプリング済みの合格品は利用可能なままで、サンプリング済みの不合格品は却下されたままです。"
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "すべての場所"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "選択されたグループのすべてのメンバーと選択された個人が承認リクエストを承認できます"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "すべての行をインポート—{inserted}行挿入、{updated}行更新。"
 
@@ -2431,6 +2459,9 @@ msgstr "添付ファイル"
 msgid "Attempts"
 msgstr "試行"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "属性"
 
@@ -2829,6 +2860,9 @@ msgstr "ロールベースの教育訓練教材を構築"
 
 msgid "Build tailored, role-based training materials"
 msgstr "カスタマイズされたロールベースの教育訓練教材を構築"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "独自の方法として構築および原価計算"
@@ -3232,6 +3266,9 @@ msgstr "チャット"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "期末時点で保有数量がマイナスの品目がないか品目台帳を確認してください — 通常、納品漏れまたは順序外の転記により、在庫価値および売上原価が歪む可能性があります。確認済みの場合はマーク完了し、スキップする場合は理由を記入してください。"
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "メールを確認してください"
@@ -5417,6 +5454,9 @@ msgstr "詳細"
 msgid "Details"
 msgstr "詳細"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "開発者"
 
@@ -6571,6 +6611,9 @@ msgstr "免除証明書"
 msgid "Exemption Reason"
 msgstr "免除理由"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "既存のマッピング。異なるプロバイダーオプションを選択して再マップしてください。"
 
@@ -7328,6 +7371,15 @@ msgstr "フォーマット"
 msgid "Forward deployed engineer"
 msgstr "現地配置エンジニア"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "基礎"
 
@@ -7712,6 +7764,9 @@ msgstr "グループ名"
 msgid "Groups"
 msgstr "グループ"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "ガイド付き"
 
@@ -7892,6 +7947,9 @@ msgstr "この測定器をどのくらい頻繁に再校正する必要がある
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "この保全がどのくらい頻繁に繰り返されるか — 毎日、毎週、毎月、循環棚卸時。毎日の場合は曜日セレクタが表示され、その他は単純な間隔計算を使用します"
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "スケジューラーが容量を割り当てるときに製造指図がどのようにランク付けされるか — ASAP が最初に請求し、その後ハード期限、ソフト期限、期限なしが最後です。ランキング信号のみ；期限タイプは配置をブロックまたはゲートしません。"
 
@@ -8012,6 +8070,9 @@ msgstr "何か問題が生じた場合"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "部品番号を変更したい場合は、[キャンセル]をクリックして、変換する前に各行アイテムの部品を手動で割り当ててください。"
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II（通常デフォルト）"
 
@@ -8033,11 +8094,20 @@ msgstr "実施ハブ"
 msgid "Implementation Lead"
 msgstr "実施リード"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "{label} CSV をインポート"
 
 msgid "Import results"
 msgstr "インポート結果"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "BOMをインポート"
@@ -8117,6 +8187,9 @@ msgstr "出荷に追加部品を含める"
 
 msgid "Include Inactive"
 msgstr "無効を含める"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "含まれています"
@@ -8897,6 +8970,9 @@ msgstr "空白のままにして、次のリビジョンを自動的に使用し
 msgid "Leave empty for exact match"
 msgstr "正確な一致のために空のままにしてください"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "このページを離れる"
 
@@ -8974,6 +9050,9 @@ msgstr "ライツアウト（24/7）"
 
 msgid "Likelihood"
 msgstr "発生可能性"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "行の説明 (オプション)"
@@ -9901,6 +9980,9 @@ msgstr "必要人数は、その日の予定作業時間を{personDayHours}hで�
 msgid "Needs a Business or Partner plan."
 msgstr "ビジネスプランまたはパートナープランが必要です。"
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "修理が必要です"
 
@@ -10459,6 +10541,9 @@ msgstr "グループ化された通知がありません"
 
 msgid "No groups assigned"
 msgstr "グループが割り当てられていません"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "画像なし"
@@ -11565,6 +11650,9 @@ msgstr "IDプロバイダーがメタデータURLを公開していない場合�
 msgid "Path"
 msgstr "パス"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "支払レート"
 
@@ -11794,6 +11882,9 @@ msgstr "{0}をピン留"
 
 msgid "Pinned"
 msgstr "ピン留め"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "計画"
@@ -13575,6 +13666,9 @@ msgstr "行"
 msgid "Rows left out of this backup"
 msgstr "このバックアップから除外された行"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "ルール"
 
@@ -13791,6 +13885,10 @@ msgstr "販売、見積、設定注文"
 
 msgid "Salesperson"
 msgstr "営業担当者"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "簿価と同じ"
@@ -14815,6 +14913,9 @@ msgstr "会社の休日の定期保全をスキップ"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "リリースされたが開始していない状態をスキップします。スキャン時にジョブがすぐに開始します。"
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "スキップ済"
@@ -16217,6 +16318,9 @@ msgstr "現金割引のパーセンテージ。割引なしの場合は 0 を使
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "このタイプの新しい従業員が自動的に受け取る権限セット。ここで編集すると、将来の雇用のみがテンプレートを変更します。既存の従業員は、明示的に大量更新されない限り、持っているものを保持します。"
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "あなたの仕事と在庫が存在する工場、倉庫、およびサイト"
 
@@ -17259,8 +17363,14 @@ msgstr "未割り当て"
 msgid "Unballoon"
 msgstr "バルーンを削除"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未計数行は投稿時に変更されないままです — ゼロにはなりません。"
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "所要量ベースの再発注では、補給数量を計算する際、計画はこのローリングウィンドウ内の所要量を合計します。"
@@ -17600,6 +17710,12 @@ msgstr "別のメールアドレスを使用"
 
 msgid "Use metric system for default material dimensions."
 msgstr "デフォルト材料ディメンションにメートル法を使用してください。"
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "使用されている"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -51,6 +51,27 @@ msgstr "（このお客様向けに除外されています）"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 行はこの会社の外部のデータにリンクしているため、現在のデータの安全なコピーを作成できません。} other {# 行はこの会社の外部のデータにリンクしているため、現在のデータの安全なコピーを作成できません。}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# 行はこの会社の外部のデータにリンク�
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# 行はこの会社の外部のデータにリンクしているため、バックアップできません。スキップすると、他のすべてがバックアップされます。} other {# 行はこの会社の外部のデータにリンクしているため、バックアップできません。スキップすると、他のすべてがバックアップされます。}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {このアイテムは1つの未完了の変更通知に含まれています} other {このアイテムは#つの未完了の変更通知に含まれています}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {このアイテムは1つの未完了の変更通知に
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} 件のアカウント"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0}が正常に削除されました"
 msgid "{0} draft journal entries"
 msgstr "{0}件の下書き仕訳"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} 件の製造指図が作成されました"
@@ -111,14 +135,6 @@ msgstr "{0}件のラインをマップします"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0}登録済み"
 msgid "{0} rows"
 msgstr "{0} 行"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0}件の残高のある仕入先"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}個の未サンプリングエンティティが利用可能にリリースされます。サンプリング済みの合格品は利用可能なままで、サンプリング済みの不合格品は却下されたままです。"
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} / {total} フェーズ完了"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行除外} other {# 行除外}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} 件さらに表示: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}件を追加、{updated}件を更新、{0}件を修正が必要、{1}件をスキップ。"
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount}個の部品はスキップ済 — 製造する必要
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} はリビジョン {0} として編集のため再度オープンされます。仕入先に送信済みの文書は、ファイナライズして発注書を再送信するまで変更されません。"
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# 個} other {# 個}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "得意先リスト、得意先フォーム、ドロップダウンで読
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "仕入先リスト、仕入先フォーム、ドロップダウンで読みやすい仕入先IDカラムを表示します。仕入先はどちらの方法でも内部的に識別されます。"
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "得意先IDを表示"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} 件の製造指図が作成されました"
 msgid "{0} lines to map"
 msgstr "{0}件のラインをマップします"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "一致する科目 {0}件: {fileCount}件はファイルの番号を使用し、{keepCount}件はCarbonの番号を維持します。"
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "照合済み"
 
 msgid "matches"
 msgstr "一致する"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "一致する科目: {0}。ファイルの番号: {fileCount}、Carbonの番号: {keepCount}。"
 
 msgid "Matching Pairs"
 msgstr "マッチングペア"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {このアイテムは1つの未完了の変更通知に
 msgid "{0} accounts"
 msgstr "{0} 件のアカウント"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0}前"
@@ -92,9 +96,9 @@ msgstr "{0}が正常に削除されました"
 msgid "{0} draft journal entries"
 msgstr "{0}件の下書き仕訳"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} 件の製造指図が作成されました"
 msgid "{0} lines to map"
 msgstr "{0}件のラインをマップします"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0}登録済み"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0}件の残高のある仕入先"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}個の未サンプリングエンティティが利用可能にリリースされます。サンプリング済みの合格品は利用可能なままで、サンプリング済みの不合格品は却下されたままです。"
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} / {total} フェーズ完了"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行除外} other {# 行除外}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} 件さらに表示: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}件を追加、{updated}件を更新、{0}件を修正が必要、{1}件をスキップ。"
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount}個の部品はスキップ済 — 製造する必要
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} はリビジョン {0} として編集のため再度オープンされます。仕入先に送信済みの文書は、ファイナライズして発注書を再送信するまで変更されません。"
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# 個} other {# 個}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}はスケジュール化できません"
@@ -1496,9 +1516,6 @@ msgstr "すべての場所"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "選択されたグループのすべてのメンバーと選択された個人が承認リクエストを承認できます"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "すべての行をインポート—{inserted}行挿入、{updated}行更新。"
@@ -2864,9 +2881,6 @@ msgstr "ロールベースの教育訓練教材を構築"
 msgid "Build tailored, role-based training materials"
 msgstr "カスタマイズされたロールベースの教育訓練教材を構築"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "独自の方法として構築および原価計算"
 
@@ -3278,6 +3292,9 @@ msgstr "メールを確認してください"
 
 msgid "Checking Stripe for this customer…"
 msgstr "この得意先の Stripe を確認中…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "チェックポイント ·"
@@ -7374,15 +7391,6 @@ msgstr "フォーマット"
 msgid "Forward deployed engineer"
 msgstr "現地配置エンジニア"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "基礎"
 
@@ -7809,8 +7817,20 @@ msgstr "生データを非表示"
 msgid "Hide system quantities until the review step"
 msgstr "レビューステップまでシステム数量を非表示にする"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "列を非表示、ピン留め、並び替え"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "高"
@@ -8824,9 +8844,6 @@ msgstr "開いたままにする"
 msgid "Keep picking"
 msgstr "ピッキングを続ける"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "注文、見積、設定を2段階認証で保護します"
 
@@ -9565,9 +9582,6 @@ msgstr "照合済み"
 
 msgid "matches"
 msgstr "一致する"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "マッチングペア"
@@ -10562,7 +10576,7 @@ msgstr "グループ化された通知がありません"
 msgid "No groups assigned"
 msgstr "グループが割り当てられていません"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "未実施の教育訓練がありません"
 
 msgid "No overtime scheduled"
 msgstr "残業予定なし"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "親ソースはまだ記録されていません。計画ページの「再計算」をクリックして属性を更新してください。"
@@ -10946,6 +10963,9 @@ msgstr "アーカイブに何もありません"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "スケジュールがありません。以下にステーションを追加してください。"
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "まだ何もありません。ステップは構成されると値を提供します。"
@@ -13689,9 +13709,6 @@ msgstr "行"
 msgid "Rows left out of this backup"
 msgstr "このバックアップから除外された行"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "ルール"
 
@@ -14815,6 +14832,10 @@ msgstr "得意先リスト、得意先フォーム、ドロップダウンで読
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "仕入先リスト、仕入先フォーム、ドロップダウンで読みやすい仕入先IDカラムを表示します。仕入先はどちらの方法でも内部的に識別されます。"
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "得意先IDを表示"
 
@@ -15091,6 +15112,9 @@ msgstr "領収書行を分割"
 
 msgid "Split shipment line"
 msgstr "出荷明細を分割"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "これらの製造指図には、この作業区に割り当てられた
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "これらの仕訳はまだ下書きであるため、それらの借方と貸方は当期の元帳に含まれていません。各仕訳を転記するか、後の開いている期間に再度日付を付け直してください。"
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "これらの行はこの会社外のデータにリンクしているため、現在のデータのバックアップを作成できません。削除を元に戻すことはできません。このグループ内の他の会社と共有されていることが判明した場合、何も削除されず、復元は開始されません。"
 
@@ -17640,6 +17667,9 @@ msgstr "参照伝票の数量を更新"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "スキャンベースの補充用かんばん情報を更新します。"
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "発注書の数量を更新"
 
@@ -17657,6 +17687,9 @@ msgstr "更新者"
 
 msgid "Updated successfully"
 msgstr "正常に更新されました"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "アップグレード"
@@ -17745,7 +17778,7 @@ msgstr "別のメールアドレスを使用"
 msgid "Use metric system for default material dimensions."
 msgstr "デフォルト材料ディメンションにメートル法を使用してください。"
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "（このお客様向けに除外されています）"
 
 msgid "(group)"
-msgstr ""
+msgstr "（グループ）"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, other {既存の科目に統合: #件}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, other {作成する科目: #件}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, other {更新する科目: #件}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, other {変更なしの科目: #件}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "作成する: {0, plural, other {グループ #件}}、{1, plural, other {科目 #件}}"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# 行はこの会社の外部のデータにリンク�
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, other {要確認の行: #件}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, other {スキップした行: #件}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, other {全 # 行を表示}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0}件のラインをマップします"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "一致する科目 {0}件: {fileCount}件はファイルの番号を使用し、{keepCount}件はCarbonの番号を維持します。"
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行除外} other {# 行除外}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, other {一致する科目 #件がファイルの番号を使用します。}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}件を追加、{updated}件を更新、{0}件を修正が必要、{1}件をスキップ。"
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, other {一致する科目 #件がCarbonの番号を維持します。}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} はリビジョン {0} として編集のため再度オープンされます。仕入先に送信済みの文書は、ファイナライズして発注書を再送信するまで変更されません。"
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, other {プランに未反映の決定: #件}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# 行を永久に削除しますか？} other {# 行を永久に削除しますか？}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未計数行} other {# 未計数行}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, other {#件の科目は別の番号でCarbonに既に存在します。}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}はスケジュール化できません"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "試行"
 
 msgid "Attention"
-msgstr ""
+msgstr "要確認"
 
 msgid "Attribute"
 msgstr "属性"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "期末時点で保有数量がマイナスの品目がないか品目台帳を確認してください — 通常、納品漏れまたは順序外の転記により、在庫価値および売上原価が歪む可能性があります。確認済みの場合はマーク完了し、スキップする場合は理由を記入してください。"
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "インポート前に、作成・変更される内容を確認してください。確認するまで何も書き込まれません。"
 
 msgid "Check your email"
 msgstr "メールを確認してください"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "この得意先の Stripe を確認中…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "ファイルを勘定科目表と照合しています…"
 
 msgid "Checkpoint ·"
 msgstr "チェックポイント ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "詳細"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "ファイルから検出"
 
 msgid "Developer"
 msgstr "開発者"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "免除理由"
 
 msgid "Existing"
-msgstr ""
+msgstr "既存"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "既存のマッピング。異なるプロバイダーオプションを選択して再マップしてください。"
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "グループ"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "グループはファイルから取得します。Carbonのグループと同名の最上位グループはそのグループに統合されます。"
 
 msgid "Guided"
 msgstr "ガイド付き"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "レビューステップまでシステム数量を非表示にする"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "全リストを非表示"
 
 msgid "Hide, pin and reorder columns"
 msgstr "列を非表示、ピン留め、並び替え"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "階層はファイルのBegin-Total / End-Total行から取得しました。"
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "階層はファイルの親科目列から取得しました。"
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "階層は科目名のパスから取得しました。"
 
 msgid "High"
 msgstr "高"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "この保全がどのくらい頻繁に繰り返されるか — 毎日、毎週、毎月、循環棚卸時。毎日の場合は曜日セレクタが表示され、その他は単純な間隔計算を使用します"
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "科目をどのように整理しますか？"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "スケジューラーが容量を割り当てるときに製造指図がどのようにランク付けされるか — ASAP が最初に請求し、その後ハード期限、ソフト期限、期限なしが最後です。ランキング信号のみ；期限タイプは配置をブロックまたはゲートしません。"
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "部品番号を変更したい場合は、[キャンセル]をクリックして、変換する前に各行アイテムの部品を手動で割り当ててください。"
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "ファイルのグループを無視し、各科目を科目タイプに対応するCarbonのグループに配置します。"
 
 msgid "II (normal default)"
 msgstr "II（通常デフォルト）"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "実施リード"
 
 msgid "Import"
-msgstr ""
+msgstr "インポート"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV をインポート"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "「{0}」としてインポート"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "{0} としてインポート"
 
 msgid "Import results"
 msgstr "インポート結果"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "別の名前でインポート"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "別の番号でインポート"
 
 msgid "Import your BOM"
 msgstr "BOMをインポート"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "保持"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Carbonの番号を維持"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Carbonの番号を維持"
 
 msgid "Keep Current"
 msgstr "現在の設定を保持"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "正確な一致のために空のままにしてください"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "この科目をそのままにする"
 
 msgid "Leave this page"
 msgstr "このページを離れる"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "発生可能性"
 
 msgid "Line"
-msgstr ""
+msgstr "行"
 
 msgid "Line description (optional)"
 msgstr "行の説明 (オプション)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "ビジネスプランまたはパートナープランが必要です。"
 
 msgid "Needs attention"
-msgstr ""
+msgstr "要確認"
 
 msgid "Needs fixing"
 msgstr "修理が必要です"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "グループが割り当てられていません"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "ファイルに階層がありません。科目は科目タイプごとにCarbonの既存グループに配置されます。"
 
 msgid "No image"
 msgstr "画像なし"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "残業予定なし"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "ファイルに親科目列、行の種類、名前内のパスのいずれも見つかりませんでした。"
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "親ソースはまだ記録されていません。計画ページの「再計算」をクリックして属性を更新してください。"
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "スケジュールがありません。以下にステーションを追加してください。"
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "インポートするものはありません。"
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "まだ何もありません。ステップは構成されると値を提供します。"
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "パス"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "科目名のパス区切り文字"
 
 msgid "Pay Rate"
 msgstr "支払レート"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "ピン留め"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Carbonの既存グループに科目を配置"
 
 msgid "Plan"
 msgstr "計画"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "NCRを完了する前にこれらを解決してください。すべての行に保留中ではない処置が必要で、リンクされたエンティティの数量は行の数量と一致する必要があります。"
 
 msgid "Resolved"
-msgstr ""
+msgstr "解決済み"
 
 msgid "Resolved Price"
 msgstr "解決済み価格"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "営業担当者"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "{target} と同じ"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "{target} と同じ（その番号を維持）"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "{target} と同じ（このファイルの番号を使用）"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "{target} と同じ（番号を維持）"
 
 msgid "Same as Book"
 msgstr "簿価と同じ"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "リリースされたが開始していない状態をスキップします。スキャン時にジョブがすぐに開始します。"
 
 msgid "Skip this row"
-msgstr ""
+msgstr "この行をスキップ"
 
 msgid "Skipped"
 msgstr "スキップ済"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "出荷明細を分割"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "区切り文字で科目名を分割します（例: 親:子）。"
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "このタイプの新しい従業員が自動的に受け取る権限セット。ここで編集すると、将来の雇用のみがテンプレートを変更します。既存の従業員は、明示的に大量更新されない限り、持っているものを保持します。"
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "プランを作成できませんでした"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "あなたの仕事と在庫が存在する工場、倉庫、およびサイト"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "これらの仕訳はまだ下書きであるため、それらの借方と貸方は当期の元帳に含まれていません。各仕訳を転記するか、後の開いている期間に再度日付を付け直してください。"
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "これらの行は解決されるまでインポートされません。それ以外は確認時にインポートされます。"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "これらの行はこの会社外のデータにリンクしているため、現在のデータのバックアップを作成できません。削除を元に戻すことはできません。このグループ内の他の会社と共有されていることが判明した場合、何も削除されず、復元は開始されません。"
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "バルーンを削除"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "変更なし"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未計数行は投稿時に変更されないままです — ゼロにはなりません。"
 
 msgid "Under"
-msgstr ""
+msgstr "所属"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "所要量ベースの再発注では、補給数量を計算する際、計画はこのローリングウィンドウ内の所要量を合計します。"
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "権限を更新"
 
 msgid "Update plan"
-msgstr ""
+msgstr "プランを更新"
 
 msgid "Update Quantity"
 msgstr "数量を更新"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "スキャンベースの補充用かんばん情報を更新します。"
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "結果を確認するにはプランを更新してください。インポートを確認するとすべて適用されます。"
 
 msgid "Update the purchase order quantities"
 msgstr "発注書の数量を更新"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "正常に更新されました"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "プランを更新しています…"
 
 msgid "Upgrade"
 msgstr "アップグレード"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "デフォルト材料ディメンションにメートル法を使用してください。"
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "ファイルの番号を使用"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "ファイルに親科目列、名前のパス、合計行がある場合はそれを使用します。"
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "ファイルの階層を使用"
 
 msgid "Used In"
 msgstr "使用されている"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount}個の部品はスキップ済 — 製造する必要
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} はリビジョン {0} として編集のため再度オープンされます。仕入先に送信済みの文書は、ファイナライズして発注書を再送信するまで変更されません。"
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# 行を永久に削除しますか？} other {# 行を永久に削除しますか？}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "{label} CSV をインポート"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "インポート結果"
 
@@ -8187,9 +8198,6 @@ msgstr "出荷に追加部品を含める"
 
 msgid "Include Inactive"
 msgstr "無効を含める"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "含まれています"
@@ -8792,6 +8800,12 @@ msgstr "かんばん"
 msgid "Keep"
 msgstr "保持"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "現在の設定を保持"
 
@@ -8809,6 +8823,9 @@ msgstr "開いたままにする"
 
 msgid "Keep picking"
 msgstr "ピッキングを続ける"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "注文、見積、設定を2段階認証で保護します"
@@ -9548,6 +9565,9 @@ msgstr "照合済み"
 
 msgid "matches"
 msgstr "一致する"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "マッチングペア"
@@ -13412,6 +13432,9 @@ msgstr "残存価額 %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "NCRを完了する前にこれらを解決してください。すべての行に保留中ではない処置が必要で、リンクされたエンティティの数量は行の数量と一致する必要があります。"
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "解決済み価格"
 
@@ -13886,8 +13909,16 @@ msgstr "販売、見積、設定注文"
 msgid "Salesperson"
 msgstr "営業担当者"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "転送先"
 msgid "Trash"
 msgstr "ゴミ箱"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "試算表"
 
@@ -17598,6 +17625,9 @@ msgstr "パスワードを更新"
 msgid "Update Permissions"
 msgstr "権限を更新"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "数量を更新"
 
@@ -17714,6 +17744,9 @@ msgstr "別のメールアドレスを使用"
 
 msgid "Use metric system for default material dimensions."
 msgstr "デフォルト材料ディメンションにメートル法を使用してください。"
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {이 품목은 1개의 미결 변경 통지에 포함되
 msgid "{0} accounts"
 msgstr "{0} 계정"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} 전"
@@ -92,9 +96,9 @@ msgstr "{0}이(가) 삭제되었습니다"
 msgid "{0} draft journal entries"
 msgstr "{0}개의 초안 분개"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0}개의 작업 지시 생성됨"
 msgid "{0} lines to map"
 msgstr "매핑할 라인 {0}개"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} 등록됨"
 msgid "{0} rows"
 msgstr "{0} 행"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "잔액이 있는 공급업체 {0}곳"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}개의 미검사 항목이 가용으로 릴리스됩니다. 검사 합격 항목은 가용으로 유지되고 검사 불합격 항목은 거부됨으로 유지됩니다."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done}개 중 {total}개 단계 완료"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 행 제외됨} other {# 행 제외됨}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{count}개 중 {from}–{to}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount}개 추가: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}개 추가, {updated}개 업데이트, {0}개 수정 필요, {1}개 건너뜀."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 줄} other {# 줄}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount}개 부품이 건너뜀 — 만들 것이 없음"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel}은(는) 리비전 {0}으로 편집하기 위해 다시 열립니다. 이미 공급업체로 전송된 문서는 리비전을 완료하고 다시 전송할 때까지 변경되지 않습니다."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# 단위} other {# 단위}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}개는 일정을 짤 수 없습니다"
@@ -1496,9 +1516,6 @@ msgstr "모든 위치"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "선택한 그룹의 모든 구성원과 선택한 개인이 요청을 승인할 수 있습니다"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "모든 행을 가져왔습니다 — {inserted}개 추가, {updated}개 업데이트."
@@ -2864,9 +2881,6 @@ msgstr "역할 기반 교육 자료 제작"
 msgid "Build tailored, role-based training materials"
 msgstr "맞춤형 역할 기반 교육 자료 제작"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "독립적인 방법으로 구성되고 원가가 산정됨"
 
@@ -3278,6 +3292,9 @@ msgstr "이메일을 확인하세요"
 
 msgid "Checking Stripe for this customer…"
 msgstr "이 고객의 Stripe 확인 중…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "체크포인트 ·"
@@ -7374,15 +7391,6 @@ msgstr "형식"
 msgid "Forward deployed engineer"
 msgstr "현장 배치 엔지니어"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "파운데이션"
 
@@ -7809,8 +7817,20 @@ msgstr "원본 숨기기"
 msgid "Hide system quantities until the review step"
 msgstr "검토 단계 전까지 시스템 수량 숨기기"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "열 숨기기, 고정, 순서 변경"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "높음"
@@ -8824,9 +8844,6 @@ msgstr "열린 상태 유지"
 msgid "Keep picking"
 msgstr "피킹 유지"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "주문, 견적 및 설정을 이중 확인으로 보호합니다"
 
@@ -9565,9 +9582,6 @@ msgstr "일치함"
 
 msgid "matches"
 msgstr "일치"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "일치하는 쌍"
@@ -10562,7 +10576,7 @@ msgstr "그룹화된 알림이 없습니다"
 msgid "No groups assigned"
 msgstr "배정된 그룹이 없습니다"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "미완료 교육이 없습니다"
 
 msgid "No overtime scheduled"
 msgstr "예정된 초과근무가 없습니다"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "아직 기록된 상위 소스가 없습니다. 계획 페이지에서 재계산을 클릭하여 귀속 정보를 새로고침하세요."
@@ -10946,6 +10963,9 @@ msgstr "보관함이 비어 있습니다"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "일정이 없습니다 — 아래에서 스테이션을 추가하세요."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "아직 없습니다. 단계는 구성된 후에만 값을 제공합니다."
@@ -13689,9 +13709,6 @@ msgstr "행"
 msgid "Rows left out of this backup"
 msgstr "이 백업에서 제외된 행"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "규칙"
 
@@ -14815,6 +14832,10 @@ msgstr "고객 목록, 고객 양식, 드롭다운에 읽기 쉬운 고객 ID �
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "공급업체 목록, 공급업체 양식, 드롭다운에 읽기 쉬운 공급업체 ID 열을 표시합니다. 어느 쪽이든 공급업체는 내부적으로 동일하게 식별됩니다."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "고객 ID 표시"
 
@@ -15091,6 +15112,9 @@ msgstr "입고 라인 분할"
 
 msgid "Split shipment line"
 msgstr "출하 라인 분할"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "이 작업장에 할당된 공정이 있는 작업 지시:"
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "이 전표들은 아직 초안 상태이므로 이 기간에 차변 및 대변이 원장에 없습니다. 각 전표를 전기하거나 이후 미결 기간으로 다시 날짜를 지정하십시오."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "이 행들은 이 회사 외부의 데이터와 연결되어 있으므로 현재 데이터의 안전한 사본을 만들 수 없습니다. 이들을 삭제하면 되돌릴 수 없습니다. 이들이 이 그룹의 다른 회사와 공유되는 경우, 아무것도 삭제되지 않고 복원이 시작되지 않습니다."
 
@@ -17640,6 +17667,9 @@ msgstr "원본 문서 수량 업데이트"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "스캔 기반 보충을 위한 칸반 정보를 업데이트합니다."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "발주서 수량 업데이트"
 
@@ -17657,6 +17687,9 @@ msgstr "업데이트한 사람"
 
 msgid "Updated successfully"
 msgstr "성공적으로 업데이트되었습니다"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "업그레이드"
@@ -17745,7 +17778,7 @@ msgstr "다른 이메일 사용"
 msgid "Use metric system for default material dimensions."
 msgstr "기본 자재 치수에 미터법을 사용합니다."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -133,10 +133,6 @@ msgstr "{0}개의 작업 지시 생성됨"
 msgid "{0} lines to map"
 msgstr "매핑할 라인 {0}개"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "일치하는 계정 {0}개: {fileCount}개는 파일의 번호를 사용하고 {keepCount}개는 Carbon의 번호를 유지합니다."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "일치함"
 
 msgid "matches"
 msgstr "일치"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "일치하는 계정: {0}. 파일의 번호: {fileCount}, Carbon의 번호: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "일치하는 쌍"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" 완료 — 설정 맵 항목 {0}개가 모두 설정되�
 msgid "(excluded for this customer)"
 msgstr "(이 고객에게는 제외됨)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 행은 이 회사 외부의 데이터에 연결되어 있어서 현재 데이터의 안전한 사본을 만들 수 없습니다.} other {# 행은 이 회사 외부의 데이터에 연결되어 있어서 현재 데이터의 안전한 사본을 만들 수 없습니다.}}"
@@ -89,6 +92,11 @@ msgstr "{0}이(가) 삭제되었습니다"
 msgid "{0} draft journal entries"
 msgstr "{0}개의 초안 분개"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0}개의 작업 지시 생성됨"
@@ -96,6 +104,14 @@ msgstr "{0}개의 작업 지시 생성됨"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "매핑할 라인 {0}개"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} 행"
 msgid "{0} suppliers with a balance"
 msgstr "잔액이 있는 공급업체 {0}곳"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}개의 미검사 항목이 가용으로 릴리스됩니다. 검사 합격 항목은 가용으로 유지되고 검사 불합격 항목은 거부됨으로 유지됩니다."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "모든 위치"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "선택한 그룹의 모든 구성원과 선택한 개인이 요청을 승인할 수 있습니다"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "모든 행을 가져왔습니다 — {inserted}개 추가, {updated}개 업데이트."
 
@@ -2431,6 +2459,9 @@ msgstr "첨부 파일"
 msgid "Attempts"
 msgstr "시도"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "속성"
 
@@ -2829,6 +2860,9 @@ msgstr "역할 기반 교육 자료 제작"
 
 msgid "Build tailored, role-based training materials"
 msgstr "맞춤형 역할 기반 교육 자료 제작"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "독립적인 방법으로 구성되고 원가가 산정됨"
@@ -3232,6 +3266,9 @@ msgstr "채팅"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "기간 종료 기준 음수 현재고 수량이 있는 품목에 대해 품목 장부를 확인하십시오 — 일반적으로 입고 누락 또는 순서 없는 전기로 인해 재고 관리 가치 및 매출원가가 왜곡됩니다. 검토 후 완료로 표시하거나 사유를 포함하여 건너뜁니다."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "이메일을 확인하세요"
@@ -5417,6 +5454,9 @@ msgstr "상세"
 msgid "Details"
 msgstr "상세 정보"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "개발자"
 
@@ -6571,6 +6611,9 @@ msgstr "면세 증명서"
 msgid "Exemption Reason"
 msgstr "면세 사유"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "기존 매핑입니다. 다시 매핑하려면 다른 제공자 옵션을 선택하세요."
 
@@ -7328,6 +7371,15 @@ msgstr "형식"
 msgid "Forward deployed engineer"
 msgstr "현장 배치 엔지니어"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "파운데이션"
 
@@ -7712,6 +7764,9 @@ msgstr "그룹 이름"
 msgid "Groups"
 msgstr "그룹"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "가이드형"
 
@@ -7892,6 +7947,9 @@ msgstr "이 계측기를 재교정해야 하는 빈도입니다. 마지막 교�
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "이 유지보수가 반복되는 빈도입니다 — 매일, 매주, 매월, 순환 실사 시; 매일을 선택하면 요일 선택 옵션이 표시되고 나머지는 더 간단한 간격 계산을 사용합니다."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "스케줄러가 용량을 배분할 때 작업 지시의 순위 — ASAP가 먼저 요청되고, 그 다음 고정 기한, 유연 기한, 기한 없음 순입니다. 순위 신호일 뿐이며, 어떤 기한 유형도 배치를 차단하거나 제한하지 않습니다."
 
@@ -8012,6 +8070,9 @@ msgstr "일정에서 벗어난 경우"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "부품 번호를 변경하려면 취소를 클릭하고 변환 전에 각 라인의 부품을 수동으로 할당하세요."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II(일반 기본값)"
 
@@ -8033,11 +8094,20 @@ msgstr "실행 허브"
 msgid "Implementation Lead"
 msgstr "실행 리드"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "{label} CSV 가져오기"
 
 msgid "Import results"
 msgstr "가져오기 결과"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "BOM 가져오기"
@@ -8117,6 +8187,9 @@ msgstr "출하에 여분 부품 포함"
 
 msgid "Include Inactive"
 msgstr "비활성 포함"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "포함됨"
@@ -8897,6 +8970,9 @@ msgstr "다음 리비전을 자동으로 사용하려면 공백으로 두세요"
 msgid "Leave empty for exact match"
 msgstr "정확히 일치시키려면 비워두세요"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "이 페이지 나가기"
 
@@ -8974,6 +9050,9 @@ msgstr "조명 꺼짐 (24/7)"
 
 msgid "Likelihood"
 msgstr "발생 가능성"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "행 설명 (선택 사항)"
@@ -9901,6 +9980,9 @@ msgstr "필요한 인력은 그 날의 작업 시간을 {personDayHours}h로 나
 msgid "Needs a Business or Partner plan."
 msgstr "Business 또는 Partner 요금제가 필요합니다."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "수정 필요"
 
@@ -10459,6 +10541,9 @@ msgstr "그룹화된 알림이 없습니다"
 
 msgid "No groups assigned"
 msgstr "배정된 그룹이 없습니다"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "이미지 없음"
@@ -11565,6 +11650,9 @@ msgstr "자격 증명 공급자가 메타데이터 URL을 게시하지 않는 �
 msgid "Path"
 msgstr "경로"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "급여율"
 
@@ -11794,6 +11882,9 @@ msgstr "{0} 고정"
 
 msgid "Pinned"
 msgstr "고정됨"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "계획"
@@ -13575,6 +13666,9 @@ msgstr "행"
 msgid "Rows left out of this backup"
 msgstr "이 백업에서 제외된 행"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "규칙"
 
@@ -13791,6 +13885,10 @@ msgstr "영업, 견적 및 주문형 구성"
 
 msgid "Salesperson"
 msgstr "영업사원"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "장부와 동일"
@@ -14815,6 +14913,9 @@ msgstr "회사 휴일에는 예정된 유지보수를 건너뜁니다"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "릴리즈되었지만 시작되지 않은 상태를 건너뜁니다 — 스캔 즉시 작업이 시작됩니다."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "건너뜀"
@@ -16217,6 +16318,9 @@ msgstr "현금 할인 비율입니다. 할인이 없으면 0을 사용하세요.
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "이 유형의 신규 직원이 자동으로 받는 권한 세트입니다. 여기서 수정하면 이후 신규 채용자에게만 템플릿이 적용되며, 기존 직원은 명시적으로 일괄 업데이트하지 않는 한 현재 권한을 유지합니다."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "작업과 재고가 위치하는 공장, 창고, 사업장"
 
@@ -17259,8 +17363,14 @@ msgstr "미배정"
 msgid "Unballoon"
 msgstr "벌룬 해제"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "미실사 라인은 전기 시 변경되지 않고 그대로 유지되며 0으로 처리되지 않습니다."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "소요량 기반 재주문에서는 재주문 수량을 계산할 때 이 기간 내의 소요량을 합산합니다."
@@ -17600,6 +17710,12 @@ msgstr "다른 이메일 사용"
 
 msgid "Use metric system for default material dimensions."
 msgstr "기본 자재 치수에 미터법을 사용합니다."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "사용처"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount}개 부품이 건너뜀 — 만들 것이 없음"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel}은(는) 리비전 {0}으로 편집하기 위해 다시 열립니다. 이미 공급업체로 전송된 문서는 리비전을 완료하고 다시 전송할 때까지 변경되지 않습니다."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# 행을 영구 삭제하시겠습니까?} other {# 행을 영구 삭제하시겠습니까?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "{label} CSV 가져오기"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "가져오기 결과"
 
@@ -8187,9 +8198,6 @@ msgstr "출하에 여분 부품 포함"
 
 msgid "Include Inactive"
 msgstr "비활성 포함"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "포함됨"
@@ -8792,6 +8800,12 @@ msgstr "칸반"
 msgid "Keep"
 msgstr "유지"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "현재 값 유지"
 
@@ -8809,6 +8823,9 @@ msgstr "열린 상태 유지"
 
 msgid "Keep picking"
 msgstr "피킹 유지"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "주문, 견적 및 설정을 이중 확인으로 보호합니다"
@@ -9548,6 +9565,9 @@ msgstr "일치함"
 
 msgid "matches"
 msgstr "일치"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "일치하는 쌍"
@@ -13412,6 +13432,9 @@ msgstr "잔존가액 %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "NCR을 완료하기 전에 이를 해결합니다: 모든 행에는 대기 중이 아닌 처분 결정이 있어야 하고, 연결된 엔티티 수량이 행 수량과 일치해야 합니다."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "확정 가격"
 
@@ -13886,8 +13909,16 @@ msgstr "영업, 견적 및 주문형 구성"
 msgid "Salesperson"
 msgstr "영업사원"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "이동 도착지"
 msgid "Trash"
 msgstr "휴지통"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "시산표"
 
@@ -17598,6 +17625,9 @@ msgstr "비밀번호 업데이트"
 msgid "Update Permissions"
 msgstr "권한 업데이트"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "수량 업데이트"
 
@@ -17714,6 +17744,9 @@ msgstr "다른 이메일 사용"
 
 msgid "Use metric system for default material dimensions."
 msgstr "기본 자재 치수에 미터법을 사용합니다."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -17270,6 +17270,10 @@ msgstr "이동 도착지"
 msgid "Trash"
 msgstr "휴지통"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "시산표"
 

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -51,6 +51,27 @@ msgstr "(이 고객에게는 제외됨)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 행은 이 회사 외부의 데이터에 연결되어 있어서 현재 데이터의 안전한 사본을 만들 수 없습니다.} other {# 행은 이 회사 외부의 데이터에 연결되어 있어서 현재 데이터의 안전한 사본을 만들 수 없습니다.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# 행은 이 회사 외부의 데이터에 연결되어
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# 행은 이 회사 외부의 데이터에 연결되어 있어서 백업할 수 없습니다. 이를 건너뛰면 다른 모든 것이 백업됩니다.} other {# 행은 이 회사 외부의 데이터에 연결되어 있어서 백업할 수 없습니다. 이를 건너뛰면 다른 모든 것이 백업됩니다.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {이 품목은 1개의 미결 변경 통지에 포함되어 있습니다} other {이 품목은 # 개의 미결 변경 통지에 포함되어 있습니다}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {이 품목은 1개의 미결 변경 통지에 포함되
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} 계정"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0}이(가) 삭제되었습니다"
 msgid "{0} draft journal entries"
 msgstr "{0}개의 초안 분개"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0}개의 작업 지시 생성됨"
@@ -111,14 +135,6 @@ msgstr "매핑할 라인 {0}개"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} 등록됨"
 msgid "{0} rows"
 msgstr "{0} 행"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "잔액이 있는 공급업체 {0}곳"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}개의 미검사 항목이 가용으로 릴리스됩니다. 검사 합격 항목은 가용으로 유지되고 검사 불합격 항목은 거부됨으로 유지됩니다."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done}개 중 {total}개 단계 완료"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 행 제외됨} other {# 행 제외됨}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount}개 추가: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}개 추가, {updated}개 업데이트, {0}개 수정 필요, {1}개 건너뜀."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount}개 부품이 건너뜀 — 만들 것이 없음"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel}은(는) 리비전 {0}으로 편집하기 위해 다시 열립니다. 이미 공급업체로 전송된 문서는 리비전을 완료하고 다시 전송할 때까지 변경되지 않습니다."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# 단위} other {# 단위}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "고객 목록, 고객 양식, 드롭다운에 읽기 쉬운 고객 ID �
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "공급업체 목록, 공급업체 양식, 드롭다운에 읽기 쉬운 공급업체 ID 열을 표시합니다. 어느 쪽이든 공급업체는 내부적으로 동일하게 식별됩니다."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "고객 ID 표시"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(이 고객에게는 제외됨)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(그룹)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, other {기존 계정에 병합된 계정 #개}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, other {생성할 계정 #개}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, other {업데이트할 계정 #개}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, other {변경 없는 계정 #개}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "생성할 {0, plural, other {그룹 #개}} 및 {1, plural, other {계정 #개}}"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# 행은 이 회사 외부의 데이터에 연결되어
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, other {확인이 필요한 행 #개}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, other {건너뛴 행 #개}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, other {전체 #개 행 표시}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "매핑할 라인 {0}개"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "일치하는 계정 {0}개: {fileCount}개는 파일의 번호를 사용하고 {keepCount}개는 Carbon의 번호를 유지합니다."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 행 제외됨} other {# 행 제외됨}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, other {일치하는 계정 #개가 파일의 번호를 사용합니다.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{count}개 중 {from}–{to}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted}개 추가, {updated}개 업데이트, {0}개 수정 필요, {1}개 건너뜀."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, other {일치하는 계정 #개가 Carbon의 번호를 유지합니다.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 줄} other {# 줄}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel}은(는) 리비전 {0}으로 편집하기 위해 다시 열립니다. 이미 공급업체로 전송된 문서는 리비전을 완료하고 다시 전송할 때까지 변경되지 않습니다."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, other {아직 계획에 반영되지 않은 결정 #개}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# 행을 영구 삭제하시겠습니까?} other {# 행을 영구 삭제하시겠습니까?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "미실사 라인 {uncounted}개"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, other {계정 #개가 이미 다른 번호로 Carbon에 존재합니다.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}개는 일정을 짤 수 없습니다"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "시도"
 
 msgid "Attention"
-msgstr ""
+msgstr "확인 필요"
 
 msgid "Attribute"
 msgstr "속성"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "기간 종료 기준 음수 현재고 수량이 있는 품목에 대해 품목 장부를 확인하십시오 — 일반적으로 입고 누락 또는 순서 없는 전기로 인해 재고 관리 가치 및 매출원가가 왜곡됩니다. 검토 후 완료로 표시하거나 사유를 포함하여 건너뜁니다."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "가져오기 전에 생성 및 변경될 내용을 확인하세요. 확인하기 전까지는 아무것도 기록되지 않습니다."
 
 msgid "Check your email"
 msgstr "이메일을 확인하세요"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "이 고객의 Stripe 확인 중…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "파일을 계정과목표와 대조하는 중…"
 
 msgid "Checkpoint ·"
 msgstr "체크포인트 ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "상세 정보"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "파일에서 감지"
 
 msgid "Developer"
 msgstr "개발자"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "면세 사유"
 
 msgid "Existing"
-msgstr ""
+msgstr "기존"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "기존 매핑입니다. 다시 매핑하려면 다른 제공자 옵션을 선택하세요."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "그룹"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "그룹은 파일에서 가져옵니다. Carbon의 그룹과 이름이 같은 최상위 그룹은 해당 그룹에 병합됩니다."
 
 msgid "Guided"
 msgstr "가이드형"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "검토 단계 전까지 시스템 수량 숨기기"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "전체 목록 숨기기"
 
 msgid "Hide, pin and reorder columns"
 msgstr "열 숨기기, 고정, 순서 변경"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "계층 구조는 파일의 Begin-Total / End-Total 행에서 가져왔습니다."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "계층 구조는 파일의 상위 계정 열에서 가져왔습니다."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "계층 구조는 계정 이름의 경로에서 가져왔습니다."
 
 msgid "High"
 msgstr "높음"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "이 유지보수가 반복되는 빈도입니다 — 매일, 매주, 매월, 순환 실사 시; 매일을 선택하면 요일 선택 옵션이 표시되고 나머지는 더 간단한 간격 계산을 사용합니다."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "계정을 어떻게 구성할까요?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "스케줄러가 용량을 배분할 때 작업 지시의 순위 — ASAP가 먼저 요청되고, 그 다음 고정 기한, 유연 기한, 기한 없음 순입니다. 순위 신호일 뿐이며, 어떤 기한 유형도 배치를 차단하거나 제한하지 않습니다."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "부품 번호를 변경하려면 취소를 클릭하고 변환 전에 각 라인의 부품을 수동으로 할당하세요."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "파일의 그룹을 무시하고 각 계정을 계정 유형에 맞는 Carbon 그룹 아래에 배치합니다."
 
 msgid "II (normal default)"
 msgstr "II(일반 기본값)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "실행 리드"
 
 msgid "Import"
-msgstr ""
+msgstr "가져오기"
 
 msgid "Import {label} CSV"
 msgstr "{label} CSV 가져오기"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "“{0}”(으)로 가져오기"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "{0}(으)로 가져오기"
 
 msgid "Import results"
 msgstr "가져오기 결과"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "다른 이름으로 가져오기"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "다른 번호로 가져오기"
 
 msgid "Import your BOM"
 msgstr "BOM 가져오기"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "유지"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Carbon의 번호 유지"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Carbon의 번호 유지"
 
 msgid "Keep Current"
 msgstr "현재 값 유지"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "정확히 일치시키려면 비워두세요"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "이 계정을 그대로 두기"
 
 msgid "Leave this page"
 msgstr "이 페이지 나가기"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "발생 가능성"
 
 msgid "Line"
-msgstr ""
+msgstr "행"
 
 msgid "Line description (optional)"
 msgstr "행 설명 (선택 사항)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Business 또는 Partner 요금제가 필요합니다."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "확인 필요"
 
 msgid "Needs fixing"
 msgstr "수정 필요"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "배정된 그룹이 없습니다"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "파일에 계층 구조가 없습니다. 계정은 계정 유형에 따라 Carbon의 기존 그룹 아래에 배치됩니다."
 
 msgid "No image"
 msgstr "이미지 없음"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "예정된 초과근무가 없습니다"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "파일에서 상위 계정 열, 행 종류 또는 이름의 경로를 찾을 수 없습니다."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "아직 기록된 상위 소스가 없습니다. 계획 페이지에서 재계산을 클릭하여 귀속 정보를 새로고침하세요."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "일정이 없습니다 — 아래에서 스테이션을 추가하세요."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "가져올 항목이 없습니다."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "아직 없습니다. 단계는 구성된 후에만 값을 제공합니다."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "경로"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "계정 이름의 경로 구분 기호"
 
 msgid "Pay Rate"
 msgstr "급여율"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "고정됨"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Carbon의 기존 그룹 아래에 계정 배치"
 
 msgid "Plan"
 msgstr "계획"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "NCR을 완료하기 전에 이를 해결합니다: 모든 행에는 대기 중이 아닌 처분 결정이 있어야 하고, 연결된 엔티티 수량이 행 수량과 일치해야 합니다."
 
 msgid "Resolved"
-msgstr ""
+msgstr "해결됨"
 
 msgid "Resolved Price"
 msgstr "확정 가격"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "영업사원"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "{target}와(과) 동일"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "{target}와(과) 동일 (해당 번호 유지)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "{target}와(과) 동일 (이 파일의 번호 사용)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "{target}와(과) 동일, 해당 번호 유지"
 
 msgid "Same as Book"
 msgstr "장부와 동일"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "릴리즈되었지만 시작되지 않은 상태를 건너뜁니다 — 스캔 즉시 작업이 시작됩니다."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "이 행 건너뛰기"
 
 msgid "Skipped"
 msgstr "건너뜀"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "출하 라인 분할"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "구분 기호로 계정 이름을 분할합니다(예: 상위:하위)."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "이 유형의 신규 직원이 자동으로 받는 권한 세트입니다. 여기서 수정하면 이후 신규 채용자에게만 템플릿이 적용되며, 기존 직원은 명시적으로 일괄 업데이트하지 않는 한 현재 권한을 유지합니다."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "계획을 만들 수 없습니다"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "작업과 재고가 위치하는 공장, 창고, 사업장"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "이 전표들은 아직 초안 상태이므로 이 기간에 차변 및 대변이 원장에 없습니다. 각 전표를 전기하거나 이후 미결 기간으로 다시 날짜를 지정하십시오."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "이 행들은 해결되기 전까지 가져오지 않습니다. 나머지는 확인 시 가져옵니다."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "이 행들은 이 회사 외부의 데이터와 연결되어 있으므로 현재 데이터의 안전한 사본을 만들 수 없습니다. 이들을 삭제하면 되돌릴 수 없습니다. 이들이 이 그룹의 다른 회사와 공유되는 경우, 아무것도 삭제되지 않고 복원이 시작되지 않습니다."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "벌룬 해제"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "변경 없음"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "미실사 라인은 전기 시 변경되지 않고 그대로 유지되며 0으로 처리되지 않습니다."
 
 msgid "Under"
-msgstr ""
+msgstr "상위"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "소요량 기반 재주문에서는 재주문 수량을 계산할 때 이 기간 내의 소요량을 합산합니다."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "권한 업데이트"
 
 msgid "Update plan"
-msgstr ""
+msgstr "계획 업데이트"
 
 msgid "Update Quantity"
 msgstr "수량 업데이트"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "스캔 기반 보충을 위한 칸반 정보를 업데이트합니다."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "결과를 보려면 계획을 업데이트하세요. 가져오기를 확인하면 모두 적용됩니다."
 
 msgid "Update the purchase order quantities"
 msgstr "발주서 수량 업데이트"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "성공적으로 업데이트되었습니다"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "계획을 업데이트하는 중…"
 
 msgid "Upgrade"
 msgstr "업그레이드"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "기본 자재 치수에 미터법을 사용합니다."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "파일의 번호 사용"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "파일에 상위 계정 열, 이름 경로 또는 합계 행이 있으면 사용합니다."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "파일의 계층 구조 사용"
 
 msgid "Used In"
 msgstr "사용처"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Przenieś do"
 msgid "Trash"
 msgstr "Kosz"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Bilans próbny"
 

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} części pominięto — nic do zrobienia"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} zostanie ponownie otwarty do edycji jako rewizja {0}. Dokument już wysłany do dostawcy pozostaje niezmieniony, aż go sfinalizujesz i ponownie wyślesz zamówienie."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Trwale usuń # wiersz?} other {Trwale usuń # wierszy?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importuj {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Wyniki Importu"
 
@@ -8187,9 +8198,6 @@ msgstr "Dołącz dodatkowe części do wysyłki"
 
 msgid "Include Inactive"
 msgstr "Uwzględnij nieaktywne"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Uwzględnione"
@@ -8792,6 +8800,12 @@ msgstr "Kanbany"
 msgid "Keep"
 msgstr "Zachowaj"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Zachowaj bieżące"
 
@@ -8809,6 +8823,9 @@ msgstr "Utrzymaj otwarte"
 
 msgid "Keep picking"
 msgstr "Zachowaj kompletację"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Utrzymuje zamówienia, oferty i ustawienia za drugą weryfikacją"
@@ -9548,6 +9565,9 @@ msgstr "Dopasowane"
 
 msgid "matches"
 msgstr "pasuje do"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pary dopasowań"
@@ -13412,6 +13432,9 @@ msgstr "Wartość Rezydualna %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Rozwiąż to przed ukończeniem NCR: każdy wiersz musi mieć dyspozycję inną niż Oczekująca, a ilości połączonych jednostek muszą odpowiadać ilości wiersza."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Cena rozliczona"
 
@@ -13886,8 +13909,16 @@ msgstr "Sprzedaż, wycena i konfiguracja na zamówienie"
 msgid "Salesperson"
 msgstr "Sprzedawca"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Przenieś do"
 msgid "Trash"
 msgstr "Kosz"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Bilans próbny"
 
@@ -17598,6 +17625,9 @@ msgstr "Zaktualizuj hasło"
 msgid "Update Permissions"
 msgstr "Aktualizuj Uprawnienia"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Aktualizuj ilość"
 
@@ -17714,6 +17744,9 @@ msgstr "Użyj innego adresu e-mail"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Użyj systemu metrycznego dla domyślnych wymiarów materiału."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Ten artykuł jest na 1 otwartym zawiadomieniu o zmianie
 msgid "{0} accounts"
 msgstr "{0} konta"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} temu"
@@ -92,9 +96,9 @@ msgstr "{0} usunięty pomyślnie"
 msgid "{0} draft journal entries"
 msgstr "{0} roboczych zapisów księgowych"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} zleceń produkcyjnych utworzonych"
 msgid "{0} lines to map"
 msgstr "{0} linii do mapowania"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} zarejestrowane"
 msgid "{0} rows"
 msgstr "{0} wierszy"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} dostawców z saldem"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nieprzetestowane jednostki zostaną zwolnione do Dostępne. Przebadane pozytywne pozostają Dostępne, a przebadane negatywne pozostają Odrzucone."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} z {total} faz ukończonych"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# wiersz wyłączony} other {# wierszy wyłączonych}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} z {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} więcej: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} wstawiono, {updated} zaktualizowano, {0} wymagają naprawy, {1} pominięte."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# linia} other {# linii}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} części pominięto — nic do zrobienia"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} zostanie ponownie otwarty do edycji jako rewizja {0}. Dokument już wysłany do dostawcy pozostaje niezmieniony, aż go sfinalizujesz i ponownie wyślesz zamówienie."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# jednostka} other {# jednostek}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "Nie można zaplanować {unschedulableCount}"
@@ -1496,9 +1516,6 @@ msgstr "Wszystkie lokalizacje"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Wszyscy członkowie wybranych grup i wybrane osoby będą mogły zatwierdzać żądania"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Wszystkie wiersze zaimportowane — {inserted} wstawiono, {updated} zaktualizowano."
@@ -2864,9 +2881,6 @@ msgstr "Twórz materiały szkoleniowe oparte na rolach"
 msgid "Build tailored, role-based training materials"
 msgstr "Twórz dostosowane materiały szkoleniowe oparte na rolach"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Zbudowany i wyceniony jako własna metoda"
 
@@ -3278,6 +3292,9 @@ msgstr "Sprawdź swoją pocztę"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Sprawdzanie Stripe dla tego klienta…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Punkt kontrolny ·"
@@ -7374,15 +7391,6 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Inżynier wdrażający"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Fundament"
 
@@ -7809,8 +7817,20 @@ msgstr "Ukryj surowe"
 msgid "Hide system quantities until the review step"
 msgstr "Ukryj ilości systemowe do kroku przeglądu"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ukryj, przypnij i zmień kolejność kolumn"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Wysoki"
@@ -8824,9 +8844,6 @@ msgstr "Utrzymaj otwarte"
 msgid "Keep picking"
 msgstr "Zachowaj kompletację"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Utrzymuje zamówienia, oferty i ustawienia za drugą weryfikacją"
 
@@ -9565,9 +9582,6 @@ msgstr "Dopasowane"
 
 msgid "matches"
 msgstr "pasuje do"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pary dopasowań"
@@ -10562,7 +10576,7 @@ msgstr "Brak zgrupowanych powiadomień"
 msgid "No groups assigned"
 msgstr "Brak przypisanych grup"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Brak zaległych szkoleń"
 
 msgid "No overtime scheduled"
 msgstr "Brak zaplanowanych nadgodzin"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Brak zarejestrowanych źródeł nadrzędnych. Kliknij Przelicz na stronie planowania, aby odświeżyć przypisanie."
@@ -10946,6 +10963,9 @@ msgstr "Nic w archiwum"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Nic nie zaplanowano — dodaj stanowisko poniżej."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Nic jeszcze. Krok oferuje wartości dopiero po skonfigurowaniu."
@@ -13689,9 +13709,6 @@ msgstr "wiersze"
 msgid "Rows left out of this backup"
 msgstr "Wiersze pominięte w tej kopii zapasowej"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Reguła"
 
@@ -14815,6 +14832,10 @@ msgstr "Pokaż kolumnę czytelnego identyfikatora klienta na liście klientów, 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Pokaż kolumnę czytelnego identyfikatora dostawcy na liście dostawców, formularzach dostawcy i listach rozwijanych. Dostawcy są nadal identyfikowani wewnętrznie w każdym przypadku."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Pokaż identyfikatory klientów"
 
@@ -15091,6 +15112,9 @@ msgstr "Podziel linię paragonu"
 
 msgid "Split shipment line"
 msgstr "Podziel pozycję wysyłki"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Te zlecenia produkcyjne mają operacje przypisane do tego stanowiska rob
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Te dowody księgowe są wciąż w wersji roboczej, dlatego ich wpisy Winien i Ma nie znajdują się w księdze dla tego okresu. Zaksięguj każdy z nich lub przesyć go do późniejszego otwartego okresu."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Te wiersze łączą się z danymi spoza tej firmy, dlatego nie można wykonać bezpiecznej kopii bieżących danych. Usunięcie ich nie może być cofnięte. Jeśli okaże się, że są współdzielone z innymi firmami w tej grupie, nic nie zostanie usunięte i przywracanie nie zostanie uruchomione."
 
@@ -17640,6 +17667,9 @@ msgstr "Aktualizuj ilości dokumentów źródłowych"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Zaktualizuj informacje kanban dla uzupełniania opartego na skanowaniu."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Zaktualizuj ilości zamówienia zakupu"
 
@@ -17657,6 +17687,9 @@ msgstr "Zaktualizowano przez"
 
 msgid "Updated successfully"
 msgstr "Pomyślnie zaktualizowano"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Uaktualnij"
@@ -17745,7 +17778,7 @@ msgstr "Użyj innego adresu e-mail"
 msgid "Use metric system for default material dimensions."
 msgstr "Użyj systemu metrycznego dla domyślnych wymiarów materiału."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} zleceń produkcyjnych utworzonych"
 msgid "{0} lines to map"
 msgstr "{0} linii do mapowania"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} pasujących kont: {fileCount} przyjmuje numery z pliku, {keepCount} zachowuje numery z Carbon."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Dopasowane"
 
 msgid "matches"
 msgstr "pasuje do"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Pasujące konta: {0}. Numery z pliku: {fileCount}, numery z Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Pary dopasowań"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -48,6 +48,9 @@ msgstr "„{taskName}\" jest gotowe — wszystkie {0} jego elementów Setup Map 
 msgid "(excluded for this customer)"
 msgstr "(wykluczone dla tego klienta)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# wiersz łączy się z danymi spoza tej firmy, dlatego nie można utworzyć kopii bezpieczeństwa bieżących danych.} other {# wierszy łączy się z danymi spoza tej firmy, dlatego nie można utworzyć kopii bezpieczeństwa bieżących danych.}}"
@@ -89,6 +92,11 @@ msgstr "{0} usunięty pomyślnie"
 msgid "{0} draft journal entries"
 msgstr "{0} roboczych zapisów księgowych"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} zleceń produkcyjnych utworzonych"
@@ -96,6 +104,14 @@ msgstr "{0} zleceń produkcyjnych utworzonych"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} linii do mapowania"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} wierszy"
 msgid "{0} suppliers with a balance"
 msgstr "{0} dostawców z saldem"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nieprzetestowane jednostki zostaną zwolnione do Dostępne. Przebadane pozytywne pozostają Dostępne, a przebadane negatywne pozostają Odrzucone."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Wszystkie lokalizacje"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Wszyscy członkowie wybranych grup i wybrane osoby będą mogły zatwierdzać żądania"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Wszystkie wiersze zaimportowane — {inserted} wstawiono, {updated} zaktualizowano."
 
@@ -2431,6 +2459,9 @@ msgstr "Załączniki"
 msgid "Attempts"
 msgstr "Próby"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Atrybut"
 
@@ -2829,6 +2860,9 @@ msgstr "Twórz materiały szkoleniowe oparte na rolach"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Twórz dostosowane materiały szkoleniowe oparte na rolach"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Zbudowany i wyceniony jako własna metoda"
@@ -3232,6 +3266,9 @@ msgstr "Czat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Sprawdź księgę artykułów pod kątem artykułów z ujemną ilością dostępną na koniec okresu — zwykle brakuje przyjęcia lub zaksięgowania poza kolejnością, które zniekształca wartość zapasów i koszt własny sprzedaży. Oznacz jako gotowe po przejrzeniu lub pomiń z uzasadnieniem."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Sprawdź swoją pocztę"
@@ -5417,6 +5454,9 @@ msgstr "Szczegóły"
 msgid "Details"
 msgstr "Szczegóły"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Deweloper"
 
@@ -6571,6 +6611,9 @@ msgstr "Certifikat Zwolnienia"
 msgid "Exemption Reason"
 msgstr "Powód Zwolnienia"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Istniejące mapowania. Wybierz inną opcję dostawcy, aby przezmapować."
 
@@ -7328,6 +7371,15 @@ msgstr "Format"
 msgid "Forward deployed engineer"
 msgstr "Inżynier wdrażający"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Fundament"
 
@@ -7712,6 +7764,9 @@ msgstr "Nazwa grupy"
 msgid "Groups"
 msgstr "Grupy"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Wspomagane"
 
@@ -7892,6 +7947,9 @@ msgstr "Jak często ten przyrząd pomiarowy musi być wzorcowany; połączone z 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Jak często to utrzymanie ruchu się powtarza — Codziennie, Co tydzień, Co miesiąc, Podczas inwentaryzacji ciągłej; Opcja Codziennie ujawnia selektor dnia tygodnia, inne używają prostszej arytmetyki interwałów."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Jak zlecenie produkcyjne jest klasyfikowane, gdy harmonogram przydziela pojemność — ASAP otrzymuje pierwszeństwo, następnie Hard Deadline, Soft Deadline i brak terminu ostatni. Sygnał rankingu tylko; żaden typ terminu nie blokuje ani nie uniemożliwia umieszczenia."
 
@@ -8012,6 +8070,9 @@ msgstr "Jeśli coś nie przebiega prawidłowo"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Jeśli chcesz zmienić numery części, kliknij Anuluj i ręcznie przypisz części dla każdej pozycji wiersza przed konwersją."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normalne domyślne)"
 
@@ -8033,11 +8094,20 @@ msgstr "Hub Wdrażania"
 msgid "Implementation Lead"
 msgstr "Lider Wdrożenia"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importuj {label} CSV"
 
 msgid "Import results"
 msgstr "Wyniki Importu"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Zaimportuj swoją BOM"
@@ -8117,6 +8187,9 @@ msgstr "Dołącz dodatkowe części do wysyłki"
 
 msgid "Include Inactive"
 msgstr "Uwzględnij nieaktywne"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Uwzględnione"
@@ -8897,6 +8970,9 @@ msgstr "Pozostaw puste, aby automatycznie użyć następnej rewizji"
 msgid "Leave empty for exact match"
 msgstr "Pozostaw puste dla dokładnego dopasowania"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Opuść tę stronę"
 
@@ -8974,6 +9050,9 @@ msgstr "Bez oświetlenia (24/7)"
 
 msgid "Likelihood"
 msgstr "Prawdopodobieństwo"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Opis linii (opcjonalnie)"
@@ -9901,6 +9980,9 @@ msgstr "Potrzebne = godziny pracy przypadające tego dnia podzielone przez {pers
 msgid "Needs a Business or Partner plan."
 msgstr "Wymaga planu Business lub Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Wymaga naprawy"
 
@@ -10459,6 +10541,9 @@ msgstr "Brak zgrupowanych powiadomień"
 
 msgid "No groups assigned"
 msgstr "Brak przypisanych grup"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Brak obrazu"
@@ -11565,6 +11650,9 @@ msgstr "Wklej kod XML metadanych, jeśli Twój dostawca tożsamości nie publiku
 msgid "Path"
 msgstr "Ścieżka"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Kurs płatności"
 
@@ -11794,6 +11882,9 @@ msgstr "Przypnij {0}"
 
 msgid "Pinned"
 msgstr "Przypięte"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "wiersze"
 msgid "Rows left out of this backup"
 msgstr "Wiersze pominięte w tej kopii zapasowej"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Reguła"
 
@@ -13791,6 +13885,10 @@ msgstr "Sprzedaż, wycena i konfiguracja na zamówienie"
 
 msgid "Salesperson"
 msgstr "Sprzedawca"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Taki sam jak w księdze"
@@ -14815,6 +14913,9 @@ msgstr "Pomiń zaplanowane utrzymanie ruchu w święta firmy"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Pomiń stan zwolniony, ale nie uruchomiony - zadanie rozpoczyna się natychmiast po skanowaniu."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Pominięte"
@@ -16217,6 +16318,9 @@ msgstr "Procent rabatu gotówkowego. Użyj 0, aby nie udzielać rabatu."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Zestaw uprawnień, które automatycznie otrzymują nowi pracownicy tego typu; edycja tutaj zmienia szablon tylko dla przyszłych wynajęć - pracownicy istniejący zachowują to, co mają, chyba że zostaną jawnie zaktualizowani zbiorczo."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Fabryki, magazyny i obiekty, w których znajduje się Twoja praca i zapasy"
 
@@ -17259,8 +17363,14 @@ msgstr "Nieprzydzielone"
 msgid "Unballoon"
 msgstr "Usuń balon"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Niezliczone linie pozostają niezmienione podczas wysyłki — nie są zerowane."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "W zamawianiu na podstawie zapotrzebowania planowanie sumuje zapotrzebowanie w ramach tego okna przesuwającego się w celu obliczenia ilości uzupełnienia zapasu."
@@ -17600,6 +17710,12 @@ msgstr "Użyj innego adresu e-mail"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Użyj systemu metrycznego dla domyślnych wymiarów materiału."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Używane w"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -51,6 +51,27 @@ msgstr "(wykluczone dla tego klienta)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# wiersz łączy się z danymi spoza tej firmy, dlatego nie można utworzyć kopii bezpieczeństwa bieżących danych.} other {# wierszy łączy się z danymi spoza tej firmy, dlatego nie można utworzyć kopii bezpieczeństwa bieżących danych.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# wiersz łączy się z danymi spoza tej firmy, dlatego
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# wiersz łączy się z danymi spoza tej firmy, dlatego nie można go zabezpieczyć. Pominięcie go pozwala na zabezpieczenie wszystkiego innego.} other {# wierszy łączy się z danymi spoza tej firmy, dlatego nie można ich zabezpieczyć. Pominięcie ich pozwala na zabezpieczenie wszystkiego innego.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Ten artykuł jest na 1 otwartym zawiadomieniu o zmianie} other {Ten artykuł jest na # otwartych zawiadomieniach o zmianie}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Ten artykuł jest na 1 otwartym zawiadomieniu o zmianie
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} konta"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} usunięty pomyślnie"
 msgid "{0} draft journal entries"
 msgstr "{0} roboczych zapisów księgowych"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} zleceń produkcyjnych utworzonych"
@@ -111,14 +135,6 @@ msgstr "{0} linii do mapowania"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} zarejestrowane"
 msgid "{0} rows"
 msgstr "{0} wierszy"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} dostawców z saldem"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} nieprzetestowane jednostki zostaną zwolnione do Dostępne. Przebadane pozytywne pozostają Dostępne, a przebadane negatywne pozostają Odrzucone."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} z {total} faz ukończonych"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# wiersz wyłączony} other {# wierszy wyłączonych}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} więcej: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} wstawiono, {updated} zaktualizowano, {0} wymagają naprawy, {1} pominięte."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} części pominięto — nic do zrobienia"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} zostanie ponownie otwarty do edycji jako rewizja {0}. Dokument już wysłany do dostawcy pozostaje niezmieniony, aż go sfinalizujesz i ponownie wyślesz zamówienie."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# jednostka} other {# jednostek}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Pokaż kolumnę czytelnego identyfikatora klienta na liście klientów, 
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Pokaż kolumnę czytelnego identyfikatora dostawcy na liście dostawców, formularzach dostawcy i listach rozwijanych. Dostawcy są nadal identyfikowani wewnętrznie w każdym przypadku."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Pokaż identyfikatory klientów"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(wykluczone dla tego klienta)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(grupa)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# konto scalone z istniejącym} few {# konta scalone z istniejącymi} many {# kont scalonych z istniejącymi} other {# konta scalone z istniejącymi}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# konto do utworzenia} few {# konta do utworzenia} many {# kont do utworzenia} other {# konta do utworzenia}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# konto do aktualizacji} few {# konta do aktualizacji} many {# kont do aktualizacji} other {# konta do aktualizacji}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# konto bez zmian} few {# konta bez zmian} many {# kont bez zmian} other {# konta bez zmian}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# grupa} few {# grupy} many {# grup} other {# grupy}} i {1, plural, one {# konto} few {# konta} many {# kont} other {# konta}} do utworzenia"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# wiersz łączy się z danymi spoza tej firmy, dlatego
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# wiersz wymaga uwagi} few {# wiersze wymagają uwagi} many {# wierszy wymaga uwagi} other {# wiersza wymaga uwagi}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# wiersz pominięty} few {# wiersze pominięte} many {# wierszy pominiętych} other {# wiersza pominiętego}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Pokaż jedyny wiersz} few {Pokaż wszystkie # wiersze} many {Pokaż wszystkie # wierszy} other {Pokaż wszystkie # wiersza}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} linii do mapowania"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} pasujących kont: {fileCount} przyjmuje numery z pliku, {keepCount} zachowuje numery z Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# wiersz wyłączony} other {# wierszy wyłączonych}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# pasujące konto przyjmuje numer z pliku.} few {# pasujące konta przyjmują numery z pliku.} many {# pasujących kont przyjmuje numery z pliku.} other {# pasującego konta przyjmuje numery z pliku.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} z {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} wstawiono, {updated} zaktualizowano, {0} wymagają naprawy, {1} pominięte."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# pasujące konto zachowuje numer z Carbon.} few {# pasujące konta zachowują numery z Carbon.} many {# pasujących kont zachowuje numery z Carbon.} other {# pasującego konta zachowuje numery z Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# linia} other {# linii}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} zostanie ponownie otwarty do edycji jako rewizja {0}. Dokument już wysłany do dostawcy pozostaje niezmieniony, aż go sfinalizujesz i ponownie wyślesz zamówienie."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# decyzja jeszcze nie w planie} few {# decyzje jeszcze nie w planie} many {# decyzji jeszcze nie w planie} other {# decyzji jeszcze nie w planie}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Trwale usuń # wiersz?} other {Trwale usuń # wierszy?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# niepoliczony wiersz} other {# niepoliczone wiersze}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# konto już istnieje w Carbon pod innym numerem.} few {# konta już istnieją w Carbon pod innymi numerami.} many {# kont już istnieje w Carbon pod innymi numerami.} other {# konta już istnieje w Carbon pod innymi numerami.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "Nie można zaplanować {unschedulableCount}"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Próby"
 
 msgid "Attention"
-msgstr ""
+msgstr "Uwaga"
 
 msgid "Attribute"
 msgstr "Atrybut"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Sprawdź księgę artykułów pod kątem artykułów z ujemną ilością dostępną na koniec okresu — zwykle brakuje przyjęcia lub zaksięgowania poza kolejnością, które zniekształca wartość zapasów i koszt własny sprzedaży. Oznacz jako gotowe po przejrzeniu lub pomiń z uzasadnieniem."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Sprawdź, co zostanie utworzone i zmienione przed importem. Nic nie zostanie zapisane, dopóki nie potwierdzisz."
 
 msgid "Check your email"
 msgstr "Sprawdź swoją pocztę"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Sprawdzanie Stripe dla tego klienta…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Porównywanie pliku z planem kont…"
 
 msgid "Checkpoint ·"
 msgstr "Punkt kontrolny ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Szczegóły"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Wykryj z pliku"
 
 msgid "Developer"
 msgstr "Deweloper"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Powód Zwolnienia"
 
 msgid "Existing"
-msgstr ""
+msgstr "Istniejące"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Istniejące mapowania. Wybierz inną opcję dostawcy, aby przezmapować."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Grupy"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Grupy pochodzą z pliku. Grupa najwyższego poziomu o tej samej nazwie co grupa w Carbon zostaje z nią scalona."
 
 msgid "Guided"
 msgstr "Wspomagane"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Ukryj ilości systemowe do kroku przeglądu"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Ukryj pełną listę"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Ukryj, przypnij i zmień kolejność kolumn"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Hierarchia pobrana z wierszy Begin-Total / End-Total w pliku."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Hierarchia pobrana z kolumny konta nadrzędnego w pliku."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Hierarchia pobrana ze ścieżek w nazwach kont."
 
 msgid "High"
 msgstr "Wysoki"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Jak często to utrzymanie ruchu się powtarza — Codziennie, Co tydzień, Co miesiąc, Podczas inwentaryzacji ciągłej; Opcja Codziennie ujawnia selektor dnia tygodnia, inne używają prostszej arytmetyki interwałów."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Jak uporządkować konta?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Jak zlecenie produkcyjne jest klasyfikowane, gdy harmonogram przydziela pojemność — ASAP otrzymuje pierwszeństwo, następnie Hard Deadline, Soft Deadline i brak terminu ostatni. Sygnał rankingu tylko; żaden typ terminu nie blokuje ani nie uniemożliwia umieszczenia."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Jeśli chcesz zmienić numery części, kliknij Anuluj i ręcznie przypisz części dla każdej pozycji wiersza przed konwersją."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Ignoruj grupy z pliku; każde konto trafia do grupy Carbon odpowiadającej jego typowi konta."
 
 msgid "II (normal default)"
 msgstr "II (normalne domyślne)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Lider Wdrożenia"
 
 msgid "Import"
-msgstr ""
+msgstr "Importuj"
 
 msgid "Import {label} CSV"
 msgstr "Importuj {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Importuj jako „{0}”"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Importuj jako {0}"
 
 msgid "Import results"
 msgstr "Wyniki Importu"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Importuj pod inną nazwą"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Importuj pod innym numerem"
 
 msgid "Import your BOM"
 msgstr "Zaimportuj swoją BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Zachowaj"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Zachowaj numer z Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Zachowaj numery z Carbon"
 
 msgid "Keep Current"
 msgstr "Zachowaj bieżące"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Pozostaw puste dla dokładnego dopasowania"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Pozostaw to konto bez zmian"
 
 msgid "Leave this page"
 msgstr "Opuść tę stronę"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Prawdopodobieństwo"
 
 msgid "Line"
-msgstr ""
+msgstr "Wiersz"
 
 msgid "Line description (optional)"
 msgstr "Opis linii (opcjonalnie)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Wymaga planu Business lub Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Wymaga uwagi"
 
 msgid "Needs fixing"
 msgstr "Wymaga naprawy"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Brak przypisanych grup"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Brak hierarchii w pliku: konta są umieszczane w istniejących grupach Carbon według typu konta."
 
 msgid "No image"
 msgstr "Brak obrazu"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Brak zaplanowanych nadgodzin"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "W pliku nie znaleziono kolumny konta nadrzędnego, rodzajów wierszy ani ścieżek w nazwach."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Brak zarejestrowanych źródeł nadrzędnych. Kliknij Przelicz na stronie planowania, aby odświeżyć przypisanie."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Nic nie zaplanowano — dodaj stanowisko poniżej."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Nic do zaimportowania."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Nic jeszcze. Krok oferuje wartości dopiero po skonfigurowaniu."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Ścieżka"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Separator ścieżki w nazwach kont"
 
 msgid "Pay Rate"
 msgstr "Kurs płatności"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Przypięte"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Umieść konta w istniejących grupach Carbon"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Rozwiąż to przed ukończeniem NCR: każdy wiersz musi mieć dyspozycję inną niż Oczekująca, a ilości połączonych jednostek muszą odpowiadać ilości wiersza."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Rozwiązane"
 
 msgid "Resolved Price"
 msgstr "Cena rozliczona"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Sprzedawca"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "To samo co {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "To samo co {target} (zachowaj jego numer)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "To samo co {target} (użyj numeru z tego pliku)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "To samo co {target}, z zachowaniem jego numeru"
 
 msgid "Same as Book"
 msgstr "Taki sam jak w księdze"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Pomiń stan zwolniony, ale nie uruchomiony - zadanie rozpoczyna się natychmiast po skanowaniu."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Pomiń ten wiersz"
 
 msgid "Skipped"
 msgstr "Pominięte"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Podziel pozycję wysyłki"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Podziel nazwy kont według separatora, np. Nadrzędne:Podrzędne."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "Zestaw uprawnień, które automatycznie otrzymują nowi pracownicy tego typu; edycja tutaj zmienia szablon tylko dla przyszłych wynajęć - pracownicy istniejący zachowują to, co mają, chyba że zostaną jawnie zaktualizowani zbiorczo."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Nie udało się utworzyć planu"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Fabryki, magazyny i obiekty, w których znajduje się Twoja praca i zapasy"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Te dowody księgowe są wciąż w wersji roboczej, dlatego ich wpisy Winien i Ma nie znajdują się w księdze dla tego okresu. Zaksięguj każdy z nich lub przesyć go do późniejszego otwartego okresu."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Te wiersze nie zostaną zaimportowane, dopóki nie zostaną rozwiązane; cała reszta zostanie zaimportowana po potwierdzeniu."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Te wiersze łączą się z danymi spoza tej firmy, dlatego nie można wykonać bezpiecznej kopii bieżących danych. Usunięcie ich nie może być cofnięte. Jeśli okaże się, że są współdzielone z innymi firmami w tej grupie, nic nie zostanie usunięte i przywracanie nie zostanie uruchomione."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Usuń balon"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Bez zmian"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Niezliczone linie pozostają niezmienione podczas wysyłki — nie są zerowane."
 
 msgid "Under"
-msgstr ""
+msgstr "W grupie"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "W zamawianiu na podstawie zapotrzebowania planowanie sumuje zapotrzebowanie w ramach tego okna przesuwającego się w celu obliczenia ilości uzupełnienia zapasu."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Aktualizuj Uprawnienia"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Aktualizuj plan"
 
 msgid "Update Quantity"
 msgstr "Aktualizuj ilość"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Zaktualizuj informacje kanban dla uzupełniania opartego na skanowaniu."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Zaktualizuj plan, aby zobaczyć wynik. Potwierdzenie importu zastosuje je wszystkie."
 
 msgid "Update the purchase order quantities"
 msgstr "Zaktualizuj ilości zamówienia zakupu"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Pomyślnie zaktualizowano"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Aktualizowanie planu…"
 
 msgid "Upgrade"
 msgstr "Uaktualnij"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Użyj systemu metrycznego dla domyślnych wymiarów materiału."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Użyj numerów z pliku"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Użyj kolumny konta nadrzędnego, ścieżek w nazwach lub wierszy sum z pliku, jeśli występują."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Użyj hierarchii z pliku"
 
 msgid "Used In"
 msgstr "Używane w"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -53,7 +53,7 @@ msgstr "(grupo)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr "{0, plural, one {# conta mesclada com uma existente} other {# contas mescladas com existentes}}"
+msgstr "{0, plural, one {# conta mesclada com uma existente} other {# contas mescladas com contas existentes}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
@@ -132,10 +132,6 @@ msgstr "{0} ordens de produção criadas"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} linhas para mapear"
-
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} contas correspondentes: {fileCount} recebem os números do arquivo, {keepCount} mantêm os do Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -9586,6 +9582,10 @@ msgstr "Correspondido"
 
 msgid "matches"
 msgstr "corresponde"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Contas correspondentes: {0}. Números do arquivo: {fileCount}, números do Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Pares Correspondentes"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" está feito — todos os {0} itens do seu Mapa de Setup e
 msgid "(excluded for this customer)"
 msgstr "(excluído para este cliente)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# linha vincula dados fora desta empresa, portanto uma cópia de segurança de seus dados atuais não pode ser feita.} other {# linhas vinculam dados fora desta empresa, portanto uma cópia de segurança de seus dados atuais não pode ser feita.}}"
@@ -89,6 +92,11 @@ msgstr "{0} eliminado com sucesso"
 msgid "{0} draft journal entries"
 msgstr "{0} lançamentos de diário em rascunho"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordens de produção criadas"
@@ -96,6 +104,14 @@ msgstr "{0} ordens de produção criadas"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} linhas para mapear"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} linhas"
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornecedores com saldo"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades não amostradas serão liberadas para Disponível. Passes amostradas permanecem Disponível e falhas amostradas permanecem Rejeitadas."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Todos os Locais"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Todos os membros dos grupos selecionados e indivíduos selecionados poderão aprovar solicitações"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas as linhas importadas — {inserted} inseridas, {updated} atualizadas."
 
@@ -2431,6 +2459,9 @@ msgstr "Anexos"
 msgid "Attempts"
 msgstr "Tentativas"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Atributo"
 
@@ -2829,6 +2860,9 @@ msgstr "Criar materiais de treinamento baseados em funções"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Criar materiais de treinamento personalizados baseados em funções"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Construído e calculado como seu próprio método"
@@ -3232,6 +3266,9 @@ msgstr "Chat"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Verifique o ledger do item para qualquer item com quantidade disponível negativa no final do período — geralmente um recebimento ausente ou uma contabilização fora de ordem que distorce o valor do inventário e o custo dos produtos vendidos. Marque como feito após revisado ou pule com um motivo."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Verifique seu email"
@@ -5417,6 +5454,9 @@ msgstr "Detalhe"
 msgid "Details"
 msgstr "Detalhes"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Desenvolvedor"
 
@@ -6571,6 +6611,9 @@ msgstr "Certificado de Isenção"
 msgid "Exemption Reason"
 msgstr "Motivo da Isenção"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeamentos existentes. Escolha uma opção de provedor diferente para remapear."
 
@@ -7328,6 +7371,15 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Engenheiro de campo"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Fundação"
 
@@ -7712,6 +7764,9 @@ msgstr "Nome do Grupo"
 msgid "Groups"
 msgstr "Grupos"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Orientado"
 
@@ -7892,6 +7947,9 @@ msgstr "Com que frequência este instrumento de medição deve ser recalibrado; 
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Com que frequência esta manutenção se repete — Diário, Semanal, Mensal, Na Contagem cíclica; Diário revela o seletor de dia da semana, os outros usam cálculo de intervalo mais simples."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Como a ordem de produção se classifica quando o agendador distribui capacidade — As solicitações ASAP vêm primeiro, depois Prazo Firme, Prazo Flexível e Sem Prazo por último. Apenas um sinal de classificação; nenhum tipo de prazo bloqueia ou impede a colocação."
 
@@ -8012,6 +8070,9 @@ msgstr "Se algo estiver fora do caminho"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Se deseja alterar os números das peças, clique em Cancelar e atribua manualmente as peças para cada item de linha antes de converter."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (padrão normal)"
 
@@ -8033,11 +8094,20 @@ msgstr "Centro de Implementação"
 msgid "Implementation Lead"
 msgstr "Líder de Implementação"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
 msgid "Import results"
 msgstr "Resultados da Importação"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Importe seu BOM"
@@ -8117,6 +8187,9 @@ msgstr "Incluir peças extras na remessa"
 
 msgid "Include Inactive"
 msgstr "Incluir Inativos"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Incluído"
@@ -8897,6 +8970,9 @@ msgstr "Deixe em branco para usar a próxima revisão automaticamente"
 msgid "Leave empty for exact match"
 msgstr "Deixe vazio para correspondência exata"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Sair desta página"
 
@@ -8974,6 +9050,9 @@ msgstr "Luzes apagadas (24/7)"
 
 msgid "Likelihood"
 msgstr "Probabilidade"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Descrição da linha (opcional)"
@@ -9901,6 +9980,9 @@ msgstr "Necessário é as horas de trabalho devidas naquele dia divididas por {p
 msgid "Needs a Business or Partner plan."
 msgstr "Requer um plano Business ou Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Precisa de reparo"
 
@@ -10459,6 +10541,9 @@ msgstr "Sem notificações agrupadas"
 
 msgid "No groups assigned"
 msgstr "Nenhum grupo atribuído"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Sem imagem"
@@ -11565,6 +11650,9 @@ msgstr "Cole o XML de metadados se seu provedor de identidade não publicar um U
 msgid "Path"
 msgstr "Caminho"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Taxa de Pagamento"
 
@@ -11794,6 +11882,9 @@ msgstr "Fixar {0}"
 
 msgid "Pinned"
 msgstr "Fixado"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plano"
@@ -13575,6 +13666,9 @@ msgstr "linhas"
 msgid "Rows left out of this backup"
 msgstr "Linhas deixadas de fora deste backup"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Regra"
 
@@ -13791,6 +13885,10 @@ msgstr "Vendas, cotação e configurar para encomendar"
 
 msgid "Salesperson"
 msgstr "Vendedor"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Igual ao livro"
@@ -14815,6 +14913,9 @@ msgstr "Ignorar manutenção programada em feriados da empresa"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Ignore o estado liberado mas não iniciado — a ordem de produção inicia imediatamente no escaneamento."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Ignorado"
@@ -16217,6 +16318,9 @@ msgstr "O percentual do desconto à vista. Use 0 para nenhum desconto."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "O conjunto de permissões que novos funcionários deste tipo recebem automaticamente; editar aqui muda apenas o modelo para futuras contratações - os funcionários existentes mantêm o que têm a menos que sejam explicitamente atualizados em massa."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "As plantas, armazéns e locais onde seu trabalho e estoque residem"
 
@@ -17259,8 +17363,14 @@ msgstr "Não atribuído"
 msgid "Unballoon"
 msgstr "Remover balão"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "As linhas não contadas são deixadas inalteradas na postagem — elas não são zeradas."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Sob Reorder Baseado em Demanda, o planejamento soma a demanda dentro desta janela móvel ao calcular uma quantidade de reabastecimento."
@@ -17600,6 +17710,12 @@ msgstr "Usar um email diferente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilize o sistema métrico para dimensões padrão de materiais."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Usado Em"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Transferir Para"
 msgid "Trash"
 msgstr "Lixo"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Balancete"
 

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} peças ignoradas — nada para fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} será reaberto para edição como revisão {0}. O documento já enviado ao fornecedor permanece inalterado até que você finalize e reenvie o pedido."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Excluir permanentemente # linha?} other {Excluir permanentemente # linhas?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Resultados da Importação"
 
@@ -8187,9 +8198,6 @@ msgstr "Incluir peças extras na remessa"
 
 msgid "Include Inactive"
 msgstr "Incluir Inativos"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Incluído"
@@ -8792,6 +8800,12 @@ msgstr "Kanbans"
 msgid "Keep"
 msgstr "Manter"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Manter Atual"
 
@@ -8809,6 +8823,9 @@ msgstr "Manter Aberto"
 
 msgid "Keep picking"
 msgstr "Manter separação"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantém pedidos, cotações e configurações atrás de uma segunda verificação"
@@ -9548,6 +9565,9 @@ msgstr "Correspondido"
 
 msgid "matches"
 msgstr "corresponde"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pares Correspondentes"
@@ -13412,6 +13432,9 @@ msgstr "Valor residual %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Resolva estes antes de concluir a NCR: cada linha deve ter uma disposição não-Pendente e suas quantidades de entidades vinculadas devem corresponder à quantidade da linha."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Preço Resolvido"
 
@@ -13886,8 +13909,16 @@ msgstr "Vendas, cotação e configurar para encomendar"
 msgid "Salesperson"
 msgstr "Vendedor"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Transferir Para"
 msgid "Trash"
 msgstr "Lixo"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Balancete"
 
@@ -17598,6 +17625,9 @@ msgstr "Atualizar Senha"
 msgid "Update Permissions"
 msgstr "Atualizar Permissões"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Atualizar Quantidade"
 
@@ -17714,6 +17744,9 @@ msgstr "Usar um email diferente"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Utilize o sistema métrico para dimensões padrão de materiais."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(excluído para este cliente)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(grupo)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# conta mesclada com uma existente} other {# contas mescladas com existentes}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# conta a criar} other {# contas a criar}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# conta a atualizar} other {# contas a atualizar}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# conta sem alterações} other {# contas sem alterações}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "{0, plural, one {# grupo} other {# grupos}} e {1, plural, one {# conta} other {# contas}} a criar"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# linha vincula dados fora desta empresa, portanto não
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# linha requer atenção} other {# linhas requerem atenção}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# linha ignorada} other {# linhas ignoradas}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Mostrar a única linha} other {Mostrar todas as # linhas}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} linhas para mapear"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} contas correspondentes: {fileCount} recebem os números do arquivo, {keepCount} mantêm os do Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# linha excluída} other {# linhas excluídas}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# conta correspondente recebe o número do arquivo.} other {# contas correspondentes recebem os números do arquivo.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} de {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseridos, {updated} atualizados, {0} precisam de correção, {1} ignorados."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# conta correspondente mantém o número do Carbon.} other {# contas correspondentes mantêm os números do Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# linha} other {# linhas}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} será reaberto para edição como revisão {0}. O documento já enviado ao fornecedor permanece inalterado até que você finalize e reenvie o pedido."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# decisão ainda não está no plano} other {# decisões ainda não estão no plano}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Excluir permanentemente # linha?} other {Excluir permanentemente # linhas?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# conta já existe no Carbon com outro número.} other {# contas já existem no Carbon com outros números.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} não podem ser programadas"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Tentativas"
 
 msgid "Attention"
-msgstr ""
+msgstr "Atenção"
 
 msgid "Attribute"
 msgstr "Atributo"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Verifique o ledger do item para qualquer item com quantidade disponível negativa no final do período — geralmente um recebimento ausente ou uma contabilização fora de ordem que distorce o valor do inventário e o custo dos produtos vendidos. Marque como feito após revisado ou pule com um motivo."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Verifique o que será criado e alterado antes de importar. Nada é gravado até você confirmar."
 
 msgid "Check your email"
 msgstr "Verifique seu email"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Comparando o arquivo com seu plano de contas…"
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Detalhes"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Detectar a partir do arquivo"
 
 msgid "Developer"
 msgstr "Desenvolvedor"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Motivo da Isenção"
 
 msgid "Existing"
-msgstr ""
+msgstr "Existente"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mapeamentos existentes. Escolha uma opção de provedor diferente para remapear."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Grupos"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Os grupos vêm do arquivo. Um grupo de nível superior com o mesmo nome de um grupo do Carbon é mesclado a ele."
 
 msgid "Guided"
 msgstr "Orientado"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Ocultar quantidades do sistema até a etapa de revisão"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Ocultar a lista completa"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, fixar e reordenar colunas"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Hierarquia obtida das linhas Begin-Total / End-Total do arquivo."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Hierarquia obtida da coluna de conta pai do arquivo."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Hierarquia obtida dos caminhos nos nomes das contas."
 
 msgid "High"
 msgstr "Alto"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Com que frequência esta manutenção se repete — Diário, Semanal, Mensal, Na Contagem cíclica; Diário revela o seletor de dia da semana, os outros usam cálculo de intervalo mais simples."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Como as contas devem ser organizadas?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Como a ordem de produção se classifica quando o agendador distribui capacidade — As solicitações ASAP vêm primeiro, depois Prazo Firme, Prazo Flexível e Sem Prazo por último. Apenas um sinal de classificação; nenhum tipo de prazo bloqueia ou impede a colocação."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Se deseja alterar os números das peças, clique em Cancelar e atribua manualmente as peças para cada item de linha antes de converter."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Ignorar os grupos do arquivo; cada conta fica sob o grupo do Carbon correspondente ao seu tipo de conta."
 
 msgid "II (normal default)"
 msgstr "II (padrão normal)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Líder de Implementação"
 
 msgid "Import"
-msgstr ""
+msgstr "Importar"
 
 msgid "Import {label} CSV"
 msgstr "Importar {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Importar como “{0}”"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Importar como {0}"
 
 msgid "Import results"
 msgstr "Resultados da Importação"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Importar com outro nome"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Importar com outro número"
 
 msgid "Import your BOM"
 msgstr "Importe seu BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Manter"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Manter o número do Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Manter os números do Carbon"
 
 msgid "Keep Current"
 msgstr "Manter Atual"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Deixe vazio para correspondência exata"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Deixar esta conta como está"
 
 msgid "Leave this page"
 msgstr "Sair desta página"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Probabilidade"
 
 msgid "Line"
-msgstr ""
+msgstr "Linha"
 
 msgid "Line description (optional)"
 msgstr "Descrição da linha (opcional)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Requer um plano Business ou Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Requer atenção"
 
 msgid "Needs fixing"
 msgstr "Precisa de reparo"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Nenhum grupo atribuído"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Sem hierarquia no arquivo: as contas são colocadas sob os grupos existentes do Carbon por tipo de conta."
 
 msgid "No image"
 msgstr "Sem imagem"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Nenhuma hora extra agendada"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "Nenhuma coluna de conta pai, tipos de linha ou caminhos nos nomes foram encontrados no arquivo."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Nenhuma fonte pai registrada ainda. Clique em Recalcular na página de planejamento para atualizar a atribuição."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Nada agendado — adicione uma estação abaixo."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Nada a importar."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Nada ainda. Uma etapa só oferece valores após ser configurada."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Caminho"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Separador de caminho nos nomes das contas"
 
 msgid "Pay Rate"
 msgstr "Taxa de Pagamento"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Fixado"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Colocar as contas sob os grupos existentes do Carbon"
 
 msgid "Plan"
 msgstr "Plano"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Resolva estes antes de concluir a NCR: cada linha deve ter uma disposição não-Pendente e suas quantidades de entidades vinculadas devem corresponder à quantidade da linha."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Resolvido"
 
 msgid "Resolved Price"
 msgstr "Preço Resolvido"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Vendedor"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "Igual a {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "Igual a {target} (manter o número dela)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "Igual a {target} (usar o número deste arquivo)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "Igual a {target}, mantendo o número dela"
 
 msgid "Same as Book"
 msgstr "Igual ao livro"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Ignore o estado liberado mas não iniciado — a ordem de produção inicia imediatamente no escaneamento."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Ignorar esta linha"
 
 msgid "Skipped"
 msgstr "Ignorado"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Dividir linha da remessa"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Dividir os nomes das contas por um separador, por ex. Pai:Filho."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "O conjunto de permissões que novos funcionários deste tipo recebem automaticamente; editar aqui muda apenas o modelo para futuras contratações - os funcionários existentes mantêm o que têm a menos que sejam explicitamente atualizados em massa."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Não foi possível montar o plano"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "As plantas, armazéns e locais onde seu trabalho e estoque residem"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Estes lançamentos de diário ainda estão em Rascunho, portanto seus débitos e créditos não estão no livro-razão para este período. Lance cada um, ou redatē-o para um período aberto posterior."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Estas linhas não são importadas até serem resolvidas; todo o resto é importado ao confirmar."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Essas linhas estão vinculadas a dados fora desta empresa, portanto não é possível criar uma cópia de segurança dos seus dados atuais. A exclusão dessas linhas não pode ser desfeita. Se forem compartilhadas com outras empresas neste grupo, nada será excluído e a restauração não será iniciada."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Remover balão"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Sem alterações"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "As linhas não contadas são deixadas inalteradas na postagem — elas não são zeradas."
 
 msgid "Under"
-msgstr ""
+msgstr "Sob"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Sob Reorder Baseado em Demanda, o planejamento soma a demanda dentro desta janela móvel ao calcular uma quantidade de reabastecimento."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Atualizar Permissões"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Atualizar plano"
 
 msgid "Update Quantity"
 msgstr "Atualizar Quantidade"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Atualize as informações do kanban para reabastecimento baseado em varredura."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Atualize o plano para ver o resultado. Confirmar a importação aplica todas elas."
 
 msgid "Update the purchase order quantities"
 msgstr "Atualizar as quantidades do pedido de compra"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Atualizado com sucesso"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Atualizando o plano…"
 
 msgid "Upgrade"
 msgstr "Atualizar"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Utilize o sistema métrico para dimensões padrão de materiais."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Usar os números do arquivo"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Usar a coluna de conta pai, os caminhos nos nomes ou as linhas de totais do arquivo, quando existirem."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Usar a hierarquia do arquivo"
 
 msgid "Used In"
 msgstr "Usado Em"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Este item está em 1 aviso de alteração aberto} other
 msgid "{0} accounts"
 msgstr "{0} contas"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} atrás"
@@ -92,9 +96,9 @@ msgstr "{0} eliminado com sucesso"
 msgid "{0} draft journal entries"
 msgstr "{0} lançamentos de diário em rascunho"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} ordens de produção criadas"
 msgid "{0} lines to map"
 msgstr "{0} linhas para mapear"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} registado"
 msgid "{0} rows"
 msgstr "{0} linhas"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornecedores com saldo"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades não amostradas serão liberadas para Disponível. Passes amostradas permanecem Disponível e falhas amostradas permanecem Rejeitadas."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} de {total} fases concluídas"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# linha excluída} other {# linhas excluídas}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} de {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} mais: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseridos, {updated} atualizados, {0} precisam de correção, {1} ignorados."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# linha} other {# linhas}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} peças ignoradas — nada para fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} será reaberto para edição como revisão {0}. O documento já enviado ao fornecedor permanece inalterado até que você finalize e reenvie o pedido."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# unidade} other {# unidades}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} não podem ser programadas"
@@ -1496,9 +1516,6 @@ msgstr "Todos os Locais"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Todos os membros dos grupos selecionados e indivíduos selecionados poderão aprovar solicitações"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Todas as linhas importadas — {inserted} inseridas, {updated} atualizadas."
@@ -2864,9 +2881,6 @@ msgstr "Criar materiais de treinamento baseados em funções"
 msgid "Build tailored, role-based training materials"
 msgstr "Criar materiais de treinamento personalizados baseados em funções"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Construído e calculado como seu próprio método"
 
@@ -3278,6 +3292,9 @@ msgstr "Verifique seu email"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Verificando Stripe para este cliente…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Checkpoint ·"
@@ -7374,15 +7391,6 @@ msgstr "Formato"
 msgid "Forward deployed engineer"
 msgstr "Engenheiro de campo"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Fundação"
 
@@ -7809,8 +7817,20 @@ msgstr "Ocultar bruto"
 msgid "Hide system quantities until the review step"
 msgstr "Ocultar quantidades do sistema até a etapa de revisão"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, fixar e reordenar colunas"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Alto"
@@ -8824,9 +8844,6 @@ msgstr "Manter Aberto"
 msgid "Keep picking"
 msgstr "Manter separação"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Mantém pedidos, cotações e configurações atrás de uma segunda verificação"
 
@@ -9565,9 +9582,6 @@ msgstr "Correspondido"
 
 msgid "matches"
 msgstr "corresponde"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Pares Correspondentes"
@@ -10562,7 +10576,7 @@ msgstr "Sem notificações agrupadas"
 msgid "No groups assigned"
 msgstr "Nenhum grupo atribuído"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Nenhum treinamento pendente"
 
 msgid "No overtime scheduled"
 msgstr "Nenhuma hora extra agendada"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Nenhuma fonte pai registrada ainda. Clique em Recalcular na página de planejamento para atualizar a atribuição."
@@ -10946,6 +10963,9 @@ msgstr "Nada no arquivo"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Nada agendado — adicione uma estação abaixo."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Nada ainda. Uma etapa só oferece valores após ser configurada."
@@ -13689,9 +13709,6 @@ msgstr "linhas"
 msgid "Rows left out of this backup"
 msgstr "Linhas deixadas de fora deste backup"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Regra"
 
@@ -14815,6 +14832,10 @@ msgstr "Mostrar uma coluna de ID de Cliente legível na lista de clientes, formu
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostrar uma coluna de ID de Fornecedor legível na lista de fornecedores, formulários de fornecedor e menus suspensos. Os fornecedores ainda são identificados internamente de qualquer forma."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Mostrar IDs de Cliente"
 
@@ -15091,6 +15112,9 @@ msgstr "Dividir linha de recebimento"
 
 msgid "Split shipment line"
 msgstr "Dividir linha da remessa"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Estas ordens de produção têm operações atribuídas a este centro de
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Estes lançamentos de diário ainda estão em Rascunho, portanto seus débitos e créditos não estão no livro-razão para este período. Lance cada um, ou redatē-o para um período aberto posterior."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Essas linhas estão vinculadas a dados fora desta empresa, portanto não é possível criar uma cópia de segurança dos seus dados atuais. A exclusão dessas linhas não pode ser desfeita. Se forem compartilhadas com outras empresas neste grupo, nada será excluído e a restauração não será iniciada."
 
@@ -17640,6 +17667,9 @@ msgstr "Atualizar quantidades do documento de origem"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Atualize as informações do kanban para reabastecimento baseado em varredura."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Atualizar as quantidades do pedido de compra"
 
@@ -17657,6 +17687,9 @@ msgstr "Atualizado por"
 
 msgid "Updated successfully"
 msgstr "Atualizado com sucesso"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Atualizar"
@@ -17745,7 +17778,7 @@ msgstr "Usar um email diferente"
 msgid "Use metric system for default material dimensions."
 msgstr "Utilize o sistema métrico para dimensões padrão de materiais."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -51,6 +51,27 @@ msgstr "(excluído para este cliente)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# linha vincula dados fora desta empresa, portanto uma cópia de segurança de seus dados atuais não pode ser feita.} other {# linhas vinculam dados fora desta empresa, portanto uma cópia de segurança de seus dados atuais não pode ser feita.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# linha vincula dados fora desta empresa, portanto uma 
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# linha vincula dados fora desta empresa, portanto não pode ser feita backup dela. Ignorá-la faz backup de tudo mais.} other {# linhas vinculam dados fora desta empresa, portanto não podem ser feitas backup delas. Ignorá-las fazem backup de tudo mais.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Este item está em 1 aviso de alteração aberto} other {Este item está em # avisos de alteração abertos}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Este item está em 1 aviso de alteração aberto} other
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} contas"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} eliminado com sucesso"
 msgid "{0} draft journal entries"
 msgstr "{0} lançamentos de diário em rascunho"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} ordens de produção criadas"
@@ -111,14 +135,6 @@ msgstr "{0} linhas para mapear"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} registado"
 msgid "{0} rows"
 msgstr "{0} linhas"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} fornecedores com saldo"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} entidades não amostradas serão liberadas para Disponível. Passes amostradas permanecem Disponível e falhas amostradas permanecem Rejeitadas."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} de {total} fases concluídas"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# linha excluída} other {# linhas excluídas}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} mais: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} inseridos, {updated} atualizados, {0} precisam de correção, {1} ignorados."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} peças ignoradas — nada para fabricar"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} será reaberto para edição como revisão {0}. O documento já enviado ao fornecedor permanece inalterado até que você finalize e reenvie o pedido."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# unidade} other {# unidades}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# linha não contada} other {# linhas não contadas}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Mostrar uma coluna de ID de Cliente legível na lista de clientes, formu
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Mostrar uma coluna de ID de Fornecedor legível na lista de fornecedores, formulários de fornecedor e menus suspensos. Os fornecedores ainda são identificados internamente de qualquer forma."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Mostrar IDs de Cliente"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(исключено для этого покупателя)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(группа)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# счёт объединён с существующим} few {# счёта объединены с существующими} many {# счетов объединены с существующими} other {# счёта объединены с существующими}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {# счёт будет создан} few {# счёта будут созданы} many {# счетов будут созданы} other {# счёта будут созданы}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {# счёт будет обновлён} few {# счёта будут обновлены} many {# счетов будут обновлены} other {# счёта будут обновлены}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# счёт без изменений} few {# счёта без изменений} many {# счетов без изменений} other {# счёта без изменений}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "Будет создано: {0, plural, one {# группа} few {# группы} many {# групп} other {# группы}} и {1, plural, one {# счёт} few {# счёта} many {# счетов} other {# счёта}}"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# строка связана с данными вне 
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# строка требует внимания} few {# строки требуют внимания} many {# строк требуют внимания} other {# строки требуют внимания}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# строка пропущена} few {# строки пропущены} many {# строк пропущено} other {# строки пропущено}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Показать единственную строку} few {Показать все # строки} many {Показать все # строк} other {Показать все # строки}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} строк для сопоставления"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "Совпадающих счетов: {0}. {fileCount} получат номера из файла, {keepCount} сохранят номера Carbon."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# строка исключена} other {# строк исключено}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# совпадающий счёт получит номер из файла.} few {# совпадающих счёта получат номера из файла.} many {# совпадающих счетов получат номера из файла.} other {# совпадающего счёта получат номера из файла.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} из {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} вставлено, {updated} обновлено, {0} требуют исправления, {1} пропущено."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# совпадающий счёт сохранит номер Carbon.} few {# совпадающих счёта сохранят номера Carbon.} many {# совпадающих счетов сохранят номера Carbon.} other {# совпадающего счёта сохранят номера Carbon.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# строка} other {# строк}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} будет переоткрыт для редактирования как ревизия {0}. Отправленный поставщику документ останется неизменным, пока вы не завершите и не переотправите заказ."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# решение ещё не в плане} few {# решения ещё не в плане} many {# решений ещё не в плане} other {# решения ещё не в плане}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Окончательно удалить # строку?} other {Окончательно удалить # строк?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# счёт уже существует в Carbon под другим номером.} few {# счёта уже существуют в Carbon под другими номерами.} many {# счетов уже существуют в Carbon под другими номерами.} other {# счёта уже существуют в Carbon под другими номерами.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} не может быть спланировано"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Попытки"
 
 msgid "Attention"
-msgstr ""
+msgstr "Внимание"
 
 msgid "Attribute"
 msgstr "Атрибут"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Проверьте реестр номенклатуры на наличие номенклатур с отрицательным количеством на складе на конец периода — обычно это недостающее поступление или неправильно проведённая операция, которая искажает стоимость запасов и себестоимость продаж. Отметьте как выполненное после проверки или пропустите с указанием причины."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "Проверьте, что будет создано и изменено, перед импортом. Ничего не записывается, пока вы не подтвердите."
 
 msgid "Check your email"
 msgstr "Проверьте вашу почту"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Проверка Stripe для этого покупателя…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Сверка файла с вашим планом счетов…"
 
 msgid "Checkpoint ·"
 msgstr "Контрольная точка ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Детали"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Определить по файлу"
 
 msgid "Developer"
 msgstr "Разработчик"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "Причина освобождения"
 
 msgid "Existing"
-msgstr ""
+msgstr "Существующий"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Существующие отображения. Выберите другой вариант провайдера для переотображения."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Группы"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Группы берутся из файла. Группа верхнего уровня с тем же названием, что и группа в Carbon, объединяется с ней."
 
 msgid "Guided"
 msgstr "Управляемый"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Скрывать системные количества до шага рассмотрения"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Скрыть полный список"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Скрывать, закреплять и переупорядочивать столбцы"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Иерархия взята из строк Begin-Total / End-Total файла."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Иерархия взята из столбца родительского счёта файла."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Иерархия взята из путей в названиях счетов."
 
 msgid "High"
 msgstr "Высокий"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Как часто это техобслуживание повторяется — Ежедневно, Еженедельно, Ежемесячно, На циклический пересчет; выбор «Ежедневно» показывает селектор дня недели, остальные используют более простую математику интервалов."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Как упорядочить счета?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Как производственный заказ рангируется, когда планировщик распределяет мощность — ASAP занимает первое место, затем Жесткий срок, Мягкий срок и Нет срока в последнюю очередь. Только сигнал ранжирования; ни один тип срока не блокирует и не ограничивает размещение."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Если вы хотите изменить номера деталей, нажмите Отмена и вручную назначьте детали для каждого элемента строки перед преобразованием."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Игнорировать группы из файла; каждый счёт помещается в группу Carbon, соответствующую его типу."
 
 msgid "II (normal default)"
 msgstr "II (обычно по умолчанию)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Руководитель внедрения"
 
 msgid "Import"
-msgstr ""
+msgstr "Импорт"
 
 msgid "Import {label} CSV"
 msgstr "Импортировать {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "Импортировать как «{0}»"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "Импортировать как {0}"
 
 msgid "Import results"
 msgstr "Импортировать результаты"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Импортировать под другим названием"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Импортировать под другим номером"
 
 msgid "Import your BOM"
 msgstr "Импортируйте вашу BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Сохранить"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Сохранить номер Carbon"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Сохранить номера Carbon"
 
 msgid "Keep Current"
 msgstr "Сохранить текущие"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Оставьте пустым для точного совпадения"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Оставить этот счёт без изменений"
 
 msgid "Leave this page"
 msgstr "Покинуть эту страницу"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Вероятность"
 
 msgid "Line"
-msgstr ""
+msgstr "Строка"
 
 msgid "Line description (optional)"
 msgstr "Описание строки (необязательно)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Требуется план Business или Partner."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Требует внимания"
 
 msgid "Needs fixing"
 msgstr "Требуется исправление"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Нет назначенных групп"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "В файле нет иерархии: счета размещаются в существующих группах Carbon по типу счёта."
 
 msgid "No image"
 msgstr "Нет изображения"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Нет запланированных переработок"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "В файле не найдены ни столбец родительского счёта, ни типы строк, ни пути в названиях."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Родительские источники еще не записаны. Нажмите \"Пересчитать\" на странице планирования, чтобы обновить атрибуцию."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Ничего не запланировано — добавьте рабочее место ниже."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "Нечего импортировать."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Пока ничего. Шаг предоставляет значения только после того, как он будет настроен."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Путь"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Разделитель пути в названиях счетов"
 
 msgid "Pay Rate"
 msgstr "Курс платежа"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Закреплено"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Разместить счета в существующих группах Carbon"
 
 msgid "Plan"
 msgstr "План"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "Решите эти вопросы перед завершением NCR: каждая строка должна иметь решение, которое не является Ожидающим, и количества связанных сущностей должны совпадать с количеством строки."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Решено"
 
 msgid "Resolved Price"
 msgstr "Разрешённая цена"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Продавец"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "То же, что {target}"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "То же, что {target} (сохранить его номер)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "То же, что {target} (использовать номер из этого файла)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "То же, что {target}, с сохранением его номера"
 
 msgid "Same as Book"
 msgstr "Как в книге"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Пропустить состояние «выпущено, но не начато» — задание начинается сразу при сканировании."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Пропустить эту строку"
 
 msgid "Skipped"
 msgstr "Пропущено"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Разделить строку отгрузки"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Разделять названия счетов по разделителю, например Родитель:Потомок."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "Набор прав доступа, который автоматически получают новые сотрудники этого типа; редактирование здесь изменяет шаблон только для будущих сотрудников — существующие сотрудники сохраняют свои права, пока их явно не обновить массово."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Не удалось построить план"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Заводы, склады и объекты, где находятся ваша работа и запасы"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Эти операции по-прежнему находятся в режиме Черновик, поэтому их дебеты и кредиты не включены в главную книгу для этого периода. Проведите каждый из них или переведите его в более поздний открытый период."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Эти строки не будут импортированы, пока не будут решены; всё остальное импортируется при подтверждении."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Эти строки связаны с данными вне этой организации, поэтому не удаётся создать резервную копию текущих данных. Удаление их не может быть отменено. Если окажется, что они используются другими организациями в этой группе, ничего не удаляется и восстановление не начинается."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Удалить выноску"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Без изменений"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Неучтённые строки остаются неизменными при отправке — они не обнуляются."
 
 msgid "Under"
-msgstr ""
+msgstr "В группе"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "При переупорядочении на основе потребности планирование суммирует потребность в этом скользящем окне при расчете количества пополнения"
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "Обновить Права доступа"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Обновить план"
 
 msgid "Update Quantity"
 msgstr "Обновить количество"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Обновите информацию канбана для пополнения на основе сканирования."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Обновите план, чтобы увидеть результат. Подтверждение импорта применит их все."
 
 msgid "Update the purchase order quantities"
 msgstr "Обновить количества Заказа поставщику"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Успешно обновлено"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Обновление плана…"
 
 msgid "Upgrade"
 msgstr "Обновить"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Используйте метрическую систему для измерений материала по умолчанию."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Использовать номера из файла"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Использовать столбец родительского счёта, пути в названиях или итоговые строки файла, если они есть."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Использовать иерархию из файла"
 
 msgid "Used In"
 msgstr "Используется в"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -51,6 +51,27 @@ msgstr "(исключено для этого покупателя)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# строка связана с данными вне этой организации, поэтому резервная копия ваших текущих данных не может быть создана.} other {# строк связаны с данными вне этой организации, поэтому резервная копия ваших текущих данных не может быть создана.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# строка связана с данными вне 
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# строка связана с данными вне этой организации, поэтому она не может быть зарезервирована. Пропуск позволит зарезервировать все остальное.} other {# строк связаны с данными вне этой организации, поэтому они не могут быть зарезервированы. Пропуск позволит зарезервировать все остальное.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Эта номенклатура находится в 1 открытом извещении об изменении} other {Эта номенклатура находится в # открытых извещениях об изменении}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Эта номенклатура находится в 1
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} счётов"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} успешно удален"
 msgid "{0} draft journal entries"
 msgstr "{0} черновых операций"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} производственных заказов создано"
@@ -111,14 +135,6 @@ msgstr "{0} строк для сопоставления"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} зарегистрирован"
 msgid "{0} rows"
 msgstr "{0} строк"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} поставщиков с остатком"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} необследованные единицы будут переведены в Доступно. Пройденные образцы остаются в Доступно, отклоненные образцы остаются в Отклонено."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} из {total} этапов завершено"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# строка исключена} other {# строк исключено}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} еще: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} вставлено, {updated} обновлено, {0} требуют исправления, {1} пропущено."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} деталей пропущено — нечего �
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} будет переоткрыт для редактирования как ревизия {0}. Отправленный поставщику документ останется неизменным, пока вы не завершите и не переотправите заказ."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# единица} other {# единиц}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Показывать столбец с читаемым ID Покупа�
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Показать читаемый столбец ID поставщика в списке поставщиков, формах поставщиков и раскрывающихся списках. Поставщики по-прежнему идентифицируются внутри системы в любом случае."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Показывать ID Покупателей"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Эта номенклатура находится в 1
 msgid "{0} accounts"
 msgstr "{0} счётов"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} назад"
@@ -92,9 +96,9 @@ msgstr "{0} успешно удален"
 msgid "{0} draft journal entries"
 msgstr "{0} черновых операций"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} производственных заказов создано"
 msgid "{0} lines to map"
 msgstr "{0} строк для сопоставления"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} зарегистрирован"
 msgid "{0} rows"
 msgstr "{0} строк"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} поставщиков с остатком"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} необследованные единицы будут переведены в Доступно. Пройденные образцы остаются в Доступно, отклоненные образцы остаются в Отклонено."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} из {total} этапов завершено"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# строка исключена} other {# строк исключено}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} из {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} еще: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} вставлено, {updated} обновлено, {0} требуют исправления, {1} пропущено."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# строка} other {# строк}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} деталей пропущено — нечего �
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} будет переоткрыт для редактирования как ревизия {0}. Отправленный поставщику документ останется неизменным, пока вы не завершите и не переотправите заказ."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# единица} other {# единиц}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# непосчитанная строка} other {# непосчитанные строки}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} не может быть спланировано"
@@ -1496,9 +1516,6 @@ msgstr "Все местоположения"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Все члены выбранных групп и выбранные лица смогут утвердить запросы"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Все строки импортированы — {inserted} вставлено, {updated} обновлено."
@@ -2864,9 +2881,6 @@ msgstr "Создавайте материалы обучения на основ
 msgid "Build tailored, role-based training materials"
 msgstr "Создавайте адаптированные материалы обучения на основе ролей"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Построен и рассчитан как собственный метод"
 
@@ -3278,6 +3292,9 @@ msgstr "Проверьте вашу почту"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Проверка Stripe для этого покупателя…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Контрольная точка ·"
@@ -7374,15 +7391,6 @@ msgstr "Формат"
 msgid "Forward deployed engineer"
 msgstr "Инженер на месте"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Основа"
 
@@ -7809,8 +7817,20 @@ msgstr "Скрыть исходное"
 msgid "Hide system quantities until the review step"
 msgstr "Скрывать системные количества до шага рассмотрения"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Скрывать, закреплять и переупорядочивать столбцы"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Высокий"
@@ -8824,9 +8844,6 @@ msgstr "Оставить открытым"
 msgid "Keep picking"
 msgstr "Сохранить отбор"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Требует дополнительную проверку для заказов, коммерческих предложений и настроек"
 
@@ -9565,9 +9582,6 @@ msgstr "Сопоставлено"
 
 msgid "matches"
 msgstr "совпадает"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Парные соответствия"
@@ -10562,7 +10576,7 @@ msgstr "Нет сгруппированных уведомлений"
 msgid "No groups assigned"
 msgstr "Нет назначенных групп"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Нет невыполненных обучений"
 
 msgid "No overtime scheduled"
 msgstr "Нет запланированных переработок"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Родительские источники еще не записаны. Нажмите \"Пересчитать\" на странице планирования, чтобы обновить атрибуцию."
@@ -10946,6 +10963,9 @@ msgstr "Ничего в архиве"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Ничего не запланировано — добавьте рабочее место ниже."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Пока ничего. Шаг предоставляет значения только после того, как он будет настроен."
@@ -13689,9 +13709,6 @@ msgstr "строк"
 msgid "Rows left out of this backup"
 msgstr "Строки, не включенные в эту резервную копию"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Правило"
 
@@ -14815,6 +14832,10 @@ msgstr "Показывать столбец с читаемым ID Покупа�
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Показать читаемый столбец ID поставщика в списке поставщиков, формах поставщиков и раскрывающихся списках. Поставщики по-прежнему идентифицируются внутри системы в любом случае."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Показывать ID Покупателей"
 
@@ -15091,6 +15112,9 @@ msgstr "Разделить строку приемки"
 
 msgid "Split shipment line"
 msgstr "Разделить строку отгрузки"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Эти производственные заказы имеют опер
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Эти операции по-прежнему находятся в режиме Черновик, поэтому их дебеты и кредиты не включены в главную книгу для этого периода. Проведите каждый из них или переведите его в более поздний открытый период."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Эти строки связаны с данными вне этой организации, поэтому не удаётся создать резервную копию текущих данных. Удаление их не может быть отменено. Если окажется, что они используются другими организациями в этой группе, ничего не удаляется и восстановление не начинается."
 
@@ -17640,6 +17667,9 @@ msgstr "Обновить количества в документе-основа
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Обновите информацию канбана для пополнения на основе сканирования."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Обновить количества Заказа поставщику"
 
@@ -17657,6 +17687,9 @@ msgstr "Обновлено"
 
 msgid "Updated successfully"
 msgstr "Успешно обновлено"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Обновить"
@@ -17745,7 +17778,7 @@ msgstr "Использовать другой адрес электронной 
 msgid "Use metric system for default material dimensions."
 msgstr "Используйте метрическую систему для измерений материала по умолчанию."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Передать в"
 msgid "Trash"
 msgstr "Корзина"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Сальдовая ведомость"
 

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -48,6 +48,9 @@ msgstr "«{taskName}» готово — все {0} позиций графика
 msgid "(excluded for this customer)"
 msgstr "(исключено для этого покупателя)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# строка связана с данными вне этой организации, поэтому резервная копия ваших текущих данных не может быть создана.} other {# строк связаны с данными вне этой организации, поэтому резервная копия ваших текущих данных не может быть создана.}}"
@@ -89,6 +92,11 @@ msgstr "{0} успешно удален"
 msgid "{0} draft journal entries"
 msgstr "{0} черновых операций"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} производственных заказов создано"
@@ -96,6 +104,14 @@ msgstr "{0} производственных заказов создано"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} строк для сопоставления"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} строк"
 msgid "{0} suppliers with a balance"
 msgstr "{0} поставщиков с остатком"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} необследованные единицы будут переведены в Доступно. Пройденные образцы остаются в Доступно, отклоненные образцы остаются в Отклонено."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Все местоположения"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Все члены выбранных групп и выбранные лица смогут утвердить запросы"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "Все строки импортированы — {inserted} вставлено, {updated} обновлено."
 
@@ -2431,6 +2459,9 @@ msgstr "Вложения"
 msgid "Attempts"
 msgstr "Попытки"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Атрибут"
 
@@ -2829,6 +2860,9 @@ msgstr "Создавайте материалы обучения на основ
 
 msgid "Build tailored, role-based training materials"
 msgstr "Создавайте адаптированные материалы обучения на основе ролей"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Построен и рассчитан как собственный метод"
@@ -3232,6 +3266,9 @@ msgstr "Чат"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Проверьте реестр номенклатуры на наличие номенклатур с отрицательным количеством на складе на конец периода — обычно это недостающее поступление или неправильно проведённая операция, которая искажает стоимость запасов и себестоимость продаж. Отметьте как выполненное после проверки или пропустите с указанием причины."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "Проверьте вашу почту"
@@ -5417,6 +5454,9 @@ msgstr "Подробности"
 msgid "Details"
 msgstr "Детали"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Разработчик"
 
@@ -6571,6 +6611,9 @@ msgstr "Сертификат освобождения"
 msgid "Exemption Reason"
 msgstr "Причина освобождения"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Существующие отображения. Выберите другой вариант провайдера для переотображения."
 
@@ -7328,6 +7371,15 @@ msgstr "Формат"
 msgid "Forward deployed engineer"
 msgstr "Инженер на месте"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Основа"
 
@@ -7712,6 +7764,9 @@ msgstr "Название группы"
 msgid "Groups"
 msgstr "Группы"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Управляемый"
 
@@ -7892,6 +7947,9 @@ msgstr "Как часто это средство измерения должн�
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Как часто это техобслуживание повторяется — Ежедневно, Еженедельно, Ежемесячно, На циклический пересчет; выбор «Ежедневно» показывает селектор дня недели, остальные используют более простую математику интервалов."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "Как производственный заказ рангируется, когда планировщик распределяет мощность — ASAP занимает первое место, затем Жесткий срок, Мягкий срок и Нет срока в последнюю очередь. Только сигнал ранжирования; ни один тип срока не блокирует и не ограничивает размещение."
 
@@ -8012,6 +8070,9 @@ msgstr "Если что-то идет не по плану"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Если вы хотите изменить номера деталей, нажмите Отмена и вручную назначьте детали для каждого элемента строки перед преобразованием."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (обычно по умолчанию)"
 
@@ -8033,11 +8094,20 @@ msgstr "Центр внедрения"
 msgid "Implementation Lead"
 msgstr "Руководитель внедрения"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "Импортировать {label} CSV"
 
 msgid "Import results"
 msgstr "Импортировать результаты"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "Импортируйте вашу BOM"
@@ -8117,6 +8187,9 @@ msgstr "Включить дополнительные детали в отгру
 
 msgid "Include Inactive"
 msgstr "Включить неактивные"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Включено"
@@ -8897,6 +8970,9 @@ msgstr "Оставить пусто, чтобы использовать сле�
 msgid "Leave empty for exact match"
 msgstr "Оставьте пустым для точного совпадения"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Покинуть эту страницу"
 
@@ -8974,6 +9050,9 @@ msgstr "Темное производство (24/7)"
 
 msgid "Likelihood"
 msgstr "Вероятность"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Описание строки (необязательно)"
@@ -9901,6 +9980,9 @@ msgstr "Необходимо - это рабочие часы, приходящ�
 msgid "Needs a Business or Partner plan."
 msgstr "Требуется план Business или Partner."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Требуется исправление"
 
@@ -10459,6 +10541,9 @@ msgstr "Нет сгруппированных уведомлений"
 
 msgid "No groups assigned"
 msgstr "Нет назначенных групп"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Нет изображения"
@@ -11565,6 +11650,9 @@ msgstr "Вставьте XML метаданных, если ваш постав�
 msgid "Path"
 msgstr "Путь"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Курс платежа"
 
@@ -11794,6 +11882,9 @@ msgstr "Закрепить {0}"
 
 msgid "Pinned"
 msgstr "Закреплено"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "План"
@@ -13575,6 +13666,9 @@ msgstr "строк"
 msgid "Rows left out of this backup"
 msgstr "Строки, не включенные в эту резервную копию"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Правило"
 
@@ -13791,6 +13885,10 @@ msgstr "Продажи, предложения и конфигурировани
 
 msgid "Salesperson"
 msgstr "Продавец"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Как в книге"
@@ -14815,6 +14913,9 @@ msgstr "Пропустить плановое техобслуживание в 
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Пропустить состояние «выпущено, но не начато» — задание начинается сразу при сканировании."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Пропущено"
@@ -16217,6 +16318,9 @@ msgstr "Процент скидки при оплате наличными. Ис
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Набор прав доступа, который автоматически получают новые сотрудники этого типа; редактирование здесь изменяет шаблон только для будущих сотрудников — существующие сотрудники сохраняют свои права, пока их явно не обновить массово."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Заводы, склады и объекты, где находятся ваша работа и запасы"
 
@@ -17259,8 +17363,14 @@ msgstr "Не назначено"
 msgid "Unballoon"
 msgstr "Удалить выноску"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Неучтённые строки остаются неизменными при отправке — они не обнуляются."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "При переупорядочении на основе потребности планирование суммирует потребность в этом скользящем окне при расчете количества пополнения"
@@ -17600,6 +17710,12 @@ msgstr "Использовать другой адрес электронной 
 
 msgid "Use metric system for default material dimensions."
 msgstr "Используйте метрическую систему для измерений материала по умолчанию."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Используется в"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} деталей пропущено — нечего �
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} будет переоткрыт для редактирования как ревизия {0}. Отправленный поставщику документ останется неизменным, пока вы не завершите и не переотправите заказ."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {Окончательно удалить # строку?} other {Окончательно удалить # строк?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "Импортировать {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "Импортировать результаты"
 
@@ -8187,9 +8198,6 @@ msgstr "Включить дополнительные детали в отгру
 
 msgid "Include Inactive"
 msgstr "Включить неактивные"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Включено"
@@ -8792,6 +8800,12 @@ msgstr "Канбаны"
 msgid "Keep"
 msgstr "Сохранить"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Сохранить текущие"
 
@@ -8809,6 +8823,9 @@ msgstr "Оставить открытым"
 
 msgid "Keep picking"
 msgstr "Сохранить отбор"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Требует дополнительную проверку для заказов, коммерческих предложений и настроек"
@@ -9548,6 +9565,9 @@ msgstr "Сопоставлено"
 
 msgid "matches"
 msgstr "совпадает"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Парные соответствия"
@@ -13412,6 +13432,9 @@ msgstr "Ликвидационная стоимость %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "Решите эти вопросы перед завершением NCR: каждая строка должна иметь решение, которое не является Ожидающим, и количества связанных сущностей должны совпадать с количеством строки."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Разрешённая цена"
 
@@ -13886,8 +13909,16 @@ msgstr "Продажи, предложения и конфигурировани
 msgid "Salesperson"
 msgstr "Продавец"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Передать в"
 msgid "Trash"
 msgstr "Корзина"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Сальдовая ведомость"
 
@@ -17598,6 +17625,9 @@ msgstr "Обновить пароль"
 msgid "Update Permissions"
 msgstr "Обновить Права доступа"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Обновить количество"
 
@@ -17714,6 +17744,9 @@ msgstr "Использовать другой адрес электронной 
 
 msgid "Use metric system for default material dimensions."
 msgstr "Используйте метрическую систему для измерений материала по умолчанию."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} производственных заказов создано"
 msgid "{0} lines to map"
 msgstr "{0} строк для сопоставления"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "Совпадающих счетов: {0}. {fileCount} получат номера из файла, {keepCount} сохранят номера Carbon."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Сопоставлено"
 
 msgid "matches"
 msgstr "совпадает"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Совпадающих счетов: {0}. Номера из файла: {fileCount}, номера Carbon: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Парные соответствия"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} parça atlandı — yapılacak bir şey yok"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} revizyon {0} olarak düzenlenmek üzere yeniden açılacaktır. Tedarikçiye gönderilen belge, siparişi sonlandırıp yeniden gönderene kadar değişmez."
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# satırı kalıcı olarak sil?} other {# satırı kalıcı olarak sil?}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "İçe aktarılacak {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "İçe Aktarma Sonuçları"
 
@@ -8187,9 +8198,6 @@ msgstr "Fazla parçaları sevkiyata dahil et"
 
 msgid "Include Inactive"
 msgstr "Pasifleri Dahil Et"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "Dahil"
@@ -8792,6 +8800,12 @@ msgstr "Kanbanlar"
 msgid "Keep"
 msgstr "Tut"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "Mevcut Tut"
 
@@ -8809,6 +8823,9 @@ msgstr "Açık Tut"
 
 msgid "Keep picking"
 msgstr "Toplamaya devam et"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Siparişleri, teklifleri ve ayarları ikinci bir kontrolün arkasında tutar"
@@ -9548,6 +9565,9 @@ msgstr "Eşleştirildi"
 
 msgid "matches"
 msgstr "eşleşir"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Eşleştirme Çiftleri"
@@ -13412,6 +13432,9 @@ msgstr "Kalıntı Değer %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "NCR'yi tamamlamadan önce bunları çöz: her satırın Bekleme Dışı bir Karar'ı olmalı ve onun bağlı varlık miktarları satır miktarıyla eşleşmeli."
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "Belirlenmiş Fiyat"
 
@@ -13886,8 +13909,16 @@ msgstr "Satış, teklif ve sipariş konfigürasyonu"
 msgid "Salesperson"
 msgstr "Satış danışmanı"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "Aktarılacak Lokasyon"
 msgid "Trash"
 msgstr "Çöp Kutusu"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "Mizan"
 
@@ -17598,6 +17625,9 @@ msgstr "Şifreyi Güncelle"
 msgid "Update Permissions"
 msgstr "İzinleri Güncelle"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "Miktarı Güncelle"
 
@@ -17714,6 +17744,9 @@ msgstr "Farklı bir e-posta kullan"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Varsayılan malzeme boyutları için metrik sistemi kullanın."
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -17270,6 +17270,10 @@ msgstr "Aktarılacak Lokasyon"
 msgid "Trash"
 msgstr "Çöp Kutusu"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "Mizan"
 

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -51,6 +51,27 @@ msgstr "(bu müşteri için hariç tutulmuş)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle mevcut verilerinizin güvenli bir kopyası oluşturulamıyor.} other {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle mevcut verilerinizin güvenli bir kopyası oluşturulamıyor.}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# satır bu şirketin dışındaki verilere bağlantı 
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle yedeklenemez. Bunu atlayarak diğer her şeyi yedekleyebilirsiniz.} other {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle yedeklenemez. Bunları atlayarak diğer her şeyi yedekleyebilirsiniz.}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {Bu ürün 1 açık değişiklik bildirisinde yer alıyor} other {Bu ürün # açık değişiklik bildirisinde yer alıyor}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {Bu ürün 1 açık değişiklik bildirisinde yer alıyo
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} hesaplar"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} başarıyla silindi"
 msgid "{0} draft journal entries"
 msgstr "{0} taslak muhasebe fişi"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} iş emri oluşturuldu"
@@ -111,14 +135,6 @@ msgstr "{0} satır eşlenecek"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0} kaydedildi"
 msgid "{0} rows"
 msgstr "{0} satır"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} bakiyesi olan tedarikçi"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} örneklenmemiş varlıklar Kullanılabilir'e bırakılacaktır. Örneklenen başarılılar Kullanılabilir ve örneklenen başarısızlar Reddedilmiş olarak kalır."
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done} / {total} aşama tamamlandı"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# satır hariç tutuldu} other {# satır hariç tutuldu}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "{hiddenCount} daha: {hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eklendi, {updated} güncellendi, {0} düzeltme gerekli, {1} atlandı."
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} parça atlandı — yapılacak bir şey yok"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} revizyon {0} olarak düzenlenmek üzere yeniden açılacaktır. Tedarikçiye gönderilen belge, siparişi sonlandırıp yeniden gönderene kadar değişmez."
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# birim} other {# birimler}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "Müşteri listesinde, müşteri formlarında ve açılır menülerde oku
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Tedarikçi listesinde, tedarikçi formlarında ve açılır menülerde okunabilir bir Tedarikçi Kimliği sütunu gösterir. Tedarikçiler her iki durumda da dahili olarak tanımlanmaya devam eder."
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "Müşteri Kimliklerini Göster"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\" bitti — tüm {0} Kurulum Haritası öğesi yapılandır
 msgid "(excluded for this customer)"
 msgstr "(bu müşteri için hariç tutulmuş)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle mevcut verilerinizin güvenli bir kopyası oluşturulamıyor.} other {# satır bu şirketin dışındaki verilere bağlantı kuruyor, bu nedenle mevcut verilerinizin güvenli bir kopyası oluşturulamıyor.}}"
@@ -89,6 +92,11 @@ msgstr "{0} başarıyla silindi"
 msgid "{0} draft journal entries"
 msgstr "{0} taslak muhasebe fişi"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "{0} iş emri oluşturuldu"
@@ -96,6 +104,14 @@ msgstr "{0} iş emri oluşturuldu"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} satır eşlenecek"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} satır"
 msgid "{0} suppliers with a balance"
 msgstr "{0} bakiyesi olan tedarikçi"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} örneklenmemiş varlıklar Kullanılabilir'e bırakılacaktır. Örneklenen başarılılar Kullanılabilir ve örneklenen başarısızlar Reddedilmiş olarak kalır."
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "Tüm Konumlar"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Seçilen gruplardaki ve bireylerdeki tüm üyeler talepleri onaylayabilecektir"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "{inserted} eklendi, {updated} güncellendi — tüm satırlar içe aktarıldı."
 
@@ -2431,6 +2459,9 @@ msgstr "Ekler"
 msgid "Attempts"
 msgstr "Denemeler"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "Öznitelik"
 
@@ -2829,6 +2860,9 @@ msgstr "Rol tabanlı eğitim materyalleri oluşturun"
 
 msgid "Build tailored, role-based training materials"
 msgstr "Özelleştirilmiş, rol tabanlı eğitim materyalleri oluşturun"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "Kendi yöntemi olarak oluşturulmuş ve maliyetlendirilmiş"
@@ -3232,6 +3266,9 @@ msgstr "Sohbet"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "Dönem sonu itibariyle negatif eldeki miktarı olan herhangi bir stok kartı için stok kartı defterini kontrol edin — genellikle eksik bir mal kabul veya envanter değerini ve satılan malın maliyetini bozan sıra dışı bir muhasebeleştirme. İncelendikten sonra bitti olarak işaretleyin veya bir gerekçeyle atlayın."
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
@@ -5417,6 +5454,9 @@ msgstr "Detay"
 msgid "Details"
 msgstr "Detaylar"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "Geliştirici"
 
@@ -6571,6 +6611,9 @@ msgstr "İstisnai Sertifika"
 msgid "Exemption Reason"
 msgstr "İstisnai Nedeni"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mevcut eşlemeler. Yeniden eşlemek için farklı bir sağlayıcı seçeneği seçin."
 
@@ -7328,6 +7371,15 @@ msgstr "Biçim"
 msgid "Forward deployed engineer"
 msgstr "Sahadaki mühendis"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "Temel"
 
@@ -7712,6 +7764,9 @@ msgstr "Grup Adı"
 msgid "Groups"
 msgstr "Gruplar"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "Rehberli"
 
@@ -7892,6 +7947,9 @@ msgstr "Bu ölçüm aletinin ne sıklıkla kalibre edilmesi gerektiği; Son Kali
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "Bu bakım ne sıklıkla tekrarlanır — Günlük, Haftalık, Aylık, Periyodik Sayımında; Günlük seçim haftanın günü seçicisini gösterir, diğerleri daha basit aralık matematiğini kullanır."
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "İş emri'nin, zamanlayıcı kapasite dağıttığında nasıl sıralandığı — ASAP ilk öncelik alır, sonra Sert Son Tarih, Esnek Son Tarih ve Son Tarih Yok son sırada. Yalnızca bir sıralama sinyali; hiçbir son tarih türü yerleştirmeyi engellemiyor veya kısıtlamıyor."
 
@@ -8012,6 +8070,9 @@ msgstr "Bir şey yolunda değilse"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "Parça numaralarını değiştirmek isterseniz, lütfen iptal'e tıklayın ve dönüştürmeden önce her bir satır öğesi için parçaları manuel olarak atayın."
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II (normal varsayılan)"
 
@@ -8033,11 +8094,20 @@ msgstr "Uygulama Merkezi"
 msgid "Implementation Lead"
 msgstr "Uygulama Müdürü"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "İçe aktarılacak {label} CSV"
 
 msgid "Import results"
 msgstr "İçe Aktarma Sonuçları"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "BOM'unuzu İçe Aktarın"
@@ -8117,6 +8187,9 @@ msgstr "Fazla parçaları sevkiyata dahil et"
 
 msgid "Include Inactive"
 msgstr "Pasifleri Dahil Et"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "Dahil"
@@ -8897,6 +8970,9 @@ msgstr "Sonraki revizyonu otomatik olarak kullanmak için boş bırakın"
 msgid "Leave empty for exact match"
 msgstr "Tam eşleşme için boş bırakın"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "Bu sayfadan ayrıl"
 
@@ -8974,6 +9050,9 @@ msgstr "Işıklar kapalı (24/7)"
 
 msgid "Likelihood"
 msgstr "Olasılık"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "Satır açıklaması (isteğe bağlı)"
@@ -9901,6 +9980,9 @@ msgstr "Gerekli olan, o gün vadesi gelen iş saatleri {personDayHours}s'ye böl
 msgid "Needs a Business or Partner plan."
 msgstr "Business veya Partner planı gereklidir."
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "Onarılması gerekir"
 
@@ -10459,6 +10541,9 @@ msgstr "Gruplanmış bildirim yok"
 
 msgid "No groups assigned"
 msgstr "Atanmış grup yok"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "Resim yok"
@@ -11565,6 +11650,9 @@ msgstr "Kimlik sağlayıcınız bir meta veri URL'si yayınlamıyorsa meta veri 
 msgid "Path"
 msgstr "Yol"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "Ödeme Oranı"
 
@@ -11794,6 +11882,9 @@ msgstr "Sabitle {0}"
 
 msgid "Pinned"
 msgstr "Sabitlenmiş"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "Plan"
@@ -13575,6 +13666,9 @@ msgstr "satırlar"
 msgid "Rows left out of this backup"
 msgstr "Bu yedeklemeden hariç tutulan satırlar"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "Kural"
 
@@ -13791,6 +13885,10 @@ msgstr "Satış, teklif ve sipariş konfigürasyonu"
 
 msgid "Salesperson"
 msgstr "Satış danışmanı"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "Kitapta aynı"
@@ -14815,6 +14913,9 @@ msgstr "Şirket tatillerinde planlanmış bakımı atla"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "Yayınlanan ancak başlatılmayan durumu atlayın - iş tarama sırasında hemen başlar."
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "Atlanmış"
@@ -16217,6 +16318,9 @@ msgstr "Peşin ödeme iskontosunun yüzdesi. İskonto yoksa 0 kullanın."
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "Bu tür yeni çalışanların otomatik olarak aldığı izin kümesi; burada düzenleme, yalnızca gelecekteki işe almalar için şablonu değiştirir - mevcut çalışanlar, açıkça toplu güncellenmediği sürece sahip olduklarını tutarlar."
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Çalışmanızın ve stokunuzun bulunduğu fabrikalar, depolar ve tesisler"
 
@@ -17259,8 +17363,14 @@ msgstr "Atanmamış"
 msgid "Unballoon"
 msgstr "Balonu Kaldır"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Sayılmayan satırlar gönderide değiştirilmeden bırakılır — sıfırlanmaz."
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Talep Tabanlı Yeniden Sipariş Altında, planlama bir yenileme miktarı hesaplanırken bu kayan pencere içinde talebi toplar."
@@ -17600,6 +17710,12 @@ msgstr "Farklı bir e-posta kullan"
 
 msgid "Use metric system for default material dimensions."
 msgstr "Varsayılan malzeme boyutları için metrik sistemi kullanın."
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "Kullanıldığı Yer"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {Bu ürün 1 açık değişiklik bildirisinde yer alıyo
 msgid "{0} accounts"
 msgstr "{0} hesaplar"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} önce"
@@ -92,9 +96,9 @@ msgstr "{0} başarıyla silindi"
 msgid "{0} draft journal entries"
 msgstr "{0} taslak muhasebe fişi"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "{0} iş emri oluşturuldu"
 msgid "{0} lines to map"
 msgstr "{0} satır eşlenecek"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0} kaydedildi"
 msgid "{0} rows"
 msgstr "{0} satır"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0} bakiyesi olan tedarikçi"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0} örneklenmemiş varlıklar Kullanılabilir'e bırakılacaktır. Örneklenen başarılılar Kullanılabilir ve örneklenen başarısızlar Reddedilmiş olarak kalır."
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done} / {total} aşama tamamlandı"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# satır hariç tutuldu} other {# satır hariç tutuldu}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
 
@@ -251,6 +265,9 @@ msgstr "{hiddenCount} daha: {hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eklendi, {updated} güncellendi, {0} düzeltme gerekli, {1} atlandı."
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# satır} other {# satırlar}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} parça atlandı — yapılacak bir şey yok"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} revizyon {0} olarak düzenlenmek üzere yeniden açılacaktır. Tedarikçiye gönderilen belge, siparişi sonlandırıp yeniden gönderene kadar değişmez."
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# birim} other {# birimler}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} planlanmıyor"
@@ -1496,9 +1516,6 @@ msgstr "Tüm Konumlar"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "Seçilen gruplardaki ve bireylerdeki tüm üyeler talepleri onaylayabilecektir"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "{inserted} eklendi, {updated} güncellendi — tüm satırlar içe aktarıldı."
@@ -2864,9 +2881,6 @@ msgstr "Rol tabanlı eğitim materyalleri oluşturun"
 msgid "Build tailored, role-based training materials"
 msgstr "Özelleştirilmiş, rol tabanlı eğitim materyalleri oluşturun"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "Kendi yöntemi olarak oluşturulmuş ve maliyetlendirilmiş"
 
@@ -3278,6 +3292,9 @@ msgstr "E-postanızı kontrol edin"
 
 msgid "Checking Stripe for this customer…"
 msgstr "Bu müşteri için Stripe kontrol ediliyor…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "Kontrol Noktası ·"
@@ -7374,15 +7391,6 @@ msgstr "Biçim"
 msgid "Forward deployed engineer"
 msgstr "Sahadaki mühendis"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "Temel"
 
@@ -7809,8 +7817,20 @@ msgstr "Ham verileri gizle"
 msgid "Hide system quantities until the review step"
 msgstr "Sistem miktarlarını inceleme adımına kadar gizle"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "Sütunları gizle, sabitle ve yeniden sırala"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "Yüksek"
@@ -8824,9 +8844,6 @@ msgstr "Açık Tut"
 msgid "Keep picking"
 msgstr "Toplamaya devam et"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "Siparişleri, teklifleri ve ayarları ikinci bir kontrolün arkasında tutar"
 
@@ -9565,9 +9582,6 @@ msgstr "Eşleştirildi"
 
 msgid "matches"
 msgstr "eşleşir"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "Eşleştirme Çiftleri"
@@ -10562,7 +10576,7 @@ msgstr "Gruplanmış bildirim yok"
 msgid "No groups assigned"
 msgstr "Atanmış grup yok"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "Bekleyen eğitim yok"
 
 msgid "No overtime scheduled"
 msgstr "Planlanmış fazla mesai yok"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Henüz üst kaynaklar kaydedilmedi. Atıfı yenilemek için planlama sayfasındaki Yeniden Hesapla düğmesine tıklayın."
@@ -10946,6 +10963,9 @@ msgstr "Arşivde hiçbir şey yok"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "Hiçbir şey zamanlanmadı — aşağıya bir istasyon ekleyin."
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Henüz hiçbir şey yok. Bir adım yalnızca yapılandırıldıktan sonra değerleri sunar."
@@ -13689,9 +13709,6 @@ msgstr "satırlar"
 msgid "Rows left out of this backup"
 msgstr "Bu yedeklemeden hariç tutulan satırlar"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "Kural"
 
@@ -14815,6 +14832,10 @@ msgstr "Müşteri listesinde, müşteri formlarında ve açılır menülerde oku
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "Tedarikçi listesinde, tedarikçi formlarında ve açılır menülerde okunabilir bir Tedarikçi Kimliği sütunu gösterir. Tedarikçiler her iki durumda da dahili olarak tanımlanmaya devam eder."
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "Müşteri Kimliklerini Göster"
 
@@ -15091,6 +15112,9 @@ msgstr "Fiş hattını böl"
 
 msgid "Split shipment line"
 msgstr "Sevkiyat satırını böl"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "Bu iş emirlerinin bu iş merkezine atanmış operasyonları vardır:"
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "Bu muhasebe fişleri hala Taslak halinde olduğundan borç ve alacakları bu dönemin defterine girmedi. Her birini muhasebeleştir veya daha sonraki açık bir döneme yeniden tarihle."
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Bu satırlar bu Şirket dışındaki verilere bağlı olduğundan, mevcut verilerinizin bir güvenlik kopyası oluşturulamaz. Bu satırları silmek geri alınamaz. Bunların bu gruptaki diğer Şirketlerle paylaşıldığı anlaşılırsa, hiçbir şey silinmez ve geri yükleme başlamaz."
 
@@ -17640,6 +17667,9 @@ msgstr "Kaynak belge miktarlarını güncelle"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "Tarama tabanlı ikmal için kanban bilgilerini güncelleyin."
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "Satın alma siparişi miktarlarını güncelle"
 
@@ -17657,6 +17687,9 @@ msgstr "Güncellendiği Kişi"
 
 msgid "Updated successfully"
 msgstr "Başarıyla güncellendi"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "Yükselt"
@@ -17745,7 +17778,7 @@ msgstr "Farklı bir e-posta kullan"
 msgid "Use metric system for default material dimensions."
 msgstr "Varsayılan malzeme boyutları için metrik sistemi kullanın."
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -133,10 +133,6 @@ msgstr "{0} iş emri oluşturuldu"
 msgid "{0} lines to map"
 msgstr "{0} satır eşlenecek"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} eşleşen hesap: {fileCount} tanesi dosyadaki numaraları alır, {keepCount} tanesi Carbon'daki numaraları korur."
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "Eşleştirildi"
 
 msgid "matches"
 msgstr "eşleşir"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "Eşleşen hesaplar: {0}. Dosyadaki numaralar: {fileCount}, Carbon'daki numaralar: {keepCount}."
 
 msgid "Matching Pairs"
 msgstr "Eşleştirme Çiftleri"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(bu müşteri için hariç tutulmuş)"
 
 msgid "(group)"
-msgstr ""
+msgstr "(grup)"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, one {# hesap mevcut bir hesapla birleştirildi} other {# hesap mevcut hesaplarla birleştirildi}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, one {oluşturulacak # hesap} other {oluşturulacak # hesap}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, one {güncellenecek # hesap} other {güncellenecek # hesap}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, one {# hesap değişmedi} other {# hesap değişmedi}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "oluşturulacak {0, plural, one {# grup} other {# grup}} ve {1, plural, one {# hesap} other {# hesap}}"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# satır bu şirketin dışındaki verilere bağlantı 
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, one {# satır dikkat gerektiriyor} other {# satır dikkat gerektiriyor}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, one {# satır atlandı} other {# satır atlandı}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, one {Tek satırı göster} other {# satırın tamamını göster}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} satır eşlenecek"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} eşleşen hesap: {fileCount} tanesi dosyadaki numaraları alır, {keepCount} tanesi Carbon'daki numaraları korur."
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# satır hariç tutuldu} other {# satır hariç tutuldu}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, one {# eşleşen hesap dosyadaki numarayı alır.} other {# eşleşen hesap dosyadaki numaraları alır.}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} / {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "{inserted} eklendi, {updated} güncellendi, {0} düzeltme gerekli, {1} atlandı."
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, one {# eşleşen hesap Carbon'daki numarasını korur.} other {# eşleşen hesap Carbon'daki numaralarını korur.}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# satır} other {# satırlar}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} revizyon {0} olarak düzenlenmek üzere yeniden açılacaktır. Tedarikçiye gönderilen belge, siparişi sonlandırıp yeniden gönderene kadar değişmez."
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, one {# karar henüz planda değil} other {# karar henüz planda değil}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {# satırı kalıcı olarak sil?} other {# satırı kalıcı olarak sil?}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# sayılmamış satır} other {# sayılmamış satırlar}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, one {# hesap Carbon'da zaten başka bir numarayla mevcut.} other {# hesap Carbon'da zaten başka numaralarla mevcut.}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount} planlanmıyor"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "Denemeler"
 
 msgid "Attention"
-msgstr ""
+msgstr "Dikkat"
 
 msgid "Attribute"
 msgstr "Öznitelik"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "Dönem sonu itibariyle negatif eldeki miktarı olan herhangi bir stok kartı için stok kartı defterini kontrol edin — genellikle eksik bir mal kabul veya envanter değerini ve satılan malın maliyetini bozan sıra dışı bir muhasebeleştirme. İncelendikten sonra bitti olarak işaretleyin veya bir gerekçeyle atlayın."
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "İçe aktarmadan önce nelerin oluşturulacağını ve değiştirileceğini kontrol edin. Onaylayana kadar hiçbir şey yazılmaz."
 
 msgid "Check your email"
 msgstr "E-postanızı kontrol edin"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "Bu müşteri için Stripe kontrol ediliyor…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "Dosya hesap planınızla karşılaştırılıyor…"
 
 msgid "Checkpoint ·"
 msgstr "Kontrol Noktası ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "Detaylar"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "Dosyadan algıla"
 
 msgid "Developer"
 msgstr "Geliştirici"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "İstisnai Nedeni"
 
 msgid "Existing"
-msgstr ""
+msgstr "Mevcut"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "Mevcut eşlemeler. Yeniden eşlemek için farklı bir sağlayıcı seçeneği seçin."
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "Gruplar"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "Gruplar dosyadan gelir. Bir Carbon grubuyla aynı ada sahip üst düzey bir grup o grupla birleştirilir."
 
 msgid "Guided"
 msgstr "Rehberli"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "Sistem miktarlarını inceleme adımına kadar gizle"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "Tam listeyi gizle"
 
 msgid "Hide, pin and reorder columns"
 msgstr "Sütunları gizle, sabitle ve yeniden sırala"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "Hiyerarşi dosyadaki Begin-Total / End-Total satırlarından alındı."
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "Hiyerarşi dosyadaki üst hesap sütunundan alındı."
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "Hiyerarşi hesap adlarındaki yollardan alındı."
 
 msgid "High"
 msgstr "Yüksek"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "Bu bakım ne sıklıkla tekrarlanır — Günlük, Haftalık, Aylık, Periyodik Sayımında; Günlük seçim haftanın günü seçicisini gösterir, diğerleri daha basit aralık matematiğini kullanır."
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "Hesaplar nasıl düzenlenmeli?"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "İş emri'nin, zamanlayıcı kapasite dağıttığında nasıl sıralandığı — ASAP ilk öncelik alır, sonra Sert Son Tarih, Esnek Son Tarih ve Son Tarih Yok son sırada. Yalnızca bir sıralama sinyali; hiçbir son tarih türü yerleştirmeyi engellemiyor veya kısıtlamıyor."
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "Parça numaralarını değiştirmek isterseniz, lütfen iptal'e tıklayın ve dönüştürmeden önce her bir satır öğesi için parçaları manuel olarak atayın."
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "Dosyadaki grupları yok say; her hesap, hesap türüyle eşleşen Carbon grubunun altına yerleştirilir."
 
 msgid "II (normal default)"
 msgstr "II (normal varsayılan)"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "Uygulama Müdürü"
 
 msgid "Import"
-msgstr ""
+msgstr "İçe aktar"
 
 msgid "Import {label} CSV"
 msgstr "İçe aktarılacak {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "“{0}” olarak içe aktar"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "{0} olarak içe aktar"
 
 msgid "Import results"
 msgstr "İçe Aktarma Sonuçları"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "Farklı bir adla içe aktar"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "Farklı bir numarayla içe aktar"
 
 msgid "Import your BOM"
 msgstr "BOM'unuzu İçe Aktarın"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "Tut"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "Carbon'daki numarayı koru"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "Carbon'daki numaraları koru"
 
 msgid "Keep Current"
 msgstr "Mevcut Tut"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "Tam eşleşme için boş bırakın"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "Bu hesabı olduğu gibi bırak"
 
 msgid "Leave this page"
 msgstr "Bu sayfadan ayrıl"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "Olasılık"
 
 msgid "Line"
-msgstr ""
+msgstr "Satır"
 
 msgid "Line description (optional)"
 msgstr "Satır açıklaması (isteğe bağlı)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "Business veya Partner planı gereklidir."
 
 msgid "Needs attention"
-msgstr ""
+msgstr "Dikkat gerektiriyor"
 
 msgid "Needs fixing"
 msgstr "Onarılması gerekir"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "Atanmış grup yok"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "Dosyada hiyerarşi yok: hesaplar, hesap türüne göre Carbon'daki mevcut grupların altına yerleştirilir."
 
 msgid "No image"
 msgstr "Resim yok"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "Planlanmış fazla mesai yok"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "Dosyada üst hesap sütunu, satır türü veya adlarda yol bulunamadı."
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "Henüz üst kaynaklar kaydedilmedi. Atıfı yenilemek için planlama sayfasındaki Yeniden Hesapla düğmesine tıklayın."
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "Hiçbir şey zamanlanmadı — aşağıya bir istasyon ekleyin."
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "İçe aktarılacak bir şey yok."
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "Henüz hiçbir şey yok. Bir adım yalnızca yapılandırıldıktan sonra değerleri sunar."
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "Yol"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "Hesap adlarındaki yol ayırıcı"
 
 msgid "Pay Rate"
 msgstr "Ödeme Oranı"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "Sabitlenmiş"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "Hesapları Carbon'daki mevcut grupların altına yerleştir"
 
 msgid "Plan"
 msgstr "Plan"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "NCR'yi tamamlamadan önce bunları çöz: her satırın Bekleme Dışı bir Karar'ı olmalı ve onun bağlı varlık miktarları satır miktarıyla eşleşmeli."
 
 msgid "Resolved"
-msgstr ""
+msgstr "Çözüldü"
 
 msgid "Resolved Price"
 msgstr "Belirlenmiş Fiyat"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "Satış danışmanı"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "{target} ile aynı"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "{target} ile aynı (numarasını koru)"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "{target} ile aynı (bu dosyadaki numarayı kullan)"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "{target} ile aynı, numarası korunuyor"
 
 msgid "Same as Book"
 msgstr "Kitapta aynı"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "Yayınlanan ancak başlatılmayan durumu atlayın - iş tarama sırasında hemen başlar."
 
 msgid "Skip this row"
-msgstr ""
+msgstr "Bu satırı atla"
 
 msgid "Skipped"
 msgstr "Atlanmış"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "Sevkiyat satırını böl"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "Hesap adlarını bir ayırıcıyla bölün, ör. Üst:Alt."
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "Bu tür yeni çalışanların otomatik olarak aldığı izin kümesi; burada düzenleme, yalnızca gelecekteki işe almalar için şablonu değiştirir - mevcut çalışanlar, açıkça toplu güncellenmediği sürece sahip olduklarını tutarlar."
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "Plan oluşturulamadı"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "Çalışmanızın ve stokunuzun bulunduğu fabrikalar, depolar ve tesisler"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Bu muhasebe fişleri hala Taslak halinde olduğundan borç ve alacakları bu dönemin defterine girmedi. Her birini muhasebeleştir veya daha sonraki açık bir döneme yeniden tarihle."
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "Bu satırlar çözülene kadar içe aktarılmaz; geri kalan her şey onaylandığında içe aktarılır."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "Bu satırlar bu Şirket dışındaki verilere bağlı olduğundan, mevcut verilerinizin bir güvenlik kopyası oluşturulamaz. Bu satırları silmek geri alınamaz. Bunların bu gruptaki diğer Şirketlerle paylaşıldığı anlaşılırsa, hiçbir şey silinmez ve geri yükleme başlamaz."
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "Balonu Kaldır"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "Değişmedi"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "Sayılmayan satırlar gönderide değiştirilmeden bırakılır — sıfırlanmaz."
 
 msgid "Under"
-msgstr ""
+msgstr "Üst grup"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "Talep Tabanlı Yeniden Sipariş Altında, planlama bir yenileme miktarı hesaplanırken bu kayan pencere içinde talebi toplar."
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "İzinleri Güncelle"
 
 msgid "Update plan"
-msgstr ""
+msgstr "Planı güncelle"
 
 msgid "Update Quantity"
 msgstr "Miktarı Güncelle"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "Tarama tabanlı ikmal için kanban bilgilerini güncelleyin."
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "Sonucu görmek için planı güncelleyin. İçe aktarmayı onaylamak hepsini uygular."
 
 msgid "Update the purchase order quantities"
 msgstr "Satın alma siparişi miktarlarını güncelle"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "Başarıyla güncellendi"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "Plan güncelleniyor…"
 
 msgid "Upgrade"
 msgstr "Yükselt"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "Varsayılan malzeme boyutları için metrik sistemi kullanın."
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "Dosyadaki numaraları kullan"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "Varsa dosyadaki üst hesap sütununu, ad yollarını veya toplam satırlarını kullan."
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "Dosyadaki hiyerarşiyi kullan"
 
 msgid "Used In"
 msgstr "Kullanıldığı Yer"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -48,6 +48,9 @@ msgstr "\"{taskName}\"已完成——其所有{0}个设置映射项都已配置�
 msgid "(excluded for this customer)"
 msgstr "(已为此客户排除)"
 
+msgid "(group)"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 行链接到该公司外的数据，无法制作当前数据的安全副本。} other {# 行链接到该公司外的数据，无法制作当前数据的安全副本。}}"
@@ -89,6 +92,11 @@ msgstr "{0} 已成功删除"
 msgid "{0} draft journal entries"
 msgstr "{0}个草稿凭证"
 
+#. placeholder {0}: plan.summary.groupsToCreate
+#. placeholder {1}: plan.summary.accountsToCreate
+msgid "{0} groups, {1} accounts to create"
+msgstr ""
+
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "已创建{0}个工单"
@@ -96,6 +104,14 @@ msgstr "已创建{0}个工单"
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} 行待映射"
+
+#. placeholder {0}: plan.summary.linked
+msgid "{0} merged into existing"
+msgstr ""
+
+#. placeholder {0}: plan.summary.errors
+msgid "{0} need attention"
+msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -130,9 +146,18 @@ msgstr "{0} 行"
 msgid "{0} suppliers with a balance"
 msgstr "{0}个有余额的供应商"
 
+#. placeholder {0}: plan.summary.updates
+msgid "{0} to update"
+msgstr ""
+
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}个未采样的实体将转为可用。已采样的合格品保持可用，已采样的不合格品保持已拒绝。"
+
+#. placeholder {0}: plan.summary.unchanged
+#. placeholder {1}: plan.summary.skipped
+msgid "{0} unchanged, {1} skipped"
+msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -1469,6 +1494,9 @@ msgstr "所有位置"
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "所选组的所有成员和所选个人都将能够审批请求"
 
+msgid "All rows"
+msgstr ""
+
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "所有行已导入—{inserted}行插入，{updated}行更新。"
 
@@ -2431,6 +2459,9 @@ msgstr "附件"
 msgid "Attempts"
 msgstr "尝试次数"
 
+msgid "Attention"
+msgstr ""
+
 msgid "Attribute"
 msgstr "属性"
 
@@ -2829,6 +2860,9 @@ msgstr "构建基于角色的培训材料"
 
 msgid "Build tailored, role-based training materials"
 msgstr "构建定制的、基于角色的培训材料"
+
+msgid "Building the plan…"
+msgstr ""
 
 msgid "Built and costed as its own method"
 msgstr "作为独立方法构建和计算成本"
@@ -3232,6 +3266,9 @@ msgstr "聊天"
 
 msgid "Check the item ledger for any items with a negative on-hand quantity as of period end — usually a missing receipt or an out-of-order posting that distorts inventory value and cost of goods sold. Mark it done once reviewed, or skip with a reason."
 msgstr "检查物料分类账以查找期末现有数量为负的任何物料 — 通常是缺少收货或过账顺序错误，导致库存价值和销售成本失真。审查后标记为完成，或因某个理由跳过。"
+
+msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
+msgstr ""
 
 msgid "Check your email"
 msgstr "检查您的电子邮件"
@@ -5417,6 +5454,9 @@ msgstr "详情"
 msgid "Details"
 msgstr "详情"
 
+msgid "Detect from the file"
+msgstr ""
+
 msgid "Developer"
 msgstr "开发人员"
 
@@ -6571,6 +6611,9 @@ msgstr "豁免证书"
 msgid "Exemption Reason"
 msgstr "豁免原因"
 
+msgid "Existing"
+msgstr ""
+
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "现有映射。选择不同的提供商选项进行重新映射。"
 
@@ -7328,6 +7371,15 @@ msgstr "格式"
 msgid "Forward deployed engineer"
 msgstr "驻场工程师"
 
+msgid "Found a parent column."
+msgstr ""
+
+msgid "Found a path in the account names, e.g. Parent:Child."
+msgstr ""
+
+msgid "Found Begin-Total / End-Total rows."
+msgstr ""
+
 msgid "Foundation"
 msgstr "基础"
 
@@ -7712,6 +7764,9 @@ msgstr "组名"
 msgid "Groups"
 msgstr "组"
 
+msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
+msgstr ""
+
 msgid "Guided"
 msgstr "引导式"
 
@@ -7892,6 +7947,9 @@ msgstr "此量具必须多久重新校准一次；与上次校准日期结合自
 msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Count; Daily reveals the day-of-week selector, the others use simpler interval math."
 msgstr "此维护的重复频率——每日、每周、每月、循环盘点；每日会显示星期选择器，其他则使用更简单的间隔计算。"
 
+msgid "How should the accounts be organised?"
+msgstr ""
+
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "调度程序分配产能时工单的排名方式——立即执行优先，然后是硬期限、软期限，最后是无期限。仅作为排序信号；任何期限类型都不会阻止或限制安排。"
 
@@ -8012,6 +8070,9 @@ msgstr "如果有什么偏离轨道"
 msgid "If you wish to change the part numbers, please click Cancel and manually assign the parts for each line item before converting."
 msgstr "如果您希望更改零件号，请点击\"取消\"并在转换前为每个行项目手动分配零件。"
 
+msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
+msgstr ""
+
 msgid "II (normal default)"
 msgstr "II（正常默认值）"
 
@@ -8033,11 +8094,20 @@ msgstr "实施中心"
 msgid "Implementation Lead"
 msgstr "实施主管"
 
+msgid "Import"
+msgstr ""
+
 msgid "Import {label} CSV"
 msgstr "导入 {label} CSV"
 
 msgid "Import results"
 msgstr "导入结果"
+
+msgid "Import under a different name"
+msgstr ""
+
+msgid "Import under a different number"
+msgstr ""
 
 msgid "Import your BOM"
 msgstr "导入您的BOM"
@@ -8117,6 +8187,9 @@ msgstr "在发货中包含额外零件"
 
 msgid "Include Inactive"
 msgstr "包括已停用"
+
+msgid "Include this row again"
+msgstr ""
 
 msgid "Included"
 msgstr "已包含"
@@ -8897,6 +8970,9 @@ msgstr "留空以自动使用下一个修订版"
 msgid "Leave empty for exact match"
 msgstr "留空以精确匹配"
 
+msgid "Leave this account as it is"
+msgstr ""
+
 msgid "Leave this page"
 msgstr "离开此页面"
 
@@ -8974,6 +9050,9 @@ msgstr "熄灯（24/7）"
 
 msgid "Likelihood"
 msgstr "可能性"
+
+msgid "Line"
+msgstr ""
 
 msgid "Line description (optional)"
 msgstr "行描述(可选)"
@@ -9901,6 +9980,9 @@ msgstr "需要的是该天的工作小时数除以 {personDayHours} 小时，向
 msgid "Needs a Business or Partner plan."
 msgstr "需要业务或合作伙伴计划。"
 
+msgid "Needs attention"
+msgstr ""
+
 msgid "Needs fixing"
 msgstr "需要修复"
 
@@ -10459,6 +10541,9 @@ msgstr "没有分组通知"
 
 msgid "No groups assigned"
 msgstr "没有已分配的组"
+
+msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgstr ""
 
 msgid "No image"
 msgstr "没有图像"
@@ -11565,6 +11650,9 @@ msgstr "如果您的身份提供商未发布元数据 URL,请粘贴元数据 XML
 msgid "Path"
 msgstr "路径"
 
+msgid "Path separator in account names"
+msgstr ""
+
 msgid "Pay Rate"
 msgstr "支付汇率"
 
@@ -11794,6 +11882,9 @@ msgstr "固定{0}"
 
 msgid "Pinned"
 msgstr "已固定"
+
+msgid "Place accounts under Carbon's existing groups"
+msgstr ""
 
 msgid "Plan"
 msgstr "计划"
@@ -13575,6 +13666,9 @@ msgstr "行"
 msgid "Rows left out of this backup"
 msgstr "此备份中遗漏的行"
 
+msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
+msgstr ""
+
 msgid "Rule"
 msgstr "规则"
 
@@ -13791,6 +13885,10 @@ msgstr "销售、报价和按订单配置"
 
 msgid "Salesperson"
 msgstr "销售人员"
+
+#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
+msgid "Same as {0}"
+msgstr ""
 
 msgid "Same as Book"
 msgstr "与账面相同"
@@ -14815,6 +14913,9 @@ msgstr "跳过公司假期的计划维护"
 
 msgid "Skip the released-but-not-started state — the job starts immediately on scan."
 msgstr "跳过已发布但未启动状态 — 扫码时工单立即启动。"
+
+msgid "Skip this row"
+msgstr ""
 
 msgid "Skipped"
 msgstr "已跳过"
@@ -16217,6 +16318,9 @@ msgstr "现金折扣的百分比。使用 0 表示无折扣。"
 msgid "The permission set new employees of this type receive automatically; editing here changes the template for future hires only — existing employees keep what they have unless explicitly bulk-updated."
 msgstr "该类型的新员工自动接收的权限集；在此处编辑仅更改模板以供将来雇用 - 现有员工保留他们拥有的内容，除非明确进行批量更新。"
 
+msgid "The plan could not be built"
+msgstr ""
+
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "您的工作和库存所在的工厂、仓库和场所"
 
@@ -17259,8 +17363,14 @@ msgstr "未分配"
 msgid "Unballoon"
 msgstr "取消气球标注"
 
+msgid "Unchanged"
+msgstr ""
+
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未计数的行在过账时保持不变——它们不会被清零。"
+
+msgid "Under"
+msgstr ""
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "在基于需求的再订购下，计划在计算补货数量时对该滚动窗口内的需求进行求和。"
@@ -17600,6 +17710,12 @@ msgstr "使用不同的电子邮件"
 
 msgid "Use metric system for default material dimensions."
 msgstr "使用公制作为默认原材料尺寸。"
+
+msgid "Use the file's parent column, name paths, or total rows when present."
+msgstr ""
+
+msgid "Use the hierarchy in the file"
+msgstr ""
 
 msgid "Used In"
 msgstr "用于"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -51,6 +51,27 @@ msgstr "(已为此客户排除)"
 msgid "(group)"
 msgstr ""
 
+#. placeholder {0}: s.linked
+msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
+msgstr ""
+
+#. placeholder {0}: s.accountsToCreate
+msgid "{0, plural, one {# account to create} other {# accounts to create}}"
+msgstr ""
+
+#. placeholder {0}: s.updates
+msgid "{0, plural, one {# account to update} other {# accounts to update}}"
+msgstr ""
+
+#. placeholder {0}: s.unchanged
+msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
+msgstr ""
+
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
+msgstr ""
+
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
 msgstr "{0, plural, one {# 行链接到该公司外的数据，无法制作当前数据的安全副本。} other {# 行链接到该公司外的数据，无法制作当前数据的安全副本。}}"
@@ -59,6 +80,18 @@ msgstr "{0, plural, one {# 行链接到该公司外的数据，无法制作当�
 msgid "{0, plural, one {# row links to data outside this company, so it can't be backed up. Skipping it backs up everything else.} other {# rows link to data outside this company, so they can't be backed up. Skipping them backs up everything else.}}"
 msgstr "{0, plural, one {# 行链接到该公司外的数据，无法备份。跳过它可以备份其他所有内容。} other {# 行链接到该公司外的数据，无法备份。跳过它们可以备份其他所有内容。}}"
 
+#. placeholder {0}: s.errors
+msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
+msgstr ""
+
+#. placeholder {0}: s.skipped
+msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
+msgstr ""
+
+#. placeholder {0}: plan.nodes.length
+msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
+msgstr ""
+
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
 msgstr "{0, plural, one {此物料有1个未结的变更通知} other {此物料有#个未结的变更通知}}"
@@ -66,10 +99,6 @@ msgstr "{0, plural, one {此物料有1个未结的变更通知} other {此物料
 #. placeholder {0}: selectedAccountIds.length
 msgid "{0} accounts"
 msgstr "{0} 个账户"
-
-#. placeholder {0}: s.accountsToCreate
-msgid "{0} accounts to create"
-msgstr ""
 
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
@@ -96,11 +125,6 @@ msgstr "{0} 已成功删除"
 msgid "{0} draft journal entries"
 msgstr "{0}个草稿凭证"
 
-#. placeholder {0}: s.groupsToCreate
-#. placeholder {1}: s.accountsToCreate
-msgid "{0} groups and {1} accounts to create"
-msgstr ""
-
 #. placeholder {0}: jobs.length
 msgid "{0} jobs created"
 msgstr "已创建{0}个工单"
@@ -111,14 +135,6 @@ msgstr "{0} 行待映射"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
-
-#. placeholder {0}: s.linked
-msgid "{0} merged into existing"
-msgstr ""
-
-#. placeholder {0}: s.errors
-msgid "{0} need attention"
 msgstr ""
 
 #. placeholder {0}: mappingReadiness.mapped
@@ -150,25 +166,13 @@ msgstr "{0}已登记"
 msgid "{0} rows"
 msgstr "{0} 行"
 
-#. placeholder {0}: s.skipped
-msgid "{0} skipped"
-msgstr ""
-
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0}个有余额的供应商"
 
-#. placeholder {0}: s.updates
-msgid "{0} to update"
-msgstr ""
-
 #. placeholder {0}: lotEntities.length - inspected
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}个未采样的实体将转为可用。已采样的合格品保持可用，已采样的不合格品保持已拒绝。"
-
-#. placeholder {0}: s.unchanged
-msgid "{0} unchanged"
-msgstr ""
 
 #. placeholder {0}: unmapped.length
 #. placeholder {1}: chart.length
@@ -249,7 +253,7 @@ msgstr "{done}个/{total}个阶段已完成"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行已排除} other {# 行已排除}}"
 
-msgid "{fileCount} matching accounts take the file's numbers."
+msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
 msgstr ""
 
 msgid "{from}–{to} of {count}"
@@ -266,7 +270,7 @@ msgstr "还有{hiddenCount}个：{hiddenNames}"
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "已插入{inserted}条，已更新{updated}条，需修复{0}条，已跳过{1}条。"
 
-msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
 msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
@@ -297,7 +301,7 @@ msgstr "{noDemandItemCount} 个零件已跳过 — 没有需要生产的"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} 将被重新打开以作为修订版本 {0} 进行编辑。已发送给供应商的文件在您完成并重新发送订单前保持不变。"
 
-msgid "{pendingCount} decision(s) not in the plan yet"
+msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -324,7 +328,7 @@ msgstr "{totalQuantity, plural, one {# 件} other {# 件}}"
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
 
-msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
 msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
@@ -14831,10 +14835,6 @@ msgstr "在客户列表、客户表单和下拉菜单上显示可读的客户ID�
 
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "在供应商列表、供应商表单和下拉菜单上显示可读的供应商 ID 列。无论哪种方式，供应商在内部仍然可以被识别。"
-
-#. placeholder {0}: plan.nodes.length
-msgid "Show all {0} rows"
-msgstr ""
 
 msgid "Show Customer IDs"
 msgstr "显示客户ID"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -133,10 +133,6 @@ msgstr "已创建{0}个工单"
 msgid "{0} lines to map"
 msgstr "{0} 行待映射"
 
-#. placeholder {0}: matching.length
-msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr "{0} 个匹配的科目：{fileCount} 个采用文件中的编号，{keepCount} 个保留 Carbon 中的编号。"
-
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
 msgid "{0} of {1} posting accounts mapped"
@@ -9586,6 +9582,10 @@ msgstr "已匹配"
 
 msgid "matches"
 msgstr "匹配"
+
+#. placeholder {0}: matching.length
+msgid "Matching accounts: {0}. File's numbers: {fileCount}, Carbon's numbers: {keepCount}."
+msgstr "匹配的科目：{0}。文件中的编号：{fileCount}，Carbon 中的编号：{keepCount}。"
 
 msgid "Matching Pairs"
 msgstr "匹配对"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -280,6 +280,9 @@ msgstr "{noDemandItemCount} 个零件已跳过 — 没有需要生产的"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} 将被重新打开以作为修订版本 {0} 进行编辑。已发送给供应商的文件在您完成并重新发送订单前保持不变。"
 
+msgid "{pendingCount} change(s) not yet in the plan"
+msgstr ""
+
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {永久删除 # 行？} other {永久删除 # 行？}}"
 
@@ -8100,6 +8103,14 @@ msgstr ""
 msgid "Import {label} CSV"
 msgstr "导入 {label} CSV"
 
+#. placeholder {0}: resolution.name
+msgid "Import as \"{0}\""
+msgstr ""
+
+#. placeholder {0}: resolution.number
+msgid "Import as {0}"
+msgstr ""
+
 msgid "Import results"
 msgstr "导入结果"
 
@@ -8187,9 +8198,6 @@ msgstr "在发货中包含额外零件"
 
 msgid "Include Inactive"
 msgstr "包括已停用"
-
-msgid "Include this row again"
-msgstr ""
 
 msgid "Included"
 msgstr "已包含"
@@ -8792,6 +8800,12 @@ msgstr "看板"
 msgid "Keep"
 msgstr "保留"
 
+msgid "Keep Carbon's number"
+msgstr ""
+
+msgid "Keep Carbon's numbers"
+msgstr ""
+
 msgid "Keep Current"
 msgstr "保持当前"
 
@@ -8809,6 +8823,9 @@ msgstr "保持未结"
 
 msgid "Keep picking"
 msgstr "继续拣货"
+
+msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
+msgstr ""
 
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "让订单、报价单和设置受到第二道检查的保护"
@@ -9548,6 +9565,9 @@ msgstr "已匹配"
 
 msgid "matches"
 msgstr "匹配"
+
+msgid "Matching accounts are updated in place; choose whose numbers they keep."
+msgstr ""
 
 msgid "Matching Pairs"
 msgstr "匹配对"
@@ -13412,6 +13432,9 @@ msgstr "残值 %"
 msgid "Resolve these before completing the NCR: every row must have a non-Pending disposition, and its linked entity quantities must match the row quantity."
 msgstr "在完成NCR之前解决这些问题：每一行必须有一个非待处理的处置，其关联实体数量必须与行数量匹配。"
 
+msgid "Resolved"
+msgstr ""
+
 msgid "Resolved Price"
 msgstr "已解决价格"
 
@@ -13886,8 +13909,16 @@ msgstr "销售、报价和按订单配置"
 msgid "Salesperson"
 msgstr "销售人员"
 
-#. placeholder {0}: [node.conflict.number, node.conflict.name].filter(Boolean).join(" ")
-msgid "Same as {0}"
+msgid "Same as {target}"
+msgstr ""
+
+msgid "Same as {target} (keep its number)"
+msgstr ""
+
+msgid "Same as {target} (use this file's number)"
+msgstr ""
+
+msgid "Same as {target}, keeping its number"
 msgstr ""
 
 msgid "Same as Book"
@@ -17270,10 +17301,6 @@ msgstr "转移至"
 msgid "Trash"
 msgstr "垃圾桶"
 
-#. placeholder {0}: mergeable.length
-msgid "Treat {0} same-name matches as the same account"
-msgstr ""
-
 msgid "Trial Balance"
 msgstr "试算平衡表"
 
@@ -17598,6 +17625,9 @@ msgstr "更新密码"
 msgid "Update Permissions"
 msgstr "更新权限"
 
+msgid "Update plan"
+msgstr ""
+
 msgid "Update Quantity"
 msgstr "更新数量"
 
@@ -17714,6 +17744,9 @@ msgstr "使用不同的电子邮件"
 
 msgid "Use metric system for default material dimensions."
 msgstr "使用公制作为默认原材料尺寸。"
+
+msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."
 msgstr ""

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -67,6 +67,10 @@ msgstr "{0, plural, one {此物料有1个未结的变更通知} other {此物料
 msgid "{0} accounts"
 msgstr "{0} 个账户"
 
+#. placeholder {0}: s.accountsToCreate
+msgid "{0} accounts to create"
+msgstr ""
+
 #. placeholder {0}: precise?.text
 msgid "{0} ago"
 msgstr "{0} 前"
@@ -92,9 +96,9 @@ msgstr "{0} 已成功删除"
 msgid "{0} draft journal entries"
 msgstr "{0}个草稿凭证"
 
-#. placeholder {0}: plan.summary.groupsToCreate
-#. placeholder {1}: plan.summary.accountsToCreate
-msgid "{0} groups, {1} accounts to create"
+#. placeholder {0}: s.groupsToCreate
+#. placeholder {1}: s.accountsToCreate
+msgid "{0} groups and {1} accounts to create"
 msgstr ""
 
 #. placeholder {0}: jobs.length
@@ -105,11 +109,15 @@ msgstr "已创建{0}个工单"
 msgid "{0} lines to map"
 msgstr "{0} 行待映射"
 
-#. placeholder {0}: plan.summary.linked
+#. placeholder {0}: matching.length
+msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
+msgstr ""
+
+#. placeholder {0}: s.linked
 msgid "{0} merged into existing"
 msgstr ""
 
-#. placeholder {0}: plan.summary.errors
+#. placeholder {0}: s.errors
 msgid "{0} need attention"
 msgstr ""
 
@@ -142,11 +150,15 @@ msgstr "{0}已登记"
 msgid "{0} rows"
 msgstr "{0} 行"
 
+#. placeholder {0}: s.skipped
+msgid "{0} skipped"
+msgstr ""
+
 #. placeholder {0}: ap.count
 msgid "{0} suppliers with a balance"
 msgstr "{0}个有余额的供应商"
 
-#. placeholder {0}: plan.summary.updates
+#. placeholder {0}: s.updates
 msgid "{0} to update"
 msgstr ""
 
@@ -154,9 +166,8 @@ msgstr ""
 msgid "{0} un-sampled entities will be released to Available. Sampled passes stay Available and sampled failures stay Rejected."
 msgstr "{0}个未采样的实体将转为可用。已采样的合格品保持可用，已采样的不合格品保持已拒绝。"
 
-#. placeholder {0}: plan.summary.unchanged
-#. placeholder {1}: plan.summary.skipped
-msgid "{0} unchanged, {1} skipped"
+#. placeholder {0}: s.unchanged
+msgid "{0} unchanged"
 msgstr ""
 
 #. placeholder {0}: unmapped.length
@@ -238,6 +249,9 @@ msgstr "{done}个/{total}个阶段已完成"
 msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行已排除} other {# 行已排除}}"
 
+msgid "{fileCount} matching accounts take the file's numbers."
+msgstr ""
+
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} 共 {count}"
 
@@ -251,6 +265,9 @@ msgstr "还有{hiddenCount}个：{hiddenNames}"
 #. placeholder {1}: skipped.length
 msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "已插入{inserted}条，已更新{updated}条，需修复{0}条，已跳过{1}条。"
+
+msgid "{keepCount} matching accounts keep their Carbon numbers."
+msgstr ""
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -280,7 +297,7 @@ msgstr "{noDemandItemCount} 个零件已跳过 — 没有需要生产的"
 msgid "{orderLabel} will be reopened for editing as revision {0}. The document already sent to the supplier is unchanged until you finalize and resend the order."
 msgstr "{orderLabel} 将被重新打开以作为修订版本 {0} 进行编辑。已发送给供应商的文件在您完成并重新发送订单前保持不变。"
 
-msgid "{pendingCount} change(s) not yet in the plan"
+msgid "{pendingCount} decision(s) not in the plan yet"
 msgstr ""
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
@@ -306,6 +323,9 @@ msgstr "{totalQuantity, plural, one {# 件} other {# 件}}"
 
 msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
+
+msgid "{undecided} accounts already exist in Carbon under other numbers."
+msgstr ""
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}无法排程"
@@ -1496,9 +1516,6 @@ msgstr "所有位置"
 
 msgid "All members of selected groups and selected individuals will be able to approve requests"
 msgstr "所选组的所有成员和所选个人都将能够审批请求"
-
-msgid "All rows"
-msgstr ""
 
 msgid "All rows imported — {inserted} inserted, {updated} updated."
 msgstr "所有行已导入—{inserted}行插入，{updated}行更新。"
@@ -2864,9 +2881,6 @@ msgstr "构建基于角色的培训材料"
 msgid "Build tailored, role-based training materials"
 msgstr "构建定制的、基于角色的培训材料"
 
-msgid "Building the plan…"
-msgstr ""
-
 msgid "Built and costed as its own method"
 msgstr "作为独立方法构建和计算成本"
 
@@ -3278,6 +3292,9 @@ msgstr "检查您的电子邮件"
 
 msgid "Checking Stripe for this customer…"
 msgstr "正在为此客户检查Stripe…"
+
+msgid "Checking the file against your chart of accounts…"
+msgstr ""
 
 msgid "Checkpoint ·"
 msgstr "检查点 ·"
@@ -7374,15 +7391,6 @@ msgstr "格式"
 msgid "Forward deployed engineer"
 msgstr "驻场工程师"
 
-msgid "Found a parent column."
-msgstr ""
-
-msgid "Found a path in the account names, e.g. Parent:Child."
-msgstr ""
-
-msgid "Found Begin-Total / End-Total rows."
-msgstr ""
-
 msgid "Foundation"
 msgstr "基础"
 
@@ -7809,8 +7817,20 @@ msgstr "隐藏原始内容"
 msgid "Hide system quantities until the review step"
 msgstr "在评审步骤前隐藏系统数量"
 
+msgid "Hide the full list"
+msgstr ""
+
 msgid "Hide, pin and reorder columns"
 msgstr "隐藏、固定和重新排序列"
+
+msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
+msgstr ""
+
+msgid "Hierarchy taken from the file's parent column."
+msgstr ""
+
+msgid "Hierarchy taken from the paths in the account names."
+msgstr ""
 
 msgid "High"
 msgstr "高"
@@ -8824,9 +8844,6 @@ msgstr "保持未结"
 msgid "Keep picking"
 msgstr "继续拣货"
 
-msgid "Keep resolving rows, then update the plan to see the result. Confirming the import applies them all."
-msgstr ""
-
 msgid "Keeps orders, quotes, and settings behind a second check"
 msgstr "让订单、报价单和设置受到第二道检查的保护"
 
@@ -9565,9 +9582,6 @@ msgstr "已匹配"
 
 msgid "matches"
 msgstr "匹配"
-
-msgid "Matching accounts are updated in place; choose whose numbers they keep."
-msgstr ""
 
 msgid "Matching Pairs"
 msgstr "匹配对"
@@ -10562,7 +10576,7 @@ msgstr "没有分组通知"
 msgid "No groups assigned"
 msgstr "没有已分配的组"
 
-msgid "No hierarchy in the file; accounts go under Carbon's existing groups by account type."
+msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
 msgstr ""
 
 msgid "No image"
@@ -10663,6 +10677,9 @@ msgstr "没有未完成的培训"
 
 msgid "No overtime scheduled"
 msgstr "没有安排加班"
+
+msgid "No parent column, row kinds, or paths in the names were found in the file."
+msgstr ""
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "尚未记录任何父源。点击计划页面上的\"重新计算\"以刷新归因。"
@@ -10946,6 +10963,9 @@ msgstr "存档中没有任何内容"
 
 msgid "Nothing scheduled — add a station below."
 msgstr "未安排任何事项——在下方添加工位。"
+
+msgid "Nothing to import."
+msgstr ""
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "暂无内容。步骤配置后才会提供值。"
@@ -13689,9 +13709,6 @@ msgstr "行"
 msgid "Rows left out of this backup"
 msgstr "此备份中遗漏的行"
 
-msgid "Rows that need attention are not imported. Resolve them here, fix the file, or import the rest now and the remainder later."
-msgstr ""
-
 msgid "Rule"
 msgstr "规则"
 
@@ -14815,6 +14832,10 @@ msgstr "在客户列表、客户表单和下拉菜单上显示可读的客户ID�
 msgid "Show a readable Supplier ID column on the supplier list, supplier forms, and dropdowns. Suppliers are still identified internally either way."
 msgstr "在供应商列表、供应商表单和下拉菜单上显示可读的供应商 ID 列。无论哪种方式，供应商在内部仍然可以被识别。"
 
+#. placeholder {0}: plan.nodes.length
+msgid "Show all {0} rows"
+msgstr ""
+
 msgid "Show Customer IDs"
 msgstr "显示客户ID"
 
@@ -15091,6 +15112,9 @@ msgstr "拆分收据行"
 
 msgid "Split shipment line"
 msgstr "拆分发货行"
+
+msgid "Split the account names on a separator, e.g. Parent:Child."
+msgstr ""
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16668,6 +16692,9 @@ msgstr "这些工单在此工作中心分配了工序:"
 msgid "These journal entries are still Draft, so their debits and credits aren't in the ledger for this period. Post each one, or re-date it into a later open period."
 msgstr "这些凭证仍是草稿，所以其借方和贷方不在此期间的账簿中。过账每一个，或将其重新标注日期到更后的未结期间。"
 
+msgid "These rows are not imported until they are resolved; everything else imports on confirm."
+msgstr ""
+
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "这些行链接到此公司外的数据，因此无法创建当前数据的安全备份。删除它们无法撤销。如果这些行实际上与此集团中的其他公司共享，则不删除任何行，且不启动还原。"
 
@@ -17640,6 +17667,9 @@ msgstr "更新源单据数量"
 msgid "Update the kanban information for scan-based replenishment."
 msgstr "更新看板信息以进行扫描式补货。"
 
+msgid "Update the plan to see the result. Confirming the import applies them all."
+msgstr ""
+
 msgid "Update the purchase order quantities"
 msgstr "更新采购订单数量"
 
@@ -17657,6 +17687,9 @@ msgstr "更新者"
 
 msgid "Updated successfully"
 msgstr "更新成功"
+
+msgid "Updating the plan…"
+msgstr ""
 
 msgid "Upgrade"
 msgstr "升级"
@@ -17745,7 +17778,7 @@ msgstr "使用不同的电子邮件"
 msgid "Use metric system for default material dimensions."
 msgstr "使用公制作为默认原材料尺寸。"
 
-msgid "Use the file's numbers for {matchingCount} matching accounts"
+msgid "Use the file's numbers"
 msgstr ""
 
 msgid "Use the file's parent column, name paths, or total rows when present."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -49,28 +49,28 @@ msgid "(excluded for this customer)"
 msgstr "(已为此客户排除)"
 
 msgid "(group)"
-msgstr ""
+msgstr "（组）"
 
 #. placeholder {0}: s.linked
 msgid "{0, plural, one {# account merged into an existing one} other {# accounts merged into existing ones}}"
-msgstr ""
+msgstr "{0, plural, other {# 个科目已合并到现有科目}}"
 
 #. placeholder {0}: s.accountsToCreate
 msgid "{0, plural, one {# account to create} other {# accounts to create}}"
-msgstr ""
+msgstr "{0, plural, other {待创建 # 个科目}}"
 
 #. placeholder {0}: s.updates
 msgid "{0, plural, one {# account to update} other {# accounts to update}}"
-msgstr ""
+msgstr "{0, plural, other {待更新 # 个科目}}"
 
 #. placeholder {0}: s.unchanged
 msgid "{0, plural, one {# account unchanged} other {# accounts unchanged}}"
-msgstr ""
+msgstr "{0, plural, other {# 个科目无变化}}"
 
 #. placeholder {0}: s.groupsToCreate
 #. placeholder {1}: s.accountsToCreate
 msgid "{0, plural, one {# group} other {# groups}} and {1, plural, one {# account} other {# accounts}} to create"
-msgstr ""
+msgstr "待创建 {0, plural, other {# 个组}}和 {1, plural, other {# 个科目}}"
 
 #. placeholder {0}: totalScopeRows(run.violationRowsByTable)
 msgid "{0, plural, one {# row links to data outside this company, so a safety copy of your current data can't be made.} other {# rows link to data outside this company, so a safety copy of your current data can't be made.}}"
@@ -82,15 +82,15 @@ msgstr "{0, plural, one {# 行链接到该公司外的数据，无法备份。�
 
 #. placeholder {0}: s.errors
 msgid "{0, plural, one {# row needs attention} other {# rows need attention}}"
-msgstr ""
+msgstr "{0, plural, other {# 行需要处理}}"
 
 #. placeholder {0}: s.skipped
 msgid "{0, plural, one {# row skipped} other {# rows skipped}}"
-msgstr ""
+msgstr "{0, plural, other {已跳过 # 行}}"
 
 #. placeholder {0}: plan.nodes.length
 msgid "{0, plural, one {Show the only row} other {Show all # rows}}"
-msgstr ""
+msgstr "{0, plural, other {显示全部 # 行}}"
 
 #. placeholder {0}: open.length
 msgid "{0, plural, one {This item is on 1 open change notice} other {This item is on # open change notices}}"
@@ -135,7 +135,7 @@ msgstr "{0} 行待映射"
 
 #. placeholder {0}: matching.length
 msgid "{0} matching accounts: {fileCount} take the file's numbers, {keepCount} keep Carbon's."
-msgstr ""
+msgstr "{0} 个匹配的科目：{fileCount} 个采用文件中的编号，{keepCount} 个保留 Carbon 中的编号。"
 
 #. placeholder {0}: mappingReadiness.mapped
 #. placeholder {1}: mappingReadiness.required
@@ -254,7 +254,7 @@ msgid "{excluded, plural, one {# row excluded} other {# rows excluded}}"
 msgstr "{excluded, plural, one {# 行已排除} other {# 行已排除}}"
 
 msgid "{fileCount, plural, one {# matching account takes the file's number.} other {# matching accounts take the file's numbers.}}"
-msgstr ""
+msgstr "{fileCount, plural, other {# 个匹配的科目采用文件中的编号。}}"
 
 msgid "{from}–{to} of {count}"
 msgstr "{from}–{to} 共 {count}"
@@ -271,7 +271,7 @@ msgid "{inserted} inserted, {updated} updated, {0} need fixing, {1} skipped."
 msgstr "已插入{inserted}条，已更新{updated}条，需修复{0}条，已跳过{1}条。"
 
 msgid "{keepCount, plural, one {# matching account keeps its Carbon number.} other {# matching accounts keep their Carbon numbers.}}"
-msgstr ""
+msgstr "{keepCount, plural, other {# 个匹配的科目保留 Carbon 中的编号。}}"
 
 msgid "{linesCount, plural, one {# line} other {# lines}}"
 msgstr "{linesCount, plural, one {# 行} other {# 行}}"
@@ -302,7 +302,7 @@ msgid "{orderLabel} will be reopened for editing as revision {0}. The document a
 msgstr "{orderLabel} 将被重新打开以作为修订版本 {0} 进行编辑。已发送给供应商的文件在您完成并重新发送订单前保持不变。"
 
 msgid "{pendingCount, plural, one {# decision not in the plan yet} other {# decisions not in the plan yet}}"
-msgstr ""
+msgstr "{pendingCount, plural, other {# 项决定尚未纳入计划}}"
 
 msgid "{purgeRowCount, plural, one {Permanently delete # row?} other {Permanently delete # rows?}}"
 msgstr "{purgeRowCount, plural, one {永久删除 # 行？} other {永久删除 # 行？}}"
@@ -329,7 +329,7 @@ msgid "{uncounted, plural, one {# uncounted line} other {# uncounted lines}}"
 msgstr "{uncounted, plural, one {# 未计数行} other {# 未计数行}}"
 
 msgid "{undecided, plural, one {# account already exists in Carbon under another number.} other {# accounts already exist in Carbon under other numbers.}}"
-msgstr ""
+msgstr "{undecided, plural, other {# 个科目已在 Carbon 中以其他编号存在。}}"
 
 msgid "{unschedulableCount} can't be scheduled"
 msgstr "{unschedulableCount}无法排程"
@@ -2484,7 +2484,7 @@ msgid "Attempts"
 msgstr "尝试次数"
 
 msgid "Attention"
-msgstr ""
+msgstr "需处理"
 
 msgid "Attribute"
 msgstr "属性"
@@ -3289,7 +3289,7 @@ msgid "Check the item ledger for any items with a negative on-hand quantity as o
 msgstr "检查物料分类账以查找期末现有数量为负的任何物料 — 通常是缺少收货或过账顺序错误，导致库存价值和销售成本失真。审查后标记为完成，或因某个理由跳过。"
 
 msgid "Check what will be created and changed before importing. Nothing is written until you confirm."
-msgstr ""
+msgstr "导入前请检查将要创建和更改的内容。在您确认之前不会写入任何数据。"
 
 msgid "Check your email"
 msgstr "检查您的电子邮件"
@@ -3298,7 +3298,7 @@ msgid "Checking Stripe for this customer…"
 msgstr "正在为此客户检查Stripe…"
 
 msgid "Checking the file against your chart of accounts…"
-msgstr ""
+msgstr "正在将文件与您的会计科目表进行核对…"
 
 msgid "Checkpoint ·"
 msgstr "检查点 ·"
@@ -5479,7 +5479,7 @@ msgid "Details"
 msgstr "详情"
 
 msgid "Detect from the file"
-msgstr ""
+msgstr "从文件中检测"
 
 msgid "Developer"
 msgstr "开发人员"
@@ -6636,7 +6636,7 @@ msgid "Exemption Reason"
 msgstr "豁免原因"
 
 msgid "Existing"
-msgstr ""
+msgstr "现有"
 
 msgid "Existing mappings. Pick a different provider option to re-map."
 msgstr "现有映射。选择不同的提供商选项进行重新映射。"
@@ -7780,7 +7780,7 @@ msgid "Groups"
 msgstr "组"
 
 msgid "Groups come from the file. A top-level group with the same name as a Carbon group is merged into it."
-msgstr ""
+msgstr "分组来自文件。与 Carbon 中的组同名的顶级组将合并到该组中。"
 
 msgid "Guided"
 msgstr "引导式"
@@ -7822,19 +7822,19 @@ msgid "Hide system quantities until the review step"
 msgstr "在评审步骤前隐藏系统数量"
 
 msgid "Hide the full list"
-msgstr ""
+msgstr "隐藏完整列表"
 
 msgid "Hide, pin and reorder columns"
 msgstr "隐藏、固定和重新排序列"
 
 msgid "Hierarchy taken from the file's Begin-Total / End-Total rows."
-msgstr ""
+msgstr "层级取自文件中的 Begin-Total / End-Total 行。"
 
 msgid "Hierarchy taken from the file's parent column."
-msgstr ""
+msgstr "层级取自文件中的上级科目列。"
 
 msgid "Hierarchy taken from the paths in the account names."
-msgstr ""
+msgstr "层级取自科目名称中的路径。"
 
 msgid "High"
 msgstr "高"
@@ -7975,7 +7975,7 @@ msgid "How often this maintenance recurs — Daily, Weekly, Monthly, On Cycle Co
 msgstr "此维护的重复频率——每日、每周、每月、循环盘点；每日会显示星期选择器，其他则使用更简单的间隔计算。"
 
 msgid "How should the accounts be organised?"
-msgstr ""
+msgstr "应如何组织这些科目？"
 
 msgid "How the job ranks when the scheduler hands out capacity — ASAP claims first, then Hard Deadline, Soft Deadline, and No Deadline last. A ranking signal only; no deadline type blocks or gates placement."
 msgstr "调度程序分配产能时工单的排名方式——立即执行优先，然后是硬期限、软期限，最后是无期限。仅作为排序信号；任何期限类型都不会阻止或限制安排。"
@@ -8098,7 +8098,7 @@ msgid "If you wish to change the part numbers, please click Cancel and manually 
 msgstr "如果您希望更改零件号，请点击\"取消\"并在转换前为每个行项目手动分配零件。"
 
 msgid "Ignore the file's groups; each account goes under the Carbon group that matches its account type."
-msgstr ""
+msgstr "忽略文件中的组；每个科目归入与其科目类型匹配的 Carbon 组。"
 
 msgid "II (normal default)"
 msgstr "II（正常默认值）"
@@ -8122,27 +8122,27 @@ msgid "Implementation Lead"
 msgstr "实施主管"
 
 msgid "Import"
-msgstr ""
+msgstr "导入"
 
 msgid "Import {label} CSV"
 msgstr "导入 {label} CSV"
 
 #. placeholder {0}: resolution.name
 msgid "Import as \"{0}\""
-msgstr ""
+msgstr "导入为“{0}”"
 
 #. placeholder {0}: resolution.number
 msgid "Import as {0}"
-msgstr ""
+msgstr "导入为 {0}"
 
 msgid "Import results"
 msgstr "导入结果"
 
 msgid "Import under a different name"
-msgstr ""
+msgstr "以其他名称导入"
 
 msgid "Import under a different number"
-msgstr ""
+msgstr "以其他编号导入"
 
 msgid "Import your BOM"
 msgstr "导入您的BOM"
@@ -8825,10 +8825,10 @@ msgid "Keep"
 msgstr "保留"
 
 msgid "Keep Carbon's number"
-msgstr ""
+msgstr "保留 Carbon 中的编号"
 
 msgid "Keep Carbon's numbers"
-msgstr ""
+msgstr "保留 Carbon 中的编号"
 
 msgid "Keep Current"
 msgstr "保持当前"
@@ -9009,7 +9009,7 @@ msgid "Leave empty for exact match"
 msgstr "留空以精确匹配"
 
 msgid "Leave this account as it is"
-msgstr ""
+msgstr "保持此科目不变"
 
 msgid "Leave this page"
 msgstr "离开此页面"
@@ -9090,7 +9090,7 @@ msgid "Likelihood"
 msgstr "可能性"
 
 msgid "Line"
-msgstr ""
+msgstr "行"
 
 msgid "Line description (optional)"
 msgstr "行描述(可选)"
@@ -10019,7 +10019,7 @@ msgid "Needs a Business or Partner plan."
 msgstr "需要业务或合作伙伴计划。"
 
 msgid "Needs attention"
-msgstr ""
+msgstr "需要处理"
 
 msgid "Needs fixing"
 msgstr "需要修复"
@@ -10581,7 +10581,7 @@ msgid "No groups assigned"
 msgstr "没有已分配的组"
 
 msgid "No hierarchy in the file: accounts are placed under Carbon's existing groups by account type."
-msgstr ""
+msgstr "文件中没有层级：科目按科目类型归入 Carbon 现有的组。"
 
 msgid "No image"
 msgstr "没有图像"
@@ -10683,7 +10683,7 @@ msgid "No overtime scheduled"
 msgstr "没有安排加班"
 
 msgid "No parent column, row kinds, or paths in the names were found in the file."
-msgstr ""
+msgstr "文件中未找到上级科目列、行类型或名称中的路径。"
 
 msgid "No parent sources recorded yet. Click Recalculate on the planning page to refresh attribution."
 msgstr "尚未记录任何父源。点击计划页面上的\"重新计算\"以刷新归因。"
@@ -10969,7 +10969,7 @@ msgid "Nothing scheduled — add a station below."
 msgstr "未安排任何事项——在下方添加工位。"
 
 msgid "Nothing to import."
-msgstr ""
+msgstr "没有可导入的内容。"
 
 msgid "Nothing yet. A step only offers values once it is configured."
 msgstr "暂无内容。步骤配置后才会提供值。"
@@ -11695,7 +11695,7 @@ msgid "Path"
 msgstr "路径"
 
 msgid "Path separator in account names"
-msgstr ""
+msgstr "科目名称中的路径分隔符"
 
 msgid "Pay Rate"
 msgstr "支付汇率"
@@ -11928,7 +11928,7 @@ msgid "Pinned"
 msgstr "已固定"
 
 msgid "Place accounts under Carbon's existing groups"
-msgstr ""
+msgstr "将科目归入 Carbon 现有的组"
 
 msgid "Plan"
 msgstr "计划"
@@ -13457,7 +13457,7 @@ msgid "Resolve these before completing the NCR: every row must have a non-Pendin
 msgstr "在完成NCR之前解决这些问题：每一行必须有一个非待处理的处置，其关联实体数量必须与行数量匹配。"
 
 msgid "Resolved"
-msgstr ""
+msgstr "已解决"
 
 msgid "Resolved Price"
 msgstr "已解决价格"
@@ -13931,16 +13931,16 @@ msgid "Salesperson"
 msgstr "销售人员"
 
 msgid "Same as {target}"
-msgstr ""
+msgstr "与 {target} 相同"
 
 msgid "Same as {target} (keep its number)"
-msgstr ""
+msgstr "与 {target} 相同（保留其编号）"
 
 msgid "Same as {target} (use this file's number)"
-msgstr ""
+msgstr "与 {target} 相同（使用此文件中的编号）"
 
 msgid "Same as {target}, keeping its number"
-msgstr ""
+msgstr "与 {target} 相同，保留其编号"
 
 msgid "Same as Book"
 msgstr "与账面相同"
@@ -14967,7 +14967,7 @@ msgid "Skip the released-but-not-started state — the job starts immediately on
 msgstr "跳过已发布但未启动状态 — 扫码时工单立即启动。"
 
 msgid "Skip this row"
-msgstr ""
+msgstr "跳过此行"
 
 msgid "Skipped"
 msgstr "已跳过"
@@ -15114,7 +15114,7 @@ msgid "Split shipment line"
 msgstr "拆分发货行"
 
 msgid "Split the account names on a separator, e.g. Parent:Child."
-msgstr ""
+msgstr "按分隔符拆分科目名称，例如“上级:下级”。"
 
 msgid "SSO/SAML"
 msgstr "SSO/SAML"
@@ -16374,7 +16374,7 @@ msgid "The permission set new employees of this type receive automatically; edit
 msgstr "该类型的新员工自动接收的权限集；在此处编辑仅更改模板以供将来雇用 - 现有员工保留他们拥有的内容，除非明确进行批量更新。"
 
 msgid "The plan could not be built"
-msgstr ""
+msgstr "无法生成计划"
 
 msgid "The plants, warehouses, and sites where your work and stock live"
 msgstr "您的工作和库存所在的工厂、仓库和场所"
@@ -16693,7 +16693,7 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "这些凭证仍是草稿，所以其借方和贷方不在此期间的账簿中。过账每一个，或将其重新标注日期到更后的未结期间。"
 
 msgid "These rows are not imported until they are resolved; everything else imports on confirm."
-msgstr ""
+msgstr "这些行在解决之前不会导入；其余内容将在确认时导入。"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
 msgstr "这些行链接到此公司外的数据，因此无法创建当前数据的安全备份。删除它们无法撤销。如果这些行实际上与此集团中的其他公司共享，则不删除任何行，且不启动还原。"
@@ -17422,13 +17422,13 @@ msgid "Unballoon"
 msgstr "取消气球标注"
 
 msgid "Unchanged"
-msgstr ""
+msgstr "无变化"
 
 msgid "Uncounted lines are left unchanged at post — they are not zeroed."
 msgstr "未计数的行在过账时保持不变——它们不会被清零。"
 
 msgid "Under"
-msgstr ""
+msgstr "所属"
 
 msgid "Under Demand-Based Reorder, planning sums demand inside this rolling window when computing a replenishment quantity."
 msgstr "在基于需求的再订购下，计划在计算补货数量时对该滚动窗口内的需求进行求和。"
@@ -17653,7 +17653,7 @@ msgid "Update Permissions"
 msgstr "更新权限"
 
 msgid "Update plan"
-msgstr ""
+msgstr "更新计划"
 
 msgid "Update Quantity"
 msgstr "更新数量"
@@ -17668,7 +17668,7 @@ msgid "Update the kanban information for scan-based replenishment."
 msgstr "更新看板信息以进行扫描式补货。"
 
 msgid "Update the plan to see the result. Confirming the import applies them all."
-msgstr ""
+msgstr "更新计划以查看结果。确认导入将全部应用。"
 
 msgid "Update the purchase order quantities"
 msgstr "更新采购订单数量"
@@ -17689,7 +17689,7 @@ msgid "Updated successfully"
 msgstr "更新成功"
 
 msgid "Updating the plan…"
-msgstr ""
+msgstr "正在更新计划…"
 
 msgid "Upgrade"
 msgstr "升级"
@@ -17779,13 +17779,13 @@ msgid "Use metric system for default material dimensions."
 msgstr "使用公制作为默认原材料尺寸。"
 
 msgid "Use the file's numbers"
-msgstr ""
+msgstr "使用文件中的编号"
 
 msgid "Use the file's parent column, name paths, or total rows when present."
-msgstr ""
+msgstr "存在时使用文件中的上级科目列、名称路径或合计行。"
 
 msgid "Use the hierarchy in the file"
-msgstr ""
+msgstr "使用文件中的层级"
 
 msgid "Used In"
 msgstr "用于"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -17270,6 +17270,10 @@ msgstr "转移至"
 msgid "Trash"
 msgstr "垃圾桶"
 
+#. placeholder {0}: mergeable.length
+msgid "Treat {0} same-name matches as the same account"
+msgstr ""
+
 msgid "Trial Balance"
 msgstr "试算平衡表"
 


### PR DESCRIPTION
## What does this PR do?

Adds `account` to the shared CSV import wizard, so a company can load or update its chart of accounts from another system's export instead of entering accounts one by one. Reached from Accounting → Chart of Accounts → Import (root company only).

- **Planner** (`import-csv/account-import.ts`, pure, 17 deno tests): builds the tree from whatever the file offers — a parent column, `Parent:Child` paths, Begin-Total / End-Total rows with indentation, or nothing (accounts placed under Carbon's existing groups by account type). Matches rows to existing accounts by Source ID, number, then name; a row referenced as a parent is promoted to a group; the two system roots are adopted, never written. Refusals (system accounts, class change or deactivation on a posted account, an account used by Default Accounts or a fixed-asset class, cycles, duplicates) are reported per row rather than failing the batch.
- **Review step** (`ChartOfAccountsReview.tsx`): runs the same edge function as a dry run and shows the plan before anything is written. One screen at a time: preparing → hierarchy question (only when the file has none, or on request) → plan. Accounts that already exist under other numbers get one decision ("use the file's numbers" / "keep Carbon's numbers"); per-row resolutions (skip, rename, renumber, same as existing) accumulate and re-plan on "Update plan". Confirm applies the plan in one transaction.
- **Wizard**: field aliases and option aliases (QuickBooks / Xero / NetSuite / Sage / Business Central / Odoo / Rillet type vocabularies), headers with a leading `*` normalised, a per-table review-step registry (`reviewSteps.ts`), and `dryRun` / `options` on the import route, service and edge function payload.
- **Writer**: parents first, ids generated up front, Source IDs stored as csv mappings so a re-import matches. Additive — creates, updates and links; never deletes.

Tracking spec: `.ai/specs/2026-09-04-chart-of-accounts-import.md`. Docs: `docs/content/docs/reference/import-export.mdx`; rule: `.claude/rules/csv-import-system.md`.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Local stack, a root company (no parent company), `accounting_update` permission. No new environment variables or migrations.

1. Accounting → Chart of Accounts → Import. Upload a CSV with at least `Account Number`, `Account Name`, `Account Type`; optionally `Class`, `Parent Account`, `Is Group`, `Row Kind`, `Indentation`, `Active`, `Source ID`. The download-template link gives the headers.
2. Map columns (auto-matched, including aliases like `Code` / `Name` / `Type` / `Detail type` / `Parent Grouping`), map account types on the enum step.
3. Review: expect the counts to match the file; rows named after an existing account under a different number appear in "Needs attention" with the two bulk buttons. Change the hierarchy via "Change", resolve rows, "Update plan", then Confirm.
4. Expected: the tree shows the file's accounts under the file's groups (or under Carbon's groups by type for a flat file); re-importing the same file reports every row unchanged; nothing is deleted.

Planner tests: `cd packages/database/supabase/functions && deno test --allow-env --allow-read --no-check=remote import-csv/account-import.test.ts`.

Verified in the browser with four export shapes: parent-column (grouping labels), `Parent:Child` paths (QuickBooks), flat with `*Code` headers (Xero), Begin-Total / End-Total with indentation (Business Central), plus a 226-row parent-column file committed end to end and checked against the database (0 missing, 226 Source ID mappings, no duplicate numbers or names, no cycles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbm8Tf1WYth1tRX2i21RUK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV import support for charts of accounts.
  * Added hierarchy detection, placement options, and conflict resolution choices.
  * Added a review step to preview proposed changes before importing.
  * Added dry-run previews without saving changes.
  * Added support for creating, updating, matching, linking, or skipping accounts.
  * Added an Import action from the Chart of Accounts page.

* **Bug Fixes**
  * Improved handling of blank status values and circular account hierarchies.
  * Improved singular and plural wording in import summaries.

* **Documentation**
  * Documented chart-of-accounts import workflows, supported formats, and review behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->