### PR TITLE
fix(planning,purchasing): stop FK/check violations from bad locationId and stale PO line refs

### DIFF
--- a/.claude/rules/mrp-system.md
+++ b/.claude/rules/mrp-system.md
@@ -119,9 +119,16 @@ Base tables defined in `20250610000433_demand-planning.sql`; lineage table in
 | `supplyActual` | `(itemId, locationId, periodId, sourceType)` | `actualQuantity`, `sourceType` | `sourceType` enum `supplySourceType` = `'Purchase Order'\|'Production Order'` |
 | `demandForecastSource` | surrogate `id` | `sourceType`, `jobId`/`salesOrderLineId`/`demandProjectionId`, `parentItemId`, `quantity` | MRP lineage; enum `demandForecastSourceType` = `'Job Material'\|'Sales Order'\|'Demand Projection'`; CHECK exactly one source id set |
 
-`locationId` is nullable on all five planning tables. Audit cols
-(`createdBy/At`, `updatedBy/At`) present except on `period` and
-`demandForecastSource` (created-only).
+`locationId` is declared `TEXT` (no `NOT NULL`) on all five planning tables, but
+it is part of the PRIMARY KEY of every one of them (see the PK column above), so
+Postgres makes it **implicitly NOT NULL** — a null `locationId` raises 23502, and
+it is also an FK to `location(id)`, so a bogus value (e.g. the empty string
+`runMrp` used to write via a `?? ""` key fallback for a source line with no
+location) raises 23503 `*_locationId_fkey` and rolls the whole run back. `runMrp`
+therefore SKIPS any source line (sales/job-material/production/PO/projection) with
+no `locationId` rather than fabricating one. Audit cols (`createdBy/At`,
+`updatedBy/At`) present except on `period` and `demandForecastSource`
+(created-only).
 
 ## Planning split functions
 

--- a/apps/erp/app/modules/purchasing/purchasing.service.ts
+++ b/apps/erp/app/modules/purchasing/purchasing.service.ts
@@ -1805,6 +1805,47 @@ export async function upsertPurchaseOrderDelivery(
     .single();
 }
 
