### PR TITLE
feat(settings): opt-in accounting delete scope for API keys

### DIFF
--- a/apps/erp/app/hooks/usePermissionMatrix.ts
+++ b/apps/erp/app/hooks/usePermissionMatrix.ts
@@ -18,6 +18,14 @@ export type UsePermissionMatrixOptions = {
   modules: ModuleDefinition;
   /** Initial permission state as a flat boolean map (e.g. { "sales_view": true }) */
   initialState?: Record<string, boolean>;
+  /**
+   * Permission keys (`${module}_${action}`) that are opt-in only: excluded from
+   * the "select all" and per-row select-all toggles, and ignored when computing
+   * whether a row/the whole matrix is fully checked. They can still be toggled
+   * individually via `toggleCell`. Bulk-clearing (unchecking select-all) does
+   * turn them off — a permission can always be revoked in bulk, just not granted.
+   */
+  bulkExcludedKeys?: readonly string[];
 };
 
 export type UsePermissionMatrixReturn = {
@@ -69,8 +77,14 @@ const HIDDEN_MODULES = new Set(["items", "timecards"]);
 
 export function usePermissionMatrix({
   modules,
-  initialState
+  initialState,
+  bulkExcludedKeys
 }: UsePermissionMatrixOptions): UsePermissionMatrixReturn {
+  const excludedKeys = useMemo(
+    () => new Set(bulkExcludedKeys ?? []),
+    [bulkExcludedKeys]
+  );
+
   const sortedModules = useMemo<[string, readonly PermissionAction[]][]>(
     () =>
       Object.entries(modules).sort(([a], [b]) => a.localeCompare(b)) as [
@@ -91,10 +105,12 @@ export function usePermissionMatrix({
 
   // Derived state
   const allKeys = useMemo(() => Object.keys(permissions), [permissions]);
-  const allChecked = useMemo(
-    () => allKeys.length > 0 && allKeys.every((k) => permissions[k]),
-    [allKeys, permissions]
-  );
+  // "All checked" ignores opt-in keys, so the header/row checkboxes can read as
+  // fully checked once every non-opt-in permission is granted.
+  const allChecked = useMemo(() => {
+    const bulkKeys = allKeys.filter((k) => !excludedKeys.has(k));
+    return bulkKeys.length > 0 && bulkKeys.every((k) => permissions[k]);
+  }, [allKeys, permissions, excludedKeys]);
   const someChecked = useMemo(
     () => allKeys.some((k) => permissions[k]),
     [allKeys, permissions]
@@ -122,48 +138,62 @@ export function usePermissionMatrix({
       setPermissionsRaw((prev) => {
         const moduleActions = modules[mod] ?? [];
         const rowKeys = moduleActions.map((a) => `${mod}_${a}`);
-        const allRowChecked = rowKeys.every((k) => prev[k]);
+        const bulkRowKeys = rowKeys.filter((k) => !excludedKeys.has(k));
+        const allRowChecked =
+          bulkRowKeys.length > 0 && bulkRowKeys.every((k) => prev[k]);
         const next = { ...prev };
-        for (const k of rowKeys) {
-          next[k] = !allRowChecked;
+        if (allRowChecked) {
+          // Clear the whole row, including opt-in keys — revoking is always fine.
+          for (const k of rowKeys) next[k] = false;
+        } else {
+          // Grant the non-opt-in keys; leave opt-in keys as the user set them.
+          for (const k of bulkRowKeys) next[k] = true;
         }
         return next;
       });
     },
-    [modules]
+    [modules, excludedKeys]
   );
 
   const toggleAll = useCallback(() => {
     setPermissionsRaw((prev) => {
       const keys = Object.keys(prev);
-      const currentAllChecked = keys.length > 0 && keys.every((k) => prev[k]);
-      const next: Record<string, boolean> = {};
-      for (const k of keys) {
-        next[k] = !currentAllChecked;
+      const bulkKeys = keys.filter((k) => !excludedKeys.has(k));
+      const currentAllChecked =
+        bulkKeys.length > 0 && bulkKeys.every((k) => prev[k]);
+      const next: Record<string, boolean> = { ...prev };
+      if (currentAllChecked) {
+        // Clear everything, including opt-in keys — revoking is always fine.
+        for (const k of keys) next[k] = false;
+      } else {
+        // Grant the non-opt-in keys; leave opt-in keys as the user set them.
+        for (const k of bulkKeys) next[k] = true;
       }
       return next;
     });
-  }, []);
+  }, [excludedKeys]);
 
   const isRowAllChecked = useCallback(
     (mod: string) => {
       const moduleActions = modules[mod] ?? [];
+      const bulkActions = moduleActions.filter(
+        (a) => !excludedKeys.has(`${mod}_${a}`)
+      );
       return (
-        moduleActions.length > 0 &&
-        moduleActions.every((a) => permissions[`${mod}_${a}`])
+        bulkActions.length > 0 &&
+        bulkActions.every((a) => permissions[`${mod}_${a}`])
       );
     },
-    [modules, permissions]
+    [modules, permissions, excludedKeys]
   );
 
   const isRowIndeterminate = useCallback(
     (mod: string) => {
       const moduleActions = modules[mod] ?? [];
       const some = moduleActions.some((a) => permissions[`${mod}_${a}`]);
-      const all = moduleActions.every((a) => permissions[`${mod}_${a}`]);
-      return some && !all;
+      return some && !isRowAllChecked(mod);
     },
-    [modules, permissions]
+    [modules, permissions, isRowAllChecked]
   );
 
   return {

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -35,7 +35,7 @@ export const purchasePriceUpdateTimingTypes = [
 
 /** All permission modules with their available CRUD actions */
 export const apiKeyPermissionModules = {
-  accounting: ["view", "create", "update"],
+  accounting: ["view", "create", "update", "delete"],
   documents: ["view", "create", "update", "delete"],
   inventory: ["view", "create", "update", "delete"],
   invoicing: ["view", "create", "update", "delete"],
@@ -51,6 +51,14 @@ export const apiKeyPermissionModules = {
 } as const;
 
 export type ApiKeyPermissionModule = keyof typeof apiKeyPermissionModules;
+
+/**
+ * Permission keys (`${module}_${action}`) that are opt-in only: they must be
+ * enabled by clicking their own cell and are never turned on by the "all
+ * modules" or per-row select-all checkboxes. Deleting accounting data via the
+ * API is high-risk, so it stays deselected unless explicitly chosen.
+ */
+export const apiKeyOptInPermissionKeys = ["accounting_delete"] as const;
 
 export const apiKeyValidator = z.object({
   id: zfd.text(z.string().optional()),

--- a/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
+++ b/apps/erp/app/modules/settings/ui/ApiKeys/ApiKeysForm.tsx
@@ -36,7 +36,11 @@ import {
   toApiKeyScopes,
   usePermissionMatrix
 } from "~/hooks/usePermissionMatrix";
-import { apiKeyPermissionModules, apiKeyValidator } from "~/modules/settings";
+import {
+  apiKeyOptInPermissionKeys,
+  apiKeyPermissionModules,
+  apiKeyValidator
+} from "~/modules/settings";
 import { path } from "~/utils/path";
 import { copyToClipboard } from "~/utils/string";
 
@@ -73,7 +77,8 @@ const ApiKeyForm = ({
 
   const matrix = usePermissionMatrix({
     modules: apiKeyPermissionModules,
-    initialState: initialScopeState
+    initialState: initialScopeState,
+    bulkExcludedKeys: apiKeyOptInPermissionKeys
   });
 
   useEffect(() => {


### PR DESCRIPTION
## What does this PR do?

Adds **delete** as a selectable API-key permission for the accounting module. It is deselected by default and, uniquely, is excluded from the "all modules" and per-row select-all checkboxes, so it can only be granted by clicking its own cell — deleting accounting data via the API is high-risk. The `usePermissionMatrix` hook gains a `bulkExcludedKeys` option that skips these opt-in keys when granting in bulk (still clearing them when revoking) and ignores them when computing whether a row/the matrix is "fully checked", so the parent checkboxes still read as checked once the normal actions are granted. Server enforcement needed no change — `auth.server.ts` derives the `accounting_delete` scope generically.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Settings → API Keys → New (or edit) key. Confirm the accounting row now shows a Delete checkbox that starts unchecked; clicking "Module" (all modules) or the accounting row's own checkbox grants view/create/update but leaves Delete off; the only way to enable it is its own cell. Unchecking select-all still clears it. A key granted `accounting_delete` should pass a request requiring `{ delete: "accounting" }`.

## Checklist

- My code follows the style guidelines of this project (biome + scoped typecheck pass on the changed files)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to grant API keys permission to delete accounting records.
  - Added explicit selection for sensitive accounting deletion permissions, preventing them from being changed by bulk “select all” actions while preserving individual control.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->