### PR TITLE
docs: nest Scrap and unscrap under the Inventory sidebar group

### DIFF
--- a/docs/app/docs/layout.tsx
+++ b/docs/app/docs/layout.tsx
@@ -102,6 +102,7 @@ const REFERENCE_GROUPS: { label: string; slugs: string[] }[] = [
     slugs: [
       "inventory",
       "inventory-count",
+      "scrap",
       "storage-rules",
       "shelf-life",
       "traceability",


### PR DESCRIPTION
## What does this PR do?

The docs Reference sidebar groups are driven by `REFERENCE_GROUPS` in `docs/app/docs/layout.tsx`, not by the flat `reference/meta.json`. PR #1573 only reordered `scrap` in `meta.json`, so "Scrap and unscrap" kept rendering as an ungrouped leftover at the bottom of the sidebar (next to two-factor, workflow runs, workflows). This adds `"scrap"` to the Inventory group so it nests after "Inventory count", matching the intended order.

## Visual Demo

Before: "Scrap and unscrap" floated below the SYSTEM group, ungrouped. After: it appears inside the INVENTORY group, right after "Inventory count".

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Run the docs app (`pnpm --filter docs dev`), open `/docs/reference`, and confirm "Scrap and unscrap" now renders under the INVENTORY sidebar group after "Inventory count" rather than as a loose leftover at the bottom.

## Checklist

- My code follows the style guidelines of this project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added the Scrap page to the Inventory section in the reference sidebar for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->