+const PURCHASE_ORDER_LINE_ITEM_TYPES = [
+  "Part",
+  "Material",
+  "Tool",
+  "Service",
+  "Consumable",
+  "Fixture"
+];
+
+/**
+ * Force the mutually-exclusive reference columns (`itemId`, `accountId`,
+ * `assetId`) to match the line's `purchaseOrderLineType`, nulling the ones that
+ * don't apply. `purchaseOrderLineType_check` requires exactly one of these set
+ * per type, but the form only submits the active tab's field and `sanitize()`
+ * turns *absent* keys into nothing (not null), so switching a G/L Account or
+ * Fixed Asset line to an item type would otherwise leave a stale `accountId`/
+ * `assetId` on the row and violate the check (23514). Setting the inapplicable
+ * ids to explicit `null` clears them on update and hardens every caller (form,
+ * public API, MCP) at once.
+ */
+function normalizePurchaseOrderLineReferences<
+  T extends {
+    purchaseOrderLineType: string;
+    itemId?: string | null;
+    accountId?: string | null;
+    assetId?: string | null;
+  }
+>(line: T): T {
+  if (PURCHASE_ORDER_LINE_ITEM_TYPES.includes(line.purchaseOrderLineType)) {
+    return { ...line, accountId: null, assetId: null };
+  }
+  if (line.purchaseOrderLineType === "G/L Account") {
+    return { ...line, itemId: null, assetId: null };
+  }
+  if (line.purchaseOrderLineType === "Fixed Asset") {
+    return { ...line, itemId: null, accountId: null };
+  }
+  // Comment (and any other non-reference type) carries no reference id.
+  return { ...line, itemId: null, accountId: null, assetId: null };
+}
+
 export async function upsertPurchaseOrderLine(
   client: SupabaseClient<Database>,
   purchaseOrderLine:
@@ -1819,11 +1860,13 @@ export async function upsertPurchaseOrderLine(
         customFields?: Json;
       })
 ) {
-  if ("id" in purchaseOrderLine) {
+  const normalized = normalizePurchaseOrderLineReferences(purchaseOrderLine);
+
+  if ("id" in normalized) {
     return client
       .from("purchaseOrderLine")
-      .update(sanitize(purchaseOrderLine))
-      .eq("id", purchaseOrderLine.id)
+      .update(sanitize(normalized))
+      .eq("id", normalized.id)
       .select("id")
       .single();
   }
@@ -1831,7 +1874,7 @@ export async function upsertPurchaseOrderLine(
   const existing = await client
     .from("purchaseOrderLine")
     .select("sortOrder")
-    .eq("purchaseOrderId", purchaseOrderLine.purchaseOrderId);
+    .eq("purchaseOrderId", normalized.purchaseOrderId);
 
   const maxSortOrder = (existing.data ?? []).reduce(
     (max, row) => Math.max(max, row.sortOrder ?? 0),
@@ -1840,7 +1883,7 @@ export async function upsertPurchaseOrderLine(
 
   return client
     .from("purchaseOrderLine")
-    .insert([{ ...purchaseOrderLine, sortOrder: maxSortOrder + 1 }])
+    .insert([{ ...normalized, sortOrder: maxSortOrder + 1 }])
     .select("id")
     .single();
 }

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-09-03T20:26:47.954Z",
+  "generated": "2026-09-05T14:06:36.085Z",
   "totalTools": 1495,
   "modules": 15,
   "tools": [

--- a/packages/ee/src/planning/mrp/mrp.ts
+++ b/packages/ee/src/planning/mrp/mrp.ts
@@ -360,7 +360,11 @@ export async function runMrp(
     const jobSupplyByLocationPeriodItem = new Map<string, number>();
 
     for (const line of productionLines.data ?? []) {
-      if (!line.itemId || !line.quantityToReceive) continue;
+      // locationId is part of the supplyActual primary key (hence NOT NULL) and
+      // an FK to location. A line with no location has nowhere to be planned and
+      // would write locationId="" (via the ?? "" key fallback), violating
+      // supplyActual_locationId_fkey and aborting the whole run. Skip it.
+      if (!line.itemId || !line.quantityToReceive || !line.locationId) continue;
 
       const dueDate = line.dueDate
         ? parseDate(line.dueDate)
@@ -386,7 +390,9 @@ export async function runMrp(
     const poSupplyByLocationPeriodItem = new Map<string, number>();
 
     for (const line of purchaseOrderLines.data ?? []) {
-      if (!line.itemId || !line.quantityToReceive) continue;
+      // See the productionLines guard above: a null locationId would write
+      // supplyActual with locationId="" and violate its FK.
+      if (!line.itemId || !line.quantityToReceive || !line.locationId) continue;
 
       const dueDate = line.promisedDate
         ? parseDate(line.promisedDate)
@@ -433,7 +439,15 @@ export async function runMrp(
     // jobAndPoSupplyByLocationPeriodItem below). Netting here as well would
     // double-count supply and under-drive child demand.
     for (const projection of demandProjections.data ?? []) {
-      if (!projection.itemId || !projection.forecastQuantity) continue;
+      // locationId is part of the demandForecast primary key (hence NOT NULL)
+      // and an FK to location; a null one would write locationId="" and violate
+      // demandForecast_locationId_fkey, aborting the run.
+      if (
+        !projection.itemId ||
+        !projection.forecastQuantity ||
+        !projection.locationId
+      )
+        continue;
 
       const netDemand = projection.forecastQuantity;
 
@@ -463,7 +477,9 @@ export async function runMrp(
 
     // Sales order lines
     for (const line of salesOrderLines.data ?? []) {
-      if (!line.itemId || !line.quantityToSend) continue;
+      // A null locationId would write demandForecast/demandActual with
+      // locationId="" and violate their locationId FK — skip (see above).
+      if (!line.itemId || !line.quantityToSend || !line.locationId) continue;
 
       const promiseDate = line.promisedDate
         ? parseDate(line.promisedDate)
@@ -499,7 +515,9 @@ export async function runMrp(
 
     // Job material lines
     for (const line of jobMaterialLines.data ?? []) {
-      if (!line.itemId || !line.quantityToIssue) continue;
+      // A null locationId would write demandForecast/demandActual with
+      // locationId="" and violate their locationId FK — skip (see above).
+      if (!line.itemId || !line.quantityToIssue || !line.locationId) continue;
 
       const dueDate = line.dueDate ? parseDate(line.dueDate) : today;
       const requiredDate = dueDate.add({ days: -(line.leadTime ?? 7) });


### PR DESCRIPTION
## What does this PR do?

Fixes two classes of production database errors coming from planning and purchasing writes.

- **MRP (`packages/ee/src/planning/mrp/mrp.ts`)**: `runMrp` built its map keys with `locationId ?? ""`, so any source line (sales/job-material/production/PO/`demandProjection`) with no location wrote `locationId = ""` into `demandForecast`/`supplyActual`. `locationId` is part of those tables' primary key (so implicitly `NOT NULL`) and an FK to `location(id)`, so `""` raised `23503 *_locationId_fkey`; because the whole write is one transaction, a single bad row rolled back *all* planning for that company. All five source loops now skip lines with no `locationId`.
- **Purchasing (`apps/erp/app/modules/purchasing/purchasing.service.ts`)**: switching a PO line's type in the edit form left a stale `accountId`/`assetId`/`itemId` on the row — the unmounted Radix tab omits its field, zod drops the absent key, and `sanitize()` can't null a key it never sees — violating `purchaseOrderLineType_check` (`23514`). `upsertPurchaseOrderLine` now nulls the inapplicable reference ids by line type, which fixes the form and hardens the public API and MCP paths at once.
- Docs: corrects the stale `mrp-system.md` note that claimed `locationId` was nullable.

Not addressed here (deliberately): the `item.type` not-null and `customFieldTable.id` errors in the same logs are **not** reproducible from ERP code — every item insert hardcodes `type` and no query selects `id` on those relations — so they originate from external `carbon-key` REST/MCP callers and need a caller-side fix.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- **MRP**: with a company that has an open sales-order/job-material/PO/production line whose `locationId` is null, trigger MRP (`POST /api/mrp` or the 3-hourly cron). Before: the run throws `insert or update on "demandForecast"/"supplyActual" violates foreign key constraint`. After: the run completes and those no-location lines are simply omitted from planning output.
- **Purchasing**: create a PO line as `G/L Account` (or `Fixed Asset`), save, then switch it to `Part` and save. Before: `new row for relation "purchaseOrderLine" violates check constraint "purchaseOrderLineType_check"`. After: the line saves and the stale `accountId`/`assetId` is cleared.
- Scoped typecheck passes: `pnpm exec turbo run typecheck --filter=erp` and `pnpm --filter @carbon/ee typecheck`.

## Checklist

- I haven't commented my code, particularly in hard-to-understand areas


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Material Requirements Planning (MRP) reliability by skipping planning lines without a location, preventing invalid records from stopping an entire run.
  - Fixed purchase order line updates when changing between item, G/L account, and fixed asset types. Inapplicable references are now cleared automatically, preventing save errors.
  - MRP location validation now prevents invalid or missing location data from creating database errors.

- **Documentation**
  - Clarified location requirements and error behavior for MRP planning tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->