### PR TITLE
fix(import): confirm before discarding a CSV import in progress

### DIFF
--- a/apps/erp/app/components/ImportCSVModal/ConfirmDiscardImport.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ConfirmDiscardImport.tsx
@@ -1,0 +1,57 @@
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalDescription,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle
+} from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+
+/**
+ * Asks before an import in progress is thrown away. The wizard holds the
+ * uploaded file, the column mappings and the enum mappings in React state, so
+ * closing it loses all of them — this dialog is what stands between a
+ * mis-clicked × (or a stray Escape) and starting the mapping over.
+ *
+ * Nested inside the wizard's own modal, the same way FieldMappings opens the
+ * payment-term and shipping-method forms.
+ */
+export function ConfirmDiscardImport({
+  onCancel,
+  onDiscard
+}: {
+  onCancel: () => void;
+  onDiscard: () => void;
+}) {
+  return (
+    <Modal
+      open
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <ModalContent size="small">
+        <ModalHeader>
+          <ModalTitle>
+            <Trans>Discard this import?</Trans>
+          </ModalTitle>
+          <ModalDescription>
+            <Trans>
+              The file you uploaded and the mappings you've made will be lost.
+            </Trans>
+          </ModalDescription>
+        </ModalHeader>
+        <ModalFooter>
+          <Button variant="secondary" onClick={onCancel}>
+            <Trans>Keep editing</Trans>
+          </Button>
+          <Button variant="destructive" onClick={onDiscard}>
+            <Trans>Discard import</Trans>
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
+++ b/apps/erp/app/components/ImportCSVModal/ImportCSVModal.tsx
@@ -9,6 +9,7 @@ import { type fieldMappings, importSchemas } from "~/modules/shared";
 import type { action } from "~/routes/x+/shared+/import.$tableId";
 import { path } from "~/utils/path";
 import { AnimatedSizeContainer } from "../AnimatedSizeContainer";
+import { ConfirmDiscardImport } from "./ConfirmDiscardImport";
 import { FieldMapping } from "./FieldMappings";
 import { ImportResultsModal } from "./ImportResultsModal";
 import { UploadCSV } from "./UploadCSV";
@@ -40,6 +41,36 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
   const [firstRows, setFirstRows] = useState<Record<string, string>[] | null>(
     null
   );
+  const [isConfirmingDiscard, setIsConfirmingDiscard] = useState(false);
+
+  // Parsed columns are what moves the wizard off the upload step, so they are
+  // also the point from which closing costs the user something: the upload and
+  // every mapping they've made, all of which the wizard keeps in memory and
+  // nowhere else. Before that (and after "choose a different file", which
+  // clears them) the × closes straight away. Once the import has landed the
+  // results modal owns the close and there is nothing left to lose.
+  const hasImportInProgress =
+    fileColumns !== null && fetcher.data?.success !== true;
+
+  const requestClose = () => {
+    if (hasImportInProgress) {
+      setIsConfirmingDiscard(true);
+      return;
+    }
+    onClose();
+  };
+
+  // A reload drops the same state, and there is nowhere to persist it to yet,
+  // so the browser's own prompt is the only guard available for that path.
+  useEffect(() => {
+    if (!hasImportInProgress) return;
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", warnBeforeUnload);
+    return () => window.removeEventListener("beforeunload", warnBeforeUnload);
+  }, [hasImportInProgress]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: suppressed due to migration
   useEffect(() => {
@@ -95,7 +126,7 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
       open
       onOpenChange={(open) => {
         if (!open) {
-          onClose();
+          requestClose();
         }
       }}
     >
@@ -155,6 +186,12 @@ export const ImportCSVModal = ({ table, onClose }: ImportCSVModalProps) => {
           </AnimatedSizeContainer>
         </div>
       </ModalContent>
+      {isConfirmingDiscard && (
+        <ConfirmDiscardImport
+          onCancel={() => setIsConfirmingDiscard(false)}
+          onDiscard={onClose}
+        />
+      )}
     </Modal>
   );
 };

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Deaktiviert"
 msgid "Discard"
 msgstr "Verwerfen"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Verworfen"
 
@@ -8946,6 +8952,9 @@ msgstr "Behalten"
 
 msgid "Keep Current"
 msgstr "Aktuell behalten"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Behalten Sie die bestehenden Preise, fügen Sie nur neue Artikel hinzu."
@@ -16344,6 +16353,9 @@ msgstr "Der erwartete Prozentsatz der Ausgabe dieses Artikels, der während der 
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Das Aufwandskonto, auf das diese indirekte Ausgabenzeile gebucht wird; erforderlich, da indirekte Zeilen keinen Bestandsposten haben, von dem das Konto abgeleitet werden kann."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "die ersten 3 bis 4 Wochen"

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Verwerfen"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Import verwerfen"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Diesen Import verwerfen?"
 
 msgid "Discarded"
 msgstr "Verworfen"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Aktuell behalten"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Weiter bearbeiten"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Behalten Sie die bestehenden Preise, fügen Sie nur neue Artikel hinzu."
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Das Aufwandskonto, auf das diese indirekte Ausgabenzeile gebucht wird; erforderlich, da indirekte Zeilen keinen Bestandsposten haben, von dem das Konto abgeleitet werden kann."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Die hochgeladene Datei und die vorgenommenen Zuordnungen gehen verloren."
 
 msgid "the first 3 to 4 weeks"
 msgstr "die ersten 3 bis 4 Wochen"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Disabled"
 msgid "Discard"
 msgstr "Discard"
 
+msgid "Discard import"
+msgstr "Discard import"
+
+msgid "Discard this import?"
+msgstr "Discard this import?"
+
 msgid "Discarded"
 msgstr "Discarded"
 
@@ -8946,6 +8952,9 @@ msgstr "Keep"
 
 msgid "Keep Current"
 msgstr "Keep Current"
+
+msgid "Keep editing"
+msgstr "Keep editing"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Keep existing pricing, only add new items"
@@ -16344,6 +16353,9 @@ msgstr "The expected percentage of this item's output lost during production; pl
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr "The file you uploaded and the mappings you've made will be lost."
 
 msgid "the first 3 to 4 weeks"
 msgstr "the first 3 to 4 weeks"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Deshabilitado"
 msgid "Discard"
 msgstr "Descartar"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Descartado"
 
@@ -8946,6 +8952,9 @@ msgstr "Mantener"
 
 msgid "Keep Current"
 msgstr "Mantener Actual"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mantener fijación de precios existente, solo agregar artículos nuevos"
@@ -16344,6 +16353,9 @@ msgstr "El porcentaje esperado de la producción de este artículo perdido duran
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "La cuenta de gastos en la que se contabiliza esta línea de gasto indirecto; es obligatoria porque las líneas indirectas no tienen un asiento de mayor de inventario del cual derivar la cuenta."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "las primeras 3 a 4 semanas"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Descartar"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Descartar importación"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "¿Descartar esta importación?"
 
 msgid "Discarded"
 msgstr "Descartado"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Mantener Actual"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Seguir editando"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mantener fijación de precios existente, solo agregar artículos nuevos"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "La cuenta de gastos en la que se contabiliza esta línea de gasto indirecto; es obligatoria porque las líneas indirectas no tienen un asiento de mayor de inventario del cual derivar la cuenta."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Se perderán el archivo que subiste y las asignaciones que hiciste."
 
 msgid "the first 3 to 4 weeks"
 msgstr "las primeras 3 a 4 semanas"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Rejeter"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Rejeter l'import"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Rejeter cet import ?"
 
 msgid "Discarded"
 msgstr "Rejeté"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Conserver les paramètres actuels"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Continuer l'édition"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Conserver la tarification existante, ajouter uniquement les nouveaux articles"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Le compte de charge auquel cette ligne de dépenses indirectes se comptabilise; requis parce que les lignes indirectes n'ont pas d'entrée de livre comptable d'article à partir de laquelle dériver le compte."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Le fichier que vous avez importé et les correspondances que vous avez définies seront perdus."
 
 msgid "the first 3 to 4 weeks"
 msgstr "les 3 à 4 premières semaines"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Désactivé"
 msgid "Discard"
 msgstr "Rejeter"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Rejeté"
 
@@ -8946,6 +8952,9 @@ msgstr "Conserver"
 
 msgid "Keep Current"
 msgstr "Conserver les paramètres actuels"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Conserver la tarification existante, ajouter uniquement les nouveaux articles"
@@ -16344,6 +16353,9 @@ msgstr "Le pourcentage attendu de la production de cet article perdu lors de la 
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Le compte de charge auquel cette ligne de dépenses indirectes se comptabilise; requis parce que les lignes indirectes n'ont pas d'entrée de livre comptable d'article à partir de laquelle dériver le compte."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "les 3 à 4 premières semaines"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "त्यागें"
 
 msgid "Discard import"
-msgstr ""
+msgstr "आयात त्यागें"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "क्या यह आयात त्यागें?"
 
 msgid "Discarded"
 msgstr "छोड़ा गया"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "वर्तमान रखें"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "संपादन जारी रखें"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "मौजूदा मूल्य निर्धारण रखें, केवल नई वस्तुएं जोड़ें"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "व्यय खाता जिस पर यह अप्रत्यक्ष-खर्च लाइन पोस्ट करता है; आवश्यक है क्योंकि अप्रत्यक्ष लाइनों के पास खाता प्राप्त करने के लिए कोई वस्तु बही प्रविष्टि नहीं है।"
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "आपके द्वारा अपलोड की गई फ़ाइल और की गई मैपिंग खो जाएँगी।"
 
 msgid "the first 3 to 4 weeks"
 msgstr "पहले 3 से 4 सप्ताह"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -5635,6 +5635,12 @@ msgstr "अक्षम"
 msgid "Discard"
 msgstr "त्यागें"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "छोड़ा गया"
 
@@ -8946,6 +8952,9 @@ msgstr "रखें"
 
 msgid "Keep Current"
 msgstr "वर्तमान रखें"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "मौजूदा मूल्य निर्धारण रखें, केवल नई वस्तुएं जोड़ें"
@@ -16344,6 +16353,9 @@ msgstr "इस आइटम के आउटपुट का अपेक्ष�
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "व्यय खाता जिस पर यह अप्रत्यक्ष-खर्च लाइन पोस्ट करता है; आवश्यक है क्योंकि अप्रत्यक्ष लाइनों के पास खाता प्राप्त करने के लिए कोई वस्तु बही प्रविष्टि नहीं है।"
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "पहले 3 से 4 सप्ताह"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Scarta"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Scarta importazione"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Scartare questa importazione?"
 
 msgid "Discarded"
 msgstr "Scartato"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Mantieni Attuale"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Continua a modificare"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mantieni la determinazione dei prezzi esistente, aggiungi solo nuovi articoli"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Il conto spese a cui questa riga di spesa indiretta viene contabilizzata; obbligatorio perché le righe indirette non hanno una voce di inventario da cui derivare il conto."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Il file caricato e le mappature effettuate andranno persi."
 
 msgid "the first 3 to 4 weeks"
 msgstr "le prime 3-4 settimane"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Disabilitato"
 msgid "Discard"
 msgstr "Scarta"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Scartato"
 
@@ -8946,6 +8952,9 @@ msgstr "Mantieni"
 
 msgid "Keep Current"
 msgstr "Mantieni Attuale"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mantieni la determinazione dei prezzi esistente, aggiungi solo nuovi articoli"
@@ -16344,6 +16353,9 @@ msgstr "La percentuale prevista di produzione di questo articolo persa durante l
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Il conto spese a cui questa riga di spesa indiretta viene contabilizzata; obbligatorio perché le righe indirette non hanno una voce di inventario da cui derivare il conto."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "le prime 3-4 settimane"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "破棄"
 
 msgid "Discard import"
-msgstr ""
+msgstr "インポートを破棄"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "このインポートを破棄しますか?"
 
 msgid "Discarded"
 msgstr "破棄されました"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "現在の設定を保持"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "編集を続ける"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "既存の価格設定を保持し、新しい品目のみを追加"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "この間接支出明細が転記される費用勘定。間接明細には品目台帳エントリがないため、勘定を導出できないため必須です。"
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "アップロードしたファイルと設定したマッピングは失われます。"
 
 msgid "the first 3 to 4 weeks"
 msgstr "最初の3～4週間"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -5635,6 +5635,12 @@ msgstr "無効"
 msgid "Discard"
 msgstr "破棄"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "破棄されました"
 
@@ -8946,6 +8952,9 @@ msgstr "保持"
 
 msgid "Keep Current"
 msgstr "現在の設定を保持"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "既存の価格設定を保持し、新しい品目のみを追加"
@@ -16344,6 +16353,9 @@ msgstr "生産中にこの品目の出力の失われると予想される割合
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "この間接支出明細が転記される費用勘定。間接明細には品目台帳エントリがないため、勘定を導出できないため必須です。"
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "最初の3～4週間"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -5635,6 +5635,12 @@ msgstr "비활성화됨"
 msgid "Discard"
 msgstr "폐기"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "폐기됨"
 
@@ -8946,6 +8952,9 @@ msgstr "유지"
 
 msgid "Keep Current"
 msgstr "현재 값 유지"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "기존 가격 책정을 유지하고 새 품목만 추가합니다."
@@ -16344,6 +16353,9 @@ msgstr "생산 중 이 품목의 출력량 손실의 예상 비율로, 계획에
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "이 간접비 지출 라인이 계상되는 비용 계정입니다. 간접비 라인은 계정을 도출할 품목 원장 항목이 없으므로 필수입니다."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "처음 3~4주"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "폐기"
 
 msgid "Discard import"
-msgstr ""
+msgstr "가져오기 폐기"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "이 가져오기를 폐기하시겠습니까?"
 
 msgid "Discarded"
 msgstr "폐기됨"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "현재 값 유지"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "계속 편집"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "기존 가격 책정을 유지하고 새 품목만 추가합니다."
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "이 간접비 지출 라인이 계상되는 비용 계정입니다. 간접비 라인은 계정을 도출할 품목 원장 항목이 없으므로 필수입니다."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "업로드한 파일과 설정한 매핑이 손실됩니다."
 
 msgid "the first 3 to 4 weeks"
 msgstr "처음 3~4주"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Odrzuć"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Odrzuć import"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Odrzucić ten import?"
 
 msgid "Discarded"
 msgstr "Odrzucono"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Zachowaj bieżące"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Kontynuuj edycję"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Zachowaj istniejące ceny, dodaj tylko nowe artykuły"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Konto wydatków, na które ta linia wydatków pośrednich jest księgowana; wymagane, ponieważ linie pośrednie nie mają wpisu do księgi inwentarzowej, z którego można pochodzić konto."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Przesłany plik i utworzone mapowania zostaną utracone."
 
 msgid "the first 3 to 4 weeks"
 msgstr "pierwsze 3 do 4 tygodnie"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Wyłączone"
 msgid "Discard"
 msgstr "Odrzuć"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Odrzucono"
 
@@ -8946,6 +8952,9 @@ msgstr "Zachowaj"
 
 msgid "Keep Current"
 msgstr "Zachowaj bieżące"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Zachowaj istniejące ceny, dodaj tylko nowe artykuły"
@@ -16344,6 +16353,9 @@ msgstr "Oczekiwany procent wyniku tego artykułu utraconego podczas produkcji; p
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Konto wydatków, na które ta linia wydatków pośrednich jest księgowana; wymagane, ponieważ linie pośrednie nie mają wpisu do księgi inwentarzowej, z którego można pochodzić konto."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "pierwsze 3 do 4 tygodnie"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Desativado"
 msgid "Discard"
 msgstr "Descartar"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Descartado"
 
@@ -8946,6 +8952,9 @@ msgstr "Manter"
 
 msgid "Keep Current"
 msgstr "Manter Atual"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Manter precificação existente, apenas adicionar itens novos"
@@ -16344,6 +16353,9 @@ msgstr "O percentual esperado de saída deste item perdida durante a produção;
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "A conta de despesas em que essa linha de despesa indireta é lançada; obrigatória porque as linhas indiretas não têm um lançamento do livro de inventário do qual derivar a conta."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "as primeiras 3 a 4 semanas"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Descartar"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Descartar importação"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Descartar esta importação?"
 
 msgid "Discarded"
 msgstr "Descartado"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Manter Atual"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Continuar editando"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Manter precificação existente, apenas adicionar itens novos"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "A conta de despesas em que essa linha de despesa indireta é lançada; obrigatória porque as linhas indiretas não têm um lançamento do livro de inventário do qual derivar a conta."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "O arquivo enviado e os mapeamentos feitos serão perdidos."
 
 msgid "the first 3 to 4 weeks"
 msgstr "as primeiras 3 a 4 semanas"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Отключено"
 msgid "Discard"
 msgstr "Отклонить"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "Отклонено"
 
@@ -8946,6 +8952,9 @@ msgstr "Сохранить"
 
 msgid "Keep Current"
 msgstr "Сохранить текущие"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Сохранить существующее ценообразование, добавить только новую номенклатуру"
@@ -16344,6 +16353,9 @@ msgstr "Ожидаемый процент выпуска этой номенкл
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Счет расходов, на который относится эта строка косвенных расходов; требуется, так как косвенные строки не имеют записи в книге товаров, из которой можно вывести счет."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "первые 3–4 недели"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Отклонить"
 
 msgid "Discard import"
-msgstr ""
+msgstr "Отклонить импорт"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Отклонить этот импорт?"
 
 msgid "Discarded"
 msgstr "Отклонено"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Сохранить текущие"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Продолжить редактирование"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Сохранить существующее ценообразование, добавить только новую номенклатуру"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Счет расходов, на который относится эта строка косвенных расходов; требуется, так как косвенные строки не имеют записи в книге товаров, из которой можно вывести счет."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Загруженный файл и созданные сопоставления будут потеряны."
 
 msgid "the first 3 to 4 weeks"
 msgstr "первые 3–4 недели"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "Atıkla"
 
 msgid "Discard import"
-msgstr ""
+msgstr "İçe aktarmadan vazgeç"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "Bu içe aktarmadan vazgeçilsin mi?"
 
 msgid "Discarded"
 msgstr "İptal edildi"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "Mevcut Tut"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "Düzenlemeye devam et"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mevcut fiyatlandırmayı koru, yalnızca yeni öğeler ekle"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "Bu dolaylı harcama satırının nakledildiği gider hesabı; dolaylı satırlar hesabı türetmek için bir envanter defter girişine sahip olmadığından gereklidir."
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "Yüklediğiniz dosya ve yaptığınız eşleştirmeler kaybolacak."
 
 msgid "the first 3 to 4 weeks"
 msgstr "ilk 3 ila 4 hafta"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -5635,6 +5635,12 @@ msgstr "Devre Dışı"
 msgid "Discard"
 msgstr "Atıkla"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "İptal edildi"
 
@@ -8946,6 +8952,9 @@ msgstr "Tut"
 
 msgid "Keep Current"
 msgstr "Mevcut Tut"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "Mevcut fiyatlandırmayı koru, yalnızca yeni öğeler ekle"
@@ -16344,6 +16353,9 @@ msgstr "Bu stok kartının üretim sırasında kaybettiği beklenen yüzde; plan
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "Bu dolaylı harcama satırının nakledildiği gider hesabı; dolaylı satırlar hesabı türetmek için bir envanter defter girişine sahip olmadığından gereklidir."
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "ilk 3 ila 4 hafta"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -5636,10 +5636,10 @@ msgid "Discard"
 msgstr "丢弃"
 
 msgid "Discard import"
-msgstr ""
+msgstr "丢弃导入"
 
 msgid "Discard this import?"
-msgstr ""
+msgstr "丢弃此次导入？"
 
 msgid "Discarded"
 msgstr "已放弃"
@@ -8954,7 +8954,7 @@ msgid "Keep Current"
 msgstr "保持当前"
 
 msgid "Keep editing"
-msgstr ""
+msgstr "继续编辑"
 
 msgid "Keep existing pricing, only add new items"
 msgstr "保留现有定价，仅添加新物料"
@@ -16355,7 +16355,7 @@ msgid "The expense account this indirect-spend line posts to; required because i
 msgstr "此间接支出行过账至的费用科目；因为间接行没有物料分类账条目来推导科目，所以这是必需的。"
 
 msgid "The file you uploaded and the mappings you've made will be lost."
-msgstr ""
+msgstr "您上传的文件和已完成的映射将会丢失。"
 
 msgid "the first 3 to 4 weeks"
 msgstr "前3到4周"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -5635,6 +5635,12 @@ msgstr "已禁用"
 msgid "Discard"
 msgstr "丢弃"
 
+msgid "Discard import"
+msgstr ""
+
+msgid "Discard this import?"
+msgstr ""
+
 msgid "Discarded"
 msgstr "已放弃"
 
@@ -8946,6 +8952,9 @@ msgstr "保留"
 
 msgid "Keep Current"
 msgstr "保持当前"
+
+msgid "Keep editing"
+msgstr ""
 
 msgid "Keep existing pricing, only add new items"
 msgstr "保留现有定价，仅添加新物料"
@@ -16344,6 +16353,9 @@ msgstr "此物料产出在生产期间预期丢失的百分比；计划将需求
 
 msgid "The expense account this indirect-spend line posts to; required because indirect lines don't have an item ledger entry to derive the account from."
 msgstr "此间接支出行过账至的费用科目；因为间接行没有物料分类账条目来推导科目，所以这是必需的。"
+
+msgid "The file you uploaded and the mappings you've made will be lost."
+msgstr ""
 
 msgid "the first 3 to 4 weeks"
 msgstr "前3到4周"


### PR DESCRIPTION
## Problem

The CSV import wizard holds the uploaded file, the column mappings and the enum mappings in React state and nowhere else. The × button, Escape, and a page reload all threw every bit of that away with no prompt — several steps of mapping work lost to one mis-click, with no way back.

## Change

`ImportCSVModal`'s `onOpenChange` now routes through `requestClose()`, which catches the ×, Escape and any other Radix dismissal:

- **`ConfirmDiscardImport.tsx`** (new) — "Discard this import?" with *Keep editing* / *Discard import*. Nested inside the wizard's own modal, the same way `FieldMappings` already opens the payment-term and shipping-method forms, so the wizard stays mounted and cancelling loses nothing.
- **Guard condition** is `fileColumns !== null && !success`. It arms the moment the file parses — which is exactly what moves the wizard off the upload step — disarms again after "choose a different file" clears the columns, and disarms once the import has landed, where `ImportResultsModal` owns the close. Dismissing an empty wizard still closes straight away.
- **`beforeunload`** on the same condition, so a reload gets the browser's own prompt. Persisting the wizard's state across a reload is not part of this change.

Four new strings, extracted into the 13 `erp` catalogs.

## Not in scope

- The uploaded CSV still stays in the private bucket when an import is discarded. It already does that after a successful import too, so this is pre-existing rather than new.
- The wizard modal has no vertical constraint (a tall step pushes the primary action below the fold) — a separate problem, untouched here.

## Testing

`pnpm exec turbo run typecheck --filter=erp` and `biome check` on the touched directory both pass. **Not yet exercised in a browser** — worth a click-through of Customers → Bulk Import before merge: map a couple of columns, hit ×, confirm the dialog appears, cancel, and check the mappings are still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TMbNqzL1QhpZBBmQEsrFri


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when closing an in-progress CSV import.
  * Users can keep editing or discard the import after reviewing a data-loss warning.
  * Added protection against losing import progress when refreshing or leaving the page.

* **Localization**
  * Added translated import-discard, keep-editing, and data-loss warning messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->