### PR TITLE
chore(deps): reapply Zod 3.25 → 4.5 upgrade

### DIFF
--- a/.claude/rules/workflow-edge-function.md
+++ b/.claude/rules/workflow-edge-function.md
@@ -59,7 +59,7 @@ relative to the function dir):
 
 ```typescript
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { corsHeaders } from "../lib/headers.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";

--- a/apps/erp/app/components/Configurator/ConfiguratorForm/ConfiguratorForm.ee.tsx
+++ b/apps/erp/app/components/Configurator/ConfiguratorForm/ConfiguratorForm.ee.tsx
@@ -53,22 +53,22 @@ function getParameterSchema(parameter: ConfigurationParameter) {
     case "numeric":
       return zfd.numeric(
         z.number({
-          required_error: `${parameter.label} is required`
+          error: `${parameter.label} is required`
         })
       );
     case "text":
       return z.string({
-        required_error: `${parameter.label} is required`
+        error: `${parameter.label} is required`
       });
     case "list":
       return z.enum(parameter.listOptions as [string, ...string[]], {
-        required_error: `${parameter.label} is required`
+        error: `${parameter.label} is required`
       });
     case "boolean":
       return z.boolean();
     case "material":
       return z.string({
-        required_error: `${parameter.label} is required`
+        error: `${parameter.label} is required`
       });
     default:
       return z.any();

--- a/apps/erp/app/modules/account/ui/UserAttributes/UserAttributesForm.tsx
+++ b/apps/erp/app/modules/account/ui/UserAttributes/UserAttributesForm.tsx
@@ -14,7 +14,6 @@ import { useLocale } from "@react-aria/i18n";
 import { useState } from "react";
 import { LuFile, LuPaperclip } from "react-icons/lu";
 import { useFetcher, useParams } from "react-router";
-import type { ZodSchema } from "zod";
 import CustomerAvatar from "~/components/CustomerAvatar";
 import { DateTime } from "~/components/DateTime";
 import FileDropzone from "~/components/FileDropzone";
@@ -167,7 +166,7 @@ function TypedForm(
         <ValidatedForm
           method="post"
           action={path.to.userAttribute(userId)}
-          validator={attributeBooleanValidator as ZodSchema}
+          validator={attributeBooleanValidator}
           defaultValues={{
             userAttributeId,
             userAttributeValueId,

--- a/apps/erp/app/modules/accounting/accounting.models.ts
+++ b/apps/erp/app/modules/accounting/accounting.models.ts
@@ -269,7 +269,7 @@ export const reportViewValidator = z.object({
     .min(1, { message: "Name is required" })
     .max(100, { message: "Name must be 100 characters or fewer" }),
   visibility: z.enum(reportViewVisibilities, {
-    errorMap: () => ({ message: "Visibility is required" })
+    error: "Visibility is required"
   }),
   config: z.string().min(2, { message: "Config is required" })
 });
@@ -281,20 +281,14 @@ export const groupAccountValidator = z
     parentId: zfd.text(z.string().optional()),
     accountType: z
       .enum(accountTypes, {
-        errorMap: () => ({
-          message: "Account type is required"
-        })
+        error: "Account type is required"
       })
       .optional(),
     incomeBalance: z.enum(incomeBalanceTypes, {
-      errorMap: () => ({
-        message: "Income balance is required"
-      })
+      error: "Income balance is required"
     }),
     class: z.enum(accountClassTypes, {
-      errorMap: () => ({
-        message: "Class is required"
-      })
+      error: "Class is required"
     })
   })
   .refine(
@@ -336,20 +330,14 @@ export const accountValidator = z
     isGroup: zfd.checkbox(),
     accountType: z
       .enum(accountTypes, {
-        errorMap: () => ({
-          message: "Account type is required"
-        })
+        error: "Account type is required"
       })
       .optional(),
     incomeBalance: z.enum(incomeBalanceTypes, {
-      errorMap: () => ({
-        message: "Income balance is required"
-      })
+      error: "Income balance is required"
     }),
     class: z.enum(accountClassTypes, {
-      errorMap: () => ({
-        message: "Class is required"
-      })
+      error: "Class is required"
     }),
     consolidatedRate: z.enum(consolidatedRateTypes)
   })
@@ -392,14 +380,10 @@ export const accountValidator = z
 
 export const fiscalYearSettingsValidator = z.object({
   startMonth: z.enum(months, {
-    errorMap: (issue, ctx) => ({
-      message: "Start month is required"
-    })
+    error: "Start month is required"
   }),
   taxStartMonth: z.enum(months, {
-    errorMap: (issue, ctx) => ({
-      message: "Tax start month is required"
-    })
+    error: "Tax start month is required"
   })
 });
 
@@ -607,9 +591,7 @@ export const paymentTermValidator = z.object({
       })
   ),
   calculationMethod: z.enum(["Net", "End of Month", "Day of Month"], {
-    errorMap: (issue, ctx) => ({
-      message: "Calculation method is required"
-    })
+    error: "Calculation method is required"
   })
 });
 
@@ -804,7 +786,7 @@ export const addCloseTaskValidator = z.object({
   periodId: z.string().min(1, { message: "Period is required" }),
   name: z.string().trim().min(1, { message: "Name is required" }),
   taskType: z.enum(periodCloseTaskTypes, {
-    errorMap: () => ({ message: "Task type is required" })
+    error: "Task type is required"
   }),
   required: zfd.checkbox(),
   assigneeId: zfd.text(z.string().optional())
@@ -815,7 +797,7 @@ export const periodCloseTaskDefinitionValidator = z.object({
   id: zfd.text(z.string().optional()),
   name: z.string().trim().min(1, { message: "Name is required" }),
   taskType: z.enum(periodCloseTaskTypes, {
-    errorMap: () => ({ message: "Task type is required" })
+    error: "Task type is required"
   }),
   autoCheckKey: zfd.text(z.string().optional()),
   sortOrder: zfd.numeric(z.number().int().min(0)),
@@ -871,7 +853,7 @@ export const dimensionValidator = z.object({
   id: zfd.text(z.string().optional()),
   name: z.string().trim().min(1, { message: "Name is required" }),
   entityType: z.enum(dimensionEntityTypes, {
-    errorMap: () => ({ message: "Entity type is required" })
+    error: "Entity type is required"
   }),
   active: zfd.checkbox(),
   required: zfd.checkbox(),
@@ -906,7 +888,7 @@ export const fixedAssetClassValidator = z.object({
   name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string().optional(),
   depreciationMethod: z.enum(depreciationMethods, {
-    errorMap: () => ({ message: "Depreciation method is required" })
+    error: "Depreciation method is required"
   }),
   usefulLifeMonths: zfd.numeric(
     z.number().int().positive({ message: "Useful life must be positive" })
@@ -960,7 +942,7 @@ export const fixedAssetValidator = z.object({
   description: z.string().optional(),
   serialNumber: z.string().optional(),
   depreciationMethod: z.enum(depreciationMethods, {
-    errorMap: () => ({ message: "Depreciation method is required" })
+    error: "Depreciation method is required"
   }),
   usefulLifeMonths: zfd.numeric(
     z.number().int().positive({ message: "Useful life must be positive" })

--- a/apps/erp/app/modules/inventory/inventory.models.ts
+++ b/apps/erp/app/modules/inventory/inventory.models.ts
@@ -327,9 +327,7 @@ export const shippingMethodValidator = z.object({
   id: zfd.text(z.string().optional()),
   name: z.string().trim().min(1, { message: "Name is required" }),
   carrier: z.enum(["UPS", "FedEx", "USPS", "DHL", "Other"], {
-    errorMap: () => ({
-      message: "Carrier is required"
-    })
+    error: "Carrier is required"
   }),
   carrierAccountId: zfd.text(z.string().optional()),
   trackingUrl: zfd.text(z.string().optional())

--- a/apps/erp/app/modules/invoicing/invoicing.models.ts
+++ b/apps/erp/app/modules/invoicing/invoicing.models.ts
@@ -109,9 +109,7 @@ export const purchaseInvoiceLineValidator = z
       [...itemType, "Fixture", "G/L Account", "Fixed Asset", "Comment"],
 
       {
-        errorMap: (issue, ctx) => ({
-          message: "Type is required"
-        })
+        error: "Type is required"
       }
     ),
     purchaseOrderId: zfd.text(z.string().optional()),
@@ -271,9 +269,7 @@ export const salesInvoiceLineValidator = z
     id: zfd.text(z.string().optional()),
     invoiceId: z.string().min(1, { message: "Invoice is required" }),
     invoiceLineType: z.enum([...itemType, "Fixture", "Fixed Asset"], {
-      errorMap: (issue, ctx) => ({
-        message: "Type is required"
-      })
+      error: "Type is required"
     }),
     // Wrapped in zfd.text so an empty-string submission (the form always posts a
     // hidden methodType) coerces to undefined instead of failing the enum check.
@@ -282,9 +278,7 @@ export const salesInvoiceLineValidator = z
     methodType: zfd.text(
       z
         .enum(methodType, {
-          errorMap: (issue, ctx) => ({
-            message: "Method is required"
-          })
+          error: "Method is required"
         })
         .optional()
     ),
@@ -374,7 +368,7 @@ export const memoValidator = z
     id: zfd.text(z.string().optional()),
     memoId: zfd.text(z.string().optional()),
     direction: z.enum(memoDirection, {
-      errorMap: () => ({ message: "Direction is required" })
+      error: "Direction is required"
     }),
     customerId: zfd.text(z.string().optional()),
     supplierId: zfd.text(z.string().optional()),
@@ -409,7 +403,7 @@ export const paymentValidator = z
     id: zfd.text(z.string().optional()),
     paymentId: zfd.text(z.string().optional()),
     paymentType: z.enum(paymentType, {
-      errorMap: () => ({ message: "Payment type is required" })
+      error: "Payment type is required"
     }),
     customerId: zfd.text(z.string().optional()),
     supplierId: zfd.text(z.string().optional()),

--- a/apps/erp/app/modules/items/items.models.ts
+++ b/apps/erp/app/modules/items/items.models.ts
@@ -181,19 +181,13 @@ export const itemValidator = z.object({
   // purchased item. Only surfaced/edited for Buy items in the Properties panel.
   mpn: zfd.text(z.string().optional()),
   replenishmentSystem: z.enum(itemReplenishmentSystems, {
-    errorMap: (issue, ctx) => ({
-      message: "Replenishment system is required"
-    })
+    error: "Replenishment system is required"
   }),
   defaultMethodType: z.enum(methodType, {
-    errorMap: (issue, ctx) => ({
-      message: "Default method is required"
-    })
+    error: "Default method is required"
   }),
   itemTrackingType: z.enum(itemTrackingTypes, {
-    errorMap: (issue, ctx) => ({
-      message: "Part type is required"
-    })
+    error: "Part type is required"
   }),
   postingGroupId: zfd.text(z.string().optional()),
   unitOfMeasureCode: z
@@ -233,10 +227,8 @@ export const itemValidator = z.object({
 // Common storage / shelf-life refines. Shared across all item-type
 // validators. Default Storage Unit is optional for every type - users can
 // set it later via the pickMethod UI once they know where the item lives.
-const applyStorageAndShelfLifeRefines = <T extends z.AnyZodObject>(
-  schema: T
-) => {
-  const refined: z.ZodEffects<z.ZodTypeAny, z.infer<T>, z.input<T>> = schema
+const applyStorageAndShelfLifeRefines = <T extends z.ZodObject>(schema: T) => {
+  const refined: z.ZodType<z.infer<T>, z.input<T>> = schema
     .refine(
       (data: z.infer<T>) =>
         data.shelfLifeDays === undefined ||
@@ -316,7 +308,7 @@ const applyStorageAndShelfLifeRefines = <T extends z.AnyZodObject>(
           "Calculate from BOM requires a BoM - only Make or Buy and Make items qualify",
         path: ["shelfLifeCalculateFromBom"]
       }
-    ) as z.ZodEffects<z.ZodTypeAny, z.infer<T>, z.input<T>>;
+    ) as unknown as z.ZodType<z.infer<T>, z.input<T>>;
 
   return refined;
 };
@@ -437,20 +429,14 @@ export const methodMaterialValidator = z.object({
   makeMethodId: z.string().min(1, { message: "Make method is required" }),
   order: zfd.numeric(z.number().min(0)),
   itemType: z.enum(methodItemType, {
-    errorMap: (issue, ctx) => ({
-      message: "Item type is required"
-    })
+    error: "Item type is required"
   }),
   kit: zfd.text(z.string().optional()).transform((value) => value === "true"),
   methodType: z.enum(methodType, {
-    errorMap: (issue, ctx) => ({
-      message: "Method type is required"
-    })
+    error: "Method type is required"
   }),
   sourcingType: z.enum(sourcingType, {
-    errorMap: (issue, ctx) => ({
-      message: "Sourcing type is required"
-    })
+    error: "Sourcing type is required"
   }),
   itemId: z.string().optional(),
   methodOperationId: zfd.text(z.string().optional()),
@@ -474,14 +460,10 @@ export const methodOperationValidator = z
     makeMethodId: z.string().min(0, { message: "Make method is required" }),
     order: zfd.numeric(z.number().min(0)),
     operationOrder: z.enum(methodOperationOrders, {
-      errorMap: (issue, ctx) => ({
-        message: "Operation order is required"
-      })
+      error: "Operation order is required"
     }),
     operationType: z.enum(operationTypes, {
-      errorMap: (issue, ctx) => ({
-        message: "Operation type is required"
-      })
+      error: "Operation type is required"
     }),
     processId: z.string().min(1, { message: "Process is required" }),
     workCenterId: zfd.text(z.string().optional()),
@@ -493,19 +475,19 @@ export const methodOperationValidator = z
     ),
     setupUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Setup unit is required" })
+        error: "Setup unit is required"
       })
       .optional(),
     setupTime: zfd.numeric(z.number().min(0).optional()),
     laborUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Labor unit is required" })
+        error: "Labor unit is required"
       })
       .optional(),
     laborTime: zfd.numeric(z.number().min(0).optional()),
     machineUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Machine unit is required" })
+        error: "Machine unit is required"
       })
       .optional(),
     machineTime: zfd.numeric(z.number().min(0).optional()),
@@ -605,9 +587,7 @@ export const itemCostValidator = z.object({
   itemId: z.string().min(1, { message: "Item ID is required" }),
   itemPostingGroupId: zfd.text(z.string().optional()),
   costingMethod: z.enum(itemCostingMethods, {
-    errorMap: () => ({
-      message: "Costing method is required"
-    })
+    error: "Costing method is required"
   }),
   // standardCost: zfd.numeric(z.number().min(0)),
   unitCost: zfd.numeric(z.number().min(0))
@@ -634,9 +614,7 @@ export const itemPlanningValidator = z
     itemId: z.string().min(1, { message: "Item ID is required" }),
     locationId: z.string().min(1, { message: "Location is required" }),
     reorderingPolicy: z.enum(itemReorderingPolicies, {
-      errorMap: (issue, ctx) => ({
-        message: "Reordering policy is required"
-      })
+      error: "Reordering policy is required"
     }),
     demandAccumulationPeriod: zfd.numeric(z.number().min(1).optional()),
     demandAccumulationSafetyStock: zfd.numeric(z.number().min(0).optional()),
@@ -936,9 +914,7 @@ export const serviceValidator = applyStorageAndShelfLifeRefines(
         .string()
         .min(1, { message: "Unit of Measure is required" }),
       replenishmentSystem: z.enum(serviceReplenishmentSystems, {
-        errorMap: (issue, ctx) => ({
-          message: "Replenishment system is required"
-        })
+        error: "Replenishment system is required"
       }),
       // Services can never be shipped, received, or stocked
       itemTrackingType: z.literal("Non-Inventory")

--- a/apps/erp/app/modules/items/items.service.ts
+++ b/apps/erp/app/modules/items/items.service.ts
@@ -4260,11 +4260,23 @@ export async function duplicateMethodOperationStep(
 export async function upsertMethodOperationStepSlide(
   client: SupabaseClient<Database>,
   slide:
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         companyId: string;
         createdBy: string;
       })
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         id: string;
         updatedBy: string;
         updatedAt: string;

--- a/apps/erp/app/modules/production/production.models.ts
+++ b/apps/erp/app/modules/production/production.models.ts
@@ -216,7 +216,7 @@ const baseJobValidator = z.object({
   customerId: zfd.text(z.string().optional()),
   dueDate: zfd.text(z.string().optional()),
   deadlineType: z.enum(deadlineTypes, {
-    errorMap: () => ({ message: "Deadline type is required" })
+    error: "Deadline type is required"
   }),
   locationId: z.string().min(1, { message: "Location is required" }),
   quantity: zfd.numeric(
@@ -249,7 +249,7 @@ export const bulkJobValidator = z
       .string()
       .min(1, { message: "Unit of measure is required" }),
     deadlineType: z.enum(deadlineTypes, {
-      errorMap: () => ({ message: "Deadline type is required" })
+      error: "Deadline type is required"
     }),
     dueDateOfFirstJob: zfd.text(z.string().optional()),
     dueDateOfLastJob: zfd.text(z.string().optional()),
@@ -350,14 +350,10 @@ export const baseJobOperationValidator = z.object({
     .min(1, { message: "Quote Make Method is required" }),
   order: zfd.numeric(z.number().min(0)),
   operationOrder: z.enum(methodOperationOrders, {
-    errorMap: (issue, ctx) => ({
-      message: "Operation order is required"
-    })
+    error: "Operation order is required"
   }),
   operationType: z.enum(operationTypes, {
-    errorMap: (issue, ctx) => ({
-      message: "Operation type is required"
-    })
+    error: "Operation type is required"
   }),
   processId: z.string().min(1, { message: "Process is required" }),
   procedureId: zfd.text(z.string().optional()),
@@ -368,19 +364,19 @@ export const baseJobOperationValidator = z.object({
   ),
   setupUnit: z
     .enum(standardFactorType, {
-      errorMap: () => ({ message: "Setup unit is required" })
+      error: "Setup unit is required"
     })
     .optional(),
   setupTime: zfd.numeric(z.number().min(0).optional()),
   laborUnit: z
     .enum(standardFactorType, {
-      errorMap: () => ({ message: "Labor unit is required" })
+      error: "Labor unit is required"
     })
     .optional(),
   laborTime: zfd.numeric(z.number().min(0).optional()),
   machineUnit: z
     .enum(standardFactorType, {
-      errorMap: () => ({ message: "Machine unit is required" })
+      error: "Machine unit is required"
     })
     .optional(),
   machineTime: zfd.numeric(z.number().min(0).optional()),
@@ -752,14 +748,10 @@ const baseMaterialValidator = z.object({
   description: z.string().min(1, { message: "Description is required" }),
   jobMakeMethodId: z.string().min(1, { message: "Make method is required" }),
   itemType: z.enum(methodItemType, {
-    errorMap: (issue, ctx) => ({
-      message: "Item type is required"
-    })
+    error: "Item type is required"
   }),
   methodType: z.enum(methodType, {
-    errorMap: (issue, ctx) => ({
-      message: "Method type is required"
-    })
+    error: "Method type is required"
   }),
   itemId: z.string().min(1, { message: "Item is required" }),
   kit: zfd.text(z.string().optional()).transform((value) => value === "true"),
@@ -897,7 +889,7 @@ export const procedureStepValidator = z
     name: z.string().trim().min(1, { message: "Name is required" }),
     description: zfd.text(z.string().optional()),
     type: z.enum(procedureStepType, {
-      errorMap: () => ({ message: "Type is required" })
+      error: "Type is required"
     }),
     unitOfMeasureCode: zfd.text(z.string().optional()),
     minValue: zfd.numeric(z.number().min(0).optional()),
@@ -963,7 +955,7 @@ export const productionEventValidator = z
     id: zfd.text(z.string().optional()),
     jobOperationId: z.string().min(1, { message: "Operation is required" }),
     type: z.enum(["Labor", "Machine", "Setup"], {
-      errorMap: () => ({ message: "Event type is required" })
+      error: "Event type is required"
     }),
     employeeId: zfd.text(z.string().optional()),
     workCenterId: zfd.text(z.string().optional()),
@@ -1005,7 +997,7 @@ export const productionQuantityValidator = z
     id: zfd.text(z.string().optional()),
     jobOperationId: z.string().min(1, { message: "Operation is required" }),
     type: z.enum(["Rework", "Scrap", "Production"], {
-      errorMap: () => ({ message: "Quantity type is required" })
+      error: "Quantity type is required"
     }),
     scrapReasonId: zfd.text(z.string().optional()),
     notes: zfd.text(z.string().optional()),
@@ -1794,7 +1786,7 @@ export const balloonCreateItemWithOverlayValidator = z
     unit: z.string().nullable().optional(),
     description: z.string().nullable().optional(),
     type: z.enum(procedureStepType).optional(),
-    data: z.record(z.unknown()).optional()
+    data: z.record(z.string(), z.unknown()).optional()
   })
   .strict();
 
@@ -1814,7 +1806,7 @@ export const balloonUpdateItemsValidator = z.array(
     regionHeight: normalizedSizeValidator.optional(),
     xCoordinate: normalizedCoordinateValidator.optional(),
     yCoordinate: normalizedCoordinateValidator.optional(),
-    data: z.record(z.unknown()).optional()
+    data: z.record(z.string(), z.unknown()).optional()
   })
 );
 

--- a/apps/erp/app/modules/production/production.service.ts
+++ b/apps/erp/app/modules/production/production.service.ts
@@ -3658,11 +3658,23 @@ export async function duplicateJobOperationStep(
 export async function upsertJobOperationStepSlide(
   client: SupabaseClient<Database>,
   slide:
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         companyId: string;
         createdBy: string;
       })
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         id: string;
         updatedBy: string;
         updatedAt: string;
@@ -6814,11 +6826,23 @@ export async function getAssemblyInstructionStepSlides(
 export async function upsertAssemblyInstructionStepSlide(
   client: SupabaseClient<Database>,
   slide:
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         companyId: string;
         createdBy: string;
       })
-    | (Omit<z.infer<typeof operationStepSlideValidator>, "id"> & {
+    | (Omit<
+        z.infer<typeof operationStepSlideValidator>,
+        "id" | "annotations"
+      > & {
+        annotations?: z.infer<
+          typeof operationStepSlideValidator
+        >["annotations"];
         id: string;
         updatedBy: string;
         updatedAt: string;

--- a/apps/erp/app/modules/purchasing/purchasing.models.ts
+++ b/apps/erp/app/modules/purchasing/purchasing.models.ts
@@ -128,9 +128,7 @@ export const purchaseOrderValidator = z.object({
   id: zfd.text(z.string().optional()),
   purchaseOrderId: zfd.text(z.string().optional()),
   purchaseOrderType: z.enum(purchaseOrderTypeType, {
-    errorMap: (issue, ctx) => ({
-      message: "Type is required"
-    })
+    error: "Type is required"
   }),
   status: z.enum(purchaseOrderStatusType).optional(),
   supplierId: z.string().min(1, { message: "Supplier is required" }),
@@ -209,9 +207,7 @@ export const purchaseOrderLineValidator = z
     purchaseOrderLineType: z.enum(
       [...itemType, "Fixture", "G/L Account", "Fixed Asset"],
       {
-        errorMap: (issue, ctx) => ({
-          message: "Type is required"
-        })
+        error: "Type is required"
       }
     ),
     itemId: zfd.text(z.string().optional()),
@@ -356,9 +352,7 @@ export const supplierApprovalValidator = z.object({
   readableId: zfd.text(z.string().optional()),
   name: z.string().trim().min(1, { message: "Name is required" }),
   supplierStatus: z.enum(supplierStatusType, {
-    errorMap: (issue, ctx) => ({
-      message: "Supplier status is required"
-    })
+    error: "Supplier status is required"
   }),
   supplierTypeId: zfd.text(z.string().optional()),
   accountManagerId: zfd.text(z.string().optional()),
@@ -451,9 +445,7 @@ export const supplierQuoteValidator = z
     id: zfd.text(z.string().optional()),
     supplierQuoteId: zfd.text(z.string().optional()),
     supplierQuoteType: z.enum(purchaseOrderTypeType, {
-      errorMap: (issue, ctx) => ({
-        message: "Type is required"
-      })
+      error: "Type is required"
     }),
     supplierId: z.string().min(1, { message: "Supplier is required" }),
     supplierLocationId: zfd.text(z.string().optional()),
@@ -485,7 +477,7 @@ export const supplierQuoteLineValidator = z
     id: zfd.text(z.string().optional()),
     supplierQuoteId: z.string(),
     supplierQuoteLineType: z.enum([...itemType, "G/L Account"], {
-      errorMap: () => ({ message: "Type is required" })
+      error: "Type is required"
     }),
     itemId: zfd.text(z.string().optional()),
     accountId: zfd.text(z.string().optional()),

--- a/apps/erp/app/modules/quality/quality.models.ts
+++ b/apps/erp/app/modules/quality/quality.models.ts
@@ -262,7 +262,7 @@ export const issueWorkflowValidator = z.object({
 const entityAssignmentItem = z.object({
   trackedEntityId: z.string().min(1, { message: "Tracked entity is required" }),
   quantity: z
-    .number({ invalid_type_error: "Quantity is required" })
+    .number({ error: "Quantity is required" })
     .positive({ message: "Quantity must be greater than zero" })
 });
 
@@ -287,7 +287,7 @@ export const splitIssueItemValidator = z
     itemId: z.string().min(1, { message: "Item is required" }),
     splitQuantity: zfd.numeric(
       z
-        .number({ invalid_type_error: "Split quantity is required" })
+        .number({ error: "Split quantity is required" })
         .positive({ message: "Split quantity must be greater than zero" })
         .optional()
     ),
@@ -330,7 +330,7 @@ export const qualityDocumentStepValidator = z
     name: z.string().trim().min(1, { message: "Name is required" }),
     description: zfd.text(z.string().optional()),
     type: z.enum(procedureStepType, {
-      errorMap: () => ({ message: "Type is required" })
+      error: "Type is required"
     }),
     unitOfMeasureCode: zfd.text(z.string().optional()),
     minValue: zfd.numeric(z.number().min(0).optional()),
@@ -445,7 +445,7 @@ export const inspectionSampleStatusType = [
 export const inspectionValidator = z.object({
   id: z.string().min(1, { message: "Id is required" }),
   status: z.enum(["Passed", "Failed"], {
-    errorMap: () => ({ message: "Status is required" })
+    error: "Status is required"
   }),
   notes: zfd.text(z.string().optional())
 });
@@ -462,7 +462,7 @@ export const inspectionSampleValidator = z.object({
   // "Pending" registers a sample without a verdict (identify-only scan when an
   // inspection document drives per-feature measurements).
   status: z.enum(["Pending", "Passed", "Failed"], {
-    errorMap: () => ({ message: "Status is required" })
+    error: "Status is required"
   }),
   notes: zfd.text(z.string().optional())
 });
@@ -470,7 +470,7 @@ export const inspectionSampleValidator = z.object({
 export const inspectionDispositionValidator = z.object({
   id: z.string().min(1, { message: "Id is required" }),
   decision: z.enum(["Accept", "Reject", "Partial"], {
-    errorMap: () => ({ message: "Decision is required" })
+    error: "Decision is required"
   }),
   notes: zfd.text(z.string().optional())
 });
@@ -482,7 +482,7 @@ export const inspectionDocumentUsages = ["Receipt"] as const;
 export const itemInspectionDocumentAssignmentValidator = z.object({
   itemId: z.string().min(1, { message: "Item is required" }),
   usage: z.enum(inspectionDocumentUsages, {
-    errorMap: () => ({ message: "Usage is required" })
+    error: "Usage is required"
   }),
   // Empty clears the slot.
   inspectionDocumentId: zfd.text(z.string().optional())

--- a/apps/erp/app/modules/resources/resources.models.ts
+++ b/apps/erp/app/modules/resources/resources.models.ts
@@ -303,11 +303,11 @@ export const processValidator = z
     id: zfd.text(z.string().optional()),
     name: z.string().trim().min(1, { message: "Process name is required" }),
     processType: z.enum(operationTypes, {
-      errorMap: () => ({ message: "Process type is required" })
+      error: "Process type is required"
     }),
     defaultStandardFactor: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Standard factor is required" })
+        error: "Standard factor is required"
       })
       .optional(),
     workCenters: z
@@ -371,7 +371,7 @@ export const trainingQuestionValidator = z
     trainingId: z.string().min(1, { message: "Training is required" }),
     question: z.string().min(1, { message: "Question is required" }),
     type: z.enum(trainingQuestionType, {
-      errorMap: () => ({ message: "Type is required" })
+      error: "Type is required"
     }),
     sortOrder: zfd.numeric(z.number().min(0).optional()),
     required: zfd.checkbox().optional(),
@@ -499,7 +499,7 @@ export const workCenterValidator = z.object({
   name: z.string().trim().min(1, { message: "Name is required" }),
   description: z.string(),
   defaultStandardFactor: z.enum(standardFactorType, {
-    errorMap: () => ({ message: "Standard factor is required" })
+    error: "Standard factor is required"
   }),
   departmentId: zfd.text(z.string().optional()),
   laborRate: zfd.numeric(z.number().min(0)),

--- a/apps/erp/app/modules/sales/sales.models.ts
+++ b/apps/erp/app/modules/sales/sales.models.ts
@@ -299,9 +299,10 @@ export const quoteValidator = z.object({
 });
 
 export const quoteLineAdditionalChargesValidator = z.record(
+  z.string(),
   z.object({
     description: z.string(),
-    amounts: z.record(z.number()),
+    amounts: z.record(z.string(), z.number()),
     taxable: z.boolean().default(true)
   })
 );
@@ -321,7 +322,7 @@ export const costCategoryKeys = [
 export type CostCategoryKey = (typeof costCategoryKeys)[number];
 
 export const quoteLineCategoryMarkupsValidator = z
-  .record(z.number().min(0))
+  .record(z.string(), z.number().min(0))
   .default({});
 
 export const quoteLineValidator = z.object({
@@ -330,12 +331,12 @@ export const quoteLineValidator = z.object({
   itemType: z.enum(itemType).optional(),
   itemId: z.string().min(1, { message: "Part is required" }),
   status: z.enum(quoteLineStatusType, {
-    errorMap: () => ({ message: "Status is required" })
+    error: "Status is required"
   }),
   estimatorId: zfd.text(z.string().optional()),
   description: z.string().min(1, { message: "Description is required" }),
   methodType: z.enum(methodType, {
-    errorMap: () => ({ message: "Method is required" })
+    error: "Method is required"
   }),
   customerPartId: zfd.text(z.string().optional()),
   customerPartRevision: zfd.text(z.string().optional()),
@@ -361,14 +362,10 @@ export const quoteMaterialValidator = z
       .min(1, { message: "Make method is required" }),
     order: zfd.numeric(z.number().min(0)),
     itemType: z.enum(methodItemType, {
-      errorMap: (issue, ctx) => ({
-        message: "Item type is required"
-      })
+      error: "Item type is required"
     }),
     methodType: z.enum(methodType, {
-      errorMap: (issue, ctx) => ({
-        message: "Method type is required"
-      })
+      error: "Method type is required"
     }),
     itemId: z.string().min(1, { message: "Item is required" }),
     kit: zfd.text(z.string().optional()).transform((value) => value === "true"),
@@ -429,14 +426,10 @@ export const quoteOperationValidator = z
       .min(1, { message: "Quote Make Method is required" }),
     order: zfd.numeric(z.number().min(0)),
     operationOrder: z.enum(methodOperationOrders, {
-      errorMap: (issue, ctx) => ({
-        message: "Operation order is required"
-      })
+      error: "Operation order is required"
     }),
     operationType: z.enum(operationTypes, {
-      errorMap: (issue, ctx) => ({
-        message: "Operation type is required"
-      })
+      error: "Operation type is required"
     }),
     processId: z.string().min(1, { message: "Process is required" }),
     procedureId: zfd.text(z.string().optional()),
@@ -448,19 +441,19 @@ export const quoteOperationValidator = z
     ),
     setupUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Setup unit is required" })
+        error: "Setup unit is required"
       })
       .optional(),
     setupTime: zfd.numeric(z.number().min(0).optional()),
     laborUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Labor unit is required" })
+        error: "Labor unit is required"
       })
       .optional(),
     laborTime: zfd.numeric(z.number().min(0).optional()),
     machineUnit: z
       .enum(standardFactorType, {
-        errorMap: () => ({ message: "Machine unit is required" })
+        error: "Machine unit is required"
       })
       .optional(),
     machineTime: zfd.numeric(z.number().min(0).optional()),
@@ -785,9 +778,7 @@ export const salesOrderLineValidator = z
     id: zfd.text(z.string().optional()),
     salesOrderId: z.string().min(1, { message: "Order is required" }),
     salesOrderLineType: z.enum(salesOrderLineType, {
-      errorMap: (issue, ctx) => ({
-        message: "Type is required"
-      })
+      error: "Type is required"
     }),
     accountId: zfd.text(z.string().optional()),
     shippingCost: zfd.numeric(z.number().optional()),
@@ -804,7 +795,7 @@ export const salesOrderLineValidator = z
     methodType: zfd.text(
       z
         .enum(methodType, {
-          errorMap: () => ({ message: "Method is required" })
+          error: "Method is required"
         })
         .optional()
     ),

--- a/apps/erp/app/modules/settings/settings.models.ts
+++ b/apps/erp/app/modules/settings/settings.models.ts
@@ -429,7 +429,7 @@ export type Theme = (typeof themes)[number];
 export const themeValidator = z.object({
   next: zfd.text(z.string().optional()),
   theme: z.enum(themes, {
-    errorMap: (issue, ctx) => ({ message: "Theme is required" })
+    error: "Theme is required"
   })
 });
 

--- a/apps/erp/app/modules/shared/shared.models.ts
+++ b/apps/erp/app/modules/shared/shared.models.ts
@@ -6,7 +6,7 @@ import { zfd } from "zod-form-data";
 export const approvalDecisionValidator = z.object({
   id: zfd.text(z.string().optional()),
   decision: z.enum(["Approved", "Rejected"], {
-    errorMap: () => ({ message: "Decision is required" })
+    error: "Decision is required"
   }),
   decisionNotes: zfd.text(z.string().optional())
 });
@@ -32,7 +32,7 @@ export const approvalDocumentTypesWithAmounts: ApprovalDocumentType[] = [
 
 export const approvalFiltersValidator = z.object({
   documentType: z.enum(approvalDocumentType, {
-    errorMap: () => ({ message: "Document type is required" })
+    error: "Document type is required"
   }),
   status: zfd.text(z.string().optional()),
   dateFrom: zfd.text(z.string().optional()),
@@ -42,7 +42,7 @@ export const approvalFiltersValidator = z.object({
 export const approvalRequestValidator = z.object({
   id: zfd.text(z.string().optional()),
   documentType: z.enum(approvalDocumentType, {
-    errorMap: () => ({ message: "Document type is required" })
+    error: "Document type is required"
   }),
   documentId: zfd.text(
     z.string().min(1, { message: "Document ID is required" })
@@ -53,7 +53,7 @@ export const approvalRequestValidator = z.object({
 export const approvalRuleValidator = z.object({
   id: zfd.text(z.string().optional()),
   documentType: z.enum(approvalDocumentType, {
-    errorMap: () => ({ message: "Document type is required" })
+    error: "Document type is required"
   }),
   approverGroupIds: z.array(
     z.string().min(1, { message: "Invalid selection" })
@@ -313,7 +313,7 @@ export const operationStepValidator = z
         return textToTiptap(String(val));
       }),
     type: z.enum(procedureStepType, {
-      errorMap: () => ({ message: "Type is required" })
+      error: "Type is required"
     }),
     unitOfMeasureCode: zfd.text(z.string().optional()),
     minValue: zfd.numeric(z.number().min(0).optional()),
@@ -457,7 +457,7 @@ export const savedViewValidator = z.object({
 export const savedViewStateValidator = z.object({
   columnOrder: z.array(z.string()),
   columnPinning: z.any(),
-  columnVisibility: z.record(z.boolean()),
+  columnVisibility: z.record(z.string(), z.boolean()),
   filters: z.array(z.string()).optional(),
   sorts: z.array(z.string()).optional()
 });

--- a/apps/erp/app/modules/users/users.models.ts
+++ b/apps/erp/app/modules/users/users.models.ts
@@ -38,10 +38,10 @@ export const createEmployeeValidator = z.object({
 // even though the browser also enforces `required`.
 export const itarEntityCertificationValidator = z.object({
   authorityToBind: z.literal(true, {
-    errorMap: () => ({ message: "You must confirm your authority to bind" })
+    error: "You must confirm your authority to bind"
   }),
   acceptRider: z.literal(true, {
-    errorMap: () => ({ message: "You must accept the Rider" })
+    error: "You must accept the Rider"
   }),
   fullLegalName: z
     .string()
@@ -57,15 +57,13 @@ export const itarEntityCertificationValidator = z.object({
 // ITAR certification — Screen 2 (user U.S.-Person attestation).
 export const itarUserCertificationValidator = z.object({
   certifyUsPerson: z.literal(true, {
-    errorMap: () => ({ message: "You must certify that you are a U.S. Person" })
+    error: "You must certify that you are a U.S. Person"
   }),
   agreeNotify: z.literal(true, {
-    errorMap: () => ({
-      message: "You must agree to the notification requirement"
-    })
+    error: "You must agree to the notification requirement"
   }),
   understandPenalty: z.literal(true, {
-    errorMap: () => ({ message: "You must acknowledge the penalties" })
+    error: "You must acknowledge the penalties"
   }),
   fullLegalName: z
     .string()

--- a/apps/erp/app/modules/workflows/workflows.models.ts
+++ b/apps/erp/app/modules/workflows/workflows.models.ts
@@ -40,7 +40,7 @@ export const workflowTestRunValidator = z.object({
 /** Parsed out of `triggerInput` after the form validator passes. */
 export const workflowTestRunInputSchema = z.union([
   z.object({ recordId: z.string().min(1) }),
-  z.object({ outputs: z.record(z.string().min(1)) }),
+  z.object({ outputs: z.record(z.string(), z.string().min(1)) }),
   z.object({})
 ]);
 

--- a/apps/erp/app/routes/api+/ai+/csv+/$table.columns.tsx
+++ b/apps/erp/app/routes/api+/ai+/csv+/$table.columns.tsx
@@ -12,7 +12,7 @@ const logger = getLogger("erp", "table-columns");
 
 const inputSchema = z.object({
   fileColumns: z.array(z.string())
-  // firstRows: z.array(z.record(z.string())),
+  // firstRows: z.array(z.record(z.string(), z.string())),
 });
 
 export async function action({ request, params }: ActionFunctionArgs) {

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-09-05T14:29:16.500Z",
+  "generated": "2026-09-05T20:25:36.076Z",
   "totalTools": 1495,
   "modules": 15,
   "tools": [

--- a/apps/erp/app/routes/x+/account+/$userId.attribute.tsx
+++ b/apps/erp/app/routes/x+/account+/$userId.attribute.tsx
@@ -78,7 +78,10 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   const upsertAttributeValue = await upsertUserAttributeValue(client, {
-    ...validation.data,
+    // validator(v as ZodSchema) intentionally erases the union of attribute-value
+    // schemas; v4's ZodSchema output is `unknown` (was `any` in v3), so restore the
+    // permissive spread the runtime already relies on.
+    ...(validation.data as any),
     userId: targetUserId,
     updatedBy: userId
   });

--- a/apps/erp/app/routes/x+/production+/planning.update.tsx
+++ b/apps/erp/app/routes/x+/production+/planning.update.tsx
@@ -54,7 +54,7 @@ export async function action({ request }: ActionFunctionArgs) {
       const parsedItems = itemsValidator.safeParse(items);
 
       if (!parsedItems.success) {
-        const errorMessages = parsedItems.error.errors.map((error) => {
+        const errorMessages = parsedItems.error.issues.map((error) => {
           const path = error.path;
           const field = path[path.length - 1];
 
@@ -79,7 +79,7 @@ export async function action({ request }: ActionFunctionArgs) {
           return error.message;
         });
 
-        logger.error("Validation errors", { errors: parsedItems.error.errors });
+        logger.error("Validation errors", { errors: parsedItems.error.issues });
         return data(
           {
             success: false,

--- a/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
+++ b/apps/erp/app/routes/x+/purchasing+/planning.update.tsx
@@ -54,7 +54,7 @@ export async function action({ request }: ActionFunctionArgs) {
       const parsedItems = itemsValidator.safeParse(items);
 
       if (!parsedItems.success) {
-        const errorMessages = parsedItems.error.errors.map((error) => {
+        const errorMessages = parsedItems.error.issues.map((error) => {
           const path = error.path;
           const field = path[path.length - 1];
 

--- a/apps/erp/app/routes/x+/quality+/risks.new.tsx
+++ b/apps/erp/app/routes/x+/quality+/risks.new.tsx
@@ -90,7 +90,8 @@ export default function NewRiskRoute() {
         status: "Open",
         severity: "1",
         likelihood: "1",
-        type: "Risk"
+        type: "Risk",
+        notes: ""
       }}
       onClose={onClose}
     />

--- a/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.cost.delete.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.cost.delete.tsx
@@ -35,7 +35,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     quoteLineAdditionalChargesValidator.safeParse(additionalCharges);
   if (parsedCharges.success === false) {
     return data(
-      { data: null, errors: parsedCharges.error.errors?.[0].message },
+      { data: null, errors: parsedCharges.error.issues?.[0].message },
       { status: 400 }
     );
   }

--- a/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.cost.new.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.cost.new.tsx
@@ -35,7 +35,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
     quoteLineAdditionalChargesValidator.safeParse(additionalCharges);
   if (parsedCharges.success === false) {
     return data(
-      { data: null, errors: parsedCharges.error.errors?.[0].message },
+      { data: null, errors: parsedCharges.error.issues?.[0].message },
       { status: 400 }
     );
   }

--- a/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
+++ b/apps/erp/app/routes/x+/quote+/$quoteId.$lineId.recalculate-price.tsx
@@ -33,7 +33,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
   );
 
   const categoryMarkupsByQuantityValidator = z.record(
-    z.record(z.number().min(0))
+    z.string(),
+    z.record(z.string(), z.number().min(0))
   );
   const categoryMarkupsByQuantity =
     categoryMarkupsByQuantityValidator.safeParse(
@@ -42,14 +43,14 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   if (unitPricesByQuantity.success === false) {
     return data(
-      { data: null, errors: unitPricesByQuantity.error.errors?.[0].message },
+      { data: null, errors: unitPricesByQuantity.error.issues?.[0].message },
       { status: 400 }
     );
   }
 
   if (quantities.success === false) {
     return data(
-      { data: null, errors: quantities.error.errors?.[0].message },
+      { data: null, errors: quantities.error.issues?.[0].message },
       { status: 400 }
     );
   }

--- a/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
+++ b/apps/erp/app/routes/x+/shared+/import.$tableId.tsx
@@ -41,7 +41,7 @@ export async function action({ request, params }: ActionFunctionArgs) {
   const importResult = await importCsv(serviceRole, {
     table,
     filePath: filePath as string,
-    columnMappings,
+    columnMappings: columnMappings as Record<string, string>,
     enumMappings: enumMappings ? JSON.parse(enumMappings as string) : undefined,
     companyId,
     userId

--- a/apps/mes/app/services/itar.service.ts
+++ b/apps/mes/app/services/itar.service.ts
@@ -15,10 +15,10 @@ const logger = getLogger("mes", "itar");
 
 export const itarEntityCertificationValidator = z.object({
   authorityToBind: z.literal(true, {
-    errorMap: () => ({ message: "You must confirm your authority to bind" })
+    error: "You must confirm your authority to bind"
   }),
   acceptRider: z.literal(true, {
-    errorMap: () => ({ message: "You must accept the Rider" })
+    error: "You must accept the Rider"
   }),
   fullLegalName: z
     .string()
@@ -33,15 +33,13 @@ export const itarEntityCertificationValidator = z.object({
 
 export const itarUserCertificationValidator = z.object({
   certifyUsPerson: z.literal(true, {
-    errorMap: () => ({ message: "You must certify that you are a U.S. Person" })
+    error: "You must certify that you are a U.S. Person"
   }),
   agreeNotify: z.literal(true, {
-    errorMap: () => ({
-      message: "You must agree to the notification requirement"
-    })
+    error: "You must agree to the notification requirement"
   }),
   understandPenalty: z.literal(true, {
-    errorMap: () => ({ message: "You must acknowledge the penalties" })
+    error: "You must acknowledge the penalties"
   }),
   fullLegalName: z
     .string()

--- a/apps/mes/app/services/models.ts
+++ b/apps/mes/app/services/models.ts
@@ -144,14 +144,10 @@ export const productionEventValidator = z.object({
     .string()
     .min(1, { message: "Job Operation ID is required" }),
   action: z.enum(productionEventAction, {
-    errorMap: (issue, ctx) => ({
-      message: "Action is required"
-    })
+    error: "Action is required"
   }),
   type: z.enum(productionEventType, {
-    errorMap: (issue, ctx) => ({
-      message: "Type is required"
-    })
+    error: "Type is required"
   }),
   workCenterId: zfd.text(z.string().optional()),
   trackedEntityId: zfd.text(z.string().optional()),
@@ -238,13 +234,13 @@ export const triggerReworkValidator = z.object({
 export const maintenanceDispatchValidator = z.object({
   workCenterId: z.string().min(1, { message: "Work Center is required" }),
   priority: z.enum(maintenanceDispatchPriority, {
-    errorMap: () => ({ message: "Priority is required" })
+    error: "Priority is required"
   }),
   severity: z.enum(maintenanceSeverity, {
-    errorMap: () => ({ message: "Severity is required" })
+    error: "Severity is required"
   }),
   oeeImpact: z.enum(oeeImpact, {
-    errorMap: () => ({ message: "OEE Impact is required" })
+    error: "OEE Impact is required"
   }),
   suspectedFailureModeId: zfd.text(z.string().optional()),
   actualFailureModeId: zfd.text(z.string().optional()),
@@ -267,7 +263,7 @@ export const qualityIssueValidator = z.object({
     .string()
     .min(1, { message: "Issue type is required" }),
   priority: z.enum(qualityIssuePriority, {
-    errorMap: () => ({ message: "Priority is required" })
+    error: "Priority is required"
   }),
   trackedEntityId: zfd.text(z.string().optional())
 });
@@ -304,7 +300,7 @@ export const inspectionSampleValidator = z.object({
   // "Pending" registers a sample without a verdict (identify-only scan when an
   // inspection document drives per-feature measurements).
   status: z.enum(["Pending", "Passed", "Failed"], {
-    errorMap: () => ({ message: "Status is required" })
+    error: "Status is required"
   }),
   notes: zfd.text(z.string().optional())
 });
@@ -319,7 +315,7 @@ export const inspectionSampleValidator = z.object({
 export const inspectionDispositionValidator = z
   .object({
     decision: z.enum(["Accept", "Reject", "Partial"], {
-      errorMap: () => ({ message: "Decision is required" })
+      error: "Decision is required"
     }),
     // The job operation, for postings + redirect back to the inspection view.
     operationId: z.string().min(1, { message: "Operation is required" }),

--- a/packages/checks/src/conformance/no-default-on-effects.test.ts
+++ b/packages/checks/src/conformance/no-default-on-effects.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { noDefaultOnEffects } from "./no-default-on-effects";
+
+describe("no-default-on-effects", () => {
+  it("flags .default() after a transform", () => {
+    const src = `const v = z.string().transform(Number).default(5);`;
+    const violations = noDefaultOnEffects.scan("a.ts", src);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.line).toBe(1);
+  });
+
+  it("flags .default() on a z.preprocess pipe", () => {
+    const src = `const v = z.preprocess((s) => String(s).trim(), z.string()).default(" padded ");`;
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(1);
+  });
+
+  it("flags .default() after refine and pipe across a multi-line chain", () => {
+    const src = [
+      "const v = z",
+      "  .object({ a: z.string() })",
+      "  .refine((d) => d.a.length > 0)",
+      "  .default({ a: 'x' });",
+      "const w = z.string().pipe(z.coerce.number()).default(1);"
+    ].join("\n");
+    const violations = noDefaultOnEffects.scan("a.ts", src);
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.line)).toEqual([4, 5]);
+  });
+
+  it("allows .default() on plain schemas, records, and coercions", () => {
+    const src = [
+      `const a = z.string().default("x");`,
+      `const b = z.record(z.string(), z.number().min(0)).default({});`,
+      `const c = z.coerce.boolean().default(false);`,
+      `const d = z.enum(values).default("Draft");`
+    ].join("\n");
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("allows .prefault() on effect-bearing schemas (that is the fix)", () => {
+    const src = `const v = z.object({ a: z.string().default("x") }).prefault({});`;
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("does not cross into a previous statement's effects", () => {
+    // The receiver walk stops at the statement boundary, so a transform in an
+    // earlier statement never taints an innocent .default().
+    const src = [
+      `const other = z.string().transform(Number);`,
+      `const v = z.string().default("x");`
+    ].join("\n");
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("stops at a block boundary instead of leaking a previous block", () => {
+    const src = [
+      "if (x) { register(z.string().transform(Number)); }",
+      `return z.string().default("x");`
+    ].join("\n");
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("flags an inner-shape transform too — the default bypasses it as well", () => {
+    // `.default({a: 1})` on this object returns the literal as-is; the shape's
+    // transform never runs on it. That is the same v4 bypass, so it counts.
+    const src = `const v = z.object({ a: z.string().transform(Number) }).default({ a: 1 });`;
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(1);
+  });
+
+  it("uses the trimmed .default line as the snippet", () => {
+    const src = [
+      "const v = z.string().transform(Number)",
+      "  .default(5);"
+    ].join("\n");
+    const [violation] = noDefaultOnEffects.scan("a.ts", src);
+    expect(violation?.snippet).toBe(".default(5);");
+    expect(violation?.line).toBe(2);
+  });
+});

--- a/packages/checks/src/conformance/no-default-on-effects.test.ts
+++ b/packages/checks/src/conformance/no-default-on-effects.test.ts
@@ -76,4 +76,39 @@ describe("no-default-on-effects", () => {
     expect(violation?.snippet).toBe(".default(5);");
     expect(violation?.line).toBe(2);
   });
+  it("ignores a chain written inside a string literal", () => {
+    const src = `const msg = "use z.string().transform(f).default(1) instead";`;
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("ignores a chain written inside a comment", () => {
+    const src = [
+      "// z.string().transform(Number).default(5) is the bad shape",
+      "/* also z.string().transform(Number).default(5) */",
+      "const v = z.string();"
+    ].join("\n");
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(0);
+  });
+
+  it("still flags a violation when a comment sits between the effect and .default()", () => {
+    // Regression: `receiverBefore` stops at `/`, so an unmasked comment here
+    // hid the violation entirely — the silent direction.
+    const src = [
+      "const v = z.string().transform(Number)",
+      "  // explain the default",
+      "  .default(5);"
+    ].join("\n");
+    expect(noDefaultOnEffects.scan("a.ts", src)).toHaveLength(1);
+  });
+
+  it("reports the real line number despite a preceding block comment", () => {
+    const src = [
+      "/* a",
+      "   multi-line",
+      "   comment */",
+      "const v = z.string().transform(Number).default(5);"
+    ].join("\n");
+    const [violation] = noDefaultOnEffects.scan("a.ts", src);
+    expect(violation?.line).toBe(4);
+  });
 });

--- a/packages/checks/src/conformance/no-default-on-effects.ts
+++ b/packages/checks/src/conformance/no-default-on-effects.ts
@@ -1,0 +1,77 @@
+import type { ConformanceCheck, Violation } from "../check";
+
+// zod v4 changed `.default()` semantics: on `undefined` input the default value
+// is returned AS-IS — it is no longer parsed through the schema. On a chain that
+// carries a transform/refinement/pipe, the default therefore bypasses the effect
+// entirely: `z.string().min(3).transform(fn).default("ab")` silently emits "ab"
+// untransformed and unvalidated (v3 would have re-parsed it). Typecheck cannot
+// catch this — the literal satisfies the OUTPUT type either way. Use
+// `.prefault()` when the default must be parsed, or verify the literal is a
+// valid output and baseline the site.
+const EFFECTS =
+  /\.(transform|refine|superRefine|check|overwrite|pipe)\s*\(|\bz\.preprocess\s*\(/;
+
+const DEFAULT_CALL = /\.default\s*\(/g;
+
+// Walk backwards from the `.` of `.default(` over the receiver expression:
+// balanced (...)/[...]/{...} groups plus identifier chars, dots, and
+// whitespace. Stops at anything else (an operator, `=`, the enclosing call's
+// open paren), which bounds the receiver to the chain `.default` is called on.
+function receiverBefore(text: string, dotIndex: number): string {
+  let i = dotIndex - 1;
+  while (i >= 0) {
+    const c = text[i];
+    if (c === undefined) break;
+    // A bare `}` here is a block/statement boundary, not part of a schema
+    // chain (an object literal in a chain sits inside an already-skipped call
+    // group) — skipping it would leak a previous block into the receiver.
+    if (c === "}") break;
+    if (c === ")" || c === "]") {
+      let depth = 1;
+      i--;
+      while (i >= 0 && depth > 0) {
+        const ch = text[i];
+        if (ch === ")" || ch === "]" || ch === "}") depth++;
+        else if (ch === "(" || ch === "[" || ch === "{") depth--;
+        i--;
+      }
+      continue;
+    }
+    if (/[\w$.\s]/.test(c)) {
+      i--;
+      continue;
+    }
+    break;
+  }
+  return text.slice(i + 1, dotIndex);
+}
+
+export const noDefaultOnEffects: ConformanceCheck = {
+  id: "no-default-on-effects",
+  description:
+    "`.default()` on a schema with transforms/refinements/pipes is not re-parsed in zod v4 — use `.prefault()` when the default must run through the schema",
+  provenance: {
+    deprecates:
+      "zod v3 `.default()` on effect-bearing schemas (the default was re-parsed through the schema)",
+    replacedBy:
+      "`.prefault()` when the default must be parsed; a verified output-typed literal otherwise",
+    since: "2026-09-05"
+  },
+  scan(file: string, contents: string): Violation[] {
+    const violations: Violation[] = [];
+    for (const match of contents.matchAll(DEFAULT_CALL)) {
+      const receiver = receiverBefore(contents, match.index);
+      if (!EFFECTS.test(receiver)) continue;
+      const line = contents.slice(0, match.index).split("\n").length;
+      const lineText = contents.split("\n")[line - 1] ?? "";
+      violations.push({
+        file,
+        line,
+        snippet: lineText.trim(),
+        message:
+          "`.default()` after a transform/refine/pipe is NOT re-parsed in zod v4 — the value bypasses the effect. Use `.prefault()` to parse it, or verify the literal is a valid OUTPUT and baseline this site."
+      });
+    }
+    return violations;
+  }
+};

--- a/packages/checks/src/conformance/no-default-on-effects.ts
+++ b/packages/checks/src/conformance/no-default-on-effects.ts
@@ -13,6 +13,71 @@ const EFFECTS =
 
 const DEFAULT_CALL = /\.default\s*\(/g;
 
+/**
+ * Blank the INTERIOR of comments and string/template literals, preserving every
+ * character position and newline so reported line numbers stay exact.
+ *
+ * Two failures this fixes, both demonstrated by tests below:
+ * - A `.transform(f).default(x)` written inside a string or a doc comment was
+ *   reported as a real violation.
+ * - A comment BETWEEN the effect and `.default()` hid a genuine violation:
+ *   `receiverBefore` stops at `/`, so the receiver never reached the
+ *   `.transform(` and the site was silently skipped. That direction is the
+ *   dangerous one — a missed violation looks identical to a clean file.
+ *
+ * Regex literals are deliberately not tracked: telling `/` division from a
+ * regex needs real parsing, and a regex containing `.default(` preceded by an
+ * effect is not a shape that occurs here.
+ */
+export function maskCommentsAndStrings(contents: string): string {
+  const out = contents.split("");
+  let i = 0;
+  const blank = (from: number, to: number) => {
+    for (let j = from; j < to && j < out.length; j++) {
+      if (out[j] !== "\n") out[j] = " ";
+    }
+  };
+
+  while (i < contents.length) {
+    const c = contents[i];
+    const next = contents[i + 1];
+
+    if (c === "/" && next === "/") {
+      const end = contents.indexOf("\n", i);
+      blank(i, end === -1 ? contents.length : end);
+      i = end === -1 ? contents.length : end;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      const end = contents.indexOf("*/", i + 2);
+      const stop = end === -1 ? contents.length : end + 2;
+      blank(i, stop);
+      i = stop;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      const quote = c;
+      let j = i + 1;
+      while (j < contents.length) {
+        if (contents[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (contents[j] === quote) break;
+        j++;
+      }
+      // Keep the quotes themselves so the receiver walk still sees a literal
+      // boundary rather than bare whitespace.
+      blank(i + 1, j);
+      i = j + 1;
+      continue;
+    }
+    i++;
+  }
+
+  return out.join("");
+}
+
 // Walk backwards from the `.` of `.default(` over the receiver expression:
 // balanced (...)/[...]/{...} groups plus identifier chars, dots, and
 // whitespace. Stops at anything else (an operator, `=`, the enclosing call's
@@ -59,8 +124,12 @@ export const noDefaultOnEffects: ConformanceCheck = {
   },
   scan(file: string, contents: string): Violation[] {
     const violations: Violation[] = [];
-    for (const match of contents.matchAll(DEFAULT_CALL)) {
-      const receiver = receiverBefore(contents, match.index);
+    // Scan the masked source so comments and string literals can neither fake
+    // a violation nor hide one; report from the ORIGINAL so the snippet the
+    // developer sees is the real line.
+    const masked = maskCommentsAndStrings(contents);
+    for (const match of masked.matchAll(DEFAULT_CALL)) {
+      const receiver = receiverBefore(masked, match.index);
       if (!EFFECTS.test(receiver)) continue;
       const line = contents.slice(0, match.index).split("\n").length;
       const lineText = contents.split("\n")[line - 1] ?? "";

--- a/packages/checks/src/index.ts
+++ b/packages/checks/src/index.ts
@@ -8,6 +8,7 @@ export type {
 export { findClobbers, objectRefs } from "./clobber";
 export { moduleShape } from "./conformance/module-shape";
 export { noDbClientInService } from "./conformance/no-db-client-in-service";
+export { noDefaultOnEffects } from "./conformance/no-default-on-effects";
 export { noDerivedPercentColumn } from "./conformance/no-derived-percent-column";
 export { noInlineFractionDigits } from "./conformance/no-inline-fraction-digits";
 export { noLegacyRls } from "./conformance/no-legacy-rls";

--- a/packages/checks/src/run.ts
+++ b/packages/checks/src/run.ts
@@ -8,6 +8,7 @@ import type {
 } from "./check";
 import { moduleShape } from "./conformance/module-shape";
 import { noDbClientInService } from "./conformance/no-db-client-in-service";
+import { noDefaultOnEffects } from "./conformance/no-default-on-effects";
 import { noDerivedPercentColumn } from "./conformance/no-derived-percent-column";
 import { noInlineFractionDigits } from "./conformance/no-inline-fraction-digits";
 import { noLegacyRls } from "./conformance/no-legacy-rls";
@@ -38,7 +39,8 @@ export const SERVER_CHECKS: ConformanceCheck[] = [
 export const TS_CHECKS: ConformanceCheck[] = [
   noRawRounding,
   noInlineFractionDigits,
-  noDbClientInService
+  noDbClientInService,
+  noDefaultOnEffects
 ];
 
 export const STRUCTURE_CHECKS: StructureCheck[] = [moduleShape];

--- a/packages/database/src/event.ts
+++ b/packages/database/src/event.ts
@@ -22,15 +22,15 @@ export const EventSchema = z.discriminatedUnion("operation", [
     table: z.string(),
     operation: z.enum(["UPDATE"]),
     recordId: z.string(),
-    new: z.record(z.any()),
-    old: z.record(z.any()),
+    new: z.record(z.string(), z.any()),
+    old: z.record(z.string(), z.any()),
     timestamp: z.string()
   }),
   z.object({
     table: z.string(),
     operation: z.enum(["INSERT"]),
     recordId: z.string(),
-    new: z.record(z.any()),
+    new: z.record(z.string(), z.any()),
     old: z.null(),
     timestamp: z.string()
   }),
@@ -39,7 +39,7 @@ export const EventSchema = z.discriminatedUnion("operation", [
     operation: z.enum(["DELETE", "TRUNCATE"]),
     recordId: z.string(),
     new: z.null(),
-    old: z.record(z.any()),
+    old: z.record(z.string(), z.any()),
     timestamp: z.string()
   })
 ]);
@@ -48,7 +48,7 @@ export const QueueMessageSchema = z.object({
   subscriptionId: z.string(),
   triggerType: z.enum(["ROW", "STATEMENT"]),
   handlerType: HandlerTypeSchema,
-  handlerConfig: z.record(z.any()),
+  handlerConfig: z.record(z.string(), z.any()),
   companyId: z.string(),
   actorId: z.string().nullish(), // Captured from auth.uid() at trigger time
   workflowRunId: z.string().nullish(), // Set when the write was made by a running workflow (workflow_run_id JWT claim)
@@ -75,9 +75,9 @@ export const CreateSubscriptionSchema = z.object({
   type: HandlerTypeSchema,
   // Configuration specific to the handler (URL for webhooks, WorkflowID for workflows)
   // We allow any object here since it's stored as JSONB
-  config: z.record(z.any()).default({}),
+  config: z.record(z.string(), z.any()).default({}),
   // Database-level filtering (e.g. { status: "paid" })
-  filter: z.record(z.any()).default({}),
+  filter: z.record(z.string(), z.any()).default({}),
   // Defaults to true
   active: z.boolean().default(true)
 });

--- a/packages/database/supabase/functions/assign-serial-numbers/index.ts
+++ b/packages/database/supabase/functions/assign-serial-numbers/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { sql } from "kysely";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";

--- a/packages/database/supabase/functions/close-job/index.ts
+++ b/packages/database/supabase/functions/close-job/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";

--- a/packages/database/supabase/functions/convert/index.ts
+++ b/packages/database/supabase/functions/convert/index.ts
@@ -1,10 +1,11 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
 
 import { format } from "https://deno.land/std@0.205.0/datetime/format.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
@@ -14,6 +15,7 @@ import { getRemainingQuantityToInvoice } from "../shared/short-close.ts";
 
 const pool = getConnectionPool(2);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("convert");
 
 // Supabase/PostgREST caps a single response at 1000 rows. Page through with
 // .range() so large reads (e.g. a quote's lines × quantity-break prices) are
@@ -161,13 +163,7 @@ serve(async (req: Request) => {
   try {
     const { type, id, companyId, userId } = payloadValidator.parse(payload);
 
-    console.log({
-      function: "convert",
-      type,
-      id,
-      companyId,
-      userId,
-    });
+    logger.info({ type, id, companyId, userId });
 
     const permissionsByType: Record<string, { view?: string | string[]; create?: string | string[]; update?: string | string[]; delete?: string | string[] }> = {
       methodVersionToActive: { update: "resources" },

--- a/packages/database/supabase/functions/create/index.ts
+++ b/packages/database/supabase/functions/create/index.ts
@@ -3,7 +3,8 @@ import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
 
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
@@ -11,6 +12,7 @@ import { getNextSequence } from "../shared/get-next-sequence.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("create");
 
 // Resolves a fallback location when a caller omits locationId, so creating a
 // blank shipment degrades gracefully instead of failing payload validation.
@@ -178,11 +180,7 @@ serve(async (req: Request) => {
     case "nonConformanceTasks": {
       const { id } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        id,
-      });
+      logger.info({ type, id });
 
       try {
 
@@ -351,7 +349,7 @@ serve(async (req: Request) => {
               });
             }
 
-            console.log({
+            logger.debug({
               description: nonConformance.data?.description,
               insertedContent,
             });
@@ -416,13 +414,7 @@ serve(async (req: Request) => {
     case "purchaseOrderFromJob": {
       const { jobId, purchaseOrdersBySupplierId } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        jobId,
-        companyId,
-        userId,
-      });
+      logger.info({ type, jobId, companyId, userId });
       try {
 
         const [job, jobOperations] = await Promise.all([
@@ -737,13 +729,7 @@ serve(async (req: Request) => {
     case "receiptDefault": {
       const { locationId } = payload;
       let createdDocumentId;
-      console.log({
-        function: "create",
-        type,
-        locationId,
-        companyId,
-        userId,
-      });
+      logger.info({ type, locationId, companyId, userId });
       try {
         await db.transaction().execute(async (trx) => {
           createdDocumentId = await getNextSequence(trx, "receipt", companyId);
@@ -774,8 +760,7 @@ serve(async (req: Request) => {
         locationId: userLocationId,
       } = payload;
 
-      console.log({
-        function: "create",
+      logger.info({
         type,
         companyId,
         purchaseOrderId,
@@ -1036,14 +1021,7 @@ serve(async (req: Request) => {
     case "receiptFromInboundTransfer": {
       const { warehouseTransferId, receiptId: existingReceiptId } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        companyId,
-        warehouseTransferId,
-        existingReceiptId,
-        userId,
-      });
+      logger.info({ type, companyId, warehouseTransferId, existingReceiptId, userId });
 
       try {
 
@@ -1203,14 +1181,7 @@ serve(async (req: Request) => {
     case "receiptFromWarehouseTransfer": {
       const { warehouseTransferId, receiptId: existingReceiptId } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        companyId,
-        warehouseTransferId,
-        existingReceiptId,
-        userId,
-      });
+      logger.info({ type, companyId, warehouseTransferId, existingReceiptId, userId });
 
       try {
 
@@ -1377,15 +1348,7 @@ serve(async (req: Request) => {
     case "receiptLineSplit": {
       const { receiptId, receiptLineId, quantity, locationId } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        locationId,
-        receiptId,
-        receiptLineId,
-        quantity,
-        userId,
-      });
+      logger.info({ type, locationId, receiptId, receiptLineId, quantity, userId });
 
       try {
 
@@ -1401,9 +1364,7 @@ serve(async (req: Request) => {
             .eq("attributes->> Receipt Line", receiptLineId),
         ]);
 
-        console.log({
-          trackedEntities,
-        });
+        logger.debug({ trackedEntities });
 
         if (!receiptLine.data) throw new Error("Receipt line not found");
 
@@ -1500,13 +1461,7 @@ serve(async (req: Request) => {
     case "shipmentDefault": {
       let createdDocumentId;
       const { locationId } = payload;
-      console.log({
-        function: "create",
-        type,
-        companyId,
-        locationId,
-        userId,
-      });
+      logger.info({ type, companyId, locationId, userId });
       try {
         const effectiveLocationId =
           locationId ?? (await getFallbackLocationId(client, companyId, userId));
@@ -1537,8 +1492,7 @@ serve(async (req: Request) => {
     case "shipmentFromWarehouseTransfer": {
       const { warehouseTransferId, shipmentId: existingShipmentId } = payload;
 
-      console.log({
-        function: "create",
+      logger.info({
         type,
         companyId,
         warehouseTransferId,
@@ -1706,8 +1660,7 @@ serve(async (req: Request) => {
         locationId,
       } = payload;
 
-      console.log({
-        function: "create",
+      logger.info({
         type,
         companyId,
         locationId,
@@ -1900,8 +1853,7 @@ serve(async (req: Request) => {
         locationId,
       } = payload;
 
-      console.log({
-        function: "create",
+      logger.info({
         type,
         companyId,
         locationId,
@@ -2248,8 +2200,7 @@ serve(async (req: Request) => {
         locationId,
       } = payload;
 
-      console.log({
-        function: "create",
+      logger.info({
         type,
         companyId,
         locationId,
@@ -2505,15 +2456,7 @@ serve(async (req: Request) => {
     case "shipmentLineSplit": {
       const { shipmentId, shipmentLineId, quantity, locationId } = payload;
 
-      console.log({
-        function: "create",
-        type,
-        locationId,
-        shipmentId,
-        shipmentLineId,
-        quantity,
-        userId,
-      });
+      logger.info({ type, locationId, shipmentId, shipmentLineId, quantity, userId });
 
       try {
 

--- a/packages/database/supabase/functions/download/index.ts
+++ b/packages/database/supabase/functions/download/index.ts
@@ -1,8 +1,11 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
+
+const logger = getFunctionLogger("download");
 
 const downloadValidator = z.object({
   bucket: z.string(),
@@ -20,13 +23,7 @@ serve(async (req: Request) => {
     const validatedPayload = downloadValidator.parse(payload);
     const { bucket, path, companyId, userId } = validatedPayload;
 
-    console.log({
-      function: "download",
-      bucket,
-      path,
-      companyId,
-      userId,
-    });
+    logger.info({ bucket, path, companyId, userId });
 
     // verify that the request is authorized by an API key or service role
     const serviceRole = await requirePermissions(req, companyId, userId, { view: "documents" });

--- a/packages/database/supabase/functions/embed/index.ts
+++ b/packages/database/supabase/functions/embed/index.ts
@@ -1,12 +1,14 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { Kysely, sql } from "kysely";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { generateEmbedding } from "../lib/ai/embedding.ts";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("embed");
 
 const jobSchema = z.object({
   jobId: z.number(),
@@ -40,10 +42,7 @@ serve(async (req: Request) => {
   // Use Zod to parse and validate the request body
   const parseResult = z.array(jobSchema).safeParse(await req.json());
 
-  console.log({
-    function: "embed",
-    ...parseResult,
-  });
+  logger.info(parseResult);
 
   if (parseResult.error) {
     return new Response(`invalid request body: ${parseResult.error.message}`, {
@@ -67,7 +66,12 @@ serve(async (req: Request) => {
         await processJob(db, currentJob);
         completedJobs.push(currentJob);
       } catch (error) {
-        console.error(error);
+        logger.error("processJob failed", {
+          error:
+            error instanceof Error
+              ? (error.stack ?? error.message)
+              : JSON.stringify(error),
+        });
         failedJobs.push({
           ...currentJob,
           error: error instanceof Error ? error.message : JSON.stringify(error),
@@ -82,7 +86,12 @@ serve(async (req: Request) => {
   } catch (error) {
     // If the worker is terminating (e.g. wall clock limit reached),
     // add pending jobs to fail list with termination reason
-    console.error(error);
+    logger.error("embed worker terminating", {
+      error:
+        error instanceof Error
+          ? (error.stack ?? error.message)
+          : JSON.stringify(error),
+    });
     failedJobs.push(
       ...pendingJobs.map((job) => ({
         ...job,
@@ -92,7 +101,7 @@ serve(async (req: Request) => {
   }
 
   // Log completed and failed jobs for traceability
-  console.log("finished processing jobs:", {
+  logger.info("finished processing jobs", {
     completedJobs: completedJobs.length,
     failedJobs: failedJobs.length,
   });
@@ -124,17 +133,17 @@ serve(async (req: Request) => {
 async function processJob(db: Kysely<DB>, job: Job) {
   const { jobId, id, table } = job;
 
-  console.log(`Processing job ${jobId} for ${table} with id ${id}`);
+  logger.debug(`Processing job ${jobId} for ${table} with id ${id}`);
 
   if (table === "item") {
-    console.log("Fetching item from database...");
+    logger.debug("Fetching item from database...");
     const item = await db
       .selectFrom("item")
       .selectAll()
       .where("id", "=", id)
       .executeTakeFirst();
 
-    console.log("Item fetched:", {
+    logger.debug("Item fetched", {
       id: item?.id,
       name: item?.name,
       description: item?.description,
@@ -145,12 +154,12 @@ async function processJob(db: Kysely<DB>, job: Job) {
     );
 
     const textToEmbed = textParts.join(" ");
-    console.log("Text to embed:", textToEmbed);
+    logger.debug("Text to embed", { textToEmbed });
 
     const embedding = await generateEmbedding(textToEmbed);
     const embeddingString = JSON.stringify(embedding);
 
-    console.log("Updating item with embedding...", {
+    logger.debug("Updating item with embedding...", {
       embeddingLength: embedding.length,
       embeddingStringLength: embeddingString.length,
     });
@@ -163,18 +172,18 @@ async function processJob(db: Kysely<DB>, job: Job) {
       .where("id", "=", id)
       .execute();
 
-    console.log("Item update result:", result);
+    logger.debug("Item update result", { result });
   }
 
   if (table === "supplier") {
-    console.log("Fetching supplier from database...");
+    logger.debug("Fetching supplier from database...");
     const supplier = await db
       .selectFrom("supplier")
       .selectAll()
       .where("id", "=", id)
       .executeTakeFirst();
 
-    console.log("Supplier fetched:", {
+    logger.debug("Supplier fetched", {
       id: supplier?.id,
       name: supplier?.name,
     });
@@ -185,12 +194,12 @@ async function processJob(db: Kysely<DB>, job: Job) {
       throw new Error(`Supplier ${id} has no name to embed`);
     }
 
-    console.log("Text to embed:", textToEmbed);
+    logger.debug("Text to embed", { textToEmbed });
 
     const embedding = await generateEmbedding(textToEmbed);
     const embeddingString = JSON.stringify(embedding);
 
-    console.log("Updating supplier with embedding...", {
+    logger.debug("Updating supplier with embedding...", {
       embeddingLength: embedding.length,
       embeddingStringLength: embeddingString.length,
     });
@@ -204,18 +213,18 @@ async function processJob(db: Kysely<DB>, job: Job) {
       .where("id", "=", id)
       .execute();
 
-    console.log("Supplier update result:", result);
+    logger.debug("Supplier update result", { result });
   }
 
   if (table === "customer") {
-    console.log("Fetching customer from database...");
+    logger.debug("Fetching customer from database...");
     const customer = await db
       .selectFrom("customer")
       .selectAll()
       .where("id", "=", id)
       .executeTakeFirst();
 
-    console.log("Customer fetched:", {
+    logger.debug("Customer fetched", {
       id: customer?.id,
       name: customer?.name,
     });
@@ -226,12 +235,12 @@ async function processJob(db: Kysely<DB>, job: Job) {
       throw new Error(`Customer ${id} has no name to embed`);
     }
 
-    console.log("Text to embed:", textToEmbed);
+    logger.debug("Text to embed", { textToEmbed });
 
     const embedding = await generateEmbedding(textToEmbed);
     const embeddingString = JSON.stringify(embedding);
 
-    console.log("Updating customer with embedding...", {
+    logger.debug("Updating customer with embedding...", {
       embeddingLength: embedding.length,
       embeddingStringLength: embeddingString.length,
     });
@@ -245,15 +254,15 @@ async function processJob(db: Kysely<DB>, job: Job) {
       .where("id", "=", id)
       .execute();
 
-    console.log("Customer update result:", result);
+    logger.debug("Customer update result", { result });
   }
 
-  console.log(`Deleting job ${jobId} from queue...`);
+  logger.debug(`Deleting job ${jobId} from queue...`);
   const deleteResult =
     await sql`select pgmq.delete(${QUEUE_NAME}, ${jobId}::bigint)`.execute(db);
-  console.log("Queue delete result:", deleteResult);
+  logger.debug("Queue delete result", { deleteResult });
 
-  console.log(`Job ${jobId} processing completed successfully`);
+  logger.debug(`Job ${jobId} processing completed successfully`);
 }
 
 /**

--- a/packages/database/supabase/functions/embed/index.ts
+++ b/packages/database/supabase/functions/embed/index.ts
@@ -10,6 +10,27 @@ const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
 const logger = getFunctionLogger("embed");
 
+/**
+ * Render a caught value for logging. Kysely's `PostgresDriver.executeQuery`
+ * rethrows non-`Error` values unchanged, so anything can land in a `catch`
+ * here — and `JSON.stringify` THROWS on a circular object or a BigInt. That
+ * throw would escape the catch block and abort failure handling before the
+ * job is recorded in `failedJobs`, turning one bad job into a silent loss of
+ * the whole batch. Always returns a string.
+ */
+function describeError(error: unknown): { detail: string; message: string } {
+  if (error instanceof Error) {
+    return { detail: error.stack ?? error.message, message: error.message };
+  }
+  let message: string;
+  try {
+    message = JSON.stringify(error) ?? String(error);
+  } catch {
+    message = String(error);
+  }
+  return { detail: message, message };
+}
+
 const jobSchema = z.object({
   jobId: z.number(),
   id: z.string(),
@@ -66,16 +87,9 @@ serve(async (req: Request) => {
         await processJob(db, currentJob);
         completedJobs.push(currentJob);
       } catch (error) {
-        logger.error("processJob failed", {
-          error:
-            error instanceof Error
-              ? (error.stack ?? error.message)
-              : JSON.stringify(error),
-        });
-        failedJobs.push({
-          ...currentJob,
-          error: error instanceof Error ? error.message : JSON.stringify(error),
-        });
+        const described = describeError(error);
+        logger.error("processJob failed", { error: described.detail });
+        failedJobs.push({ ...currentJob, error: described.message });
       }
     }
   }
@@ -86,17 +100,10 @@ serve(async (req: Request) => {
   } catch (error) {
     // If the worker is terminating (e.g. wall clock limit reached),
     // add pending jobs to fail list with termination reason
-    logger.error("embed worker terminating", {
-      error:
-        error instanceof Error
-          ? (error.stack ?? error.message)
-          : JSON.stringify(error),
-    });
+    const described = describeError(error);
+    logger.error("embed worker terminating", { error: described.detail });
     failedJobs.push(
-      ...pendingJobs.map((job) => ({
-        ...job,
-        error: error instanceof Error ? error.message : JSON.stringify(error),
-      }))
+      ...pendingJobs.map((job) => ({ ...job, error: described.message }))
     );
   }
 

--- a/packages/database/supabase/functions/get-method/index.ts
+++ b/packages/database/supabase/functions/get-method/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import type {
     PostgrestError,
@@ -27,6 +27,7 @@ import {
     traverseJobMethodAsync,
     traverseQuoteMethod,
 } from "../lib/methods.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { KyselyDatabase } from "../lib/postgres/index.ts";
 import { importTypeScript } from "../lib/sandbox.ee.ts";
 import { getStorageUnitId } from "../lib/storage-units.ts";
@@ -43,6 +44,7 @@ import { scrapAllowance } from "../shared/precision.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("get-method");
 
 // Stored configurator rules are user-authored JS that may still return legacy "Inside"/"Outside" operationType values.
 const normalizeOperationType = (value: unknown) =>
@@ -159,7 +161,9 @@ const partsValidator = z.object({
   tools: z.boolean().default(true),
   steps: z.boolean().default(true),
   workInstructions: z.boolean().default(true),
-}).default({});
+  // prefault, not default: v4's .default() returns {} AS-IS on undefined input,
+  // which would skip every inner default and disable all six part flags.
+}).prefault({});
 
 const payloadValidator = z.object({
   type: z.enum([
@@ -183,7 +187,7 @@ const payloadValidator = z.object({
   targetId: z.string(),
   companyId: z.string(),
   userId: z.string(),
-  configuration: z.record(z.unknown()).optional(),
+  configuration: z.record(z.string(), z.unknown()).optional(),
   parts: partsValidator,
   // A specific source makeMethod version (itemToJob / itemToJobMakeMethod
   // only). Absent = the item's active method, as before.
@@ -207,8 +211,7 @@ serve(async (req: Request) => {
       versionId,
     } = payloadValidator.parse(payload);
 
-    console.log({
-      function: "get-method",
+    logger.info({
       type,
       sourceId,
       targetId,
@@ -865,7 +868,9 @@ serve(async (req: Request) => {
                 const result = await mod.configure(hydratedConfiguration);
                 return (result ?? defaultValue) as T;
               } catch (err) {
-                console.error(err);
+                logger.error("configuration field resolver failed", {
+                  error: String((err as Error)?.stack ?? err),
+                });
                 return defaultValue;
               }
             }
@@ -2602,7 +2607,9 @@ serve(async (req: Request) => {
 
                 return (result ?? defaultValue) as T;
               } catch (err) {
-                console.error(err);
+                logger.error("configuration field resolver failed", {
+                  error: String((err as Error)?.stack ?? err),
+                });
                 return defaultValue;
               }
             }
@@ -2618,7 +2625,7 @@ serve(async (req: Request) => {
             node: MethodTreeItem,
             parentQuoteMakeMethodId: string | null
           ) {
-            console.log("[traverseMethod]", {
+            logger.debug("[traverseMethod]", {
               isRoot: node.data.isRoot,
               itemId: node.data.itemId,
               methodType: node.data.methodType,
@@ -2731,7 +2738,7 @@ serve(async (req: Request) => {
                 processId,
                 op.workCenterId
               );
-              console.log({
+              logger.debug({
                 processId,
                 ...operationRates,
               });
@@ -3075,7 +3082,7 @@ serve(async (req: Request) => {
               (child) => child.data.methodType === "Make to Order"
             );
 
-            console.log("[traverseMethod] materials", {
+            logger.debug("[traverseMethod] materials", {
               totalChildren: materialsWithConfiguredFields.length,
               madeMaterialsCount: madeMaterials.length,
               madeChildrenCount: madeChildren.length,
@@ -3103,7 +3110,7 @@ serve(async (req: Request) => {
                   .where("parentMaterialId", "=", materialId)
                   .execute();
 
-                console.log("[traverseMethod] processing made child", {
+                logger.debug("[traverseMethod] processing made child", {
                   index,
                   materialId,
                   newMakeMethodId,
@@ -3130,7 +3137,7 @@ serve(async (req: Request) => {
           }
 
           function logTree(node: MethodTreeItem, depth = 0) {
-            console.log("  ".repeat(depth) + `[tree] ${node.data.itemId} (${node.data.methodType}, isRoot=${node.data.isRoot}, children=${node.children.length})`);
+            logger.debug("  ".repeat(depth) + `[tree] ${node.data.itemId} (${node.data.methodType}, isRoot=${node.data.isRoot}, children=${node.children.length})`);
             for (const child of node.children) {
               logTree(child, depth + 1);
             }
@@ -3275,7 +3282,9 @@ serve(async (req: Request) => {
                 const result = await mod.configure(hydratedConfiguration);
                 return (result ?? defaultValue) as T;
               } catch (err) {
-                console.error(err);
+                logger.error("configuration field resolver failed", {
+                  error: String((err as Error)?.stack ?? err),
+                });
                 return defaultValue;
               }
             }
@@ -5997,14 +6006,13 @@ serve(async (req: Request) => {
           quoteOperations.error
         ) {
           if (quoteMakeMethod.error) {
-            console.log("quoteMakeMethodError");
-            console.log(quoteMakeMethod.error);
+            logger.error("quoteMakeMethodError", { error: quoteMakeMethod.error });
           }
           if (quoteMaterials.error) {
-            console.log(quoteMaterials.error);
+            logger.error("quoteMaterialsError", { error: quoteMaterials.error });
           }
           if (quoteOperations.error) {
-            console.log(quoteOperations.error);
+            logger.error("quoteOperationsError", { error: quoteOperations.error });
           }
           throw new Error("Failed to fetch quote data");
         }
@@ -6528,7 +6536,9 @@ serve(async (req: Request) => {
         ]);
 
         if (targetQuoteMakeMethod.error || !targetQuoteMakeMethod.data) {
-          console.error(targetQuoteMakeMethod.error);
+          logger.error("Failed to get target quote make method", {
+            error: targetQuoteMakeMethod.error,
+          });
           throw new Error("Failed to get target quote make method");
         }
 
@@ -7098,7 +7108,9 @@ serve(async (req: Request) => {
             ]);
 
             if (targetQuoteMakeMethod.error) {
-              console.error(targetQuoteMakeMethod.error);
+              logger.error("Failed to get target quote make method", {
+                error: targetQuoteMakeMethod.error,
+              });
               throw new Error("Failed to get target quote make method");
             }
 
@@ -8155,7 +8167,9 @@ async function hydrateConfiguration(
 
     return transformed;
   } catch (err) {
-    console.error(err);
+    logger.error("configuration transform failed", {
+      error: String((err as Error)?.stack ?? err),
+    });
     return configuration;
   }
 }

--- a/packages/database/supabase/functions/import-csv/index.ts
+++ b/packages/database/supabase/functions/import-csv/index.ts
@@ -2,8 +2,9 @@ import { parse } from "https://deno.land/std@0.175.0/encoding/csv.ts";
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
 import { sql } from "npm:kysely@0.27.6";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
@@ -14,6 +15,7 @@ import { importMethods } from "./method-import.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("import-csv");
 
 const importCsvValidator = z.object({
   table: z.enum([
@@ -40,8 +42,10 @@ const importCsvValidator = z.object({
     "materialDimension",
   ]),
   filePath: z.string(),
-  columnMappings: z.record(z.string()),
-  enumMappings: z.record(z.record(z.string())).optional(),
+  columnMappings: z.record(z.string(), z.string()),
+  enumMappings: z
+    .record(z.string(), z.record(z.string(), z.string()))
+    .optional(),
   companyId: z.string(),
   userId: z.string(),
 });
@@ -953,15 +957,7 @@ serve(async (req: Request) => {
       userId,
     } = importCsvValidator.parse(payload);
 
-    console.log({
-      function: "import-csv",
-      table,
-      filePath,
-      columnMappings,
-      enumMappings,
-      companyId,
-      userId,
-    });
+    logger.info({ table, filePath, columnMappings, enumMappings, companyId, userId });
 
     const client = await requirePermissions(req, companyId, userId, { create: "resources" });
 
@@ -1143,7 +1139,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             customerInserts: customerInserts.length,
             customerUpdates: customerUpdates.length,
@@ -1344,7 +1340,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             supplierInserts: supplierInserts.length,
             supplierUpdates: supplierUpdates.length,
@@ -1971,7 +1967,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             itemInserts: itemInserts.length,
             itemUpdates: itemUpdates.length,
@@ -2138,7 +2134,7 @@ serve(async (req: Request) => {
           summary.inserted += contactInserts.length;
           summary.updated += contactUpdates.length;
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             contactInserts: contactInserts.length,
             contactUpdates: contactUpdates.length,
@@ -2258,7 +2254,7 @@ serve(async (req: Request) => {
           summary.inserted += contactInserts.length;
           summary.updated += contactUpdates.length;
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             contactInserts: contactInserts.length,
             contactUpdates: contactUpdates.length,
@@ -2371,7 +2367,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             workCenterInserts: workCenterInserts.length,
             workCenterUpdates: workCenterUpdates.length,
@@ -2480,7 +2476,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             processInserts: processInserts.length,
             processUpdates: processUpdates.length,
@@ -2787,7 +2783,7 @@ serve(async (req: Request) => {
             }
           }
 
-          console.log({
+          logger.info({
             totalRecords: mappedRecords.length,
             storageUnitInserts: inserts.length,
             storageUnitUpdates: updates.length,

--- a/packages/database/supabase/functions/issue/index.ts
+++ b/packages/database/supabase/functions/issue/index.ts
@@ -1,12 +1,13 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { type CalendarDate, parseDate } from "@internationalized/date";
 import { Transaction } from "kysely";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
 
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/nanoid.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import {
   getStorageUnitWithHighestQuantity,
@@ -809,6 +810,7 @@ async function createMaterialWipEntries(
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("issue");
 
 const payloadValidator = z.discriminatedUnion("type", [
   z.object({
@@ -988,15 +990,12 @@ serve(async (req: Request) => {
   const preflight = corsPreflight(req);
   if (preflight) return preflight;
   const payload = await req.json();
-  console.log({ payload });
+  logger.info({ payload });
 
   try {
     const validatedPayload = payloadValidator.parse(payload);
 
-    console.log({
-      function: "issue",
-      ...validatedPayload,
-    });
+    logger.info(validatedPayload);
 
     const itemLedgerInserts: Database["public"]["Tables"]["itemLedger"]["Insert"][] =
       [];
@@ -1875,10 +1874,9 @@ serve(async (req: Request) => {
             signal: AbortSignal.timeout(10_000),
           });
         } catch (rescheduleError) {
-          console.error(
-            "Failed to trigger reschedule after scrap:",
-            rescheduleError
-          );
+          logger.error("Failed to trigger reschedule after scrap", {
+            error: String((rescheduleError as Error)?.stack ?? rescheduleError),
+          });
         }
 
         return jsonResponse({
@@ -2676,10 +2674,9 @@ serve(async (req: Request) => {
               signal: AbortSignal.timeout(10_000),
             });
           } catch (rescheduleError) {
-            console.error(
-              "Failed to trigger reschedule after scrap:",
-              rescheduleError
-            );
+            logger.error("Failed to trigger reschedule after scrap", {
+              error: String((rescheduleError as Error)?.stack ?? rescheduleError),
+            });
           }
         }
 
@@ -3244,7 +3241,7 @@ serve(async (req: Request) => {
               .where("id", "=", actualMaterialId)
               .execute();
 
-            console.log("Job material quantity updated:", {
+            logger.info("Job material quantity updated", {
               materialId: actualMaterialId,
               newQuantityIssued,
             });
@@ -3743,7 +3740,7 @@ serve(async (req: Request) => {
             await trx.insertInto("itemLedger").values(ledgerEntries).execute();
           }
 
-          console.log("Entity converted:", {
+          logger.info("Entity converted", {
             trackedEntityId,
             oldRevision: oldItem.revision,
             newRevision,

--- a/packages/database/supabase/functions/pick/index.ts
+++ b/packages/database/supabase/functions/pick/index.ts
@@ -1,13 +1,15 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 
 import { corsPreflight, errorResponse } from "../lib/response.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("pick");
 
 const payloadValidator = z.discriminatedUnion("type", [
   z.object({
@@ -46,12 +48,7 @@ serve(async (req: Request) => {
   try {
     const { type, companyId, userId } = payloadValidator.parse(payload);
 
-    console.log({
-      function: "pick",
-      type,
-      companyId,
-      userId,
-    });
+    logger.info({ type, companyId, userId });
 
     const client = await requirePermissions(req, companyId, userId, { update: "inventory" });
 
@@ -64,7 +61,9 @@ serve(async (req: Request) => {
         return errorResponse("Invalid operation type", 400);
     }
   } catch (error) {
-    console.error("Error in pick:", error);
+    logger.error("pick failed", {
+      error: String((error as Error)?.stack ?? error),
+    });
     return errorResponse(error, 500);
   }
 });

--- a/packages/database/supabase/functions/post-memo/index.ts
+++ b/packages/database/supabase/functions/post-memo/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { getSupabaseServiceRole } from "../lib/supabase.ts";
 
@@ -13,6 +14,7 @@ import { buildMemoJournal, type MemoJournalLine } from "./build-memo-journal.ts"
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("post-memo");
 
 const payloadValidator = z.object({
   type: z.enum(["post", "void"]).default("post"),
@@ -30,7 +32,7 @@ serve(async (req: Request) => {
   try {
     const { type, memoId, userId, companyId } = payloadValidator.parse(payload);
 
-    console.log({ function: "post-memo", type, memoId, userId, companyId });
+    logger.info({ type, memoId, userId, companyId });
 
     const client = await getSupabaseServiceRole(
       req.headers.get("Authorization"),

--- a/packages/database/supabase/functions/post-payment/index.ts
+++ b/packages/database/supabase/functions/post-payment/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { getSupabaseServiceRole } from "../lib/supabase.ts";
 
@@ -17,6 +18,7 @@ import { round } from "../shared/precision.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("post-payment");
 
 const payloadValidator = z.object({
   type: z.enum(["post", "void"]).default("post"),
@@ -46,7 +48,7 @@ serve(async (req: Request) => {
     const { type, paymentId, userId, companyId, fee } =
       payloadValidator.parse(payload);
 
-    console.log({ function: "post-payment", type, paymentId, userId, companyId });
+    logger.info({ type, paymentId, userId, companyId });
 
     const client = await getSupabaseServiceRole(
       req.headers.get("Authorization"),

--- a/packages/database/supabase/functions/post-production-event/index.ts
+++ b/packages/database/supabase/functions/post-production-event/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";

--- a/packages/database/supabase/functions/post-purchase-invoice/index.ts
+++ b/packages/database/supabase/functions/post-purchase-invoice/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import type { Database } from "../lib/types.ts";
@@ -26,6 +27,7 @@ import { round } from "../shared/precision.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("post-purchase-invoice");
 
 const payloadValidator = z.object({
   type: z.enum(["post", "void"]).default("post"),
@@ -45,13 +47,7 @@ serve(async (req: Request) => {
     const { type, invoiceId, userId, companyId, skipReceiptPost } =
       payloadValidator.parse(payload);
 
-    console.log({
-      function: "post-purchase-invoice",
-      type,
-      invoiceId,
-      userId,
-      skipReceiptPost,
-    });
+    logger.info({ type, invoiceId, userId, skipReceiptPost });
     const client = await requirePermissions(req, companyId, userId, { update: "invoicing" });
     const today = datetime.today(await getCompanyTimeZone(client, companyId)).toString();
 
@@ -548,7 +544,7 @@ serve(async (req: Request) => {
     if (purchaseInvoiceDelivery.error)
       throw new Error("Failed to fetch purchase invoice delivery");
     if (dimensions.error) {
-      console.error("Failed to fetch dimensions", dimensions.error);
+      logger.error("Failed to fetch dimensions", { error: dimensions.error });
     }
 
     const dimensionMap = new Map<string, string>();
@@ -886,7 +882,7 @@ serve(async (req: Request) => {
             );
             const itemTrackingType = item?.itemTrackingType ?? "Inventory";
 
-            console.log({
+            logger.debug({
               invoiceLineItemId: invoiceLine.itemId,
               foundItem: item,
               itemTrackingType,
@@ -2274,7 +2270,9 @@ serve(async (req: Request) => {
       receiptIds: createdReceiptIds,
     });
   } catch (err) {
-    console.error(err);
+    logger.error("post-purchase-invoice failed", {
+      error: String((err as Error)?.stack ?? err),
+    });
     if (payload.type !== "void" && "invoiceId" in payload) {
       const client = await requirePermissions(req, payload.companyId, payload.userId, { update: "invoicing" });
       await client

--- a/packages/database/supabase/functions/post-sales-invoice/index.ts
+++ b/packages/database/supabase/functions/post-sales-invoice/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/mod.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import type { Database } from "../lib/types.ts";
@@ -20,6 +21,7 @@ import { calculateCOGS } from "../shared/calculate-cogs.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("post-sales-invoice");
 
 const payloadValidator = z.object({
   type: z.enum(["post", "void"]).default("post"),
@@ -38,13 +40,7 @@ serve(async (req: Request) => {
     const { type, invoiceId, userId, companyId } =
       payloadValidator.parse(payload);
 
-    console.log({
-      function: "post-sales-invoice",
-      type,
-      invoiceId,
-      userId,
-      companyId,
-    });
+    logger.info({ type, invoiceId, userId, companyId });
 
     const client = await requirePermissions(req, companyId, userId, { update: "invoicing" });
     const today = datetime.today(await getCompanyTimeZone(client, companyId)).toString();
@@ -1696,7 +1692,9 @@ serve(async (req: Request) => {
 
     return jsonResponse({ success: true });
   } catch (err) {
-    console.error(err);
+    logger.error("post-sales-invoice failed", {
+      error: String((err as Error)?.stack ?? err),
+    });
     if ("invoiceId" in payload) {
       const client = await requirePermissions(req, payload.companyId, payload.userId, { update: "invoicing" });
       await client

--- a/packages/database/supabase/functions/recalculate/index.ts
+++ b/packages/database/supabase/functions/recalculate/index.ts
@@ -1,9 +1,10 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 
 import { sql, Transaction } from "kysely";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import {
   computeJobQuantities,
@@ -15,6 +16,7 @@ import { requirePermissions } from "../lib/supabase.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("recalculate");
 
 const payloadValidator = z.object({
   type: z.enum(["jobMakeMethodRequirements", "jobRequirements"]),
@@ -31,13 +33,7 @@ serve(async (req: Request) => {
   try {
     const { type, id, companyId, userId } = payloadValidator.parse(payload);
 
-    console.log({
-      function: "recalculate",
-      type,
-      id,
-      companyId,
-      userId,
-    });
+    logger.info({ type, id, companyId, userId });
 
     const client = await requirePermissions(req, companyId, userId, { update: "production" });
 
@@ -83,7 +79,7 @@ serve(async (req: Request) => {
           }
 
           if (jobMaterial.data.methodType !== "Make to Order") {
-            console.log(
+            logger.info(
               `Job material ${jobMakeMethod.data.parentMaterialId} is not a 'Make' type. Skipping recalculation.`
             );
             return jsonResponse({ success: true });
@@ -242,10 +238,9 @@ const updateJobQuantities = async (
   const allCycleNodeIds = new Set([...flattenCycles, ...cycleNodeIds]);
   if (allCycleNodeIds.size > 0) {
     // Corrupt tree data — the nodes were skipped rather than looped on.
-    console.error(
-      "recalculate: cyclic job method tree; skipped node ids:",
-      [...allCycleNodeIds]
-    );
+    logger.error("recalculate: cyclic job method tree; skipped nodes", {
+      skippedNodeIds: [...allCycleNodeIds],
+    });
   }
 
   // jobMaterial scrap/estimated — one VALUES-join update for the whole tree

--- a/packages/database/supabase/functions/sync/index.ts
+++ b/packages/database/supabase/functions/sync/index.ts
@@ -2,13 +2,15 @@ import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { Transaction } from "npm:kysely";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { getReadableIdWithRevision } from "../lib/utils.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("sync");
 
 const onShapeDataValidator = z.object({
   index: z.string(),
@@ -175,14 +177,7 @@ serve(async (req: Request) => {
     case "onshape": {
       const { makeMethodId, data } = payload;
 
-      console.log({
-        function: "sync",
-        type,
-        makeMethodId,
-        data,
-        companyId,
-        userId,
-      });
+      logger.info({ type, makeMethodId, data, companyId, userId });
 
       const client = await requirePermissions(req, companyId, userId, { update: "resources" });
 
@@ -225,8 +220,7 @@ serve(async (req: Request) => {
           const maxVersion = Number(allVersions.data?.version ?? 0);
           const newVersion = maxVersion + 1;
 
-          console.log({
-            function: "sync",
+          logger.info({
             action: "creating_top_level_draft",
             itemId: topLevelMakeMethod.data.itemId,
             maxVersion,
@@ -271,8 +265,7 @@ serve(async (req: Request) => {
           .in("id", Array.from(existingItemIds)),
       ]);
 
-      console.log({
-        function: "sync",
+      logger.info({
         action: "fetched_active_make_methods",
         count: existingMakeMethods.data?.length ?? 0,
         data: existingMakeMethods.data,
@@ -546,8 +539,7 @@ serve(async (req: Request) => {
               existingMakeMethodsByItemId.get(itemId) ||
               newlyCreatedMakeMethodsByItemId.get(itemId);
 
-            console.log({
-              function: "sync",
+            logger.info({
               action: "processing_item",
               itemId,
               partId,
@@ -572,8 +564,7 @@ serve(async (req: Request) => {
                     .orderBy("version", "desc")
                     .executeTakeFirst();
 
-                  console.log({
-                    function: "sync",
+                  logger.info({
                     action: "check_existing_draft",
                     itemId,
                     companyId,
@@ -604,8 +595,7 @@ serve(async (req: Request) => {
                     const maxVersion = Number(maxVersionRow?.version ?? 0);
                     const newVersion = maxVersion + 1;
 
-                    console.log({
-                      function: "sync",
+                    logger.info({
                       action: "creating_child_draft",
                       itemId,
                       companyId,

--- a/packages/database/supabase/functions/textract/index.ts
+++ b/packages/database/supabase/functions/textract/index.ts
@@ -9,9 +9,12 @@ import {
   TextractClient,
 } from "https://deno.land/x/aws_sdk@v3.32.0-1/client-textract/mod.ts";
 
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { getSupabaseServiceRole } from "../lib/supabase.ts";
+
+const logger = getFunctionLogger("textract");
 
 const AWS_REGION = Deno.env.get("AWS_REGION");
 const AWS_ACCESS_KEY_ID = Deno.env.get("AWS_ACCESS_KEY_ID");
@@ -56,10 +59,7 @@ serve(async (req: Request) => {
   try {
     const { path } = payloadValidator.parse(payload);
 
-    console.log({
-      function: "textract",
-      path,
-    });
+    logger.info({ path });
 
     const supabase = await getSupabaseServiceRole(
       req.headers.get("Authorization")
@@ -74,7 +74,7 @@ serve(async (req: Request) => {
           Key: s3Key,
         })
       );
-      console.log("File already exists in S3, skipping upload");
+      logger.info("File already exists in S3, skipping upload");
     } catch (error) {
       if (error.name === "NotFound") {
         // File doesn't exist, proceed with download and upload
@@ -93,7 +93,7 @@ serve(async (req: Request) => {
             Body: data,
           })
         );
-        console.log("File uploaded to S3");
+        logger.info("File uploaded to S3");
       } else {
         // Unexpected error
         throw error;

--- a/packages/database/supabase/functions/thumbnail/index.ts
+++ b/packages/database/supabase/functions/thumbnail/index.ts
@@ -1,8 +1,9 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import puppeteer from "npm:puppeteer-core@16.2.0";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 import { Buffer } from "node:buffer";
 import { corsHeaders } from "../lib/headers.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse } from "../lib/response.ts";
 
 import {
@@ -11,6 +12,8 @@ import {
   MagickFormat,
   initializeImageMagick,
 } from "npm:@imagemagick/magick-wasm@0.0.30";
+
+const logger = getFunctionLogger("thumbnail");
 
 const wasmBytes = await Deno.readFile(
   new URL(
@@ -39,10 +42,7 @@ serve(async (req: Request) => {
     const payload = await req.json();
     const { url } = payloadSchema.parse(payload);
 
-    console.log({
-      function: "thumbnail",
-      url,
-    });
+    logger.info({ url });
 
     browser = await puppeteer.connect({
       browserWSEndpoint,
@@ -50,18 +50,18 @@ serve(async (req: Request) => {
       // valid cert so this is a no-op there.
       ignoreHTTPSErrors: true,
     });
-    console.log("browser connected");
+    logger.debug("browser connected");
     const page = await browser.newPage();
-    console.log("page created");
+    logger.debug("page created");
     await page.setViewport({ width: 1000, height: 1000 });
-    console.log("viewport set");
+    logger.debug("viewport set");
     await page.goto(url);
-    console.log(`navigated to ${url}`);
+    logger.debug(`navigated to ${url}`);
     // Wait for the canvas with id=viewer to be visible, but no longer than 5 seconds
     await page.waitForSelector("#model-viewer-canvas", {
       timeout: 10000,
     });
-    console.log("model-viewer-canvas visible");
+    logger.debug("model-viewer-canvas visible");
     // Capture just the center portion of the viewport to avoid the ring
     const screenshot = await page.screenshot({
       encoding: "binary",
@@ -95,7 +95,7 @@ serve(async (req: Request) => {
   } finally {
     if (browser) {
       await browser.close();
-      console.log("browser closed");
+      logger.debug("browser closed");
     }
   }
 });

--- a/packages/database/supabase/functions/transcription/index.ts
+++ b/packages/database/supabase/functions/transcription/index.ts
@@ -1,12 +1,15 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 import { experimental_transcribe as transcribe } from "npm:ai@5.0.87";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 import { openai } from "../lib/ai/openai.ts";
 import { corsHeaders } from "../lib/headers.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { getSupabase } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
+
+const logger = getFunctionLogger("transcription");
 
 const transcriptionRequestSchema = z.object({
   audio: z.string().describe("Base64 encoded audio data"),
@@ -17,9 +20,7 @@ serve(async (req: Request) => {
   const preflight = corsPreflight(req);
   if (preflight) return preflight;
 
-  console.log({
-    function: "transcription",
-  });
+  logger.info("invoked");
 
   let client: SupabaseClient<Database> | null = null;
   let userId: string | null = null;
@@ -67,11 +68,7 @@ serve(async (req: Request) => {
 
     const { audio, mimeType } = validationResult.data;
 
-    console.log({
-      function: "transcription",
-      mimeType,
-      audioLength: audio.length,
-    });
+    logger.info({ mimeType, audioLength: audio.length });
 
     // Convert base64 to Uint8Array
     const audioBuffer = Uint8Array.from(atob(audio), (c) => c.charCodeAt(0));
@@ -87,8 +84,7 @@ serve(async (req: Request) => {
       audio: audioBuffer,
     });
 
-    console.log({
-      function: "Audio transcription completed",
+    logger.info("Audio transcription completed", {
       userId,
       companyId,
       transcriptLength: result.text.length,
@@ -100,7 +96,9 @@ serve(async (req: Request) => {
       language: result.language,
     });
   } catch (error) {
-    console.error("Transcription failed:", error);
+    logger.error("Transcription failed", {
+      error: String((error as Error)?.stack ?? error),
+    });
 
     return errorResponse(error, 500);
   }

--- a/packages/database/supabase/functions/trigger-rework/index.ts
+++ b/packages/database/supabase/functions/trigger-rework/index.ts
@@ -1,14 +1,16 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import type { Transaction } from "kysely";
 import { nanoid } from "https://deno.land/x/nanoid@v3.0.0/nanoid.ts";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { getConnectionPool, getDatabaseClient } from "../lib/database.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import type { DB } from "../lib/types.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("trigger-rework");
 
 interface TriggerReworkRequest {
   jobId: string;
@@ -110,7 +112,7 @@ async function triggerRework(
     triggeredAtJobOperationId
   );
 
-  console.info(
+  logger.info(
     `📋 Rework path: ${operationPath.length} operations to clone`
   );
 
@@ -263,7 +265,7 @@ async function triggerRework(
     sourceToCloneMap.set(sourceOp.id, clonedOps[i].id);
   });
 
-  console.info(`🔧 Cloned ${clonedOperationIds.length} operations`);
+  logger.info(`🔧 Cloned ${clonedOperationIds.length} operations`);
 
   // 6. Clone steps, tools, and parameters (batch fetch + batch insert)
   const [allSteps, allTools, allParams] = await Promise.all([
@@ -380,7 +382,7 @@ async function triggerRework(
       .execute();
   }
 
-  console.info(`🔗 DAG wired with ${downstreamDeps.length} downstream deps rewired`);
+  logger.info(`🔗 DAG wired with ${downstreamDeps.length} downstream deps rewired`);
 
   // 8. Record a productionQuantity entry for the rework
   await trx
@@ -458,7 +460,7 @@ serve(async (req) => {
       return errorResponse("Job not found in this company", 404);
     }
 
-    console.info(
+    logger.info(
       `🔰 Starting rework for job ${body.jobId}: go back to ${body.targetJobOperationId} from ${body.triggeredAtJobOperationId}`
     );
 
@@ -483,12 +485,14 @@ serve(async (req) => {
         }),
       });
     } catch (err) {
-      console.error("Failed to trigger reschedule after rework:", err);
+      logger.error("Failed to trigger reschedule after rework", {
+        error: String((err as Error)?.stack ?? err),
+      });
     }
 
     return jsonResponse({ success: true, ...result });
   } catch (error) {
-    console.error(
+    logger.error(
       `❌ Rework failed: ${
         error instanceof Error ? error.message : String(error)
       }`

--- a/packages/database/supabase/functions/trigger/index.ts
+++ b/packages/database/supabase/functions/trigger/index.ts
@@ -1,8 +1,11 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
-import { z } from "npm:zod@^3.24.1";
+import { z } from "npm:zod@^4.5.4";
 
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { sendInngestEvent } from "../lib/inngest.ts";
+
+const logger = getFunctionLogger("trigger");
 
 const recipientValidator = z.discriminatedUnion("type", [
   z.object({
@@ -44,11 +47,7 @@ serve(async (req: Request) => {
     const validatedPayload = payloadValidator.parse(payload);
     const { type, ...data } = validatedPayload;
 
-    console.log({
-      function: "trigger",
-      type,
-      ...data,
-    });
+    logger.info({ type, ...data });
 
     switch (type) {
       case "notify": {

--- a/packages/database/supabase/functions/update-purchased-prices/index.ts
+++ b/packages/database/supabase/functions/update-purchased-prices/index.ts
@@ -1,15 +1,17 @@
 import { serve } from "https://deno.land/std@0.175.0/http/server.ts";
 
 import { sql } from "kysely";
-import z from "npm:zod@^3.24.1";
+import z from "npm:zod@^4.5.4";
 import { DB, getConnectionPool, getDatabaseClient } from "../lib/database.ts";
 import { datetime, getCompanyTimeZone } from "../lib/datetime.ts";
+import { getFunctionLogger } from "../lib/logging.ts";
 import { corsPreflight, errorResponse, jsonResponse } from "../lib/response.ts";
 import { requirePermissions } from "../lib/supabase.ts";
 import { Database } from "../lib/types.ts";
 
 const pool = getConnectionPool(1);
 const db = getDatabaseClient<DB>(pool);
+const logger = getFunctionLogger("update-purchased-prices");
 
 const payloadValidator = z.discriminatedUnion("source", [
   z.object({
@@ -63,13 +65,7 @@ serve(async (req: Request) => {
   const shouldUpdatePrices = parsedPayload.updatePrices ?? true;
   const shouldUpdateLeadTimes = parsedPayload.updateLeadTimes ?? false;
 
-  console.log({
-    function: "update-purchased-prices",
-    source,
-    companyId,
-    shouldUpdatePrices,
-    shouldUpdateLeadTimes,
-  });
+  logger.info({ source, companyId, shouldUpdatePrices, shouldUpdateLeadTimes });
 
   try {
     const client = await requirePermissions(req, companyId, userId, { update: "purchasing" });
@@ -81,12 +77,7 @@ serve(async (req: Request) => {
       case "purchaseOrder": {
         const { purchaseOrderId } = parsedPayload;
 
-        console.log({
-          function: "update-purchased-prices",
-          source,
-          purchaseOrderId,
-          companyId,
-        });
+        logger.info({ source, purchaseOrderId, companyId });
 
         const [purchaseOrder, purchaseOrderLines] = await Promise.all([
           client
@@ -165,12 +156,7 @@ serve(async (req: Request) => {
       case "purchaseInvoice": {
         const { invoiceId } = parsedPayload;
 
-        console.log({
-          function: "update-purchased-prices",
-          source,
-          invoiceId,
-          companyId,
-        });
+        logger.info({ source, invoiceId, companyId });
 
         const [purchaseInvoice, purchaseInvoiceLines] = await Promise.all([
           client

--- a/packages/ee/src/accounting/core/models.ts
+++ b/packages/ee/src/accounting/core/models.ts
@@ -115,7 +115,7 @@ export const AccountingSyncSchema = z.object({
   syncType: z.enum(["webhook", "scheduled", "trigger"]),
   syncDirection: SyncDirectionSchema,
   entities: z.array(z.custom<AccountingEntity>()),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.string(), z.any()).optional()
 });
 
 export const ENTITY_DEFINITIONS: Record<
@@ -777,7 +777,7 @@ export const SyncOperationSchema = z.object({
   errorCode: z.string().nullable(),
   errorMessage: z.string().nullable(),
   externalId: z.string().nullable(),
-  metadata: z.record(z.any()).nullable(),
+  metadata: z.record(z.string(), z.any()).nullable(),
   createdBy: z.string(),
   createdAt: z.string(),
   updatedBy: z.string().nullable(),
@@ -879,7 +879,7 @@ export const ContactSchema = z.object({
       postalCode: z.string().nullish()
     })
   ),
-  raw: z.record(z.any())
+  raw: z.record(z.string(), z.any())
 });
 
 export const EmployeeSchema = z.object({
@@ -904,7 +904,7 @@ export const EmployeeSchema = z.object({
     })
     .optional(),
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // ============================================================================
@@ -949,7 +949,7 @@ export const SalesOrderSchema = z.object({
   customerReference: withNullable(z.string()),
   lines: z.array(SalesOrderLineSchema),
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // Sales Invoice schemas
@@ -1000,7 +1000,7 @@ export const SalesInvoiceSchema = z.object({
   balance: z.number(),
   lines: z.array(SalesInvoiceLineSchema),
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // Bill (Purchase Invoice) schemas
@@ -1050,7 +1050,7 @@ export const BillSchema = z.object({
   supplierReference: withNullable(z.string()),
   lines: z.array(BillLineSchema),
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // Purchase Order schemas
@@ -1101,7 +1101,7 @@ export const PurchaseOrderSchema = z.object({
   supplierReference: withNullable(z.string()),
   lines: z.array(PurchaseOrderLineSchema),
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // ============================================================================
@@ -1132,7 +1132,7 @@ export const ItemSchema = z.object({
   isSold: z.boolean(),
   isTrackedAsInventory: z.boolean(),
   updatedAt: z.string(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // ============================================================================
@@ -1152,7 +1152,7 @@ export const InventoryAdjustmentSchema = z.object({
   inventoryAccount: z.string(), // resolved GL account from accountDefault (rawMaterialsAccount for Buy items, finishedGoodsAccount for Make / Buy and Make)
   adjustmentVarianceAccount: z.string(), // GL account code from accountDefault
   updatedAt: z.string().datetime(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });
 
 // ============================================================================
@@ -1202,5 +1202,5 @@ export const JournalEntrySchema = z.object({
   reversal: z.boolean(),
   lines: z.array(JournalEntryLineSchema),
   updatedAt: z.string(),
-  raw: z.record(z.any()).optional()
+  raw: z.record(z.string(), z.any()).optional()
 });

--- a/packages/ee/src/accounting/models.ts
+++ b/packages/ee/src/accounting/models.ts
@@ -59,7 +59,7 @@ export const AttachmentSchema = BaseEntitySchema.extend({
   isPublic: z.boolean().default(false),
   uploadedBy: z.string().optional(),
   checksum: z.string().optional(), // For file integrity
-  metadata: z.record(z.any()).optional() // Provider-specific metadata
+  metadata: z.record(z.string(), z.any()).optional() // Provider-specific metadata
 });
 
 // Account schema for chart of accounts
@@ -117,7 +117,7 @@ export const CustomerSchema = BaseEntitySchema.extend({
   balance: z.number().optional(),
   notes: z.string().optional(),
   tags: z.array(z.string()).optional(),
-  customFields: z.record(z.any()).optional(),
+  customFields: z.record(z.string(), z.any()).optional(),
   attachments: z.array(AttachmentSchema).optional()
 });
 
@@ -140,7 +140,7 @@ export const VendorSchema = BaseEntitySchema.extend({
   balance: z.number().optional(),
   notes: z.string().optional(),
   tags: z.array(z.string()).optional(),
-  customFields: z.record(z.any()).optional(),
+  customFields: z.record(z.string(), z.any()).optional(),
   attachments: z.array(AttachmentSchema).optional()
 });
 
@@ -162,7 +162,7 @@ export const ItemSchema = BaseEntitySchema.extend({
   isSold: z.boolean().default(true),
   isPurchased: z.boolean().default(false),
   taxCode: z.string().optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Enhanced invoice schema with attachments
@@ -212,7 +212,7 @@ export const InvoiceSchema = BaseEntitySchema.extend({
     })
   ),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Bill schema (for vendor bills)
@@ -259,7 +259,7 @@ export const BillSchema = BaseEntitySchema.extend({
     })
   ),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Enhanced transaction schema with attachments and reconciliation
@@ -309,7 +309,7 @@ export const TransactionSchema = BaseEntitySchema.extend({
     )
     .optional(),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Expense schema
@@ -350,7 +350,7 @@ export const ExpenseSchema = BaseEntitySchema.extend({
     )
     .optional(),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Journal Entry schema
@@ -385,7 +385,7 @@ export const JournalEntrySchema = BaseEntitySchema.extend({
   totalCredit: z.number(),
   notes: z.string().optional(),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Payment schema
@@ -416,7 +416,7 @@ export const PaymentSchema = BaseEntitySchema.extend({
   fees: z.number().optional(),
   notes: z.string().optional(),
   attachments: z.array(AttachmentSchema).optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Company info schema
@@ -435,7 +435,7 @@ export const CompanyInfoSchema = BaseEntitySchema.extend({
   logo: z.string().url().optional(),
   industry: z.string().optional(),
   employees: z.number().optional(),
-  customFields: z.record(z.any()).optional()
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Enhanced provider-specific metadata
@@ -445,8 +445,8 @@ export const ProviderMetadataSchema = z.object({
   lastSyncAt: z.string().datetime().optional(),
   syncHash: z.string().optional(),
   version: z.string().optional(),
-  rawData: z.record(z.any()).optional(), // Store original provider data
-  customFields: z.record(z.any()).optional()
+  rawData: z.record(z.string(), z.any()).optional(), // Store original provider data
+  customFields: z.record(z.string(), z.any()).optional()
 });
 
 // Enhanced API Request/Response schemas

--- a/packages/ee/src/accounting/providers/rillet/models.ts
+++ b/packages/ee/src/accounting/providers/rillet/models.ts
@@ -86,7 +86,7 @@ export namespace Rillet {
     id: z.string(),
     name: z.string(),
     values: z.array(FieldValueSchema).default([]),
-    settings: z.record(z.unknown()).nullish(),
+    settings: z.record(z.string(), z.unknown()).nullish(),
     updated_at: z.string().nullish()
   });
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -22,7 +22,8 @@
     "ts-toolbelt": "9.6.0",
     "tsconfig": "*",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod-form-data": "catalog:"
   },
   "dependencies": {
     "@carbon/glossary": "workspace:*",

--- a/packages/form/src/ValidatedForm.tsx
+++ b/packages/form/src/ValidatedForm.tsx
@@ -63,7 +63,7 @@ export type FormProps<DataType, Subaction extends string | undefined> = {
   /**
    * A `Validator` object that describes how to validate the form.
    */
-  validator: z.Schema<DataType> | z.ZodEffects<any> | z.ZodObject<any>;
+  validator: z.Schema<DataType> | z.ZodObject<any> | z.ZodPipe<any, any>;
   /**
    * A submit callback that gets called when the form is submitted
    * after all validations have been run.

--- a/packages/form/src/internal/isFieldOptional.test.ts
+++ b/packages/form/src/internal/isFieldOptional.test.ts
@@ -1,43 +1,91 @@
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
+import { zfd } from "zod-form-data";
 import { isFieldOptional } from "./isFieldOptional";
 
+// Pins the schema walk that drives each field's required/optional marker.
+// The zfd cases matter most: a zfd wrapper is pipe(in: transform, out: schema),
+// and walking into the bare transform used to report every optional zfd field
+// as required.
+
 describe("isFieldOptional", () => {
-  const schema = z.object({
-    requiredName: z.string(),
-    optionalName: z.string().optional(),
-    defaultedName: z.string().default(""),
-    nested: z.object({
-      requiredChild: z.string(),
-      optionalChild: z.string().optional()
-    }),
-    optionalNested: z
-      .object({
-        requiredChild: z.string()
-      })
-      .optional(),
-    items: z.array(
+  it("reports plain optional / required / default fields", () => {
+    const schema = z.object({
+      required: z.string().min(1),
+      optional: z.string().optional(),
+      defaulted: z.string().default("draft"),
+      prefaulted: z.string().prefault("draft")
+    });
+    expect(isFieldOptional(schema, "required")).toBe(false);
+    expect(isFieldOptional(schema, "optional")).toBe(true);
+    expect(isFieldOptional(schema, "defaulted")).toBe(true);
+    expect(isFieldOptional(schema, "prefaulted")).toBe(true);
+  });
+
+  it("nullable is not optional", () => {
+    const schema = z.object({ n: z.string().nullable() });
+    expect(isFieldOptional(schema, "n")).toBe(false);
+  });
+
+  it("sees through zfd preprocess pipes to the real schema", () => {
+    const schema = z.object({
+      id: zfd.text(z.string().optional()),
+      name: zfd.text(z.string().min(1)),
+      qty: zfd.numeric(z.number().min(0)),
+      active: zfd.checkbox()
+    });
+    expect(isFieldOptional(schema, "id")).toBe(true);
+    expect(isFieldOptional(schema, "name")).toBe(false);
+    expect(isFieldOptional(schema, "qty")).toBe(false);
+    expect(isFieldOptional(schema, "active")).toBe(true);
+  });
+
+  it("sees through z.preprocess the same way", () => {
+    const schema = z.object({
+      reason: z.preprocess(
+        (val) => (val === "" ? undefined : val),
+        z.enum(["a", "b"]).optional()
+      )
+    });
+    expect(isFieldOptional(schema, "reason")).toBe(true);
+  });
+
+  it("resolves nested object and array-element paths", () => {
+    const schema = z.object({
+      user: z.object({ email: z.string().optional(), name: z.string() }),
+      items: z.array(z.object({ label: z.string().optional() }))
+    });
+    expect(isFieldOptional(schema, "user.email")).toBe(true);
+    expect(isFieldOptional(schema, "user.name")).toBe(false);
+    expect(isFieldOptional(schema, "items[0].label")).toBe(true);
+  });
+
+  it("an optional parent makes every child optional", () => {
+    const schema = z.object({
+      address: z.object({ city: z.string() }).optional()
+    });
+    expect(isFieldOptional(schema, "address.city")).toBe(true);
+  });
+
+  it("resolves record values and returns undefined for unknown fields", () => {
+    const schema = z.object({
+      amounts: z.record(z.string(), z.number().optional())
+    });
+    expect(isFieldOptional(schema, "amounts.anything")).toBe(true);
+    expect(isFieldOptional(schema, "nope")).toBeUndefined();
+    expect(isFieldOptional(undefined, "x")).toBeUndefined();
+  });
+
+  it("resolves lazy schemas without looping", () => {
+    type Node = { name?: string; child?: Node };
+    const node: z.ZodType<Node> = z.lazy(() =>
       z.object({
-        code: z.string().optional()
+        name: z.string().optional(),
+        child: node.optional()
       })
-    )
-  });
-
-  it("returns false for required fields", () => {
-    expect(isFieldOptional(schema, "requiredName")).toBe(false);
-    expect(isFieldOptional(schema, "nested.requiredChild")).toBe(false);
-  });
-
-  it("returns true for optional fields", () => {
-    expect(isFieldOptional(schema, "optionalName")).toBe(true);
-    expect(isFieldOptional(schema, "defaultedName")).toBe(true);
-    expect(isFieldOptional(schema, "nested.optionalChild")).toBe(true);
-    expect(isFieldOptional(schema, "optionalNested.requiredChild")).toBe(true);
-    expect(isFieldOptional(schema, "items[0].code")).toBe(true);
-  });
-
-  it("returns undefined when field path is not in schema", () => {
-    expect(isFieldOptional(schema, "missingField")).toBeUndefined();
-    expect(isFieldOptional(schema, "optionalNested.missing")).toBeUndefined();
+    );
+    const schema = z.object({ root: node });
+    expect(isFieldOptional(schema, "root.name")).toBe(true);
+    expect(isFieldOptional(schema, "root.child.name")).toBe(true);
   });
 });

--- a/packages/form/src/internal/isFieldOptional.test.ts
+++ b/packages/form/src/internal/isFieldOptional.test.ts
@@ -88,4 +88,20 @@ describe("isFieldOptional", () => {
     expect(isFieldOptional(schema, "root.name")).toBe(true);
     expect(isFieldOptional(schema, "root.child.name")).toBe(true);
   });
+  it("treats .optional().nonoptional() as required", () => {
+    // zod rejects undefined here, so the field IS required; unwrapping used to
+    // continue into the inner ZodOptional and flip it back to optional.
+    const inner = z.string().optional().nonoptional();
+    expect(inner.safeParse(undefined).success).toBe(false);
+    const schema = z.object({ name: inner });
+    expect(isFieldOptional(schema, "name")).toBe(false);
+  });
+
+  it("treats .nonoptional().optional() as optional", () => {
+    // The mirror case: the OUTER wrapper accepts undefined, so it wins.
+    const inner = z.string().nonoptional().optional();
+    expect(inner.safeParse(undefined).success).toBe(true);
+    const schema = z.object({ name: inner });
+    expect(isFieldOptional(schema, "name")).toBe(true);
+  });
 });

--- a/packages/form/src/internal/isFieldOptional.ts
+++ b/packages/form/src/internal/isFieldOptional.ts
@@ -1,119 +1,84 @@
-import { type ZodSchema, z } from "zod";
+import { z } from "zod";
 import { stringToPathArray } from "../utils";
 
+// v4's wrapper generics default to the core `$ZodType` interface; every schema
+// an app hands the form library is built with the classic API, so re-viewing an
+// unwrapped child as a classic `ZodType` is sound.
+const classic = (schema: z.core.$ZodType): z.ZodType => schema as z.ZodType;
+
 type UnwrapResult = {
-  schema: ZodSchema;
+  schema: z.ZodType;
   isOptional: boolean;
   hasDefault: boolean;
 };
 
 function unwrapSchema(
-  schema: ZodSchema,
+  schema: z.ZodType,
   io: "input" | "output" = "output"
 ): UnwrapResult {
   let current = schema;
   let isOptional = false;
   let hasDefault = false;
-  const seen = new Set<ZodSchema>();
+  const seen = new Set<z.ZodType>();
 
-  while (true) {
-    if (seen.has(current)) return { schema: current, isOptional, hasDefault };
+  while (!seen.has(current)) {
     seen.add(current);
 
-    const def: any = (current as any)._zod?.def ?? (current as any)._def;
-    const type: string | undefined = def?.type ?? def?.typeName;
-
-    switch (type) {
-      // optionality wrappers
-      case "optional":
-      case "ZodOptional":
-        isOptional = true;
-        current = def.innerType;
-        continue;
-
-      case "default":
-      case "ZodDefault":
-        isOptional = true;
-        hasDefault = true;
-        current = def.innerType;
-        continue;
-
-      case "prefault":
-        isOptional = true;
-        hasDefault = true;
-        current = def.innerType;
-        continue;
-
-      case "catch":
-      case "ZodCatch":
-        isOptional = true;
-        current = def.innerType;
-        continue;
-
-      // nullable — semantically distinct from optional
-      case "nullable":
-      case "ZodNullable":
-        current = def.innerType;
-        continue;
-
-      // transparent wrappers
-      case "readonly":
-      case "ZodReadonly":
-        current = def.innerType;
-        continue;
-
-      case "nonoptional":
-        isOptional = false;
-        current = def.innerType;
-        continue;
-
-      case "promise":
-      case "ZodPromise":
-        current = def.innerType;
-        continue;
-
-      case "ZodBranded":
-        current = def.type;
-        continue;
-
-      // lazy — resolve the thunk
-      case "lazy":
-      case "ZodLazy": {
-        const inner = (current as any)._zod?.innerType ?? def.getter?.();
-        if (!inner) return { schema: current, isOptional, hasDefault };
-        current = inner;
-        continue;
-      }
-
-      // pipe — direction matters
-      case "pipe":
-      case "ZodPipeline":
-        current = io === "input" ? def.in : def.out;
-        continue;
-
-      // effects (v3 refine/transform/preprocess)
-      case "ZodEffects":
-        current = def.schema;
-        continue;
-
-      default:
-        return { schema: current, isOptional, hasDefault };
+    if (current instanceof z.ZodOptional) {
+      isOptional = true;
+      current = classic(current.unwrap());
+    } else if (
+      current instanceof z.ZodDefault ||
+      current instanceof z.ZodPrefault
+    ) {
+      isOptional = true;
+      hasDefault = true;
+      current = classic(current.unwrap());
+    } else if (current instanceof z.ZodCatch) {
+      isOptional = true;
+      current = classic(current.unwrap());
+    } else if (current instanceof z.ZodNonOptional) {
+      isOptional = false;
+      current = classic(current.unwrap());
+    } else if (
+      // nullable is semantically distinct from optional; the rest are transparent
+      current instanceof z.ZodNullable ||
+      current instanceof z.ZodReadonly ||
+      current instanceof z.ZodPromise ||
+      current instanceof z.ZodLazy
+    ) {
+      current = classic(current.unwrap());
+    } else if (current instanceof z.ZodPipe) {
+      // Direction matters — except that a preprocess pipe (zfd.text, zfd.numeric,
+      // z.preprocess) carries a bare transform on its input side, which accepts
+      // anything: whether the FIELD is required is decided by what the output
+      // side demands. Walking into the transform reported every optional zfd
+      // field as required.
+      const side =
+        io === "input" && !(current.in instanceof z.ZodTransform)
+          ? current.in
+          : current.out;
+      current = classic(side);
+    } else {
+      break;
     }
   }
+
+  return { schema: current, isOptional, hasDefault };
 }
 
 function getChildSchema(
-  schema: ZodSchema,
+  schema: z.ZodType,
   segment: string | number
-): ZodSchema | null {
+): z.ZodType | null {
   if (schema instanceof z.ZodObject) {
-    const shape = schema.shape;
     if (typeof segment !== "string") return null;
-    return shape[segment] ?? null;
+    const child = (schema.shape as Record<string, z.core.$ZodType>)[segment];
+    return child ? classic(child) : null;
   }
 
   if (schema instanceof z.ZodArray) {
-    return schema.element;
+    return classic(schema.element);
   }
 
   if (schema instanceof z.ZodTuple) {
@@ -124,26 +89,28 @@ function getChildSchema(
           ? null
           : Number(segment);
     if (index === null) return null;
-    return schema.items[index] ?? null;
+    const item = schema.def.items[index];
+    return item ? classic(item) : null;
   }
 
   if (schema instanceof z.ZodRecord) {
-    return schema._def.valueType;
+    return classic(schema.valueType);
   }
 
   return null;
 }
 
 export function isFieldOptional(
-  schema: ZodSchema | undefined,
+  schema: z.ZodType | undefined,
   fieldName: string
 ): boolean | undefined {
-  const dir = "input"; // Can be a param
+  // Fields receive caller input, so requiredness is judged on the input side.
+  const dir = "input";
 
   if (!schema || !fieldName) return undefined;
 
   const path = stringToPathArray(fieldName);
-  let current: ZodSchema | null = schema;
+  let current: z.ZodType | null = schema;
   let optionalFromParent = false;
 
   for (const segment of path) {

--- a/packages/form/src/internal/isFieldOptional.ts
+++ b/packages/form/src/internal/isFieldOptional.ts
@@ -19,26 +19,39 @@ function unwrapSchema(
   let current = schema;
   let isOptional = false;
   let hasDefault = false;
+  // The OUTERMOST optionality wrapper decides, so an inner one can't overrule
+  // it. `z.string().optional().nonoptional()` rejects undefined — the field is
+  // required — but unwrapping continues into the `ZodOptional` underneath, and
+  // letting that write `isOptional` again reported the field as optional. The
+  // mirror case (`.nonoptional().optional()`) accepts undefined and must stay
+  // optional. Only the first decision is recorded either way.
+  let decided = false;
+  const decide = (optional: boolean) => {
+    if (!decided) {
+      isOptional = optional;
+      decided = true;
+    }
+  };
   const seen = new Set<z.ZodType>();
 
   while (!seen.has(current)) {
     seen.add(current);
 
     if (current instanceof z.ZodOptional) {
-      isOptional = true;
+      decide(true);
       current = classic(current.unwrap());
     } else if (
       current instanceof z.ZodDefault ||
       current instanceof z.ZodPrefault
     ) {
-      isOptional = true;
+      decide(true);
       hasDefault = true;
       current = classic(current.unwrap());
     } else if (current instanceof z.ZodCatch) {
-      isOptional = true;
+      decide(true);
       current = classic(current.unwrap());
     } else if (current instanceof z.ZodNonOptional) {
-      isOptional = false;
+      decide(false);
       current = classic(current.unwrap());
     } else if (
       // nullable is semantically distinct from optional; the rest are transparent

--- a/packages/form/src/zod.test.ts
+++ b/packages/form/src/zod.test.ts
@@ -1,0 +1,153 @@
+import { assert, describe, expect, it } from "vitest";
+import { z } from "zod";
+import { zfd } from "zod-form-data";
+import { validator } from "./zod";
+
+// Runtime coverage for the zod adapter — the paths typecheck can't prove:
+// `.default()` output semantics, ZodError -> FieldErrors mapping, dotted and
+// array-indexed paths, the union-issue shape (`issue.errors`) that
+// getIssuesForError recurses into, and the FormData -> object preprocessing a
+// route action's `validator(schema).validate(formData)` relies on.
+
+describe("validator (zod adapter)", () => {
+  it("parses a valid value and applies a default", async () => {
+    const schema = z.object({
+      name: z.string().min(1),
+      active: z.boolean().default(true)
+    });
+    const result = await validator(schema).validate({ name: "hi" });
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({ name: "hi", active: true });
+  });
+
+  it("maps an invalid field to a FieldErrors entry keyed by path", async () => {
+    const schema = z.object({
+      name: z.string().min(1, { message: "Name is required" })
+    });
+    const result = await validator(schema).validate({ name: "" });
+    expect(result.data).toBeUndefined();
+    expect(result.error?.fieldErrors?.name).toBe("Name is required");
+  });
+
+  it("surfaces a nested field error at a dotted path", async () => {
+    const schema = z.object({
+      user: z.object({ email: z.email({ message: "Bad email" }) })
+    });
+    const result = await validator(schema).validate({
+      user: { email: "nope" }
+    });
+    expect(result.error?.fieldErrors?.["user.email"]).toBe("Bad email");
+  });
+
+  it("keys an array element error with an index path", async () => {
+    const schema = z.object({
+      items: z.array(
+        z.object({ name: z.string().min(1, { message: "Required" }) })
+      )
+    });
+    const result = await validator(schema).validate({
+      items: [{ name: "ok" }, { name: "" }]
+    });
+    expect(result.error?.fieldErrors?.["items[1].name"]).toBe("Required");
+  });
+
+  it("recurses into a union issue's sub-errors without crashing", async () => {
+    const schema = z.object({
+      val: z.union([z.string().min(3), z.number()])
+    });
+    // "ab" fails both members -> an invalid_union issue carrying `errors`.
+    const result = await validator(schema).validate({ val: "ab" });
+    expect(result.data).toBeUndefined();
+    expect(Object.keys(result.error?.fieldErrors ?? {}).length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it("surfaces a discriminated-union branch error at its own path", async () => {
+    const schema = z.object({
+      op: z.discriminatedUnion("kind", [
+        z.object({ kind: z.literal("email"), address: z.email() }),
+        z.object({ kind: z.literal("phone"), number: z.string().min(7) })
+      ])
+    });
+    const result = await validator(schema).validate({
+      op: { kind: "email", address: "nope" }
+    });
+    expect(result.data).toBeUndefined();
+    expect(result.error?.fieldErrors?.["op.address"]).toBeDefined();
+  });
+
+  it("validateField returns the message for one field only", async () => {
+    const schema = z.object({
+      name: z.string().min(1, { message: "Name is required" }),
+      age: z.number()
+    });
+    const v = validator(schema);
+    assert(v.validateField);
+    const nameErr = await v.validateField({ name: "", age: 1 }, "name");
+    expect(nameErr.error).toBe("Name is required");
+  });
+
+  it("validateField resolves a nested dotted path", async () => {
+    const schema = z.object({
+      user: z.object({ email: z.email({ message: "Bad email" }) }),
+      name: z.string()
+    });
+    const v = validator(schema);
+    assert(v.validateField);
+    const err = await v.validateField(
+      { user: { email: "nope" }, name: "ok" },
+      "user.email"
+    );
+    expect(err.error).toBe("Bad email");
+    const clean = await v.validateField(
+      { user: { email: "nope" }, name: "ok" },
+      "name"
+    );
+    expect(clean.error).toBeUndefined();
+  });
+});
+
+describe("validator with FormData (the route-action path)", () => {
+  const schema = z.object({
+    id: zfd.text(z.string().optional()),
+    name: z.string().min(1, { message: "Name is required" }),
+    quantity: zfd.numeric(z.number().min(0)),
+    isActive: zfd.checkbox(),
+    tags: zfd.repeatableOfType(z.string()).optional()
+  });
+
+  it("coerces zfd fields from a real FormData submission", async () => {
+    const fd = new FormData();
+    fd.append("name", "Widget");
+    fd.append("quantity", "42");
+    fd.append("tags", "a");
+    fd.append("tags", "b");
+    // id omitted, isActive unchecked (absent)
+    const result = await validator(schema).validate(fd);
+    expect(result.error).toBeUndefined();
+    expect(result.data).toEqual({
+      name: "Widget",
+      quantity: 42,
+      isActive: false,
+      tags: ["a", "b"]
+    });
+  });
+
+  it("treats a checked checkbox's 'on' as true", async () => {
+    const fd = new FormData();
+    fd.append("name", "Widget");
+    fd.append("quantity", "1");
+    fd.append("isActive", "on");
+    const result = await validator(schema).validate(fd);
+    expect(result.data?.isActive).toBe(true);
+  });
+
+  it("maps an empty required text field to its error", async () => {
+    const fd = new FormData();
+    fd.append("name", "");
+    fd.append("quantity", "1");
+    const result = await validator(schema).validate(fd);
+    expect(result.error?.fieldErrors?.name).toBe("Name is required");
+  });
+});

--- a/packages/form/src/zod.ts
+++ b/packages/form/src/zod.ts
@@ -4,18 +4,22 @@ import { stringToPathArray } from "./utils";
 import { createValidator } from "./validation/createValidator";
 import type { FieldErrors, Validator } from "./validation/types";
 
-const getIssuesForError = (err: z.ZodError<any>): z.ZodIssue[] => {
-  return err.issues.flatMap((issue) => {
-    if ("unionErrors" in issue) {
-      return issue.unionErrors.flatMap((err) => getIssuesForError(err));
-    } else {
-      return [issue];
-    }
-  });
+// Flatten a ZodError's issues, recursing into union issues (`invalid_union`
+// carries `errors: $ZodIssue[][]`) so a nested field error surfaces at its own
+// path. A union issue with no sub-errors is kept as-is so a message survives.
+const getIssuesForError = (err: z.ZodError): z.core.$ZodIssue[] => {
+  const collect = (issues: readonly z.core.$ZodIssue[]): z.core.$ZodIssue[] =>
+    issues.flatMap((issue) =>
+      issue.code === "invalid_union" && issue.errors.length > 0
+        ? collect(issue.errors.flat())
+        : [issue]
+    );
+  return collect(err.issues);
 };
 
-function pathToString(array: (string | number)[]): string {
-  return array.reduce<string>(function (string: string, item: string | number) {
+function pathToString(array: PropertyKey[]): string {
+  return array.reduce<string>(function (string: string, itemRaw: PropertyKey) {
+    const item = String(itemRaw);
     const prefix = string === "" ? "" : ".";
     return string + (isNaN(Number(item)) ? prefix + item : "[" + item + "]");
   }, "");
@@ -24,10 +28,10 @@ function pathToString(array: (string | number)[]): string {
 /**
  * Create a validator using a `zod` schema.
  */
-export function validator<T, U extends z.ZodTypeDef>(
-  zodSchema: z.Schema<T, U, unknown>,
-  parseParams?: Partial<z.ParseParams>
-): Validator<T> {
+export function validator<Schema extends z.ZodType>(
+  zodSchema: Schema,
+  parseParams?: Parameters<Schema["safeParseAsync"]>[1]
+): Validator<z.output<Schema>> {
   return createValidator({
     validate: async (value) => {
       const result = await zodSchema.safeParseAsync(value, parseParams);

--- a/packages/jobs/src/inngest/functions/events/audit.ts
+++ b/packages/jobs/src/inngest/functions/events/audit.ts
@@ -33,13 +33,13 @@ const AuditRecordSchema = z.object({
     table: z.string(),
     operation: z.enum(["INSERT", "UPDATE", "DELETE", "TRUNCATE"]),
     recordId: z.string(),
-    new: z.record(z.any()).nullable(),
-    old: z.record(z.any()).nullable(),
+    new: z.record(z.string(), z.any()).nullable(),
+    old: z.record(z.string(), z.any()).nullable(),
     timestamp: z.string()
   }),
   companyId: z.string(),
   actorId: z.string().nullish(),
-  handlerConfig: z.record(z.any())
+  handlerConfig: z.record(z.string(), z.any())
 });
 
 const AuditPayloadSchema = z.object({

--- a/packages/jobs/src/inngest/functions/events/embedding.ts
+++ b/packages/jobs/src/inngest/functions/events/embedding.ts
@@ -14,8 +14,8 @@ const EmbeddingRecordSchema = z.object({
     table: z.string(),
     operation: z.enum(["INSERT", "UPDATE", "DELETE", "TRUNCATE"]),
     recordId: z.string(),
-    new: z.record(z.any()).nullable(),
-    old: z.record(z.any()).nullable(),
+    new: z.record(z.string(), z.any()).nullable(),
+    old: z.record(z.string(), z.any()).nullable(),
     timestamp: z.string()
   }),
   companyId: z.string()

--- a/packages/jobs/src/inngest/functions/events/search.ts
+++ b/packages/jobs/src/inngest/functions/events/search.ts
@@ -337,8 +337,8 @@ const SearchRecordSchema = z.object({
     table: z.string(),
     operation: z.enum(["INSERT", "UPDATE", "DELETE", "TRUNCATE"]),
     recordId: z.string(),
-    new: z.record(z.any()).nullable(),
-    old: z.record(z.any()).nullable(),
+    new: z.record(z.string(), z.any()).nullable(),
+    old: z.record(z.string(), z.any()).nullable(),
     timestamp: z.string()
   }),
   companyId: z.string()

--- a/packages/jobs/src/inngest/functions/events/webhook-body.ts
+++ b/packages/jobs/src/inngest/functions/events/webhook-body.ts
@@ -7,8 +7,8 @@ const eventSchema = z.object({
   table: z.string(),
   operation: z.enum(["INSERT", "UPDATE", "DELETE", "TRUNCATE"]),
   recordId: z.string().optional(),
-  new: z.record(z.any()).nullable().optional(),
-  old: z.record(z.any()).nullable().optional(),
+  new: z.record(z.string(), z.any()).nullable().optional(),
+  old: z.record(z.string(), z.any()).nullable().optional(),
   timestamp: z.string().optional()
 });
 
@@ -19,7 +19,7 @@ export const webhookPayloadSchema = z.object({
   data: eventSchema,
   config: z
     .object({
-      headers: z.record(z.string()).optional(),
+      headers: z.record(z.string(), z.string()).optional(),
       webhookId: z.string().optional()
     })
     .passthrough()

--- a/packages/jobs/src/inngest/functions/integrations/accounting-backfill.ts
+++ b/packages/jobs/src/inngest/functions/integrations/accounting-backfill.ts
@@ -98,7 +98,7 @@ const BackfillPayloadSchema = z.object({
       vendors: z.boolean().default(true),
       items: z.boolean().default(true)
     })
-    .default({})
+    .prefault({})
 });
 
 /**

--- a/packages/jobs/src/inngest/functions/workflows/moment.ts
+++ b/packages/jobs/src/inngest/functions/workflows/moment.ts
@@ -8,7 +8,7 @@ const momentPayloadSchema = z.object({
   momentId: z.string(),
   moment: z.string(),
   companyId: z.string(),
-  outputs: z.record(z.object({ id: z.string() }).passthrough())
+  outputs: z.record(z.string(), z.object({ id: z.string() }).passthrough())
 });
 
 /** Moment entry point of the workflow matcher. A moment already IS a catalog event

--- a/packages/workflows/src/definition/schema.ts
+++ b/packages/workflows/src/definition/schema.ts
@@ -69,7 +69,7 @@ const computeNode = z.object({
   type: z.literal("compute"),
   data: z.object({
     operation: z.string(),
-    inputs: z.record(valueOrRefSchema).default({})
+    inputs: z.record(z.string(), valueOrRefSchema).default({})
   })
 });
 
@@ -99,7 +99,7 @@ const actionNode = z.object({
   // No `batch` flag: whether the step repeats is read off the wiring. See `batch.ts`.
   data: z.object({
     action: z.string(),
-    inputs: z.record(valueOrRefSchema).default({})
+    inputs: z.record(z.string(), valueOrRefSchema).default({})
   })
 });
 

--- a/packages/workflows/src/run-trigger.ts
+++ b/packages/workflows/src/run-trigger.ts
@@ -7,14 +7,14 @@ export const runTriggerSchema = z.discriminatedUnion("kind", [
     table: z.string(),
     recordId: z.string(),
     operation: z.enum(["INSERT", "UPDATE", "DELETE"]),
-    record: z.record(z.unknown()).nullable(),
-    before: z.record(z.unknown()).nullable(),
-    after: z.record(z.unknown()).nullable()
+    record: z.record(z.string(), z.unknown()).nullable(),
+    before: z.record(z.string(), z.unknown()).nullable(),
+    after: z.record(z.string(), z.unknown()).nullable()
   }),
   z.object({
     kind: z.literal("moment"),
     moment: z.string(),
-    outputs: z.record(z.object({ id: z.string() }).passthrough())
+    outputs: z.record(z.string(), z.object({ id: z.string() }).passthrough())
   }),
   z.object({
     kind: z.literal("schedule"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,11 +271,11 @@ catalogs:
       specifier: 7.2.0
       version: 7.2.0
     zod:
-      specifier: 3.25.76
-      version: 3.25.76
+      specifier: 4.5.4
+      version: 4.5.4
     zod-form-data:
-      specifier: 2.0.8
-      version: 2.0.8
+      specifier: 3.0.3
+      version: 3.0.3
     zustand:
       specifier: 5.0.12
       version: 5.0.12
@@ -535,10 +535,10 @@ importers:
         version: 1.0.7(tailwindcss@4.3.0)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -593,31 +593,31 @@ importers:
     dependencies:
       '@ai-sdk-tools/agents':
         specifier: 1.2.0
-        version: 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(ai@5.0.172(zod@3.25.76)))(ai@5.0.172(zod@3.25.76))(zod@3.25.76)
+        version: 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(ai@5.0.172(zod@4.5.4)))(ai@5.0.172(zod@4.5.4))(zod@4.5.4)
       '@ai-sdk-tools/artifacts':
         specifier: 1.2.0
-        version: 1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1)
+        version: 1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1)
       '@ai-sdk-tools/cache':
         specifier: 1.2.0
-        version: 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(ai@5.0.172(zod@3.25.76))
+        version: 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(ai@5.0.172(zod@4.5.4))
       '@ai-sdk-tools/devtools':
         specifier: 1.2.0
-        version: 1.2.0(@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(react@18.3.1)(zod@3.25.76)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))))(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)
+        version: 1.2.0(@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(react@18.3.1)(zod@4.5.4)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))))(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.5.4)
       '@ai-sdk-tools/memory':
         specifier: 1.2.0
-        version: 1.2.0(@upstash/redis@1.37.0)(ai@5.0.172(zod@3.25.76))(ioredis@5.10.1)
+        version: 1.2.0(@upstash/redis@1.37.0)(ai@5.0.172(zod@4.5.4))(ioredis@5.10.1)
       '@ai-sdk-tools/store':
         specifier: 1.2.0
-        version: 1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(react@18.3.1)(zod@3.25.76)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))
+        version: 1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(react@18.3.1)(zod@4.5.4)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))
       '@ai-sdk/anthropic':
         specifier: 2.0.74
-        version: 2.0.74(zod@3.25.76)
+        version: 2.0.74(zod@4.5.4)
       '@ai-sdk/openai':
         specifier: 'catalog:'
-        version: 2.0.102(zod@3.25.76)
+        version: 2.0.102(zod@4.5.4)
       '@ai-sdk/react':
         specifier: 2.0.174
-        version: 2.0.174(react@18.3.1)(zod@3.25.76)
+        version: 2.0.174(react@18.3.1)(zod@4.5.4)
       '@base-ui-components/react':
         specifier: 1.0.0-rc.0
         version: 1.0.0-rc.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -716,7 +716,7 @@ importers:
         version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.5.4)
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.44.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -737,7 +737,7 @@ importers:
         version: 3.4.5(encoding@0.1.13)(react@18.3.1)
       '@react-router/remix-routes-option-adapter':
         specifier: 'catalog:'
-        version: 7.18.0(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
+        version: 7.18.0(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)
       '@react-router/serve':
         specifier: 'catalog:'
         version: 7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
@@ -782,7 +782,7 @@ importers:
         version: 1.6.1(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@vercel/react-router':
         specifier: 'catalog:'
-        version: 1.2.6(patch_hash=fdc988df95f5639f888c552079014d0e615cb4c762f8c25a16d43e4498e21a6a)(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.2.6(patch_hash=fdc988df95f5639f888c552079014d0e615cb4c762f8c25a16d43e4498e21a6a)(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@visx/responsive':
         specifier: 2.17.0
         version: 2.17.0(react@18.3.1)
@@ -791,7 +791,7 @@ importers:
         version: 12.10.2(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ai:
         specifier: 5.0.172
-        version: 5.0.172(zod@3.25.76)
+        version: 5.0.172(zod@4.5.4)
       assert-never:
         specifier: 1.4.0
         version: 1.4.0
@@ -827,7 +827,7 @@ importers:
         version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       inngest:
         specifier: ^3.52.7
-        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@4.22.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@3.25.76)
+        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@4.22.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@4.5.4)
       intl-parse-accept-language:
         specifier: 'catalog:'
         version: 1.0.0
@@ -992,13 +992,13 @@ importers:
         version: 1.1.3(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
       zod-to-json-schema:
         specifier: 3.25.2
-        version: 3.25.2(zod@3.25.76)
+        version: 3.25.2(zod@4.5.4)
       zustand:
         specifier: 'catalog:'
         version: 5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -1014,16 +1014,16 @@ importers:
         version: 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3))(babel-plugin-macros@3.1.0)(react@18.3.1)
       '@lingui/vite-plugin':
         specifier: 'catalog:'
-        version: 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@react-router/dev':
         specifier: 'catalog:'
-        version: 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       '@tailwindcss/typography':
         specifier: 'catalog:'
         version: 0.5.19(tailwindcss@4.3.0)
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.3.0(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.3.0(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       '@types/d3':
         specifier: 7.4.3
         version: 7.4.3
@@ -1083,13 +1083,13 @@ importers:
         version: 5.8.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
       vite-plugin-babel-macros:
         specifier: 'catalog:'
-        version: 1.0.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.0.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
 
   apps/mes:
     dependencies:
@@ -1344,10 +1344,10 @@ importers:
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -1498,10 +1498,10 @@ importers:
         version: 1.0.7(tailwindcss@4.3.0)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -1617,10 +1617,10 @@ importers:
         version: 4.6.9
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@tailwindcss/vite':
         specifier: 'catalog:'
@@ -1881,10 +1881,10 @@ importers:
         version: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
       zustand:
         specifier: 'catalog:'
         version: 5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2021,7 +2021,7 @@ importers:
         version: 4.6.9
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -2164,7 +2164,7 @@ importers:
         version: 4.6.9
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -2234,7 +2234,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: 'catalog:'
-        version: 2.0.102(zod@3.25.76)
+        version: 2.0.102(zod@4.5.4)
       '@carbon/auth':
         specifier: workspace:*
         version: link:../auth
@@ -2282,7 +2282,7 @@ importers:
         version: 2.80.0
       ai:
         specifier: 5.0.172
-        version: 5.0.172(zod@3.25.76)
+        version: 5.0.172(zod@4.5.4)
       axios:
         specifier: 1.16.0
         version: 1.16.0
@@ -2327,10 +2327,10 @@ importers:
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.18)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.3)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -2425,7 +2425,7 @@ importers:
         version: 1.3.3
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zustand:
         specifier: 'catalog:'
         version: 5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2466,6 +2466,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.6(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      zod-form-data:
+        specifier: 'catalog:'
+        version: 3.0.3(zod@4.5.4)
 
   packages/glossary:
     dependencies:
@@ -2520,7 +2523,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: 'catalog:'
-        version: 2.0.102(zod@3.25.76)
+        version: 2.0.102(zod@4.5.4)
       '@carbon/auth':
         specifier: workspace:*
         version: link:../auth
@@ -2583,13 +2586,13 @@ importers:
         version: 2.80.0
       ai:
         specifier: 5.0.172
-        version: 5.0.172(zod@3.25.76)
+        version: 5.0.172(zod@4.5.4)
       axios:
         specifier: 1.16.0
         version: 1.16.0
       inngest:
         specifier: ^3.52.7
-        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@3.25.76)
+        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@4.5.4)
       kysely:
         specifier: 'catalog:'
         version: 0.28.17
@@ -2628,7 +2631,7 @@ importers:
         version: 8.10.0
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -2738,7 +2741,7 @@ importers:
         version: 2.80.0
       inngest:
         specifier: 3.54.0
-        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@3.25.76)
+        version: 3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@4.5.4)
       nanoid:
         specifier: 'catalog:'
         version: 5.1.16
@@ -2753,7 +2756,7 @@ importers:
         version: 2.89.0(patch_hash=f278052dbb83b89896a8f742e486a879c8f00b1b22e188717aeb199b1f1a4b4c)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -2900,7 +2903,7 @@ importers:
         version: 5.6.0(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zustand:
         specifier: 'catalog:'
         version: 5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -2949,10 +2952,10 @@ importers:
         version: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
       zod-form-data:
         specifier: 'catalog:'
-        version: 2.0.8(zod@3.25.76)
+        version: 3.0.3(zod@4.5.4)
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -3357,7 +3360,7 @@ importers:
         version: 5.8.3
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
 
   packages/tiptap:
     dependencies:
@@ -3541,7 +3544,7 @@ importers:
         version: 5.1.16
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -3651,7 +3654,7 @@ importers:
         version: 5.9.4(@lingui/babel-plugin-lingui-macro@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3))(babel-plugin-macros@3.1.0)
       zod:
         specifier: 'catalog:'
-        version: 3.25.76
+        version: 4.5.4
     devDependencies:
       '@carbon/config':
         specifier: workspace:*
@@ -16506,10 +16509,10 @@ packages:
   yoga-layout@3.2.1:
     resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
-  zod-form-data@2.0.8:
-    resolution: {integrity: sha512-X31GkEc8uk5/L387L4TVI1z7obBbN/0MRHBHfHW3uMOWkVJeSsa+grvkTvY9qyFbNshKEnqK+jLJNlY+d7jpLw==}
+  zod-form-data@3.0.3:
+    resolution: {integrity: sha512-1qXJ6hayyUr3TqxfXqmm5qwCa8f/mnG/o8Itcny03iFyrwX/dZkCwfCcYoJDyQP8RxEkycw0c/ldCJXBeaCstg==}
     peerDependencies:
-      zod: '>= 3.11.0'
+      zod: '>= 3.25.0'
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -16524,6 +16527,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zustand@3.7.2:
     resolution: {integrity: sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==}
@@ -16572,42 +16578,42 @@ packages:
 
 snapshots:
 
-  '@ai-sdk-tools/agents@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(ai@5.0.172(zod@3.25.76)))(ai@5.0.172(zod@3.25.76))(zod@3.25.76)':
+  '@ai-sdk-tools/agents@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(ai@5.0.172(zod@4.5.4)))(ai@5.0.172(zod@4.5.4))(zod@4.5.4)':
     dependencies:
-      ai: 5.0.172(zod@3.25.76)
-      zod: 3.25.76
+      ai: 5.0.172(zod@4.5.4)
+      zod: 4.5.4
     optionalDependencies:
-      '@ai-sdk-tools/artifacts': 1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1)
-      '@ai-sdk-tools/cache': 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(ai@5.0.172(zod@3.25.76))
+      '@ai-sdk-tools/artifacts': 1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1)
+      '@ai-sdk-tools/cache': 1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(ai@5.0.172(zod@4.5.4))
 
-  '@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1)':
+  '@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1)':
     dependencies:
-      ai: 5.0.172(zod@3.25.76)
+      ai: 5.0.172(zod@4.5.4)
       react: 18.3.1
-      zod: 4.4.3
+      zod: 4.5.4
 
-  '@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1))(ai@5.0.172(zod@3.25.76))':
+  '@ai-sdk-tools/cache@1.2.0(@ai-sdk-tools/artifacts@1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1))(ai@5.0.172(zod@4.5.4))':
     dependencies:
-      ai: 5.0.172(zod@3.25.76)
+      ai: 5.0.172(zod@4.5.4)
     optionalDependencies:
-      '@ai-sdk-tools/artifacts': 1.2.0(ai@5.0.172(zod@3.25.76))(react@18.3.1)
+      '@ai-sdk-tools/artifacts': 1.2.0(ai@5.0.172(zod@4.5.4))(react@18.3.1)
 
-  '@ai-sdk-tools/devtools@1.2.0(@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(react@18.3.1)(zod@3.25.76)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))))(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@3.25.76)':
+  '@ai-sdk-tools/devtools@1.2.0(@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(react@18.3.1)(zod@4.5.4)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))))(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(zod@4.5.4)':
     dependencies:
-      '@ai-sdk/react': 2.0.174(react@18.3.1)(zod@3.25.76)
+      '@ai-sdk/react': 2.0.174(react@18.3.1)(zod@4.5.4)
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@mui/icons-material': 7.3.10(@mui/material@7.3.10(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
       '@mui/material': 7.3.10(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/dagre': 0.7.54
       '@xyflow/react': 12.10.2(@types/react@18.3.28)(immer@9.0.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      ai: 5.0.172(zod@3.25.76)
+      ai: 5.0.172(zod@4.5.4)
       dagre: 0.8.5
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-json-view-lite: 2.5.0(react@18.3.1)
     optionalDependencies:
-      '@ai-sdk-tools/store': 1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(react@18.3.1)(zod@3.25.76)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))
+      '@ai-sdk-tools/store': 1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(react@18.3.1)(zod@4.5.4)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))
     transitivePeerDependencies:
       - '@mui/material-pigment-css'
       - '@types/react'
@@ -16615,19 +16621,19 @@ snapshots:
       - supports-color
       - zod
 
-  '@ai-sdk-tools/memory@1.2.0(@upstash/redis@1.37.0)(ai@5.0.172(zod@3.25.76))(ioredis@5.10.1)':
+  '@ai-sdk-tools/memory@1.2.0(@upstash/redis@1.37.0)(ai@5.0.172(zod@4.5.4))(ioredis@5.10.1)':
     dependencies:
-      zod: 4.4.3
+      zod: 4.5.4
     optionalDependencies:
       '@upstash/redis': 1.37.0
-      ai: 5.0.172(zod@3.25.76)
+      ai: 5.0.172(zod@4.5.4)
       ioredis: 5.10.1
 
-  '@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76))(react@18.3.1)(zod@3.25.76)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))':
+  '@ai-sdk-tools/store@1.2.0(patch_hash=b16f28188d77cbc082143745663e4379eae4fae4380a3d6d1102b960cb829870)(@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4))(react@18.3.1)(zod@4.5.4)(zustand@5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1)))':
     dependencies:
-      '@ai-sdk/react': 2.0.174(react@18.3.1)(zod@3.25.76)
+      '@ai-sdk/react': 2.0.174(react@18.3.1)(zod@4.5.4)
       '@types/node': 24.12.2
-      ai: 5.0.172(zod@3.25.76)
+      ai: 5.0.172(zod@4.5.4)
       react: 18.3.1
       zustand: 5.0.12(@types/react@18.3.28)(immer@9.0.21)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
     transitivePeerDependencies:
@@ -16639,18 +16645,18 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/anthropic@2.0.74(zod@3.25.76)':
+  '@ai-sdk/anthropic@2.0.74(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.5.4)
+      zod: 4.5.4
 
-  '@ai-sdk/gateway@2.0.76(zod@3.25.76)':
+  '@ai-sdk/gateway@2.0.76(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.5.4)
       '@vercel/oidc': 3.1.0
-      zod: 3.25.76
+      zod: 4.5.4
 
   '@ai-sdk/openai-compatible@0.2.16(zod@3.25.76)':
     dependencies:
@@ -16664,11 +16670,11 @@ snapshots:
       '@ai-sdk/provider-utils': 2.2.8(zod@3.25.76)
       zod: 3.25.76
 
-  '@ai-sdk/openai@2.0.102(zod@3.25.76)':
+  '@ai-sdk/openai@2.0.102(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.5.4)
+      zod: 4.5.4
 
   '@ai-sdk/provider-utils@2.2.8(zod@3.25.76)':
     dependencies:
@@ -16677,12 +16683,12 @@ snapshots:
       secure-json-parse: 2.7.0
       zod: 3.25.76
 
-  '@ai-sdk/provider-utils@3.0.23(zod@3.25.76)':
+  '@ai-sdk/provider-utils@3.0.23(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.5.4
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
@@ -16702,15 +16708,15 @@ snapshots:
     optionalDependencies:
       zod: 3.25.76
 
-  '@ai-sdk/react@2.0.174(react@18.3.1)(zod@3.25.76)':
+  '@ai-sdk/react@2.0.174(react@18.3.1)(zod@4.5.4)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
-      ai: 5.0.172(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.5.4)
+      ai: 5.0.172(zod@4.5.4)
       react: 18.3.1
       swr: 2.4.1(react@18.3.1)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.5.4
 
   '@ai-sdk/ui-utils@1.2.11(zod@3.25.76)':
     dependencies:
@@ -17112,7 +17118,7 @@ snapshots:
       '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.4
@@ -17132,7 +17138,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 7.7.4
@@ -17302,7 +17308,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -17315,7 +17321,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18334,16 +18340,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lingui/vite-plugin@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@lingui/cli': 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
-      '@lingui/conf': 5.9.4(typescript@5.8.3)
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - typescript
-
   '@lingui/vite-plugin@5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@lingui/cli': 5.9.4(babel-plugin-macros@3.1.0)(typescript@5.8.3)
@@ -18421,7 +18417,7 @@ snapshots:
 
   '@mjackson/node-fetch-server@0.2.0': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.5.4)':
     dependencies:
       '@hono/node-server': 1.19.13(hono@4.12.25)
       ajv: 8.18.0
@@ -18438,8 +18434,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.5.4
+      zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -18705,7 +18701,7 @@ snapshots:
     dependencies:
       '@oclif/core': 4.11.7
       ansis: 3.17.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       npm: 11.17.0
       npm-package-arg: 11.0.3
       npm-run-path: 5.3.0
@@ -22201,56 +22197,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/parser': 7.29.2
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-      '@react-router/node': 7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
-      '@remix-run/node-fetch-server': 0.13.1
-      arg: 5.0.2
-      babel-dead-code-elimination: 1.0.12
-      chokidar: 4.0.3
-      dedent: 1.7.2(babel-plugin-macros@3.1.0)
-      es-module-lexer: 1.7.0
-      exit-hook: 2.2.1
-      isbot: 5.1.37
-      jsesc: 3.0.2
-      lodash: 4.18.1
-      p-map: 7.0.4
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      pkg-types: 2.3.0
-      prettier: 3.8.1
-      react-refresh: 0.14.2
-      react-router: 7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      semver: 7.7.4
-      tinyglobby: 0.2.17
-      valibot: 1.3.1(typescript@5.8.3)
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-    optionalDependencies:
-      '@react-router/serve': 7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
     dependencies:
       '@babel/core': 7.29.0
@@ -22326,12 +22272,6 @@ snapshots:
   '@react-router/remix-routes-option-adapter@7.18.0(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.5(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)':
     dependencies:
       '@react-router/dev': 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.5(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
-    optionalDependencies:
-      typescript: 5.8.3
-
-  '@react-router/remix-routes-option-adapter@7.18.0(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@react-router/dev': 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -23620,13 +23560,6 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@tailwindcss/node': 4.3.0
-      '@tailwindcss/oxide': 4.3.0
-      tailwindcss: 4.3.0
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-
   '@tailwindcss/vite@4.3.0(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@tailwindcss/node': 4.3.0
@@ -24406,7 +24339,7 @@ snapshots:
     dependencies:
       '@types/node': 22.19.7
       tapable: 2.3.3
-      webpack: 5.108.4(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.18)
+      webpack: 5.108.4(esbuild@0.27.7)(lightningcss@1.32.0)(postcss@8.5.18)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -24497,16 +24430,6 @@ snapshots:
   '@vercel/react-router@1.2.6(patch_hash=fdc988df95f5639f888c552079014d0e615cb4c762f8c25a16d43e4498e21a6a)(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-router/dev': 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
-      '@react-router/node': 7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
-      '@vercel/static-config': 3.2.0
-      isbot: 5.1.37
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      ts-morph: 12.0.0
-
-  '@vercel/react-router@1.2.6(patch_hash=fdc988df95f5639f888c552079014d0e615cb4c762f8c25a16d43e4498e21a6a)(@react-router/dev@7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))(@react-router/node@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(isbot@5.1.37)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@react-router/dev': 7.18.0(patch_hash=10eab9c1af1b5cc376e67a81f64216bb5d6fcd8a94fc807eb46ecf1982b2cde4)(@react-router/serve@7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3))(@types/node@26.1.0)(babel-plugin-macros@3.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(terser@5.48.0)(tsx@4.21.0)(typescript@5.8.3)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
       '@react-router/node': 7.18.0(react-router@7.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)
       '@vercel/static-config': 3.2.0
       isbot: 5.1.37
@@ -24659,14 +24582,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-
-  '@vitest/mocker@4.1.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -24853,13 +24768,13 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
 
-  ai@5.0.172(zod@3.25.76):
+  ai@5.0.172(zod@4.5.4):
     dependencies:
-      '@ai-sdk/gateway': 2.0.76(zod@3.25.76)
+      '@ai-sdk/gateway': 2.0.76(zod@4.5.4)
       '@ai-sdk/provider': 2.0.1
-      '@ai-sdk/provider-utils': 3.0.23(zod@3.25.76)
+      '@ai-sdk/provider-utils': 3.0.23(zod@4.5.4)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.5.4
 
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
@@ -25127,7 +25042,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -25994,7 +25909,7 @@ snapshots:
   engine.io-client@6.6.6:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       engine.io-parser: 5.2.3
       ws: 8.21.0
       xmlhttprequest-ssl: 2.1.2
@@ -26014,7 +25929,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       engine.io-parser: 5.2.3
       ws: 8.21.0
     transitivePeerDependencies:
@@ -26431,7 +26346,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -26560,7 +26475,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -27125,14 +27040,14 @@ snapshots:
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@9.0.0:
     dependencies:
       agent-base: 9.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27226,7 +27141,7 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  inngest@3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@4.22.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@3.25.76):
+  inngest@3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@4.22.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@4.5.4):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -27245,7 +27160,7 @@ snapshots:
       canonicalize: 1.0.8
       chalk: 4.1.2
       cross-fetch: 4.1.0(encoding@0.1.13)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
@@ -27253,7 +27168,7 @@ snapshots:
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
       ulid: 2.4.0
-      zod: 3.25.76
+      zod: 4.5.4
     optionalDependencies:
       express: 4.22.1
       hono: 4.12.25
@@ -27264,7 +27179,7 @@ snapshots:
       - encoding
       - supports-color
 
-  inngest@3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@3.25.76):
+  inngest@3.54.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(express@5.2.1)(hono@4.12.25)(next@15.5.21(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.8.3)(zod@4.5.4):
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       '@inngest/ai': 0.1.7
@@ -27283,7 +27198,7 @@ snapshots:
       canonicalize: 1.0.8
       chalk: 4.1.2
       cross-fetch: 4.1.0(encoding@0.1.13)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       hash.js: 1.1.7
       json-stringify-safe: 5.0.1
       ms: 2.1.3
@@ -27291,7 +27206,7 @@ snapshots:
       strip-ansi: 5.2.0
       temporal-polyfill: 0.2.5
       ulid: 2.4.0
-      zod: 3.25.76
+      zod: 4.5.4
     optionalDependencies:
       express: 5.2.1
       hono: 4.12.25
@@ -27345,7 +27260,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.5.1
       cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -28474,7 +28389,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -28544,7 +28459,7 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.108.4(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.18)
+      webpack: 5.108.4(esbuild@0.27.7)(lightningcss@1.32.0)(postcss@8.5.18)
     optionalDependencies:
       esbuild: 0.25.0
       lightningcss: 1.32.0
@@ -30073,7 +29988,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -30081,7 +29996,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -30198,7 +30113,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -30306,7 +30221,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -30486,7 +30401,7 @@ snapshots:
 
   socket.io-adapter@2.5.8:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -30507,7 +30422,7 @@ snapshots:
   socket.io-parser@4.2.7:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30516,7 +30431,7 @@ snapshots:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       engine.io: 6.6.9
       socket.io-adapter: 2.5.8
       socket.io-parser: 4.2.7
@@ -30973,7 +30888,7 @@ snapshots:
   threads@1.7.0:
     dependencies:
       callsites: 3.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       is-observable: 2.1.0
       observable-fns: 0.6.1
     optionalDependencies:
@@ -31114,7 +31029,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -31142,7 +31057,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -31444,7 +31359,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.5(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -31465,7 +31380,7 @@ snapshots:
   vite-node@3.2.4(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
@@ -31502,17 +31417,6 @@ snapshots:
       '@types/babel__core': 7.20.5
       babel-plugin-macros: 3.1.0
       vite: 7.3.5(@types/node@26.1.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  vite-plugin-babel-macros@1.0.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-      '@types/babel__core': 7.20.5
-      babel-plugin-macros: 3.1.0
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -31608,22 +31512,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
-      terser: 5.48.0
-      tsx: 4.21.0
-      yaml: 2.8.3
-
-  vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.18
-      rolldown: 1.0.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.1.0
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
       terser: 5.48.0
       tsx: 4.21.0
       yaml: 2.8.3
@@ -31784,34 +31672,6 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.6
-      '@vitest/mocker': 4.1.6(vite@8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.6
-      '@vitest/runner': 4.1.6
-      '@vitest/snapshot': 4.1.6
-      '@vitest/spy': 4.1.6
-      '@vitest/utils': 4.1.6
-      es-module-lexer: 2.3.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@26.1.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 26.1.0
-    transitivePeerDependencies:
-      - msw
-
   vitest@4.1.6(@opentelemetry/api@1.9.0)(@types/node@26.1.0)(vite@8.0.16(@types/node@26.1.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.6
@@ -31878,7 +31738,7 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack@5.108.4(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.18):
+  webpack@5.108.4(esbuild@0.27.7)(lightningcss@1.32.0)(postcss@8.5.18):
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
@@ -32055,20 +31915,26 @@ snapshots:
 
   yoga-layout@3.2.1: {}
 
-  zod-form-data@2.0.8(zod@3.25.76):
+  zod-form-data@3.0.3(zod@4.5.4):
     dependencies:
       '@rvf/set-get': 7.0.2
-      zod: 3.25.76
+      zod: 4.5.4
 
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.5.4):
+    dependencies:
+      zod: 4.5.4
 
   zod@3.24.3: {}
 
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zod@4.5.4: {}
 
   zustand@3.7.2(react@18.3.1):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,6 +148,6 @@ catalog:
   vite-plugin-babel-macros: 1.0.6
   vitest: 4.1.6
   wait-on: 7.2.0
-  zod: 3.25.76
-  zod-form-data: 2.0.8
+  zod: 4.5.4
+  zod-form-data: 3.0.3
   zustand: 5.0.12


### PR DESCRIPTION
Relands #1576, which was reverted in #1579.

## Why it was reverted, and why that no longer applies

#1576 was reverted while a "company form won't save" regression was being investigated — Zod was the most recent dependency change and the obvious suspect. It turned out not to be the cause. The actual causes were:

1. **The unsaved-changes blocker intercepting the form's own save.** `Submit` blocks any cross-pathname navigation while the form has touched fields. A form posting to a *different* route — the Add Company modal lives on `/x` but posts to `/x/settings/company/new` — submits via exactly such a navigation, so the blocker caught the POST before it was sent. Clicking "Stay on this page" (the natural instinct when you meant to save) cancelled the save silently, with no error anywhere.
2. **A placeholder PostHog key breaking hydration**, local-only: an all-asterisks `POSTHOG_PROJECT_PUBLIC_KEY` is truthy, so `posthog.init` ran and injected script tags into the document before `hydrateRoot(document)`, failing hydration app-wide.

Both are fixed on main in 3be8a0fe5b. Neither had anything to do with Zod, and the blocker bug predates #1576 by a long way.

## What's in this PR

Content is **identical to #1576** — no forward-porting was needed. The two commits that landed after the revert (3be8a0fe5b, #1580) add no Zod usage; every added line in that range was checked for zod imports and v3-only APIs (`errorMap`, `required_error`, `invalid_type_error`, `ZodEffects`, …) and came back empty.

- Catalog: `zod 3.25.76 → 4.5.4`, `zod-form-data 2.0.8 → 3.0.3`
- 23 Deno edge functions move `npm:zod@^3.24.1 → npm:zod@^4.5.4`

## Verification

Run on top of f43f46092d:

- **Typecheck** clean for `erp`, `mes`, and `@carbon/{form,jobs,checks,ee,workflows,database}` (8/8)
- **Lint** exits 0, and warning counts are byte-identical to the pre-reland baseline (erp 77, ee 56, mes 8, quote-configurator 4) — the reland introduces no new findings
- **`@carbon/form` tests** 26/26, including `zod.test.ts` and `isFieldOptional.test.ts`, which cover the zod-4 compatibility shim

## Reviewer note

The Deno edge functions aren't covered by turbo typecheck, so they're worth exercising once against a running edge runtime (a receipt post or an MRP run touches them) before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error handling across ERP, MES, forms, workflows, and database operations.
  * Added default notes for new risk forms.
  * Corrected workflow output validation to require non-empty text values.
  * Improved copying of jobs, assemblies, slides, materials, and related production data.

* **Improvements**
  * Updated form validation compatibility and expanded coverage for optional, nullable, and processed fields.
  * Strengthened handling of keyed records and imported configuration data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->