### PR TITLE
feat(dashboard): configurable homepage analytics with drag-to-reorder widgets

### DIFF
--- a/.ai/plans/2026-09-05-homepage-analytics-dashboard.md
+++ b/.ai/plans/2026-09-05-homepage-analytics-dashboard.md
@@ -1,0 +1,539 @@
+# Homepage Analytics Dashboard — implementation plan
+
+**Spec:** .ai/specs/2026-09-05-homepage-analytics-dashboard.md
+**Research:** .ai/research/homepage-analytics-dashboard.md
+**Branch:** configurable-homepage-analytics
+
+## Progress
+- [x] Task 1: Migration — `userDashboardWidget`, `userDashboardPreference`, five KPI functions
+- [x] Task 2: Regenerate DB types
+- [x] Task 3: `dashboard.models.ts` — ranges, widget registry, validators, payload types (+ unit tests)
+- [x] Task 4: `dashboard.service.ts` — layout/preference CRUD and the widget data dispatcher
+- [x] Task 5: API routes + `path.ts` entries
+- [x] Task 6: Home loader additions
+- [x] Task 7: UI — section, range select, widget shell, kind renderers, catalog drawer; wire into home
+- [x] Task 8: Validation gates (lint, typecheck, tests, translations)
+- [ ] Task 9: Browser verification (only with the user's go-ahead)
+
+## Execution notes (2026-09-05)
+- Task 1: `inboundInspection` was renamed to `inspection` by `20260722132135_inspections-refactor.sql`; the function is `get_inspection_pass_rate` over `inspection.status` / `dispositionedAt`, and the widget key is `quality.inspectionPassRate`.
+- Task 3: `msg` descriptors and `path.to.*` links live in `dashboard.labels.ts` / `dashboard.links.ts`, not the registry — importing either from the models file breaks vitest (`~/utils/path` pulls the glossary's macro).
+- Task 4: `production.utilization` is a per-work-center **breakdown** (hours), since the shared computation is per work center, not a time series. AR/AP totals are summed locally in the service (same bucket definition as the invoicing route) rather than moving the invoicing helpers.
+- Task 8: `pnpm db:check:backups` must be run with `SUPABASE_DB_URL` pointing at this worktree's port; the worktree `.env` still carries the default 54322.
+
+## Dependencies
+- Task 2 needs Task 1 (applied migration).
+- Task 3 is independent of Tasks 1–2 (pure TypeScript; the `range` enum literal is duplicated in SQL CHECK and zod on purpose).
+- Task 4 needs Tasks 2 and 3 (generated types for the new tables/RPCs, registry keys).
+- Task 5 needs Tasks 3 and 4. Task 6 needs Task 4. Task 7 needs Tasks 3, 5, 6.
+- Task 8 needs everything before it. Task 9 needs Task 8.
+
+---
+
+## Task 1: Migration — tables and KPI functions
+
+**Depends on:** none
+**Files:**
+- Create: `packages/database/supabase/migrations/<timestamp>_homepage-dashboard.sql` (via `pnpm db:migrate:new homepage-dashboard`)
+- Copy from (precedent): `packages/database/supabase/migrations/20260809161618_report-pins.sql` (table + owner-only RLS), `packages/database/supabase/migrations/20240927033740_job-operations-for-mes.sql:258` (`get_active_job_count` SQL function shape)
+
+**Steps:**
+1. Run `pnpm db:migrate:new homepage-dashboard` from the repo root. Never hand-pick the timestamp.
+2. Paste this SQL into the generated file:
+
+```sql
+-- ============================================================
+-- Homepage analytics dashboard: per-user widget visibility + page range, and
+-- five read-only KPI functions for numbers Carbon never computed before.
+-- Widgets are static definitions keyed by slug in
+-- apps/erp/app/modules/dashboard/dashboard.models.ts, so, like reportPin, a row
+-- stores an EXPLICIT value and an absent row means the registry default.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "userDashboardWidget" (
+    "widgetKey" TEXT NOT NULL,
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "visible" BOOLEAN NOT NULL,
+    "range" TEXT,
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("widgetKey", "userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardWidget_range_check"
+      CHECK ("range" IS NULL OR "range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_userId_companyId_idx"
+  ON "userDashboardWidget" ("userId", "companyId");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_companyId_idx"
+  ON "userDashboardWidget" ("companyId");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_createdBy_idx"
+  ON "userDashboardWidget" ("createdBy");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_updatedBy_idx"
+  ON "userDashboardWidget" ("updatedBy");
+
+ALTER TABLE "public"."userDashboardWidget" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "SELECT" ON "public"."userDashboardWidget";
+CREATE POLICY "SELECT" ON "public"."userDashboardWidget" FOR SELECT USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."userDashboardWidget";
+CREATE POLICY "INSERT" ON "public"."userDashboardWidget" FOR INSERT WITH CHECK (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."userDashboardWidget";
+CREATE POLICY "UPDATE" ON "public"."userDashboardWidget" FOR UPDATE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."userDashboardWidget";
+CREATE POLICY "DELETE" ON "public"."userDashboardWidget" FOR DELETE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+-- One row per user per company: the page-wide time range. Absent = '30d'.
+CREATE TABLE IF NOT EXISTS "userDashboardPreference" (
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "range" TEXT NOT NULL DEFAULT '30d',
+
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardPreference_range_check"
+      CHECK ("range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+
+CREATE INDEX IF NOT EXISTS "userDashboardPreference_companyId_idx"
+  ON "userDashboardPreference" ("companyId");
+
+ALTER TABLE "public"."userDashboardPreference" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "SELECT" ON "public"."userDashboardPreference";
+CREATE POLICY "SELECT" ON "public"."userDashboardPreference" FOR SELECT USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."userDashboardPreference";
+CREATE POLICY "INSERT" ON "public"."userDashboardPreference" FOR INSERT WITH CHECK (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."userDashboardPreference";
+CREATE POLICY "UPDATE" ON "public"."userDashboardPreference" FOR UPDATE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."userDashboardPreference";
+CREATE POLICY "DELETE" ON "public"."userDashboardPreference" FOR DELETE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+-- ------------------------------------------------------------
+-- KPI functions. All SECURITY INVOKER so RLS on the underlying tables applies;
+-- all take an explicit company id; none divides — the app computes the ratio.
+-- ------------------------------------------------------------
+
+-- On-time delivery: sales order lines SENT in the window that carried a
+-- promise date. Lines with no promisedDate are excluded from both counts.
+CREATE OR REPLACE FUNCTION get_on_time_delivery(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("shipped" INTEGER, "onTime" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COUNT(*)::INTEGER AS "shipped",
+    COUNT(*) FILTER (WHERE "sentDate" <= "promisedDate")::INTEGER AS "onTime"
+  FROM "salesOrderLine"
+  WHERE "companyId" = company_id
+    AND "sentDate" IS NOT NULL
+    AND "promisedDate" IS NOT NULL
+    AND "sentDate" >= start_date
+    AND "sentDate" <= end_date;
+$$;
+
+-- Production quantities recorded in the window, split by type. Serves both the
+-- scrap-rate widget (scrap / (production + scrap)) and first-pass yield
+-- (production / (production + rework + scrap)).
+CREATE OR REPLACE FUNCTION get_production_quantity_summary(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("production" NUMERIC, "scrap" NUMERIC, "rework" NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Production'), 0) AS "production",
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Scrap'), 0) AS "scrap",
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Rework'), 0) AS "rework"
+  FROM "productionQuantity"
+  WHERE "companyId" = company_id
+    AND "createdAt" >= start_date::TIMESTAMPTZ
+    AND "createdAt" < (end_date + 1)::TIMESTAMPTZ;
+$$;
+
+-- Inbound inspections dispositioned in the window.
+CREATE OR REPLACE FUNCTION get_inbound_inspection_pass_rate(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("passed" INTEGER, "failed" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE "status" = 'Passed')::INTEGER AS "passed",
+    COUNT(*) FILTER (WHERE "status" = 'Failed')::INTEGER AS "failed"
+  FROM "inboundInspection"
+  WHERE "companyId" = company_id
+    AND "dispositionedAt" IS NOT NULL
+    AND "dispositionedAt" >= start_date::TIMESTAMPTZ
+    AND "dispositionedAt" < (end_date + 1)::TIMESTAMPTZ;
+$$;
+
+-- Open backlog: value still to ship on open sales orders, in base currency
+-- (convertedUnitPrice is unitPrice × exchangeRate, generated). as_of is the
+-- company's current day, passed in by the caller — never CURRENT_DATE.
+CREATE OR REPLACE FUNCTION get_open_backlog(company_id TEXT, as_of DATE)
+RETURNS TABLE ("value" NUMERIC, "lines" INTEGER, "pastDueLines" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COALESCE(SUM(o."quantityToSend" * COALESCE(sol."convertedUnitPrice", 0)), 0) AS "value",
+    COUNT(*)::INTEGER AS "lines",
+    COUNT(*) FILTER (WHERE o."promisedDate" IS NOT NULL AND o."promisedDate" < as_of)::INTEGER AS "pastDueLines"
+  FROM "openSalesOrderLines" o
+  JOIN "salesOrderLine" sol ON sol."id" = o."id" AND sol."companyId" = o."companyId"
+  WHERE o."companyId" = company_id
+    AND o."quantityToSend" > 0;
+$$;
+
+-- Overdue purchase orders: open POs with at least one line past its promised
+-- date and quantity still outstanding. Returns one row per PO for the list
+-- widget; the stat widget counts the rows.
+CREATE OR REPLACE FUNCTION get_overdue_purchase_orders(company_id TEXT, as_of DATE)
+RETURNS TABLE (
+  "id" TEXT, "purchaseOrderId" TEXT, "supplierId" TEXT,
+  "earliestPromisedDate" DATE, "overdueLines" INTEGER
+)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    po."id",
+    po."purchaseOrderId",
+    po."supplierId",
+    MIN(pol."promisedDate") AS "earliestPromisedDate",
+    COUNT(*)::INTEGER AS "overdueLines"
+  FROM "purchaseOrder" po
+  JOIN "purchaseOrderLine" pol
+    ON pol."purchaseOrderId" = po."id" AND pol."companyId" = po."companyId"
+  WHERE po."companyId" = company_id
+    AND po."status" IN ('To Receive', 'To Receive and Invoice')
+    AND pol."promisedDate" IS NOT NULL
+    AND pol."promisedDate" < as_of
+    AND COALESCE(pol."purchaseQuantity", 0) - COALESCE(pol."quantityReceived", 0) > 0
+  GROUP BY po."id", po."purchaseOrderId", po."supplierId"
+  ORDER BY MIN(pol."promisedDate") ASC;
+$$;
+```
+
+3. If `purchaseOrderLine` has no `purchaseQuantity` column (check with `grep -rn '"purchaseQuantity"' packages/database/supabase/migrations/ | head -3`), STOP and report — do not guess the quantity column name.
+4. Apply with `pnpm db:migrate` (requires the worktree's Docker stack: `crbn status` must show containers running).
+
+**Verify:**
+```bash
+pnpm db:migrate
+# Expected: the new migration is listed as applied, no ERROR lines
+psql "$(grep SUPABASE_DB_URL .env.local | cut -d= -f2-)" -c '\df get_on_time_delivery' -c '\d "userDashboardWidget"'
+# Expected: one function row; table with columns widgetKey, userId, companyId, visible, range
+```
+
+**Out of scope:** any change to `reportPin`, `userModulePreference`, or existing KPI routes.
+
+---
+
+## Task 2: Regenerate DB types
+
+**Depends on:** Task 1
+**Files:**
+- Modify (generated): `packages/database/src/types.ts`, `packages/database/supabase/functions/lib/types.ts`
+
+**Steps:**
+1. `pnpm run generate:types`
+2. Do not hand-edit either file. If generation fails, STOP and report.
+
+**Verify:**
+```bash
+grep -c "userDashboardWidget\|userDashboardPreference\|get_on_time_delivery\|get_production_quantity_summary\|get_inbound_inspection_pass_rate\|get_open_backlog\|get_overdue_purchase_orders" packages/database/src/types.ts
+# Expected: a number ≥ 7
+```
+
+**Out of scope:** committing; any other schema change.
+
+---
+
+## Task 3: `dashboard.models.ts` — ranges, registry, validators, payloads
+
+**Depends on:** none (parallel-safe with Tasks 1–2)
+**Files:**
+- Create: `apps/erp/app/modules/dashboard/dashboard.models.ts`
+- Create: `apps/erp/app/modules/dashboard/dashboard.models.test.ts`
+- Create: `apps/erp/app/modules/dashboard/index.ts` (barrel: `export * from "./dashboard.models"; export * from "./dashboard.service";` — the service export is added in Task 4; create the file now with the models line only)
+- Copy from (precedent): `apps/erp/app/modules/accounting/accounting.models.ts:102-155` (`analyticsReports` registry shape), `packages/utils/src/accounting.ts` (`defaultReportRange` date arithmetic with `@internationalized/date`)
+
+**Steps:**
+1. Ranges:
+   ```ts
+   import { CalendarDate, parseDate, startOfMonth, startOfYear } from "@internationalized/date";
+   import { msg } from "@lingui/core/macro";
+   import type { MessageDescriptor } from "@lingui/core";
+   import { z } from "zod";
+
+   export const DASHBOARD_RANGES = ["7d", "30d", "90d", "mtd", "qtd", "ytd", "12m"] as const;
+   export type DashboardRange = (typeof DASHBOARD_RANGES)[number];
+   export const DEFAULT_DASHBOARD_RANGE: DashboardRange = "30d";
+   export const dashboardRangeLabels: Record<DashboardRange, MessageDescriptor> = {
+     "7d": msg`Last 7 days`, "30d": msg`Last 30 days`, "90d": msg`Last 90 days`,
+     mtd: msg`Month to date`, qtd: msg`Quarter to date`, ytd: msg`Year to date`, "12m": msg`Last 12 months`
+   };
+
+   /** Inclusive YYYY-MM-DD window ending on `today`, plus the same-length window immediately before it. */
+   export function resolveDashboardRange(range: DashboardRange, today: string): {
+     start: string; end: string; previousStart: string; previousEnd: string; bucket: "day" | "month";
+   }
+   ```
+   Rules: `end = today`. `7d/30d/90d`: `start = today.subtract({ days: n - 1 })`. `mtd`: `startOfMonth(today)`. `qtd`: first day of the calendar quarter (`new CalendarDate(y, ((m-1) - (m-1)%3) + 1, 1)`). `ytd`: `startOfYear(today)`. `12m`: `today.subtract({ months: 12 }).add({ days: 1 })`. Previous window: `previousEnd = start.subtract({ days: 1 })`, `previousStart = previousEnd.subtract({ days: end.compare(start) })`. `bucket = "day"` when `end.compare(start) < 92`, else `"month"`. Never use JS `Date`.
+2. Registry types and entries exactly as the spec's catalog table (31 widgets). `module` values are the permission keys used by `useModules`: `"sales" | "purchasing" | "production" | "quality" | "invoicing" | "inventory" | "workflows"`. Use `"workflows"` (not `"settings"`) for `workflows.failedRuns` — that is the key `useModules.tsx:150-151` gates on. `to` is a plain `string` from `path.to.*` (import `path` from `~/utils/path`): sales → `path.to.salesOrders` / `path.to.quotes`; purchasing → `path.to.purchaseOrders`; production → `path.to.jobs`; quality → `path.to.issues`; invoicing AR → `path.to.receivables`, AP → `path.to.payables`; inventory → `path.to.inventoryValuation`; workflows → `path.to.workflowRuns`.
+   ```ts
+   export type WidgetKind = "stat" | "trend" | "breakdown" | "list";
+   export type WidgetSize = "sm" | "md" | "lg";
+   export type WidgetModule = "sales" | "purchasing" | "production" | "quality" | "invoicing" | "inventory" | "workflows";
+   export type WidgetValueKind = "count" | "money" | "percent" | "quantity";
+   export type WidgetDefinition = {
+     key: string; module: WidgetModule; kind: WidgetKind; size: WidgetSize;
+     title: MessageDescriptor; description: MessageDescriptor; defaultVisible: boolean;
+     supportsRange: boolean; goal?: "higher" | "lower"; valueKind?: WidgetValueKind; to?: string;
+   };
+   export const DASHBOARD_WIDGETS = [ /* 31 entries */ ] as const satisfies readonly WidgetDefinition[];
+   export type WidgetKey = (typeof DASHBOARD_WIDGETS)[number]["key"];
+   export const WIDGET_KEYS = DASHBOARD_WIDGETS.map((w) => w.key) as [WidgetKey, ...WidgetKey[]];
+   export function getWidgetDefinition(key: string): WidgetDefinition | undefined
+   ```
+   Because `msg` is a babel macro, this file is importable only by Vite-built app code and vitest (which runs the Lingui plugin for `apps/erp`); do not import it from `packages/jobs` or scripts (lesson `.ai/lessons.md:669`).
+3. Validators:
+   ```ts
+   export const dashboardLayoutValidator = z.object({
+     widgets: z.array(z.object({ key: z.enum(WIDGET_KEYS), visible: z.boolean(), range: z.enum(DASHBOARD_RANGES).nullable() }))
+   });
+   export const dashboardPreferenceValidator = z.object({ range: z.enum(DASHBOARD_RANGES) });
+   ```
+4. Payload types (`StatPayload`, `TrendPayload`, `BreakdownPayload`, `ListPayload`, union `WidgetPayload`) exactly as the spec's API section.
+5. Pure layout resolver (client- and server-safe; takes a `can` function, not the hook):
+   ```ts
+   export type ResolvedWidget = WidgetDefinition & { visible: boolean; range: DashboardRange | null };
+   export function resolveDashboardLayout(
+     can: (action: "view", module: string) => boolean | undefined,
+     rows: { widgetKey: string; visible: boolean; range: string | null }[]
+   ): ResolvedWidget[]
+   ```
+   Returns registry order, filtered to `can("view", module)`, `visible = row?.visible ?? defaultVisible`, `range = row?.range ?? null` (only if it is a valid `DashboardRange`). Rows whose key is not in the registry are ignored.
+6. Delta helper: `export function percentChange(value: number, previous: number): number | null` — `null` when `previous === 0`, else `round(((value - previous) / previous) * 100)` using `round` from `@carbon/utils` at its default scale (no scale literal).
+7. Tests in `dashboard.models.test.ts` (vitest): `resolveDashboardRange("30d","2026-09-05")` → `{start:"2026-08-07", end:"2026-09-05", previousStart:"2026-07-08", previousEnd:"2026-08-06", bucket:"day"}`; `qtd` on `2026-09-05` → start `2026-07-01`; `12m` on `2026-09-05` → start `2025-09-06`, bucket `"month"`; `resolveDashboardLayout` with `can` true only for `sales` returns only sales widgets, honours a `visible:false` row, ignores an unknown key, and ignores an invalid range string; `percentChange(10000, 8000) === 25`, `percentChange(5, 0) === null`.
+
+**Verify:**
+```bash
+pnpm --filter erp test -- app/modules/dashboard/dashboard.models.test.ts
+# Expected: all tests pass, 0 failed
+```
+
+**Out of scope:** any service or UI code; changing `analyticsReports`.
+
+---
+
+## Task 4: `dashboard.service.ts` — layout CRUD and widget data
+
+**Depends on:** Tasks 2, 3
+**Files:**
+- Create: `apps/erp/app/modules/dashboard/dashboard.service.ts`
+- Modify: `apps/erp/app/modules/dashboard/index.ts` — add `export * from "./dashboard.service";`
+- Copy from (precedent): `apps/erp/app/modules/users/users.server.ts:833-864` (`getModulePreferences` / `upsertModulePreferences`), `apps/erp/app/routes/api+/sales.kpi.$key.ts` (windowed queries + previous period), `apps/erp/app/routes/x+/quality+/_index.tsx:155-200` (issue counts), `apps/erp/app/routes/x+/purchasing+/_index.tsx:87-102` (open-status constants), `apps/erp/app/modules/invoicing/invoicing.service.ts:2440-2475` (`getArAging`/`getApAging`), `apps/erp/app/modules/inventory/inventory.service.ts:340-350` (`getInventoryValuation`), `apps/erp/app/routes/api+/quality.kpi.$key.ts:165-195` (`paretoByType`), `apps/erp/app/routes/api+/production.kpi.$key.ts:62-120` (`utilization`)
+
+**Steps:**
+1. Layout/preference functions, each `(client: SupabaseClient<Database>, userId, companyId, …)` returning the raw supabase response:
+   - `getDashboardLayout(client, userId, companyId)` → `from("userDashboardWidget").select("widgetKey, visible, range").eq("userId", userId).eq("companyId", companyId)`
+   - `getDashboardPreference(client, userId, companyId)` → `from("userDashboardPreference").select("range")…maybeSingle()`
+   - `upsertDashboardWidgets(client, userId, companyId, rows: { key; visible; range }[])` → `upsert(rows.map(r => ({ widgetKey: r.key, userId, companyId, visible: r.visible, range: r.range, createdBy: userId, updatedBy: userId, updatedAt: datetime.timestamp() })), { onConflict: "widgetKey,userId,companyId" })`
+   - `upsertDashboardPreference(client, userId, companyId, range)` → `upsert({ userId, companyId, range, updatedAt }, { onConflict: "userId,companyId" })`
+2. Window type and dispatcher:
+   ```ts
+   export type WidgetWindow = { start: string; end: string; previousStart: string; previousEnd: string; bucket: "day" | "month"; today: string };
+   export async function getWidgetData(client, args: { key: WidgetKey; companyId: string; userId: string; window: WidgetWindow }): Promise<WidgetPayload>
+   ```
+   A `switch (args.key)` with one arm per registry key; the switch must have no `default` arm so an unhandled key is a type error (`.ai/lessons.md:625`). Query rules per widget:
+   - **Open counts** (`sales.openOrders`, `sales.openQuotes`, `purchasing.openOrders`, `production.activeJobs`, `quality.openIssues`): `select("id", { count: "exact", head: true }).eq("companyId", companyId).in("status", STATUSES)`. Copy the status arrays verbatim from the module dashboards: sales `OPEN_SALES_ORDER_STATUSES` / `OPEN_QUOTE_STATUSES` (`x+/sales+/_index.tsx:70-84`), purchasing `OPEN_PURCHASE_ORDER_STATUSES` (`x+/purchasing+/_index.tsx:94-102`), production `ACTIVE_JOB_STATUSES` (import from `~/modules/production`, `production.models.ts:1622`), quality `["Registered","In Progress"]` on the `issues` view.
+   - **Ranged money stats** (`sales.revenue`, `purchasing.spend`): select `orderTotal, orderDate` from the `salesOrders` / `purchaseOrders` views with `.gte("orderDate", start).lte("orderDate", end)`, sum `orderTotal` in TS; repeat for the previous window → `{ value, previous }`.
+   - **Trends** (`sales.revenueTrend`, `purchasing.spendTrend`, `quality.issuesTrend`): same rows, bucketed with `groupDataByDay` / `groupDataByMonth` from `~/utils/chart` on `window.bucket`; `points = Object.entries(grouped).map(([key, rows]) => ({ key, label: key, value: sum }))`.
+   - `sales.onTimeDelivery`: `client.rpc("get_on_time_delivery", { company_id, start_date: start, end_date: end })` and again for the previous window; `value = onTime/shipped*100` (TS, `round`), `null` numerator → value 0 and `empty: true`.
+   - `sales.openBacklog`: `rpc("get_open_backlog", { company_id, as_of: window.today })` → `{ value, description: pastDueLines }` (StatPayload gets an optional `detail?: number`).
+   - `purchasing.overdueOrders` / `purchasing.overdueList`: `rpc("get_overdue_purchase_orders", { company_id, as_of: today })`; count rows / map first 8 rows to `ListPayload` with `to: path.to.purchaseOrder(id)`.
+   - `purchasing.bySupplier`: `purchaseOrders` view rows in range, group by `supplierId`, join names via `from("supplier").select("id,name").in("id", ids)` (one call), top 8.
+   - `production.lateJobs`: `from("job").select("id", {count:"exact", head:true}).eq("companyId").lt("dueDate", today).in("status", ACTIVE_JOB_STATUSES)`.
+   - `production.assignedToMe`: `rpc("get_active_job_count", { employee_id: userId, company_id: companyId })`.
+   - `production.dueThisWeek`: `from("jobs").select("id, jobId, itemReadableIdWithRevision, dueDate, status").eq("companyId").in("status", ACTIVE_JOB_STATUSES).gte("dueDate", today).lte("dueDate", today+6d).order("dueDate").limit(8)` → `ListPayload` with `to: path.to.job(id)`.
+   - `production.byStatus`: `from("job").select("status").eq("companyId").in("status", ACTIVE_JOB_STATUSES)`, count in TS.
+   - `production.utilization`: extract the body of the `utilization` case from `api+/production.kpi.$key.ts:62-120` into `getUtilizationSeries(client, companyId, start, end)` in `apps/erp/app/modules/production/production.service.ts` and call it from both places (route keeps its behaviour); map to `TrendPayload`.
+   - `production.scrapRate` / `production.firstPassYield`: `rpc("get_production_quantity_summary", …)` current and previous; scrap = `scrap/(production+scrap)*100`; FPY = `production/(production+rework+scrap)*100`.
+   - `quality.issuesByType`: extract `paretoByType` body (`quality.kpi.$key.ts:165-195`) into `getIssueCountsByType(client, companyId, start, end)` in `quality.service.ts`; map top 8 to `BreakdownPayload`.
+   - `quality.inboundPassRate`: `rpc("get_inbound_inspection_pass_rate", …)` → `passed/(passed+failed)*100`.
+   - `invoicing.ar*` / `invoicing.ap*`: `getArAging(client, companyId, today, {})` / `getApAging`; outstanding = sum of every row's total; overdue = sum of buckets past due — reuse `overdueOf` from `InvoicingDashboard.tsx` by moving it to `invoicing.models.ts` as an exported pure function (`InvoicingDashboard.tsx` imports it from there afterwards).
+   - `inventory.value`: `getInventoryValuation(client, companyId, { asOfDate: today })`, sum `totalValue`.
+   - `workflows.failedRuns`: `from("workflowRun").select("id", {count:"exact", head:true}).eq("companyId").eq("status","Failed").gte("completedAt", start).lt("completedAt", end + 1 day)`, and previous.
+   - `sales.assignedToMe`: `getSalesDocumentsAssignedToMe(client, userId, companyId)` → first 8 → `ListPayload` (`to` by `type`: `path.to.salesOrder(id)` / `path.to.quote(id)` / `path.to.salesRfq(id)`).
+3. Every query includes `.eq("companyId", companyId)`; never a query inside a loop.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: 0 errors (the exhaustive switch fails typecheck if a registry key has no arm)
+```
+
+**Out of scope:** changing what `production.kpi` / `quality.kpi` routes return; new SQL beyond Task 1.
+
+---
+
+## Task 5: API routes and path entries
+
+**Depends on:** Tasks 3, 4
+**Files:**
+- Create: `apps/erp/app/routes/api+/dashboard.widget.$key.ts`
+- Create: `apps/erp/app/routes/api+/dashboard.layout.ts`
+- Create: `apps/erp/app/routes/api+/dashboard.preference.ts`
+- Modify: `apps/erp/app/utils/path.ts` — inside `api: {` add `dashboardWidget: (key: string) => generatePath(\`${api}/dashboard/widget/${key}\`)`, `dashboardLayout: \`${api}/dashboard/layout\``, `dashboardPreference: \`${api}/dashboard/preference\``
+- Copy from (precedent): `apps/erp/app/routes/api+/sales.kpi.$key.ts:1-60` (param parsing, 500-day cap), `apps/erp/app/routes/api+/module-preferences.tsx` (JSON POST + upsert)
+
+**Steps:**
+1. `dashboard.widget.$key.ts` loader: `const def = getWidgetDefinition(params.key)`; if none → `throw data({ error: "Unknown widget" }, { status: 404 })`. Then `const { client, companyId, userId } = await requirePermissions(request, { view: def.module })`. Read `start`, `end` (`YYYY-MM-DD`), `today`; validate with `parseDate`; if `end.compare(start) < 0 || > 500` return an empty payload for the kind. Derive `previousStart/previousEnd/bucket` with the same arithmetic as `resolveDashboardRange` (export a helper `windowFromDates(start, end, today)` from models). Return `getWidgetData(...)`.
+2. `dashboard.layout.ts` action: `assertIsPost`; `requirePermissions(request, {})`; `dashboardLayoutValidator.safeParse(await request.json())` → 400 on failure; `upsertDashboardWidgets`; return `{ success: true }` or 500 with `error.message`.
+3. `dashboard.preference.ts` action: same shape with `dashboardPreferenceValidator` and `upsertDashboardPreference`.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: 0 errors
+```
+
+**Out of scope:** UI; the home loader.
+
+---
+
+## Task 6: Home loader additions
+
+**Depends on:** Task 4
+**Files:**
+- Modify: `apps/erp/app/routes/x+/_index.tsx` — loader only
+
+**Steps:**
+1. Destructure `userId` from `requirePermissions`. Alongside the existing greeting computation add:
+   ```ts
+   const today = datetime.today(tz).toString();
+   const [layout, preference] = await Promise.all([
+     getDashboardLayout(client, userId, companyId),
+     getDashboardPreference(client, userId, companyId)
+   ]);
+   const url = new URL(request.url);
+   const urlRange = url.searchParams.get("range");
+   const range = DASHBOARD_RANGES.includes(urlRange as DashboardRange) ? (urlRange as DashboardRange)
+     : (preference.data?.range as DashboardRange | undefined) ?? DEFAULT_DASHBOARD_RANGE;
+   return { greeting, agentDismissed, dashboard: { rows: layout.data ?? [], range, today } };
+   ```
+2. Import from `~/modules/dashboard`.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp
+# Expected: 0 errors
+```
+
+**Out of scope:** the component body (Task 7).
+
+---
+
+## Task 7: UI — section, range select, widgets, catalog drawer
+
+**Depends on:** Tasks 3, 5, 6
+**Files:**
+- Create: `apps/erp/app/modules/dashboard/ui/DashboardSection.tsx`
+- Create: `apps/erp/app/modules/dashboard/ui/DashboardRangeSelect.tsx`
+- Create: `apps/erp/app/modules/dashboard/ui/DashboardWidget.tsx` (shell + fetcher + kind switch)
+- Create: `apps/erp/app/modules/dashboard/ui/StatWidget.tsx`, `TrendWidget.tsx`, `BreakdownWidget.tsx`, `ListWidget.tsx`
+- Create: `apps/erp/app/modules/dashboard/ui/DashboardCatalogDrawer.tsx`
+- Create: `apps/erp/app/modules/dashboard/ui/index.ts`
+- Modify: `apps/erp/app/routes/x+/_index.tsx` — render `<DashboardSection>` after the closing `</div>` of the `grid-cols-1 lg:grid-cols-3` block (line ~246)
+- Copy from (precedent): `apps/erp/app/components/MetricCard.tsx` (stat card), `apps/erp/app/routes/x+/sales+/_index.tsx:150-330,500-560` (fetcher load with `start`/`end`, `ChartContainer` + `BarChart`, delta arithmetic), `apps/erp/app/routes/x+/person+/$personId.timecard.tsx:537-556` (`Select` / `SelectTrigger size="sm"` / `SelectContent` / `SelectItem`), `apps/erp/app/modules/accounting/ui/PaymentTerms/PaymentTermForm.tsx:78-120` (`ModalDrawer*` with footer buttons), `apps/erp/app/components/Layout/Navigation/useNavigationEditMode.tsx` (draft / isDirty / save shape), `apps/erp/app/routes/x+/_index.tsx:392-460` (`RecentDocumentRow`, `SectionLabel` styling)
+
+**Steps:**
+1. `DashboardSection` props: `{ rows, range, today }` from loader data. Compute `const widgets = resolveDashboardLayout(permissions.can, rows)` with `usePermissions()`. If `widgets.length === 0` render nothing. Header: `<SectionLabel><Trans>Analytics</Trans></SectionLabel>` on the left; right side `<DashboardRangeSelect value={range} />` and an `IconButton aria-label={t\`Customize widgets\`} icon={<LuPencil />} variant="ghost" size="sm"` that opens the drawer. Grid: `grid grid-cols-1 lg:grid-cols-3 gap-4`, size classes `sm → ""`, `md → "lg:col-span-2"`, `lg → "lg:col-span-3"`. Render `widgets.filter(w => w.visible)`. If none visible, one `Card` with `Empty` and a `Button` "Add widgets" opening the drawer. Wrap in `mb-8`.
+2. `DashboardRangeSelect`: `Select` with the seven presets labelled via `i18n._(dashboardRangeLabels[r])`. `onValueChange`: `setParams({ range: value })` from `useUrlParams()` AND `fetcher.submit(JSON.stringify({ range: value }), { method: "post", action: path.to.api.dashboardPreference, encType: "application/json" })`.
+3. `DashboardWidget` props `{ widget: ResolvedWidget; pageRange: DashboardRange; today: string }`. Effective range = `widget.range ?? pageRange`; `const w = resolveDashboardRange(effectiveRange, today)`; `useEffect` → `fetcher.load(\`${path.to.api.dashboardWidget(widget.key)}?start=${w.start}&end=${w.end}&today=${today}\`)` keyed on `widget.key, w.start, w.end`. Shell is `Card` with `CardHeader` (title via `i18n._(widget.title)`, `View` link button when `widget.to`, and when `widget.supportsRange` a `DropdownMenu` (`LuEllipsisVertical`) listing the seven presets plus `Follow page`, each item posting `{ widgets: [{ key, visible: true, range }] }` to `path.to.api.dashboardLayout` with `encType: "application/json"` then `revalidator.revalidate()`). A muted caption `i18n._(dashboardRangeLabels[widget.range])` under the title when overridden. Body: `Skeleton` while `fetcher.state !== "idle" || !fetcher.data`, else the kind component.
+4. `StatWidget`: value formatted by `valueKind` — `money` → `useCurrencyFormatter()`, `percent` → `usePercentFormatter()` on `value / 100`, `quantity` → `useQuantityFormatter()`, `count` → `useNumberFormatter({ maximumFractionDigits: 0 })` is NOT allowed (inline digits) — use `useQuantityFormatter()` for counts too. Value in `text-4xl font-medium tracking-tighter tabular-nums` (same as `MetricCard`). Delta: `percentChange(value, previous)`; render `▲ 25% vs prior period` in `text-emerald-600` when the change direction matches `goal` (`higher` and positive, or `lower` and negative), `text-red-600` when it opposes, `text-muted-foreground` when `goal` is unset or change is `null`/0. `detail` (backlog past-due lines) renders as the `MetricCard` description line.
+5. `TrendWidget`: `ChartContainer` config `{ value: { color: "hsl(var(--primary))" } }`, recharts `AreaChart` with `XAxis dataKey="label"` and `Area dataKey="value" type="monotone"`, height class `h-40`. `BreakdownWidget`: `BarChart layout="vertical"` with `YAxis dataKey="name" type="category" width={120}` and `Bar dataKey="value"`. `ListWidget`: up to 8 rows styled like `RecentDocumentRow` (`flex items-center gap-3 p-3 rounded-lg border`), each a `Link to={row.to}` with title, subtitle, optional `Badge` status and `formatRelativeTime(dueDate)` when present; empty → `Empty`.
+6. `DashboardCatalogDrawer` props `{ open, onClose, widgets: ResolvedWidget[] }`. Draft state seeded from `widgets` on open; group by module with the module name from `useModules()` (`name` of the entry whose `key`/`permission` equals `widget.module`); each row `Switch` toggling `visible`; footer `Cancel` + `Save` (`isDisabled={!isDirty}`, `isLoading` while the fetcher is submitting). Save posts `{ widgets: draft.map(({ key, visible, range }) => ({ key, visible, range })) }` to `path.to.api.dashboardLayout` with `encType: "application/json"`; on `fetcher.data?.success` call `revalidator.revalidate()` and `onClose()`.
+7. All strings through Lingui (`t`/`Trans`/`msg`). Icons from `react-icons/lu`.
+
+**Verify:**
+```bash
+pnpm exec turbo run typecheck --filter=erp && pnpm run lint
+# Expected: 0 type errors; biome reports no errors
+```
+
+**Out of scope:** drag-and-drop, resizing, MES, module dashboards.
+
+---
+
+## Task 8: Validation gates
+
+**Depends on:** Tasks 1–7
+**Files:** none new
+
+**Steps:**
+1. `pnpm run lint`
+2. `pnpm exec turbo run typecheck --filter=erp --filter=@carbon/database`
+3. `pnpm --filter erp test -- app/modules/dashboard`
+4. `pnpm db:check:datasets` and `pnpm db:check:backups` (both need the migrated local DB).
+5. `pnpm --filter @carbon/checks` conformance (if a `check` script exists at the root, run `pnpm run check`; otherwise skip and note it).
+6. Run `/translate` only if the `.po` catalogs report missing strings (`pnpm --filter @carbon/locale extract` then inspect).
+
+**Verify:**
+```bash
+pnpm run lint && pnpm exec turbo run typecheck --filter=erp && pnpm --filter erp test -- app/modules/dashboard
+# Expected: every command exits 0
+```
+
+**Out of scope:** committing — that is the `/check-and-commit` skill, and only on the user's explicit ask.
+
+---
+
+## Task 9: Browser verification
+
+**Depends on:** Task 8
+**Files:** none
+
+**Steps:**
+1. Ask the user before opening a browser (memory: no browser unless asked). If approved: `crbn up` with the ERP app, `/auth`, then `/test` against the acceptance criteria in the spec: default widgets per permission, range change persists, per-widget override caption, catalog save/cancel, 403/404 on the widget API.
+
+**Verify:**
+```bash
+# /test run record in .ai/runs/ shows each acceptance criterion PASS
+```
+
+**Out of scope:** any code change discovered here goes back through Task 7, not a hot-fix in the browser session.

--- a/.ai/research/homepage-analytics-dashboard.md
+++ b/.ai/research/homepage-analytics-dashboard.md
@@ -1,0 +1,417 @@
+# Configurable Homepage Analytics Research: Best Practices Survey
+
+## Summary
+
+Surveyed how enterprise ERPs (SAP S/4HANA Fiori, NetSuite, Epicor Kinetic, Odoo),
+job-shop ERP/MES products (Fulcrum, ProShop, JobBOSS², Global Shop, Katana, MRPeasy,
+First Resonance ION, Plex) and modern SaaS dashboards (Cloudflare, Grafana, Datadog,
+Stripe, PostHog) let a user put analytics on their home page and adjust what they see.
+The consensus is a **widget dashboard with an explicit edit mode and a widget catalog**:
+a curated library of pre-built KPI tiles and charts, a per-user layout that starts from a
+role-based default, a page-wide time-range control, and click-through from every widget
+to the list or report behind it. Nobody ships a blank canvas or a free-form query builder
+on the home page. Notably, Cloudflare's *home* is not customizable at all; what the user
+is picturing is Cloudflare **Custom Dashboards** (edit mode, chart catalog, dashboard-wide
+filters). Carbon already has most of the raw material: five module dashboards with
+KPI API endpoints, a `MetricCard` tile, recharts wrappers, a drag-to-reorder + hide
+navigation editor persisted in `userModulePreference`, and per-user report pins.
+
+## Competitors Surveyed
+
+- **SAP S/4HANA (Fiori Launchpad, My Home, Overview Pages, Smart Business)** — the
+  enterprise reference for role-based defaults with a user personalization layer, KPI
+  tile types, threshold colouring, and tile-to-app drill-down.
+- **Oracle NetSuite** — the most mature "portlet" home dashboard: admin publishes per
+  role, users personalize, explicit lock modes, KPI comparison periods and thresholds.
+- **Epicor Kinetic** — discrete-manufacturing ERP; widget home page with personal vs
+  published layouts and BAQ-driven tiles; ships four role home pages.
+- **Odoo 17/18** — "add any view to my dashboard" affordance and spreadsheet dashboards
+  with global filters; shows the cheapest possible path from an existing screen to a
+  widget.
+- **Job-shop ERP/MES (Fulcrum, ProShop, JobBOSS², Global Shop, Katana, MRPeasy, ION,
+  Plex, Manufacturo)** — what KPIs a shop of Carbon's target size actually expects on
+  day one.
+- **Cloudflare Custom Dashboards + Grafana, Datadog, Stripe, PostHog** — the
+  interaction pattern the user asked for by name.
+
+## Key Consensus Patterns
+
+### 1. Curated widget catalog, not a query builder
+
+- **SAP**: users add tiles from the App Finder or "Add to My Home"; KPI definitions,
+  thresholds and data sources are authored by key users, not end users.
+- **NetSuite**: the Personalize palette lists fixed portlet types; a KPI is picked from
+  75+ standard KPIs or a saved search that satisfies a strict contract.
+- **Stripe**: "Add" opens a checklist of every available chart; tick and Apply.
+- **Cloudflare Custom Dashboards**: add a chart from a fixed set of seven chart types
+  over named datasets.
+- **Rationale**: a home page is a landing surface, not an analysis tool. A closed catalog
+  keeps every widget fast, permission-safe and visually consistent. Ad-hoc analysis lives
+  in a separate reports/analytics area (SAP APF, NetSuite saved search, Carbon's pivot
+  reports).
+
+### 2. Role-based default, per-user override
+
+- **SAP**: spaces/pages assigned to business roles; the user's personalization is a
+  delta stored on top; admins can disable personalization but not force a layout.
+- **NetSuite**: admin publishes a dashboard to roles with a lock mode per tab
+  (Unlocked / Locked / Add-Move-only); republishing only overwrites user changes if the
+  admin explicitly opts in.
+- **Epicor**: Personal layout vs Published layout; users can always start from a
+  published layout and then diverge.
+- **Rationale**: the first render must be useful with zero setup, and the default must
+  respect what the role is allowed to see. Personalization is the second step.
+
+### 3. Explicit edit mode, view mode by default
+
+- **Cloudflare**: enter edit mode to add, remove, rearrange; auto-saves on exit.
+- **Grafana / Datadog / PostHog**: Edit → drag/resize/remove → Save or Discard.
+- **NetSuite / Epicor**: pencil or Personalize toggle; drag-and-drop between columns.
+- **Rationale**: prevents accidental layout changes and lets the view mode stay clean.
+  Carbon's navigation editor already follows this exact shape
+  (`useNavigationEditMode`: draft state, dirty flag, Save / Cancel).
+
+### 4. Page-wide time range and filters
+
+- **Cloudflare**: one time-range dropdown and "Add filter" chips re-query every card.
+- **SAP OVP**: one global filter bar over all cards; **My Home** Insights cards carry
+  the user's saved filters.
+- **NetSuite**: date range is per KPI, but scorecards and Viewing options apply one
+  range to all; Datadog/Grafana/PostHog use a global range with per-widget override.
+- **Rationale**: comparing widgets is only meaningful when they share a window. Carbon's
+  module dashboards already take `start`/`end`/`interval` on every KPI endpoint, so a
+  shared range is a prop, not a redesign.
+
+### 5. Widgets are links, not endpoints
+
+- **SAP**: tile → app opened with the tile's filter variant; OVP card header → filtered
+  list, line item → object.
+- **NetSuite**: KPI → underlying report/saved search; Report Snapshot → "view report".
+- **MRPeasy**: every widget clicks through to its report.
+- **Rationale**: a number on the home page is a prompt to act. Carbon's `MetricCard`
+  already has `to` + `linkLabel` for this.
+
+### 6. Fixed set of tile shapes with constrained sizes
+
+- **SAP Smart Business**: Numeric, Comparison (bars), Trend (micro line), Actual vs
+  Target (bullet), Dual; OVP cards: List, Table, Analytical, Link list.
+- **NetSuite**: KPI (numeric + comparison), KPI Meter (gauge), Trend Graph, Report
+  Snapshot (list or chart), Custom Search (table), Reminders (counts).
+- **Cloudflare**: Timeseries, Bar, Donut, Map, Stat, Percentage, Top N.
+- **Rubrik design notes / Pencil & Paper**: offer 2–3 size presets rather than free
+  resize; "structured flexibility".
+- **Rationale**: a small taxonomy (stat, trend, breakdown, list) covers >90% of demand
+  and keeps the grid legible.
+
+### 7. Threshold colouring and comparison period on stat tiles
+
+- **SAP**: evaluation defines goal type (maximize / minimize / range) with warning and
+  critical thresholds → green/orange/red.
+- **NetSuite**: Compare Range shows prior value and % change with arrows; "Highlight
+  if" threshold flags the tile red.
+- **Stripe**: comparison period dropdown alongside date range.
+- **Rationale**: a bare number has no meaning; the delta vs last period or vs target is
+  what makes a tile glanceable.
+
+### 8. Permission-derived visibility, not per-widget grants
+
+- **NetSuite**: "KPIs available depend on the role you used to log in."
+- **MRPeasy**: widgets hidden by user rights.
+- **Odoo**: dashboard data respects the viewer's record rules.
+- **Rationale**: a widget is a view on an existing module; if you cannot open the
+  module you should not see its number. Carbon's KPI endpoints already gate on
+  `view: <module>`.
+
+## Answers to Research Questions
+
+1. **What entity/data model do competitors use for a personalized home page?** — A
+   *dashboard* (per user, optionally per role) holding an ordered list or grid of
+   *widgets*; each widget references a *definition* from a catalog plus small per-instance
+   *config* (time range, filter, size). SAP: space → page → section → tile with a
+   per-user personalization delta. NetSuite: dashboard → portlets, stored per user per
+   role. Epicor: personal vs published *Layout*. Grafana/Datadog store `x,y,w,h` on a
+   12- or 24-column grid; Stripe stores only an ordered list of enabled widgets.
+2. **Per-user or shared?** — Home dashboards are per user (SAP My Home, NetSuite
+   personalization, Epicor Personal layout, Odoo My Dashboard, Stripe Home). Shared
+   dashboards exist as a separate "published/analytics dashboards" concept with
+   role-gated editing (NetSuite Publish, Epicor Published layout, Odoo Dashboards app,
+   Grafana/Datadog/PostHog). Carbon's `reportView` table already models exactly this
+   Private / Company split.
+3. **What do users get to change?** — Add/remove widgets from a catalog, reorder
+   (drag-and-drop), sometimes resize among presets, set the widget's time range or
+   filter, and hide sections. Users do **not** author KPI definitions, thresholds or
+   queries on the home page in any surveyed ERP.
+4. **What manufacturing KPIs ship out of the box?** — Ranked by how many job-shop
+   products ship them: late/open POs and supplier on-time delivery (7), customer
+   on-time delivery % (6), scrap/defect rate (5), late jobs (4), inventory value / low
+   stock (4), capacity/utilization (4), sales revenue & margin (4), open quotes / win
+   rate (3), first pass yield (3), backlog $ and recent shipments (2–3). SAP's role
+   overview pages add: overdue PO items, purchase requisitions awaiting approval,
+   material coverage shortages, GR-blocked stock, incoming sales orders, customer
+   returns, open quality notifications. NetSuite adds AR/AP aging, cash, unbilled
+   orders, open quotes, pipeline.
+5. **Is there a standard term?** — "Widget" (Epicor, Grafana, Datadog, Atlassian) or
+   "portlet" (NetSuite) for the unit; "tile" (SAP) for a stat-only unit; "card" (SAP
+   OVP, Cloudflare) for a richer unit. "KPI" for the metric definition; "dashboard"
+   for the page. Recommend **widget** for the unit and **KPI** for a metric definition.
+6. **What edge cases do they handle?** — (a) republish vs user overrides (NetSuite's
+   opt-in "override existing users"); (b) widget definition removed or renamed after
+   layout saved (PostHog and Carbon's own run-history handle unknown ids by appending
+   or skipping); (c) empty/no-data states with action prompts (Cloudflare Teams Home);
+   (d) stale-cache indicators (NetSuite "cached data, last updated at"; SAP per-tile
+   cache duration); (e) narrow layouts truncating content (NetSuite narrow column
+   rules); (f) plan/feature gating of analytics (Katana tiers, Cloudflare granularity).
+7. **How does Cloudflare specifically do it?** — Account Home and zone Overview are
+   fixed. Cloudflare Custom Dashboards (GA 2026-04-22): start from a template or blank,
+   explicit edit mode with auto-save on exit, per-chart kebab (edit / duplicate / drill
+   down), seven chart types, dashboard-level filters including time range applied to
+   all charts. Built-in analytics pages share the top-right time-range dropdown and
+   "Add filter" pattern. Resizing and per-user scope are not documented.
+
+## Competitor-Specific Details
+
+### SAP S/4HANA
+- KPI → Evaluation → Tile → Drill-down chain; one KPI can have many tiles.
+- Tile types: Numeric, Comparison, Trend, Actual vs Target (bullet), Dual, Harvey Ball,
+  Radial. Goal type drives colour direction.
+- Dynamic tiles poll a count every N seconds (default 10 s); Smart Business tiles use a
+  per-tile cache duration.
+- "Save as Tile" from any list report creates a personal count tile that reopens the
+  list pre-filtered — the cheapest user-authored widget in any surveyed product.
+- My Home sections: To-Dos, Pages, Apps, Insights (tiles + up to 10 cards).
+
+### NetSuite
+- Portlet caps per dashboard (Report Snapshots 10, Custom Search 6, Trend Graphs 5,
+  KPI Meter 3) — a precedent for capping widget count.
+- KPI setup: Range, Compare + Compare Range (prior value, % change, arrows), Highlight
+  If + Threshold, Headline, Employee scope (All / Only Mine / My Team's), Cached Data.
+- Publish restriction modes: Unlocked / Locked / Add-Move Content ("sticky" widgets
+  users cannot remove).
+- No standard KPI for backorders, POs or work orders — customers build those.
+
+### Epicor Kinetic
+- Widget types: App Link, BAQ Grid, Updatable Grid, Discovery Chart / KPI / Dashboard,
+  Image, Text, Web App, Website. KPI views are stoplight-coloured against a goal.
+- Ships four role home pages (Executive, Financial, Manufacturing, Supply Chain) and
+  ~30 EDD metrics (job count by status, hours vs downtime, scrap/rework, on-time vs
+  overdue shipments, AR/AP aging, sales, orders).
+- Weakness worth avoiding: default layout is assignable only per user, not per role;
+  standard dashboards break on version upgrades.
+
+### Odoo
+- Favorites ▾ → "Add to my dashboard" turns any list/graph/pivot into a personal widget
+  that keeps sort/measure interactivity but freezes the filter.
+- Spreadsheet dashboards: per-app sections, star favourites, Access Groups, Is Published
+  toggle, global date/relation filters.
+- Manufacturing has no KPI landing page; OEE, Lost time, Load, Performance are smart
+  buttons per work center.
+
+### Job-shop ERP/MES
+- **MRPeasy** is the closest literal model: a fixed widget list (Late CO, Late PO,
+  Deliveries on time, Cash flow, Cash flow forecast, Sales, Invoices, Total inventory,
+  MOs), add/remove/drag, click-through, hidden by user rights.
+- **Fulcrum**: fixed KPI strip on each grid (late orders, how late, excess capacity,
+  low inventory, last 7 days shipments); no widget picker.
+- **Plex / Global Shop / ProShop**: role-specific named dashboards (Purchasing, Master
+  Schedule, Labor Performance, Finance) with 25–60 standard KPIs.
+- **ION**: eight standard dashboards, read vs write analytics permissions.
+
+### Cloudflare, Grafana, Datadog, Stripe, PostHog
+
+| | Layout storage | Scope | Sizes | Add flow | Time range | Edit mode |
+|---|---|---|---|---|---|---|
+| Cloudflare Custom Dashboards | ordered charts | account list | undocumented | template or blank → chart | dashboard filters apply to all | explicit, auto-save on exit |
+| Grafana | `gridPos {x,y,w,h}`, 24 cols | shared | free | Edit → Add element → viz picker | header picker + URL `from`/`to` | Edit / Save / Discard |
+| Datadog | `layout {x,y,w,h}`, 12 cols | shared, role-restricted edit | free, min widths | Add Widget tray with preview | global selector, per-widget override | Edit widgets |
+| Stripe Home | ordered list of enabled charts | per account | none | checklist → Apply | range + unit + comparison | Add / Edit → Done |
+| PostHog | per-breakpoint `x,y,w,h` | project-shared | free | New insight / Add to dashboard | dashboard range + per-tile override | `E` toggles, `Esc` discards |
+
+## Carbon Today (what a spec can reuse)
+
+- **Chart primitives**: `packages/react/src/Chart.tsx` (recharts wrappers,
+  `ChartConfig`), `FunnelChart.tsx`; `apps/erp/app/components/MetricCard.tsx` is the
+  existing stat tile (title, value, icon, link).
+- **Five module dashboards** already compute KPIs with a shared `start`/`end`/`interval`
+  contract via `useFetcher` against `api+/{sales,purchasing,production,quality,resources}.kpi.$key.ts`;
+  keys live in each module's `*.models.ts`. Invoicing dashboard uses the `get_ar_aging`
+  / `get_ap_aging` RPCs. Every endpoint gates with `requirePermissions({ view: module })`.
+- **Cheap data sources**: `get_inventory_valuation`, `get_active_job_count`,
+  `accountTreeBalancePeriodSeries` (Executive P&L), `journalDimensionPivot`,
+  `workflowLastRun`, and the `salesOrders` / `purchaseOrders` / `jobs` / `issues` /
+  `openSalesOrderLines` / `openPurchaseOrderLines` / `itemQuantities` views.
+- **Gaps in data**: no on-time-delivery view or RPC; no scrap-count aggregate outside
+  the GL scrap report; no NCR aging aggregate (derived from `issues` at query time).
+- **Per-user layout precedent**: `userModulePreference` (`userId, companyId, module,
+  position, hidden`) + `useNavigationEditMode` (`@dnd-kit` sortable, draft/dirty/save)
+  is a near-exact template for a widget layout editor. `reportPin` is per-user pinning
+  with a default fallback. `reportView` is the Private / Company shared-config model.
+- **Persistence rule**: Carbon persists layout to the DB, never localStorage;
+  localStorage is only for dismissals and recently-viewed.
+- **Libraries**: `@dnd-kit` is already a dependency in ERP and MES; there is no
+  `react-grid-layout`. A 1-D sortable list needs no new dependency; a 2-D resizable
+  grid would.
+- **Gating**: `FEATURE_PLANS` in `packages/ee/src/plan.ts` + `usePlanGate` /
+  `requirePlan`; the pivot/report-view services are already in `accounting.ee.service.ts`.
+- **Prior art**: no spec, plan or research on a homepage dashboard exists. The closest
+  is `.ai/specs/2026-08-09-dimensional-pivot-reporting.md` (saved, shareable analytics
+  config).
+
+## Recommended Approach for Carbon
+
+1. **Widget catalog + per-user layout, no query builder** (SAP, NetSuite, Stripe).
+   Define widgets in code as a typed registry (`key`, module permission, kind, default
+   size, data loader). Users add/remove/reorder from a catalog drawer. This keeps every
+   widget fast and permission-safe and reuses the five existing KPI endpoints.
+2. **Role-derived default layout with user override** (SAP, NetSuite, Epicor). The
+   default set is derived from the user's module permissions (a user who can view
+   sales, production and quality gets those modules' headline widgets), not from a
+   hard-coded list, so it is useful on first render and never shows a widget the user
+   cannot drill into. User edits are stored as a delta in a new per-user, per-company
+   table shaped like `userModulePreference` (`widgetKey, position, hidden, config JSONB`).
+   Do not use `user.flags` (company-agnostic) or localStorage.
+3. **Explicit edit mode copied from the navigation editor** (Cloudflare, Grafana,
+   Carbon's own `useNavigationEditMode`). Pencil → drag-to-reorder with `@dnd-kit`
+   sortable, hide/show, Save/Cancel. Ship a 1-D ordered list with two or three width
+   presets (1/3, 2/3, full) rendered in the existing `lg:grid-cols-3` on the home page
+   rather than a free 2-D grid; that avoids a new dependency and matches Rubrik's
+   "constrained sizes" guidance.
+4. **One page-wide time range** (Cloudflare, SAP OVP). A single range picker above the
+   widgets (This week / This month / Last 30 days / Quarter / Year to date) passed to
+   every widget's loader; the KPI endpoints already accept it. Per-widget override can
+   be a later layer.
+5. **Four widget kinds** (SAP tile types, Cloudflare chart types): **Stat** (number +
+   delta vs prior period + link), **Trend** (small area/bar over the range), **Breakdown**
+   (top-N bars or donut), **List** (a short table such as "Jobs due this week" or
+   "Overdue POs"). Every widget carries a `to` link to the filtered list or report.
+6. **Initial catalog, prioritised by the cross-vendor ranking and by what Carbon can
+   compute today**:
+   - Stat: Open sales orders, Open quotes, Open POs, Overdue POs, Active jobs, Jobs
+     assigned to me, Open issues (NCRs), AR outstanding / overdue, AP outstanding /
+     overdue, Inventory value, Failed workflow runs (last 24 h).
+   - Trend: Sales order revenue, PO spend, Issues opened per week, Utilization.
+   - Breakdown: Issues by type (Pareto), Jobs by status, Purchases by supplier.
+   - List: Jobs due this week, Late jobs, Overdue purchase orders, Recently viewed.
+   - Defer until a data source exists: On-time delivery %, Scrap rate, First pass
+     yield, Backlog $ (these are the top-ranked job-shop KPIs and belong in the spec's
+     Open Questions with a proposed view/RPC each).
+7. **Delta and colour on stat tiles** (NetSuite Compare, SAP goal type). Show prior
+   period value and % change; colour by a `goal: "higher" | "lower"` on the widget
+   definition. No user-editable thresholds in v1.
+8. **Permission and plan gating fall out of the registry**. A widget declares its
+   module; the loader filters the catalog and the default layout by `permissions.can`,
+   and unknown or now-forbidden keys in a saved layout are skipped, not errored. If
+   the feature is Business-plan only, add one `FEATURE_PLANS` key and gate the editor,
+   not the default widgets.
+9. **Keep shared/company dashboards out of v1** but leave the door open: the
+   `reportView` Private / Company model is the pattern to copy when a "publish to
+   team" request arrives (NetSuite Publish, Epicor Published layout).
+10. **Naming**: call the unit a *widget*, the page area the *dashboard*, the definition a
+    *KPI*. Avoid "portlet" and "tile".
+
+## Open Questions for the Spec
+
+- Should the dashboard replace the module-card grid on the home page, sit above it,
+  or be a separate route linked from home? (SAP My Home keeps Apps + Insights as sibling
+  sections; NetSuite makes the dashboard the home.)
+- Time-range scope: page-wide only, or per-widget override in v1?
+- Which of on-time delivery, scrap rate, backlog $ need a new view or RPC, and are
+  they in scope?
+- Is the feature plan-gated, and if so is it the editor, the catalog size, or the
+  whole area?
+- Widget count cap (NetSuite caps per type; Cloudflare caps dashboards at 25)?
+- Should "Recently viewed" and the Implementation Hub card become widgets so the whole
+  home page is one layout, or stay fixed?
+
+## Sources
+
+### SAP
+- https://www.sap.com/design-system/fiori-design-web/v1-130/foundations/integration-and-services/sap-fiori-launchpad/sap-fiori-launchpad-my-home
+- https://help.sap.com/doc/34796706f38646f68d51a0fa0d4636e4/100/en-US/c0a1907907fa4365a83247c0c9bbc247.html
+- https://learning.sap.com/courses/learning-the-basics-of-sap-fiori/personalizing-sap-fiori_decea017-0eda-41c1-bea9-c83627443035
+- https://community.sap.com/t5/technology-blog-posts-by-sap/manage-spaces-and-pages-for-sap-fiori-launchpad/ba-p/13458100
+- https://community.sap.com/t5/technology-blog-posts-by-sap/how-sap-smart-business-works/ba-p/13326746
+- https://help.sap.com/docs/SAP_S4HANA_CLOUD/a630d57fc5004c6383e7a81efee7a8bb/c00cbf7fe8464663aee830fb6e7eec13.html
+- https://community.sap.com/t5/technology-blog-posts-by-sap/kpi-tile-refresh-in-smart-business-service/ba-p/13331305
+- https://github.com/SAP-docs/sapui5/blob/main/docs/07_APF/configuring-the-sap-smart-business-kpi-tile-374364e.md
+- https://github.com/SAP-docs/sapui5/blob/main/docs/06_SAP_Fiori_Elements/overview-page-card-74332d5.md
+- https://github.com/SAP-docs/sapui5/blob/main/docs/06_SAP_Fiori_Elements/creating-cards-for-the-insights-cards-section-of-my-home-in-sap-s-4hana-cloud-public-edit-9b13559.md
+- https://blog.sap-press.com/sap-fiori-overview-pages-features-and-personalization
+- https://community.sap.com/t5/enterprise-resource-planning-blog-posts-by-members/dynamic-sap-fiori-tiles-using-variants-in-sap-s-4hana-1909/ba-p/13425514
+- https://learning.sap.com/courses/business-processes-in-sap-s-4hana-sourcing-procurement/using-the-procurement-overview-app
+- https://learning.sap.com/courses/functions-innovations-in-sap-s-4hana-sales/getting-an-overview-of-the-analytical-features-of-sap-s-4hana-sales_e361c6ec-03b1-4e42-b7eb-1ba63aabda0b
+- https://learning.sap.com/courses/inventory-management-and-physical-inventory-in-sap-s-4hana/using-analytical-apps-for-inventory-management
+- https://help.sap.com/doc/474a13c5e9964c849c3a14d6c04339b5/100/en-US/a685871d1f2b4f5f91613d99e701e3df.html
+
+### NetSuite
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_N595760.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N601098.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N596767.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N597713.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N609047.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N605338.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N605811.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_N610592.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N626371.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N577248.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N578457.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_4072488196.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/chapter_N633149.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N634268.html
+- https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/section_N634404.html
+- https://blog.proteloinc.com/faq-netsuite-dashboards
+
+### Epicor Kinetic
+- https://www.scribd.com/document/567994443/Personalizing-Kinetic-Home-Page
+- https://datixinc.com/blog/how-to-add-new-baq-tiles-to-the-epicor-active-home-page/
+- https://www.epiusers.help/t/2023-1-4-homepage-default-layout-or-deploying-a-custom-one/103861
+- https://www.epiusers.help/t/set-homepage-layout-based-on-user-group/122169
+- https://www.epiusers.help/t/publishing-home-page/134811
+- https://www.epiusers.help/t/shop-dashboards/121801
+- https://www.corporateservetech.com/erp-software/epicor-data-discovery/
+- https://www.epicor.com/en/products/business-intelligence-and-data-management/epicor-data-analytics/data-analytics-for-advanced-mes/
+
+### Odoo
+- https://www.odoo.com/documentation/18.0/applications/productivity/dashboards.html
+- https://www.odoo.com/documentation/18.0/applications/productivity/dashboards/build_and_customize_dashboards.html
+- https://www.odoo.com/documentation/19.0/applications/productivity/dashboards/my_dashboard.html
+- https://www.odoo.com/odoo-18-release-notes
+- https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/manufacturing/advanced_configuration/using_work_centers.html
+- https://www.odoo.com/documentation/18.0/applications/inventory_and_mrp/manufacturing/reporting/oee.html
+- https://www.odoo.com/forum/help-1/customize-and-share-dashboards-250429
+
+### Job-shop ERP / MES
+- https://fulcrumpro.com/article/manufacturing-dashboards-for-actionable-data
+- https://fulcrumpro.com/manufacturing-software/manufacturing-dashboard-live-reports
+- https://www.paperlessparts.com/demos/efficiently-managing-quote-throughput-owners-ceos/
+- https://www.selecthub.com/p/manufacturing-software/proshop-erp/
+- https://www.ecisolutions.com/products/jobboss2/features/cost-reporting-and-dashboards/
+- https://www.globalshopsolutions.com/dashboards-for-manufacturing
+- https://www.globalshopsolutions.com/key-performance-indicators-software-for-manufacturing
+- https://support.katanamrp.com/en/articles/6529431-using-the-insights-dashboard
+- https://www.mrpeasy.com/resources/user-manual/dashboard/
+- https://manual.firstresonance.io/ion-analytics
+- https://www.firstresonance.io/blog/manufacturing-kpis
+- https://plex.rockwellautomation.com/en-us/products/manufacturing-analytics.html
+- https://www.ascm.org/ascm-insights/the-10-essential-kpis-for-supply-chain/
+- https://harmoni.io/feeds/blog/manufacturing-metrics-dashboard
+- https://jobpack.com/manufacturing-kpi-dashboard-examples/
+
+### Cloudflare and SaaS dashboards
+- https://developers.cloudflare.com/analytics/custom-dashboards/
+- https://developers.cloudflare.com/changelog/post/2026-04-22-custom-dashboards-ga/
+- https://blog.cloudflare.com/a-new-look-on-your-cloudflare-dashboard/
+- https://blog.cloudflare.com/the-teams-dashboard-home/
+- https://community.cloudflare.com/t/pin-or-favorite-sites-on-the-dashboard-home-page/57514
+- https://developers.cloudflare.com/analytics/account-and-zone-analytics/zone-analytics/
+- https://developers.cloudflare.com/analytics/network-analytics/configure/time-range/
+- https://developers.cloudflare.com/web-analytics/configuration-options/filters/
+- https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/view-dashboard-json-model/
+- https://grafana.com/docs/grafana/latest/visualizations/dashboards/use-dashboards/
+- https://docs.datadoghq.com/dashboards/
+- https://docs.datadoghq.com/dashboards/widgets/configuration/
+- https://github.com/DataDog/effective-dashboards/blob/main/guidelines.md
+- https://support.stripe.com/questions/customize-your-dashboard-home-page-charts-for-better-business-insights
+- https://posthog.com/docs/product-analytics/dashboards
+- https://github.com/posthog/posthog/issues/44766
+- https://medium.com/rubrik-design/customizable-dashboard-framework-design-step-by-step-c04fc75e1cb5
+- https://www.pencilandpaper.io/articles/ux-pattern-analysis-data-dashboards

--- a/.ai/specs/2026-09-05-homepage-analytics-dashboard.md
+++ b/.ai/specs/2026-09-05-homepage-analytics-dashboard.md
@@ -1,0 +1,313 @@
+# Homepage Analytics Dashboard
+
+> Status: in-progress
+> Author: naveenkash
+> Date: 2026-09-05
+> Research: `.ai/research/homepage-analytics-dashboard.md`
+
+## TLDR
+
+Add an **Analytics** section at the bottom of the ERP home page (`/x`) made of
+pre-built widgets: stat tiles with a delta vs the prior period, small trend charts,
+top-N breakdowns, and short action lists. Widgets are defined in code in a typed
+registry; each declares the module permission it needs. A page-wide time-range
+select drives every widget, and any widget can override it. Users choose which
+widgets are shown (show/hide from a catalog); order and size are fixed by the
+registry. The choice is stored per user per company in a new `userDashboardWidget`
+table following the `reportPin` pattern. A first-time user sees a curated default
+subset derived from their permissions. The feature is available on every plan and
+edition. Four job-shop KPIs that Carbon has never computed — on-time delivery,
+scrap rate, first-pass yield, and open backlog — ship as new read-only RPCs.
+
+## Problem Statement
+
+The home page today is a greeting, a search bar, the module cards, and a Recent
+list. It shows no operational numbers. To learn "how many jobs are late" or "what
+is AR overdue" a user opens each module dashboard in turn (`/x/sales`,
+`/x/purchasing`, `/x/production`, `/x/quality`, `/x/invoicing`), each with its own
+date picker. Every competitor surveyed (SAP My Home, NetSuite portlets, Epicor
+Kinetic home, MRPeasy, Cloudflare Custom Dashboards) puts a personalizable set of
+KPIs on the landing page. Carbon already has the data endpoints, the chart
+primitives, and a per-user layout-preference pattern; nothing composes them on
+the home page.
+
+## Proposed Solution
+
+A `dashboard` module (`apps/erp/app/modules/dashboard/`) owning:
+
+1. **A widget registry** — `dashboard.models.ts` exports `DASHBOARD_WIDGETS`, a
+   `readonly` array of `WidgetDefinition`:
+   ```ts
+   type WidgetKind = "stat" | "trend" | "breakdown" | "list";
+   type WidgetSize = "sm" | "md" | "lg"; // 1/3, 2/3, full of the lg:grid-cols-3 grid
+   type WidgetDefinition = {
+     key: WidgetKey;                 // stable string literal, e.g. "sales.openOrders"
+     module: Module;                 // permission module gating catalog, default, and data
+     kind: WidgetKind;
+     size: WidgetSize;               // fixed; not user-adjustable
+     title: MessageDescriptor;       // Lingui msg`…`
+     description: MessageDescriptor;
+     defaultVisible: boolean;        // curated default subset (Q4)
+     goal?: "higher" | "lower";      // stat delta colouring
+     valueKind?: "count" | "money" | "percent" | "quantity"; // formatter kind
+     supportsRange: boolean;         // false for "as of now" stats (open counts, AR aging, inventory value)
+     to?: (companyRoutes) => string; // drill-down link
+   };
+   ```
+   Registry order is the render order. Keys are namespaced by module so a later
+   rename of a module keeps old keys readable.
+2. **A layout table** `userDashboardWidget` — one row per widget the user has
+   explicitly toggled, `visible BOOLEAN NOT NULL`. Absent row = `defaultVisible`.
+3. **One data route** `api+/dashboard.widget.$key.ts` — returns the payload for one
+   widget for a `start`/`end` window, gated on the widget's module permission.
+4. **A home-page section** rendered below the Modules/Recent grid: range select,
+   edit toggle, widget grid, catalog drawer.
+5. **Four new RPCs** for the KPIs with no existing query: `get_on_time_delivery`,
+   `get_scrap_rate`, `get_first_pass_yield`, `get_open_backlog`.
+
+### Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Where widgets are defined | Typed registry in `dashboard.models.ts`, not DB rows | Every surveyed ERP ships a curated catalog; no user-authored KPIs on a home page. Keeps every widget fast, translated, and permission-tagged at compile time. |
+| Placement | New section at the **bottom** of `/x`, below Recent + Modules (Q1) | User decision, mirrors Cloudflare's overview: quick actions first, analytics below. Existing home content is untouched. |
+| User control | **Show/hide + drag-to-reorder** (Q2, revised 2026-09-07); size fixed by the registry | User decision. Order is one `widgetOrder TEXT[]` on the preference row, saved on drop. Hide is in each card's menu; the catalog (opened by "Add widgets") remains the way to re-add. |
+| Layout storage | New `userDashboardWidget(widgetKey, userId, companyId, visible)`, PK `(widgetKey, userId, companyId)`, absent row = registry default | Exact `reportPin` shape: explicit override over a code default. Per user per company, DB-backed — Carbon never persists layout in localStorage (`useRecentlyViewed` comment; `tableView` precedent). |
+| Default layout | Registry `defaultVisible` flag, then filtered by `permissions.can("view", module)` (Q4 option 2) | A permission-only default would render ~25 widgets for an owner. Admin-published company defaults (NetSuite Publish) are a later spec. |
+| Time range | Page-wide range select in the URL (`?range=`) and persisted per user; **per-widget override** allowed (Q3 option 3) | User decision. Override is stored in `userDashboardWidget.range` so it survives reloads with the visibility row. |
+| Range presets | `7d`, `30d`, `90d`, `mtd`, `qtd`, `ytd`, `12m` | Presets only, no custom dates — a home page, not a report. Resolved server-side against the company timezone with `@internationalized/date`; no JS `Date`. |
+| Range persistence | `userDashboardPreference` row per user per company: `range` | One row, not a column on every widget row. Absent = `30d`. |
+| Data loading | Each widget calls `api/dashboard/widget/:key?start&end` via `useFetcher` after mount; the home loader loads only layout + preference | Mirrors the five module dashboards; the home page SSR never waits on 20 queries. |
+| Data route permissions | `requirePermissions(request, { view: widget.module })` per request, resolved from the registry by key | The route's own permission check cannot be static because widgets span modules. Unknown key → 404; forbidden → 403. |
+| Delta vs prior period | Every `supportsRange` stat returns `{ value, previous }`; prior period = same length immediately before `start` | Same arithmetic as `sales.kpi.$key.ts`. `goal` decides whether an increase renders positive or negative. |
+| Stat formatting | `valueKind` picks the `@carbon/utils` formatter kind (`formatMoney` / `formatPercent` / `formatQuantity` / integer count) | `numeric-precision.md`: named kinds only, never inline fraction digits. Money uses the company base currency and `currency.decimalPlaces`. |
+| Charts | `@carbon/react/Chart` (`ChartContainer`, recharts `AreaChart`/`BarChart`) | Already used by module dashboards; no new dependency. |
+| Plan / edition gating | **None** (Q6) | User decision. All data is already visible on module dashboards to anyone with view permission. |
+| Module folder | New `apps/erp/app/modules/dashboard/` with no permission family | Cross-module by nature; `agent` is the precedent for a module folder without its own permission. Lesson "features live inside existing permission modules" is about *domain* features; every widget's data still belongs to its domain module's permission. |
+| New KPIs | `get_on_time_delivery`, `get_scrap_rate`, `get_first_pass_yield`, `get_open_backlog` as `security_invoker` SQL functions (Q5) | User decision: all four, limited to data that exists. Each is computable from current columns (see Data Model). Company-scoped via `companyId` argument and RLS on the underlying tables. |
+| Unknown / forbidden saved keys | Skipped silently on read; rows are never deleted by the reader | A widget removed from the registry or a revoked permission must not error the home page. |
+| Empty data | Widget renders the `Empty` component with a one-line prompt and its drill-down link | Cloudflare Teams Home pattern: empty state carries an action. |
+| Heuristic 1 multi-tenancy | `userDashboardWidget` and `userDashboardPreference` carry `companyId`; PK is the natural key `(widgetKey, userId, companyId)` / `(userId, companyId)` | Same as `reportPin` and `userModulePreference` — preference tables key on the natural tuple, not `id('prefix')`. |
+| Heuristic 2 service shape | `getDashboardLayout`, `upsertDashboardWidgets`, `upsertDashboardPreference`, one `getWidgetData` dispatcher — all `(client, …) → { data, error }` | Module convention. |
+| Heuristic 3 RLS | Owner-only policies on both tables, company membership via `get_companies_with_employee_role()` | Copied from `reportPin`. |
+| Heuristic 4 permissions | Home loader: `requirePermissions(request, {})`; layout API: `requirePermissions(request, {})` (own rows only); widget data: `{ view: widget.module }` | Personal preferences need no module permission; data does. |
+| Heuristic 5 forms | Edit mode posts JSON to `api/dashboard/layout` from a fetcher, no `ValidatedForm` | Same as `api/module-preferences`; a switch list is not a form. Payload validated with `dashboardLayoutValidator` (zod) in the action. |
+| Heuristic 6 module layout | `dashboard.models.ts`, `dashboard.service.ts`, `index.ts`, `ui/` | Convention. |
+| Heuristic 7 backward compatibility | No frozen surface touched; new tables, new route, new RPCs; existing KPI routes unchanged | Additive only. |
+
+## Data Model Changes
+
+### `userDashboardWidget`
+
+```sql
+-- Per-user show/hide override and optional range override for one dashboard
+-- widget. Widgets are static definitions keyed by slug in
+-- apps/erp/app/modules/dashboard/dashboard.models.ts, so, like reportPin, a row
+-- stores an EXPLICIT value and an absent row means the registry default.
+CREATE TABLE "userDashboardWidget" (
+    "widgetKey" TEXT NOT NULL,
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "visible" BOOLEAN NOT NULL,
+    "range" TEXT,                      -- per-widget override; NULL = follow page range
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("widgetKey", "userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardWidget_range_check"
+      CHECK ("range" IS NULL OR "range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+
+CREATE INDEX "userDashboardWidget_userId_companyId_idx"
+  ON "userDashboardWidget" ("userId", "companyId");
+
+ALTER TABLE "userDashboardWidget" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "SELECT" ON "userDashboardWidget" FOR SELECT USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+CREATE POLICY "INSERT" ON "userDashboardWidget" FOR INSERT WITH CHECK (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+CREATE POLICY "UPDATE" ON "userDashboardWidget" FOR UPDATE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+CREATE POLICY "DELETE" ON "userDashboardWidget" FOR DELETE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+```
+
+### `userDashboardPreference`
+
+```sql
+-- One row per user per company: the page-wide time range. Absent = '30d'.
+CREATE TABLE "userDashboardPreference" (
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "range" TEXT NOT NULL DEFAULT '30d',
+
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardPreference_range_check"
+      CHECK ("range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+-- RLS: identical four owner-only policies as userDashboardWidget.
+```
+
+### New RPCs (all `LANGUAGE sql STABLE SECURITY INVOKER`, args `(company_id TEXT, start_date DATE, end_date DATE)`)
+
+| Function | Definition | Source columns (verified) |
+|---|---|---|
+| `get_on_time_delivery` | `on_time / shipped` over `salesOrderLine` rows with `sentDate` in range and `promisedDate IS NOT NULL`; on time = `sentDate <= promisedDate`. Returns `(shipped INT, on_time INT)`. | `salesOrderLine.sentDate` (`20250209170952_shipment.sql`), `salesOrderLine.promisedDate` |
+| `get_scrap_rate` | `scrap / (production + scrap)` over `productionQuantity` rows with `createdAt` in range, by `type`. Returns `(production NUMERIC, scrap NUMERIC, rework NUMERIC)`. | `productionQuantity.type` enum `Production | Scrap | Rework`, `createdAt` |
+| `get_first_pass_yield` | `production / (production + rework + scrap)` from the same rows as `get_scrap_rate` — one function serves both widgets. | same |
+| `get_inspection_pass_rate` | `passed / (passed + failed)` over `inspection` with `dispositionedAt` in range (Passed vs Failed). Separate widget from production FPY. | `inspection.status` enum `inspectionStatusType`, `dispositionedAt` |
+| `get_open_backlog` | `SUM(quantityToSend × convertedUnitPrice)` over `openSalesOrderLines` (already filtered to `To Ship` / `To Ship and Invoice`), plus count of lines with `promisedDate < CURRENT company day`. Not range-driven (`supportsRange: false`). Returns `(value NUMERIC, lines INT, past_due_lines INT)`. | `openSalesOrderLines.quantityToSend`, `salesOrderLine.convertedUnitPrice` (base currency, generated) |
+
+Scrap rate and FPY are reported on **operation-level production quantities**, not job header `quantityScrapped`, because only `productionQuantity` carries a timestamp for windowing. Percentages are computed in TypeScript from the returned numerators and denominators with `round()` from `@carbon/utils` at internal scale; the SQL never divides.
+
+### Generated types
+
+`pnpm run generate:types` after the migration; both tables and all five functions must appear in `@carbon/database` before typecheck.
+
+## API / Service Changes
+
+### `apps/erp/app/modules/dashboard/dashboard.models.ts`
+
+- `DASHBOARD_RANGES = ["7d","30d","90d","mtd","qtd","ytd","12m"] as const` and `resolveDashboardRange(range, todayInCompanyTz): { start, end, previousStart, previousEnd }` using `@internationalized/date`.
+- `DASHBOARD_WIDGETS` registry (see catalog below) and `WidgetKey` union derived from it.
+- `dashboardLayoutValidator = z.object({ widgets: z.array(z.object({ key: z.enum(keys), visible: z.boolean(), range: z.enum(DASHBOARD_RANGES).nullable() })) })`.
+- `dashboardPreferenceValidator = z.object({ range: z.enum(DASHBOARD_RANGES) })`.
+- Payload types per kind: `StatPayload { value: number; previous?: number }`, `TrendPayload { points: { key: string; label: string; value: number }[] }`, `BreakdownPayload { rows: { name: string; value: number; to?: string }[] }`, `ListPayload { rows: { id: string; title: string; subtitle?: string; status?: string; dueDate?: string; to: string }[] }`.
+
+### `apps/erp/app/modules/dashboard/dashboard.service.ts`
+
+- `getDashboardLayout(client, userId, companyId)` → rows from `userDashboardWidget`.
+- `getDashboardPreference(client, userId, companyId)` → `maybeSingle()`.
+- `upsertDashboardWidgets(client, userId, companyId, rows)` → `upsert(..., { onConflict: "widgetKey,userId,companyId" })`.
+- `upsertDashboardPreference(client, userId, companyId, range)`.
+- `getWidgetData(client, { key, companyId, userId, start, end, previousStart, previousEnd })` → a `switch` on `key` that calls the per-widget query. Existing module service functions are reused where they exist (`getArAging`, `getApAging`, `get_inventory_valuation`, `getSalesDocumentsAssignedToMe`, the open-status constants from each module dashboard). The five new RPCs are called with `client.rpc(...)`.
+- `resolveDefaultLayout(permissions, rows)` (pure, tested): registry filtered by `permissions.can("view", module)`, visibility = row override ?? `defaultVisible`, range = row override ?? null.
+
+### Routes
+
+| Route | Method | Permission | Purpose |
+|---|---|---|---|
+| `x+/_index.tsx` (existing) | loader | `{}` | Adds `dashboard: { layout, range, today }` to loader data; nothing else changes. |
+| `api+/dashboard.widget.$key.ts` | GET | `{ view: widget.module }` resolved from the registry; 404 on unknown key | Parses `start`, `end` (`YYYY-MM-DD`), computes prior window, returns the kind's payload. Window capped at 500 days like the KPI routes. |
+| `api+/dashboard.layout.ts` | POST | `{}` | Validates `dashboardLayoutValidator`, calls `upsertDashboardWidgets`. Keys not in the registry are rejected with 400. |
+| `api+/dashboard.preference.ts` | POST | `{}` | Validates `dashboardPreferenceValidator`, upserts the page range. |
+
+`path.to.api.dashboardWidget(key)`, `path.to.api.dashboardLayout`, `path.to.api.dashboardPreference` added to `utils/path.ts`.
+
+### Widget catalog (v1)
+
+`defaultVisible` marks the curated first-render subset (Q4). All are filtered by the module's `view` permission.
+
+| Key | Module | Kind | Size | Range | Default | Source |
+|---|---|---|---|---|---|---|
+| `sales.openOrders` | sales | stat (count) | sm | no | ✓ | `salesOrder` count in `OPEN_SALES_ORDER_STATUSES` |
+| `sales.openQuotes` | sales | stat (count) | sm | no | ✓ | `quote` count in `OPEN_QUOTE_STATUSES` |
+| `sales.revenue` | sales | stat (money, goal higher) | sm | yes | ✓ | `salesOrders.orderTotal` by `orderDate` in range, with previous |
+| `sales.revenueTrend` | sales | trend | md | yes | ✓ | same, bucketed by day (≤ 90d) or month |
+| `sales.onTimeDelivery` | sales | stat (percent, goal higher) | sm | yes | ✓ | `get_on_time_delivery` |
+| `sales.openBacklog` | sales | stat (money) with "N lines past due" description | sm | no | ✓ | `get_open_backlog` |
+| `sales.assignedToMe` | sales | list | md | no | | `getSalesDocumentsAssignedToMe` |
+| `purchasing.openOrders` | purchasing | stat (count) | sm | no | ✓ | `purchaseOrder` open statuses |
+| `purchasing.overdueOrders` | purchasing | stat (count, goal lower) | sm | no | ✓ | open POs whose `purchaseOrderLine.promisedDate` < today with quantity outstanding |
+| `purchasing.spend` | purchasing | stat (money) | sm | yes | | `purchaseOrders` total by `orderDate` in range |
+| `purchasing.spendTrend` | purchasing | trend | md | yes | | same, bucketed |
+| `purchasing.bySupplier` | purchasing | breakdown | md | yes | | top 8 suppliers by PO total in range |
+| `purchasing.overdueList` | purchasing | list | md | no | ✓ | overdue POs, oldest first, max 8 |
+| `production.activeJobs` | production | stat (count) | sm | no | ✓ | `job` in `Ready | In Progress | Paused` |
+| `production.lateJobs` | production | stat (count, goal lower) | sm | no | ✓ | `job.dueDate < today` and not `Completed | Cancelled` |
+| `production.assignedToMe` | production | stat (count) | sm | no | | `get_active_job_count(userId, companyId)` |
+| `production.dueThisWeek` | production | list | md | no | ✓ | jobs with `dueDate` in the next 7 company days, max 8 |
+| `production.byStatus` | production | breakdown | md | no | | job count by status |
+| `production.utilization` | production | trend | md | yes | | reuse `production.kpi` `utilization` query |
+| `production.scrapRate` | production | stat (percent, goal lower) | sm | yes | ✓ | `get_scrap_rate` |
+| `production.firstPassYield` | production | stat (percent, goal higher) | sm | yes | | `get_scrap_rate` (production / total) |
+| `quality.openIssues` | quality | stat (count, goal lower) | sm | no | ✓ | `issues` view open statuses |
+| `quality.issuesTrend` | quality | trend | md | yes | | issues opened per bucket |
+| `quality.issuesByType` | quality | breakdown | md | yes | ✓ | reuse `quality.kpi` `paretoByType` query |
+| `quality.inspectionPassRate` | quality | stat (percent, goal higher) | sm | yes | | `get_inspection_pass_rate` |
+| `invoicing.arOutstanding` | invoicing | stat (money) | sm | no | ✓ | `getArAging` total |
+| `invoicing.arOverdue` | invoicing | stat (money, goal lower) | sm | no | ✓ | `getArAging` past-due buckets |
+| `invoicing.apOutstanding` | invoicing | stat (money) | sm | no | | `getApAging` total |
+| `invoicing.apOverdue` | invoicing | stat (money, goal lower) | sm | no | | `getApAging` past-due buckets |
+| `inventory.value` | inventory | stat (money) | sm | no | ✓ | `get_inventory_valuation` summed |
+| `workflows.failedRuns` | settings | stat (count, goal lower) | sm | yes | | `workflowRun` `Failed` with `completedAt` in range |
+
+`purchasing.overdueOrders` and `purchasing.overdueList` share one query. Money stats are in the company base currency (`convertedUnitPrice` / order totals already converted).
+
+## UI Changes
+
+All under `apps/erp/app/modules/dashboard/ui/`:
+
+- **`DashboardSection`** — rendered in `x+/_index.tsx` after the Modules/Recent grid, under a `SectionLabel` "Analytics". Header row: the label, `DashboardRangeSelect`, and an edit `IconButton` (pencil). Below it the widget grid `grid grid-cols-1 lg:grid-cols-3 gap-4`; `sm` = `col-span-1`, `md` = `lg:col-span-2`, `lg` = `lg:col-span-3`. Renders only visible widgets in registry order. If the user has hidden every widget, shows one `Empty` card with "Add widgets".
+- **`DashboardRangeSelect`** — a `Select` of the seven presets, labels via Lingui (`Last 7 days`, `Last 30 days`, `Last 90 days`, `Month to date`, `Quarter to date`, `Year to date`, `Last 12 months`). Writes `?range=` to the URL and POSTs to `api/dashboard/preference` via a fetcher; the URL wins on first render so a shared link is reproducible.
+- **`DashboardWidget`** — `Card` shell that owns the `useFetcher` load (`api/dashboard/widget/:key?start&end`), a `Skeleton` while loading, the `Empty` state, the drill-down `View` button (same `MetricCard` affordance), and, when `supportsRange`, a small per-widget range menu (kebab → the same seven presets plus "Follow page") that POSTs the override through `api/dashboard/layout`. A per-widget override shows as a muted caption under the title.
+- **Kind renderers** — `StatWidget` (reuses `MetricCard` layout; value formatted by `valueKind`; delta chip "▲ 12% vs prior 30 days" coloured by `goal`), `TrendWidget` (`ChartContainer` + recharts `AreaChart`, `groupDataByDay`/`groupDataByMonth` bucketing), `BreakdownWidget` (horizontal `BarChart`, top 8), `ListWidget` (up to 8 `Hyperlink` rows with status badge and relative due date).
+- **`DashboardCatalogDrawer`** — opened by the pencil. A `Drawer` listing every registry widget the user is permitted to see, grouped by module, each with a `Switch`. Toggling edits a draft; `Save` POSTs the full draft (one row per permitted widget) to `api/dashboard/layout`, `Cancel` discards. Same draft/dirty/save shape as `useNavigationEditMode`, minus drag-and-drop. Rows for widgets the user is not permitted to see are never written.
+- **Loader data** — `x+/_index.tsx` loader adds `getDashboardLayout`, `getDashboardPreference`, and `today` in the company timezone (already computed for the greeting). `resolveDefaultLayout` runs on the client with `usePermissions()`.
+
+No MES changes.
+
+## Acceptance Criteria
+
+- [ ] A user with `sales_view`, `production_view` and `quality_view` who has never customized opens `/x` and sees, below Modules and Recent, exactly the `defaultVisible` widgets for those three modules in registry order, and none from purchasing, invoicing, inventory or settings.
+- [ ] A user with no module `view` permission at all sees no Analytics section and no pencil.
+- [ ] Changing the page range from "Last 30 days" to "Quarter to date" updates the URL to `?range=qtd`, re-fetches every `supportsRange` widget, leaves "as of now" widgets untouched, and after a full reload the range is still "Quarter to date" from `userDashboardPreference`.
+- [ ] Setting a per-widget override of "Last 7 days" on `sales.revenue` while the page is on "Last 30 days" shows a "Last 7 days" caption on that card, fetches that widget with a 7-day window, and persists in `userDashboardWidget.range`.
+- [ ] Opening the catalog, switching `quality.openIssues` off and `invoicing.apOverdue` on, and saving writes two rows to `userDashboardWidget` (`visible=false`, `visible=true`), re-renders without a reload, and survives a reload.
+- [ ] Cancel in the catalog discards draft changes and writes nothing.
+- [ ] `GET /api/dashboard/widget/sales.revenue` by a user without `sales_view` returns 403; an unknown key returns 404; a window longer than 500 days returns an empty payload.
+- [ ] A row in `userDashboardWidget` whose key is not in the registry, or whose module the user can no longer view, is ignored and the page renders.
+- [ ] `sales.revenue` for a company with orders totalling 10,000 in the window and 8,000 in the prior window shows "10,000" and a positive "+25%" delta; with `goal: lower` widgets the same increase renders as negative.
+- [ ] `sales.onTimeDelivery` with 8 lines sent in range, of which 2 have no `promisedDate`, 4 were sent on or before their `promisedDate`, and 2 were sent after, shows "66.667%": the denominator is the 6 promised lines, never the 8 sent lines.
+- [ ] `production.scrapRate` with `productionQuantity` rows of 90 Production, 10 Scrap, 5 Rework in range shows "10%" and `production.firstPassYield` shows "85.71%" (percent kind, max 3 digits).
+- [ ] `sales.openBacklog` sums `quantityToSend × convertedUnitPrice` over open lines only and reports the count of lines with `promisedDate` before the company's current day.
+- [ ] Every money stat renders through the money formatter kind with the base currency's `decimalPlaces`; every percent through the percent kind; no inline fraction-digit options (`no-inline-fraction-digits` passes).
+- [ ] `pnpm run generate:types`, `pnpm exec turbo run typecheck --filter=erp`, `pnpm run lint`, and the `dashboard` unit tests (`resolveDashboardRange`, `resolveDefaultLayout`, delta sign) pass.
+- [ ] `pnpm db:check:datasets` and `pnpm db:check:backups` pass (new tables are company-scoped and included in backup/wipe discovery automatically).
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Home page issues up to ~15 fetches on mount for a user with many widgets | Med | Fetches are parallel and per-widget after SSR; each query is an indexed count or an existing RPC. Cap visible widgets at 16 in the catalog if load tests show contention; no caching layer in v1. |
+| `get_inventory_valuation` and the aging RPCs are heavier than a count | Med | They already back the invoicing and inventory pages; `inventory.value` is one call summed server-side. Mark these widgets `defaultVisible` only where the module dashboard already runs them on load. |
+| Timezone drift between "today" for open/late counts and the range window | Med | Both come from one `today` computed in the company timezone in the loader and passed as `start`/`end`; SQL never uses `CURRENT_DATE` (`.claude/rules/date-handling.md`). |
+| Registry key rename orphans saved rows | Low | Keys are namespaced and documented as stable; a rename ships with a migration that `UPDATE`s `widgetKey`. |
+| Per-widget override plus page range confuses users | Low | Override is shown as a caption on the card and can be cleared with "Follow page". |
+| Scrap/FPY defined on `productionQuantity` differs from job-header quantities on legacy data | Low | Definition is stated in the widget description tooltip; both widgets link to the production dashboard where the job-level view lives. |
+| Backlog value mixes currencies | Low | Uses `convertedUnitPrice`, a generated base-currency column; the widget is labelled with the base currency. |
+
+## Open Questions
+
+> Resolved with the user before this spec was written (spec-writing Step 5).
+
+- [x] Where does the dashboard sit on the home page? — **Answer:** At the bottom of `/x`, below the existing Recent and Modules grid, like Cloudflare's overview. Module cards and Recent are untouched.
+- [x] How much layout control does the user have? — **Answer:** Show/hide and drag-to-reorder (revised 2026-09-07 from show/hide only). Size is fixed by the registry. No resize.
+- [x] Are "hide" and "remove" one action? — **Answer:** One action (assumed with the user's tacit agreement when asked): a widget is shown or not, and hidden widgets are re-addable from the catalog. Layout row is `widgetKey` + `visible`.
+- [x] Time range model? — **Answer:** A page-wide range select shown to the user, persisted per user, **plus** a per-widget override.
+- [x] Default layout for a first-time user? — **Answer:** Curated subset via a `defaultVisible` flag on each registry entry, filtered by module permissions. Admin-published company defaults are a later spec.
+- [x] Which KPIs needing new SQL are in scope? — **Answer:** All of on-time delivery, scrap rate, first-pass yield, and backlog, limited to what existing data supports. Verified: all four are computable from `salesOrderLine.sentDate/promisedDate`, `productionQuantity.type/createdAt`, `openSalesOrderLines` + `convertedUnitPrice`; inbound inspection pass rate added as a fifth since `inspection.status/dispositionedAt` exist.
+- [x] Plan or edition gating? — **Answer:** None. Available to all.
+- [x] Initial catalog? — **Answer:** Ship the full proposed list (stats, trends, breakdowns, lists), as tabulated above.
+
+## Changelog
+
+- 2026-09-05: Created after research (`.ai/research/homepage-analytics-dashboard.md`) and an eight-question interview; all questions resolved before writing.
+- 2026-09-05: Implemented (migration `20260904202730_homepage-dashboard.sql`, `modules/dashboard/`, three `api+/dashboard.*` routes, home-page section). Deviations from the design text above: (1) the inspection KPI reads the `inspection` table (`inboundInspection` no longer exists) and is keyed `quality.inspectionPassRate`; (2) `production.utilization` is a per-work-center hours **breakdown**, not a trend, because the shared computation is per work center; (3) scrap rate and first-pass yield share one function, `get_production_quantity_summary`; (4) the registry's translatable copy and drill-down links live in `dashboard.labels.ts` and `dashboard.links.ts` so the registry stays importable from vitest.

--- a/apps/erp/app/modules/dashboard/AGENTS.md
+++ b/apps/erp/app/modules/dashboard/AGENTS.md
@@ -1,0 +1,60 @@
+# Dashboard Module — Agent Guide
+
+The **Analytics** section at the bottom of the ERP home page (`/x`): pre-built
+widgets (stat, trend, breakdown, list) that users show or hide, a page-wide time
+range with per-widget overrides, and five KPI SQL functions. No permission
+family of its own — every widget declares the module whose `view` permission
+gates it. Spec: `.ai/specs/2026-09-05-homepage-analytics-dashboard.md`.
+
+## Files
+
+| File | What it is |
+|---|---|
+| `dashboard.models.ts` | `DASHBOARD_RANGES` + `resolveDashboardRange` / `windowFromDates` (pure `@internationalized/date`), the `DASHBOARD_WIDGETS` registry, `resolveDashboardLayout`, `percentChange` / `ratioPercent`, zod validators, payload types. **Imports nothing from Lingui or `~/utils/path`** so vitest can load it. |
+| `dashboard.labels.ts` | `useWidgetLabels()` (title + description per key) and `useDashboardRangeLabels()` — React-macro `t` hooks. Vite-only. |
+| `dashboard.links.ts` | `widgetLinks`: drill-down `path.to.*` per key. Kept apart from the registry because `~/utils/path` pulls the glossary's `msg` macro. |
+| `dashboard.service.ts` | `getDashboardLayout`, `getDashboardPreference`, `upsertDashboardWidgets`, `upsertDashboardPreference`, and `getWidgetData` — one exhaustive `switch` arm per registry key (no `default`). |
+| `dashboard.models.test.ts` | Range arithmetic, layout resolution, delta math, validator cases. |
+| `ui/DashboardSection.tsx` | Rendered by `routes/x+/_index.tsx`; range select, "Add widgets" button, drag-to-reorder widget grid (dnd-kit), catalog drawer. |
+| `ui/DashboardWidget.tsx` | Card shell: per-widget `useFetcher` load, skeleton, drill-down link, range-override menu. |
+| `ui/{Stat,Trend,Breakdown,List}Widget.tsx` | Kind renderers. |
+| `ui/DashboardCatalogDrawer.tsx` | Show/hide switches grouped by module; Save posts the full layout. |
+
+Routes: `routes/api+/dashboard.widget.$key.ts` (GET, gated on the widget's module),
+`routes/api+/dashboard.layout.ts` and `routes/api+/dashboard.preference.ts` (POST
+JSON, personal rows only). Path helpers: `path.to.api.dashboardWidget(key)`,
+`.dashboardLayout`, `.dashboardPreference`.
+
+## Data
+
+- `userDashboardWidget (widgetKey, userId, companyId, visible, range)` — explicit
+  override per widget; absent row = the registry's `defaultVisible`, `range` null =
+  follow the page. `userDashboardPreference (userId, companyId, range)` — the page
+  range; absent = `30d`. Both owner-only RLS (`reportPin` pattern). Migration
+  `20260904202730_homepage-dashboard.sql`.
+- SQL functions (all `SECURITY INVOKER`, company id explicit, never divide):
+  `get_on_time_delivery`, `get_production_quantity_summary` (scrap rate + first-pass
+  yield), `get_inspection_pass_rate` (table `inspection`, `dispositionedAt`),
+  `get_open_backlog`, `get_overdue_purchase_orders`. Ratios are computed in the
+  service with `ratioPercent` (rounded once at internal scale).
+
+## Adding a widget
+
+1. Add the entry to `DASHBOARD_WIDGETS` (key namespaced by module, `module` = the
+   permission key, `kind`, `size`, `defaultVisible`, `supportsRange`, optional
+   `goal` / `valueKind`).
+2. Add its `useWidgetLabels` and `widgetLinks` entries — both are `Record<WidgetKey, …>`,
+   so typecheck fails until you do.
+3. Add the `switch` arm in `getWidgetData` — the switch has no `default`, so a
+   missing arm is a type error.
+4. Money values are base currency; percent values are 0–100 (the UI divides by
+   100 for the percent formatter); counts and quantities go through the quantity
+   formatter. Never inline fraction digits.
+
+## Rules
+
+- Every query scopes by `companyId`; "as of now" widgets take `today` from the
+  loader (company timezone), never `CURRENT_DATE`.
+- Unknown or now-forbidden keys in a saved layout are skipped by
+  `resolveDashboardLayout`, never deleted.
+- Drag-to-reorder saves `userDashboardPreference.widgetOrder` (the full key list, hidden widgets keep their slot); `resolveDashboardLayout` puts listed keys first, unlisted after in registry order. No resize: size is registry-fixed.

--- a/apps/erp/app/modules/dashboard/dashboard.labels.ts
+++ b/apps/erp/app/modules/dashboard/dashboard.labels.ts
@@ -1,0 +1,160 @@
+import { useLingui } from "@lingui/react/macro";
+import { useMemo } from "react";
+import type { DashboardRange, WidgetKey } from "./dashboard.models";
+
+// Translatable copy for the registry in dashboard.models.ts, as hooks: the
+// `t` macro is build-time babel, so it lives apart from the runtime registry
+// (which vitest / Node import untransformed), and the React macro is the
+// house form (test/i18n-react-macros.test.ts bans `t` in app files).
+
+export function useDashboardRangeLabels(): Record<DashboardRange, string> {
+  const { t } = useLingui();
+  return useMemo(
+    () => ({
+      "7d": t`Last 7 days`,
+      "30d": t`Last 30 days`,
+      "90d": t`Last 90 days`,
+      mtd: t`Month to date`,
+      qtd: t`Quarter to date`,
+      ytd: t`Year to date`,
+      "12m": t`Last 12 months`
+    }),
+    [t]
+  );
+}
+
+export function useWidgetLabels(): Record<
+  WidgetKey,
+  { title: string; description: string }
+> {
+  const { t } = useLingui();
+  return useMemo(
+    () => ({
+      "sales.openOrders": {
+        title: t`Open sales orders`,
+        description: t`Sales orders not yet shipped and invoiced`
+      },
+      "sales.openQuotes": {
+        title: t`Open quotes`,
+        description: t`Quotes in draft or sent to the customer`
+      },
+      "sales.revenue": {
+        title: t`Sales revenue`,
+        description: t`Total of sales orders placed in the period`
+      },
+      "sales.revenueTrend": {
+        title: t`Revenue trend`,
+        description: t`Sales order value over the period`
+      },
+      "sales.onTimeDelivery": {
+        title: t`On-time delivery`,
+        description: t`Lines shipped on or before their promised date`
+      },
+      "sales.openBacklog": {
+        title: t`Open backlog`,
+        description: t`Value still to ship on open sales orders`
+      },
+      "sales.assignedToMe": {
+        title: t`Sales documents assigned to me`,
+        description: t`Orders, quotes and RFQs where you are the assignee`
+      },
+      "purchasing.openOrders": {
+        title: t`Open purchase orders`,
+        description: t`Purchase orders not yet received and invoiced`
+      },
+      "purchasing.overdueOrders": {
+        title: t`Overdue purchase orders`,
+        description: t`Open orders with a line past its promised date`
+      },
+      "purchasing.spend": {
+        title: t`Purchase spend`,
+        description: t`Total of purchase orders placed in the period`
+      },
+      "purchasing.spendTrend": {
+        title: t`Spend trend`,
+        description: t`Purchase order value over the period`
+      },
+      "purchasing.bySupplier": {
+        title: t`Purchases by supplier`,
+        description: t`Top suppliers by purchase order value in the period`
+      },
+      "purchasing.overdueList": {
+        title: t`Overdue purchase orders`,
+        description: t`Oldest overdue orders first`
+      },
+      "production.activeJobs": {
+        title: t`Active jobs`,
+        description: t`Jobs planned, ready, in progress or paused`
+      },
+      "production.lateJobs": {
+        title: t`Late jobs`,
+        description: t`Active jobs past their due date`
+      },
+      "production.assignedToMe": {
+        title: t`My active operations`,
+        description: t`Operations you currently have running`
+      },
+      "production.dueThisWeek": {
+        title: t`Jobs due this week`,
+        description: t`Active jobs due in the next seven days`
+      },
+      "production.byStatus": {
+        title: t`Jobs by status`,
+        description: t`Active jobs grouped by status`
+      },
+      "production.utilization": {
+        title: t`Utilization`,
+        description: t`Hours of production time per work center in the period`
+      },
+      "production.scrapRate": {
+        title: t`Scrap rate`,
+        description: t`Scrap as a share of production plus scrap quantities`
+      },
+      "production.firstPassYield": {
+        title: t`First-pass yield`,
+        description: t`Production quantity without rework or scrap`
+      },
+      "quality.openIssues": {
+        title: t`Open issues`,
+        description: t`Registered and in-progress issues`
+      },
+      "quality.issuesTrend": {
+        title: t`Issues opened`,
+        description: t`New issues over the period`
+      },
+      "quality.issuesByType": {
+        title: t`Issues by type`,
+        description: t`Most frequent issue types in the period`
+      },
+      "quality.inspectionPassRate": {
+        title: t`Inspection pass rate`,
+        description: t`Inspections passed as a share of those dispositioned`
+      },
+      "invoicing.arOutstanding": {
+        title: t`AR outstanding`,
+        description: t`Customer balances not yet paid`
+      },
+      "invoicing.arOverdue": {
+        title: t`AR overdue`,
+        description: t`Customer balances past their due date`
+      },
+      "invoicing.apOutstanding": {
+        title: t`AP outstanding`,
+        description: t`Supplier balances not yet paid`
+      },
+      "invoicing.apOverdue": {
+        title: t`AP overdue`,
+        description: t`Supplier balances past their due date`
+      },
+      "inventory.value": {
+        title: t`Inventory value`,
+        description: t`On-hand inventory at cost`
+      },
+      "workflows.failedRuns": {
+        title: t`Failed workflow runs`,
+        description: t`Workflow runs that failed in the period`
+      }
+    }),
+    [t]
+  );
+}

--- a/apps/erp/app/modules/dashboard/dashboard.links.ts
+++ b/apps/erp/app/modules/dashboard/dashboard.links.ts
@@ -1,0 +1,39 @@
+import { path } from "~/utils/path";
+import type { WidgetKey } from "./dashboard.models";
+
+// Drill-down targets, kept out of dashboard.models.ts so the registry does not
+// import `~/utils/path` (which transitively pulls the glossary's Lingui `msg`
+// macro and breaks vitest / Node imports).
+export const widgetLinks: Record<WidgetKey, string> = {
+  "sales.openOrders": path.to.salesOrders,
+  "sales.openQuotes": path.to.quotes,
+  "sales.revenue": path.to.salesOrders,
+  "sales.revenueTrend": path.to.salesOrders,
+  "sales.onTimeDelivery": path.to.salesOrders,
+  "sales.openBacklog": path.to.salesOrders,
+  "sales.assignedToMe": path.to.sales,
+  "purchasing.openOrders": path.to.purchaseOrders,
+  "purchasing.overdueOrders": path.to.purchaseOrders,
+  "purchasing.spend": path.to.purchaseOrders,
+  "purchasing.spendTrend": path.to.purchaseOrders,
+  "purchasing.bySupplier": path.to.purchaseOrders,
+  "purchasing.overdueList": path.to.purchaseOrders,
+  "production.activeJobs": path.to.jobs,
+  "production.lateJobs": path.to.jobs,
+  "production.assignedToMe": path.to.jobs,
+  "production.dueThisWeek": path.to.jobs,
+  "production.byStatus": path.to.jobs,
+  "production.utilization": path.to.production,
+  "production.scrapRate": path.to.production,
+  "production.firstPassYield": path.to.production,
+  "quality.openIssues": path.to.issues,
+  "quality.issuesTrend": path.to.issues,
+  "quality.issuesByType": path.to.issues,
+  "quality.inspectionPassRate": path.to.quality,
+  "invoicing.arOutstanding": path.to.receivables,
+  "invoicing.arOverdue": path.to.receivables,
+  "invoicing.apOutstanding": path.to.payables,
+  "invoicing.apOverdue": path.to.payables,
+  "inventory.value": path.to.inventoryValuation,
+  "workflows.failedRuns": path.to.workflowRuns
+};

--- a/apps/erp/app/modules/dashboard/dashboard.models.test.ts
+++ b/apps/erp/app/modules/dashboard/dashboard.models.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+import {
+  DASHBOARD_WIDGETS,
+  dashboardLayoutValidator,
+  dashboardPreferenceValidator,
+  percentChange,
+  ratioPercent,
+  resolveDashboardLayout,
+  resolveDashboardRange
+} from "./dashboard.models";
+
+describe("resolveDashboardRange", () => {
+  it("30d ends today and spans 30 inclusive days, previous window abuts it", () => {
+    expect(resolveDashboardRange("30d", "2026-09-05")).toEqual({
+      start: "2026-08-07",
+      end: "2026-09-05",
+      previousStart: "2026-07-08",
+      previousEnd: "2026-08-06",
+      bucket: "day"
+    });
+  });
+
+  it("qtd starts on the first day of the calendar quarter", () => {
+    expect(resolveDashboardRange("qtd", "2026-09-05").start).toBe("2026-07-01");
+    expect(resolveDashboardRange("qtd", "2026-01-15").start).toBe("2026-01-01");
+    expect(resolveDashboardRange("qtd", "2026-12-31").start).toBe("2026-10-01");
+  });
+
+  it("mtd and ytd start on the 1st", () => {
+    expect(resolveDashboardRange("mtd", "2026-09-05").start).toBe("2026-09-01");
+    expect(resolveDashboardRange("ytd", "2026-09-05").start).toBe("2026-01-01");
+  });
+
+  it("12m spans a year and buckets by month", () => {
+    const w = resolveDashboardRange("12m", "2026-09-05");
+    expect(w.start).toBe("2025-09-06");
+    expect(w.bucket).toBe("month");
+  });
+
+  it("90d buckets by day, crossing a year boundary without drift", () => {
+    const w = resolveDashboardRange("90d", "2026-02-15");
+    expect(w.start).toBe("2025-11-18");
+    expect(w.bucket).toBe("day");
+  });
+});
+
+describe("resolveDashboardLayout", () => {
+  const canSalesOnly = (_a: "view", module: string) => module === "sales";
+
+  it("returns only widgets the user may view, in registry order", () => {
+    const widgets = resolveDashboardLayout(canSalesOnly, []);
+    expect(widgets.length).toBeGreaterThan(0);
+    expect(widgets.every((w) => w.module === "sales")).toBe(true);
+    expect(widgets.map((w) => w.key)).toEqual(
+      DASHBOARD_WIDGETS.filter((w) => w.module === "sales").map((w) => w.key)
+    );
+  });
+
+  it("uses defaultVisible when there is no row", () => {
+    const widgets = resolveDashboardLayout(canSalesOnly, []);
+    const open = widgets.find((w) => w.key === "sales.openOrders");
+    const mine = widgets.find((w) => w.key === "sales.assignedToMe");
+    expect(open?.visible).toBe(true);
+    expect(mine?.visible).toBe(false);
+  });
+
+  it("honours an explicit row and ignores unknown keys and bad ranges", () => {
+    const widgets = resolveDashboardLayout(canSalesOnly, [
+      { widgetKey: "sales.openOrders", visible: false, range: "7d" },
+      { widgetKey: "sales.revenue", visible: true, range: "bogus" },
+      { widgetKey: "does.notExist", visible: true, range: null }
+    ]);
+    const open = widgets.find((w) => w.key === "sales.openOrders");
+    const revenue = widgets.find((w) => w.key === "sales.revenue");
+    expect(open?.visible).toBe(false);
+    expect(open?.range).toBe("7d");
+    expect(revenue?.range).toBeNull();
+    expect(widgets.some((w) => w.key === "does.notExist")).toBe(false);
+  });
+
+  it("returns nothing for a user with no module permissions", () => {
+    expect(resolveDashboardLayout(() => false, [])).toEqual([]);
+  });
+
+  it("applies a saved order, then registry order for unlisted keys", () => {
+    const registry = DASHBOARD_WIDGETS.filter((w) => w.module === "sales").map(
+      (w) => w.key
+    );
+    const [a, b, c, ...rest] = registry;
+    const widgets = resolveDashboardLayout(canSalesOnly, [], [c, a]);
+    expect(widgets.map((w) => w.key)).toEqual([c, a, b, ...rest]);
+  });
+
+  it("ignores unknown and unpermitted keys in the saved order", () => {
+    const registry = DASHBOARD_WIDGETS.filter((w) => w.module === "sales").map(
+      (w) => w.key
+    );
+    const widgets = resolveDashboardLayout(
+      canSalesOnly,
+      [],
+      ["does.notExist", "production.activeJobs", registry[1]]
+    );
+    expect(widgets.map((w) => w.key)).toEqual([
+      registry[1],
+      registry[0],
+      ...registry.slice(2)
+    ]);
+  });
+});
+
+describe("dashboardPreferenceValidator", () => {
+  it("accepts a range, an order, or both — but not neither", () => {
+    expect(
+      dashboardPreferenceValidator.safeParse({ range: "7d" }).success
+    ).toBe(true);
+    expect(
+      dashboardPreferenceValidator.safeParse({
+        order: ["sales.revenue", "sales.openOrders"]
+      }).success
+    ).toBe(true);
+    expect(dashboardPreferenceValidator.safeParse({}).success).toBe(false);
+  });
+  it("rejects unknown keys in the order", () => {
+    expect(
+      dashboardPreferenceValidator.safeParse({ order: ["nope"] }).success
+    ).toBe(false);
+  });
+});
+
+describe("percentChange / ratioPercent", () => {
+  it("computes the delta vs the prior period", () => {
+    expect(percentChange(10000, 8000)).toBe(25);
+    expect(percentChange(8000, 10000)).toBe(-20);
+  });
+  it("is null with no prior value", () => {
+    expect(percentChange(5, 0)).toBeNull();
+  });
+  it("ratioPercent handles empty denominators and rounds at internal scale", () => {
+    expect(ratioPercent(0, 0)).toBe(0);
+    expect(ratioPercent(6, 6)).toBe(100);
+    expect(ratioPercent(4, 6)).toBe(66.66667);
+    expect(ratioPercent(90, 105)).toBe(85.71429);
+  });
+});
+
+describe("dashboardLayoutValidator", () => {
+  it("rejects unknown keys and ranges", () => {
+    expect(
+      dashboardLayoutValidator.safeParse({
+        widgets: [{ key: "nope", visible: true, range: null }]
+      }).success
+    ).toBe(false);
+    expect(
+      dashboardLayoutValidator.safeParse({
+        widgets: [{ key: "sales.openOrders", visible: true, range: "1d" }]
+      }).success
+    ).toBe(false);
+  });
+  it("accepts a valid layout", () => {
+    expect(
+      dashboardLayoutValidator.safeParse({
+        widgets: [{ key: "sales.openOrders", visible: false, range: "7d" }]
+      }).success
+    ).toBe(true);
+  });
+});

--- a/apps/erp/app/modules/dashboard/dashboard.models.ts
+++ b/apps/erp/app/modules/dashboard/dashboard.models.ts
@@ -1,0 +1,609 @@
+import { round } from "@carbon/utils";
+import {
+  CalendarDate,
+  parseDate,
+  startOfMonth,
+  startOfYear
+} from "@internationalized/date";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Time ranges
+// ---------------------------------------------------------------------------
+
+export const DASHBOARD_RANGES = [
+  "7d",
+  "30d",
+  "90d",
+  "mtd",
+  "qtd",
+  "ytd",
+  "12m"
+] as const;
+export type DashboardRange = (typeof DASHBOARD_RANGES)[number];
+export const DEFAULT_DASHBOARD_RANGE: DashboardRange = "30d";
+
+export function isDashboardRange(value: unknown): value is DashboardRange {
+  return (
+    typeof value === "string" &&
+    (DASHBOARD_RANGES as readonly string[]).includes(value)
+  );
+}
+
+export type DashboardWindow = {
+  /** Inclusive YYYY-MM-DD */
+  start: string;
+  /** Inclusive YYYY-MM-DD (= today) */
+  end: string;
+  previousStart: string;
+  previousEnd: string;
+  bucket: "day" | "month";
+};
+
+/** Ranges of this many days or more are bucketed by month in trend widgets. */
+const MONTH_BUCKET_THRESHOLD_DAYS = 92;
+
+/**
+ * Resolve a preset into an inclusive window ending on `today` (the company's
+ * calendar day, YYYY-MM-DD) plus the same-length window immediately before it.
+ * Pure calendar arithmetic — no JS Date.
+ */
+export function resolveDashboardRange(
+  range: DashboardRange,
+  today: string
+): DashboardWindow {
+  const end = parseDate(today);
+  let start: CalendarDate;
+  switch (range) {
+    case "7d":
+      start = end.subtract({ days: 6 });
+      break;
+    case "30d":
+      start = end.subtract({ days: 29 });
+      break;
+    case "90d":
+      start = end.subtract({ days: 89 });
+      break;
+    case "mtd":
+      start = startOfMonth(end);
+      break;
+    case "qtd": {
+      const quarterStartMonth = end.month - ((end.month - 1) % 3);
+      start = new CalendarDate(end.year, quarterStartMonth, 1);
+      break;
+    }
+    case "ytd":
+      start = startOfYear(end);
+      break;
+    case "12m":
+      start = end.subtract({ months: 12 }).add({ days: 1 });
+      break;
+  }
+  return windowFromDates(start, end);
+}
+
+/** The window for an explicit start/end pair (the widget API's contract). */
+export function windowFromDates(
+  start: CalendarDate,
+  end: CalendarDate
+): DashboardWindow {
+  const spanDays = end.compare(start); // whole days between, exclusive of end
+  const previousEnd = start.subtract({ days: 1 });
+  const previousStart = previousEnd.subtract({ days: spanDays });
+  return {
+    start: start.toString(),
+    end: end.toString(),
+    previousStart: previousStart.toString(),
+    previousEnd: previousEnd.toString(),
+    bucket: spanDays + 1 >= MONTH_BUCKET_THRESHOLD_DAYS ? "month" : "day"
+  };
+}
+
+/** Longest window the widget API will serve, matching the module KPI routes. */
+export const MAX_WINDOW_DAYS = 500;
+
+// ---------------------------------------------------------------------------
+// Widget registry
+// ---------------------------------------------------------------------------
+
+export type WidgetKind = "stat" | "trend" | "breakdown" | "list";
+/** sm = 1/3, md = 2/3, lg = full width of the home page's lg:grid-cols-3 grid. */
+export type WidgetSize = "sm" | "md" | "lg";
+/** Permission module keys as used by `useModules` / `permissions.can("view", …)`. */
+export type WidgetModule =
+  | "sales"
+  | "purchasing"
+  | "production"
+  | "quality"
+  | "invoicing"
+  | "inventory"
+  | "workflows";
+export type WidgetValueKind = "count" | "money" | "percent" | "quantity";
+
+export type WidgetDefinition = {
+  /** Stable, module-namespaced slug persisted in userDashboardWidget.widgetKey. */
+  key: string;
+  module: WidgetModule;
+  kind: WidgetKind;
+  size: WidgetSize;
+  /** Part of the curated first-render subset. */
+  defaultVisible: boolean;
+  /** false = "as of now" (open counts, aging, inventory value): ignores the range. */
+  supportsRange: boolean;
+  /** Which direction of change is good — colours the stat delta. */
+  goal?: "higher" | "lower";
+  /** Formatter kind for stat values. */
+  valueKind?: WidgetValueKind;
+};
+
+// Registry order is render order. Titles/descriptions live in
+// dashboard.labels.ts (Lingui `msg` is a build-time macro and must not be
+// imported by vitest / Node — see .ai/lessons.md "Lingui's msg macro").
+export const DASHBOARD_WIDGETS = [
+  // Sales
+  {
+    key: "sales.openOrders",
+    module: "sales",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "sales.openQuotes",
+    module: "sales",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "sales.revenue",
+    module: "sales",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: true,
+    goal: "higher",
+    valueKind: "money"
+  },
+  {
+    key: "sales.revenueTrend",
+    module: "sales",
+    kind: "trend",
+    size: "md",
+    defaultVisible: true,
+    supportsRange: true,
+    valueKind: "money"
+  },
+  {
+    key: "sales.onTimeDelivery",
+    module: "sales",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: true,
+    goal: "higher",
+    valueKind: "percent"
+  },
+  {
+    key: "sales.openBacklog",
+    module: "sales",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "money"
+  },
+  {
+    key: "sales.assignedToMe",
+    module: "sales",
+    kind: "list",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: false
+  },
+  // Purchasing
+  {
+    key: "purchasing.openOrders",
+    module: "purchasing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "purchasing.overdueOrders",
+    module: "purchasing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    goal: "lower",
+    valueKind: "count"
+  },
+  {
+    key: "purchasing.spend",
+    module: "purchasing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: true,
+    valueKind: "money"
+  },
+  {
+    key: "purchasing.spendTrend",
+    module: "purchasing",
+    kind: "trend",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: true,
+    valueKind: "money"
+  },
+  {
+    key: "purchasing.bySupplier",
+    module: "purchasing",
+    kind: "breakdown",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: true,
+    valueKind: "money"
+  },
+  {
+    key: "purchasing.overdueList",
+    module: "purchasing",
+    kind: "list",
+    size: "md",
+    defaultVisible: true,
+    supportsRange: false
+  },
+  // Production
+  {
+    key: "production.activeJobs",
+    module: "production",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "production.lateJobs",
+    module: "production",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    goal: "lower",
+    valueKind: "count"
+  },
+  {
+    key: "production.assignedToMe",
+    module: "production",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "production.dueThisWeek",
+    module: "production",
+    kind: "list",
+    size: "md",
+    defaultVisible: true,
+    supportsRange: false
+  },
+  {
+    key: "production.byStatus",
+    module: "production",
+    kind: "breakdown",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: false,
+    valueKind: "count"
+  },
+  {
+    key: "production.utilization",
+    module: "production",
+    kind: "breakdown",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: true,
+    valueKind: "quantity"
+  },
+  {
+    key: "production.scrapRate",
+    module: "production",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: true,
+    goal: "lower",
+    valueKind: "percent"
+  },
+  {
+    key: "production.firstPassYield",
+    module: "production",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: true,
+    goal: "higher",
+    valueKind: "percent"
+  },
+  // Quality
+  {
+    key: "quality.openIssues",
+    module: "quality",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    goal: "lower",
+    valueKind: "count"
+  },
+  {
+    key: "quality.issuesTrend",
+    module: "quality",
+    kind: "trend",
+    size: "md",
+    defaultVisible: false,
+    supportsRange: true,
+    valueKind: "count"
+  },
+  {
+    key: "quality.issuesByType",
+    module: "quality",
+    kind: "breakdown",
+    size: "md",
+    defaultVisible: true,
+    supportsRange: true,
+    valueKind: "count"
+  },
+  {
+    key: "quality.inspectionPassRate",
+    module: "quality",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: true,
+    goal: "higher",
+    valueKind: "percent"
+  },
+  // Invoicing
+  {
+    key: "invoicing.arOutstanding",
+    module: "invoicing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "money"
+  },
+  {
+    key: "invoicing.arOverdue",
+    module: "invoicing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    goal: "lower",
+    valueKind: "money"
+  },
+  {
+    key: "invoicing.apOutstanding",
+    module: "invoicing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: false,
+    valueKind: "money"
+  },
+  {
+    key: "invoicing.apOverdue",
+    module: "invoicing",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: false,
+    goal: "lower",
+    valueKind: "money"
+  },
+  // Inventory
+  {
+    key: "inventory.value",
+    module: "inventory",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: true,
+    supportsRange: false,
+    valueKind: "money"
+  },
+  // Workflows
+  {
+    key: "workflows.failedRuns",
+    module: "workflows",
+    kind: "stat",
+    size: "sm",
+    defaultVisible: false,
+    supportsRange: true,
+    goal: "lower",
+    valueKind: "count"
+  }
+] as const satisfies readonly WidgetDefinition[];
+
+export type WidgetKey = (typeof DASHBOARD_WIDGETS)[number]["key"];
+
+export const WIDGET_KEYS = DASHBOARD_WIDGETS.map((w) => w.key) as [
+  WidgetKey,
+  ...WidgetKey[]
+];
+
+export function isWidgetKey(value: unknown): value is WidgetKey {
+  return typeof value === "string" && (WIDGET_KEYS as string[]).includes(value);
+}
+
+export type RegisteredWidget = WidgetDefinition & { key: WidgetKey };
+
+export function getWidgetDefinition(key: string): RegisteredWidget | undefined {
+  return DASHBOARD_WIDGETS.find((w) => w.key === key);
+}
+
+// ---------------------------------------------------------------------------
+// Layout resolution
+// ---------------------------------------------------------------------------
+
+export type DashboardLayoutRow = {
+  widgetKey: string;
+  visible: boolean;
+  range: string | null;
+};
+
+export type ResolvedWidget = WidgetDefinition & {
+  visible: boolean;
+  /** Per-widget override; null = follow the page range. */
+  range: DashboardRange | null;
+};
+
+/**
+ * The widgets the user may view, with the user's explicit overrides applied,
+ * in the user's saved order. Keys in `order` come first in that order; keys
+ * not listed (never dragged, or added to the registry since) follow in
+ * registry order. Rows for unknown keys (a widget removed from the registry)
+ * or with an invalid range are ignored — a saved layout must never error the
+ * home page.
+ */
+export function resolveDashboardLayout(
+  can: (action: "view", module: string) => boolean | undefined,
+  rows: DashboardLayoutRow[],
+  order: string[] = []
+): ResolvedWidget[] {
+  const byKey = new Map(rows.map((r) => [r.widgetKey, r]));
+  const rank = new Map(order.map((key, index) => [key, index]));
+  return DASHBOARD_WIDGETS.filter((w) => can("view", w.module) === true)
+    .map((w, registryIndex) => {
+      const row = byKey.get(w.key);
+      return {
+        widget: {
+          ...w,
+          visible: row?.visible ?? w.defaultVisible,
+          range: isDashboardRange(row?.range) ? row.range : null
+        },
+        // Unlisted keys sort after every listed one, keeping registry order.
+        rank: rank.get(w.key) ?? order.length + registryIndex
+      };
+    })
+    .sort((a, b) => a.rank - b.rank)
+    .map(({ widget }) => widget);
+}
+
+/**
+ * Percent change vs the prior period, rounded at internal scale. null when
+ * there is no prior value to compare against (avoids a meaningless +∞).
+ */
+export function percentChange(value: number, previous: number): number | null {
+  if (!Number.isFinite(value) || !Number.isFinite(previous)) return null;
+  if (previous === 0) return null;
+  return round(((value - previous) / previous) * 100);
+}
+
+/** numerator / denominator as a percentage, or 0 when there is no denominator. */
+export function ratioPercent(numerator: number, denominator: number): number {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) return 0;
+  if (denominator === 0) return 0;
+  return round((numerator / denominator) * 100);
+}
+
+// ---------------------------------------------------------------------------
+// Validators (JSON bodies of the layout / preference API routes)
+// ---------------------------------------------------------------------------
+
+export const dashboardLayoutValidator = z.object({
+  widgets: z
+    .array(
+      z.object({
+        key: z.enum(WIDGET_KEYS),
+        visible: z.boolean(),
+        range: z.enum(DASHBOARD_RANGES).nullable()
+      })
+    )
+    .min(1)
+});
+export type DashboardLayoutInput = z.infer<typeof dashboardLayoutValidator>;
+
+/**
+ * A partial patch of the page-wide preference row: the range, the widget
+ * order, or both. `order` is the full key list in display order — the section
+ * posts every widget it resolved, so a hidden widget keeps its slot.
+ */
+export const dashboardPreferenceValidator = z
+  .object({
+    range: z.enum(DASHBOARD_RANGES).optional(),
+    order: z.array(z.enum(WIDGET_KEYS)).optional()
+  })
+  .refine((v) => v.range !== undefined || v.order !== undefined, {
+    message: "range or order is required"
+  });
+export type DashboardPreferenceInput = z.infer<
+  typeof dashboardPreferenceValidator
+>;
+
+// ---------------------------------------------------------------------------
+// Widget payloads (what the widget API returns per kind)
+// ---------------------------------------------------------------------------
+
+export type StatPayload = {
+  kind: "stat";
+  value: number;
+  /** Same measure over the previous window; absent for "as of now" stats. */
+  previous?: number;
+  /** A secondary count shown under the value (e.g. past-due backlog lines). */
+  detail?: number;
+  /** True when the denominator was empty, so 0 means "no data" not "0%". */
+  empty?: boolean;
+};
+
+export type TrendPayload = {
+  kind: "trend";
+  points: { key: string; label: string; value: number }[];
+};
+
+export type BreakdownPayload = {
+  kind: "breakdown";
+  rows: { name: string; value: number; to?: string }[];
+};
+
+export type ListPayload = {
+  kind: "list";
+  rows: {
+    id: string;
+    title: string;
+    subtitle?: string;
+    status?: string;
+    date?: string;
+    to: string;
+  }[];
+};
+
+export type WidgetPayload =
+  | StatPayload
+  | TrendPayload
+  | BreakdownPayload
+  | ListPayload;
+
+export function emptyPayload(kind: WidgetKind): WidgetPayload {
+  switch (kind) {
+    case "stat":
+      return { kind, value: 0, empty: true };
+    case "trend":
+      return { kind, points: [] };
+    case "breakdown":
+      return { kind, rows: [] };
+    case "list":
+      return { kind, rows: [] };
+  }
+}

--- a/apps/erp/app/modules/dashboard/dashboard.service.ts
+++ b/apps/erp/app/modules/dashboard/dashboard.service.ts
@@ -1,0 +1,740 @@
+import type { Database } from "@carbon/database";
+import { datetime, round } from "@carbon/utils";
+import { parseDate } from "@internationalized/date";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getInventoryValuation } from "~/modules/inventory/inventory.service";
+import { getApAging, getArAging } from "~/modules/invoicing/invoicing.service";
+import { ACTIVE_JOB_STATUSES } from "~/modules/production/production.models";
+import { getWorkCenterUtilization } from "~/modules/production/production.service";
+import { getSalesDocumentsAssignedToMe } from "~/modules/sales/sales.service";
+import { groupDataByDay, groupDataByMonth } from "~/utils/chart";
+import { path } from "~/utils/path";
+import type {
+  BreakdownPayload,
+  DashboardPreferenceInput,
+  DashboardRange,
+  DashboardWindow,
+  ListPayload,
+  StatPayload,
+  TrendPayload,
+  WidgetKey,
+  WidgetPayload
+} from "./dashboard.models";
+import { ratioPercent } from "./dashboard.models";
+
+// ---------------------------------------------------------------------------
+// Layout + preference (per user, per company; RLS restricts rows to the owner)
+// ---------------------------------------------------------------------------
+
+export async function getDashboardLayout(
+  client: SupabaseClient<Database>,
+  userId: string,
+  companyId: string
+) {
+  return client
+    .from("userDashboardWidget")
+    .select("widgetKey, visible, range")
+    .eq("userId", userId)
+    .eq("companyId", companyId);
+}
+
+export async function getDashboardPreference(
+  client: SupabaseClient<Database>,
+  userId: string,
+  companyId: string
+) {
+  return client
+    .from("userDashboardPreference")
+    .select("range, widgetOrder")
+    .eq("userId", userId)
+    .eq("companyId", companyId)
+    .maybeSingle();
+}
+
+export async function upsertDashboardWidgets(
+  client: SupabaseClient<Database>,
+  userId: string,
+  companyId: string,
+  widgets: { key: WidgetKey; visible: boolean; range: DashboardRange | null }[]
+) {
+  const now = datetime.timestamp();
+  return client.from("userDashboardWidget").upsert(
+    widgets.map((w) => ({
+      widgetKey: w.key,
+      userId,
+      companyId,
+      visible: w.visible,
+      range: w.range,
+      createdBy: userId,
+      updatedBy: userId,
+      updatedAt: now
+    })),
+    { onConflict: "widgetKey,userId,companyId" }
+  );
+}
+
+/**
+ * Patch the one preference row. Only the fields present are written, so a
+ * range change never resets the order and a drag never resets the range
+ * (an upsert updates only the columns it is given).
+ */
+export async function upsertDashboardPreference(
+  client: SupabaseClient<Database>,
+  userId: string,
+  companyId: string,
+  patch: DashboardPreferenceInput
+) {
+  return client.from("userDashboardPreference").upsert(
+    {
+      userId,
+      companyId,
+      ...(patch.range !== undefined ? { range: patch.range } : {}),
+      ...(patch.order !== undefined ? { widgetOrder: patch.order } : {}),
+      updatedAt: datetime.timestamp()
+    },
+    { onConflict: "userId,companyId" }
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Widget data
+// ---------------------------------------------------------------------------
+
+export type WidgetWindow = DashboardWindow & {
+  /** The company's current calendar day, YYYY-MM-DD — for "as of now" widgets. */
+  today: string;
+};
+
+// Status constants mirror the module dashboards so the home page and the
+// module page agree on what "open" means.
+// apps/erp/app/routes/x+/sales+/_index.tsx
+const OPEN_SALES_ORDER_STATUSES = [
+  "Confirmed",
+  "To Ship and Invoice",
+  "To Ship",
+  "To Invoice",
+  "Needs Approval",
+  "In Progress",
+  "Draft"
+] as const;
+const OPEN_QUOTE_STATUSES = ["Sent", "Draft"] as const;
+// apps/erp/app/routes/x+/purchasing+/_index.tsx
+const OPEN_PURCHASE_ORDER_STATUSES = [
+  "Draft",
+  "To Review",
+  "To Receive",
+  "To Receive and Invoice",
+  "Needs Approval",
+  "Planned",
+  "To Invoice"
+] as const;
+// apps/erp/app/routes/x+/quality+/_index.tsx
+const OPEN_ISSUE_STATUSES = ["Registered", "In Progress"] as const;
+
+/** Rows shown by a list widget, and bars in a breakdown. */
+const TOP_N = 8;
+const DAYS_IN_WEEK = 7;
+const MS_PER_HOUR = 3_600_000;
+
+const nextDay = (date: string) => parseDate(date).add({ days: 1 }).toString();
+
+const stat = (
+  value: number,
+  previous?: number,
+  extra?: Partial<StatPayload>
+): StatPayload => ({ kind: "stat", value, previous, ...extra });
+
+const sumBy = <T>(rows: T[] | null | undefined, pick: (row: T) => number) =>
+  (rows ?? []).reduce((sum, row) => sum + (pick(row) || 0), 0);
+
+function trendFrom<
+  T extends { orderDate?: string | null; openDate?: string | null }
+>(
+  rows: T[],
+  window: WidgetWindow,
+  groupBy: keyof T,
+  pick: (row: T) => number
+): TrendPayload {
+  const grouped =
+    window.bucket === "day"
+      ? groupDataByDay(rows, { start: window.start, end: window.end, groupBy })
+      : groupDataByMonth(rows, {
+          start: window.start,
+          end: window.end,
+          groupBy
+        });
+  return {
+    kind: "trend",
+    points: Object.entries(grouped).map(([key, bucketRows]) => ({
+      key,
+      label: key,
+      value: sumBy(bucketRows, pick)
+    }))
+  };
+}
+
+async function salesOrdersInWindow(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  start: string,
+  end: string
+) {
+  return client
+    .from("salesOrders")
+    .select("orderTotal, orderDate")
+    .eq("companyId", companyId)
+    .gte("orderDate", start)
+    .lte("orderDate", end);
+}
+
+async function purchaseOrdersInWindow(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  start: string,
+  end: string
+) {
+  return client
+    .from("purchaseOrders")
+    .select("orderTotal, orderDate, supplierId")
+    .eq("companyId", companyId)
+    .gte("orderDate", start)
+    .lte("orderDate", end);
+}
+
+async function issuesInWindow(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  start: string,
+  end: string
+) {
+  return client
+    .from("issues")
+    .select("id, openDate, nonConformanceTypeId")
+    .eq("companyId", companyId)
+    .gte("openDate", start)
+    .lte("openDate", end);
+}
+
+/** Count rows in a status set. The caller builds the query so each table keeps its own row type. */
+async function countOpen(query: PromiseLike<{ count: number | null }>) {
+  return (await query).count ?? 0;
+}
+
+const openCount = (client: SupabaseClient<Database>, companyId: string) => ({
+  salesOrders: () =>
+    countOpen(
+      client
+        .from("salesOrder")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", [...OPEN_SALES_ORDER_STATUSES])
+    ),
+  quotes: () =>
+    countOpen(
+      client
+        .from("quote")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", [...OPEN_QUOTE_STATUSES])
+    ),
+  purchaseOrders: () =>
+    countOpen(
+      client
+        .from("purchaseOrder")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", [...OPEN_PURCHASE_ORDER_STATUSES])
+    ),
+  jobs: () =>
+    countOpen(
+      client
+        .from("job")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", ACTIVE_JOB_STATUSES)
+    ),
+  issues: () =>
+    countOpen(
+      client
+        .from("issues")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", [...OPEN_ISSUE_STATUSES])
+    )
+});
+
+/** Sum of an aging RPC's rows. "Overdue" = every bucket past current. */
+function agingTotals(
+  rows:
+    | {
+        current: number | null;
+        bucket1: number | null;
+        bucket2: number | null;
+        bucket3: number | null;
+        bucket4: number | null;
+        total: number | null;
+      }[]
+    | null
+) {
+  const outstanding = sumBy(rows, (r) => Number(r.total ?? 0));
+  const overdue = sumBy(
+    rows,
+    (r) =>
+      Number(r.bucket1 ?? 0) +
+      Number(r.bucket2 ?? 0) +
+      Number(r.bucket3 ?? 0) +
+      Number(r.bucket4 ?? 0)
+  );
+  return { outstanding, overdue };
+}
+
+async function supplierNames(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  ids: string[]
+) {
+  if (ids.length === 0) return new Map<string, string>();
+  const result = await client
+    .from("supplier")
+    .select("id, name")
+    .eq("companyId", companyId)
+    .in("id", ids);
+  return new Map((result.data ?? []).map((s) => [s.id, s.name]));
+}
+
+/**
+ * The payload for one widget. One arm per registry key, no `default`, so a
+ * key added to the registry without an arm is a type error rather than a
+ * silent empty card (.ai/lessons.md: a default arm defeats exhaustiveness).
+ */
+export async function getWidgetData(
+  client: SupabaseClient<Database>,
+  args: {
+    key: WidgetKey;
+    companyId: string;
+    userId: string;
+    window: WidgetWindow;
+  }
+): Promise<WidgetPayload> {
+  const { key, companyId, userId, window } = args;
+  const { start, end, previousStart, previousEnd, today } = window;
+
+  switch (key) {
+    // ---------------------------------------------------------------- sales
+    case "sales.openOrders":
+      return stat(await openCount(client, companyId).salesOrders());
+
+    case "sales.openQuotes":
+      return stat(await openCount(client, companyId).quotes());
+
+    case "sales.revenue": {
+      const [current, previous] = await Promise.all([
+        salesOrdersInWindow(client, companyId, start, end),
+        salesOrdersInWindow(client, companyId, previousStart, previousEnd)
+      ]);
+      return stat(
+        sumBy(current.data, (r) => Number(r.orderTotal ?? 0)),
+        sumBy(previous.data, (r) => Number(r.orderTotal ?? 0))
+      );
+    }
+
+    case "sales.revenueTrend": {
+      const current = await salesOrdersInWindow(client, companyId, start, end);
+      return trendFrom(current.data ?? [], window, "orderDate", (r) =>
+        Number(r.orderTotal ?? 0)
+      );
+    }
+
+    case "sales.onTimeDelivery": {
+      const [current, previous] = await Promise.all([
+        client.rpc("get_on_time_delivery", {
+          company_id: companyId,
+          start_date: start,
+          end_date: end
+        }),
+        client.rpc("get_on_time_delivery", {
+          company_id: companyId,
+          start_date: previousStart,
+          end_date: previousEnd
+        })
+      ]);
+      const c = current.data?.[0];
+      const p = previous.data?.[0];
+      const shipped = Number(c?.shipped ?? 0);
+      return stat(
+        ratioPercent(Number(c?.onTime ?? 0), shipped),
+        ratioPercent(Number(p?.onTime ?? 0), Number(p?.shipped ?? 0)),
+        { empty: shipped === 0 }
+      );
+    }
+
+    case "sales.openBacklog": {
+      const result = await client.rpc("get_open_backlog", {
+        company_id: companyId,
+        as_of: today
+      });
+      const row = result.data?.[0];
+      return stat(Number(row?.value ?? 0), undefined, {
+        detail: Number(row?.pastDueLines ?? 0),
+        empty: Number(row?.lines ?? 0) === 0
+      });
+    }
+
+    case "sales.assignedToMe": {
+      const docs = await getSalesDocumentsAssignedToMe(
+        client,
+        userId,
+        companyId
+      );
+      const rows: ListPayload["rows"] = docs
+        .slice(-TOP_N)
+        .reverse()
+        .map((doc) => {
+          switch (doc.type) {
+            case "salesOrder":
+              return {
+                id: doc.id,
+                title:
+                  (doc as { salesOrderId?: string }).salesOrderId ?? doc.id,
+                status: doc.status ?? undefined,
+                date: doc.createdAt ?? undefined,
+                to: path.to.salesOrder(doc.id)
+              };
+            case "quote":
+              return {
+                id: doc.id,
+                title: (doc as { quoteId?: string }).quoteId ?? doc.id,
+                status: doc.status ?? undefined,
+                date: doc.createdAt ?? undefined,
+                to: path.to.quote(doc.id)
+              };
+            default:
+              return {
+                id: doc.id,
+                title: (doc as { rfqId?: string }).rfqId ?? doc.id,
+                status: doc.status ?? undefined,
+                date: doc.createdAt ?? undefined,
+                to: path.to.salesRfq(doc.id)
+              };
+          }
+        });
+      return { kind: "list", rows };
+    }
+
+    // ----------------------------------------------------------- purchasing
+    case "purchasing.openOrders":
+      return stat(await openCount(client, companyId).purchaseOrders());
+
+    case "purchasing.overdueOrders": {
+      const result = await client.rpc("get_overdue_purchase_orders", {
+        company_id: companyId,
+        as_of: today
+      });
+      return stat(result.data?.length ?? 0);
+    }
+
+    case "purchasing.overdueList": {
+      const result = await client.rpc("get_overdue_purchase_orders", {
+        company_id: companyId,
+        as_of: today
+      });
+      const top = (result.data ?? []).slice(0, TOP_N);
+      const names = await supplierNames(
+        client,
+        companyId,
+        top.map((r) => r.supplierId).filter((id): id is string => !!id)
+      );
+      return {
+        kind: "list",
+        rows: top.map((r) => ({
+          id: r.id,
+          title: r.purchaseOrderId,
+          subtitle: r.supplierId ? names.get(r.supplierId) : undefined,
+          date: r.earliestPromisedDate ?? undefined,
+          to: path.to.purchaseOrder(r.id)
+        }))
+      };
+    }
+
+    case "purchasing.spend": {
+      const [current, previous] = await Promise.all([
+        purchaseOrdersInWindow(client, companyId, start, end),
+        purchaseOrdersInWindow(client, companyId, previousStart, previousEnd)
+      ]);
+      return stat(
+        sumBy(current.data, (r) => Number(r.orderTotal ?? 0)),
+        sumBy(previous.data, (r) => Number(r.orderTotal ?? 0))
+      );
+    }
+
+    case "purchasing.spendTrend": {
+      const current = await purchaseOrdersInWindow(
+        client,
+        companyId,
+        start,
+        end
+      );
+      return trendFrom(current.data ?? [], window, "orderDate", (r) =>
+        Number(r.orderTotal ?? 0)
+      );
+    }
+
+    case "purchasing.bySupplier": {
+      const current = await purchaseOrdersInWindow(
+        client,
+        companyId,
+        start,
+        end
+      );
+      const totals = new Map<string, number>();
+      for (const row of current.data ?? []) {
+        if (!row.supplierId) continue;
+        totals.set(
+          row.supplierId,
+          (totals.get(row.supplierId) ?? 0) + Number(row.orderTotal ?? 0)
+        );
+      }
+      const top = [...totals.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, TOP_N);
+      const names = await supplierNames(
+        client,
+        companyId,
+        top.map(([id]) => id)
+      );
+      return {
+        kind: "breakdown",
+        rows: top.map(([id, value]) => ({
+          name: names.get(id) ?? id,
+          value
+        }))
+      };
+    }
+
+    // ----------------------------------------------------------- production
+    case "production.activeJobs":
+      return stat(await openCount(client, companyId).jobs());
+
+    case "production.lateJobs": {
+      const result = await client
+        .from("job")
+        .select("id", { count: "exact", head: true })
+        .eq("companyId", companyId)
+        .in("status", ACTIVE_JOB_STATUSES)
+        .lt("dueDate", today);
+      return stat(result.count ?? 0);
+    }
+
+    case "production.assignedToMe": {
+      const result = await client.rpc("get_active_job_count", {
+        employee_id: userId,
+        company_id: companyId
+      });
+      return stat(Number(result.data ?? 0));
+    }
+
+    case "production.dueThisWeek": {
+      const weekEnd = parseDate(today)
+        .add({ days: DAYS_IN_WEEK - 1 })
+        .toString();
+      const result = await client
+        .from("jobs")
+        .select("id, jobId, itemReadableIdWithRevision, dueDate, status")
+        .eq("companyId", companyId)
+        .in("status", ACTIVE_JOB_STATUSES)
+        .gte("dueDate", today)
+        .lte("dueDate", weekEnd)
+        .order("dueDate", { ascending: true })
+        .limit(TOP_N);
+      return {
+        kind: "list",
+        rows: (result.data ?? []).map((j) => ({
+          id: j.id!,
+          title: j.jobId ?? j.id!,
+          subtitle: j.itemReadableIdWithRevision ?? undefined,
+          status: j.status ?? undefined,
+          date: j.dueDate ?? undefined,
+          to: path.to.job(j.id!)
+        }))
+      };
+    }
+
+    case "production.byStatus": {
+      const result = await client
+        .from("job")
+        .select("status")
+        .eq("companyId", companyId)
+        .in("status", ACTIVE_JOB_STATUSES);
+      const counts = new Map<string, number>();
+      for (const row of result.data ?? []) {
+        counts.set(row.status, (counts.get(row.status) ?? 0) + 1);
+      }
+      return {
+        kind: "breakdown",
+        rows: ACTIVE_JOB_STATUSES.map((status) => ({
+          name: status,
+          value: counts.get(status) ?? 0
+        }))
+      };
+    }
+
+    case "production.utilization": {
+      const result = await getWorkCenterUtilization(client, companyId, {
+        start,
+        end,
+        previousStart,
+        previousEnd,
+        currentDate: datetime.timestamp()
+      });
+      return {
+        kind: "breakdown",
+        rows: result.data.slice(0, TOP_N).map((r) => ({
+          name: r.key,
+          value: round(r.value / MS_PER_HOUR)
+        }))
+      };
+    }
+
+    case "production.scrapRate":
+    case "production.firstPassYield": {
+      const [current, previous] = await Promise.all([
+        client.rpc("get_production_quantity_summary", {
+          company_id: companyId,
+          start_date: start,
+          end_date: end
+        }),
+        client.rpc("get_production_quantity_summary", {
+          company_id: companyId,
+          start_date: previousStart,
+          end_date: previousEnd
+        })
+      ]);
+      const c = current.data?.[0];
+      const p = previous.data?.[0];
+      const cp = Number(c?.production ?? 0);
+      const cs = Number(c?.scrap ?? 0);
+      const cr = Number(c?.rework ?? 0);
+      const pp = Number(p?.production ?? 0);
+      const ps = Number(p?.scrap ?? 0);
+      const pr = Number(p?.rework ?? 0);
+      if (key === "production.scrapRate") {
+        return stat(ratioPercent(cs, cp + cs), ratioPercent(ps, pp + ps), {
+          empty: cp + cs === 0
+        });
+      }
+      return stat(
+        ratioPercent(cp, cp + cr + cs),
+        ratioPercent(pp, pp + pr + ps),
+        { empty: cp + cr + cs === 0 }
+      );
+    }
+
+    // -------------------------------------------------------------- quality
+    case "quality.openIssues":
+      return stat(await openCount(client, companyId).issues());
+
+    case "quality.issuesTrend": {
+      const current = await issuesInWindow(client, companyId, start, end);
+      return trendFrom(current.data ?? [], window, "openDate", () => 1);
+    }
+
+    case "quality.issuesByType": {
+      const current = await issuesInWindow(client, companyId, start, end);
+      const counts = new Map<string, number>();
+      for (const row of current.data ?? []) {
+        const id = row.nonConformanceTypeId ?? "";
+        counts.set(id, (counts.get(id) ?? 0) + 1);
+      }
+      const ids = [...counts.keys()].filter(Boolean);
+      const types =
+        ids.length === 0
+          ? { data: [] as { id: string; name: string }[] }
+          : await client
+              .from("nonConformanceType")
+              .select("id, name")
+              .eq("companyId", companyId)
+              .in("id", ids);
+      const names = new Map((types.data ?? []).map((t) => [t.id, t.name]));
+      return {
+        kind: "breakdown",
+        rows: [...counts.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, TOP_N)
+          .map(([id, value]) => ({ name: names.get(id) ?? "Unknown", value }))
+      };
+    }
+
+    case "quality.inspectionPassRate": {
+      const [current, previous] = await Promise.all([
+        client.rpc("get_inspection_pass_rate", {
+          company_id: companyId,
+          start_date: start,
+          end_date: end
+        }),
+        client.rpc("get_inspection_pass_rate", {
+          company_id: companyId,
+          start_date: previousStart,
+          end_date: previousEnd
+        })
+      ]);
+      const c = current.data?.[0];
+      const p = previous.data?.[0];
+      const total = Number(c?.passed ?? 0) + Number(c?.failed ?? 0);
+      return stat(
+        ratioPercent(Number(c?.passed ?? 0), total),
+        ratioPercent(
+          Number(p?.passed ?? 0),
+          Number(p?.passed ?? 0) + Number(p?.failed ?? 0)
+        ),
+        { empty: total === 0 }
+      );
+    }
+
+    // ------------------------------------------------------------ invoicing
+    case "invoicing.arOutstanding":
+    case "invoicing.arOverdue": {
+      const aging = await getArAging(client, companyId, today, {});
+      const totals = agingTotals(aging.data);
+      return stat(
+        key === "invoicing.arOutstanding" ? totals.outstanding : totals.overdue
+      );
+    }
+
+    case "invoicing.apOutstanding":
+    case "invoicing.apOverdue": {
+      const aging = await getApAging(client, companyId, today, {});
+      const totals = agingTotals(aging.data);
+      return stat(
+        key === "invoicing.apOutstanding" ? totals.outstanding : totals.overdue
+      );
+    }
+
+    // ------------------------------------------------------------ inventory
+    case "inventory.value": {
+      const result = await getInventoryValuation(client, companyId, {
+        asOfDate: today
+      });
+      return stat(sumBy(result.data, (r) => Number(r.totalValue ?? 0)));
+    }
+
+    // ------------------------------------------------------------ workflows
+    case "workflows.failedRuns": {
+      const failedIn = (from: string, to: string) =>
+        client
+          .from("workflowRun")
+          .select("id", { count: "exact", head: true })
+          .eq("companyId", companyId)
+          .eq("status", "Failed")
+          .gte("completedAt", from)
+          .lt("completedAt", nextDay(to));
+      const [current, previous] = await Promise.all([
+        failedIn(start, end),
+        failedIn(previousStart, previousEnd)
+      ]);
+      return stat(current.count ?? 0, previous.count ?? 0);
+    }
+  }
+}
+
+// Keep the exported payload types reachable from the barrel for UI consumers.
+export type { BreakdownPayload, ListPayload, StatPayload, TrendPayload };

--- a/apps/erp/app/modules/dashboard/index.ts
+++ b/apps/erp/app/modules/dashboard/index.ts
@@ -1,0 +1,4 @@
+export * from "./dashboard.labels";
+export * from "./dashboard.links";
+export * from "./dashboard.models";
+export * from "./dashboard.service";

--- a/apps/erp/app/modules/dashboard/ui/BreakdownWidget.tsx
+++ b/apps/erp/app/modules/dashboard/ui/BreakdownWidget.tsx
@@ -1,0 +1,52 @@
+import type { ChartConfig } from "@carbon/react/Chart";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@carbon/react/Chart";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import { Empty } from "~/components";
+import type { BreakdownPayload } from "../dashboard.models";
+
+const chartConfig = {
+  value: { color: "hsl(var(--primary))" }
+} satisfies ChartConfig;
+
+export function BreakdownWidget({
+  payload,
+  formatValue
+}: {
+  payload: BreakdownPayload;
+  formatValue: (value: number) => string;
+}) {
+  if (payload.rows.length === 0 || payload.rows.every((r) => r.value === 0)) {
+    return <Empty className="h-40" />;
+  }
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-40 w-full">
+      <BarChart
+        data={payload.rows}
+        layout="vertical"
+        margin={{ left: 4, right: 4 }}
+      >
+        <XAxis type="number" hide />
+        <YAxis
+          dataKey="name"
+          type="category"
+          width={120}
+          tickLine={false}
+          axisLine={false}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={
+            <ChartTooltipContent
+              formatter={(value) => formatValue(Number(value))}
+            />
+          }
+        />
+        <Bar dataKey="value" fill="var(--color-value)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/DashboardCatalogDrawer.tsx
+++ b/apps/erp/app/modules/dashboard/ui/DashboardCatalogDrawer.tsx
@@ -1,0 +1,160 @@
+import {
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+  HStack,
+  Switch,
+  VStack
+} from "@carbon/react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { useEffect, useMemo, useState } from "react";
+import { useFetcher, useRevalidator } from "react-router";
+import { useAllModules } from "~/hooks";
+import { path } from "~/utils/path";
+import { useWidgetLabels } from "../dashboard.labels";
+import type { ResolvedWidget, WidgetKey } from "../dashboard.models";
+
+/**
+ * Show/hide every widget the user is permitted to see, grouped by module.
+ * Draft → Save writes one row per permitted widget (explicit values, so a
+ * later change to a registry default never flips a choice the user made).
+ */
+export function DashboardCatalogDrawer({
+  open,
+  onClose,
+  widgets
+}: {
+  open: boolean;
+  onClose: () => void;
+  widgets: ResolvedWidget[];
+}) {
+  const { t } = useLingui();
+  const widgetLabels = useWidgetLabels();
+  const fetcher = useFetcher<{ success?: boolean; error?: string }>();
+  const revalidator = useRevalidator();
+  const modules = useAllModules();
+
+  const [draft, setDraft] = useState<Record<string, boolean>>({});
+  useEffect(() => {
+    if (open) {
+      setDraft(Object.fromEntries(widgets.map((w) => [w.key, w.visible])));
+    }
+  }, [open, widgets]);
+
+  const isDirty = widgets.some((w) => draft[w.key] !== w.visible);
+  const isSaving = fetcher.state !== "idle";
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: close once the save settles
+  useEffect(() => {
+    if (fetcher.state === "idle" && fetcher.data?.success) {
+      revalidator.revalidate();
+      onClose();
+    }
+  }, [fetcher.state, fetcher.data]);
+
+  const groups = useMemo(() => {
+    const byModule = new Map<string, ResolvedWidget[]>();
+    for (const w of widgets) {
+      byModule.set(w.module, [...(byModule.get(w.module) ?? []), w]);
+    }
+    return [...byModule.entries()].map(([module, items]) => ({
+      module,
+      name:
+        modules.find((m) => m.key === module || m.permission === module)
+          ?.name ?? module,
+      items
+    }));
+  }, [widgets, modules]);
+
+  const save = () => {
+    fetcher.submit(
+      JSON.stringify({
+        widgets: widgets.map((w) => ({
+          key: w.key,
+          visible: draft[w.key] ?? w.visible,
+          range: w.range
+        }))
+      }),
+      {
+        method: "post",
+        action: path.to.api.dashboardLayout,
+        encType: "application/json"
+      }
+    );
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>
+            <Trans>Customize analytics</Trans>
+          </DrawerTitle>
+          <DrawerDescription>
+            <Trans>Choose which widgets appear on your home page.</Trans>
+          </DrawerDescription>
+        </DrawerHeader>
+        <DrawerBody>
+          <VStack spacing={4}>
+            {groups.map((group) => (
+              <VStack key={group.module} spacing={2}>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {group.name}
+                </h3>
+                {group.items.map((w) => {
+                  const labels = widgetLabels[w.key as WidgetKey];
+                  return (
+                    <label
+                      key={w.key}
+                      className="flex items-center justify-between gap-4 w-full py-1 cursor-pointer"
+                    >
+                      <span className="flex flex-col min-w-0">
+                        <span className="text-sm font-medium truncate">
+                          {labels.title}
+                        </span>
+                        <span className="text-xs text-muted-foreground truncate">
+                          {labels.description}
+                        </span>
+                      </span>
+                      <Switch
+                        checked={draft[w.key] ?? w.visible}
+                        onCheckedChange={(checked) =>
+                          setDraft((prev) => ({ ...prev, [w.key]: checked }))
+                        }
+                      />
+                    </label>
+                  );
+                })}
+              </VStack>
+            ))}
+          </VStack>
+        </DrawerBody>
+        <DrawerFooter>
+          <HStack>
+            <Button
+              variant="solid"
+              onClick={save}
+              isDisabled={!isDirty || isSaving}
+              isLoading={isSaving}
+            >
+              {t`Save`}
+            </Button>
+            <Button variant="secondary" onClick={onClose} isDisabled={isSaving}>
+              {t`Cancel`}
+            </Button>
+          </HStack>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/DashboardRangeSelect.tsx
+++ b/apps/erp/app/modules/dashboard/ui/DashboardRangeSelect.tsx
@@ -1,0 +1,48 @@
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  useUrlParams
+} from "@carbon/react";
+import { useFetcher } from "react-router";
+import { path } from "~/utils/path";
+import { useDashboardRangeLabels } from "../dashboard.labels";
+import type { DashboardRange } from "../dashboard.models";
+import { DASHBOARD_RANGES } from "../dashboard.models";
+
+/**
+ * Page-wide range. Writes `?range=` (so the URL is shareable and the loader
+ * picks it up on the next render) AND saves it as the user's preference.
+ */
+export function DashboardRangeSelect({ value }: { value: DashboardRange }) {
+  const rangeLabels = useDashboardRangeLabels();
+  const [, setParams] = useUrlParams();
+  const fetcher = useFetcher();
+
+  const onChange = (next: string) => {
+    if (next === value) return;
+    fetcher.submit(JSON.stringify({ range: next }), {
+      method: "post",
+      action: path.to.api.dashboardPreference,
+      encType: "application/json"
+    });
+    setParams({ range: next });
+  };
+
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger size="sm" className="w-44">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {DASHBOARD_RANGES.map((range) => (
+          <SelectItem key={range} value={range}>
+            {rangeLabels[range]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/DashboardSection.tsx
+++ b/apps/erp/app/modules/dashboard/ui/DashboardSection.tsx
@@ -1,0 +1,204 @@
+import { Button, Card, CardContent, cn } from "@carbon/react";
+import type { DragEndEvent } from "@dnd-kit/core";
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  rectSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Trans } from "@lingui/react/macro";
+import { useEffect, useMemo, useState } from "react";
+import { LuPlus } from "react-icons/lu";
+import { useFetcher } from "react-router";
+import { Empty } from "~/components";
+import { usePermissions } from "~/hooks";
+import { path } from "~/utils/path";
+import type {
+  DashboardLayoutRow,
+  DashboardRange,
+  ResolvedWidget,
+  WidgetSize
+} from "../dashboard.models";
+import { resolveDashboardLayout } from "../dashboard.models";
+import { DashboardCatalogDrawer } from "./DashboardCatalogDrawer";
+import { DashboardRangeSelect } from "./DashboardRangeSelect";
+import { DashboardWidget } from "./DashboardWidget";
+
+const SIZE_CLASS: Record<WidgetSize, string> = {
+  sm: "",
+  md: "lg:col-span-2",
+  lg: "lg:col-span-3"
+};
+
+/**
+ * The analytics area at the bottom of the home page: page-wide range select,
+ * an "Add widgets" button that opens the show/hide catalog, and the visible
+ * widgets on the same 3-column grid the rest of the page uses. Cards are
+ * dragged by their grip to reorder; the new order is saved immediately.
+ */
+export function DashboardSection({
+  rows,
+  order,
+  range,
+  today
+}: {
+  rows: DashboardLayoutRow[];
+  /** Saved widget keys in display order; empty = registry order. */
+  order: string[];
+  range: DashboardRange;
+  today: string;
+}) {
+  const permissions = usePermissions();
+  const [editing, setEditing] = useState(false);
+  const orderFetcher = useFetcher();
+
+  const resolved = useMemo(
+    () => resolveDashboardLayout(permissions.can, rows, order),
+    [permissions.can, rows, order]
+  );
+
+  // The order the grid renders: the server's until the user drags, then the
+  // dragged order until the loader revalidates with it saved. Resetting on a
+  // server change keeps a save from another tab from being overwritten.
+  const [widgets, setWidgets] = useState<ResolvedWidget[]>(resolved);
+  useEffect(() => {
+    setWidgets(resolved);
+  }, [resolved]);
+
+  const visible = widgets.filter((w) => w.visible);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  );
+
+  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+    if (!over || active.id === over.id) return;
+    // Move within the FULL list (hidden widgets keep their slots) so the
+    // saved order is the complete key list the resolver expects.
+    const from = widgets.findIndex((w) => w.key === active.id);
+    const to = widgets.findIndex((w) => w.key === over.id);
+    if (from === -1 || to === -1) return;
+    const next = arrayMove(widgets, from, to);
+    setWidgets(next);
+    orderFetcher.submit(JSON.stringify({ order: next.map((w) => w.key) }), {
+      method: "post",
+      action: path.to.api.dashboardPreference,
+      encType: "application/json"
+    });
+  };
+
+  // Nothing the user may view → no section, no controls.
+  if (widgets.length === 0) return null;
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center gap-3 mb-3">
+        <h2 className="text-base font-medium tracking-tight flex-1">
+          <Trans>Analytics</Trans>
+        </h2>
+        <DashboardRangeSelect value={range} />
+        <Button
+          variant="secondary"
+          size="sm"
+          leftIcon={<LuPlus />}
+          onClick={() => setEditing(true)}
+        >
+          <Trans>Add widgets</Trans>
+        </Button>
+      </div>
+      {visible.length === 0 ? (
+        <Card className="shadow-none">
+          <CardContent className="py-8">
+            <Empty>
+              <Button variant="secondary" onClick={() => setEditing(true)}>
+                <Trans>Add widgets</Trans>
+              </Button>
+            </Empty>
+          </CardContent>
+        </Card>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={visible.map((w) => w.key)}
+            strategy={rectSortingStrategy}
+          >
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+              {visible.map((widget) => (
+                <SortableWidget
+                  key={widget.key}
+                  widget={widget}
+                  pageRange={range}
+                  today={today}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+      <DashboardCatalogDrawer
+        open={editing}
+        onClose={() => setEditing(false)}
+        widgets={widgets}
+      />
+    </div>
+  );
+}
+
+function SortableWidget({
+  widget,
+  pageRange,
+  today
+}: {
+  widget: ResolvedWidget;
+  pageRange: DashboardRange;
+  today: string;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id: widget.key });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Translate.toString(transform),
+        transition: transition ?? undefined
+      }}
+      className={cn(
+        SIZE_CLASS[widget.size],
+        "transition-opacity duration-150",
+        isDragging && "z-10 opacity-60"
+      )}
+    >
+      <DashboardWidget
+        widget={widget}
+        pageRange={pageRange}
+        today={today}
+        dragHandle={{ ref: setActivatorNodeRef, attributes, listeners }}
+      />
+    </div>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/DashboardWidget.tsx
+++ b/apps/erp/app/modules/dashboard/ui/DashboardWidget.tsx
@@ -1,0 +1,261 @@
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  IconButton,
+  Skeleton
+} from "@carbon/react";
+import type { useSortable } from "@dnd-kit/sortable";
+import { useLingui } from "@lingui/react/macro";
+import { useEffect, useMemo } from "react";
+import {
+  LuArrowUpRight,
+  LuEllipsisVertical,
+  LuEyeOff,
+  LuGripVertical
+} from "react-icons/lu";
+import { Link, useFetcher, useRevalidator } from "react-router";
+import {
+  useCurrencyFormatter,
+  usePercentFormatter,
+  useQuantityFormatter
+} from "~/hooks";
+import { path } from "~/utils/path";
+import { useDashboardRangeLabels, useWidgetLabels } from "../dashboard.labels";
+import { widgetLinks } from "../dashboard.links";
+import type {
+  DashboardRange,
+  ResolvedWidget,
+  WidgetKey,
+  WidgetPayload
+} from "../dashboard.models";
+import { DASHBOARD_RANGES, resolveDashboardRange } from "../dashboard.models";
+import { BreakdownWidget } from "./BreakdownWidget";
+import { ListWidget } from "./ListWidget";
+import { StatWidget } from "./StatWidget";
+import { TrendWidget } from "./TrendWidget";
+
+const FOLLOW_PAGE = "__page__";
+
+/** What the sortable wrapper hands the card so its grip starts a drag. */
+export type WidgetDragHandle = {
+  ref: ReturnType<typeof useSortable>["setActivatorNodeRef"];
+  attributes: ReturnType<typeof useSortable>["attributes"];
+  listeners: ReturnType<typeof useSortable>["listeners"];
+};
+
+/**
+ * One card: owns the data fetch for its (possibly overridden) window, the
+ * loading/empty states, the drill-down link, the drag grip, and the menu
+ * (hide, and the per-widget range when the widget supports one).
+ */
+export function DashboardWidget({
+  widget,
+  pageRange,
+  today,
+  dragHandle
+}: {
+  widget: ResolvedWidget;
+  pageRange: DashboardRange;
+  today: string;
+  dragHandle?: WidgetDragHandle;
+}) {
+  const { t } = useLingui();
+  const rangeLabels = useDashboardRangeLabels();
+  const labels = useWidgetLabels()[widget.key as WidgetKey];
+  const fetcher = useFetcher<WidgetPayload>();
+  const layoutFetcher = useFetcher();
+  const revalidator = useRevalidator();
+
+  const effectiveRange = widget.range ?? pageRange;
+  const window = useMemo(
+    () => resolveDashboardRange(effectiveRange, today),
+    [effectiveRange, today]
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fetcher.load is stable; re-fetch only when the window changes
+  useEffect(() => {
+    fetcher.load(
+      `${path.to.api.dashboardWidget(widget.key)}?start=${window.start}&end=${window.end}&today=${today}`
+    );
+  }, [widget.key, window.start, window.end, today]);
+
+  const money = useCurrencyFormatter();
+  const percent = usePercentFormatter();
+  const quantity = useQuantityFormatter();
+  const formatValue = (value: number) => {
+    switch (widget.valueKind) {
+      case "money":
+        return money.format(value);
+      case "percent":
+        return percent.format(value / 100);
+      default:
+        return quantity(value);
+    }
+  };
+
+  const saveLayout = (visible: boolean, range: DashboardRange | null) => {
+    layoutFetcher.submit(
+      JSON.stringify({ widgets: [{ key: widget.key, visible, range }] }),
+      {
+        method: "post",
+        action: path.to.api.dashboardLayout,
+        encType: "application/json"
+      }
+    );
+  };
+
+  const setRange = (next: string) => {
+    const range = next === FOLLOW_PAGE ? null : (next as DashboardRange);
+    if (range === widget.range) return;
+    saveLayout(true, range);
+  };
+
+  // Hiding keeps the range override, so re-adding the widget from the
+  // catalog brings its window back.
+  const hide = () => saveLayout(false, widget.range);
+
+  // Once the override is saved, re-read the layout so the card re-fetches
+  // with its new window (or disappears, when hidden).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: revalidate only when the save settles
+  useEffect(() => {
+    if (layoutFetcher.state === "idle" && layoutFetcher.data) {
+      revalidator.revalidate();
+    }
+  }, [layoutFetcher.state, layoutFetcher.data]);
+
+  const isLoading = fetcher.state !== "idle" || !fetcher.data;
+  const to = widgetLinks[widget.key as keyof typeof widgetLinks];
+
+  return (
+    <Card className="shadow-none h-full">
+      <CardHeader className="flex-row items-start gap-2">
+        {dragHandle ? (
+          <button
+            type="button"
+            ref={dragHandle.ref}
+            aria-label={t`Drag to reorder`}
+            className="flex-shrink-0 -ml-2 -my-1 p-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted cursor-grab active:cursor-grabbing touch-none"
+            {...dragHandle.attributes}
+            {...dragHandle.listeners}
+          >
+            <LuGripVertical className="w-4 h-4" />
+          </button>
+        ) : null}
+        <div className="flex-1 min-w-0">
+          <CardTitle
+            className="truncate line-clamp-none"
+            title={labels.description}
+          >
+            {labels.title}
+          </CardTitle>
+          {widget.supportsRange && widget.range ? (
+            <span className="text-xs text-muted-foreground">
+              {rangeLabels[widget.range]}
+            </span>
+          ) : null}
+        </div>
+        {to ? (
+          <Button
+            asChild
+            variant="secondary"
+            size="sm"
+            rightIcon={<LuArrowUpRight />}
+            className="flex-shrink-0 -my-1"
+          >
+            <Link to={to}>{t`View`}</Link>
+          </Button>
+        ) : null}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <IconButton
+              aria-label={t`Widget options`}
+              icon={<LuEllipsisVertical />}
+              variant="ghost"
+              size="sm"
+              className="flex-shrink-0 -my-1"
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {widget.supportsRange ? (
+              <>
+                <DropdownMenuRadioGroup
+                  value={widget.range ?? FOLLOW_PAGE}
+                  onValueChange={setRange}
+                >
+                  <DropdownMenuRadioItem value={FOLLOW_PAGE}>
+                    {t`Follow page range`}
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuSeparator />
+                  {DASHBOARD_RANGES.map((range) => (
+                    <DropdownMenuRadioItem key={range} value={range}>
+                      {rangeLabels[range]}
+                    </DropdownMenuRadioItem>
+                  ))}
+                </DropdownMenuRadioGroup>
+                <DropdownMenuSeparator />
+              </>
+            ) : null}
+            <DropdownMenuItem onClick={hide}>
+              <LuEyeOff className="mr-2 w-4 h-4" />
+              {t`Hide widget`}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <WidgetSkeleton kind={widget.kind} />
+        ) : (
+          <WidgetBody
+            widget={widget}
+            payload={fetcher.data!}
+            formatValue={formatValue}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function WidgetSkeleton({ kind }: { kind: ResolvedWidget["kind"] }) {
+  if (kind === "stat") {
+    return (
+      <div className="flex flex-col gap-2">
+        <Skeleton className="h-10 w-2/3" />
+        <Skeleton className="h-3 w-1/3" />
+      </div>
+    );
+  }
+  return <Skeleton className="h-40 w-full" />;
+}
+
+function WidgetBody({
+  widget,
+  payload,
+  formatValue
+}: {
+  widget: ResolvedWidget;
+  payload: WidgetPayload;
+  formatValue: (value: number) => string;
+}) {
+  switch (payload.kind) {
+    case "stat":
+      return <StatWidget widget={widget} payload={payload} />;
+    case "trend":
+      return <TrendWidget payload={payload} formatValue={formatValue} />;
+    case "breakdown":
+      return <BreakdownWidget payload={payload} formatValue={formatValue} />;
+    case "list":
+      return <ListWidget payload={payload} />;
+  }
+}

--- a/apps/erp/app/modules/dashboard/ui/ListWidget.tsx
+++ b/apps/erp/app/modules/dashboard/ui/ListWidget.tsx
@@ -1,0 +1,51 @@
+import { Badge } from "@carbon/react";
+import { formatDate } from "@carbon/utils";
+import { useLocale } from "@react-aria/i18n";
+import { Link } from "react-router";
+import { Empty } from "~/components";
+import type { ListPayload } from "../dashboard.models";
+
+/** Up to eight rows styled like the home page's Recent list. */
+export function ListWidget({ payload }: { payload: ListPayload }) {
+  const { locale } = useLocale();
+  if (payload.rows.length === 0) {
+    return <Empty className="h-40" />;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {payload.rows.map((row) => (
+        <Link
+          key={row.id}
+          to={row.to}
+          prefetch="intent"
+          className="flex items-center gap-3 px-3 py-2 bg-muted/20 rounded-lg border border-border hover:border-foreground/20 transition-colors"
+        >
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-medium tracking-tight truncate">
+              {row.title}
+            </div>
+            {row.subtitle ? (
+              <div className="text-xs text-muted-foreground truncate">
+                {row.subtitle}
+              </div>
+            ) : null}
+          </div>
+          {row.status ? (
+            <Badge variant="secondary" className="shrink-0">
+              {row.status}
+            </Badge>
+          ) : null}
+          {row.date ? (
+            <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+              {formatDate(
+                row.date.slice(0, 10),
+                { month: "short", day: "numeric" },
+                locale
+              )}
+            </span>
+          ) : null}
+        </Link>
+      ))}
+    </div>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/StatWidget.tsx
+++ b/apps/erp/app/modules/dashboard/ui/StatWidget.tsx
@@ -1,0 +1,88 @@
+import { cn } from "@carbon/react";
+import { Trans } from "@lingui/react/macro";
+import { LuMoveDownRight, LuMoveUpRight } from "react-icons/lu";
+import {
+  useCurrencyFormatter,
+  usePercentFormatter,
+  useQuantityFormatter
+} from "~/hooks";
+import type {
+  ResolvedWidget,
+  StatPayload,
+  WidgetValueKind
+} from "../dashboard.models";
+import { percentChange } from "../dashboard.models";
+
+function useStatFormatter(kind: WidgetValueKind | undefined) {
+  const money = useCurrencyFormatter();
+  const percent = usePercentFormatter();
+  const quantity = useQuantityFormatter();
+  return (value: number) => {
+    switch (kind) {
+      case "money":
+        return money.format(value);
+      case "percent":
+        // Stored as a percentage (0–100); Intl percent style expects a fraction.
+        return percent.format(value / 100);
+      default:
+        return quantity(value);
+    }
+  };
+}
+
+/** Big number + delta vs the prior window, coloured by the widget's goal. */
+export function StatWidget({
+  widget,
+  payload
+}: {
+  widget: ResolvedWidget;
+  payload: StatPayload;
+}) {
+  const format = useStatFormatter(widget.valueKind);
+  const percent = usePercentFormatter();
+  const change =
+    payload.previous === undefined
+      ? null
+      : percentChange(payload.value, payload.previous);
+
+  // Positive change is good for "higher" goals, bad for "lower" ones; with no
+  // goal (or no prior value) the delta is informational only.
+  const tone =
+    change === null || change === 0 || !widget.goal
+      ? "neutral"
+      : change > 0 === (widget.goal === "higher")
+        ? "good"
+        : "bad";
+
+  return (
+    <div className="flex flex-col gap-1">
+      <h3 className="text-4xl font-medium tracking-tighter tabular-nums truncate">
+        {payload.empty && widget.valueKind === "percent"
+          ? "—"
+          : format(payload.value)}
+      </h3>
+      {change !== null ? (
+        <span
+          className={cn(
+            "flex items-center gap-1 text-xs tabular-nums",
+            tone === "good" && "text-emerald-600 dark:text-emerald-500",
+            tone === "bad" && "text-red-600 dark:text-red-500",
+            tone === "neutral" && "text-muted-foreground"
+          )}
+        >
+          {change > 0 ? (
+            <LuMoveUpRight className="size-3" />
+          ) : change < 0 ? (
+            <LuMoveDownRight className="size-3" />
+          ) : null}
+          {percent.format(Math.abs(change) / 100)}{" "}
+          <Trans>vs prior period</Trans>
+        </span>
+      ) : payload.detail !== undefined ? (
+        <span className="text-xs text-muted-foreground tabular-nums">
+          <Trans>{payload.detail} lines past due</Trans>
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/TrendWidget.tsx
+++ b/apps/erp/app/modules/dashboard/ui/TrendWidget.tsx
@@ -1,0 +1,59 @@
+import type { ChartConfig } from "@carbon/react/Chart";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent
+} from "@carbon/react/Chart";
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts";
+import { Empty } from "~/components";
+import type { TrendPayload } from "../dashboard.models";
+
+const chartConfig = {
+  value: { color: "hsl(var(--primary))" }
+} satisfies ChartConfig;
+
+export function TrendWidget({
+  payload,
+  formatValue
+}: {
+  payload: TrendPayload;
+  formatValue: (value: number) => string;
+}) {
+  if (
+    payload.points.length === 0 ||
+    payload.points.every((p) => p.value === 0)
+  ) {
+    return <Empty className="h-40" />;
+  }
+  return (
+    <ChartContainer config={chartConfig} className="aspect-auto h-40 w-full">
+      <AreaChart data={payload.points} margin={{ left: 4, right: 4 }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey="label"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={24}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={
+            <ChartTooltipContent
+              hideLabel={false}
+              formatter={(value) => formatValue(Number(value))}
+            />
+          }
+        />
+        <Area
+          dataKey="value"
+          type="monotone"
+          fill="var(--color-value)"
+          fillOpacity={0.15}
+          stroke="var(--color-value)"
+          strokeWidth={2}
+        />
+      </AreaChart>
+    </ChartContainer>
+  );
+}

--- a/apps/erp/app/modules/dashboard/ui/index.ts
+++ b/apps/erp/app/modules/dashboard/ui/index.ts
@@ -1,0 +1,1 @@
+export { DashboardSection } from "./DashboardSection";

--- a/apps/erp/app/modules/production/production.service.ts
+++ b/apps/erp/app/modules/production/production.service.ts
@@ -9285,3 +9285,137 @@ export async function completeOperation(
 
   return issue;
 }
+
+type UtilizationEvent = {
+  startTime: string;
+  endTime: string;
+  workCenterId: string;
+};
+
+/**
+ * Non-overlapping production-event time per active work center (ms) for the
+ * window and for the same-length window before it. Moved verbatim from the
+ * `utilization` case of api+/production.kpi.$key.ts so the homepage dashboard
+ * and the production dashboard compute the same number. `currentDate` closes
+ * still-running events.
+ */
+export async function getWorkCenterUtilization(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  args: {
+    start: string;
+    end: string;
+    previousStart: string;
+    previousEnd: string;
+    currentDate: string;
+  }
+): Promise<{
+  data: { key: string; value: number }[];
+  previousPeriodData: { key: string; value: number }[];
+}> {
+  const { start, end, previousStart, previousEnd, currentDate } = args;
+  const [workCenters, productionEvents, previousUtilizationEvents] =
+    await Promise.all([
+      client
+        .from("workCenter")
+        .select("id, name")
+        .eq("companyId", companyId)
+        .eq("active", true),
+      client
+        .from("productionEvent")
+        .select("startTime, endTime, workCenterId")
+        .eq("companyId", companyId)
+        .gte("startTime", start)
+        .or(`endTime.lte.${end},endTime.is.null`)
+        .order("startTime", { ascending: false })
+        .order("endTime", { ascending: false }),
+      client
+        .from("productionEvent")
+        .select("startTime, endTime, workCenterId")
+        .eq("companyId", companyId)
+        .gte("startTime", previousStart)
+        .or(`endTime.lte.${previousEnd},endTime.is.null`)
+        .order("startTime", { ascending: false })
+        .order("endTime", { ascending: false })
+    ]);
+
+  const [groupedEvents, previousGroupedEvents] = [
+    productionEvents.data ?? [],
+    previousUtilizationEvents.data ?? []
+  ].map((events) =>
+    events.reduce<Record<string, UtilizationEvent[]>>((acc, event) => {
+      if (!event.workCenterId) return acc;
+
+      if (!acc[event.workCenterId]) {
+        acc[event.workCenterId] = [];
+      }
+
+      acc[event.workCenterId].push({
+        ...event,
+        workCenterId: event.workCenterId!,
+        endTime: event.endTime === null ? currentDate : event.endTime
+      });
+      return acc;
+    }, {})
+  );
+
+  const [data, previousPeriodData] = [groupedEvents, previousGroupedEvents].map(
+    (events) =>
+      Object.entries(events)
+        .map(([workCenterId, events]) => {
+          const workCenter = workCenters.data?.find(
+            (wc) => wc.id === workCenterId
+          );
+          if (!workCenter) return { key: workCenterId, value: 0 };
+
+          // Sort events by start time, then end time if start times are equal
+          const sortedEvents = [...events].sort((a, b) => {
+            const aStart = new Date(a.startTime).getTime();
+            const bStart = new Date(b.startTime).getTime();
+            if (aStart !== bStart) return aStart - bStart;
+            return (
+              new Date(a.endTime).getTime() - new Date(b.endTime).getTime()
+            );
+          });
+
+          let totalTime = 0;
+          let lastEndTime: number | null = null;
+
+          // Calculate non-overlapping time
+          for (const event of sortedEvents) {
+            const startTime = new Date(event.startTime).getTime();
+            const endTime = new Date(event.endTime).getTime();
+
+            if (lastEndTime === null) {
+              totalTime += endTime - startTime;
+            } else {
+              // If this event starts after the last end time, add the full duration
+              if (startTime > lastEndTime) {
+                totalTime += endTime - startTime;
+              }
+              // If this event overlaps but ends later, add the non-overlapping portion
+              else if (endTime > lastEndTime) {
+                totalTime += endTime - lastEndTime;
+              }
+              // If this event is completely contained within the last event, skip it
+            }
+
+            // Update lastEndTime if this event ends later
+            if (lastEndTime === null || endTime > lastEndTime) {
+              lastEndTime = endTime;
+            }
+          }
+
+          return {
+            key: workCenter.name,
+            value: totalTime
+          };
+        })
+        .sort((a, b) => b.value - a.value)
+  );
+
+  return {
+    data,
+    previousPeriodData
+  };
+}

--- a/apps/erp/app/routes/api+/dashboard.layout.ts
+++ b/apps/erp/app/routes/api+/dashboard.layout.ts
@@ -1,0 +1,29 @@
+import { assertIsPost } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import { dashboardLayoutValidator } from "~/modules/dashboard/dashboard.models";
+import { upsertDashboardWidgets } from "~/modules/dashboard/dashboard.service";
+
+// Personal preference: no module permission, RLS restricts rows to the owner.
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, userId, companyId } = await requirePermissions(request, {});
+
+  const parsed = dashboardLayoutValidator.safeParse(await request.json());
+  if (!parsed.success) {
+    return data({ error: "Invalid layout" }, { status: 400 });
+  }
+
+  const result = await upsertDashboardWidgets(
+    client,
+    userId,
+    companyId,
+    parsed.data.widgets
+  );
+  if (result.error) {
+    return data({ error: result.error.message }, { status: 500 });
+  }
+
+  return data({ success: true });
+}

--- a/apps/erp/app/routes/api+/dashboard.preference.ts
+++ b/apps/erp/app/routes/api+/dashboard.preference.ts
@@ -1,0 +1,29 @@
+import { assertIsPost } from "@carbon/auth";
+import { requirePermissions } from "@carbon/auth/auth.server";
+import type { ActionFunctionArgs } from "react-router";
+import { data } from "react-router";
+import { dashboardPreferenceValidator } from "~/modules/dashboard/dashboard.models";
+import { upsertDashboardPreference } from "~/modules/dashboard/dashboard.service";
+
+// Personal preference: no module permission, RLS restricts rows to the owner.
+export async function action({ request }: ActionFunctionArgs) {
+  assertIsPost(request);
+  const { client, userId, companyId } = await requirePermissions(request, {});
+
+  const parsed = dashboardPreferenceValidator.safeParse(await request.json());
+  if (!parsed.success) {
+    return data({ error: "Invalid preference" }, { status: 400 });
+  }
+
+  const result = await upsertDashboardPreference(
+    client,
+    userId,
+    companyId,
+    parsed.data
+  );
+  if (result.error) {
+    return data({ error: result.error.message }, { status: 500 });
+  }
+
+  return data({ success: true });
+}

--- a/apps/erp/app/routes/api+/dashboard.widget.$key.ts
+++ b/apps/erp/app/routes/api+/dashboard.widget.$key.ts
@@ -1,0 +1,53 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { parseDate } from "@internationalized/date";
+import type { LoaderFunctionArgs } from "react-router";
+import { data } from "react-router";
+import {
+  emptyPayload,
+  getWidgetDefinition,
+  MAX_WINDOW_DAYS,
+  windowFromDates
+} from "~/modules/dashboard/dashboard.models";
+import { getWidgetData } from "~/modules/dashboard/dashboard.service";
+
+/**
+ * One widget's payload for an inclusive YYYY-MM-DD window. The permission
+ * gate is the widget's own module, resolved from the registry — the route
+ * cannot check a static module because widgets span modules. Unknown key →
+ * 404; a malformed or over-long window → the kind's empty payload.
+ */
+export async function loader({ request, params }: LoaderFunctionArgs) {
+  const definition = params.key ? getWidgetDefinition(params.key) : undefined;
+  if (!definition) {
+    throw data({ error: "Unknown widget" }, { status: 404 });
+  }
+
+  const { client, companyId, userId } = await requirePermissions(request, {
+    view: definition.module
+  });
+
+  const url = new URL(request.url);
+  const start = url.searchParams.get("start");
+  const end = url.searchParams.get("end");
+  const today = url.searchParams.get("today");
+
+  let window: ReturnType<typeof windowFromDates>;
+  try {
+    if (!start || !end || !today) throw new Error("missing window");
+    const startDate = parseDate(start);
+    const endDate = parseDate(end);
+    parseDate(today);
+    const span = endDate.compare(startDate);
+    if (span < 0 || span > MAX_WINDOW_DAYS) throw new Error("bad window");
+    window = windowFromDates(startDate, endDate);
+  } catch {
+    return emptyPayload(definition.kind);
+  }
+
+  return getWidgetData(client, {
+    key: definition.key,
+    companyId,
+    userId,
+    window: { ...window, today: today as string }
+  });
+}

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-metadata.json
@@ -1,6 +1,6 @@
 {
-  "generated": "2026-09-03T20:26:47.954Z",
-  "totalTools": 1495,
+  "generated": "2026-09-07T14:19:14.316Z",
+  "totalTools": 1496,
   "modules": 15,
   "tools": [
     {
@@ -27801,6 +27801,48 @@
         "required": [
           "operationId",
           "quantity"
+        ]
+      }
+    },
+    {
+      "name": "production_getWorkCenterUtilization",
+      "module": "production",
+      "classification": "READ",
+      "description": "get work center utilization",
+      "paramCount": 5,
+      "serviceParams": [
+        "client",
+        "companyId",
+        "args"
+      ],
+      "injectAuth": [
+        "companyId"
+      ],
+      "schema": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "string"
+          },
+          "end": {
+            "type": "string"
+          },
+          "previousStart": {
+            "type": "string"
+          },
+          "previousEnd": {
+            "type": "string"
+          },
+          "currentDate": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "previousStart",
+          "previousEnd",
+          "currentDate"
         ]
       }
     },

--- a/apps/erp/app/routes/api+/production.kpi.$key.ts
+++ b/apps/erp/app/routes/api+/production.kpi.$key.ts
@@ -6,13 +6,8 @@ import {
 } from "@internationalized/date";
 import type { LoaderFunctionArgs } from "react-router";
 import { KPIs } from "~/modules/production/production.models";
+import { getWorkCenterUtilization } from "~/modules/production/production.service";
 import { makeDurations } from "~/utils/duration";
-
-type ProductionEvent = {
-  startTime: string;
-  endTime: string;
-  workCenterId: string;
-};
 
 export async function loader({ request, params }: LoaderFunctionArgs) {
   const { client, companyId } = await requirePermissions(request, {
@@ -60,113 +55,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
 
   switch (kpi.key) {
     case "utilization": {
-      const [workCenters, productionEvents, previousProductionEvents] =
-        await Promise.all([
-          client
-            .from("workCenter")
-            .select("id, name")
-            .eq("companyId", companyId)
-            .eq("active", true),
-          client
-            .from("productionEvent")
-            .select("startTime, endTime, workCenterId")
-            .eq("companyId", companyId)
-            .gte("startTime", start)
-            .or(`endTime.lte.${end},endTime.is.null`)
-            .order("startTime", { ascending: false })
-            .order("endTime", { ascending: false }),
-          client
-            .from("productionEvent")
-            .select("startTime, endTime, workCenterId")
-            .eq("companyId", companyId)
-            .gte("startTime", previousStart.toString())
-            .or(`endTime.lte.${previousEnd.toString()},endTime.is.null`)
-            .order("startTime", { ascending: false })
-            .order("endTime", { ascending: false })
-        ]);
-
-      const [groupedEvents, previousGroupedEvents] = [
-        productionEvents.data ?? [],
-        previousProductionEvents.data ?? []
-      ].map((events) =>
-        events.reduce<Record<string, ProductionEvent[]>>((acc, event) => {
-          if (!event.workCenterId) return acc;
-
-          if (!acc[event.workCenterId]) {
-            acc[event.workCenterId] = [];
-          }
-
-          acc[event.workCenterId].push({
-            ...event,
-            workCenterId: event.workCenterId!,
-            endTime:
-              event.endTime === null ? currentDate.toString() : event.endTime
-          });
-          return acc;
-        }, {})
-      );
-
-      const [data, previousPeriodData] = [
-        groupedEvents,
-        previousGroupedEvents
-      ].map((events) =>
-        Object.entries(events)
-          .map(([workCenterId, events]) => {
-            const workCenter = workCenters.data?.find(
-              (wc) => wc.id === workCenterId
-            );
-            if (!workCenter) return { key: workCenterId, value: 0 };
-
-            // Sort events by start time, then end time if start times are equal
-            const sortedEvents = [...events].sort((a, b) => {
-              const aStart = new Date(a.startTime).getTime();
-              const bStart = new Date(b.startTime).getTime();
-              if (aStart !== bStart) return aStart - bStart;
-              return (
-                new Date(a.endTime).getTime() - new Date(b.endTime).getTime()
-              );
-            });
-
-            let totalTime = 0;
-            let lastEndTime: number | null = null;
-
-            // Calculate non-overlapping time
-            for (const event of sortedEvents) {
-              const startTime = new Date(event.startTime).getTime();
-              const endTime = new Date(event.endTime).getTime();
-
-              if (lastEndTime === null) {
-                totalTime += endTime - startTime;
-              } else {
-                // If this event starts after the last end time, add the full duration
-                if (startTime > lastEndTime) {
-                  totalTime += endTime - startTime;
-                }
-                // If this event overlaps but ends later, add the non-overlapping portion
-                else if (endTime > lastEndTime) {
-                  totalTime += endTime - lastEndTime;
-                }
-                // If this event is completely contained within the last event, skip it
-              }
-
-              // Update lastEndTime if this event ends later
-              if (lastEndTime === null || endTime > lastEndTime) {
-                lastEndTime = endTime;
-              }
-            }
-
-            return {
-              key: workCenter.name,
-              value: totalTime
-            };
-          })
-          .sort((a, b) => b.value - a.value)
-      );
-
-      return {
-        data,
-        previousPeriodData
-      };
+      return getWorkCenterUtilization(client, companyId, {
+        start,
+        end,
+        previousStart: previousStart.toString(),
+        previousEnd: previousEnd.toString(),
+        currentDate: currentDate.toString()
+      });
     }
     case "estimatesVsActuals": {
       const jobs = await client

--- a/apps/erp/app/routes/x+/_index.tsx
+++ b/apps/erp/app/routes/x+/_index.tsx
@@ -62,6 +62,16 @@ import {
 } from "~/hooks";
 import { useHubDismissed } from "~/hooks/useHubDismissed";
 import type { RecentDocument } from "~/hooks/useRecentlyViewed";
+import type { DashboardRange } from "~/modules/dashboard/dashboard.models";
+import {
+  DEFAULT_DASHBOARD_RANGE,
+  isDashboardRange
+} from "~/modules/dashboard/dashboard.models";
+import {
+  getDashboardLayout,
+  getDashboardPreference
+} from "~/modules/dashboard/dashboard.service";
+import { DashboardSection } from "~/modules/dashboard/ui";
 import { useUIStore } from "~/stores/ui";
 import type { Authenticated, NavItem } from "~/types";
 import { path } from "~/utils/path";
@@ -75,7 +85,7 @@ const AGENT_WIDGET_COOKIE = "onboardAgentDismissed";
 // finished) it surfaces as a primary-nav item (`useImplementationNavItem`) and a
 // summary card below — it never replaces the home page for anyone.
 export async function loader({ request }: LoaderFunctionArgs) {
-  const { client, companyId } = await requirePermissions(request, {});
+  const { client, companyId, userId } = await requirePermissions(request, {});
 
   // Compute the greeting on the server so SSR and hydration render the SAME
   // line — no client-side randomness, so no flash on refresh. `pick` is the
@@ -93,7 +103,31 @@ export async function loader({ request }: LoaderFunctionArgs) {
   const cookies = cookie.parse(request.headers.get("Cookie") ?? "");
   const agentDismissed = cookies[AGENT_WIDGET_COOKIE] === "1";
 
-  return { greeting, agentDismissed };
+  // Analytics widgets: the user's saved show/hide rows, drag order and
+  // page-wide range. The URL range wins over the saved one so a shared link is
+  // reproducible; widget data itself is fetched per widget on the client.
+  const [layout, preference] = await Promise.all([
+    getDashboardLayout(client, userId, companyId),
+    getDashboardPreference(client, userId, companyId)
+  ]);
+  const urlRange = new URL(request.url).searchParams.get("range");
+  const savedRange = preference.data?.range;
+  const range: DashboardRange = isDashboardRange(urlRange)
+    ? urlRange
+    : isDashboardRange(savedRange)
+      ? savedRange
+      : DEFAULT_DASHBOARD_RANGE;
+
+  return {
+    greeting,
+    agentDismissed,
+    dashboard: {
+      rows: layout.data ?? [],
+      order: preference.data?.widgetOrder ?? [],
+      range,
+      today: datetime.today(tz).toString()
+    }
+  };
 }
 
 const NO_SIGNALS: Signals = {
@@ -139,7 +173,8 @@ function useImplementationSummary() {
 }
 
 export default function AppIndexRoute() {
-  const { greeting, agentDismissed } = useLoaderData<typeof loader>();
+  const { greeting, agentDismissed, dashboard } =
+    useLoaderData<typeof loader>();
   const modules = useModules();
   const implementation = useImplementationSummary();
   const layout = useRouteData<{ implementationHub: unknown | null }>(
@@ -245,6 +280,12 @@ export default function AppIndexRoute() {
               </div>
             </div>
           </div>
+          <DashboardSection
+            rows={dashboard.rows}
+            order={dashboard.order}
+            range={dashboard.range}
+            today={dashboard.today}
+          />
         </div>
       </div>
     </div>

--- a/apps/erp/app/utils/path.ts
+++ b/apps/erp/app/utils/path.ts
@@ -107,8 +107,13 @@ export const path = {
         generatePath(`${api}/sales/customer-locations/${id}`),
       customerStatuses: `${api}/sales/customer-statuses`,
       customerTypes: `${api}/sales/customer-types`,
+
       customFieldOptions: (table: string, fieldId: string) =>
         generatePath(`${api}/settings/custom-fields/${table}/${fieldId}`),
+      dashboardLayout: `${api}/dashboard/layout`,
+      dashboardPreference: `${api}/dashboard/preference`,
+      dashboardWidget: (key: string) =>
+        generatePath(`${api}/dashboard/widget/${key}`),
       departments: `${api}/people/departments`,
       digitalQuote: (id: string) =>
         generatePath(`${api}/sales/digital-quote/${id}`),

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -38356,119 +38356,119 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "companies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "company"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "customFieldTables"
             referencedColumns: ["companyId"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "integrations"
             referencedColumns: ["companyId"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employeesAcrossCompanies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employeeSummary"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "user"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
           {
-            foreignKeyName: "procedureStep_procedureId_fkey"
+            foreignKeyName: "procedureAttribute_procedureId_fkey"
             columns: ["procedureId"]
             isOneToOne: false
             referencedRelation: "procedure"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_procedureId_fkey"
+            foreignKeyName: "procedureAttribute_procedureId_fkey"
             columns: ["procedureId"]
             isOneToOne: false
             referencedRelation: "procedures"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_unitOfMeasureCode_fkey"
+            foreignKeyName: "procedureAttribute_unitOfMeasureCode_fkey"
             columns: ["unitOfMeasureCode", "companyId"]
             isOneToOne: false
             referencedRelation: "unitOfMeasure"
             referencedColumns: ["code", "companyId"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employeesAcrossCompanies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employeeSummary"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "user"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
@@ -58940,6 +58940,267 @@ export type Database = {
           },
         ]
       }
+      userDashboardPreference: {
+        Row: {
+          companyId: string
+          createdAt: string
+          range: string
+          updatedAt: string | null
+          userId: string
+          widgetOrder: string[]
+        }
+        Insert: {
+          companyId: string
+          createdAt?: string
+          range?: string
+          updatedAt?: string | null
+          userId: string
+          widgetOrder?: string[]
+        }
+        Update: {
+          companyId?: string
+          createdAt?: string
+          range?: string
+          updatedAt?: string | null
+          userId?: string
+          widgetOrder?: string[]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
+      userDashboardWidget: {
+        Row: {
+          companyId: string
+          createdAt: string
+          createdBy: string
+          range: string | null
+          updatedAt: string | null
+          updatedBy: string | null
+          userId: string
+          visible: boolean
+          widgetKey: string
+        }
+        Insert: {
+          companyId: string
+          createdAt?: string
+          createdBy: string
+          range?: string | null
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userId: string
+          visible: boolean
+          widgetKey: string
+        }
+        Update: {
+          companyId?: string
+          createdAt?: string
+          createdBy?: string
+          range?: string | null
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userId?: string
+          visible?: boolean
+          widgetKey?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
       userModulePreference: {
         Row: {
           companyId: string
@@ -59166,6 +59427,21 @@ export type Database = {
             referencedColumns: ["userId"]
           },
         ]
+      }
+      v_readable_id: {
+        Row: {
+          companyId: string | null
+          readableId: string | null
+        }
+        Insert: {
+          companyId?: string | null
+          readableId?: string | null
+        }
+        Update: {
+          companyId?: string | null
+          readableId?: string | null
+        }
+        Relationships: []
       }
       warehouse: {
         Row: {
@@ -65574,7 +65850,6 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
-          readyAt: string | null
           reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
@@ -65627,7 +65902,6 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
-          readyAt?: string | null
           reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
@@ -65680,7 +65954,6 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
-          readyAt?: string | null
           reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
@@ -66003,7 +66276,6 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
-          readyAt: string | null
           reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
@@ -73517,13 +73789,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73532,6 +73797,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -74078,14 +74350,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78160,6 +78432,13 @@ export type Database = {
           targetTable: string
         }[]
       }
+      get_inspection_pass_rate: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          failed: number
+          passed: number
+        }[]
+      }
       get_integration_secret: {
         Args: { p_company_id: string; p_integration_id: string }
         Returns: Json
@@ -78689,6 +78968,21 @@ export type Database = {
         Args: { company_id: string; sequence_name: string }
         Returns: string
       }
+      get_on_time_delivery: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          onTime: number
+          shipped: number
+        }[]
+      }
+      get_open_backlog: {
+        Args: { as_of: string; company_id: string }
+        Returns: {
+          lines: number
+          pastDueLines: number
+          value: number
+        }[]
+      }
       get_opportunity_with_related_records: {
         Args: { opportunity_id: string }
         Returns: {
@@ -78709,6 +79003,16 @@ export type Database = {
           p_work_center_id: string
         }
         Returns: string
+      }
+      get_overdue_purchase_orders: {
+        Args: { as_of: string; company_id: string }
+        Returns: {
+          earliestPromisedDate: string
+          id: string
+          overdueLines: number
+          purchaseOrderId: string
+          supplierId: string
+        }[]
       }
       get_part_details: {
         Args: { item_id: string }
@@ -78975,6 +79279,14 @@ export type Database = {
           week7: number
           week8: number
           week9: number
+        }[]
+      }
+      get_production_quantity_summary: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          production: number
+          rework: number
+          scrap: number
         }[]
       }
       get_purchasing_planning: {

--- a/packages/database/supabase/functions/lib/types.ts
+++ b/packages/database/supabase/functions/lib/types.ts
@@ -38356,119 +38356,119 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "companies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "company"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "customFieldTables"
             referencedColumns: ["companyId"]
           },
           {
-            foreignKeyName: "procedureStep_companyId_fkey"
+            foreignKeyName: "procedureAttribute_companyId_fkey"
             columns: ["companyId"]
             isOneToOne: false
             referencedRelation: "integrations"
             referencedColumns: ["companyId"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employeesAcrossCompanies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "employeeSummary"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "user"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_createdBy_fkey"
+            foreignKeyName: "procedureAttribute_createdBy_fkey"
             columns: ["createdBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
             referencedColumns: ["userId"]
           },
           {
-            foreignKeyName: "procedureStep_procedureId_fkey"
+            foreignKeyName: "procedureAttribute_procedureId_fkey"
             columns: ["procedureId"]
             isOneToOne: false
             referencedRelation: "procedure"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_procedureId_fkey"
+            foreignKeyName: "procedureAttribute_procedureId_fkey"
             columns: ["procedureId"]
             isOneToOne: false
             referencedRelation: "procedures"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_unitOfMeasureCode_fkey"
+            foreignKeyName: "procedureAttribute_unitOfMeasureCode_fkey"
             columns: ["unitOfMeasureCode", "companyId"]
             isOneToOne: false
             referencedRelation: "unitOfMeasure"
             referencedColumns: ["code", "companyId"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employees"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employeesAcrossCompanies"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "employeeSummary"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "user"
             referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "procedureStep_updatedBy_fkey"
+            foreignKeyName: "procedureAttribute_updatedBy_fkey"
             columns: ["updatedBy"]
             isOneToOne: false
             referencedRelation: "userDefaults"
@@ -58940,6 +58940,267 @@ export type Database = {
           },
         ]
       }
+      userDashboardPreference: {
+        Row: {
+          companyId: string
+          createdAt: string
+          range: string
+          updatedAt: string | null
+          userId: string
+          widgetOrder: string[]
+        }
+        Insert: {
+          companyId: string
+          createdAt?: string
+          range?: string
+          updatedAt?: string | null
+          userId: string
+          widgetOrder?: string[]
+        }
+        Update: {
+          companyId?: string
+          createdAt?: string
+          range?: string
+          updatedAt?: string | null
+          userId?: string
+          widgetOrder?: string[]
+        }
+        Relationships: [
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardPreference_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
+      userDashboardWidget: {
+        Row: {
+          companyId: string
+          createdAt: string
+          createdBy: string
+          range: string | null
+          updatedAt: string | null
+          updatedBy: string | null
+          userId: string
+          visible: boolean
+          widgetKey: string
+        }
+        Insert: {
+          companyId: string
+          createdAt?: string
+          createdBy: string
+          range?: string | null
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userId: string
+          visible: boolean
+          widgetKey: string
+        }
+        Update: {
+          companyId?: string
+          createdAt?: string
+          createdBy?: string
+          range?: string | null
+          updatedAt?: string | null
+          updatedBy?: string | null
+          userId?: string
+          visible?: boolean
+          widgetKey?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "companies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "company"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "customFieldTables"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_companyId_fkey"
+            columns: ["companyId"]
+            isOneToOne: false
+            referencedRelation: "integrations"
+            referencedColumns: ["companyId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_createdBy_fkey"
+            columns: ["createdBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_updatedBy_fkey"
+            columns: ["updatedBy"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeesAcrossCompanies"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "employeeSummary"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "user"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "userDashboardWidget_userId_fkey"
+            columns: ["userId"]
+            isOneToOne: false
+            referencedRelation: "userDefaults"
+            referencedColumns: ["userId"]
+          },
+        ]
+      }
       userModulePreference: {
         Row: {
           companyId: string
@@ -59166,6 +59427,21 @@ export type Database = {
             referencedColumns: ["userId"]
           },
         ]
+      }
+      v_readable_id: {
+        Row: {
+          companyId: string | null
+          readableId: string | null
+        }
+        Insert: {
+          companyId?: string | null
+          readableId?: string | null
+        }
+        Update: {
+          companyId?: string | null
+          readableId?: string | null
+        }
+        Relationships: []
       }
       warehouse: {
         Row: {
@@ -65574,7 +65850,6 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
-          readyAt: string | null
           reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
@@ -65627,7 +65902,6 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
-          readyAt?: string | null
           reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
@@ -65680,7 +65954,6 @@ export type Database = {
           quantityComplete?: number | null
           quantityReworked?: number | null
           quantityScrapped?: number | null
-          readyAt?: string | null
           reworkId?: string | null
           setupTime?: number | null
           setupUnit?: Database["public"]["Enums"]["factor"] | null
@@ -66003,7 +66276,6 @@ export type Database = {
           quantityComplete: number | null
           quantityReworked: number | null
           quantityScrapped: number | null
-          readyAt: string | null
           reworkId: string | null
           setupTime: number | null
           setupUnit: Database["public"]["Enums"]["factor"] | null
@@ -73517,13 +73789,6 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["invoiceCountryCode"]
-            isOneToOne: false
-            referencedRelation: "country"
-            referencedColumns: ["alpha2"]
-          },
-          {
-            foreignKeyName: "address_countryCode_fkey"
             columns: ["shipmentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
@@ -73532,6 +73797,13 @@ export type Database = {
           {
             foreignKeyName: "address_countryCode_fkey"
             columns: ["customerCountryCode"]
+            isOneToOne: false
+            referencedRelation: "country"
+            referencedColumns: ["alpha2"]
+          },
+          {
+            foreignKeyName: "address_countryCode_fkey"
+            columns: ["invoiceCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -74078,14 +74350,14 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["paymentCountryCode"]
+            columns: ["customerCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
           },
           {
             foreignKeyName: "address_countryCode_fkey"
-            columns: ["customerCountryCode"]
+            columns: ["paymentCountryCode"]
             isOneToOne: false
             referencedRelation: "country"
             referencedColumns: ["alpha2"]
@@ -78160,6 +78432,13 @@ export type Database = {
           targetTable: string
         }[]
       }
+      get_inspection_pass_rate: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          failed: number
+          passed: number
+        }[]
+      }
       get_integration_secret: {
         Args: { p_company_id: string; p_integration_id: string }
         Returns: Json
@@ -78689,6 +78968,21 @@ export type Database = {
         Args: { company_id: string; sequence_name: string }
         Returns: string
       }
+      get_on_time_delivery: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          onTime: number
+          shipped: number
+        }[]
+      }
+      get_open_backlog: {
+        Args: { as_of: string; company_id: string }
+        Returns: {
+          lines: number
+          pastDueLines: number
+          value: number
+        }[]
+      }
       get_opportunity_with_related_records: {
         Args: { opportunity_id: string }
         Returns: {
@@ -78709,6 +79003,16 @@ export type Database = {
           p_work_center_id: string
         }
         Returns: string
+      }
+      get_overdue_purchase_orders: {
+        Args: { as_of: string; company_id: string }
+        Returns: {
+          earliestPromisedDate: string
+          id: string
+          overdueLines: number
+          purchaseOrderId: string
+          supplierId: string
+        }[]
       }
       get_part_details: {
         Args: { item_id: string }
@@ -78975,6 +79279,14 @@ export type Database = {
           week7: number
           week8: number
           week9: number
+        }[]
+      }
+      get_production_quantity_summary: {
+        Args: { company_id: string; end_date: string; start_date: string }
+        Returns: {
+          production: number
+          rework: number
+          scrap: number
         }[]
       }
       get_purchasing_planning: {

--- a/packages/database/supabase/migrations/20260904202730_homepage-dashboard.sql
+++ b/packages/database/supabase/migrations/20260904202730_homepage-dashboard.sql
@@ -1,0 +1,212 @@
+-- ============================================================
+-- Homepage analytics dashboard: per-user widget visibility + page range, and
+-- five read-only KPI functions for numbers Carbon never computed before.
+-- Widgets are static definitions keyed by slug in
+-- apps/erp/app/modules/dashboard/dashboard.models.ts, so, like reportPin, a row
+-- stores an EXPLICIT value and an absent row means the registry default.
+-- Spec: .ai/specs/2026-09-05-homepage-analytics-dashboard.md
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS "userDashboardWidget" (
+    "widgetKey" TEXT NOT NULL,
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "visible" BOOLEAN NOT NULL,
+    -- Per-widget override of the page-wide range; NULL = follow the page.
+    "range" TEXT,
+
+    "createdBy" TEXT NOT NULL REFERENCES "user"("id"),
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedBy" TEXT REFERENCES "user"("id"),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("widgetKey", "userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardWidget_range_check"
+      CHECK ("range" IS NULL OR "range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_userId_companyId_idx"
+  ON "userDashboardWidget" ("userId", "companyId");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_companyId_idx"
+  ON "userDashboardWidget" ("companyId");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_createdBy_idx"
+  ON "userDashboardWidget" ("createdBy");
+CREATE INDEX IF NOT EXISTS "userDashboardWidget_updatedBy_idx"
+  ON "userDashboardWidget" ("updatedBy");
+
+ALTER TABLE "public"."userDashboardWidget" ENABLE ROW LEVEL SECURITY;
+
+-- A personal UI preference: rows are visible/writable only by their owner,
+-- within companies the user belongs to (reportPin pattern).
+DROP POLICY IF EXISTS "SELECT" ON "public"."userDashboardWidget";
+CREATE POLICY "SELECT" ON "public"."userDashboardWidget" FOR SELECT USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."userDashboardWidget";
+CREATE POLICY "INSERT" ON "public"."userDashboardWidget" FOR INSERT WITH CHECK (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."userDashboardWidget";
+CREATE POLICY "UPDATE" ON "public"."userDashboardWidget" FOR UPDATE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."userDashboardWidget";
+CREATE POLICY "DELETE" ON "public"."userDashboardWidget" FOR DELETE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+-- One row per user per company: the page-wide time range. Absent = '30d'.
+CREATE TABLE IF NOT EXISTS "userDashboardPreference" (
+    "userId" TEXT NOT NULL REFERENCES "user"("id") ON DELETE CASCADE,
+    "companyId" TEXT NOT NULL,
+    "range" TEXT NOT NULL DEFAULT '30d',
+    -- Widget keys in the user's drag-and-drop order. Empty = registry order.
+    -- Keys not listed (added to the registry later) follow in registry order;
+    -- unknown keys (removed from the registry) are ignored on read.
+    "widgetOrder" TEXT[] NOT NULL DEFAULT '{}',
+
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE,
+
+    PRIMARY KEY ("userId", "companyId"),
+    FOREIGN KEY ("companyId") REFERENCES "company"("id") ON DELETE CASCADE,
+    CONSTRAINT "userDashboardPreference_range_check"
+      CHECK ("range" IN ('7d','30d','90d','mtd','qtd','ytd','12m'))
+);
+
+CREATE INDEX IF NOT EXISTS "userDashboardPreference_companyId_idx"
+  ON "userDashboardPreference" ("companyId");
+
+ALTER TABLE "public"."userDashboardPreference" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "SELECT" ON "public"."userDashboardPreference";
+CREATE POLICY "SELECT" ON "public"."userDashboardPreference" FOR SELECT USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "INSERT" ON "public"."userDashboardPreference";
+CREATE POLICY "INSERT" ON "public"."userDashboardPreference" FOR INSERT WITH CHECK (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "UPDATE" ON "public"."userDashboardPreference";
+CREATE POLICY "UPDATE" ON "public"."userDashboardPreference" FOR UPDATE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+DROP POLICY IF EXISTS "DELETE" ON "public"."userDashboardPreference";
+CREATE POLICY "DELETE" ON "public"."userDashboardPreference" FOR DELETE USING (
+  (SELECT auth.uid())::text = "userId"
+  AND "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+-- ------------------------------------------------------------
+-- KPI functions. All SECURITY INVOKER so RLS on the underlying tables applies;
+-- all take an explicit company id; none divides — the app computes the ratio
+-- (numeric-precision rule: round once, at the display boundary).
+-- ------------------------------------------------------------
+
+-- On-time delivery: sales order lines SENT in the window that carried a
+-- promise date. Lines with no promisedDate are excluded from both counts.
+CREATE OR REPLACE FUNCTION get_on_time_delivery(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("shipped" INTEGER, "onTime" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COUNT(*)::INTEGER AS "shipped",
+    COUNT(*) FILTER (WHERE "sentDate" <= "promisedDate")::INTEGER AS "onTime"
+  FROM "salesOrderLine"
+  WHERE "companyId" = company_id
+    AND "sentDate" IS NOT NULL
+    AND "promisedDate" IS NOT NULL
+    AND "sentDate" >= start_date
+    AND "sentDate" <= end_date;
+$$;
+
+-- Production quantities recorded in the window, split by type. Serves both the
+-- scrap-rate widget (scrap / (production + scrap)) and first-pass yield
+-- (production / (production + rework + scrap)).
+CREATE OR REPLACE FUNCTION get_production_quantity_summary(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("production" NUMERIC, "scrap" NUMERIC, "rework" NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Production'), 0)::NUMERIC AS "production",
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Scrap'), 0)::NUMERIC AS "scrap",
+    COALESCE(SUM("quantity") FILTER (WHERE "type" = 'Rework'), 0)::NUMERIC AS "rework"
+  FROM "productionQuantity"
+  WHERE "companyId" = company_id
+    AND "createdAt" >= start_date::TIMESTAMPTZ
+    AND "createdAt" < (end_date + 1)::TIMESTAMPTZ;
+$$;
+
+-- Inspections dispositioned (passed or failed) in the window.
+CREATE OR REPLACE FUNCTION get_inspection_pass_rate(
+  company_id TEXT, start_date DATE, end_date DATE
+)
+RETURNS TABLE ("passed" INTEGER, "failed" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COUNT(*) FILTER (WHERE "status" = 'Passed')::INTEGER AS "passed",
+    COUNT(*) FILTER (WHERE "status" = 'Failed')::INTEGER AS "failed"
+  FROM "inspection"
+  WHERE "companyId" = company_id
+    AND "dispositionedAt" IS NOT NULL
+    AND "dispositionedAt" >= start_date::TIMESTAMPTZ
+    AND "dispositionedAt" < (end_date + 1)::TIMESTAMPTZ;
+$$;
+
+-- Open backlog: value still to ship on open sales orders, in base currency
+-- (convertedUnitPrice is unitPrice × exchangeRate, generated). as_of is the
+-- company's current day, passed in by the caller — never CURRENT_DATE.
+CREATE OR REPLACE FUNCTION get_open_backlog(company_id TEXT, as_of DATE)
+RETURNS TABLE ("value" NUMERIC, "lines" INTEGER, "pastDueLines" INTEGER)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    COALESCE(SUM(o."quantityToSend" * COALESCE(sol."convertedUnitPrice", 0)), 0)::NUMERIC AS "value",
+    COUNT(*)::INTEGER AS "lines",
+    COUNT(*) FILTER (WHERE o."promisedDate" IS NOT NULL AND o."promisedDate" < as_of)::INTEGER AS "pastDueLines"
+  FROM "openSalesOrderLines" o
+  JOIN "salesOrderLine" sol ON sol."id" = o."id" AND sol."companyId" = o."companyId"
+  WHERE o."companyId" = company_id
+    AND o."quantityToSend" > 0;
+$$;
+
+-- Overdue purchase orders: open POs with at least one line past its promised
+-- date and quantity still outstanding. One row per PO for the list widget;
+-- the stat widget counts the rows.
+CREATE OR REPLACE FUNCTION get_overdue_purchase_orders(company_id TEXT, as_of DATE)
+RETURNS TABLE (
+  "id" TEXT, "purchaseOrderId" TEXT, "supplierId" TEXT,
+  "earliestPromisedDate" DATE, "overdueLines" INTEGER
+)
+LANGUAGE sql STABLE SECURITY INVOKER
+AS $$
+  SELECT
+    po."id",
+    po."purchaseOrderId",
+    po."supplierId",
+    MIN(pol."promisedDate") AS "earliestPromisedDate",
+    COUNT(*)::INTEGER AS "overdueLines"
+  FROM "purchaseOrder" po
+  JOIN "purchaseOrderLine" pol
+    ON pol."purchaseOrderId" = po."id" AND pol."companyId" = po."companyId"
+  WHERE po."companyId" = company_id
+    AND po."status" IN ('To Receive', 'To Receive and Invoice')
+    AND pol."promisedDate" IS NOT NULL
+    AND pol."promisedDate" < as_of
+    AND COALESCE(pol."purchaseQuantity", 0) - COALESCE(pol."quantityReceived", 0) > 0
+  GROUP BY po."id", po."purchaseOrderId", po."supplierId"
+  ORDER BY MIN(pol."promisedDate") ASC;
+$$;

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} Entwurfs-Buchungszeilen"
 msgid "{0} jobs created"
 msgstr "{0} Fertigungsaufträge erstellt"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} Positionen überfällig"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} Zeilen zum Zuordnen"
@@ -1095,8 +1099,20 @@ msgstr "Aktivierungsgebühr · wir beraten"
 msgid "Active"
 msgstr "Aktiv"
 
+msgid "Active jobs"
+msgstr "Aktive Fertigungsaufträge"
+
 msgid "Active Jobs"
 msgstr "Aktive Fertigungsaufträge"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Aktive Fertigungsaufträge mit Fälligkeitsdatum in den nächsten sieben Tagen"
+
+msgid "Active jobs grouped by status"
+msgstr "Aktive Fertigungsaufträge nach Status gruppiert"
+
+msgid "Active jobs past their due date"
+msgstr "Aktive Fertigungsaufträge überfällig"
 
 msgid "Active Statuses"
 msgstr "Aktive Status"
@@ -1340,6 +1356,9 @@ msgstr "Zum Bestand hinzufügen zur zukünftigen Verwendung"
 
 msgid "Add tools"
 msgstr "Werkzeuge hinzufügen"
+
+msgid "Add widgets"
+msgstr "Widgets hinzufügen"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Kreditorenalterung"
 msgid "AP Clerk"
 msgstr "Kreditoren-Sachbearbeiter"
 
+msgid "AP outstanding"
+msgstr "Kreditoren ausstehend"
+
 msgid "AP Outstanding"
 msgstr "Ausstehende Kreditoren"
+
+msgid "AP overdue"
+msgstr "Kreditoren überfällig"
 
 msgid "AP Overdue"
 msgstr "Überfällige Kreditoren"
@@ -1844,8 +1869,14 @@ msgstr "Debitorenalterung"
 msgid "AR Clerk"
 msgstr "Debitoren-Sachbearbeiter"
 
+msgid "AR outstanding"
+msgstr "Debitoren ausstehend"
+
 msgid "AR Outstanding"
 msgstr "Ausstehende Debitoren"
+
+msgid "AR overdue"
+msgstr "Debitoren überfällig"
 
 msgid "AR Overdue"
 msgstr "Überfällige Debitoren"
@@ -3263,6 +3294,9 @@ msgstr "Wählen Sie eine andere Datei"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Wählen Sie, was auf der gedruckten Laufkarte erscheint."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Wählen Sie, welche Widgets auf Ihrer Startseite angezeigt werden."
+
 msgid "Choose your style"
 msgstr "Wählen Sie Ihren Stil"
 
@@ -4533,6 +4567,12 @@ msgstr "Kunde"
 msgid "Customer Accounts"
 msgstr "Kundenkonten"
 
+msgid "Customer balances not yet paid"
+msgstr "Kundensalden nicht bezahlt"
+
+msgid "Customer balances past their due date"
+msgstr "Kundensalden überfällig"
+
 msgid "Customer contact"
 msgstr "Kundenkontakt"
 
@@ -4658,6 +4698,9 @@ msgstr "Anpassungen, Schulung und Integrationen"
 
 msgid "Customize"
 msgstr "Anpassen"
+
+msgid "Customize analytics"
+msgstr "Analysen anpassen"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Passen Sie das Layout Ihrer PDF-Dokumente an — ordnen Sie Abschnitte neu, verbergen Sie, was Sie nicht benötigen, und fügen Sie eigene Blöcke hinzu."
@@ -7103,6 +7146,9 @@ msgstr "PDF konnte nicht hochgeladen werden"
 msgid "Failed to upload thumbnail"
 msgstr "Fehler beim Hochladen des Vorschaubildes"
 
+msgid "Failed workflow runs"
+msgstr "Fehlerhafte Workflow-Ausführungen"
+
 msgid "Failure"
 msgstr "Fehler"
 
@@ -7252,6 +7298,9 @@ msgstr "Vorname"
 msgid "First Operation"
 msgstr "Erste Operation"
 
+msgid "First-pass yield"
+msgstr "First-Pass-Ausbeute"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Anlage"
 
@@ -7308,6 +7357,9 @@ msgstr "Vorrichtungs-ID"
 
 msgid "Flags"
 msgstr "Flaggen"
+
+msgid "Follow page range"
+msgstr "Seitenbereich folgen"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "für alles. Sie werden die richtige Person hinzuziehen."
@@ -7751,6 +7803,9 @@ msgstr "Roh ausblenden"
 msgid "Hide system quantities until the review step"
 msgstr "Systemmengen bis zum Überprüfungsschritt ausblenden"
 
+msgid "Hide widget"
+msgstr "Widget ausblenden"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Spalten ausblenden, fixieren und neu anordnen"
 
@@ -7810,6 +7865,9 @@ msgstr "Stunden bei dieser Station"
 
 msgid "Hours not yet assigned"
 msgstr "Noch nicht zugewiesene Stunden"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Produktionsstunden pro Arbeitsplatz im Zeitraum"
 
 msgid "Hours per Week"
 msgstr "Stunden pro Woche"
@@ -8223,6 +8281,9 @@ msgstr "Prüfdokument"
 msgid "Inspection Level"
 msgstr "Prüfniveau"
 
+msgid "Inspection pass rate"
+msgstr "Prüfungsbestandsquote"
+
 msgid "Inspection Plan"
 msgstr "Prüfplan"
 
@@ -8237,6 +8298,9 @@ msgstr "Prüfstatus"
 
 msgid "Inspections"
 msgstr "Prüfungen"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Bestandene Prüfungen als Anteil der abschließend beurteilten Prüfungen"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Prüfungen, Nichtkonformität und CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Bestands-Mengeneinheit"
 
 msgid "Inventory Valuation"
 msgstr "Bestandsbewertung"
+
+msgid "Inventory value"
+msgstr "Bestandswert"
 
 msgid "Invite"
 msgstr "Einladen"
@@ -8535,6 +8602,12 @@ msgstr "Ausstellungsdatum"
 msgid "Issues"
 msgstr "Probleme"
 
+msgid "Issues by type"
+msgstr "Materialentnahmen nach Typ"
+
+msgid "Issues opened"
+msgstr "Materialentnahmen erstellt"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Es wird nicht mehr ausgeführt, bis Sie erneut eine Version veröffentlichen. Nichts wird gelöscht."
 
@@ -8673,6 +8746,15 @@ msgstr "Fertigungsaufträge"
 msgid "Jobs Assigned to Me"
 msgstr "Mir zugewiesene Fertigungsaufträge"
 
+msgid "Jobs by status"
+msgstr "Fertigungsaufträge nach Status"
+
+msgid "Jobs due this week"
+msgstr "Diese Woche fällige Fertigungsaufträge"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Fertigungsaufträge Geplant, Bereit, In Bearbeitung oder Pausiert"
+
 msgid "Jobs Required"
 msgstr "Erforderliche Fertigungsaufträge"
 
@@ -8804,8 +8886,20 @@ msgstr "Personaleinheit"
 msgid "Language"
 msgstr "Sprache"
 
+msgid "Last 12 months"
+msgstr "Letzte 12 Monate"
+
+msgid "Last 30 days"
+msgstr "Letzte 30 Tage"
+
 msgid "Last 6 Months"
 msgstr "Letzte 6 Monate"
+
+msgid "Last 7 days"
+msgstr "Letzte 7 Tage"
+
+msgid "Last 90 days"
+msgstr "Letzte 90 Tage"
 
 msgid "Last attempt"
 msgstr "Letzter Versuch"
@@ -8857,6 +8951,9 @@ msgstr "Zuletzt verwendet"
 
 msgid "Late in the evening, {name}."
 msgstr "Spät am Abend, {name}."
+
+msgid "Late jobs"
+msgstr "Verspätete Fertigungsaufträge"
 
 msgid "Latest operation end"
 msgstr "Ende der neuesten Operation"
@@ -8998,6 +9095,9 @@ msgstr "Zeilen benötigen interne Teilenummern"
 
 msgid "Lines need prices or lead times"
 msgstr "Positionen benötigen Preise oder Beschaffungszeiten"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Positionen versendet am oder vor dem zugesagten Termin"
 
 msgid "Lineside"
 msgstr "Linienlager"
@@ -9773,6 +9873,9 @@ msgstr "Geld, das dir geschuldet wird"
 msgid "Money you owe"
 msgstr "Geld, das Sie schulden"
 
+msgid "Month to date"
+msgstr "Laufender Monat"
+
 msgid "Monthly"
 msgstr "Monatlich"
 
@@ -9799,6 +9902,9 @@ msgstr "Mehr Überstunden"
 
 msgid "Morning, {name}."
 msgstr "Morgen, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Häufigste Materialentnahmetypen im Zeitraum"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "Die meisten Dinge werden hier erkannt und gelöst. Benennen Sie es deutlich."
@@ -9858,6 +9964,9 @@ msgstr "MRP wird automatisch alle 3 Stunden ausgeführt, aber Sie können es hie
 
 msgid "Must be in the same location"
 msgstr "Muss sich am selben Ort befinden"
+
+msgid "My active operations"
+msgstr "Meine aktiven Arbeitsgänge"
 
 msgid "My Documents"
 msgstr "Meine Dokumente"
@@ -10044,6 +10153,9 @@ msgstr "Neue Rechnung"
 
 msgid "New Issue"
 msgstr "Neuer Vorfall"
+
+msgid "New issues over the period"
+msgstr "Neue Materialentnahmen im Zeitraum"
 
 msgid "New Item Group"
 msgstr "Neue Artikelgruppe"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Älteste zuerst"
 
+msgid "Oldest overdue orders first"
+msgstr "Älteste überfälligen Bestellungen zuerst"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Am Umstellungstag arbeiten Sie die Checkliste unten der Reihe nach ab. Akzeptanztests stammen aus Ihren im Umfang enthaltenen Anforderungen. Supportdetails finden Sie unten."
 
@@ -10962,6 +11077,9 @@ msgstr "Verfügbare Bestände"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Mindestbestand zur Wartung für die Nutzung an diesem Standort"
+
+msgid "On-hand inventory at cost"
+msgstr "Verfügbare Bestände zu Kosten"
 
 msgid "On-hand inventory remains"
 msgstr "Bestandsinventar vorhanden"
@@ -11055,6 +11173,9 @@ msgstr "Offene Debitoren"
 msgid "Open Audit Log"
 msgstr "Änderungsprotokoll öffnen"
 
+msgid "Open backlog"
+msgstr "Offener Rückstand"
+
 msgid "Open date"
 msgstr "Öffnungsdatum"
 
@@ -11076,6 +11197,9 @@ msgstr "In den Änderungsmitteilungen {ids} öffnen. Geben Sie sie frei, um neue
 msgid "Open in MES"
 msgstr "Im MES öffnen"
 
+msgid "Open issues"
+msgstr "Offene Materialentnahmen"
+
 msgid "Open Issues"
 msgstr "Offene Probleme"
 
@@ -11094,6 +11218,9 @@ msgstr "Menü öffnen"
 msgid "Open navigation"
 msgstr "Navigation öffnen"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Offene Bestellungen mit einer Position nach dem zugesagten Termin"
+
 msgid "Open payables by supplier and age"
 msgstr "Offene Verbindlichkeiten nach Lieferant und Fälligkeitsdauer"
 
@@ -11105,6 +11232,9 @@ msgstr "Offene Bestellungen"
 
 msgid "Open Purchase Orders"
 msgstr "Offene Bestellungen"
+
+msgid "Open quotes"
+msgstr "Offene Angebote"
 
 msgid "Open Quotes"
 msgstr "Offene Angebote"
@@ -11208,6 +11338,9 @@ msgstr "Arbeitsgänge / Schritte"
 
 msgid "Operations Type"
 msgstr "Arbeitsgangstyp"
+
+msgid "Operations you currently have running"
+msgstr "Arbeitsgänge, die gerade laufen"
 
 msgid "Operator"
 msgstr "Werker"
@@ -11318,6 +11451,9 @@ msgstr "Bestellungen"
 msgid "Orders submitted"
 msgstr "Bestellungen eingereicht"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Kundenaufträge, Angebote und Anfragen, bei denen Sie der Bearbeiter sind"
+
 msgid "Origin"
 msgstr "Ursprung"
 
@@ -11371,6 +11507,9 @@ msgstr "Gesamtergebnis"
 
 msgid "Overdue"
 msgstr "Überfällig"
+
+msgid "Overdue purchase orders"
+msgstr "Überfällige Bestellungen"
 
 msgid "Overhead Absorption"
 msgstr "Gemeinkostenverrechnung"
@@ -12179,6 +12318,9 @@ msgstr "Produktionsmenge"
 msgid "Production Quantity"
 msgstr "Produktionsmenge"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Produktionsmenge ohne Nacharbeit oder Ausschuss"
+
 msgid "Production variance"
 msgstr "Produktionsabweichung"
 
@@ -12382,6 +12524,9 @@ msgstr "Bestellung erfolgreich entfernt"
 msgid "Purchase Order Type"
 msgstr "Bestellungstyp"
 
+msgid "Purchase order value over the period"
+msgstr "Bestellungswert über den Zeitraum"
+
 msgid "Purchase orders"
 msgstr "Bestellungen"
 
@@ -12390,6 +12535,9 @@ msgstr "Bestellungen"
 
 msgid "Purchase Orders and Planning"
 msgstr "Bestellungen und Planung"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Bestellungen noch nicht erhalten und fakturiert"
 
 msgid "Purchase orders required"
 msgstr "Bestellungen erforderlich"
@@ -12408,6 +12556,9 @@ msgstr "Einkaufspreisabweichung (Standard)"
 
 msgid "Purchase Qty"
 msgstr "Kaufmenge"
+
+msgid "Purchase spend"
+msgstr "Einkaufsvolumen"
 
 msgid "Purchase Tax Payable"
 msgstr "Umsatzsteuer Verbindlichkeiten (Standard)"
@@ -12429,6 +12580,9 @@ msgstr "Gekauft"
 
 msgid "Purchases"
 msgstr "Käufe"
+
+msgid "Purchases by supplier"
+msgstr "Einkäufe nach Lieferant"
 
 msgid "purchasing"
 msgstr "Einkauf & Kosten der verkauften Waren"
@@ -12603,6 +12757,9 @@ msgstr "Mengenbasierte Preisstufen für diese Übersteuerung; der angewendete Ei
 msgid "Quantity: {0}"
 msgstr "Menge: {0}"
 
+msgid "Quarter to date"
+msgstr "Quartal bis heute"
+
 msgid "Quarterly"
 msgstr "Vierteljährlich"
 
@@ -12665,6 +12822,9 @@ msgstr "Angebotsdatum"
 
 msgid "Quotes"
 msgstr "Angebote"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Angebote im Entwurf oder an den Kunden gesendet"
 
 msgid "Quoting and sales orders"
 msgstr "Angebote und Kundenaufträge"
@@ -12948,6 +13108,9 @@ msgstr "Registriert"
 
 msgid "Registered"
 msgstr "Registriert"
+
+msgid "Registered and in-progress issues"
+msgstr "Registrierte und laufende Materialentnahmen"
 
 msgid "Registration failed"
 msgstr "Registrierung fehlgeschlagen"
@@ -13414,6 +13577,9 @@ msgstr "Umsatzerlöse"
 msgid "Revenue and expenses over a period"
 msgstr "Umsatzerlöse und Aufwand über einen Zeitraum"
 
+msgid "Revenue trend"
+msgstr "Umsatztrend"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Alle Bestandskorrektionen rückgängig machen"
 
@@ -13720,6 +13886,9 @@ msgstr "Vertriebsrabatte"
 msgid "Sales Discounts (default)"
 msgstr "Vertriebsrabatte (Standard)"
 
+msgid "Sales documents assigned to me"
+msgstr "Mir zugeordnete Verkaufsdokumente"
+
 msgid "Sales Funnel"
 msgstr "Vertriebstrichter"
 
@@ -13765,14 +13934,23 @@ msgstr "Kundenauftrag Standort"
 msgid "Sales Order Number"
 msgstr "Kundenauftragsnummer"
 
+msgid "Sales order value over the period"
+msgstr "Kundenauftragswert über den Zeitraum"
+
 msgid "Sales orders"
 msgstr "Verkaufsaufträge"
 
 msgid "Sales Orders"
 msgstr "Kundenaufträge"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Kundenaufträge noch nicht versendet und fakturiert"
+
 msgid "Sales Person"
 msgstr "Verkäufer"
+
+msgid "Sales revenue"
+msgstr "Verkaufserlöse"
 
 msgid "Sales Revenue"
 msgstr "Umsatzerlöse"
@@ -13954,6 +14132,9 @@ msgstr "Ausschuss"
 msgid "Scrap / Cost of Quality"
 msgstr "Ausschuss / Qualitätskosten"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Ausschuss als Anteil der Produktion plus Ausschussmengen"
+
 msgid "Scrap Percent"
 msgstr "Ausschussquote"
 
@@ -13971,6 +14152,9 @@ msgstr "Ausschussmenge"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Ausschussmenge pro Auftrag"
+
+msgid "Scrap rate"
+msgstr "Ausschussquote"
 
 msgid "scrap reason"
 msgstr "Ausschussgrund"
@@ -14945,6 +15129,9 @@ msgstr "Spezifische Artikel"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Ausgaben nach Lieferant, Artikel oder Kategorie – Ihre größten Kostenverursacher"
 
+msgid "Spend trend"
+msgstr "Ausgabentrend"
+
 msgid "Split"
 msgstr "Teilen"
 
@@ -15336,6 +15523,12 @@ msgstr "Lieferantenkonten"
 
 msgid "Supplier added and selected"
 msgstr "Lieferant hinzugefügt und ausgewählt"
+
+msgid "Supplier balances not yet paid"
+msgstr "Lieferanten-Salden noch nicht bezahlt"
+
+msgid "Supplier balances past their due date"
+msgstr "Lieferanten-Salden überfällig"
 
 msgid "Supplier contact"
 msgstr "Lieferantenkontakt"
@@ -16977,6 +17170,9 @@ msgstr "Werkzeuge"
 msgid "Tools"
 msgstr "Werkzeuge"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Top-Lieferanten nach Bestellungswert in dem Zeitraum"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Oberste Klassifizierung (Vermögenswert / Verbindlichkeit / Eigenkapital / Umsatzerlöse / Aufwand); nur auf Root-Gruppen festgelegt, wird von Untergruppen geerbt."
 
@@ -17006,6 +17202,12 @@ msgstr "Gesamtstunden"
 
 msgid "Total Minutes"
 msgstr "Gesamtminuten"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Gesamtbetrag der in dem Zeitraum aufgegebenen Bestellungen"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Gesamtbetrag der in dem Zeitraum aufgegebenen Kundenaufträge"
 
 msgid "Total Price"
 msgstr "Gesamtpreis"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Ursprungsbeleg-Typ nicht unterstützt: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Ohne Titel"
 
 msgid "Untitled Diagram"
 msgstr "Unbenanntes Diagramm"
@@ -17658,6 +17860,9 @@ msgstr "Benutzer auf abgedeckten Domänen können sich nur mit SAML SSO anmelden
 msgid "Users to Update"
 msgstr "Benutzer zum Aktualisieren"
 
+msgid "Utilization"
+msgstr "Auslastung"
+
 msgid "Valid From"
 msgstr "Gültig ab"
 
@@ -17687,6 +17892,9 @@ msgstr "Wert-Snapshot"
 
 msgid "Value source by surface"
 msgstr "Wertquelle nach Oberfläche"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Wert noch zu versendender offener Kundenaufträge"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Umsatzsteuer-Identifikationsnummer; erforderlich auf EU-Rechnungen für Reverse-Charge oder Nullsteuersätze."
@@ -17988,6 +18196,9 @@ msgstr "Das Stornieren dieses Belegs führt zu:"
 
 msgid "Voiding this shipment will:"
 msgstr "Das Stornieren dieser Lieferung wird:"
+
+msgid "vs prior period"
+msgstr "ggü. vorherige Periode"
 
 msgid "Waited"
 msgstr "Wartezeit"
@@ -18483,6 +18694,9 @@ msgstr "Warum diese Zeile abgelehnt wird; auf dem druckbaren Angebot angezeigt u
 msgid "Why this restore failed"
 msgstr "Warum diese Wiederherstellung fehlgeschlagen ist"
 
+msgid "Widget options"
+msgstr "Widget-Optionen"
+
 msgid "Will remain as a comment line"
 msgstr "Bleibt als Kommentarzeile erhalten"
 
@@ -18575,6 +18789,9 @@ msgstr "Workflow-Name"
 msgid "Workflow run"
 msgstr "Workflow-Ausführung"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Workflow-Läufe, die in dem Zeitraum fehlgeschlagen sind"
+
 msgid "Workflows"
 msgstr "Workflows"
 
@@ -18608,6 +18825,9 @@ msgstr "Den Wert eines Vermögenswerts über seine Lebensdauer abschreiben — e
 
 msgid "Year"
 msgstr "Jahr"
+
+msgid "Year to date"
+msgstr "Jahr bis heute"
 
 msgid "Yearly"
 msgstr "Jährlich"

--- a/packages/locale/locales/en/erp.po
+++ b/packages/locale/locales/en/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} draft journal entries"
 msgid "{0} jobs created"
 msgstr "{0} jobs created"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} lines past due"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} lines to map"
@@ -1095,8 +1099,20 @@ msgstr "Activation fee · we advise"
 msgid "Active"
 msgstr "Active"
 
+msgid "Active jobs"
+msgstr "Active jobs"
+
 msgid "Active Jobs"
 msgstr "Active Jobs"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Active jobs due in the next seven days"
+
+msgid "Active jobs grouped by status"
+msgstr "Active jobs grouped by status"
+
+msgid "Active jobs past their due date"
+msgstr "Active jobs past their due date"
 
 msgid "Active Statuses"
 msgstr "Active Statuses"
@@ -1340,6 +1356,9 @@ msgstr "Add to stock for future use"
 
 msgid "Add tools"
 msgstr "Add tools"
+
+msgid "Add widgets"
+msgstr "Add widgets"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "AP Aging"
 msgid "AP Clerk"
 msgstr "AP Clerk"
 
+msgid "AP outstanding"
+msgstr "AP outstanding"
+
 msgid "AP Outstanding"
 msgstr "AP Outstanding"
+
+msgid "AP overdue"
+msgstr "AP overdue"
 
 msgid "AP Overdue"
 msgstr "AP Overdue"
@@ -1844,8 +1869,14 @@ msgstr "AR Aging"
 msgid "AR Clerk"
 msgstr "AR Clerk"
 
+msgid "AR outstanding"
+msgstr "AR outstanding"
+
 msgid "AR Outstanding"
 msgstr "AR Outstanding"
+
+msgid "AR overdue"
+msgstr "AR overdue"
 
 msgid "AR Overdue"
 msgstr "AR Overdue"
@@ -3263,6 +3294,9 @@ msgstr "Choose another file"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Choose what appears on the printed job traveler."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Choose which widgets appear on your home page."
+
 msgid "Choose your style"
 msgstr "Choose your style"
 
@@ -4533,6 +4567,12 @@ msgstr "Customer"
 msgid "Customer Accounts"
 msgstr "Customer Accounts"
 
+msgid "Customer balances not yet paid"
+msgstr "Customer balances not yet paid"
+
+msgid "Customer balances past their due date"
+msgstr "Customer balances past their due date"
+
 msgid "Customer contact"
 msgstr "Customer contact"
 
@@ -4658,6 +4698,9 @@ msgstr "Customizations, training, and integrations"
 
 msgid "Customize"
 msgstr "Customize"
+
+msgid "Customize analytics"
+msgstr "Customize analytics"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
@@ -7103,6 +7146,9 @@ msgstr "Failed to upload PDF"
 msgid "Failed to upload thumbnail"
 msgstr "Failed to upload thumbnail"
 
+msgid "Failed workflow runs"
+msgstr "Failed workflow runs"
+
 msgid "Failure"
 msgstr "Failure"
 
@@ -7252,6 +7298,9 @@ msgstr "First Name"
 msgid "First Operation"
 msgstr "First Operation"
 
+msgid "First-pass yield"
+msgstr "First-pass yield"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "First-year additional deduction taken before the regular MACRS schedule begins."
 
@@ -7308,6 +7357,9 @@ msgstr "Fixture ID"
 
 msgid "Flags"
 msgstr "Flags"
+
+msgid "Follow page range"
+msgstr "Follow page range"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "for anything. They'll pull in the right person."
@@ -7751,6 +7803,9 @@ msgstr "Hide raw"
 msgid "Hide system quantities until the review step"
 msgstr "Hide system quantities until the review step"
 
+msgid "Hide widget"
+msgstr "Hide widget"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Hide, pin and reorder columns"
 
@@ -7810,6 +7865,9 @@ msgstr "Hours at this station"
 
 msgid "Hours not yet assigned"
 msgstr "Hours not yet assigned"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Hours of production time per work center in the period"
 
 msgid "Hours per Week"
 msgstr "Hours per Week"
@@ -8223,6 +8281,9 @@ msgstr "Inspection document"
 msgid "Inspection Level"
 msgstr "Inspection Level"
 
+msgid "Inspection pass rate"
+msgstr "Inspection pass rate"
+
 msgid "Inspection Plan"
 msgstr "Inspection Plan"
 
@@ -8237,6 +8298,9 @@ msgstr "Inspection Status"
 
 msgid "Inspections"
 msgstr "Inspections"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Inspections passed as a share of those dispositioned"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Inspections, nonconformance, and CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Inventory Unit of Measure"
 
 msgid "Inventory Valuation"
 msgstr "Inventory Valuation"
+
+msgid "Inventory value"
+msgstr "Inventory value"
 
 msgid "Invite"
 msgstr "Invite"
@@ -8535,6 +8602,12 @@ msgstr "Issued Date"
 msgid "Issues"
 msgstr "Issues"
 
+msgid "Issues by type"
+msgstr "Issues by type"
+
+msgid "Issues opened"
+msgstr "Issues opened"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "It will stop running until you publish a version again. Nothing is deleted."
 
@@ -8673,6 +8746,15 @@ msgstr "Jobs"
 msgid "Jobs Assigned to Me"
 msgstr "Jobs Assigned to Me"
 
+msgid "Jobs by status"
+msgstr "Jobs by status"
+
+msgid "Jobs due this week"
+msgstr "Jobs due this week"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Jobs planned, ready, in progress or paused"
+
 msgid "Jobs Required"
 msgstr "Jobs Required"
 
@@ -8804,8 +8886,20 @@ msgstr "Labor Unit"
 msgid "Language"
 msgstr "Language"
 
+msgid "Last 12 months"
+msgstr "Last 12 months"
+
+msgid "Last 30 days"
+msgstr "Last 30 days"
+
 msgid "Last 6 Months"
 msgstr "Last 6 Months"
+
+msgid "Last 7 days"
+msgstr "Last 7 days"
+
+msgid "Last 90 days"
+msgstr "Last 90 days"
 
 msgid "Last attempt"
 msgstr "Last attempt"
@@ -8857,6 +8951,9 @@ msgstr "Last used"
 
 msgid "Late in the evening, {name}."
 msgstr "Late in the evening, {name}."
+
+msgid "Late jobs"
+msgstr "Late jobs"
 
 msgid "Latest operation end"
 msgstr "Latest operation end"
@@ -8998,6 +9095,9 @@ msgstr "Lines need internal part numbers"
 
 msgid "Lines need prices or lead times"
 msgstr "Lines need prices or lead times"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Lines shipped on or before their promised date"
 
 msgid "Lineside"
 msgstr "Lineside"
@@ -9773,6 +9873,9 @@ msgstr "Money owed to you"
 msgid "Money you owe"
 msgstr "Money you owe"
 
+msgid "Month to date"
+msgstr "Month to date"
+
 msgid "Monthly"
 msgstr "Monthly"
 
@@ -9799,6 +9902,9 @@ msgstr "More overtime"
 
 msgid "Morning, {name}."
 msgstr "Morning, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Most frequent issue types in the period"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "Most things get caught and resolved here. Name it plainly."
@@ -9858,6 +9964,9 @@ msgstr "MRP runs automatically every 3 hours, but you can run it manually here."
 
 msgid "Must be in the same location"
 msgstr "Must be in the same location"
+
+msgid "My active operations"
+msgstr "My active operations"
 
 msgid "My Documents"
 msgstr "My Documents"
@@ -10044,6 +10153,9 @@ msgstr "New Invoice"
 
 msgid "New Issue"
 msgstr "New Issue"
+
+msgid "New issues over the period"
+msgstr "New issues over the period"
 
 msgid "New Item Group"
 msgstr "New Item Group"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Oldest first"
 
+msgid "Oldest overdue orders first"
+msgstr "Oldest overdue orders first"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 
@@ -10962,6 +11077,9 @@ msgstr "On-hand counts"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "On-hand floor to maintain for service use at this location"
+
+msgid "On-hand inventory at cost"
+msgstr "On-hand inventory at cost"
 
 msgid "On-hand inventory remains"
 msgstr "On-hand inventory remains"
@@ -11055,6 +11173,9 @@ msgstr "Open AR"
 msgid "Open Audit Log"
 msgstr "Open Audit Log"
 
+msgid "Open backlog"
+msgstr "Open backlog"
+
 msgid "Open date"
 msgstr "Open date"
 
@@ -11076,6 +11197,9 @@ msgstr "Open in change notices {ids}. Release them to create new versions or rev
 msgid "Open in MES"
 msgstr "Open in MES"
 
+msgid "Open issues"
+msgstr "Open issues"
+
 msgid "Open Issues"
 msgstr "Open Issues"
 
@@ -11094,6 +11218,9 @@ msgstr "Open menu"
 msgid "Open navigation"
 msgstr "Open navigation"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Open orders with a line past its promised date"
+
 msgid "Open payables by supplier and age"
 msgstr "Open payables by supplier and age"
 
@@ -11105,6 +11232,9 @@ msgstr "Open purchase orders"
 
 msgid "Open Purchase Orders"
 msgstr "Open Purchase Orders"
+
+msgid "Open quotes"
+msgstr "Open quotes"
 
 msgid "Open Quotes"
 msgstr "Open Quotes"
@@ -11208,6 +11338,9 @@ msgstr "Operations / steps"
 
 msgid "Operations Type"
 msgstr "Operations Type"
+
+msgid "Operations you currently have running"
+msgstr "Operations you currently have running"
 
 msgid "Operator"
 msgstr "Operator"
@@ -11318,6 +11451,9 @@ msgstr "Orders"
 msgid "Orders submitted"
 msgstr "Orders submitted"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Orders, quotes and RFQs where you are the assignee"
+
 msgid "Origin"
 msgstr "Origin"
 
@@ -11371,6 +11507,9 @@ msgstr "Overall result"
 
 msgid "Overdue"
 msgstr "Overdue"
+
+msgid "Overdue purchase orders"
+msgstr "Overdue purchase orders"
 
 msgid "Overhead Absorption"
 msgstr "Overhead Absorption"
@@ -12179,6 +12318,9 @@ msgstr "Production quantity"
 msgid "Production Quantity"
 msgstr "Production Quantity"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Production quantity without rework or scrap"
+
 msgid "Production variance"
 msgstr "Production variance"
 
@@ -12382,6 +12524,9 @@ msgstr "Purchase order removed successfully"
 msgid "Purchase Order Type"
 msgstr "Purchase Order Type"
 
+msgid "Purchase order value over the period"
+msgstr "Purchase order value over the period"
+
 msgid "Purchase orders"
 msgstr "Purchase orders"
 
@@ -12390,6 +12535,9 @@ msgstr "Purchase Orders"
 
 msgid "Purchase Orders and Planning"
 msgstr "Purchase Orders and Planning"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Purchase orders not yet received and invoiced"
 
 msgid "Purchase orders required"
 msgstr "Purchase orders required"
@@ -12408,6 +12556,9 @@ msgstr "Purchase Price Variance (default)"
 
 msgid "Purchase Qty"
 msgstr "Purchase Qty"
+
+msgid "Purchase spend"
+msgstr "Purchase spend"
 
 msgid "Purchase Tax Payable"
 msgstr "Purchase Tax Payable"
@@ -12429,6 +12580,9 @@ msgstr "Purchased"
 
 msgid "Purchases"
 msgstr "Purchases"
+
+msgid "Purchases by supplier"
+msgstr "Purchases by supplier"
 
 msgid "purchasing"
 msgstr "purchasing"
@@ -12603,6 +12757,9 @@ msgstr "Quantity-based pricing tiers for this override; the unit price applied i
 msgid "Quantity: {0}"
 msgstr "Quantity: {0}"
 
+msgid "Quarter to date"
+msgstr "Quarter to date"
+
 msgid "Quarterly"
 msgstr "Quarterly"
 
@@ -12665,6 +12822,9 @@ msgstr "Quoted Date"
 
 msgid "Quotes"
 msgstr "Quotes"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Quotes in draft or sent to the customer"
 
 msgid "Quoting and sales orders"
 msgstr "Quoting and sales orders"
@@ -12948,6 +13108,9 @@ msgstr "Register Existing Asset"
 
 msgid "Registered"
 msgstr "Registered"
+
+msgid "Registered and in-progress issues"
+msgstr "Registered and in-progress issues"
 
 msgid "Registration failed"
 msgstr "Registration failed"
@@ -13414,6 +13577,9 @@ msgstr "Revenue"
 msgid "Revenue and expenses over a period"
 msgstr "Revenue and expenses over a period"
 
+msgid "Revenue trend"
+msgstr "Revenue trend"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Reverse all inventory adjustments"
 
@@ -13720,6 +13886,9 @@ msgstr "Sales Discounts"
 msgid "Sales Discounts (default)"
 msgstr "Sales Discounts (default)"
 
+msgid "Sales documents assigned to me"
+msgstr "Sales documents assigned to me"
+
 msgid "Sales Funnel"
 msgstr "Sales Funnel"
 
@@ -13765,14 +13934,23 @@ msgstr "Sales Order Location"
 msgid "Sales Order Number"
 msgstr "Sales Order Number"
 
+msgid "Sales order value over the period"
+msgstr "Sales order value over the period"
+
 msgid "Sales orders"
 msgstr "Sales orders"
 
 msgid "Sales Orders"
 msgstr "Sales Orders"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Sales orders not yet shipped and invoiced"
+
 msgid "Sales Person"
 msgstr "Sales Person"
+
+msgid "Sales revenue"
+msgstr "Sales revenue"
 
 msgid "Sales Revenue"
 msgstr "Sales Revenue"
@@ -13954,6 +14132,9 @@ msgstr "Scrap"
 msgid "Scrap / Cost of Quality"
 msgstr "Scrap / Cost of Quality"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Scrap as a share of production plus scrap quantities"
+
 msgid "Scrap Percent"
 msgstr "Scrap Percent"
 
@@ -13971,6 +14152,9 @@ msgstr "Scrap Quantity"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Scrap Quantity Per Job"
+
+msgid "Scrap rate"
+msgstr "Scrap rate"
 
 msgid "scrap reason"
 msgstr "scrap reason"
@@ -14945,6 +15129,9 @@ msgstr "Specific Items"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Spend by supplier, item, or category — your biggest cost drivers"
 
+msgid "Spend trend"
+msgstr "Spend trend"
+
 msgid "Split"
 msgstr "Split"
 
@@ -15336,6 +15523,12 @@ msgstr "Supplier Accounts"
 
 msgid "Supplier added and selected"
 msgstr "Supplier added and selected"
+
+msgid "Supplier balances not yet paid"
+msgstr "Supplier balances not yet paid"
+
+msgid "Supplier balances past their due date"
+msgstr "Supplier balances past their due date"
 
 msgid "Supplier contact"
 msgstr "Supplier contact"
@@ -16977,6 +17170,9 @@ msgstr "tools"
 msgid "Tools"
 msgstr "Tools"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Top suppliers by purchase order value in the period"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 
@@ -17006,6 +17202,12 @@ msgstr "Total Hours"
 
 msgid "Total Minutes"
 msgstr "Total Minutes"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Total of purchase orders placed in the period"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Total of sales orders placed in the period"
 
 msgid "Total Price"
 msgstr "Total Price"
@@ -17658,6 +17860,9 @@ msgstr "Users on covered domains can sign in only with SAML SSO; magic link, Goo
 msgid "Users to Update"
 msgstr "Users to Update"
 
+msgid "Utilization"
+msgstr "Utilization"
+
 msgid "Valid From"
 msgstr "Valid From"
 
@@ -17687,6 +17892,9 @@ msgstr "Value Snapshot"
 
 msgid "Value source by surface"
 msgstr "Value source by surface"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Value still to ship on open sales orders"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
@@ -17988,6 +18196,9 @@ msgstr "Voiding this receipt will:"
 
 msgid "Voiding this shipment will:"
 msgstr "Voiding this shipment will:"
+
+msgid "vs prior period"
+msgstr "vs prior period"
 
 msgid "Waited"
 msgstr "Waited"
@@ -18483,6 +18694,9 @@ msgstr "Why this line is being declined; surfaced on the printable quote and rec
 msgid "Why this restore failed"
 msgstr "Why this restore failed"
 
+msgid "Widget options"
+msgstr "Widget options"
+
 msgid "Will remain as a comment line"
 msgstr "Will remain as a comment line"
 
@@ -18575,6 +18789,9 @@ msgstr "Workflow name"
 msgid "Workflow run"
 msgstr "Workflow run"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Workflow runs that failed in the period"
+
 msgid "Workflows"
 msgstr "Workflows"
 
@@ -18608,6 +18825,9 @@ msgstr "Writing an asset's value down over its life — a monthly batch you crea
 
 msgid "Year"
 msgstr "Year"
+
+msgid "Year to date"
+msgstr "Year to date"
 
 msgid "Yearly"
 msgstr "Yearly"

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} asientos de diario en borrador"
 msgid "{0} jobs created"
 msgstr "{0} órdenes de trabajo creadas"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} líneas atrasadas"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} líneas para mapear"
@@ -1095,8 +1099,20 @@ msgstr "Tarifa de activación · asesoramos"
 msgid "Active"
 msgstr "Activo"
 
+msgid "Active jobs"
+msgstr "Trabajos activos"
+
 msgid "Active Jobs"
 msgstr "Órdenes de trabajo activas"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Trabajos activos que vencen en los próximos siete días"
+
+msgid "Active jobs grouped by status"
+msgstr "Trabajos activos agrupados por estado"
+
+msgid "Active jobs past their due date"
+msgstr "Trabajos activos atrasados"
 
 msgid "Active Statuses"
 msgstr "Estados Activos"
@@ -1340,6 +1356,9 @@ msgstr "Agregar al inventario para uso futuro"
 
 msgid "Add tools"
 msgstr "Agregar herramientas"
+
+msgid "Add widgets"
+msgstr "Agregar widgets"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Antigüedad de Cuentas por pagar"
 msgid "AP Clerk"
 msgstr "Empleado de Cuentas por Pagar"
 
+msgid "AP outstanding"
+msgstr "Cuentas por pagar pendientes"
+
 msgid "AP Outstanding"
 msgstr "Cuentas por pagar pendientes"
+
+msgid "AP overdue"
+msgstr "Cuentas por pagar atrasadas"
 
 msgid "AP Overdue"
 msgstr "Cuentas por pagar vencidas"
@@ -1844,8 +1869,14 @@ msgstr "Antigüedad de Cuentas por cobrar"
 msgid "AR Clerk"
 msgstr "Empleado de Cuentas por Cobrar"
 
+msgid "AR outstanding"
+msgstr "Cuentas por cobrar pendientes"
+
 msgid "AR Outstanding"
 msgstr "Cuentas por Cobrar Pendientes"
+
+msgid "AR overdue"
+msgstr "Cuentas por cobrar atrasadas"
 
 msgid "AR Overdue"
 msgstr "Cuentas por cobrar Atrasadas"
@@ -3263,6 +3294,9 @@ msgstr "Elegir otro archivo"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Elija qué aparece en la hoja viajera de la orden de trabajo impresa."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Elige qué widgets aparecen en tu página de inicio."
+
 msgid "Choose your style"
 msgstr "Elige tu estilo"
 
@@ -4533,6 +4567,12 @@ msgstr "Cliente"
 msgid "Customer Accounts"
 msgstr "Cuentas de Cliente"
 
+msgid "Customer balances not yet paid"
+msgstr "Saldos de clientes no pagados aún"
+
+msgid "Customer balances past their due date"
+msgstr "Saldos de clientes atrasados"
+
 msgid "Customer contact"
 msgstr "Contacto del cliente"
 
@@ -4658,6 +4698,9 @@ msgstr "Personalizaciones, capacitación e integraciones"
 
 msgid "Customize"
 msgstr "Personalizar"
+
+msgid "Customize analytics"
+msgstr "Personalizar analítica"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Personaliza el diseño de tus documentos PDF — reordena secciones, oculta lo que no necesites y añade tus propios bloques."
@@ -7103,6 +7146,9 @@ msgstr "No se pudo subir PDF"
 msgid "Failed to upload thumbnail"
 msgstr "No se pudo subir miniatura"
 
+msgid "Failed workflow runs"
+msgstr "Ejecuciones de flujo de trabajo fallidas"
+
 msgid "Failure"
 msgstr "Fallo"
 
@@ -7252,6 +7298,9 @@ msgstr "Nombre"
 msgid "First Operation"
 msgstr "Primera Operación"
 
+msgid "First-pass yield"
+msgstr "Rendimiento de primera pasada"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Activo Fijo"
 
@@ -7308,6 +7357,9 @@ msgstr "ID de dispositivo de sujeción"
 
 msgid "Flags"
 msgstr "Banderas"
+
+msgid "Follow page range"
+msgstr "Seguir rango de página"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "para cualquier cosa. Ellos traerán a la persona indicada."
@@ -7751,6 +7803,9 @@ msgstr "Ocultar sin procesar"
 msgid "Hide system quantities until the review step"
 msgstr "Ocultar cantidades del sistema hasta el paso de revisión"
 
+msgid "Hide widget"
+msgstr "Ocultar widget"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, anclar y reordenar columnas"
 
@@ -7810,6 +7865,9 @@ msgstr "Horas en esta estación"
 
 msgid "Hours not yet assigned"
 msgstr "Horas aún no asignadas"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Horas de tiempo de producción por centro de trabajo en el período"
 
 msgid "Hours per Week"
 msgstr "Horas por Semana"
@@ -8223,6 +8281,9 @@ msgstr "Documento de inspección"
 msgid "Inspection Level"
 msgstr "Nivel de Inspección"
 
+msgid "Inspection pass rate"
+msgstr "Tasa de conformidad de inspección"
+
 msgid "Inspection Plan"
 msgstr "Plan de inspección"
 
@@ -8237,6 +8298,9 @@ msgstr "Estado de Inspección"
 
 msgid "Inspections"
 msgstr "Inspecciones"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Inspecciones superadas como proporción de las disposiciones"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Inspecciones, No conformidad y CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Unidad de Medida de Inventario"
 
 msgid "Inventory Valuation"
 msgstr "Valoración de Inventario"
+
+msgid "Inventory value"
+msgstr "Valor del inventario"
 
 msgid "Invite"
 msgstr "Invitar"
@@ -8535,6 +8602,12 @@ msgstr "Fecha de Emisión"
 msgid "Issues"
 msgstr "Problemas"
 
+msgid "Issues by type"
+msgstr "Incidencias por tipo"
+
+msgid "Issues opened"
+msgstr "Incidencias abiertas"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Se detendrá hasta que publique una Versión nuevamente. Nada se elimina."
 
@@ -8673,6 +8746,15 @@ msgstr "Órdenes de trabajo"
 msgid "Jobs Assigned to Me"
 msgstr "Órdenes de trabajo asignadas a mí"
 
+msgid "Jobs by status"
+msgstr "Órdenes de trabajo por estado"
+
+msgid "Jobs due this week"
+msgstr "Órdenes de trabajo que vencen esta semana"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Órdenes de trabajo planificadas, listas, en curso o en pausa"
+
 msgid "Jobs Required"
 msgstr "Órdenes de trabajo requeridas"
 
@@ -8804,8 +8886,20 @@ msgstr "Unidad de mano de obra"
 msgid "Language"
 msgstr "Idioma"
 
+msgid "Last 12 months"
+msgstr "Últimos 12 meses"
+
+msgid "Last 30 days"
+msgstr "Últimos 30 días"
+
 msgid "Last 6 Months"
 msgstr "Últimos 6 Meses"
+
+msgid "Last 7 days"
+msgstr "Últimos 7 días"
+
+msgid "Last 90 days"
+msgstr "Últimos 90 días"
 
 msgid "Last attempt"
 msgstr "Último intento"
@@ -8857,6 +8951,9 @@ msgstr "Último uso"
 
 msgid "Late in the evening, {name}."
 msgstr "Noche avanzada, {name}."
+
+msgid "Late jobs"
+msgstr "Órdenes de trabajo atrasadas"
 
 msgid "Latest operation end"
 msgstr "Fin de la última operación"
@@ -8998,6 +9095,9 @@ msgstr "Las líneas necesitan números de parte internos"
 
 msgid "Lines need prices or lead times"
 msgstr "Las líneas necesitan precios o plazos de entrega"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Líneas enviadas en o antes de su fecha prometida"
 
 msgid "Lineside"
 msgstr "Pie de línea"
@@ -9773,6 +9873,9 @@ msgstr "Dinero que te deben"
 msgid "Money you owe"
 msgstr "Dinero que debes"
 
+msgid "Month to date"
+msgstr "Del mes a la fecha"
+
 msgid "Monthly"
 msgstr "Mensual"
 
@@ -9799,6 +9902,9 @@ msgstr "Más horas extra"
 
 msgid "Morning, {name}."
 msgstr "Mañana, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Tipos de incidencias más frecuentes en el período"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "La mayoría de las cosas se detectan y resuelven aquí. Nómbralo claramente."
@@ -9858,6 +9964,9 @@ msgstr "MRP se ejecuta automáticamente cada 3 horas, pero puedes ejecutarlo man
 
 msgid "Must be in the same location"
 msgstr "Debe estar en la misma ubicación"
+
+msgid "My active operations"
+msgstr "Mis operaciones activas"
 
 msgid "My Documents"
 msgstr "Mis Documentos"
@@ -10044,6 +10153,9 @@ msgstr "Factura Nueva"
 
 msgid "New Issue"
 msgstr "Nuevo Problema"
+
+msgid "New issues over the period"
+msgstr "Nuevas incidencias durante el período"
 
 msgid "New Item Group"
 msgstr "Nuevo Grupo de Artículos"
@@ -10912,6 +11024,9 @@ msgstr "Aceptar"
 msgid "Oldest first"
 msgstr "Más antiguo primero"
 
+msgid "Oldest overdue orders first"
+msgstr "Órdenes atrasadas más antiguas primero"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "En el día de la migración, trabaja la lista de verificación a continuación en orden. Las pruebas de aceptación provienen de tus requisitos dentro del alcance. Los detalles de soporte están en la parte inferior."
 
@@ -10962,6 +11077,9 @@ msgstr "Conteos disponibles"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Piso de existencias a mantener para uso de servicio en esta ubicación"
+
+msgid "On-hand inventory at cost"
+msgstr "Inventario disponible al costo"
 
 msgid "On-hand inventory remains"
 msgstr "El inventario disponible permanece"
@@ -11055,6 +11173,9 @@ msgstr "Cuentas por cobrar abiertas"
 msgid "Open Audit Log"
 msgstr "Abrir Registro de Auditoría"
 
+msgid "Open backlog"
+msgstr "Cartera abierta"
+
 msgid "Open date"
 msgstr "Fecha de apertura"
 
@@ -11076,6 +11197,9 @@ msgstr "Abierto en avisos de cambio {ids}. Libérelos para crear nuevas versione
 msgid "Open in MES"
 msgstr "Abrir en MES"
 
+msgid "Open issues"
+msgstr "Problemas abiertos"
+
 msgid "Open Issues"
 msgstr "Problemas Abiertos"
 
@@ -11094,6 +11218,9 @@ msgstr "Abrir menú"
 msgid "Open navigation"
 msgstr "Abrir navegación"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Órdenes abiertas con una línea pasada su fecha prometida"
+
 msgid "Open payables by supplier and age"
 msgstr "Cuentas por pagar abiertas por proveedor y antigüedad"
 
@@ -11105,6 +11232,9 @@ msgstr "Órdenes de compra abiertas"
 
 msgid "Open Purchase Orders"
 msgstr "Órdenes de Compra Abiertas"
+
+msgid "Open quotes"
+msgstr "Cotizaciones abiertas"
 
 msgid "Open Quotes"
 msgstr "Presupuestos Abiertos"
@@ -11208,6 +11338,9 @@ msgstr "Operaciones / pasos"
 
 msgid "Operations Type"
 msgstr "Tipo de Operaciones"
+
+msgid "Operations you currently have running"
+msgstr "Operaciones que actualmente tienes en ejecución"
 
 msgid "Operator"
 msgstr "Operador"
@@ -11318,6 +11451,9 @@ msgstr "Pedidos"
 msgid "Orders submitted"
 msgstr "Pedidos enviados"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Órdenes, cotizaciones y RFQs asignados a ti"
+
 msgid "Origin"
 msgstr "Origen"
 
@@ -11371,6 +11507,9 @@ msgstr "Resultado general"
 
 msgid "Overdue"
 msgstr "Atrasado"
+
+msgid "Overdue purchase orders"
+msgstr "Órdenes de compra atrasadas"
 
 msgid "Overhead Absorption"
 msgstr "Absorción de costos indirectos"
@@ -12179,6 +12318,9 @@ msgstr "Cantidad de producción"
 msgid "Production Quantity"
 msgstr "Cantidad de Producción"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Cantidad de producción sin retrabajo o desperdicio"
+
 msgid "Production variance"
 msgstr "Desviación de producción"
 
@@ -12382,6 +12524,9 @@ msgstr "Orden de compra eliminada exitosamente"
 msgid "Purchase Order Type"
 msgstr "Tipo de Orden de Compra"
 
+msgid "Purchase order value over the period"
+msgstr "Valor de orden de compra en el período"
+
 msgid "Purchase orders"
 msgstr "Órdenes de Compra"
 
@@ -12390,6 +12535,9 @@ msgstr "Órdenes de Compra"
 
 msgid "Purchase Orders and Planning"
 msgstr "Órdenes de Compra y Planificación"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Órdenes de compra no recibidas ni facturadas aún"
 
 msgid "Purchase orders required"
 msgstr "Órdenes de compra requeridas"
@@ -12408,6 +12556,9 @@ msgstr "Desviación de precio de compra (default)"
 
 msgid "Purchase Qty"
 msgstr "Cantidad de Compra"
+
+msgid "Purchase spend"
+msgstr "Gasto en compras"
 
 msgid "Purchase Tax Payable"
 msgstr "Impuesto de Compra por Pagar (predeterminado)"
@@ -12429,6 +12580,9 @@ msgstr "Comprado"
 
 msgid "Purchases"
 msgstr "Compras"
+
+msgid "Purchases by supplier"
+msgstr "Compras por proveedor"
 
 msgid "purchasing"
 msgstr "Compras y Costo de Bienes Vendidos"
@@ -12603,6 +12757,9 @@ msgstr "Escalas de precios basadas en cantidad para esta sobrescritura; el preci
 msgid "Quantity: {0}"
 msgstr "Cantidad: {0}"
 
+msgid "Quarter to date"
+msgstr "Lo que va del trimestre"
+
 msgid "Quarterly"
 msgstr "Trimestral"
 
@@ -12665,6 +12822,9 @@ msgstr "Fecha de Cotización"
 
 msgid "Quotes"
 msgstr "Cotizaciones"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Cotizaciones en borrador o enviadas al cliente"
 
 msgid "Quoting and sales orders"
 msgstr "Presupuestos y pedidos de venta"
@@ -12948,6 +13108,9 @@ msgstr "Registrado"
 
 msgid "Registered"
 msgstr "Registrado"
+
+msgid "Registered and in-progress issues"
+msgstr "Incidencias registradas y en progreso"
 
 msgid "Registration failed"
 msgstr "Error en el registro"
@@ -13414,6 +13577,9 @@ msgstr "Ingresos por ventas"
 msgid "Revenue and expenses over a period"
 msgstr "Ingresos por ventas y gastos durante un período"
 
+msgid "Revenue trend"
+msgstr "Tendencia de ingresos por ventas"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Revertir todos los ajustes de inventario"
 
@@ -13720,6 +13886,9 @@ msgstr "Descuentos de ventas"
 msgid "Sales Discounts (default)"
 msgstr "Descuentos de ventas (predeterminado)"
 
+msgid "Sales documents assigned to me"
+msgstr "Documentos de ventas asignados a mí"
+
 msgid "Sales Funnel"
 msgstr "Embudo de Ventas"
 
@@ -13765,14 +13934,23 @@ msgstr "Ubicación de pedido de venta"
 msgid "Sales Order Number"
 msgstr "Número de pedido de venta"
 
+msgid "Sales order value over the period"
+msgstr "Valor de pedido de venta en el período"
+
 msgid "Sales orders"
 msgstr "Órdenes de Venta"
 
 msgid "Sales Orders"
 msgstr "Pedidos de venta"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Pedidos de venta no enviados ni facturados aún"
+
 msgid "Sales Person"
 msgstr "Persona de Ventas"
+
+msgid "Sales revenue"
+msgstr "Ingresos por ventas"
 
 msgid "Sales Revenue"
 msgstr "Ingresos por ventas"
@@ -13954,6 +14132,9 @@ msgstr "Desperdicio"
 msgid "Scrap / Cost of Quality"
 msgstr "Desperdicio / Costo de Calidad"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Desperdicio como fracción de cantidades de producción más desperdicio"
+
 msgid "Scrap Percent"
 msgstr "Porcentaje de desperdicio"
 
@@ -13971,6 +14152,9 @@ msgstr "Cantidad de desperdicio"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Cantidad de Desperdicio Por Trabajo"
+
+msgid "Scrap rate"
+msgstr "Tasa de desperdicio"
 
 msgid "scrap reason"
 msgstr "motivo de desperdicio"
@@ -14945,6 +15129,9 @@ msgstr "Artículos Específicos"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Gasto por proveedor, artículo o categoría — sus mayores generadores de costos"
 
+msgid "Spend trend"
+msgstr "Tendencia de gasto"
+
 msgid "Split"
 msgstr "Dividir"
 
@@ -15336,6 +15523,12 @@ msgstr "Cuentas de Proveedores"
 
 msgid "Supplier added and selected"
 msgstr "Proveedor agregado y seleccionado"
+
+msgid "Supplier balances not yet paid"
+msgstr "Saldos de proveedores no pagados aún"
+
+msgid "Supplier balances past their due date"
+msgstr "Saldos de proveedores pasados su fecha de vencimiento"
 
 msgid "Supplier contact"
 msgstr "Contacto del proveedor"
@@ -16977,6 +17170,9 @@ msgstr "Herramientas"
 msgid "Tools"
 msgstr "Herramientas"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Principales proveedores por valor de orden de compra en el período"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Clasificación de nivel superior (activo / pasivo / patrimonio / ingresos por ventas / gasto); se establece solo en grupos raíz, heredado por secundarios."
 
@@ -17006,6 +17202,12 @@ msgstr "Horas totales"
 
 msgid "Total Minutes"
 msgstr "Minutos totales"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Total de órdenes de compra colocadas en el período"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Total de pedidos de venta colocados en el período"
 
 msgid "Total Price"
 msgstr "Precio Total"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Tipo de documento de origen no compatible: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Sin título"
 
 msgid "Untitled Diagram"
 msgstr "Diagrama sin título"
@@ -17658,6 +17860,9 @@ msgstr "Los usuarios en dominios cubiertos solo pueden iniciar sesión con SAML 
 msgid "Users to Update"
 msgstr "Usuarios a Actualizar"
 
+msgid "Utilization"
+msgstr "Utilización"
+
 msgid "Valid From"
 msgstr "Válido desde"
 
@@ -17687,6 +17892,9 @@ msgstr "Resumen de Valor"
 
 msgid "Value source by surface"
 msgstr "Fuente de valor por superficie"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Valor por enviar en pedidos de venta abiertos"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Número de registro del impuesto al valor agregado; requerido en facturas de la UE para suministros de cargo inverso o sin impuestos."
@@ -17988,6 +18196,9 @@ msgstr "Anular este recibo hará lo siguiente:"
 
 msgid "Voiding this shipment will:"
 msgstr "Anular este envío hará lo siguiente:"
+
+msgid "vs prior period"
+msgstr "vs período anterior"
 
 msgid "Waited"
 msgstr "Esperado"
@@ -18483,6 +18694,9 @@ msgstr "Por qué se rechaza esta línea; mostrado en el presupuesto imprimible y
 msgid "Why this restore failed"
 msgstr "Por qué falló esta restauración"
 
+msgid "Widget options"
+msgstr "Opciones de widget"
+
 msgid "Will remain as a comment line"
 msgstr "Permanecerá como una línea de comentario"
 
@@ -18575,6 +18789,9 @@ msgstr "Nombre del flujo de trabajo"
 msgid "Workflow run"
 msgstr "Ejecución del flujo de trabajo"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Ejecuciones de flujo de trabajo que fallaron en el período"
+
 msgid "Workflows"
 msgstr "Flujos de trabajo"
 
@@ -18608,6 +18825,9 @@ msgstr "Reducir el valor de un activo a lo largo de su vida útil — un lote me
 
 msgid "Year"
 msgstr "Año"
+
+msgid "Year to date"
+msgstr "Lo que va del año"
 
 msgid "Yearly"
 msgstr "Anual"

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} écritures de journal brouillon"
 msgid "{0} jobs created"
 msgstr "{0} ordres de fabrication créés"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} lignes en retard"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} lignes à mapper"
@@ -1095,8 +1099,20 @@ msgstr "Frais d'activation · nous conseillons"
 msgid "Active"
 msgstr "Actif"
 
+msgid "Active jobs"
+msgstr "Ordres actifs"
+
 msgid "Active Jobs"
 msgstr "Ordres de fabrication actifs"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Ordres actifs dus dans les sept prochains jours"
+
+msgid "Active jobs grouped by status"
+msgstr "Ordres actifs regroupés par statut"
+
+msgid "Active jobs past their due date"
+msgstr "Ordres actifs en retard"
 
 msgid "Active Statuses"
 msgstr "Statuts actifs"
@@ -1340,6 +1356,9 @@ msgstr "Ajouter au stock pour utilisation future"
 
 msgid "Add tools"
 msgstr "Ajouter des outils"
+
+msgid "Add widgets"
+msgstr "Ajouter des widgets"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Ancienneté des Comptes fournisseurs"
 msgid "AP Clerk"
 msgstr "Commis aux Comptes fournisseurs"
 
+msgid "AP outstanding"
+msgstr "Comptes fournisseurs impayés"
+
 msgid "AP Outstanding"
 msgstr "Comptes fournisseurs en attente"
+
+msgid "AP overdue"
+msgstr "Comptes fournisseurs en retard"
 
 msgid "AP Overdue"
 msgstr "Comptes fournisseurs En retard"
@@ -1844,8 +1869,14 @@ msgstr "Ancienneté des comptes clients"
 msgid "AR Clerk"
 msgstr "Commis aux comptes clients"
 
+msgid "AR outstanding"
+msgstr "Comptes clients impayés"
+
 msgid "AR Outstanding"
 msgstr "Comptes clients en attente"
+
+msgid "AR overdue"
+msgstr "Comptes clients en retard"
 
 msgid "AR Overdue"
 msgstr "Comptes clients en retard"
@@ -3263,6 +3294,9 @@ msgstr "Choisir un autre fichier"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Choisir ce qui apparaît sur la fiche suiveuse d'ordre de fabrication imprimée."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Choisissez les widgets qui s'affichent sur votre page d'accueil."
+
 msgid "Choose your style"
 msgstr "Choisissez votre style"
 
@@ -4533,6 +4567,12 @@ msgstr "Client"
 msgid "Customer Accounts"
 msgstr "Comptes Clients"
 
+msgid "Customer balances not yet paid"
+msgstr "Soldes clients non encore payés"
+
+msgid "Customer balances past their due date"
+msgstr "Soldes clients en retard"
+
 msgid "Customer contact"
 msgstr "Contact client"
 
@@ -4658,6 +4698,9 @@ msgstr "Personnalisations, formations et intégrations"
 
 msgid "Customize"
 msgstr "Personnaliser"
+
+msgid "Customize analytics"
+msgstr "Personnaliser l'analytique"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Personnalisez la mise en page de vos documents PDF — réorganisez les sections, masquez ce dont vous n'avez pas besoin et ajoutez vos propres blocs."
@@ -7103,6 +7146,9 @@ msgstr "Impossible de téléverser le PDF"
 msgid "Failed to upload thumbnail"
 msgstr "Impossible de téléverser la miniature"
 
+msgid "Failed workflow runs"
+msgstr "Exécutions de Workflow échouées"
+
 msgid "Failure"
 msgstr "Échec"
 
@@ -7252,6 +7298,9 @@ msgstr "Prénom"
 msgid "First Operation"
 msgstr "Première opération"
 
+msgid "First-pass yield"
+msgstr "Rendement au premier passage"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Immobilisation"
 
@@ -7308,6 +7357,9 @@ msgstr "ID montage d'usinage"
 
 msgid "Flags"
 msgstr "Indicateurs"
+
+msgid "Follow page range"
+msgstr "Suivre la plage de pages"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "pour n'importe quoi. Ils vont faire intervenir la bonne personne."
@@ -7751,6 +7803,9 @@ msgstr "Masquer le brut"
 msgid "Hide system quantities until the review step"
 msgstr "Masquer les quantités système jusqu'à l'étape de revue"
 
+msgid "Hide widget"
+msgstr "Masquer le widget"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Masquer, épingler et réorganiser les colonnes"
 
@@ -7810,6 +7865,9 @@ msgstr "Heures à cette station"
 
 msgid "Hours not yet assigned"
 msgstr "Heures non encore affectées"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Heures de production par poste de travail sur la période"
 
 msgid "Hours per Week"
 msgstr "Heures par semaine"
@@ -8223,6 +8281,9 @@ msgstr "Document de contrôle"
 msgid "Inspection Level"
 msgstr "Niveau de contrôle"
 
+msgid "Inspection pass rate"
+msgstr "Taux de passage des contrôles"
+
 msgid "Inspection Plan"
 msgstr "Plan de contrôle"
 
@@ -8237,6 +8298,9 @@ msgstr "Statut du contrôle"
 
 msgid "Inspections"
 msgstr "Contrôles"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Contrôles conformes en proportion des contrôles traités"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Contrôles, non-conformité et CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Unité de mesure d'inventaire"
 
 msgid "Inventory Valuation"
 msgstr "Évaluation des Stocks"
+
+msgid "Inventory value"
+msgstr "Valeur des stocks"
 
 msgid "Invite"
 msgstr "Inviter"
@@ -8535,6 +8602,12 @@ msgstr "Date d'émission"
 msgid "Issues"
 msgstr "Problèmes"
 
+msgid "Issues by type"
+msgstr "Anomalies par type"
+
+msgid "Issues opened"
+msgstr "Anomalies ouvertes"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Elle s'arrêtera d'être exécutée jusqu'à ce que vous publiiez une nouvelle version. Rien n'est supprimé."
 
@@ -8673,6 +8746,15 @@ msgstr "Ordres de fabrication"
 msgid "Jobs Assigned to Me"
 msgstr "Ordres de fabrication qui m'ont été attribués"
 
+msgid "Jobs by status"
+msgstr "Ordres par statut"
+
+msgid "Jobs due this week"
+msgstr "Ordres dus cette semaine"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Ordres planifiés, prêts, en cours ou en pause"
+
 msgid "Jobs Required"
 msgstr "Ordres de fabrication requis"
 
@@ -8804,8 +8886,20 @@ msgstr "Unité de main-d'œuvre"
 msgid "Language"
 msgstr "Langue"
 
+msgid "Last 12 months"
+msgstr "12 derniers mois"
+
+msgid "Last 30 days"
+msgstr "30 derniers jours"
+
 msgid "Last 6 Months"
 msgstr "6 derniers mois"
+
+msgid "Last 7 days"
+msgstr "7 derniers jours"
+
+msgid "Last 90 days"
+msgstr "90 derniers jours"
 
 msgid "Last attempt"
 msgstr "Dernière tentative"
@@ -8857,6 +8951,9 @@ msgstr "Dernière utilisation"
 
 msgid "Late in the evening, {name}."
 msgstr "Tard en soirée, {name}."
+
+msgid "Late jobs"
+msgstr "Ordres en retard"
 
 msgid "Latest operation end"
 msgstr "Fin de la dernière opération"
@@ -8998,6 +9095,9 @@ msgstr "Les lignes ont besoin de numéros de pièces internes"
 
 msgid "Lines need prices or lead times"
 msgstr "Les lignes ont besoin de prix ou de délais d'approvisionnement"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Lignes expédiées à la date promise ou avant"
 
 msgid "Lineside"
 msgstr "Bord de ligne"
@@ -9773,6 +9873,9 @@ msgstr "Argent qui vous est dû"
 msgid "Money you owe"
 msgstr "L'argent que vous devez"
 
+msgid "Month to date"
+msgstr "Depuis le début du mois"
+
 msgid "Monthly"
 msgstr "Mensuel"
 
@@ -9799,6 +9902,9 @@ msgstr "Plus d'heures supplémentaires"
 
 msgid "Morning, {name}."
 msgstr "Bon matin, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Types d'anomalies les plus fréquents sur la période"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "La plupart des choses sont détectées et résolues ici. Nommez-les clairement."
@@ -9858,6 +9964,9 @@ msgstr "MRP s'exécute automatiquement toutes les 3 heures, mais vous pouvez l'e
 
 msgid "Must be in the same location"
 msgstr "Doit être au même endroit"
+
+msgid "My active operations"
+msgstr "Mes opérations actives"
 
 msgid "My Documents"
 msgstr "Mes Documents"
@@ -10044,6 +10153,9 @@ msgstr "Nouvelle facture"
 
 msgid "New Issue"
 msgstr "Nouveau Problème"
+
+msgid "New issues over the period"
+msgstr "Anomalies créées sur la période"
 
 msgid "New Item Group"
 msgstr "Nouveau groupe d'articles"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Le plus ancien en premier"
 
+msgid "Oldest overdue orders first"
+msgstr "Commandes les plus anciennes en retard"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Le jour du basculement, travaillez la liste de contrôle ci-dessous dans l'ordre. Les tests d'acceptation proviennent de vos exigences dans le périmètre. Les détails du support se trouvent en bas."
 
@@ -10962,6 +11077,9 @@ msgstr "Stocks disponibles"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Plancher disponible à maintenir pour utilisation en service à cet emplacement"
+
+msgid "On-hand inventory at cost"
+msgstr "Stocks en main évalués au coût"
 
 msgid "On-hand inventory remains"
 msgstr "Stock en main disponible"
@@ -11055,6 +11173,9 @@ msgstr "Comptes clients ouverts"
 msgid "Open Audit Log"
 msgstr "Ouvrir le journal d'audit"
 
+msgid "Open backlog"
+msgstr "Carnet de commandes ouvert"
+
 msgid "Open date"
 msgstr "Date d'ouverture"
 
@@ -11076,6 +11197,9 @@ msgstr "Ouverts dans les avis de modification {ids}. Lancez-les pour créer de n
 msgid "Open in MES"
 msgstr "Ouvrir dans MES"
 
+msgid "Open issues"
+msgstr "Problèmes ouverts"
+
 msgid "Open Issues"
 msgstr "Problèmes ouverts"
 
@@ -11094,6 +11218,9 @@ msgstr "Ouvrir le menu"
 msgid "Open navigation"
 msgstr "Ouvrir la navigation"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Commandes ouvertes avec une ligne après sa date promise"
+
 msgid "Open payables by supplier and age"
 msgstr "Dettes fournisseurs ouvertes par fournisseur et ancienneté"
 
@@ -11105,6 +11232,9 @@ msgstr "Bons de commande ouverts"
 
 msgid "Open Purchase Orders"
 msgstr "Bons de commande ouverts"
+
+msgid "Open quotes"
+msgstr "Devis ouverts"
 
 msgid "Open Quotes"
 msgstr "Devis Ouverts"
@@ -11208,6 +11338,9 @@ msgstr "Opérations / étapes"
 
 msgid "Operations Type"
 msgstr "Type Opérations"
+
+msgid "Operations you currently have running"
+msgstr "Opérations actuellement en cours d'exécution"
 
 msgid "Operator"
 msgstr "Opérateur"
@@ -11318,6 +11451,9 @@ msgstr "Commandes"
 msgid "Orders submitted"
 msgstr "Commandes soumises"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Commandes, devis et RFQ dont vous êtes l'assigné"
+
 msgid "Origin"
 msgstr "Origine"
 
@@ -11371,6 +11507,9 @@ msgstr "Résultat global"
 
 msgid "Overdue"
 msgstr "En retard"
+
+msgid "Overdue purchase orders"
+msgstr "Bons de commande en retard"
 
 msgid "Overhead Absorption"
 msgstr "Imputation des frais généraux"
@@ -12179,6 +12318,9 @@ msgstr "Quantité de production"
 msgid "Production Quantity"
 msgstr "Quantité de Production"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Quantité de production sans retouche ni rebut"
+
 msgid "Production variance"
 msgstr "Écart de production"
 
@@ -12382,6 +12524,9 @@ msgstr "Bon de commande supprimé avec succès"
 msgid "Purchase Order Type"
 msgstr "Type de bon de commande"
 
+msgid "Purchase order value over the period"
+msgstr "Valeur du bon de commande sur la période"
+
 msgid "Purchase orders"
 msgstr "Bons de commande"
 
@@ -12390,6 +12535,9 @@ msgstr "Bons de commande"
 
 msgid "Purchase Orders and Planning"
 msgstr "Bons de commande et planification"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Bons de commande non encore reçus et facturés"
 
 msgid "Purchase orders required"
 msgstr "Bons de commande requis"
@@ -12408,6 +12556,9 @@ msgstr "Écart de prix d'achat (par défaut)"
 
 msgid "Purchase Qty"
 msgstr "Quantité d'achat"
+
+msgid "Purchase spend"
+msgstr "Dépenses d'achat"
 
 msgid "Purchase Tax Payable"
 msgstr "Taxe d'Achat à Payer (par défaut)"
@@ -12429,6 +12580,9 @@ msgstr "Acheté"
 
 msgid "Purchases"
 msgstr "Achats"
+
+msgid "Purchases by supplier"
+msgstr "Achats par fournisseur"
 
 msgid "purchasing"
 msgstr "achats"
@@ -12603,6 +12757,9 @@ msgstr "Niveaux de tarification basés sur la quantité pour cette substitution 
 msgid "Quantity: {0}"
 msgstr "Quantité : {0}"
 
+msgid "Quarter to date"
+msgstr "Trimestre à jour"
+
 msgid "Quarterly"
 msgstr "Trimestriel"
 
@@ -12665,6 +12822,9 @@ msgstr "Date de devis"
 
 msgid "Quotes"
 msgstr "Devis"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Devis en brouillon ou envoyés au client"
 
 msgid "Quoting and sales orders"
 msgstr "Devis et commandes clients"
@@ -12948,6 +13108,9 @@ msgstr "Enregistré"
 
 msgid "Registered"
 msgstr "Enregistré"
+
+msgid "Registered and in-progress issues"
+msgstr "Problèmes enregistrés et en cours"
 
 msgid "Registration failed"
 msgstr "L'enregistrement a échoué"
@@ -13414,6 +13577,9 @@ msgstr "Revenu"
 msgid "Revenue and expenses over a period"
 msgstr "Revenus et charges sur une période"
 
+msgid "Revenue trend"
+msgstr "Tendance des revenus"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Extourner tous les ajustements de stock"
 
@@ -13720,6 +13886,9 @@ msgstr "Remises commerciales"
 msgid "Sales Discounts (default)"
 msgstr "Remises commerciales (par défaut)"
 
+msgid "Sales documents assigned to me"
+msgstr "Documents commerciaux qui me sont attribués"
+
 msgid "Sales Funnel"
 msgstr "Entonnoir de ventes"
 
@@ -13765,14 +13934,23 @@ msgstr "Localisation de la commande client"
 msgid "Sales Order Number"
 msgstr "Numéro de commande client"
 
+msgid "Sales order value over the period"
+msgstr "Valeur de la commande client sur la période"
+
 msgid "Sales orders"
 msgstr "Commandes de vente"
 
 msgid "Sales Orders"
 msgstr "Commandes client"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Commandes client non encore expédiées et facturées"
+
 msgid "Sales Person"
 msgstr "Vendeur"
+
+msgid "Sales revenue"
+msgstr "Revenus des ventes"
 
 msgid "Sales Revenue"
 msgstr "Revenus des ventes"
@@ -13954,6 +14132,9 @@ msgstr "Rebut"
 msgid "Scrap / Cost of Quality"
 msgstr "Rebut / Coût de la qualité"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Rebut en tant que proportion des quantités de production plus rebut"
+
 msgid "Scrap Percent"
 msgstr "Pourcentage de rebut"
 
@@ -13971,6 +14152,9 @@ msgstr "Quantité de rebut"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Quantité de rebut par travail"
+
+msgid "Scrap rate"
+msgstr "Taux de rebut"
 
 msgid "scrap reason"
 msgstr "Motif de rebut"
@@ -14945,6 +15129,9 @@ msgstr "Articles spécifiques"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Dépenses par fournisseur, article ou catégorie — vos principaux moteurs de coûts"
 
+msgid "Spend trend"
+msgstr "Tendance des dépenses"
+
 msgid "Split"
 msgstr "Diviser"
 
@@ -15336,6 +15523,12 @@ msgstr "Comptes Fournisseurs"
 
 msgid "Supplier added and selected"
 msgstr "Fournisseur ajouté et sélectionné"
+
+msgid "Supplier balances not yet paid"
+msgstr "Soldes des fournisseurs non encore payés"
+
+msgid "Supplier balances past their due date"
+msgstr "Soldes des fournisseurs après leur date d'échéance"
 
 msgid "Supplier contact"
 msgstr "Contact fournisseur"
@@ -16977,6 +17170,9 @@ msgstr "Outils"
 msgid "Tools"
 msgstr "Outils"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Principaux fournisseurs par valeur du bon de commande de la période"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Classification de haut niveau (actif / passif / capitaux propres / revenus / charges) ; définie uniquement sur les groupes racines, héritée par les enfants."
 
@@ -17006,6 +17202,12 @@ msgstr "Heures totales"
 
 msgid "Total Minutes"
 msgstr "Minutes totales"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Total des bons de commande passés de la période"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Total des commandes client passées de la période"
 
 msgid "Total Price"
 msgstr "Prix Total"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Type de document d'origine non pris en charge : {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Sans titre"
 
 msgid "Untitled Diagram"
 msgstr "Diagramme sans titre"
@@ -17658,6 +17860,9 @@ msgstr "Les utilisateurs des domaines couverts ne peuvent se connecter qu'avec S
 msgid "Users to Update"
 msgstr "Utilisateurs à mettre à jour"
 
+msgid "Utilization"
+msgstr "Utilisation"
+
 msgid "Valid From"
 msgstr "Valide à partir du"
 
@@ -17687,6 +17892,9 @@ msgstr "Aperçu de la valeur"
 
 msgid "Value source by surface"
 msgstr "Source de valeur par surface"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Valeur encore à expédier sur les commandes client ouvertes"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Numéro d'enregistrement de la taxe sur la valeur ajoutée ; requis sur les factures de l'UE pour les fournitures à autoliquidation ou à taux zéro."
@@ -17988,6 +18196,9 @@ msgstr "L'annulation de ce reçu va :"
 
 msgid "Voiding this shipment will:"
 msgstr "L'invalidation de cette expédition :"
+
+msgid "vs prior period"
+msgstr "par rapport à la période précédente"
 
 msgid "Waited"
 msgstr "En attente"
@@ -18483,6 +18694,9 @@ msgstr "Pourquoi cette ligne est refusée ; affiché sur le devis imprimable et 
 msgid "Why this restore failed"
 msgstr "Raison de l'échec de cette restauration"
 
+msgid "Widget options"
+msgstr "Options du widget"
+
 msgid "Will remain as a comment line"
 msgstr "Restera comme ligne de commentaire"
 
@@ -18575,6 +18789,9 @@ msgstr "Nom du flux de travail"
 msgid "Workflow run"
 msgstr "Exécution du flux de travail"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Exécutions de workflow qui ont échoué de la période"
+
 msgid "Workflows"
 msgstr "Flux de travail"
 
@@ -18608,6 +18825,9 @@ msgstr "Réduire progressivement la valeur d'un bien sur sa durée de vie — un
 
 msgid "Year"
 msgstr "Année"
+
+msgid "Year to date"
+msgstr "Année à jour"
 
 msgid "Yearly"
 msgstr "Annuel"

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} ड्राफ्ट जर्नल प्रविष्टिय
 msgid "{0} jobs created"
 msgstr "{0} जॉब बनाए गए"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} पंक्तियाँ अतिदेय"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} लाइनें मैप करने के लिए"
@@ -1095,8 +1099,20 @@ msgstr "सक्रियण शुल्क · हम सलाह देत�
 msgid "Active"
 msgstr "सक्रिय"
 
+msgid "Active jobs"
+msgstr "चालू जॉब"
+
 msgid "Active Jobs"
 msgstr "सक्रिय जॉब"
+
+msgid "Active jobs due in the next seven days"
+msgstr "अगले सात दिनों में देय चालू जॉब"
+
+msgid "Active jobs grouped by status"
+msgstr "स्थिति द्वारा समूहित चालू जॉब"
+
+msgid "Active jobs past their due date"
+msgstr "अपनी नियत तिथि के बाद के चालू जॉब"
 
 msgid "Active Statuses"
 msgstr "सक्रिय स्थितियाँ"
@@ -1340,6 +1356,9 @@ msgstr "भविष्य के उपयोग के लिए स्टॉ�
 
 msgid "Add tools"
 msgstr "उपकरण जोड़ें"
+
+msgid "Add widgets"
+msgstr "विजेट जोड़ें"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "देय खाते की आयु"
 msgid "AP Clerk"
 msgstr "देय खाते क्लर्क"
 
+msgid "AP outstanding"
+msgstr "देय खाते बकाया"
+
 msgid "AP Outstanding"
 msgstr "देय खाते शेष राशि"
+
+msgid "AP overdue"
+msgstr "देय खाते अतिदेय"
 
 msgid "AP Overdue"
 msgstr "देय खाते अतिदेय"
@@ -1844,8 +1869,14 @@ msgstr "प्राप्य खाते पुरानिता"
 msgid "AR Clerk"
 msgstr "प्राप्य खाते लिपिक"
 
+msgid "AR outstanding"
+msgstr "प्राप्य खाते बकाया"
+
 msgid "AR Outstanding"
 msgstr "प्राप्य खाते बकाया"
+
+msgid "AR overdue"
+msgstr "प्राप्य खाते अतिदेय"
 
 msgid "AR Overdue"
 msgstr "प्राप्य खाते अतिदेय"
@@ -3263,6 +3294,9 @@ msgstr "दूसरी फ़ाइल चुनें"
 msgid "Choose what appears on the printed job traveler."
 msgstr "मुद्रित जॉब ट्रैवलर पर क्या दिखाई दे, इसे चुनें।"
 
+msgid "Choose which widgets appear on your home page."
+msgstr "चुनें कि आपके होम पेज पर कौन से विजेट दिखाई दें।"
+
 msgid "Choose your style"
 msgstr "अपनी शैली चुनें"
 
@@ -4533,6 +4567,12 @@ msgstr "ग्राहक"
 msgid "Customer Accounts"
 msgstr "ग्राहक खाते"
 
+msgid "Customer balances not yet paid"
+msgstr "ग्राहक शेष राशि अभी तक भुगतान नहीं की गई"
+
+msgid "Customer balances past their due date"
+msgstr "ग्राहक शेष राशि अपनी नियत तिथि के बाद"
+
 msgid "Customer contact"
 msgstr "ग्राहक संपर्क"
 
@@ -4658,6 +4698,9 @@ msgstr "कस्टमाइज़ेशन, प्रशिक्षण और
 
 msgid "Customize"
 msgstr "अनुकूलित करें"
+
+msgid "Customize analytics"
+msgstr "विश्लेषण को कस्टमाइज़ करें"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "अपने PDF दस्तावेज़ों के लेआउट को कस्टमाइज़ करें — अनुभागों को पुनः व्यवस्थित करें, जो आपको आवश्यकता नहीं है उसे छिपाएं, और अपने स्वयं के ब्लॉक जोड़ें।"
@@ -7103,6 +7146,9 @@ msgstr "PDF अपलोड करने में विफल"
 msgid "Failed to upload thumbnail"
 msgstr "थंबनेल अपलोड करने में विफल"
 
+msgid "Failed workflow runs"
+msgstr "विफल वर्कफ़्लो रन"
+
 msgid "Failure"
 msgstr "विफलता"
 
@@ -7252,6 +7298,9 @@ msgstr "पहला नाम"
 msgid "First Operation"
 msgstr "पहली ऑपरेशन"
 
+msgid "First-pass yield"
+msgstr "पहली पास उपज"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "स्थिर संपत्ति"
 
@@ -7308,6 +7357,9 @@ msgstr "फिक्सचर आईडी"
 
 msgid "Flags"
 msgstr "झंडे"
+
+msgid "Follow page range"
+msgstr "पेज रेंज का पालन करें"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "किसी भी चीज़ के लिए। वे सही व्यक्ति को शामिल करेंगे।"
@@ -7751,6 +7803,9 @@ msgstr "कच्चे को छुपाएं"
 msgid "Hide system quantities until the review step"
 msgstr "समीक्षा चरण तक सिस्टम मात्रा को छिपाएं"
 
+msgid "Hide widget"
+msgstr "विजेट छिपाएँ"
+
 msgid "Hide, pin and reorder columns"
 msgstr "कॉलम को छिपाएं, पिन करें और पुनः क्रमित करें"
 
@@ -7810,6 +7865,9 @@ msgstr "इस स्टेशन पर घंटे"
 
 msgid "Hours not yet assigned"
 msgstr "अभी तक असाइन न किए गए घंटे"
+
+msgid "Hours of production time per work center in the period"
+msgstr "अवधि में प्रति वर्क सेंटर उत्पादन समय के घंटे"
 
 msgid "Hours per Week"
 msgstr "सप्ताह में घंटे"
@@ -8223,6 +8281,9 @@ msgstr "निरीक्षण दस्तावेज़"
 msgid "Inspection Level"
 msgstr "निरीक्षण स्तर"
 
+msgid "Inspection pass rate"
+msgstr "निरीक्षण उत्तीर्ण दर"
+
 msgid "Inspection Plan"
 msgstr "निरीक्षण योजना"
 
@@ -8237,6 +8298,9 @@ msgstr "निरीक्षण स्थिति"
 
 msgid "Inspections"
 msgstr "निरीक्षण"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "निपटारे किए गए लोगों के हिस्से के रूप में निरीक्षण उत्तीर्ण"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "निरीक्षण, गैर-अनुरूपता, और CAPA"
@@ -8369,6 +8433,9 @@ msgstr "इन्वेंटरी माप की इकाई"
 
 msgid "Inventory Valuation"
 msgstr "इन्वेंटरी मूल्यांकन"
+
+msgid "Inventory value"
+msgstr "इन्वेंटरी मूल्य"
 
 msgid "Invite"
 msgstr "आमंत्रित करें"
@@ -8535,6 +8602,12 @@ msgstr "जारी तारीख"
 msgid "Issues"
 msgstr "समस्याएं"
 
+msgid "Issues by type"
+msgstr "प्रकार के अनुसार निर्गम"
+
+msgid "Issues opened"
+msgstr "खुले निर्गम"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "यह तब तक चलना बंद कर देगा जब तक आप फिर से एक संस्करण प्रकाशित नहीं करते। कुछ भी हटाया नहीं गया है।"
 
@@ -8673,6 +8746,15 @@ msgstr "जॉब"
 msgid "Jobs Assigned to Me"
 msgstr "मुझे असाइन किए गए जॉब"
 
+msgid "Jobs by status"
+msgstr "स्थिति के अनुसार जॉब"
+
+msgid "Jobs due this week"
+msgstr "इस सप्ताह देय जॉब"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "जॉब योजनाबद्ध, तैयार, प्रगति में या रुके हुए"
+
 msgid "Jobs Required"
 msgstr "आवश्यक जॉब"
 
@@ -8804,8 +8886,20 @@ msgstr "श्रम इकाई"
 msgid "Language"
 msgstr "भाषा"
 
+msgid "Last 12 months"
+msgstr "पिछले 12 महीने"
+
+msgid "Last 30 days"
+msgstr "पिछले 30 दिन"
+
 msgid "Last 6 Months"
 msgstr "पिछले 6 महीने"
+
+msgid "Last 7 days"
+msgstr "पिछले 7 दिन"
+
+msgid "Last 90 days"
+msgstr "पिछले 90 दिन"
 
 msgid "Last attempt"
 msgstr "अंतिम प्रयास"
@@ -8857,6 +8951,9 @@ msgstr "अंतिम उपयोग"
 
 msgid "Late in the evening, {name}."
 msgstr "शाम को देर में, {name}।"
+
+msgid "Late jobs"
+msgstr "विलंबित जॉब"
 
 msgid "Latest operation end"
 msgstr "नवीनतम ऑपरेशन अंत"
@@ -8998,6 +9095,9 @@ msgstr "लाइनों को आंतरिक भाग संख्य�
 
 msgid "Lines need prices or lead times"
 msgstr "पंक्तियों को मूल्य या लीड टाइम की आवश्यकता है"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "पंक्तियों को उनकी वादा की गई तिथि पर या उससे पहले भेजा गया"
 
 msgid "Lineside"
 msgstr "लाइनसाइड"
@@ -9773,6 +9873,9 @@ msgstr "आपको देय धन"
 msgid "Money you owe"
 msgstr "आप जो पैसे देते हैं"
 
+msgid "Month to date"
+msgstr "महीने की तारीख तक"
+
 msgid "Monthly"
 msgstr "मासिक"
 
@@ -9799,6 +9902,9 @@ msgstr "अधिक ओवरटाइम"
 
 msgid "Morning, {name}."
 msgstr "सुबह, {name}।"
+
+msgid "Most frequent issue types in the period"
+msgstr "अवधि में सबसे लगातार निर्गम प्रकार"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "अधिकांश चीजें यहां पकड़ी जाती हैं और हल की जाती हैं। इसे स्पष्ट रूप से नाम दें।"
@@ -9858,6 +9964,9 @@ msgstr "MRP हर 3 घंटे में स्वचालित रूप �
 
 msgid "Must be in the same location"
 msgstr "एक ही स्थान में होना चाहिए"
+
+msgid "My active operations"
+msgstr "मेरे सक्रिय ऑपरेशन"
 
 msgid "My Documents"
 msgstr "मेरे दस्तावेज़"
@@ -10044,6 +10153,9 @@ msgstr "नया चालान"
 
 msgid "New Issue"
 msgstr "नया मुद्दा"
+
+msgid "New issues over the period"
+msgstr "अवधि में नए निर्गम"
 
 msgid "New Item Group"
 msgstr "नया आइटम समूह"
@@ -10912,6 +11024,9 @@ msgstr "ठीक है"
 msgid "Oldest first"
 msgstr "सबसे पुराना पहले"
 
+msgid "Oldest overdue orders first"
+msgstr "सबसे पुराने अतिदेय ऑर्डर पहले"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "कटओवर दिन पर, नीचे दी गई चेकलिस्ट को क्रम में काम करें। स्वीकृति परीक्षण आपकी स्कोप में शामिल आवश्यकताओं से आते हैं। समर्थन विवरण नीचे हैं।"
 
@@ -10962,6 +11077,9 @@ msgstr "हाथ में मौजूद गिनती"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "इस स्थान पर सेवा उपयोग के लिए बनाए रखने के लिए न्यूनतम स्टॉक स्तर"
+
+msgid "On-hand inventory at cost"
+msgstr "लागत पर हाथ में इन्वेंटरी"
 
 msgid "On-hand inventory remains"
 msgstr "हाथ में इन्वेंटरी बची है"
@@ -11055,6 +11173,9 @@ msgstr "खुले प्राप्य खाते"
 msgid "Open Audit Log"
 msgstr "ऑडिट लॉग खोलें"
 
+msgid "Open backlog"
+msgstr "खुली बकलॉग"
+
 msgid "Open date"
 msgstr "खोलने की तारीख"
 
@@ -11076,6 +11197,9 @@ msgstr "परिवर्तन सूचनाओं {ids} में खुल
 msgid "Open in MES"
 msgstr "MES में खोलें"
 
+msgid "Open issues"
+msgstr "खुले निर्गम"
+
 msgid "Open Issues"
 msgstr "खुले मुद्दे"
 
@@ -11094,6 +11218,9 @@ msgstr "मेनू खोलें"
 msgid "Open navigation"
 msgstr "नेविगेशन खोलें"
 
+msgid "Open orders with a line past its promised date"
+msgstr "खुले ऑर्डर जिनकी एक पंक्ति अपनी वादा की गई तिथि से आगे है"
+
 msgid "Open payables by supplier and age"
 msgstr "आपूर्तिकर्ता और आयु के अनुसार खुली देय राशि"
 
@@ -11105,6 +11232,9 @@ msgstr "खुले क्रय आदेश"
 
 msgid "Open Purchase Orders"
 msgstr "खुले क्रय आदेश"
+
+msgid "Open quotes"
+msgstr "खुले कोटेशन"
 
 msgid "Open Quotes"
 msgstr "खुली उद्धरणें"
@@ -11208,6 +11338,9 @@ msgstr "ऑपरेशन / चरण"
 
 msgid "Operations Type"
 msgstr "ऑपरेशन प्रकार"
+
+msgid "Operations you currently have running"
+msgstr "आप वर्तमान में चला रहे ऑपरेशन"
 
 msgid "Operator"
 msgstr "ऑपरेटर"
@@ -11318,6 +11451,9 @@ msgstr "आदेश"
 msgid "Orders submitted"
 msgstr "ऑर्डर जमा किए गए"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "ऑर्डर, कोटेशन और RFQ जहां आप असाइनी हैं"
+
 msgid "Origin"
 msgstr "मूल"
 
@@ -11371,6 +11507,9 @@ msgstr "समग्र परिणाम"
 
 msgid "Overdue"
 msgstr "अतिदेय"
+
+msgid "Overdue purchase orders"
+msgstr "अतिदेय क्रय आदेश"
 
 msgid "Overhead Absorption"
 msgstr "उपरिव्यय अवशोषण"
@@ -12179,6 +12318,9 @@ msgstr "उत्पादन मात्रा"
 msgid "Production Quantity"
 msgstr "उत्पादन मात्रा"
 
+msgid "Production quantity without rework or scrap"
+msgstr "पुनः कार्य या स्क्रैप के बिना उत्पादन मात्रा"
+
 msgid "Production variance"
 msgstr "उत्पादन विचलन"
 
@@ -12382,6 +12524,9 @@ msgstr "क्रय आदेश सफलतापूर्वक हटा �
 msgid "Purchase Order Type"
 msgstr "क्रय आदेश प्रकार"
 
+msgid "Purchase order value over the period"
+msgstr "अवधि में क्रय आदेश मूल्य"
+
 msgid "Purchase orders"
 msgstr "क्रय आदेश"
 
@@ -12390,6 +12535,9 @@ msgstr "क्रय आदेश"
 
 msgid "Purchase Orders and Planning"
 msgstr "क्रय आदेश और योजना"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "अभी तक प्राप्त और चालान नहीं किए गए क्रय आदेश"
 
 msgid "Purchase orders required"
 msgstr "क्रय आदेश आवश्यक हैं"
@@ -12408,6 +12556,9 @@ msgstr "क्रय मूल्य विचलन (डिफ़ॉल्ट)"
 
 msgid "Purchase Qty"
 msgstr "खरीद मात्रा"
+
+msgid "Purchase spend"
+msgstr "क्रय व्यय"
 
 msgid "Purchase Tax Payable"
 msgstr "खरीद कर देय (डिफ़ॉल्ट)"
@@ -12429,6 +12580,9 @@ msgstr "खरीदा गया"
 
 msgid "Purchases"
 msgstr "खरीद"
+
+msgid "Purchases by supplier"
+msgstr "आपूर्तिकर्ता द्वारा क्रय"
 
 msgid "purchasing"
 msgstr "क्रय और बेचे गए माल की लागत"
@@ -12603,6 +12757,9 @@ msgstr "इस ओवरराइड के लिए मात्रा-आध�
 msgid "Quantity: {0}"
 msgstr "मात्रा: {0}"
 
+msgid "Quarter to date"
+msgstr "त्रैमासिक से तारीख तक"
+
 msgid "Quarterly"
 msgstr "त्रैमासिक"
 
@@ -12665,6 +12822,9 @@ msgstr "उद्धृत तारीख"
 
 msgid "Quotes"
 msgstr "उद्धरण"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "ड्राफ्ट में कोटेशन या ग्राहक को भेजे गए कोटेशन"
 
 msgid "Quoting and sales orders"
 msgstr "कोटेशन और विक्रय आदेश"
@@ -12948,6 +13108,9 @@ msgstr "पंजीकृत"
 
 msgid "Registered"
 msgstr "पंजीकृत"
+
+msgid "Registered and in-progress issues"
+msgstr "पंजीकृत और चल रहे निर्गम"
 
 msgid "Registration failed"
 msgstr "पंजीकरण विफल"
@@ -13414,6 +13577,9 @@ msgstr "राजस्व"
 msgid "Revenue and expenses over a period"
 msgstr "एक अवधि में राजस्व और व्यय"
 
+msgid "Revenue trend"
+msgstr "राजस्व प्रवृत्ति"
+
 msgid "Reverse all inventory adjustments"
 msgstr "सभी इन्वेंटरी समायोजन को उलट दें"
 
@@ -13720,6 +13886,9 @@ msgstr "बिक्रय छूट"
 msgid "Sales Discounts (default)"
 msgstr "बिक्रय छूट (डिफ़ॉल्ट)"
 
+msgid "Sales documents assigned to me"
+msgstr "मुझे असाइन किए गए बिक्री दस्तावेज़"
+
 msgid "Sales Funnel"
 msgstr "बिक्रय फनल"
 
@@ -13765,14 +13934,23 @@ msgstr "विक्रय आदेश स्थान"
 msgid "Sales Order Number"
 msgstr "विक्रय आदेश संख्या"
 
+msgid "Sales order value over the period"
+msgstr "अवधि में विक्रय आदेश मूल्य"
+
 msgid "Sales orders"
 msgstr "बिक्रय आदेश"
 
 msgid "Sales Orders"
 msgstr "विक्रय आदेश"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "अभी तक भेजे और चालान नहीं किए गए विक्रय आदेश"
+
 msgid "Sales Person"
 msgstr "विक्रय प्रतिनिधि"
+
+msgid "Sales revenue"
+msgstr "बिक्री राजस्व"
 
 msgid "Sales Revenue"
 msgstr "बिक्रय राजस्व"
@@ -13954,6 +14132,9 @@ msgstr "स्क्रैप"
 msgid "Scrap / Cost of Quality"
 msgstr "स्क्रैप / गुणवत्ता की लागत"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "उत्पादन प्लस स्क्रैप मात्रा में स्क्रैप का हिस्सा"
+
 msgid "Scrap Percent"
 msgstr "स्क्रैप प्रतिशत"
 
@@ -13971,6 +14152,9 @@ msgstr "स्क्रैप मात्रा"
 
 msgid "Scrap Quantity Per Job"
 msgstr "प्रति जॉब स्क्रैप मात्रा"
+
+msgid "Scrap rate"
+msgstr "स्क्रैप दर"
 
 msgid "scrap reason"
 msgstr "स्क्रैप कारण"
@@ -14945,6 +15129,9 @@ msgstr "विशिष्ट आइटम"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "आपूर्तिकर्ता, आइटम, या श्रेणी द्वारा व्यय — आपके सबसे बड़े लागत ड्राइवर"
 
+msgid "Spend trend"
+msgstr "व्यय प्रवृत्ति"
+
 msgid "Split"
 msgstr "विभाजित करें"
 
@@ -15336,6 +15523,12 @@ msgstr "आपूर्तिकर्ता खाते"
 
 msgid "Supplier added and selected"
 msgstr "आपूर्तिकर्ता जोड़ा गया और चयनित किया गया"
+
+msgid "Supplier balances not yet paid"
+msgstr "अभी तक भुगतान नहीं की गई आपूर्तिकर्ता शेष राशि"
+
+msgid "Supplier balances past their due date"
+msgstr "अपनी नियत तिथि से आगे आपूर्तिकर्ता शेष राशि"
 
 msgid "Supplier contact"
 msgstr "आपूर्तिकर्ता संपर्क"
@@ -16977,6 +17170,9 @@ msgstr "उपकरण"
 msgid "Tools"
 msgstr "उपकरण"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "अवधि में क्रय आदेश मूल्य द्वारा शीर्ष आपूर्तिकर्ता"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "शीर्ष-स्तर वर्गीकरण (संपत्ति / देयता / इक्विटी / राजस्व / व्यय); केवल मूल समूहों पर सेट, बच्चों द्वारा विरासत में।"
 
@@ -17006,6 +17202,12 @@ msgstr "कुल घंटे"
 
 msgid "Total Minutes"
 msgstr "कुल मिनट"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "अवधि में रखे गए क्रय आदेश का कुल"
+
+msgid "Total of sales orders placed in the period"
+msgstr "अवधि में रखे गए विक्रय आदेश का कुल"
 
 msgid "Total Price"
 msgstr "कुल मूल्य"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "असमर्थित स्रोत दस्तावेज़ प्रकार: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "बिना शीर्षक"
 
 msgid "Untitled Diagram"
 msgstr "बिना शीर्षक वाला आरेख"
@@ -17658,6 +17860,9 @@ msgstr "कवर किए गए डोमेन पर उपयोगकर�
 msgid "Users to Update"
 msgstr "अपडेट करने के लिए उपयोगकर्ता"
 
+msgid "Utilization"
+msgstr "उपयोग"
+
 msgid "Valid From"
 msgstr "वैध से"
 
@@ -17687,6 +17892,9 @@ msgstr "मूल्य स्नैपशॉट"
 
 msgid "Value source by surface"
 msgstr "सतह द्वारा मान स्रोत"
+
+msgid "Value still to ship on open sales orders"
+msgstr "खुले विक्रय आदेश पर भेजने के लिए अभी भी मूल्य"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "मूल्य वर्धित कर पंजीकरण संख्या; यूरोपीय संघ के चालानों पर रिवर्स-चार्ज या शून्य-दर वाली आपूर्ति के लिए आवश्यक।"
@@ -17988,6 +18196,9 @@ msgstr "इस रसीद को रद्द करने से:"
 
 msgid "Voiding this shipment will:"
 msgstr "इस शिपमेंट को रद्द करने से:"
+
+msgid "vs prior period"
+msgstr "पूर्व अवधि के विरुद्ध"
 
 msgid "Waited"
 msgstr "प्रतीक्षा की"
@@ -18483,6 +18694,9 @@ msgstr "यह पंक्ति क्यों अस्वीकार क�
 msgid "Why this restore failed"
 msgstr "यह पुनर्स्थापन क्यों विफल हुआ"
 
+msgid "Widget options"
+msgstr "विजेट विकल्प"
+
 msgid "Will remain as a comment line"
 msgstr "टिप्पणी पंक्ति के रूप में रहेगा"
 
@@ -18575,6 +18789,9 @@ msgstr "वर्कफ़्लो का नाम"
 msgid "Workflow run"
 msgstr "वर्कफ़्लो रन"
 
+msgid "Workflow runs that failed in the period"
+msgstr "अवधि में विफल वर्कफ़्लो चलाता है"
+
 msgid "Workflows"
 msgstr "वर्कफ़्लो"
 
@@ -18608,6 +18825,9 @@ msgstr "किसी संपत्ति के मूल्य को उस�
 
 msgid "Year"
 msgstr "साल"
+
+msgid "Year to date"
+msgstr "वर्ष से तारीख तक"
 
 msgid "Yearly"
 msgstr "वार्षिक"

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} righe di registrazione in bozza"
 msgid "{0} jobs created"
 msgstr "{0} ordini di produzione creati"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} righe scadute"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} righe da mappare"
@@ -1095,8 +1099,20 @@ msgstr "Commissione di attivazione · ti consigliamo"
 msgid "Active"
 msgstr "Attivo"
 
+msgid "Active jobs"
+msgstr "Ordini di produzione in corso"
+
 msgid "Active Jobs"
 msgstr "Ordini di produzione in corso"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Ordini di produzione in corso in scadenza nei prossimi sette giorni"
+
+msgid "Active jobs grouped by status"
+msgstr "Ordini di produzione in corso raggruppati per stato"
+
+msgid "Active jobs past their due date"
+msgstr "Ordini di produzione in corso scaduti"
 
 msgid "Active Statuses"
 msgstr "Stati Attivi"
@@ -1340,6 +1356,9 @@ msgstr "Aggiungi alle scorte per uso futuro"
 
 msgid "Add tools"
 msgstr "Aggiungi strumenti"
+
+msgid "Add widgets"
+msgstr "Aggiungi widget"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Invecchiamento Debiti verso fornitori"
 msgid "AP Clerk"
 msgstr "Impiegato Debiti verso fornitori"
 
+msgid "AP outstanding"
+msgstr "Debiti verso fornitori in sospeso"
+
 msgid "AP Outstanding"
 msgstr "Debiti verso fornitori in sospeso"
+
+msgid "AP overdue"
+msgstr "Debiti verso fornitori in ritardo"
 
 msgid "AP Overdue"
 msgstr "Debiti verso fornitori in ritardo"
@@ -1844,8 +1869,14 @@ msgstr "Invecchiamento Crediti verso clienti"
 msgid "AR Clerk"
 msgstr "Impiegato Crediti verso clienti"
 
+msgid "AR outstanding"
+msgstr "Crediti verso clienti in sospeso"
+
 msgid "AR Outstanding"
 msgstr "Crediti verso clienti in sospeso"
+
+msgid "AR overdue"
+msgstr "Crediti verso clienti in ritardo"
 
 msgid "AR Overdue"
 msgstr "Crediti verso clienti in ritardo"
@@ -3263,6 +3294,9 @@ msgstr "Scegli un altro file"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Scegli cosa appare sul cartellino di produzione stampato."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Scegli quali widget visualizzare nella tua pagina iniziale."
+
 msgid "Choose your style"
 msgstr "Scegli il tuo stile"
 
@@ -4533,6 +4567,12 @@ msgstr "Cliente"
 msgid "Customer Accounts"
 msgstr "Account Cliente"
 
+msgid "Customer balances not yet paid"
+msgstr "Saldi cliente non ancora pagati"
+
+msgid "Customer balances past their due date"
+msgstr "Saldi cliente scaduti"
+
 msgid "Customer contact"
 msgstr "Contatto cliente"
 
@@ -4658,6 +4698,9 @@ msgstr "Personalizzazioni, formazione e integrazioni"
 
 msgid "Customize"
 msgstr "Personalizza"
+
+msgid "Customize analytics"
+msgstr "Personalizza analitiche"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Personalizza il layout dei tuoi documenti PDF — riordina le sezioni, nascondi quello che non ti serve e aggiungi i tuoi blocchi."
@@ -7103,6 +7146,9 @@ msgstr "Caricamento PDF non riuscito"
 msgid "Failed to upload thumbnail"
 msgstr "Impossibile caricare la miniatura"
 
+msgid "Failed workflow runs"
+msgstr "Esecuzioni flusso di lavoro non riuscite"
+
 msgid "Failure"
 msgstr "Errore"
 
@@ -7252,6 +7298,9 @@ msgstr "Nome"
 msgid "First Operation"
 msgstr "Prima Operazione"
 
+msgid "First-pass yield"
+msgstr "Resa al primo passaggio"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Immobilizzazione"
 
@@ -7308,6 +7357,9 @@ msgstr "ID attrezzatura di fissaggio"
 
 msgid "Flags"
 msgstr "Flag"
+
+msgid "Follow page range"
+msgstr "Rispetta intervallo pagine"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "per qualsiasi cosa. Porteranno la persona giusta."
@@ -7751,6 +7803,9 @@ msgstr "Nascondi raw"
 msgid "Hide system quantities until the review step"
 msgstr "Nascondi le quantità di sistema fino al passaggio di revisione"
 
+msgid "Hide widget"
+msgstr "Nascondi widget"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Nascondi, fissa e riordina le colonne"
 
@@ -7810,6 +7865,9 @@ msgstr "Ore presso questa stazione"
 
 msgid "Hours not yet assigned"
 msgstr "Ore non ancora assegnate"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Ore di produzione per centro di lavoro nel periodo"
 
 msgid "Hours per Week"
 msgstr "Ore per Settimana"
@@ -8223,6 +8281,9 @@ msgstr "Documento di controllo"
 msgid "Inspection Level"
 msgstr "Livello di controllo"
 
+msgid "Inspection pass rate"
+msgstr "Tasso di superamento dei controlli"
+
 msgid "Inspection Plan"
 msgstr "Piano di controllo"
 
@@ -8237,6 +8298,9 @@ msgstr "Stato del controllo"
 
 msgid "Inspections"
 msgstr "Controlli"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Controlli superati come percentuale di quelli esaminati"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Controlli, non conformità e CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Unità di Misura Inventario"
 
 msgid "Inventory Valuation"
 msgstr "Valutazione Inventario"
+
+msgid "Inventory value"
+msgstr "Valore giacenze"
 
 msgid "Invite"
 msgstr "Invita"
@@ -8535,6 +8602,12 @@ msgstr "Data di Emissione"
 msgid "Issues"
 msgstr "Problemi"
 
+msgid "Issues by type"
+msgstr "Rilievi per tipo"
+
+msgid "Issues opened"
+msgstr "Rilievi aperti"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Si interromperà fino a quando non pubblichi di nuovo una versione. Nulla viene eliminato."
 
@@ -8673,6 +8746,15 @@ msgstr "Ordini di produzione"
 msgid "Jobs Assigned to Me"
 msgstr "Ordini di produzione assegnati a me"
 
+msgid "Jobs by status"
+msgstr "Ordini di produzione per stato"
+
+msgid "Jobs due this week"
+msgstr "Ordini di produzione in scadenza questa settimana"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Ordini di produzione pianificati, pronti, in corso o in pausa"
+
 msgid "Jobs Required"
 msgstr "Ordini di produzione richiesti"
 
@@ -8804,8 +8886,20 @@ msgstr "Unità di manodopera"
 msgid "Language"
 msgstr "Lingua"
 
+msgid "Last 12 months"
+msgstr "Ultimi 12 mesi"
+
+msgid "Last 30 days"
+msgstr "Ultimi 30 giorni"
+
 msgid "Last 6 Months"
 msgstr "Ultimi 6 Mesi"
+
+msgid "Last 7 days"
+msgstr "Ultimi 7 giorni"
+
+msgid "Last 90 days"
+msgstr "Ultimi 90 giorni"
 
 msgid "Last attempt"
 msgstr "Ultimo tentativo"
@@ -8857,6 +8951,9 @@ msgstr "Ultimo utilizzo"
 
 msgid "Late in the evening, {name}."
 msgstr "Tardi la sera, {name}."
+
+msgid "Late jobs"
+msgstr "Ordini di produzione in ritardo"
 
 msgid "Latest operation end"
 msgstr "Fine dell'ultimo operazione"
@@ -8998,6 +9095,9 @@ msgstr "Le righe necessitano di numeri di parte interni"
 
 msgid "Lines need prices or lead times"
 msgstr "Le righe hanno bisogno di prezzi o lead time"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Righe spedite entro o prima della data promessa"
 
 msgid "Lineside"
 msgstr "Bordo linea"
@@ -9773,6 +9873,9 @@ msgstr "Denaro che ti è dovuto"
 msgid "Money you owe"
 msgstr "Denaro che devi"
 
+msgid "Month to date"
+msgstr "Da inizio mese"
+
 msgid "Monthly"
 msgstr "Mensile"
 
@@ -9799,6 +9902,9 @@ msgstr "Più straordinario"
 
 msgid "Morning, {name}."
 msgstr "Mattino, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Tipi di rilievo più frequenti nel periodo"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "La maggior parte dei problemi viene identificata e risolta qui. Nominala chiaramente."
@@ -9858,6 +9964,9 @@ msgstr "MRP viene eseguito automaticamente ogni 3 ore, ma puoi eseguirlo manualm
 
 msgid "Must be in the same location"
 msgstr "Deve essere nella stessa posizione"
+
+msgid "My active operations"
+msgstr "Le mie operazioni attive"
 
 msgid "My Documents"
 msgstr "I miei documenti"
@@ -10044,6 +10153,9 @@ msgstr "Nuova Fattura"
 
 msgid "New Issue"
 msgstr "Nuovo Problema"
+
+msgid "New issues over the period"
+msgstr "Nuovi rilievi nel periodo"
 
 msgid "New Item Group"
 msgstr "Nuovo Gruppo Articoli"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Più vecchio prima"
 
+msgid "Oldest overdue orders first"
+msgstr "Ordini in ritardo più datati prima"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Nel giorno del cutover, esegui la checklist sottostante in ordine. I test di accettazione provengono dai tuoi requisiti in ambito. I dettagli di supporto sono in fondo."
 
@@ -10962,6 +11077,9 @@ msgstr "Conteggi disponibili"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Quantità minima da mantenere per uso in servizio presso questa ubicazione"
+
+msgid "On-hand inventory at cost"
+msgstr "Giacenze disponibili al costo"
 
 msgid "On-hand inventory remains"
 msgstr "L'inventario disponibile rimane"
@@ -11055,6 +11173,9 @@ msgstr "Crediti verso clienti aperti"
 msgid "Open Audit Log"
 msgstr "Apri Registro di Audit"
 
+msgid "Open backlog"
+msgstr "Arretrato aperto"
+
 msgid "Open date"
 msgstr "Data di apertura"
 
@@ -11076,6 +11197,9 @@ msgstr "Apri negli avvisi di modifica {ids}. Rilasciali per creare nuove version
 msgid "Open in MES"
 msgstr "Apri in MES"
 
+msgid "Open issues"
+msgstr "Problemi aperti"
+
 msgid "Open Issues"
 msgstr "Problemi Aperti"
 
@@ -11094,6 +11218,9 @@ msgstr "Apri menu"
 msgid "Open navigation"
 msgstr "Apri navigazione"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Ordini aperti con una riga che ha superato la data promessa"
+
 msgid "Open payables by supplier and age"
 msgstr "Debiti aperti per fornitore e anzianità"
 
@@ -11105,6 +11232,9 @@ msgstr "Ordini di acquisto aperti"
 
 msgid "Open Purchase Orders"
 msgstr "Ordini di acquisto aperti"
+
+msgid "Open quotes"
+msgstr "Offerte aperte"
 
 msgid "Open Quotes"
 msgstr "Preventivi Aperti"
@@ -11208,6 +11338,9 @@ msgstr "Operazioni / Passi"
 
 msgid "Operations Type"
 msgstr "Tipo Operazioni"
+
+msgid "Operations you currently have running"
+msgstr "Operazioni attualmente in corso"
 
 msgid "Operator"
 msgstr "Operatore"
@@ -11318,6 +11451,9 @@ msgstr "Ordini"
 msgid "Orders submitted"
 msgstr "Ordini inviati"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Ordini, offerte e RdO dove sei l'assegnatario"
+
 msgid "Origin"
 msgstr "Origine"
 
@@ -11371,6 +11507,9 @@ msgstr "Risultato complessivo"
 
 msgid "Overdue"
 msgstr "In ritardo"
+
+msgid "Overdue purchase orders"
+msgstr "Ordini di acquisto in ritardo"
 
 msgid "Overhead Absorption"
 msgstr "Assorbimento dei Costi Generali"
@@ -12179,6 +12318,9 @@ msgstr "Quantità di produzione"
 msgid "Production Quantity"
 msgstr "Quantità di Produzione"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Quantità di produzione senza rilavorazione o scarto"
+
 msgid "Production variance"
 msgstr "Scostamento di produzione"
 
@@ -12382,6 +12524,9 @@ msgstr "Ordine di acquisto rimosso con successo"
 msgid "Purchase Order Type"
 msgstr "Tipo di Ordine d'Acquisto"
 
+msgid "Purchase order value over the period"
+msgstr "Valore dell'ordine di acquisto nel periodo"
+
 msgid "Purchase orders"
 msgstr "Ordini di Acquisto"
 
@@ -12390,6 +12535,9 @@ msgstr "Ordini di Acquisto"
 
 msgid "Purchase Orders and Planning"
 msgstr "Ordini di Acquisto e Pianificazione"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Ordini di acquisto non ancora ricevuti e fatturati"
 
 msgid "Purchase orders required"
 msgstr "Ordini di acquisto richiesti"
@@ -12408,6 +12556,9 @@ msgstr "Scostamento di Prezzo di Acquisto (default)"
 
 msgid "Purchase Qty"
 msgstr "Quantità Acquisto"
+
+msgid "Purchase spend"
+msgstr "Spesa di acquisto"
 
 msgid "Purchase Tax Payable"
 msgstr "Imposta di Acquisto Pagabile (predefinita)"
@@ -12429,6 +12580,9 @@ msgstr "Acquistato"
 
 msgid "Purchases"
 msgstr "Acquisti"
+
+msgid "Purchases by supplier"
+msgstr "Acquisti per fornitore"
 
 msgid "purchasing"
 msgstr "Acquisti e Costo del Venduto"
@@ -12603,6 +12757,9 @@ msgstr "Scaglioni di prezzo basati sulla quantità per questa forzatura; il prez
 msgid "Quantity: {0}"
 msgstr "Quantità: {0}"
 
+msgid "Quarter to date"
+msgstr "Da inizio trimestre"
+
 msgid "Quarterly"
 msgstr "Trimestrale"
 
@@ -12665,6 +12822,9 @@ msgstr "Data Quotata"
 
 msgid "Quotes"
 msgstr "Preventivi"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Offerte in bozza o inviate al cliente"
 
 msgid "Quoting and sales orders"
 msgstr "Preventivi e ordini di vendita"
@@ -12948,6 +13108,9 @@ msgstr "Registrato"
 
 msgid "Registered"
 msgstr "Registrato"
+
+msgid "Registered and in-progress issues"
+msgstr "Problemi registrati e in corso"
 
 msgid "Registration failed"
 msgstr "Registrazione non riuscita"
@@ -13414,6 +13577,9 @@ msgstr "Ricavi"
 msgid "Revenue and expenses over a period"
 msgstr "Ricavi e spese in un periodo"
 
+msgid "Revenue trend"
+msgstr "Tendenza dei ricavi"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Inverti tutte le rettifiche di magazzino"
 
@@ -13720,6 +13886,9 @@ msgstr "Sconti di vendita"
 msgid "Sales Discounts (default)"
 msgstr "Sconti di vendita (predefinito)"
 
+msgid "Sales documents assigned to me"
+msgstr "Documenti di vendita assegnati a me"
+
 msgid "Sales Funnel"
 msgstr "Funnel di vendita"
 
@@ -13765,14 +13934,23 @@ msgstr "Ubicazione Ordine di Vendita"
 msgid "Sales Order Number"
 msgstr "Numero Ordine Vendita"
 
+msgid "Sales order value over the period"
+msgstr "Valore dell'ordine di vendita nel periodo"
+
 msgid "Sales orders"
 msgstr "Ordini di vendita"
 
 msgid "Sales Orders"
 msgstr "Ordini di vendita"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Ordini di vendita non ancora spediti e fatturati"
+
 msgid "Sales Person"
 msgstr "Addetto alle vendite"
+
+msgid "Sales revenue"
+msgstr "Ricavi delle vendite"
 
 msgid "Sales Revenue"
 msgstr "Ricavi di vendita"
@@ -13954,6 +14132,9 @@ msgstr "Scarto"
 msgid "Scrap / Cost of Quality"
 msgstr "Scarto / Costo della Qualità"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Scarto come percentuale della quantità di produzione più scarto"
+
 msgid "Scrap Percent"
 msgstr "Percentuale di Scarto"
 
@@ -13971,6 +14152,9 @@ msgstr "Quantità di Scarto"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Quantità di Scarto Per Lavoro"
+
+msgid "Scrap rate"
+msgstr "Tasso di scarto"
 
 msgid "scrap reason"
 msgstr "causale di scarto"
@@ -14945,6 +15129,9 @@ msgstr "Articoli Specifici"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Spesa per fornitore, articolo o categoria — i tuoi principali driver di costo"
 
+msgid "Spend trend"
+msgstr "Tendenza della spesa"
+
 msgid "Split"
 msgstr "Dividi"
 
@@ -15336,6 +15523,12 @@ msgstr "Account Fornitori"
 
 msgid "Supplier added and selected"
 msgstr "Fornitore aggiunto e selezionato"
+
+msgid "Supplier balances not yet paid"
+msgstr "Saldi fornitori non ancora pagati"
+
+msgid "Supplier balances past their due date"
+msgstr "Saldi fornitori oltre la data di scadenza"
 
 msgid "Supplier contact"
 msgstr "Contatto fornitore"
@@ -16977,6 +17170,9 @@ msgstr "Strumenti"
 msgid "Tools"
 msgstr "Strumenti"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Fornitori principali per valore dell'ordine di acquisto nel periodo"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Classificazione di primo livello (attivo/passivo/patrimonio netto/ricavi/spese); impostato solo su gruppi radice, ereditato dai figli."
 
@@ -17006,6 +17202,12 @@ msgstr "Ore totali"
 
 msgid "Total Minutes"
 msgstr "Minuti totali"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Totale degli ordini di acquisto piazzati nel periodo"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Totale degli ordini di vendita piazzati nel periodo"
 
 msgid "Total Price"
 msgstr "Prezzo Totale"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Tipo di documento di origine non supportato: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Senza titolo"
 
 msgid "Untitled Diagram"
 msgstr "Diagramma senza titolo"
@@ -17658,6 +17860,9 @@ msgstr "Gli utenti sui domini coperti possono accedere solo con SAML SSO; il col
 msgid "Users to Update"
 msgstr "Utenti da aggiornare"
 
+msgid "Utilization"
+msgstr "Utilizzo"
+
 msgid "Valid From"
 msgstr "Valido da"
 
@@ -17687,6 +17892,9 @@ msgstr "Snapshot di Valore"
 
 msgid "Value source by surface"
 msgstr "Fonte del valore per superficie"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Valore ancora da spedire su ordini di vendita aperti"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Numero di registrazione dell'imposta sul valore aggiunto; richiesto sulle fatture dell'UE per le forniture in reverse charge o a tasso zero."
@@ -17988,6 +18196,9 @@ msgstr "L'annullamento di questa ricevuta comporterà:"
 
 msgid "Voiding this shipment will:"
 msgstr "Annullare questa spedizione comporterà:"
+
+msgid "vs prior period"
+msgstr "vs periodo precedente"
 
 msgid "Waited"
 msgstr "Atteso"
@@ -18483,6 +18694,9 @@ msgstr "Perché questa linea viene rifiutata; visualizzato sul preventivo stampa
 msgid "Why this restore failed"
 msgstr "Motivo per cui questo ripristino è fallito"
 
+msgid "Widget options"
+msgstr "Opzioni widget"
+
 msgid "Will remain as a comment line"
 msgstr "Rimarrà come riga di commento"
 
@@ -18575,6 +18789,9 @@ msgstr "Nome del flusso di lavoro"
 msgid "Workflow run"
 msgstr "Esecuzione del flusso di lavoro"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Esecuzioni del flusso di lavoro non riuscite nel periodo"
+
 msgid "Workflows"
 msgstr "Flussi di lavoro"
 
@@ -18608,6 +18825,9 @@ msgstr "Ammortamento del valore di un bene nel corso della sua vita — un lotto
 
 msgid "Year"
 msgstr "Anno"
+
+msgid "Year to date"
+msgstr "Da inizio anno"
 
 msgid "Yearly"
 msgstr "Annuale"

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -93,6 +93,10 @@ msgstr "{0}件の下書き仕訳"
 msgid "{0} jobs created"
 msgstr "{0} 件の製造指図が作成されました"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0}件の明細が期限超過"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0}件のラインをマップします"
@@ -1095,8 +1099,20 @@ msgstr "アクティベーション料金 · アドバイス提供"
 msgid "Active"
 msgstr "有効"
 
+msgid "Active jobs"
+msgstr "稼働中の製造指図"
+
 msgid "Active Jobs"
 msgstr "有効な製造指図"
+
+msgid "Active jobs due in the next seven days"
+msgstr "今後7日以内に期日を迎える稼働中の製造指図"
+
+msgid "Active jobs grouped by status"
+msgstr "ステータス別に分類した稼働中の製造指図"
+
+msgid "Active jobs past their due date"
+msgstr "期限超過の稼働中の製造指図"
 
 msgid "Active Statuses"
 msgstr "アクティブなステータス"
@@ -1340,6 +1356,9 @@ msgstr "将来の使用のためにストックに追加"
 
 msgid "Add tools"
 msgstr "ツールを追加"
+
+msgid "Add widgets"
+msgstr "ウィジェットを追加"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "買掛金エージング"
 msgid "AP Clerk"
 msgstr "買掛金担当者"
 
+msgid "AP outstanding"
+msgstr "買掛金残高"
+
 msgid "AP Outstanding"
 msgstr "未払買掛金"
+
+msgid "AP overdue"
+msgstr "買掛金期限超過"
 
 msgid "AP Overdue"
 msgstr "期限超過買掛金"
@@ -1844,8 +1869,14 @@ msgstr "売掛金エージング"
 msgid "AR Clerk"
 msgstr "売掛金係員"
 
+msgid "AR outstanding"
+msgstr "売掛金残高"
+
 msgid "AR Outstanding"
 msgstr "売掛金未払い"
+
+msgid "AR overdue"
+msgstr "売掛金期限超過"
 
 msgid "AR Overdue"
 msgstr "売掛金期限超過"
@@ -3263,6 +3294,9 @@ msgstr "別のファイルを選択"
 msgid "Choose what appears on the printed job traveler."
 msgstr "印刷された製造指図現品票に表示される内容を選択します。"
 
+msgid "Choose which widgets appear on your home page."
+msgstr "ホームページに表示するウィジェットを選択してください。"
+
 msgid "Choose your style"
 msgstr "あなたのスタイルを選択"
 
@@ -4533,6 +4567,12 @@ msgstr "得意先"
 msgid "Customer Accounts"
 msgstr "得意先アカウント"
 
+msgid "Customer balances not yet paid"
+msgstr "未払いの得意先残高"
+
+msgid "Customer balances past their due date"
+msgstr "期限超過の得意先残高"
+
 msgid "Customer contact"
 msgstr "得意先担当者"
 
@@ -4658,6 +4698,9 @@ msgstr "カスタマイズ、教育訓練、連携"
 
 msgid "Customize"
 msgstr "カスタマイズ"
+
+msgid "Customize analytics"
+msgstr "分析をカスタマイズ"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "PDFドキュメントのレイアウトをカスタマイズ — セクションを並べ替え、不要な部分を非表示にし、独自のブロックを追加できます。"
@@ -7103,6 +7146,9 @@ msgstr "PDFのアップロードに失敗しました"
 msgid "Failed to upload thumbnail"
 msgstr "サムネイルのアップロードに失敗しました"
 
+msgid "Failed workflow runs"
+msgstr "失敗したワークフロー実行"
+
 msgid "Failure"
 msgstr "失敗"
 
@@ -7252,6 +7298,9 @@ msgstr "名"
 msgid "First Operation"
 msgstr "最初の操作"
 
+msgid "First-pass yield"
+msgstr "初回合格率"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "固定資産"
 
@@ -7308,6 +7357,9 @@ msgstr "治具ID"
 
 msgid "Flags"
 msgstr "フラグ"
+
+msgid "Follow page range"
+msgstr "ページ範囲に従う"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "何でも構いません。彼らが適切な人を連れてきます。"
@@ -7751,6 +7803,9 @@ msgstr "生データを非表示"
 msgid "Hide system quantities until the review step"
 msgstr "レビューステップまでシステム数量を非表示にする"
 
+msgid "Hide widget"
+msgstr "ウィジェットを非表示"
+
 msgid "Hide, pin and reorder columns"
 msgstr "列を非表示、ピン留め、並び替え"
 
@@ -7810,6 +7865,9 @@ msgstr "このステーションの時間"
 
 msgid "Hours not yet assigned"
 msgstr "未配置の時間"
+
+msgid "Hours of production time per work center in the period"
+msgstr "期間内の作業区ごとの生産時間"
 
 msgid "Hours per Week"
 msgstr "週間あたりの時間"
@@ -8223,6 +8281,9 @@ msgstr "検査文書"
 msgid "Inspection Level"
 msgstr "検査水準"
 
+msgid "Inspection pass rate"
+msgstr "検査合格率"
+
 msgid "Inspection Plan"
 msgstr "検査計画"
 
@@ -8237,6 +8298,9 @@ msgstr "検査ステータス"
 
 msgid "Inspections"
 msgstr "検査"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "処理されたもののうち合格した検査の割合"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "検査、不適合、およびCAPA"
@@ -8369,6 +8433,9 @@ msgstr "在庫単位"
 
 msgid "Inventory Valuation"
 msgstr "在庫評価"
+
+msgid "Inventory value"
+msgstr "在庫価値"
 
 msgid "Invite"
 msgstr "招待"
@@ -8535,6 +8602,12 @@ msgstr "発行日"
 msgid "Issues"
 msgstr "問題"
 
+msgid "Issues by type"
+msgstr "不適合タイプ別"
+
+msgid "Issues opened"
+msgstr "新規不適合"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "バージョンを再度公開するまで実行は停止します。削除されるものはありません。"
 
@@ -8673,6 +8746,15 @@ msgstr "製造指図"
 msgid "Jobs Assigned to Me"
 msgstr "私に割り当てられた製造指図"
 
+msgid "Jobs by status"
+msgstr "ステータス別製造指図"
+
+msgid "Jobs due this week"
+msgstr "今週期日の製造指図"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "計画済、準備完了、進行中、または一時停止の製造指図"
+
 msgid "Jobs Required"
 msgstr "必要な製造指図"
 
@@ -8804,8 +8886,20 @@ msgstr "労務単位"
 msgid "Language"
 msgstr "言語"
 
+msgid "Last 12 months"
+msgstr "過去12ヶ月"
+
+msgid "Last 30 days"
+msgstr "過去30日"
+
 msgid "Last 6 Months"
 msgstr "過去6ヶ月"
+
+msgid "Last 7 days"
+msgstr "過去7日"
+
+msgid "Last 90 days"
+msgstr "過去90日"
 
 msgid "Last attempt"
 msgstr "最後の試行"
@@ -8857,6 +8951,9 @@ msgstr "最後に使用"
 
 msgid "Late in the evening, {name}."
 msgstr "夜遅く、{name}さん。"
+
+msgid "Late jobs"
+msgstr "遅延した製造指図"
 
 msgid "Latest operation end"
 msgstr "最終操作終了"
@@ -8998,6 +9095,9 @@ msgstr "明細には社内部品番号が必要です"
 
 msgid "Lines need prices or lead times"
 msgstr "ラインには価格またはリードタイムが必要です"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "回答納期以前に出荷された明細"
 
 msgid "Lineside"
 msgstr "ラインサイド"
@@ -9773,6 +9873,9 @@ msgstr "あなたに支払われるべき金額"
 msgid "Money you owe"
 msgstr "あなたが負っている金額"
 
+msgid "Month to date"
+msgstr "当月"
+
 msgid "Monthly"
 msgstr "月次"
 
@@ -9799,6 +9902,9 @@ msgstr "残業を増やす"
 
 msgid "Morning, {name}."
 msgstr "朝、{name}さん。"
+
+msgid "Most frequent issue types in the period"
+msgstr "期間中の最も頻繁な不適合タイプ"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "ほとんどのことはここで発見され、解決されます。明確に名前を付けてください。"
@@ -9858,6 +9964,9 @@ msgstr "MRPは3時間ごとに自動的に実行されますが、ここで手�
 
 msgid "Must be in the same location"
 msgstr "同じ場所にある必要があります"
+
+msgid "My active operations"
+msgstr "自分の工程"
 
 msgid "My Documents"
 msgstr "マイドキュメント"
@@ -10044,6 +10153,9 @@ msgstr "新しい請求書"
 
 msgid "New Issue"
 msgstr "新しい問題"
+
+msgid "New issues over the period"
+msgstr "期間中の新規不適合"
 
 msgid "New Item Group"
 msgstr "新しいアイテムグループ"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "最も古いものから"
 
+msgid "Oldest overdue orders first"
+msgstr "最も古い期限超過の注文から"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "カットオーバー日に、下のチェックリストを順番に作業してください。受け入れテストはあなたの対象要求事項から取得されます。サポートの詳細は下部にあります。"
 
@@ -10962,6 +11077,9 @@ msgstr "手持在庫数"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "このロケーションでのサービス使用のために維持する最小在庫数"
+
+msgid "On-hand inventory at cost"
+msgstr "手持在庫の原価"
 
 msgid "On-hand inventory remains"
 msgstr "現在庫が残っています"
@@ -11055,6 +11173,9 @@ msgstr "未払い売掛金"
 msgid "Open Audit Log"
 msgstr "監査ログを開く"
 
+msgid "Open backlog"
+msgstr "オープン受注残"
+
 msgid "Open date"
 msgstr "開始日"
 
@@ -11076,6 +11197,9 @@ msgstr "変更通知{ids}で開いています。新しいバージョンまた�
 msgid "Open in MES"
 msgstr "MESで開く"
 
+msgid "Open issues"
+msgstr "オープンな課題"
+
 msgid "Open Issues"
 msgstr "未解決の問題"
 
@@ -11094,6 +11218,9 @@ msgstr "メニューを開く"
 msgid "Open navigation"
 msgstr "ナビゲーションを開く"
 
+msgid "Open orders with a line past its promised date"
+msgstr "回答納期を超過した明細を含むオープンな発注書"
+
 msgid "Open payables by supplier and age"
 msgstr "仕入先・日数別オープン買掛金"
 
@@ -11105,6 +11232,9 @@ msgstr "未処理の発注書"
 
 msgid "Open Purchase Orders"
 msgstr "未処理の発注書"
+
+msgid "Open quotes"
+msgstr "オープンな見積"
 
 msgid "Open Quotes"
 msgstr "オープン見積"
@@ -11208,6 +11338,9 @@ msgstr "工程 / ステップ"
 
 msgid "Operations Type"
 msgstr "工程タイプ"
+
+msgid "Operations you currently have running"
+msgstr "現在実行中の工程"
 
 msgid "Operator"
 msgstr "作業者"
@@ -11318,6 +11451,9 @@ msgstr "注文"
 msgid "Orders submitted"
 msgstr "注文が送信されました"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "自分が担当者である受注、見積、見積依頼"
+
 msgid "Origin"
 msgstr "オリジン"
 
@@ -11371,6 +11507,9 @@ msgstr "総合結果"
 
 msgid "Overdue"
 msgstr "期限超過"
+
+msgid "Overdue purchase orders"
+msgstr "期限超過の発注書"
 
 msgid "Overhead Absorption"
 msgstr "間接費配賦"
@@ -12179,6 +12318,9 @@ msgstr "生産数量"
 msgid "Production Quantity"
 msgstr "生産数量"
 
+msgid "Production quantity without rework or scrap"
+msgstr "手直しおよびスクラップのない生産数量"
+
 msgid "Production variance"
 msgstr "生産差異"
 
@@ -12382,6 +12524,9 @@ msgstr "発注書は正常に削除されました"
 msgid "Purchase Order Type"
 msgstr "発注書種別"
 
+msgid "Purchase order value over the period"
+msgstr "期間中の発注書額"
+
 msgid "Purchase orders"
 msgstr "購入注文"
 
@@ -12390,6 +12535,9 @@ msgstr "発注書"
 
 msgid "Purchase Orders and Planning"
 msgstr "発注書と計画"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "未受領かつ未請求の発注書"
 
 msgid "Purchase orders required"
 msgstr "発注書が必要です"
@@ -12408,6 +12556,9 @@ msgstr "仕入価格差異（デフォルト）"
 
 msgid "Purchase Qty"
 msgstr "購入数量"
+
+msgid "Purchase spend"
+msgstr "購買額"
 
 msgid "Purchase Tax Payable"
 msgstr "仕入税金支払い（デフォルト）"
@@ -12429,6 +12580,9 @@ msgstr "購入済み"
 
 msgid "Purchases"
 msgstr "購買"
+
+msgid "Purchases by supplier"
+msgstr "仕入先別購買"
 
 msgid "purchasing"
 msgstr "購買と売上原価"
@@ -12603,6 +12757,9 @@ msgstr "この上書きの数量ベース価格設定段階。適用される単
 msgid "Quantity: {0}"
 msgstr "数量: {0}"
 
+msgid "Quarter to date"
+msgstr "四半期累計"
+
 msgid "Quarterly"
 msgstr "四半期ごと"
 
@@ -12665,6 +12822,9 @@ msgstr "見積日"
 
 msgid "Quotes"
 msgstr "見積"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "下書きまたは得意先送付済みの見積"
 
 msgid "Quoting and sales orders"
 msgstr "見積と受注"
@@ -12948,6 +13108,9 @@ msgstr "登録済み"
 
 msgid "Registered"
 msgstr "登録済"
+
+msgid "Registered and in-progress issues"
+msgstr "登録済みおよび進行中の課題"
 
 msgid "Registration failed"
 msgstr "登録に失敗しました"
@@ -13414,6 +13577,9 @@ msgstr "売上高"
 msgid "Revenue and expenses over a period"
 msgstr "期間中の売上高と費用"
 
+msgid "Revenue trend"
+msgstr "売上高の推移"
+
 msgid "Reverse all inventory adjustments"
 msgstr "すべての在庫調整を取り消す"
 
@@ -13720,6 +13886,9 @@ msgstr "販売値引"
 msgid "Sales Discounts (default)"
 msgstr "販売値引（デフォルト）"
 
+msgid "Sales documents assigned to me"
+msgstr "自分に割り当てられた販売ドキュメント"
+
 msgid "Sales Funnel"
 msgstr "販売ファネル"
 
@@ -13765,14 +13934,23 @@ msgstr "受注拠点"
 msgid "Sales Order Number"
 msgstr "受注番号"
 
+msgid "Sales order value over the period"
+msgstr "期間中の受注額"
+
 msgid "Sales orders"
 msgstr "販売注文"
 
 msgid "Sales Orders"
 msgstr "受注"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "未出荷かつ未請求の受注"
+
 msgid "Sales Person"
 msgstr "営業担当者"
+
+msgid "Sales revenue"
+msgstr "販売売上高"
 
 msgid "Sales Revenue"
 msgstr "販売売上高"
@@ -13954,6 +14132,9 @@ msgstr "スクラップ"
 msgid "Scrap / Cost of Quality"
 msgstr "スクラップ/品質コスト"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "生産量に占めるスクラップの割合"
+
 msgid "Scrap Percent"
 msgstr "スクラップ率"
 
@@ -13971,6 +14152,9 @@ msgstr "スクラップ数量"
 
 msgid "Scrap Quantity Per Job"
 msgstr "ジョブあたりのスクラップ数量"
+
+msgid "Scrap rate"
+msgstr "スクラップ率"
 
 msgid "scrap reason"
 msgstr "不良理由"
@@ -14945,6 +15129,9 @@ msgstr "特定の品目"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "仕入先、品目、またはカテゴリ別の支出 — 最大の原価ドライバー"
 
+msgid "Spend trend"
+msgstr "支出の推移"
+
 msgid "Split"
 msgstr "分割"
 
@@ -15336,6 +15523,12 @@ msgstr "仕入先アカウント"
 
 msgid "Supplier added and selected"
 msgstr "仕入先が追加され選択されました"
+
+msgid "Supplier balances not yet paid"
+msgstr "未払いの仕入先残高"
+
+msgid "Supplier balances past their due date"
+msgstr "期日超過の仕入先残高"
 
 msgid "Supplier contact"
 msgstr "仕入先担当者"
@@ -16977,6 +17170,9 @@ msgstr "ツール"
 msgid "Tools"
 msgstr "ツール"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "期間中の発注額上位の仕入先"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "トップレベルの分類（資産/負債/純資産/売上高/費用）；ルートグループにのみ設定され、子に継承されます。"
 
@@ -17006,6 +17202,12 @@ msgstr "合計時間"
 
 msgid "Total Minutes"
 msgstr "合計分"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "期間中の発注書合計額"
+
+msgid "Total of sales orders placed in the period"
+msgstr "期間中の受注合計額"
 
 msgid "Total Price"
 msgstr "合計価格"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "対応していない参照伝票タイプ：{sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "無題"
 
 msgid "Untitled Diagram"
 msgstr "無題の図"
@@ -17658,6 +17860,9 @@ msgstr "対象ドメインのユーザーは SAML SSO でのみサインイン�
 msgid "Users to Update"
 msgstr "更新するユーザー"
 
+msgid "Utilization"
+msgstr "稼働率"
+
 msgid "Valid From"
 msgstr "有効期間開始"
 
@@ -17687,6 +17892,9 @@ msgstr "バリュー スナップショット"
 
 msgid "Value source by surface"
 msgstr "サーフェスごとの値のソース"
+
+msgid "Value still to ship on open sales orders"
+msgstr "オープンな受注における出荷待ち金額"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "付加価値税登録番号;EUの請求書でのリバースチャージまたはゼロレート供給に必要。"
@@ -17988,6 +18196,9 @@ msgstr "このレシートを無効にすると:"
 
 msgid "Voiding this shipment will:"
 msgstr "この出荷をキャンセルすると、以下のようになります:"
+
+msgid "vs prior period"
+msgstr "対前期"
 
 msgid "Waited"
 msgstr "待機"
@@ -18483,6 +18694,9 @@ msgstr "この行が拒否されている理由。印刷可能な見積もりに
 msgid "Why this restore failed"
 msgstr "この復元が失敗した理由"
 
+msgid "Widget options"
+msgstr "ウィジェットオプション"
+
 msgid "Will remain as a comment line"
 msgstr "コメント行として残ります"
 
@@ -18575,6 +18789,9 @@ msgstr "ワークフロー名"
 msgid "Workflow run"
 msgstr "ワークフロー実行"
 
+msgid "Workflow runs that failed in the period"
+msgstr "期間中に失敗したワークフロー実行"
+
 msgid "Workflows"
 msgstr "ワークフロー"
 
@@ -18608,6 +18825,9 @@ msgstr "資産の価値を耐用年数にわたって減額する―毎月作成
 
 msgid "Year"
 msgstr "年"
+
+msgid "Year to date"
+msgstr "当年累計"
 
 msgid "Yearly"
 msgstr "年次"

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -93,6 +93,10 @@ msgstr "{0}개의 초안 분개"
 msgid "{0} jobs created"
 msgstr "{0}개의 작업 지시 생성됨"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0}개의 기한 초과 라인"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "매핑할 라인 {0}개"
@@ -1095,8 +1099,20 @@ msgstr "활성화 수수료 · 저희가 자문"
 msgid "Active"
 msgstr "활성"
 
+msgid "Active jobs"
+msgstr "진행 중인 작업 지시"
+
 msgid "Active Jobs"
 msgstr "진행 중인 작업 지시"
+
+msgid "Active jobs due in the next seven days"
+msgstr "다음 7일 내에 마감일이 있는 진행 중인 작업 지시"
+
+msgid "Active jobs grouped by status"
+msgstr "상태별로 분류된 진행 중인 작업 지시"
+
+msgid "Active jobs past their due date"
+msgstr "마감일을 초과한 진행 중인 작업 지시"
 
 msgid "Active Statuses"
 msgstr "활성 상태"
@@ -1340,6 +1356,9 @@ msgstr "향후 사용을 위해 재고에 추가"
 
 msgid "Add tools"
 msgstr "도구 추가"
+
+msgid "Add widgets"
+msgstr "위젯 추가"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "매입채무 기간별 분석"
 msgid "AP Clerk"
 msgstr "매입채무 담당자"
 
+msgid "AP outstanding"
+msgstr "미결제 매입채무"
+
 msgid "AP Outstanding"
 msgstr "매입채무 미결제액"
+
+msgid "AP overdue"
+msgstr "기한 초과 매입채무"
 
 msgid "AP Overdue"
 msgstr "매입채무 기한 초과"
@@ -1844,8 +1869,14 @@ msgstr "매출채권 기간별 분석"
 msgid "AR Clerk"
 msgstr "매출채권 담당자"
 
+msgid "AR outstanding"
+msgstr "미회수 매출채권"
+
 msgid "AR Outstanding"
 msgstr "매출채권 미결제액"
+
+msgid "AR overdue"
+msgstr "기한 초과 매출채권"
 
 msgid "AR Overdue"
 msgstr "매출채권 기한 초과"
@@ -3263,6 +3294,9 @@ msgstr "다른 파일을 선택하세요"
 msgid "Choose what appears on the printed job traveler."
 msgstr "인쇄된 작업 이동표에 나타날 내용을 선택하십시오."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "홈페이지에 나타날 위젯을 선택하세요."
+
 msgid "Choose your style"
 msgstr "스타일을 선택하세요"
 
@@ -4533,6 +4567,12 @@ msgstr "고객"
 msgid "Customer Accounts"
 msgstr "고객 계정"
 
+msgid "Customer balances not yet paid"
+msgstr "미결제 고객 잔액"
+
+msgid "Customer balances past their due date"
+msgstr "마감일을 초과한 고객 잔액"
+
 msgid "Customer contact"
 msgstr "고객 담당자"
 
@@ -4658,6 +4698,9 @@ msgstr "사용자정의, 교육 및 연동"
 
 msgid "Customize"
 msgstr "사용자 지정"
+
+msgid "Customize analytics"
+msgstr "분석 맞춤 설정"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "PDF 문서의 레이아웃을 사용자 지정하세요 — 섹션 순서를 변경하고, 필요 없는 항목을 숨기고, 원하는 블록을 추가할 수 있습니다."
@@ -7103,6 +7146,9 @@ msgstr "PDF를 업로드하지 못했습니다"
 msgid "Failed to upload thumbnail"
 msgstr "썸네일을 업로드하지 못했습니다"
 
+msgid "Failed workflow runs"
+msgstr "실패한 워크플로 실행"
+
 msgid "Failure"
 msgstr "실패"
 
@@ -7252,6 +7298,9 @@ msgstr "이름"
 msgid "First Operation"
 msgstr "첫 번째 공정작업"
 
+msgid "First-pass yield"
+msgstr "초회 양산 수율"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "정규 MACRS 스케줄이 시작되기 전에 적용되는 1차연도 추가 공제입니다."
 
@@ -7308,6 +7357,9 @@ msgstr "지그 ID"
 
 msgid "Flags"
 msgstr "플래그"
+
+msgid "Follow page range"
+msgstr "페이지 범위 따르기"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "무엇이든지요. 적임자를 연결해 드립니다."
@@ -7751,6 +7803,9 @@ msgstr "원본 숨기기"
 msgid "Hide system quantities until the review step"
 msgstr "검토 단계 전까지 시스템 수량 숨기기"
 
+msgid "Hide widget"
+msgstr "위젯 숨기기"
+
 msgid "Hide, pin and reorder columns"
 msgstr "열 숨기기, 고정, 순서 변경"
 
@@ -7810,6 +7865,9 @@ msgstr "이 스테이션의 시간"
 
 msgid "Hours not yet assigned"
 msgstr "아직 배정되지 않은 시간"
+
+msgid "Hours of production time per work center in the period"
+msgstr "기간별 작업장당 생산 시간"
 
 msgid "Hours per Week"
 msgstr "주당 시간"
@@ -8223,6 +8281,9 @@ msgstr "검사 문서"
 msgid "Inspection Level"
 msgstr "검사 수준"
 
+msgid "Inspection pass rate"
+msgstr "검사 합격률"
+
 msgid "Inspection Plan"
 msgstr "검사 계획"
 
@@ -8237,6 +8298,9 @@ msgstr "검사 상태"
 
 msgid "Inspections"
 msgstr "검사"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "처리된 검사 중 통과한 검사의 비율"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "검사, 부적합, CAPA"
@@ -8369,6 +8433,9 @@ msgstr "재고 측정 단위"
 
 msgid "Inventory Valuation"
 msgstr "재고 평가"
+
+msgid "Inventory value"
+msgstr "재고 가치"
 
 msgid "Invite"
 msgstr "초대"
@@ -8535,6 +8602,12 @@ msgstr "출고일"
 msgid "Issues"
 msgstr "이슈"
 
+msgid "Issues by type"
+msgstr "유형별 이슈"
+
+msgid "Issues opened"
+msgstr "개시된 이슈"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "다시 버전을 게시할 때까지 실행이 중지됩니다. 삭제된 내용은 없습니다."
 
@@ -8673,6 +8746,15 @@ msgstr "작업 지시"
 msgid "Jobs Assigned to Me"
 msgstr "내게 할당된 작업 지시"
 
+msgid "Jobs by status"
+msgstr "상태별 작업 지시"
+
+msgid "Jobs due this week"
+msgstr "이번 주 마감일이 있는 작업 지시"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "계획됨, 준비됨, 진행 중 또는 일시 중지된 작업 지시"
+
 msgid "Jobs Required"
 msgstr "필요한 작업 지시"
 
@@ -8804,8 +8886,20 @@ msgstr "노무 단위"
 msgid "Language"
 msgstr "언어"
 
+msgid "Last 12 months"
+msgstr "지난 12개월"
+
+msgid "Last 30 days"
+msgstr "지난 30일"
+
 msgid "Last 6 Months"
 msgstr "지난 6개월"
+
+msgid "Last 7 days"
+msgstr "지난 7일"
+
+msgid "Last 90 days"
+msgstr "지난 90일"
 
 msgid "Last attempt"
 msgstr "마지막 시도"
@@ -8857,6 +8951,9 @@ msgstr "마지막 사용"
 
 msgid "Late in the evening, {name}."
 msgstr "{name}님, 저녁이 늦어가는군요."
+
+msgid "Late jobs"
+msgstr "기한 초과 작업 지시"
 
 msgid "Latest operation end"
 msgstr "최신 작업 종료"
@@ -8998,6 +9095,9 @@ msgstr "내부 품번이 필요한 라인"
 
 msgid "Lines need prices or lead times"
 msgstr "가격 또는 리드타임이 필요한 라인"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "약속일에 또는 그 이전에 배송된 라인"
 
 msgid "Lineside"
 msgstr "라인사이드"
@@ -9773,6 +9873,9 @@ msgstr "귀사가 받아야 할 금액"
 msgid "Money you owe"
 msgstr "귀사가 지급해야 할 금액"
 
+msgid "Month to date"
+msgstr "월 누적"
+
 msgid "Monthly"
 msgstr "월간"
 
@@ -9799,6 +9902,9 @@ msgstr "초과 근무 증가"
 
 msgid "Morning, {name}."
 msgstr "{name}님, 아침이군요."
+
+msgid "Most frequent issue types in the period"
+msgstr "기간 내 가장 빈번한 이슈 유형"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "대부분의 문제는 여기서 발견되고 해결됩니다. 명확하게 이름을 붙이세요."
@@ -9858,6 +9964,9 @@ msgstr "MRP는 3시간마다 자동으로 실행되지만, 여기서 수동으�
 
 msgid "Must be in the same location"
 msgstr "동일한 위치에 있어야 합니다"
+
+msgid "My active operations"
+msgstr "내 진행 중인 공정"
 
 msgid "My Documents"
 msgstr "내 문서"
@@ -10044,6 +10153,9 @@ msgstr "신규 송장"
 
 msgid "New Issue"
 msgstr "새 이슈"
+
+msgid "New issues over the period"
+msgstr "기간 내 새로운 이슈"
 
 msgid "New Item Group"
 msgstr "새 품목 그룹"
@@ -10912,6 +11024,9 @@ msgstr "확인"
 msgid "Oldest first"
 msgstr "오래된순"
 
+msgid "Oldest overdue orders first"
+msgstr "가장 오래된 기한 초과 주문부터"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "전환일 당일에는 아래 체크리스트를 순서대로 진행하세요. 승인 테스트는 범위 내 요구사항을 기준으로 하며, 지원 관련 세부 정보는 하단에 있습니다."
 
@@ -10962,6 +11077,9 @@ msgstr "보유 재고 실사"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "이 위치에서 서비스용으로 유지해야 할 최소 보유 재고 수량입니다."
+
+msgid "On-hand inventory at cost"
+msgstr "원가 기준 현재 재고"
 
 msgid "On-hand inventory remains"
 msgstr "보유 재고가 남아 있습니다"
@@ -11055,6 +11173,9 @@ msgstr "미결 매출채권"
 msgid "Open Audit Log"
 msgstr "감사 로그 열기"
 
+msgid "Open backlog"
+msgstr "미결 백로그"
+
 msgid "Open date"
 msgstr "개설 날짜"
 
@@ -11076,6 +11197,9 @@ msgstr "변경 통지 {ids}에서 열기. 새로운 버전 또는 리비전을 �
 msgid "Open in MES"
 msgstr "MES에서 열기"
 
+msgid "Open issues"
+msgstr "미결 이슈"
+
 msgid "Open Issues"
 msgstr "미결 이슈"
 
@@ -11094,6 +11218,9 @@ msgstr "메뉴 열기"
 msgid "Open navigation"
 msgstr "탐색 열기"
 
+msgid "Open orders with a line past its promised date"
+msgstr "약속일이 지난 라인이 있는 미결 발주서"
+
 msgid "Open payables by supplier and age"
 msgstr "공급업체 및 기간별 미결 매입채무"
 
@@ -11105,6 +11232,9 @@ msgstr "미결 발주서"
 
 msgid "Open Purchase Orders"
 msgstr "미결 발주서"
+
+msgid "Open quotes"
+msgstr "미결 견적서"
 
 msgid "Open Quotes"
 msgstr "미결 견적"
@@ -11208,6 +11338,9 @@ msgstr "공정작업/단계"
 
 msgid "Operations Type"
 msgstr "공정작업 유형"
+
+msgid "Operations you currently have running"
+msgstr "현재 실행 중인 공정"
 
 msgid "Operator"
 msgstr "작업자"
@@ -11318,6 +11451,9 @@ msgstr "주문"
 msgid "Orders submitted"
 msgstr "제출된 주문"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "담당자인 주문, 견적서 및 견적 요청"
+
 msgid "Origin"
 msgstr "출처"
 
@@ -11371,6 +11507,9 @@ msgstr "전체 결과"
 
 msgid "Overdue"
 msgstr "기한 초과"
+
+msgid "Overdue purchase orders"
+msgstr "기한 초과 발주서"
 
 msgid "Overhead Absorption"
 msgstr "간접비 배부"
@@ -12179,6 +12318,9 @@ msgstr "생산 수량"
 msgid "Production Quantity"
 msgstr "생산 수량"
 
+msgid "Production quantity without rework or scrap"
+msgstr "재작업 및 스크랩이 없는 생산 수량"
+
 msgid "Production variance"
 msgstr "생산 차이"
 
@@ -12382,6 +12524,9 @@ msgstr "발주서가 성공적으로 제거되었습니다"
 msgid "Purchase Order Type"
 msgstr "발주서 유형"
 
+msgid "Purchase order value over the period"
+msgstr "기간 동안의 발주서 금액"
+
 msgid "Purchase orders"
 msgstr "구매주문"
 
@@ -12390,6 +12535,9 @@ msgstr "발주서"
 
 msgid "Purchase Orders and Planning"
 msgstr "발주서 및 계획"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "아직 수령 및 송장이 발행되지 않은 발주서"
 
 msgid "Purchase orders required"
 msgstr "발주서가 필요합니다"
@@ -12408,6 +12556,9 @@ msgstr "구매가격차이(기본값)"
 
 msgid "Purchase Qty"
 msgstr "구매 수량"
+
+msgid "Purchase spend"
+msgstr "구매 지출"
 
 msgid "Purchase Tax Payable"
 msgstr "매입 세금 미지급"
@@ -12429,6 +12580,9 @@ msgstr "구매됨"
 
 msgid "Purchases"
 msgstr "구매"
+
+msgid "Purchases by supplier"
+msgstr "공급업체별 구매"
 
 msgid "purchasing"
 msgstr "구매"
@@ -12603,6 +12757,9 @@ msgstr "이 재정의에 대한 수량 기반 가격 책정 단계입니다. 적
 msgid "Quantity: {0}"
 msgstr "수량: {0}"
 
+msgid "Quarter to date"
+msgstr "분기 누계"
+
 msgid "Quarterly"
 msgstr "분기별"
 
@@ -12665,6 +12822,9 @@ msgstr "견적일"
 
 msgid "Quotes"
 msgstr "견적"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "초안이거나 고객에게 전송된 견적서"
 
 msgid "Quoting and sales orders"
 msgstr "견적서 작성 및 수주"
@@ -12948,6 +13108,9 @@ msgstr "기존 자산 등록"
 
 msgid "Registered"
 msgstr "등록됨"
+
+msgid "Registered and in-progress issues"
+msgstr "등록되고 진행 중인 이슈"
 
 msgid "Registration failed"
 msgstr "등록 실패"
@@ -13414,6 +13577,9 @@ msgstr "매출"
 msgid "Revenue and expenses over a period"
 msgstr "기간별 매출 및 비용"
 
+msgid "Revenue trend"
+msgstr "매출 추이"
+
 msgid "Reverse all inventory adjustments"
 msgstr "모든 재고 조정 취소"
 
@@ -13720,6 +13886,9 @@ msgstr "영업 할인"
 msgid "Sales Discounts (default)"
 msgstr "영업 할인 (기본값)"
 
+msgid "Sales documents assigned to me"
+msgstr "내게 할당된 영업 문서"
+
 msgid "Sales Funnel"
 msgstr "영업 퍼널"
 
@@ -13765,14 +13934,23 @@ msgstr "수주 사업장"
 msgid "Sales Order Number"
 msgstr "수주 번호"
 
+msgid "Sales order value over the period"
+msgstr "기간 동안의 수주 금액"
+
 msgid "Sales orders"
 msgstr "판매주문"
 
 msgid "Sales Orders"
 msgstr "수주"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "아직 출하 및 송장이 발행되지 않은 수주"
+
 msgid "Sales Person"
 msgstr "영업 담당자"
+
+msgid "Sales revenue"
+msgstr "영업 매출"
 
 msgid "Sales Revenue"
 msgstr "매출"
@@ -13954,6 +14132,9 @@ msgstr "스크랩"
 msgid "Scrap / Cost of Quality"
 msgstr "스크랩 / 품질 원가"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "생산 플러스 스크랩 수량 중 스크랩의 비중"
+
 msgid "Scrap Percent"
 msgstr "스크랩 비율"
 
@@ -13971,6 +14152,9 @@ msgstr "스크랩 수량"
 
 msgid "Scrap Quantity Per Job"
 msgstr "작업당 스크랩 수량"
+
+msgid "Scrap rate"
+msgstr "스크랩 비율"
 
 msgid "scrap reason"
 msgstr "스크랩 사유"
@@ -14945,6 +15129,9 @@ msgstr "특정 품목"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "공급업체, 품목 또는 범주별 지출 — 가장 큰 비용 동인"
 
+msgid "Spend trend"
+msgstr "지출 추이"
+
 msgid "Split"
 msgstr "분할"
 
@@ -15336,6 +15523,12 @@ msgstr "공급업체 계정"
 
 msgid "Supplier added and selected"
 msgstr "공급업체가 추가되고 선택되었습니다"
+
+msgid "Supplier balances not yet paid"
+msgstr "아직 지불되지 않은 공급업체 잔액"
+
+msgid "Supplier balances past their due date"
+msgstr "마감일이 지난 공급업체 잔액"
 
 msgid "Supplier contact"
 msgstr "공급업체 담당자"
@@ -16977,6 +17170,9 @@ msgstr "공구"
 msgid "Tools"
 msgstr "공구"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "기간 동안 발주서 금액으로 상위 공급업체"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "최상위 분류 (자산 / 부채 / 자본 / 매출 / 비용); 루트 그룹에만 설정되며 자식이 상속합니다."
 
@@ -17006,6 +17202,12 @@ msgstr "총 시간"
 
 msgid "Total Minutes"
 msgstr "총 분"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "기간 동안 발행된 발주서의 총계"
+
+msgid "Total of sales orders placed in the period"
+msgstr "기간 동안 발행된 수주의 총계"
 
 msgid "Total Price"
 msgstr "총 가격"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "지원되지 않는 원본 문서 유형: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "제목 없음"
 
 msgid "Untitled Diagram"
 msgstr "제목 없는 다이어그램"
@@ -17658,6 +17860,9 @@ msgstr "포함된 도메인의 사용자는 SAML SSO로만 로그인할 수 있�
 msgid "Users to Update"
 msgstr "업데이트할 사용자"
 
+msgid "Utilization"
+msgstr "가동률"
+
 msgid "Valid From"
 msgstr "유효 시작일"
 
@@ -17687,6 +17892,9 @@ msgstr "값 스냅샷"
 
 msgid "Value source by surface"
 msgstr "표면별 값 소스"
+
+msgid "Value still to ship on open sales orders"
+msgstr "미결 수주에서 아직 출하할 금액"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "부가가치세 등록 번호; 역계산 또는 영율 공급에 대한 EU 송장에 필수입니다."
@@ -17988,6 +18196,9 @@ msgstr "이 입고를 무효화하면 다음과 같은 결과가 발생합니다
 
 msgid "Voiding this shipment will:"
 msgstr "이 출하를 무효화하면 다음과 같은 결과가 발생합니다:"
+
+msgid "vs prior period"
+msgstr "전 기간 대비"
 
 msgid "Waited"
 msgstr "대기함"
@@ -18483,6 +18694,9 @@ msgstr "이 라인이 거절되는 이유로, 인쇄용 견적서에 표시되�
 msgid "Why this restore failed"
 msgstr "이 복원이 실패한 이유"
 
+msgid "Widget options"
+msgstr "위젯 옵션"
+
 msgid "Will remain as a comment line"
 msgstr "댓글 라인으로 유지됩니다"
 
@@ -18575,6 +18789,9 @@ msgstr "워크플로우 이름"
 msgid "Workflow run"
 msgstr "워크플로우 실행"
 
+msgid "Workflow runs that failed in the period"
+msgstr "기간 동안 실패한 워크플로 실행"
+
 msgid "Workflows"
 msgstr "워크플로우"
 
@@ -18608,6 +18825,9 @@ msgstr "자산의 가치를 내용연수에 걸쳐 상각하는 것 — 매월 �
 
 msgid "Year"
 msgstr "연도"
+
+msgid "Year to date"
+msgstr "연간 누계"
 
 msgid "Yearly"
 msgstr "연간"

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} roboczych zapisów księgowych"
 msgid "{0} jobs created"
 msgstr "{0} zleceń produkcyjnych utworzonych"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} pozycji po terminie"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} linii do mapowania"
@@ -1095,8 +1099,20 @@ msgstr "Opłata aktywacyjna · doradzamy"
 msgid "Active"
 msgstr "Aktywny"
 
+msgid "Active jobs"
+msgstr "Bieżące zlecenia produkcyjne"
+
 msgid "Active Jobs"
 msgstr "Bieżące zlecenia produkcyjne"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Bieżące zlecenia produkcyjne z terminem w ciągu siedmiu dni"
+
+msgid "Active jobs grouped by status"
+msgstr "Bieżące zlecenia produkcyjne pogrupowane wg statusu"
+
+msgid "Active jobs past their due date"
+msgstr "Bieżące zlecenia produkcyjne po terminie"
 
 msgid "Active Statuses"
 msgstr "Aktywne statusy"
@@ -1340,6 +1356,9 @@ msgstr "Dodaj do zapasów do przyszłego użytku"
 
 msgid "Add tools"
 msgstr "Dodaj narzędzia"
+
+msgid "Add widgets"
+msgstr "Dodaj widżety"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Wiekowanie zobowiązań"
 msgid "AP Clerk"
 msgstr "Pracownik ds. zobowiązań"
 
+msgid "AP outstanding"
+msgstr "Niezapłacone zobowiązania"
+
 msgid "AP Outstanding"
 msgstr "Zobowiązania do zapłaty"
+
+msgid "AP overdue"
+msgstr "Zobowiązania po terminie"
 
 msgid "AP Overdue"
 msgstr "Zobowiązania po terminie"
@@ -1844,8 +1869,14 @@ msgstr "Wiekowanie należności"
 msgid "AR Clerk"
 msgstr "Pracownik ds. Należności"
 
+msgid "AR outstanding"
+msgstr "Niezapłacone należności"
+
 msgid "AR Outstanding"
 msgstr "Zaległości z tytułu należności"
+
+msgid "AR overdue"
+msgstr "Należności po terminie"
 
 msgid "AR Overdue"
 msgstr "Należności przeterminowane"
@@ -3263,6 +3294,9 @@ msgstr "Wybierz inny plik"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Wybierz, co pojawia się na drukowanym przewodniku zlecenia produkcyjnego."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Wybierz, które widżety pojawią się na twojej stronie głównej."
+
 msgid "Choose your style"
 msgstr "Wybierz swój styl"
 
@@ -4533,6 +4567,12 @@ msgstr "Klient"
 msgid "Customer Accounts"
 msgstr "Konta Klientów"
 
+msgid "Customer balances not yet paid"
+msgstr "Niezapłacone salda klientów"
+
+msgid "Customer balances past their due date"
+msgstr "Salda klientów po terminie"
+
 msgid "Customer contact"
 msgstr "Kontakt klienta"
 
@@ -4658,6 +4698,9 @@ msgstr "Dostosowania, szkolenia i integracje"
 
 msgid "Customize"
 msgstr "Dostosuj"
+
+msgid "Customize analytics"
+msgstr "Dostosuj analitykę"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Dostosuj układ swoich dokumentów PDF — zmień kolejność sekcji, ukryj to, czego nie potrzebujesz, i dodaj własne bloki."
@@ -7103,6 +7146,9 @@ msgstr "Nie udało się przesłać pliku PDF"
 msgid "Failed to upload thumbnail"
 msgstr "Nie udało się przesłać miniatury"
 
+msgid "Failed workflow runs"
+msgstr "Nieudane przebiegi przepływu pracy"
+
 msgid "Failure"
 msgstr "Niepowodzenie"
 
@@ -7252,6 +7298,9 @@ msgstr "Imię"
 msgid "First Operation"
 msgstr "Pierwsza operacja"
 
+msgid "First-pass yield"
+msgstr "Wydajność przy pierwszym przejściu"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Środek Trwały"
 
@@ -7308,6 +7357,9 @@ msgstr "ID przyrządu obróbkowego"
 
 msgid "Flags"
 msgstr "Flagi"
+
+msgid "Follow page range"
+msgstr "Śledź zakres stron"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "w sprawie czegokolwiek. Zaangażują odpowiednią osobę."
@@ -7751,6 +7803,9 @@ msgstr "Ukryj surowe"
 msgid "Hide system quantities until the review step"
 msgstr "Ukryj ilości systemowe do kroku przeglądu"
 
+msgid "Hide widget"
+msgstr "Ukryj widżet"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ukryj, przypnij i zmień kolejność kolumn"
 
@@ -7810,6 +7865,9 @@ msgstr "Godziny na tym stanowisku"
 
 msgid "Hours not yet assigned"
 msgstr "Godziny jeszcze nieprzydzielone"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Godziny czasu produkcji na stanowisko robocze w tym okresie"
 
 msgid "Hours per Week"
 msgstr "Godziny na tydzień"
@@ -8223,6 +8281,9 @@ msgstr "Dokument kontroli"
 msgid "Inspection Level"
 msgstr "Poziom kontroli"
 
+msgid "Inspection pass rate"
+msgstr "Wskaźnik zaliczenia kontroli"
+
 msgid "Inspection Plan"
 msgstr "Plan kontroli"
 
@@ -8237,6 +8298,9 @@ msgstr "Status kontroli"
 
 msgid "Inspections"
 msgstr "Kontrole"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Kontrole zaliczone jako udział w zdysponowanych"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Kontrole, niezgodności i CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Jednostka miary zapasów"
 
 msgid "Inventory Valuation"
 msgstr "Wycena zapasów"
+
+msgid "Inventory value"
+msgstr "Wartość zapasów"
 
 msgid "Invite"
 msgstr "Zaproś"
@@ -8535,6 +8602,12 @@ msgstr "Data wystawienia"
 msgid "Issues"
 msgstr "Problemy"
 
+msgid "Issues by type"
+msgstr "Niezgodności wg typu"
+
+msgid "Issues opened"
+msgstr "Otwarte niezgodności"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "To przestanie działać, dopóki nie opublikujesz wersji ponownie. Nic nie jest usunięte."
 
@@ -8673,6 +8746,15 @@ msgstr "Zlecenia produkcyjne"
 msgid "Jobs Assigned to Me"
 msgstr "Zlecenia produkcyjne przypisane do mnie"
 
+msgid "Jobs by status"
+msgstr "Zlecenia produkcyjne wg statusu"
+
+msgid "Jobs due this week"
+msgstr "Zlecenia produkcyjne z terminem w tym tygodniu"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Zlecenia produkcyjne zaplanowane, gotowe, w toku lub wstrzymane"
+
 msgid "Jobs Required"
 msgstr "Wymagane zlecenia produkcyjne"
 
@@ -8804,8 +8886,20 @@ msgstr "Jednostka robocizny"
 msgid "Language"
 msgstr "Język"
 
+msgid "Last 12 months"
+msgstr "Ostatnie 12 miesięcy"
+
+msgid "Last 30 days"
+msgstr "Ostatnie 30 dni"
+
 msgid "Last 6 Months"
 msgstr "Ostatnie 6 miesięcy"
+
+msgid "Last 7 days"
+msgstr "Ostatnie 7 dni"
+
+msgid "Last 90 days"
+msgstr "Ostatnie 90 dni"
 
 msgid "Last attempt"
 msgstr "Ostatnia próba"
@@ -8857,6 +8951,9 @@ msgstr "Ostatnio używany"
 
 msgid "Late in the evening, {name}."
 msgstr "Późny wieczór, {name}."
+
+msgid "Late jobs"
+msgstr "Opóźnione zlecenia produkcyjne"
 
 msgid "Latest operation end"
 msgstr "Koniec ostatniej operacji"
@@ -8998,6 +9095,9 @@ msgstr "Linie wymagają wewnętrznych numerów części"
 
 msgid "Lines need prices or lead times"
 msgstr "Linie wymagają cen lub czasów realizacji"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Pozycje wysłane w lub przed datą potwierdzoną"
 
 msgid "Lineside"
 msgstr "Magazyn przyliniowy"
@@ -9773,6 +9873,9 @@ msgstr "Pieniądze należne Tobie"
 msgid "Money you owe"
 msgstr "Pieniądze, które jesteś winien"
 
+msgid "Month to date"
+msgstr "Od początku miesiąca"
+
 msgid "Monthly"
 msgstr "Miesięcznie"
 
@@ -9799,6 +9902,9 @@ msgstr "Więcej nadgodzin"
 
 msgid "Morning, {name}."
 msgstr "Poranek, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Najczęstsze typy niezgodności w tym okresie"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "Większość rzeczy zostaje tutaj wychwycona i rozwiązana. Nazwij to jasno."
@@ -9858,6 +9964,9 @@ msgstr "MRP uruchamia się automatycznie co 3 godziny, ale możesz uruchomić go
 
 msgid "Must be in the same location"
 msgstr "Musi być w tej samej lokalizacji"
+
+msgid "My active operations"
+msgstr "Moje bieżące operacje"
 
 msgid "My Documents"
 msgstr "Moje dokumenty"
@@ -10044,6 +10153,9 @@ msgstr "Nowa Faktura"
 
 msgid "New Issue"
 msgstr "Nowy Problem"
+
+msgid "New issues over the period"
+msgstr "Nowe niezgodności w tym okresie"
 
 msgid "New Item Group"
 msgstr "Nowa Grupa Pozycji"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Najstarsze najpierw"
 
+msgid "Oldest overdue orders first"
+msgstr "Najstarsze zamówienia po terminie najpierw"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "W dniu przejścia pracuj nad listą kontrolną poniżej w kolejności. Testy akceptacyjne pochodzą z Twoich wymagań objętych zakresem. Szczegóły dotyczące wsparcia znajdują się na dole."
 
@@ -10962,6 +11077,9 @@ msgstr "Dostępne ilości"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Minimalna ilość do utrzymania na potrzeby serwisu w tej lokalizacji"
+
+msgid "On-hand inventory at cost"
+msgstr "Dostępne zapasy po koszcie"
 
 msgid "On-hand inventory remains"
 msgstr "Pozostały zapas w magazynie"
@@ -11055,6 +11173,9 @@ msgstr "Otwarte należności"
 msgid "Open Audit Log"
 msgstr "Otwórz dziennik audytu"
 
+msgid "Open backlog"
+msgstr "Zalegająca praca"
+
 msgid "Open date"
 msgstr "Data otwarcia"
 
@@ -11076,6 +11197,9 @@ msgstr "Otwarte w zawiadomieniach o zmianie {ids}. Zwolnij je aby utworzyć nowe
 msgid "Open in MES"
 msgstr "Otwórz w MES"
 
+msgid "Open issues"
+msgstr "Otwarte wydania"
+
 msgid "Open Issues"
 msgstr "Otwarte problemy"
 
@@ -11094,6 +11218,9 @@ msgstr "Otwórz menu"
 msgid "Open navigation"
 msgstr "Otwórz nawigację"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Otwarte zamówienia z pozycją po dacie potwierdzonej"
+
 msgid "Open payables by supplier and age"
 msgstr "Otwarte zobowiązania wg dostawcy i wieku"
 
@@ -11105,6 +11232,9 @@ msgstr "Otwarte zamówienia zakupu"
 
 msgid "Open Purchase Orders"
 msgstr "Otwarte Zamówienia Zakupu"
+
+msgid "Open quotes"
+msgstr "Otwarte oferty"
 
 msgid "Open Quotes"
 msgstr "Otwarte Oferty"
@@ -11208,6 +11338,9 @@ msgstr "Operacje / kroki"
 
 msgid "Operations Type"
 msgstr "Typ operacyjny"
+
+msgid "Operations you currently have running"
+msgstr "Operacje, które aktualnie wykonujesz"
 
 msgid "Operator"
 msgstr "Operator"
@@ -11318,6 +11451,9 @@ msgstr "Zamówienia"
 msgid "Orders submitted"
 msgstr "Zamówienia przesłane"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Zamówienia, oferty i RFQ, gdzie jesteś osobą przypisaną"
+
 msgid "Origin"
 msgstr "Pochodzenie"
 
@@ -11371,6 +11507,9 @@ msgstr "Ogólny wynik"
 
 msgid "Overdue"
 msgstr "Po terminie"
+
+msgid "Overdue purchase orders"
+msgstr "Zamówienia zakupu po terminie"
 
 msgid "Overhead Absorption"
 msgstr "Rozliczenie kosztów pośrednich"
@@ -12179,6 +12318,9 @@ msgstr "Ilość produkcji"
 msgid "Production Quantity"
 msgstr "Ilość Produkcji"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Ilość produkcji bez poprawek i braków"
+
 msgid "Production variance"
 msgstr "Odchylenie produkcji"
 
@@ -12382,6 +12524,9 @@ msgstr "Zamówienie zakupu zostało pomyślnie usunięte"
 msgid "Purchase Order Type"
 msgstr "Typ Zamówienia Zakupu"
 
+msgid "Purchase order value over the period"
+msgstr "Wartość zamówienia zakupu w okresie"
+
 msgid "Purchase orders"
 msgstr "Zamówienia Zakupu"
 
@@ -12390,6 +12535,9 @@ msgstr "Zamówienia Zakupu"
 
 msgid "Purchase Orders and Planning"
 msgstr "Zamówienia zakupu i planowanie"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Zamówienia zakupu nie jeszcze otrzymane i zafakturowane"
 
 msgid "Purchase orders required"
 msgstr "Wymagane zamówienia zakupu"
@@ -12408,6 +12556,9 @@ msgstr "Odchylenie ceny zakupu (domyślnie)"
 
 msgid "Purchase Qty"
 msgstr "Ilość zakupu"
+
+msgid "Purchase spend"
+msgstr "Wydatki na zakupy"
 
 msgid "Purchase Tax Payable"
 msgstr "Podatek od Zakupów do Zapłacenia (domyślnie)"
@@ -12429,6 +12580,9 @@ msgstr "Zakupione"
 
 msgid "Purchases"
 msgstr "Zakupy"
+
+msgid "Purchases by supplier"
+msgstr "Zakupy przez dostawcę"
 
 msgid "purchasing"
 msgstr "Zakupy i Koszt Sprzedanych Towarów"
@@ -12603,6 +12757,9 @@ msgstr "Strefy cenowe oparte na ilości dla tego nadpisania; zastosowana cena je
 msgid "Quantity: {0}"
 msgstr "Ilość: {0}"
 
+msgid "Quarter to date"
+msgstr "Od początku kwartału"
+
 msgid "Quarterly"
 msgstr "Kwartalnie"
 
@@ -12665,6 +12822,9 @@ msgstr "Data wyceny"
 
 msgid "Quotes"
 msgstr "Oferty"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Oferty w wersji roboczej lub wysłane do klienta"
 
 msgid "Quoting and sales orders"
 msgstr "Wycena i zamówienia sprzedaży"
@@ -12948,6 +13108,9 @@ msgstr "Zarejestrowany"
 
 msgid "Registered"
 msgstr "Zarejestrowano"
+
+msgid "Registered and in-progress issues"
+msgstr "Zarejestrowane i będące w trakcie wydania"
 
 msgid "Registration failed"
 msgstr "Rejestracja nie powiodła się"
@@ -13414,6 +13577,9 @@ msgstr "Przychody ze sprzedaży"
 msgid "Revenue and expenses over a period"
 msgstr "Przychody ze sprzedaży i wydatki za okres"
 
+msgid "Revenue trend"
+msgstr "Trend przychodów ze sprzedaży"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Odwróć wszystkie korekty zapasów"
 
@@ -13720,6 +13886,9 @@ msgstr "Rabaty na sprzedaż"
 msgid "Sales Discounts (default)"
 msgstr "Rabaty na sprzedaż (domyślnie)"
 
+msgid "Sales documents assigned to me"
+msgstr "Dokumenty sprzedaży przypisane do mnie"
+
 msgid "Sales Funnel"
 msgstr "Lejek sprzedaży"
 
@@ -13765,14 +13934,23 @@ msgstr "Lokalizacja Zamówienia Sprzedaży"
 msgid "Sales Order Number"
 msgstr "Numer zamówienia sprzedaży"
 
+msgid "Sales order value over the period"
+msgstr "Wartość zamówienia sprzedaży w okresie"
+
 msgid "Sales orders"
 msgstr "Zamówienia sprzedaży"
 
 msgid "Sales Orders"
 msgstr "Zamówienia sprzedaży"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Zamówienia sprzedaży nie jeszcze wysłane i zafakturowane"
+
 msgid "Sales Person"
 msgstr "Pracownik sprzedaży"
+
+msgid "Sales revenue"
+msgstr "Przychody ze sprzedaży"
 
 msgid "Sales Revenue"
 msgstr "Przychód ze sprzedaży"
@@ -13954,6 +14132,9 @@ msgstr "Braki"
 msgid "Scrap / Cost of Quality"
 msgstr "Braki / Koszt jakości"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Braki jako procent produkcji plus ilości braków"
+
 msgid "Scrap Percent"
 msgstr "Procent braków"
 
@@ -13971,6 +14152,9 @@ msgstr "Ilość braków"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Ilość braków na zlecenie produkcyjne"
+
+msgid "Scrap rate"
+msgstr "Wskaźnik braków"
 
 msgid "scrap reason"
 msgstr "przyczyna braku"
@@ -14945,6 +15129,9 @@ msgstr "Określone artykuły"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Wydatki według dostawcy, pozycji lub kategorii — Twoje największe czynniki kosztowe"
 
+msgid "Spend trend"
+msgstr "Trend wydatków"
+
 msgid "Split"
 msgstr "Podziel"
 
@@ -15336,6 +15523,12 @@ msgstr "Konta dostawców"
 
 msgid "Supplier added and selected"
 msgstr "Dostawca dodany i wybrany"
+
+msgid "Supplier balances not yet paid"
+msgstr "Saldo dostawcy nie jeszcze opłacone"
+
+msgid "Supplier balances past their due date"
+msgstr "Saldo dostawcy po ich terminie"
 
 msgid "Supplier contact"
 msgstr "Kontakt dostawcy"
@@ -16977,6 +17170,9 @@ msgstr "Narzędzia"
 msgid "Tools"
 msgstr "Narzędzia"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Główni dostawcy według wartości zamówienia zakupu w okresie"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Klasyfikacja najwyższego poziomu (aktywa / pasywa / kapitał własny / przychody ze sprzedaży / wydatek) — ustawiana tylko na grupach głównych, dziedziczona przez podgrupy."
 
@@ -17006,6 +17202,12 @@ msgstr "Łącznie godzin"
 
 msgid "Total Minutes"
 msgstr "Łącznie minut"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Suma zamówień zakupu złożonych w okresie"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Suma zamówień sprzedaży złożonych w okresie"
 
 msgid "Total Price"
 msgstr "Cena całkowita"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Nieobsługiwany typ dokumentu źródłowego: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Bez tytułu"
 
 msgid "Untitled Diagram"
 msgstr "Diagram bez tytułu"
@@ -17658,6 +17860,9 @@ msgstr "Użytkownicy w domenach objętych wymogiem mogą się logować tylko za 
 msgid "Users to Update"
 msgstr "Użytkownicy do aktualizacji"
 
+msgid "Utilization"
+msgstr "Wykorzystanie"
+
 msgid "Valid From"
 msgstr "Ważne od"
 
@@ -17687,6 +17892,9 @@ msgstr "Przegląd Wartości"
 
 msgid "Value source by surface"
 msgstr "Źródło wartości według powierzchni"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Wartość do wysyłki na otwartych zamówieniach sprzedaży"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Numer rejestracyjny podatku od wartości dodanej; wymagany na fakturach UE dla dostaw na zasadzie odwrotnego obciążenia lub ze stawką zerową."
@@ -17988,6 +18196,9 @@ msgstr "Anulowanie tego paragonu spowoduje:"
 
 msgid "Voiding this shipment will:"
 msgstr "Unieważnienie tej wysyłki spowoduje:"
+
+msgid "vs prior period"
+msgstr "vs poprzedni okres"
 
 msgid "Waited"
 msgstr "Czekał"
@@ -18483,6 +18694,9 @@ msgstr "Dlaczego ta linia jest odrzucana; wyświetlane na drukowanym cytacie i z
 msgid "Why this restore failed"
 msgstr "Dlaczego to przywrócenie nie powiodło się"
 
+msgid "Widget options"
+msgstr "Opcje widżetu"
+
 msgid "Will remain as a comment line"
 msgstr "Pozostanie jako linia komentarza"
 
@@ -18575,6 +18789,9 @@ msgstr "Nazwa przepływu pracy"
 msgid "Workflow run"
 msgstr "Przebieg przepływu pracy"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Przepływy pracy, które nie powiodły się w okresie"
+
 msgid "Workflows"
 msgstr "Przepływy pracy"
 
@@ -18608,6 +18825,9 @@ msgstr "Redukcja wartości aktywu w okresie użytkowania — miesięczna seria, 
 
 msgid "Year"
 msgstr "Rok"
+
+msgid "Year to date"
+msgstr "Od początku roku"
 
 msgid "Yearly"
 msgstr "Rocznie"

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} lançamentos de diário em rascunho"
 msgid "{0} jobs created"
 msgstr "{0} ordens de produção criadas"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} linhas atrasadas"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} linhas para mapear"
@@ -1095,8 +1099,20 @@ msgstr "Taxa de ativação · aconselhamos"
 msgid "Active"
 msgstr "Ativo"
 
+msgid "Active jobs"
+msgstr "Ordens ativas"
+
 msgid "Active Jobs"
 msgstr "Ordens de produção ativas"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Ordens ativas com vencimento nos próximos sete dias"
+
+msgid "Active jobs grouped by status"
+msgstr "Ordens ativas agrupadas por status"
+
+msgid "Active jobs past their due date"
+msgstr "Ordens ativas com atraso na data de vencimento"
 
 msgid "Active Statuses"
 msgstr "Status Ativos"
@@ -1340,6 +1356,9 @@ msgstr "Adicionar ao estoque para uso futuro"
 
 msgid "Add tools"
 msgstr "Adicionar ferramentas"
+
+msgid "Add widgets"
+msgstr "Adicionar widgets"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Envelhecimento de Contas a Pagar"
 msgid "AP Clerk"
 msgstr "Assistente de Contas a Pagar"
 
+msgid "AP outstanding"
+msgstr "Contas a pagar pendentes"
+
 msgid "AP Outstanding"
 msgstr "Contas a pagar em aberto"
+
+msgid "AP overdue"
+msgstr "Contas a pagar vencidas"
 
 msgid "AP Overdue"
 msgstr "Contas a pagar atrasadas"
@@ -1844,8 +1869,14 @@ msgstr "Envelhecimento de Contas a Receber"
 msgid "AR Clerk"
 msgstr "Funcionário de Contas a Receber"
 
+msgid "AR outstanding"
+msgstr "Contas a receber pendentes"
+
 msgid "AR Outstanding"
 msgstr "Contas a receber em aberto"
+
+msgid "AR overdue"
+msgstr "Contas a receber vencidas"
 
 msgid "AR Overdue"
 msgstr "Contas a receber atrasadas"
@@ -3263,6 +3294,9 @@ msgstr "Escolher outro arquivo"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Escolha o que aparece na ficha de acompanhamento impressa."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Escolha quais widgets aparecem em sua página inicial."
+
 msgid "Choose your style"
 msgstr "Escolha seu estilo"
 
@@ -4533,6 +4567,12 @@ msgstr "Cliente"
 msgid "Customer Accounts"
 msgstr "Contas de Cliente"
 
+msgid "Customer balances not yet paid"
+msgstr "Saldos de clientes ainda não pagos"
+
+msgid "Customer balances past their due date"
+msgstr "Saldos de clientes com atraso na data de vencimento"
+
 msgid "Customer contact"
 msgstr "Contato do cliente"
 
@@ -4658,6 +4698,9 @@ msgstr "Personalizações, treinamento e integrações"
 
 msgid "Customize"
 msgstr "Personalizar"
+
+msgid "Customize analytics"
+msgstr "Personalizar análises"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Personalize o layout dos seus documentos PDF — reordene seções, oculte o que não precisa e adicione seus próprios blocos."
@@ -7103,6 +7146,9 @@ msgstr "Falha ao enviar PDF"
 msgid "Failed to upload thumbnail"
 msgstr "Falha ao enviar miniatura"
 
+msgid "Failed workflow runs"
+msgstr "Execuções de fluxo de trabalho falhadas"
+
 msgid "Failure"
 msgstr "Falha"
 
@@ -7252,6 +7298,9 @@ msgstr "Primeiro Nome"
 msgid "First Operation"
 msgstr "Primeira Operação"
 
+msgid "First-pass yield"
+msgstr "Rendimento na primeira passagem"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Ativo Fixo"
 
@@ -7308,6 +7357,9 @@ msgstr "ID do dispositivo de fixação"
 
 msgid "Flags"
 msgstr "Sinalizadores"
+
+msgid "Follow page range"
+msgstr "Acompanhar intervalo de páginas"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "para qualquer coisa. Eles vão trazer a pessoa certa."
@@ -7751,6 +7803,9 @@ msgstr "Ocultar bruto"
 msgid "Hide system quantities until the review step"
 msgstr "Ocultar quantidades do sistema até a etapa de revisão"
 
+msgid "Hide widget"
+msgstr "Ocultar widget"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Ocultar, fixar e reordenar colunas"
 
@@ -7810,6 +7865,9 @@ msgstr "Horas nesta estação"
 
 msgid "Hours not yet assigned"
 msgstr "Horas ainda não atribuídas"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Horas de tempo de produção por centro de trabalho no período"
 
 msgid "Hours per Week"
 msgstr "Horas por Semana"
@@ -8223,6 +8281,9 @@ msgstr "Documento de inspeção"
 msgid "Inspection Level"
 msgstr "Nível de Inspeção"
 
+msgid "Inspection pass rate"
+msgstr "Taxa de aprovação na inspeção"
+
 msgid "Inspection Plan"
 msgstr "Plano de Inspeção"
 
@@ -8237,6 +8298,9 @@ msgstr "Status de Inspeção"
 
 msgid "Inspections"
 msgstr "Inspeções"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Inspeções aprovadas como fração daquelas disposicionadas"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Inspeções, não conformidade e CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Unidade de Medida do Inventário"
 
 msgid "Inventory Valuation"
 msgstr "Avaliação de Inventário"
+
+msgid "Inventory value"
+msgstr "Valor do inventário"
 
 msgid "Invite"
 msgstr "Convidar"
@@ -8535,6 +8602,12 @@ msgstr "Data de Emissão"
 msgid "Issues"
 msgstr "Problemas"
 
+msgid "Issues by type"
+msgstr "Requisições por tipo"
+
+msgid "Issues opened"
+msgstr "Requisições abertas"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Ele parará de ser executado até que você publique uma versão novamente. Nada é excluído."
 
@@ -8673,6 +8746,15 @@ msgstr "Ordens de produção"
 msgid "Jobs Assigned to Me"
 msgstr "Ordens de produção designadas a mim"
 
+msgid "Jobs by status"
+msgstr "Ordens de produção por status"
+
+msgid "Jobs due this week"
+msgstr "Ordens de produção com vencimento esta semana"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Ordens de produção planejadas, prontas, em andamento ou pausadas"
+
 msgid "Jobs Required"
 msgstr "Ordens de produção necessárias"
 
@@ -8804,8 +8886,20 @@ msgstr "Unidade de mão de obra"
 msgid "Language"
 msgstr "Idioma"
 
+msgid "Last 12 months"
+msgstr "Últimos 12 meses"
+
+msgid "Last 30 days"
+msgstr "Últimos 30 dias"
+
 msgid "Last 6 Months"
 msgstr "Últimos 6 Meses"
+
+msgid "Last 7 days"
+msgstr "Últimos 7 dias"
+
+msgid "Last 90 days"
+msgstr "Últimos 90 dias"
 
 msgid "Last attempt"
 msgstr "Última tentativa"
@@ -8857,6 +8951,9 @@ msgstr "Última utilização"
 
 msgid "Late in the evening, {name}."
 msgstr "Tarde da noite, {name}."
+
+msgid "Late jobs"
+msgstr "Ordens atrasadas"
 
 msgid "Latest operation end"
 msgstr "Término da operação mais recente"
@@ -8998,6 +9095,9 @@ msgstr "As linhas precisam de números de peça internos"
 
 msgid "Lines need prices or lead times"
 msgstr "Linhas precisam de preços ou lead times"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Linhas enviadas em ou antes da sua data prometida"
 
 msgid "Lineside"
 msgstr "Borda de linha"
@@ -9773,6 +9873,9 @@ msgstr "Dinheiro que lhe devem"
 msgid "Money you owe"
 msgstr "Dinheiro que você deve"
 
+msgid "Month to date"
+msgstr "Mês até o momento"
+
 msgid "Monthly"
 msgstr "Mensal"
 
@@ -9799,6 +9902,9 @@ msgstr "Mais horas extras"
 
 msgid "Morning, {name}."
 msgstr "Bom dia, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Tipos de requisições mais frequentes no período"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "A maioria das coisas é detectada e resolvida aqui. Nomeie-a claramente."
@@ -9858,6 +9964,9 @@ msgstr "MRP é executado automaticamente a cada 3 horas, mas você pode executá
 
 msgid "Must be in the same location"
 msgstr "Deve estar no mesmo local"
+
+msgid "My active operations"
+msgstr "Minhas operações ativas"
 
 msgid "My Documents"
 msgstr "Meus Documentos"
@@ -10044,6 +10153,9 @@ msgstr "Nova Fatura"
 
 msgid "New Issue"
 msgstr "Novo Problema"
+
+msgid "New issues over the period"
+msgstr "Novas requisições durante o período"
 
 msgid "New Item Group"
 msgstr "Novo Grupo de Itens"
@@ -10912,6 +11024,9 @@ msgstr "OK"
 msgid "Oldest first"
 msgstr "Mais antigos primeiro"
 
+msgid "Oldest overdue orders first"
+msgstr "Pedidos mais antigos em atraso primeiro"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "No dia de cutover, trabalhe a lista de verificação abaixo em ordem. Os testes de aceitação vêm dos seus requisitos no escopo. Os detalhes de suporte estão na parte inferior."
 
@@ -10962,6 +11077,9 @@ msgstr "Contagens em estoque"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Piso de estoque em mão a manter para uso de serviço neste local"
+
+msgid "On-hand inventory at cost"
+msgstr "Inventário disponível ao custo"
 
 msgid "On-hand inventory remains"
 msgstr "Inventário em mão permanece"
@@ -11055,6 +11173,9 @@ msgstr "Contas a receber abertas"
 msgid "Open Audit Log"
 msgstr "Abrir log de auditoria"
 
+msgid "Open backlog"
+msgstr "Backlog aberto"
+
 msgid "Open date"
 msgstr "Data de abertura"
 
@@ -11076,6 +11197,9 @@ msgstr "Aberto em avisos de alteração {ids}. Libere-os para criar novas versõ
 msgid "Open in MES"
 msgstr "Abrir no MES"
 
+msgid "Open issues"
+msgstr "Requisições abertas"
+
 msgid "Open Issues"
 msgstr "Problemas Abertos"
 
@@ -11094,6 +11218,9 @@ msgstr "Abrir menu"
 msgid "Open navigation"
 msgstr "Abrir navegação"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Pedidos abertos com uma linha cuja data prometida já venceu"
+
 msgid "Open payables by supplier and age"
 msgstr "Contas a pagar em aberto por fornecedor e idade"
 
@@ -11105,6 +11232,9 @@ msgstr "Pedidos de compra abertos"
 
 msgid "Open Purchase Orders"
 msgstr "Pedidos de Compra Abertos"
+
+msgid "Open quotes"
+msgstr "Orçamentos em aberto"
 
 msgid "Open Quotes"
 msgstr "Cotações Abertas"
@@ -11208,6 +11338,9 @@ msgstr "Operações / etapas"
 
 msgid "Operations Type"
 msgstr "Tipo de Operações"
+
+msgid "Operations you currently have running"
+msgstr "Operações que você tem em execução no momento"
 
 msgid "Operator"
 msgstr "Operador"
@@ -11318,6 +11451,9 @@ msgstr "Pedidos"
 msgid "Orders submitted"
 msgstr "Pedidos enviados"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Pedidos, orçamentos e RFQs onde você é o designado"
+
 msgid "Origin"
 msgstr "Origem"
 
@@ -11371,6 +11507,9 @@ msgstr "Resultado geral"
 
 msgid "Overdue"
 msgstr "Atrasado"
+
+msgid "Overdue purchase orders"
+msgstr "Pedidos de compra atrasados"
 
 msgid "Overhead Absorption"
 msgstr "Absorção de custos indiretos"
@@ -12179,6 +12318,9 @@ msgstr "Quantidade de produção"
 msgid "Production Quantity"
 msgstr "Quantidade de Produção"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Quantidade de produção sem retrabalho ou refugo"
+
 msgid "Production variance"
 msgstr "Variação de produção"
 
@@ -12382,6 +12524,9 @@ msgstr "Pedido de compra removido com sucesso"
 msgid "Purchase Order Type"
 msgstr "Tipo de pedido de compra"
 
+msgid "Purchase order value over the period"
+msgstr "Valor do pedido de compra no período"
+
 msgid "Purchase orders"
 msgstr "Pedidos de Compra"
 
@@ -12390,6 +12535,9 @@ msgstr "Pedidos de Compra"
 
 msgid "Purchase Orders and Planning"
 msgstr "Pedidos de compra e planejamento"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Pedidos de compra ainda não recebidos e faturados"
 
 msgid "Purchase orders required"
 msgstr "Pedidos de compra necessários"
@@ -12408,6 +12556,9 @@ msgstr "Variação de preço de compra (padrão)"
 
 msgid "Purchase Qty"
 msgstr "Qtd. de Compra"
+
+msgid "Purchase spend"
+msgstr "Gasto em compras"
 
 msgid "Purchase Tax Payable"
 msgstr "Imposto de Compra a Pagar (padrão)"
@@ -12429,6 +12580,9 @@ msgstr "Comprado"
 
 msgid "Purchases"
 msgstr "Compras"
+
+msgid "Purchases by supplier"
+msgstr "Compras por fornecedor"
 
 msgid "purchasing"
 msgstr "Compras e Custo dos Bens Vendidos"
@@ -12603,6 +12757,9 @@ msgstr "Níveis de precificação baseados em quantidade para esta sobrescrita; 
 msgid "Quantity: {0}"
 msgstr "Quantidade: {0}"
 
+msgid "Quarter to date"
+msgstr "Trimestre até à data"
+
 msgid "Quarterly"
 msgstr "Trimestral"
 
@@ -12665,6 +12822,9 @@ msgstr "Data da Cotação"
 
 msgid "Quotes"
 msgstr "Orçamentos"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Orçamentos em rascunho ou enviados para o cliente"
 
 msgid "Quoting and sales orders"
 msgstr "Cotação e pedidos de venda"
@@ -12948,6 +13108,9 @@ msgstr "Registrado"
 
 msgid "Registered"
 msgstr "Registrado"
+
+msgid "Registered and in-progress issues"
+msgstr "Requisições registradas e em andamento"
 
 msgid "Registration failed"
 msgstr "Falha no registo"
@@ -13414,6 +13577,9 @@ msgstr "Receita"
 msgid "Revenue and expenses over a period"
 msgstr "Receita e despesas em um período"
 
+msgid "Revenue trend"
+msgstr "Tendência de receita"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Reverter todos os ajustes de estoque"
 
@@ -13720,6 +13886,9 @@ msgstr "Descontos de vendas"
 msgid "Sales Discounts (default)"
 msgstr "Descontos de vendas (padrão)"
 
+msgid "Sales documents assigned to me"
+msgstr "Documentos de vendas designados para mim"
+
 msgid "Sales Funnel"
 msgstr "Funil de Vendas"
 
@@ -13765,14 +13934,23 @@ msgstr "Local do pedido de venda"
 msgid "Sales Order Number"
 msgstr "Número de Pedido de Venda"
 
+msgid "Sales order value over the period"
+msgstr "Valor do pedido de venda no período"
+
 msgid "Sales orders"
 msgstr "Pedidos de Venda"
 
 msgid "Sales Orders"
 msgstr "Pedidos de Venda"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Pedidos de venda ainda não enviados e faturados"
+
 msgid "Sales Person"
 msgstr "Pessoa de Vendas"
+
+msgid "Sales revenue"
+msgstr "Receita de vendas"
 
 msgid "Sales Revenue"
 msgstr "Receita de Vendas"
@@ -13954,6 +14132,9 @@ msgstr "Refugo"
 msgid "Scrap / Cost of Quality"
 msgstr "Refugo / Custo da qualidade"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Refugo em proporção à produção e quantidades de refugo"
+
 msgid "Scrap Percent"
 msgstr "Percentual de refugo"
 
@@ -13971,6 +14152,9 @@ msgstr "Quantidade de refugo"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Quantidade de refugo por ordem de produção"
+
+msgid "Scrap rate"
+msgstr "Taxa de refugo"
 
 msgid "scrap reason"
 msgstr "motivo de refugo"
@@ -14945,6 +15129,9 @@ msgstr "Itens Específicos"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Gastos por fornecedor, item ou categoria — seus maiores impulsionadores de custo"
 
+msgid "Spend trend"
+msgstr "Tendência de gasto"
+
 msgid "Split"
 msgstr "Dividir"
 
@@ -15336,6 +15523,12 @@ msgstr "Contas de Fornecedor"
 
 msgid "Supplier added and selected"
 msgstr "Fornecedor adicionado e selecionado"
+
+msgid "Supplier balances not yet paid"
+msgstr "Saldos dos fornecedores ainda não pagos"
+
+msgid "Supplier balances past their due date"
+msgstr "Saldos dos fornecedores após sua data de vencimento"
 
 msgid "Supplier contact"
 msgstr "Contato do fornecedor"
@@ -16977,6 +17170,9 @@ msgstr "Ferramentas"
 msgid "Tools"
 msgstr "Ferramentas"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Principais fornecedores por valor do pedido de compra no período"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Classificação de nível superior (ativo / passivo / patrimônio líquido / receita / despesa); definir apenas em grupos raiz, herdados pelos filhos."
 
@@ -17006,6 +17202,12 @@ msgstr "Total de Horas"
 
 msgid "Total Minutes"
 msgstr "Total de Minutos"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Total de pedidos de compra emitidos no período"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Total de pedidos de venda emitidos no período"
 
 msgid "Total Price"
 msgstr "Preço Total"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Tipo de documento de origem não suportado: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Sem título"
 
 msgid "Untitled Diagram"
 msgstr "Diagrama sem título"
@@ -17658,6 +17860,9 @@ msgstr "Os usuários em domínios cobertos podem entrar apenas com SAML SSO; lin
 msgid "Users to Update"
 msgstr "Usuários a atualizar"
 
+msgid "Utilization"
+msgstr "Utilização"
+
 msgid "Valid From"
 msgstr "Válido a partir de"
 
@@ -17687,6 +17892,9 @@ msgstr "Resumo de Valor"
 
 msgid "Value source by surface"
 msgstr "Fonte de valor por superfície"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Valor a enviar em pedidos de venda em aberto"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Número de registro de imposto sobre valor agregado; obrigatório em faturas da UE para fornecimentos de cobrança reversa ou de taxa zero."
@@ -17988,6 +18196,9 @@ msgstr "Anular este recibo irá:"
 
 msgid "Voiding this shipment will:"
 msgstr "Anular esta remessa vai:"
+
+msgid "vs prior period"
+msgstr "vs período anterior"
 
 msgid "Waited"
 msgstr "Aguardado"
@@ -18483,6 +18694,9 @@ msgstr "Por que esta linha está sendo recusada; mostrado na cotação imprimív
 msgid "Why this restore failed"
 msgstr "Por que esta restauração falhou"
 
+msgid "Widget options"
+msgstr "Opções do widget"
+
 msgid "Will remain as a comment line"
 msgstr "Permanecerá como uma linha de comentário"
 
@@ -18575,6 +18789,9 @@ msgstr "Nome do fluxo de trabalho"
 msgid "Workflow run"
 msgstr "Execução do fluxo de trabalho"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Execuções de fluxo de trabalho que falharam no período"
+
 msgid "Workflows"
 msgstr "Fluxos de trabalho"
 
@@ -18608,6 +18825,9 @@ msgstr "Reduzir o valor de um ativo ao longo de sua vida útil — um lote mensa
 
 msgid "Year"
 msgstr "Ano"
+
+msgid "Year to date"
+msgstr "Acumulado do ano"
 
 msgid "Yearly"
 msgstr "Anual"

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} черновых операций"
 msgid "{0} jobs created"
 msgstr "{0} производственных заказов создано"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} строк просрочено"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} строк для сопоставления"
@@ -1095,8 +1099,20 @@ msgstr "Плата за активацию · мы консультируем"
 msgid "Active"
 msgstr "Активно"
 
+msgid "Active jobs"
+msgstr "Активные производственные заказы"
+
 msgid "Active Jobs"
 msgstr "Активные производственные заказы"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Активные производственные заказы со сроком в следующие семь дней"
+
+msgid "Active jobs grouped by status"
+msgstr "Активные производственные заказы, сгруппированные по статусу"
+
+msgid "Active jobs past their due date"
+msgstr "Активные производственные заказы, превысившие срок выполнения"
 
 msgid "Active Statuses"
 msgstr "Активные статусы"
@@ -1340,6 +1356,9 @@ msgstr "Добавить в запас для будущего использо�
 
 msgid "Add tools"
 msgstr "Добавить инструменты"
+
+msgid "Add widgets"
+msgstr "Добавить виджеты"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Анализ возраста кредиторской задолжен�
 msgid "AP Clerk"
 msgstr "Специалист по учету кредиторской задолженности"
 
+msgid "AP outstanding"
+msgstr "Кредиторская задолженность, ожидающая погашения"
+
 msgid "AP Outstanding"
 msgstr "Неоплаченная кредиторская задолженность"
+
+msgid "AP overdue"
+msgstr "Просроченная кредиторская задолженность"
 
 msgid "AP Overdue"
 msgstr "Просроченные кредиторские задолженности"
@@ -1844,8 +1869,14 @@ msgstr "Анализ возраста дебиторской задолженн�
 msgid "AR Clerk"
 msgstr "Менеджер дебиторской задолженности"
 
+msgid "AR outstanding"
+msgstr "Дебиторская задолженность, ожидающая погашения"
+
 msgid "AR Outstanding"
 msgstr "Дебиторская задолженность"
+
+msgid "AR overdue"
+msgstr "Просроченная дебиторская задолженность"
 
 msgid "AR Overdue"
 msgstr "Просроченная дебиторская задолженность"
@@ -3263,6 +3294,9 @@ msgstr "Выбрать другой файл"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Выбрать, что отображается на распечатанном маршрутном листе работы."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Выберите, какие виджеты отображаются на вашей домашней странице."
+
 msgid "Choose your style"
 msgstr "Выберите свой стиль"
 
@@ -4533,6 +4567,12 @@ msgstr "Покупатель"
 msgid "Customer Accounts"
 msgstr "Счета покупателя"
 
+msgid "Customer balances not yet paid"
+msgstr "Остатки покупателей, не оплаченные"
+
+msgid "Customer balances past their due date"
+msgstr "Остатки покупателей со сроком выполнения, превышенным"
+
 msgid "Customer contact"
 msgstr "Контактное лицо покупателя"
 
@@ -4658,6 +4698,9 @@ msgstr "Настройки, обучение и интеграции"
 
 msgid "Customize"
 msgstr "Настроить"
+
+msgid "Customize analytics"
+msgstr "Настроить аналитику"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "Настройте макет ваших PDF-документов — переупорядочивайте разделы, скрывайте ненужное и добавляйте собственные блоки."
@@ -7103,6 +7146,9 @@ msgstr "Ошибка загрузки PDF"
 msgid "Failed to upload thumbnail"
 msgstr "Не удалось загрузить миниатюру"
 
+msgid "Failed workflow runs"
+msgstr "Ошибки рабочих процессов"
+
 msgid "Failure"
 msgstr "Сбой"
 
@@ -7252,6 +7298,9 @@ msgstr "Имя"
 msgid "First Operation"
 msgstr "Первая операция"
 
+msgid "First-pass yield"
+msgstr "Выход с первого прохода"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Основной Актив"
 
@@ -7308,6 +7357,9 @@ msgstr "ID приспособления"
 
 msgid "Flags"
 msgstr "Флаги"
+
+msgid "Follow page range"
+msgstr "Следить за диапазоном страниц"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "для чего угодно. Они привлекут нужного человека."
@@ -7751,6 +7803,9 @@ msgstr "Скрыть исходное"
 msgid "Hide system quantities until the review step"
 msgstr "Скрывать системные количества до шага рассмотрения"
 
+msgid "Hide widget"
+msgstr "Скрыть виджет"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Скрывать, закреплять и переупорядочивать столбцы"
 
@@ -7810,6 +7865,9 @@ msgstr "Часы на этом рабочем месте"
 
 msgid "Hours not yet assigned"
 msgstr "Часы, ещё не назначенные"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Часы производства на рабочий центр за период"
 
 msgid "Hours per Week"
 msgstr "Часов в неделю"
@@ -8223,6 +8281,9 @@ msgstr "Документ контроля"
 msgid "Inspection Level"
 msgstr "Уровень контроля"
 
+msgid "Inspection pass rate"
+msgstr "Процент успешного контроля"
+
 msgid "Inspection Plan"
 msgstr "План контроля"
 
@@ -8237,6 +8298,9 @@ msgstr "Статус контроля"
 
 msgid "Inspections"
 msgstr "Контроли"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Успешный контроль как доля от всех проверок"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Контроли, несоответствия и CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Единица измерения запасов"
 
 msgid "Inventory Valuation"
 msgstr "Оценка товарно-материального запаса"
+
+msgid "Inventory value"
+msgstr "Стоимость запасов"
 
 msgid "Invite"
 msgstr "Пригласить"
@@ -8535,6 +8602,12 @@ msgstr "Дата выпуска"
 msgid "Issues"
 msgstr "Проблемы"
 
+msgid "Issues by type"
+msgstr "Списания в производство по типам"
+
+msgid "Issues opened"
+msgstr "Открытые списания в производство"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Он перестанет работать, пока вы не опубликуете версию снова. Ничего не удаляется."
 
@@ -8673,6 +8746,15 @@ msgstr "Производственные заказы"
 msgid "Jobs Assigned to Me"
 msgstr "Производственные заказы, назначенные мне"
 
+msgid "Jobs by status"
+msgstr "Производственные заказы по статусу"
+
+msgid "Jobs due this week"
+msgstr "Производственные заказы, подлежащие выполнению на этой неделе"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Запланированные, готовые, в работе или приостановленные производственные заказы"
+
 msgid "Jobs Required"
 msgstr "Необходимые производственные заказы"
 
@@ -8804,8 +8886,20 @@ msgstr "Единица труда"
 msgid "Language"
 msgstr "Язык"
 
+msgid "Last 12 months"
+msgstr "Последние 12 месяцев"
+
+msgid "Last 30 days"
+msgstr "Последние 30 дней"
+
 msgid "Last 6 Months"
 msgstr "Последние 6 месяцев"
+
+msgid "Last 7 days"
+msgstr "Последние 7 дней"
+
+msgid "Last 90 days"
+msgstr "Последние 90 дней"
 
 msgid "Last attempt"
 msgstr "Последняя попытка"
@@ -8857,6 +8951,9 @@ msgstr "Последний раз использован"
 
 msgid "Late in the evening, {name}."
 msgstr "Поздно вечером, {name}."
+
+msgid "Late jobs"
+msgstr "Просроченные производственные заказы"
 
 msgid "Latest operation end"
 msgstr "Конец последней операции"
@@ -8998,6 +9095,9 @@ msgstr "Строки требуют внутренние номера детал
 
 msgid "Lines need prices or lead times"
 msgstr "Строки требуют цены или сроки поставки"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Строки, отправленные к подтвержденной дате или ранее"
 
 msgid "Lineside"
 msgstr "Прилинейный запас"
@@ -9773,6 +9873,9 @@ msgstr "Деньги, которые вам должны"
 msgid "Money you owe"
 msgstr "Деньги, которые вы должны"
 
+msgid "Month to date"
+msgstr "С начала месяца"
+
 msgid "Monthly"
 msgstr "Ежемесячно"
 
@@ -9799,6 +9902,9 @@ msgstr "Больше переработки"
 
 msgid "Morning, {name}."
 msgstr "Доброе утро, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Наиболее частые типы списаний в производство за период"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "Большинство проблем выявляются и решаются здесь. Называйте их четко."
@@ -9858,6 +9964,9 @@ msgstr "MRP запускается автоматически каждые 3 ч�
 
 msgid "Must be in the same location"
 msgstr "Должно быть в одном месте"
+
+msgid "My active operations"
+msgstr "Мои активные операции"
 
 msgid "My Documents"
 msgstr "Мои документы"
@@ -10044,6 +10153,9 @@ msgstr "Новая счет-фактура"
 
 msgid "New Issue"
 msgstr "Новая проблема"
+
+msgid "New issues over the period"
+msgstr "Новые списания в производство за период"
 
 msgid "New Item Group"
 msgstr "Новая группа товаров"
@@ -10912,6 +11024,9 @@ msgstr "ОК"
 msgid "Oldest first"
 msgstr "Сначала самые старые"
 
+msgid "Oldest overdue orders first"
+msgstr "Самые старые просроченные заказы в первую очередь"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "В день переключения выполняйте контрольный список ниже по порядку. Тесты приемки основаны на ваших требованиях в области действия. Детали поддержки находятся внизу."
 
@@ -10962,6 +11077,9 @@ msgstr "Наличные остатки"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Минимальный остаток для обслуживания в этом месте"
+
+msgid "On-hand inventory at cost"
+msgstr "Запасы в наличии по себестоимости"
 
 msgid "On-hand inventory remains"
 msgstr "Остаток на складе"
@@ -11055,6 +11173,9 @@ msgstr "Открытая дебиторская задолженность"
 msgid "Open Audit Log"
 msgstr "Открыть журнал аудита"
 
+msgid "Open backlog"
+msgstr "Открытые невыполненные заказы"
+
 msgid "Open date"
 msgstr "Дата открытия"
 
@@ -11076,6 +11197,9 @@ msgstr "Открыть в Извещениях об изменении {ids}. З
 msgid "Open in MES"
 msgstr "Открыть в MES"
 
+msgid "Open issues"
+msgstr "Открытые проблемы"
+
 msgid "Open Issues"
 msgstr "Открытые проблемы"
 
@@ -11094,6 +11218,9 @@ msgstr "Открыть меню"
 msgid "Open navigation"
 msgstr "Открыть навигацию"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Открытые заказы со строкой, превышающей подтвержденную дату"
+
 msgid "Open payables by supplier and age"
 msgstr "Открытая кредиторская задолженность по поставщикам и срокам"
 
@@ -11105,6 +11232,9 @@ msgstr "Открытые заказы поставщикам"
 
 msgid "Open Purchase Orders"
 msgstr "Открытые Заказы поставщикам"
+
+msgid "Open quotes"
+msgstr "Открытые коммерческие предложения"
 
 msgid "Open Quotes"
 msgstr "Открытые предложения"
@@ -11208,6 +11338,9 @@ msgstr "Операции / шаги"
 
 msgid "Operations Type"
 msgstr "Тип операций"
+
+msgid "Operations you currently have running"
+msgstr "Операции, которые в настоящее время выполняются"
 
 msgid "Operator"
 msgstr "Оператор"
@@ -11318,6 +11451,9 @@ msgstr "Заказы"
 msgid "Orders submitted"
 msgstr "Заказы отправлены"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Заказы, коммерческие предложения и запросы цен, где вы являетесь исполнителем"
+
 msgid "Origin"
 msgstr "Источник"
 
@@ -11371,6 +11507,9 @@ msgstr "Общий результат"
 
 msgid "Overdue"
 msgstr "Просрочено"
+
+msgid "Overdue purchase orders"
+msgstr "Просроченные заказы поставщику"
 
 msgid "Overhead Absorption"
 msgstr "Распределение накладных расходов"
@@ -12179,6 +12318,9 @@ msgstr "Производственное количество"
 msgid "Production Quantity"
 msgstr "Производственное количество"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Производственное количество без доработки или брака"
+
 msgid "Production variance"
 msgstr "Отклонение производства"
 
@@ -12382,6 +12524,9 @@ msgstr "Заказ поставщику успешно удален"
 msgid "Purchase Order Type"
 msgstr "Тип Заказа поставщику"
 
+msgid "Purchase order value over the period"
+msgstr "Стоимость заказов поставщику за период"
+
 msgid "Purchase orders"
 msgstr "Заказы на покупку"
 
@@ -12390,6 +12535,9 @@ msgstr "Заказы поставщику"
 
 msgid "Purchase Orders and Planning"
 msgstr "Заказы поставщику и Планирование"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Заказы поставщику, еще не полученные и счета не выставлены"
 
 msgid "Purchase orders required"
 msgstr "Требуются заказы поставщику"
@@ -12408,6 +12556,9 @@ msgstr "Отклонение цены закупки (по умолчанию)"
 
 msgid "Purchase Qty"
 msgstr "Кол-во покупки"
+
+msgid "Purchase spend"
+msgstr "Расходы на закупки"
 
 msgid "Purchase Tax Payable"
 msgstr "Налог на покупку подлежащий уплате (по умолчанию)"
@@ -12429,6 +12580,9 @@ msgstr "Закупленный"
 
 msgid "Purchases"
 msgstr "Покупки"
+
+msgid "Purchases by supplier"
+msgstr "Закупки по поставщикам"
 
 msgid "purchasing"
 msgstr "Закупки и стоимость проданных товаров"
@@ -12603,6 +12757,9 @@ msgstr "Уровни ценообразования на основе колич
 msgid "Quantity: {0}"
 msgstr "Количество: {0}"
 
+msgid "Quarter to date"
+msgstr "С начала квартала"
+
 msgid "Quarterly"
 msgstr "Ежеквартально"
 
@@ -12665,6 +12822,9 @@ msgstr "Дата предложения"
 
 msgid "Quotes"
 msgstr "Предложения"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Коммерческие предложения в черновике или отправленные покупателю"
 
 msgid "Quoting and sales orders"
 msgstr "Коммерческие предложения и заказы покупателей"
@@ -12948,6 +13108,9 @@ msgstr "Зарегистрирован"
 
 msgid "Registered"
 msgstr "Зарегистрировано"
+
+msgid "Registered and in-progress issues"
+msgstr "Зарегистрированные и выполняемые проблемы"
 
 msgid "Registration failed"
 msgstr "Регистрация не удалась"
@@ -13414,6 +13577,9 @@ msgstr "Выручка"
 msgid "Revenue and expenses over a period"
 msgstr "Выручка и расходы за период"
 
+msgid "Revenue trend"
+msgstr "Тренд выручки"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Отменить все корректировки запасов"
 
@@ -13720,6 +13886,9 @@ msgstr "Скидки на продажи"
 msgid "Sales Discounts (default)"
 msgstr "Скидки на продажи (по умолчанию)"
 
+msgid "Sales documents assigned to me"
+msgstr "Документы продаж, закрепленные за мной"
+
 msgid "Sales Funnel"
 msgstr "Воронка продаж"
 
@@ -13765,14 +13934,23 @@ msgstr "Площадка заказа покупателя"
 msgid "Sales Order Number"
 msgstr "Номер заказа покупателя"
 
+msgid "Sales order value over the period"
+msgstr "Стоимость заказов покупателей за период"
+
 msgid "Sales orders"
 msgstr "Заказы на продажу"
 
 msgid "Sales Orders"
 msgstr "Заказы покупателей"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Заказы покупателей, еще не отгруженные и счета не выставлены"
+
 msgid "Sales Person"
 msgstr "Менеджер по продажам"
+
+msgid "Sales revenue"
+msgstr "Выручка от продаж"
 
 msgid "Sales Revenue"
 msgstr "Выручка от продаж"
@@ -13954,6 +14132,9 @@ msgstr "Брак"
 msgid "Scrap / Cost of Quality"
 msgstr "Брак / Стоимость качества"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Брак как доля производства и количества брака"
+
 msgid "Scrap Percent"
 msgstr "Процент брака"
 
@@ -13971,6 +14152,9 @@ msgstr "Количество брака"
 
 msgid "Scrap Quantity Per Job"
 msgstr "Количество брака на задание"
+
+msgid "Scrap rate"
+msgstr "Уровень брака"
 
 msgid "scrap reason"
 msgstr "Причина брака"
@@ -14945,6 +15129,9 @@ msgstr "Конкретные товары"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Расходы по поставщикам, номенклатуре или категориям — ваши основные факторы затрат"
 
+msgid "Spend trend"
+msgstr "Тренд расходов"
+
 msgid "Split"
 msgstr "Разделить"
 
@@ -15336,6 +15523,12 @@ msgstr "Учетные записи поставщиков"
 
 msgid "Supplier added and selected"
 msgstr "Поставщик добавлен и выбран"
+
+msgid "Supplier balances not yet paid"
+msgstr "Остатки поставщиков, еще не оплаченные"
+
+msgid "Supplier balances past their due date"
+msgstr "Остатки поставщиков, превышающие срок выполнения"
 
 msgid "Supplier contact"
 msgstr "Контактное лицо поставщика"
@@ -16977,6 +17170,9 @@ msgstr "Инструменты"
 msgid "Tools"
 msgstr "Инструменты"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Основные поставщики по стоимости заказов поставщику за период"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Верхнеуровневая классификация (активы/обязательства/собственный капитал/выручка/расходы); устанавливается только в корневых группах, наследуется подчиненными"
 
@@ -17006,6 +17202,12 @@ msgstr "Всего часов"
 
 msgid "Total Minutes"
 msgstr "Всего минут"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Итого заказов поставщику, размещенных в периоде"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Итого заказов покупателей, размещенных в периоде"
 
 msgid "Total Price"
 msgstr "Общая цена"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Неподдерживаемый тип документа-основания: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Без названия"
 
 msgid "Untitled Diagram"
 msgstr "Безымянная диаграмма"
@@ -17658,6 +17860,9 @@ msgstr "Пользователи на охватываемых доменах м
 msgid "Users to Update"
 msgstr "Пользователи для обновления"
 
+msgid "Utilization"
+msgstr "Загрузка"
+
 msgid "Valid From"
 msgstr "Действительно с"
 
@@ -17687,6 +17892,9 @@ msgstr "Снимок стоимости"
 
 msgid "Value source by surface"
 msgstr "Источник значения по поверхности"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Стоимость, еще к отгрузке по открытым заказам покупателей"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Номер регистрации для целей налога на добавленную стоимость; требуется в счетах-фактурах ЕС для обратного взимания налога или нулевых ставок."
@@ -17988,6 +18196,9 @@ msgstr "Аннулирование этого чека приведет к:"
 
 msgid "Voiding this shipment will:"
 msgstr "Аннулирование этой отгрузки приведет к:"
+
+msgid "vs prior period"
+msgstr "по сравнению с предыдущим периодом"
 
 msgid "Waited"
 msgstr "Ожидание"
@@ -18483,6 +18694,9 @@ msgstr "Почему эта строка отклоняется; отображ�
 msgid "Why this restore failed"
 msgstr "Почему это восстановление не удалось"
 
+msgid "Widget options"
+msgstr "Параметры виджета"
+
 msgid "Will remain as a comment line"
 msgstr "Останется в виде строки комментария"
 
@@ -18575,6 +18789,9 @@ msgstr "Имя рабочего процесса"
 msgid "Workflow run"
 msgstr "Запуск рабочего процесса"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Запуски рабочих процессов, которые не удались за период"
+
 msgid "Workflows"
 msgstr "Рабочие процессы"
 
@@ -18608,6 +18825,9 @@ msgstr "Уменьшение стоимости актива в течение �
 
 msgid "Year"
 msgstr "Год"
+
+msgid "Year to date"
+msgstr "С начала года"
 
 msgid "Yearly"
 msgstr "Ежегодно"

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -93,6 +93,10 @@ msgstr "{0} taslak muhasebe fişi"
 msgid "{0} jobs created"
 msgstr "{0} iş emri oluşturuldu"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} satır gecikmiş"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} satır eşlenecek"
@@ -1095,8 +1099,20 @@ msgstr "Aktivasyon ücreti · biz tavsiye ederiz"
 msgid "Active"
 msgstr "Aktif"
 
+msgid "Active jobs"
+msgstr "Aktif iş emirleri"
+
 msgid "Active Jobs"
 msgstr "Aktif İş emirleri"
+
+msgid "Active jobs due in the next seven days"
+msgstr "Sonraki yedi gün içinde teslim edilecek aktif iş emirleri"
+
+msgid "Active jobs grouped by status"
+msgstr "Duruma göre gruplandırılmış aktif iş emirleri"
+
+msgid "Active jobs past their due date"
+msgstr "Son tarihi geçmiş aktif iş emirleri"
 
 msgid "Active Statuses"
 msgstr "Aktif Durumlar"
@@ -1340,6 +1356,9 @@ msgstr "Gelecekteki kullanım için stoğa ekle"
 
 msgid "Add tools"
 msgstr "Araç ekle"
+
+msgid "Add widgets"
+msgstr "Widget ekle"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "Borç Hesapları Yaşlandırması"
 msgid "AP Clerk"
 msgstr "Borç Hesapları Memuru"
 
+msgid "AP outstanding"
+msgstr "Ödenmemiş borç hesapları"
+
 msgid "AP Outstanding"
 msgstr "Ödenmemiş Borç Hesapları"
+
+msgid "AP overdue"
+msgstr "Gecikmiş borç hesapları"
 
 msgid "AP Overdue"
 msgstr "Gecikmiş Borç Hesapları"
@@ -1844,8 +1869,14 @@ msgstr "Alacak Hesapları Yaşlandırması"
 msgid "AR Clerk"
 msgstr "Alacak Hesapları Memuru"
 
+msgid "AR outstanding"
+msgstr "Ödenmemiş alacak hesapları"
+
 msgid "AR Outstanding"
 msgstr "Ödenmemiş Alacak Hesapları"
+
+msgid "AR overdue"
+msgstr "Gecikmiş alacak hesapları"
 
 msgid "AR Overdue"
 msgstr "Gecikmiş Alacak Hesapları"
@@ -3263,6 +3294,9 @@ msgstr "Başka bir dosya seç"
 msgid "Choose what appears on the printed job traveler."
 msgstr "Yazdırılan İş takip kartında neyin görüneceğini seçin."
 
+msgid "Choose which widgets appear on your home page."
+msgstr "Ana sayfanızda görünecek araçları seçin."
+
 msgid "Choose your style"
 msgstr "Stilini seçin"
 
@@ -4533,6 +4567,12 @@ msgstr "Müşteri"
 msgid "Customer Accounts"
 msgstr "Müşteri Hesapları"
 
+msgid "Customer balances not yet paid"
+msgstr "Ödenmemiş müşteri bakiyeleri"
+
+msgid "Customer balances past their due date"
+msgstr "Son tarihi geçmiş müşteri bakiyeleri"
+
 msgid "Customer contact"
 msgstr "Müşteri ilgili kişisi"
 
@@ -4658,6 +4698,9 @@ msgstr "Özelleştirmeler, eğitim ve entegrasyonlar"
 
 msgid "Customize"
 msgstr "Özelleştir"
+
+msgid "Customize analytics"
+msgstr "Analitikleri özelleştir"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "PDF belgelerinizin düzenini özelleştirin — bölümleri yeniden sıralayın, ihtiyacınız olmayanları gizleyin ve kendi bloklarınızı ekleyin."
@@ -7103,6 +7146,9 @@ msgstr "PDF yüklenemedi"
 msgid "Failed to upload thumbnail"
 msgstr "Küçük resim yüklenemedi"
 
+msgid "Failed workflow runs"
+msgstr "Başarısız iş akışı çalıştırmaları"
+
 msgid "Failure"
 msgstr "Başarısızlık"
 
@@ -7252,6 +7298,9 @@ msgstr "Adı Soyad"
 msgid "First Operation"
 msgstr "İlk İşlem"
 
+msgid "First-pass yield"
+msgstr "İlk geçiş oranı"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "Sabit Kıymet"
 
@@ -7308,6 +7357,9 @@ msgstr "Bağlama aparatı ID"
 
 msgid "Flags"
 msgstr "Bayraklar"
+
+msgid "Follow page range"
+msgstr "Sayfa aralığını takip et"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "herhangi bir şey için. Doğru kişiyi çekerler."
@@ -7751,6 +7803,9 @@ msgstr "Ham verileri gizle"
 msgid "Hide system quantities until the review step"
 msgstr "Sistem miktarlarını inceleme adımına kadar gizle"
 
+msgid "Hide widget"
+msgstr "Widget gizle"
+
 msgid "Hide, pin and reorder columns"
 msgstr "Sütunları gizle, sabitle ve yeniden sırala"
 
@@ -7810,6 +7865,9 @@ msgstr "Bu istasyonda saatler"
 
 msgid "Hours not yet assigned"
 msgstr "Henüz atanmayan saatler"
+
+msgid "Hours of production time per work center in the period"
+msgstr "Dönem içinde iş merkezi başına üretim saatleri"
 
 msgid "Hours per Week"
 msgstr "Haftalık Saat"
@@ -8223,6 +8281,9 @@ msgstr "Muayene belgesi"
 msgid "Inspection Level"
 msgstr "Muayene Seviyesi"
 
+msgid "Inspection pass rate"
+msgstr "Muayene başarı oranı"
+
 msgid "Inspection Plan"
 msgstr "Kontrol planı"
 
@@ -8237,6 +8298,9 @@ msgstr "Muayene Durumu"
 
 msgid "Inspections"
 msgstr "Muayeneler"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "Sonuçlandırılan muayenelerin uygun olanlarının oranı"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "Muayeneler, uygunsuzluk ve CAPA"
@@ -8369,6 +8433,9 @@ msgstr "Envanter Ölçü Birimi"
 
 msgid "Inventory Valuation"
 msgstr "Envanter Değerlemesi"
+
+msgid "Inventory value"
+msgstr "Envanter değeri"
 
 msgid "Invite"
 msgstr "Davet et"
@@ -8535,6 +8602,12 @@ msgstr "Düzenlenme Tarihi"
 msgid "Issues"
 msgstr "Sorunlar"
 
+msgid "Issues by type"
+msgstr "Sorunlar türe göre"
+
+msgid "Issues opened"
+msgstr "Açılan sorunlar"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "Yeniden bir sürüm yayınlayana kadar çalışmayı durdurur. Hiçbir şey silinmez."
 
@@ -8673,6 +8746,15 @@ msgstr "İş emirleri"
 msgid "Jobs Assigned to Me"
 msgstr "Bana Atanan İş emirleri"
 
+msgid "Jobs by status"
+msgstr "Duruma göre iş emirleri"
+
+msgid "Jobs due this week"
+msgstr "Bu hafta teslim edilecek iş emirleri"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "Planlandı, hazır, devam ediyor veya duraklatılmış iş emirleri"
+
 msgid "Jobs Required"
 msgstr "Gereken İş emirleri"
 
@@ -8804,8 +8886,20 @@ msgstr "İşçilik Birimi"
 msgid "Language"
 msgstr "Dil"
 
+msgid "Last 12 months"
+msgstr "Son 12 ay"
+
+msgid "Last 30 days"
+msgstr "Son 30 gün"
+
 msgid "Last 6 Months"
 msgstr "Son 6 Ay"
+
+msgid "Last 7 days"
+msgstr "Son 7 gün"
+
+msgid "Last 90 days"
+msgstr "Son 90 gün"
 
 msgid "Last attempt"
 msgstr "Son deneme"
@@ -8857,6 +8951,9 @@ msgstr "Son Kullanılan"
 
 msgid "Late in the evening, {name}."
 msgstr "Akşamın geç saatlerinde, {name}."
+
+msgid "Late jobs"
+msgstr "Gecikmiş iş emirleri"
 
 msgid "Latest operation end"
 msgstr "En son işlem sonu"
@@ -8998,6 +9095,9 @@ msgstr "Satırlar dahili parça numaralarına ihtiyaç duyuyor"
 
 msgid "Lines need prices or lead times"
 msgstr "Satırlar fiyat veya tedarik süresi gerektirir"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "Taahhüt tarihinde veya öncesinde gönderilen satırlar"
 
 msgid "Lineside"
 msgstr "Üretim Hattı Yanı"
@@ -9773,6 +9873,9 @@ msgstr "Size borçlu"
 msgid "Money you owe"
 msgstr "Borçlu olduğunuz para"
 
+msgid "Month to date"
+msgstr "Ay başından bugüne"
+
 msgid "Monthly"
 msgstr "Aylık"
 
@@ -9799,6 +9902,9 @@ msgstr "Daha fazla fazla mesai"
 
 msgid "Morning, {name}."
 msgstr "Sabah, {name}."
+
+msgid "Most frequent issue types in the period"
+msgstr "Dönem içinde en sık karşılaşılan sorun türleri"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "Çoğu şey burada yakalanır ve çözülür. Açıkça adlandırın."
@@ -9858,6 +9964,9 @@ msgstr "MRP otomatik olarak her 3 saatte bir çalışır, ancak buradan manuel o
 
 msgid "Must be in the same location"
 msgstr "Aynı konumda olmalıdır"
+
+msgid "My active operations"
+msgstr "Benim aktif operasyonlarım"
 
 msgid "My Documents"
 msgstr "Belgelerim"
@@ -10044,6 +10153,9 @@ msgstr "Yeni Fatura"
 
 msgid "New Issue"
 msgstr "Yeni Sorun"
+
+msgid "New issues over the period"
+msgstr "Dönem içinde açılan yeni sorunlar"
 
 msgid "New Item Group"
 msgstr "Yeni Ürün Grubu"
@@ -10912,6 +11024,9 @@ msgstr "Tamam"
 msgid "Oldest first"
 msgstr "En eski önce"
 
+msgid "Oldest overdue orders first"
+msgstr "En eski gecikmiş siparişler önce"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "Geçiş gününde, aşağıdaki kontrol listesini sırayla çalışın. Kabul testleri kapsam içi gerekliliklerinizden gelir. Destek ayrıntıları altta yer alır."
 
@@ -10962,6 +11077,9 @@ msgstr "Eldeki stok sayıları"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "Bu konumdaki servis kullanımı için korunacak minimum stok seviyesi"
+
+msgid "On-hand inventory at cost"
+msgstr "Eldeki envanterin maliyet değeri"
 
 msgid "On-hand inventory remains"
 msgstr "Eldeki envanter kaldı"
@@ -11055,6 +11173,9 @@ msgstr "Açık Alacak hesapları"
 msgid "Open Audit Log"
 msgstr "Açık Denetim günlüğü"
 
+msgid "Open backlog"
+msgstr "Açık iş birikintisi"
+
 msgid "Open date"
 msgstr "Açılış tarihi"
 
@@ -11076,6 +11197,9 @@ msgstr "Değişiklik bildirimleri {ids} içinde aç. Yeni sürümler veya revizy
 msgid "Open in MES"
 msgstr "MES'te Aç"
 
+msgid "Open issues"
+msgstr "Açık Sorunlar"
+
 msgid "Open Issues"
 msgstr "Açık Sorunlar"
 
@@ -11094,6 +11218,9 @@ msgstr "Menüyü aç"
 msgid "Open navigation"
 msgstr "Gezinmeyi aç"
 
+msgid "Open orders with a line past its promised date"
+msgstr "Taahhüt Tarihini Geçen Bir Satırı Olan Açık Siparişler"
+
 msgid "Open payables by supplier and age"
 msgstr "Tedarikçi ve yaşa göre açık borçlar"
 
@@ -11105,6 +11232,9 @@ msgstr "Açık satın alma siparişleri"
 
 msgid "Open Purchase Orders"
 msgstr "Açık Satın Alma Siparişleri"
+
+msgid "Open quotes"
+msgstr "Açık Teklifler"
 
 msgid "Open Quotes"
 msgstr "Açık Teklifler"
@@ -11208,6 +11338,9 @@ msgstr "Operasyonlar / Adımlar"
 
 msgid "Operations Type"
 msgstr "Operasyon Türü"
+
+msgid "Operations you currently have running"
+msgstr "Şu Anda Çalışan Operasyonlar"
 
 msgid "Operator"
 msgstr "Operatör"
@@ -11318,6 +11451,9 @@ msgstr "Siparişler"
 msgid "Orders submitted"
 msgstr "Siparişler gönderildi"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "Atanan Olduğunuz Siparişler, Teklifler ve Teklif Talepleri"
+
 msgid "Origin"
 msgstr "Kaynak"
 
@@ -11371,6 +11507,9 @@ msgstr "Genel sonuç"
 
 msgid "Overdue"
 msgstr "Gecikmiş"
+
+msgid "Overdue purchase orders"
+msgstr "Gecikmiş Satın Alma Siparişleri"
 
 msgid "Overhead Absorption"
 msgstr "Genel üretim gideri dağıtımı"
@@ -12179,6 +12318,9 @@ msgstr "Üretim miktarı"
 msgid "Production Quantity"
 msgstr "Üretim Miktarı"
 
+msgid "Production quantity without rework or scrap"
+msgstr "Yeniden İşleme veya Fire Olmayan Üretim Miktarı"
+
 msgid "Production variance"
 msgstr "Üretim sapması"
 
@@ -12382,6 +12524,9 @@ msgstr "Satın alma siparişi başarıyla kaldırıldı"
 msgid "Purchase Order Type"
 msgstr "Satın Alma Siparişi Türü"
 
+msgid "Purchase order value over the period"
+msgstr "Dönem İçerisindeki Satın Alma Siparişi Değeri"
+
 msgid "Purchase orders"
 msgstr "Satın Alma Siparişleri"
 
@@ -12390,6 +12535,9 @@ msgstr "Satın Alma Siparişleri"
 
 msgid "Purchase Orders and Planning"
 msgstr "Satın Alma Siparişleri ve Planlama"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "Henüz Alınmamış ve Faturalanmamış Satın Alma Siparişleri"
 
 msgid "Purchase orders required"
 msgstr "Satın alma siparişleri gerekli"
@@ -12408,6 +12556,9 @@ msgstr "Satın alma fiyat sapması (varsayılan)"
 
 msgid "Purchase Qty"
 msgstr "Satın Alma Miktarı"
+
+msgid "Purchase spend"
+msgstr "Satın Alma Harcaması"
 
 msgid "Purchase Tax Payable"
 msgstr "Satın Alma Vergisi Ödenecek (varsayılan)"
@@ -12429,6 +12580,9 @@ msgstr "Satın Alındı"
 
 msgid "Purchases"
 msgstr "Satın almalar"
+
+msgid "Purchases by supplier"
+msgstr "Tedarikçiye Göre Satın Almalar"
 
 msgid "purchasing"
 msgstr "Satın Alma ve Satılan Malların Maliyeti"
@@ -12603,6 +12757,9 @@ msgstr "Bu geçersiz kılma için miktar tabanlı fiyatlandırma seviyeleri; uyg
 msgid "Quantity: {0}"
 msgstr "Miktar: {0}"
 
+msgid "Quarter to date"
+msgstr "Çeyrek Başından Beri"
+
 msgid "Quarterly"
 msgstr "Üç Aylık"
 
@@ -12665,6 +12822,9 @@ msgstr "Teklif Tarihi"
 
 msgid "Quotes"
 msgstr "Teklifler"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "Taslak Olan veya Müşteriye Gönderilen Teklifler"
 
 msgid "Quoting and sales orders"
 msgstr "Teklifler ve satış siparişleri"
@@ -12948,6 +13108,9 @@ msgstr "Kayıtlı"
 
 msgid "Registered"
 msgstr "Kaydedildi"
+
+msgid "Registered and in-progress issues"
+msgstr "Kaydedilen ve Devam Eden Sorunlar"
 
 msgid "Registration failed"
 msgstr "Kayıt Başarısız Oldu"
@@ -13414,6 +13577,9 @@ msgstr "Hasılat"
 msgid "Revenue and expenses over a period"
 msgstr "Bir dönem içinde hasılat ve giderler"
 
+msgid "Revenue trend"
+msgstr "Hasılat Trendi"
+
 msgid "Reverse all inventory adjustments"
 msgstr "Tüm stok düzeltmelerini ters kayıt yap"
 
@@ -13720,6 +13886,9 @@ msgstr "Satış İskontoları"
 msgid "Sales Discounts (default)"
 msgstr "Satış İskontoları (varsayılan)"
 
+msgid "Sales documents assigned to me"
+msgstr "Bana Atanan Satış Belgeleri"
+
 msgid "Sales Funnel"
 msgstr "Satış Hunisi"
 
@@ -13765,14 +13934,23 @@ msgstr "Satış Siparişi Konumu"
 msgid "Sales Order Number"
 msgstr "Satış Siparişi Numarası"
 
+msgid "Sales order value over the period"
+msgstr "Dönem İçerisindeki Satış Siparişi Değeri"
+
 msgid "Sales orders"
 msgstr "Satış Siparişleri"
 
 msgid "Sales Orders"
 msgstr "Satış Siparişleri"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "Henüz Sevk Edilmemiş ve Faturalanmamış Satış Siparişleri"
+
 msgid "Sales Person"
 msgstr "Satış Temsilcisi"
+
+msgid "Sales revenue"
+msgstr "Satış Hasılatı"
 
 msgid "Sales Revenue"
 msgstr "Satış Hasılat"
@@ -13954,6 +14132,9 @@ msgstr "Fire"
 msgid "Scrap / Cost of Quality"
 msgstr "Fire / Kalite Maliyeti"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "Fire'ın Üretim Artı Fire Miktarlarındaki Payı"
+
 msgid "Scrap Percent"
 msgstr "Fire Oranı"
 
@@ -13971,6 +14152,9 @@ msgstr "Fire Miktarı"
 
 msgid "Scrap Quantity Per Job"
 msgstr "İş Emri Başına Fire Miktarı"
+
+msgid "Scrap rate"
+msgstr "Fire Oranı"
 
 msgid "scrap reason"
 msgstr "Fire nedeni"
@@ -14945,6 +15129,9 @@ msgstr "Belirli Ürünler"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "Tedarikçi, ürün veya kategoriye göre harcama — en büyük maliyet sürücüleriniz"
 
+msgid "Spend trend"
+msgstr "Harcama Trendi"
+
 msgid "Split"
 msgstr "Bölünmüş"
 
@@ -15336,6 +15523,12 @@ msgstr "Tedarikçi Hesapları"
 
 msgid "Supplier added and selected"
 msgstr "Tedarikçi eklendi ve seçildi"
+
+msgid "Supplier balances not yet paid"
+msgstr "Henüz Ödenmemiş Tedarikçi Bakiyeleri"
+
+msgid "Supplier balances past their due date"
+msgstr "Son Tarihini Geçen Tedarikçi Bakiyeleri"
 
 msgid "Supplier contact"
 msgstr "tedarikçi ilgili kişisi"
@@ -16977,6 +17170,9 @@ msgstr "Araçlar"
 msgid "Tools"
 msgstr "Araçlar"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "Dönemdeki Satın Alma Siparişi Değerine Göre En İyi Tedarikçiler"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "Üst düzey sınıflandırma (varlık / yükümlülük / özkaynak / hasılat / gider); yalnızca kök gruplar üzerinde ayarlayın, alt gruplar tarafından devralınır."
 
@@ -17006,6 +17202,12 @@ msgstr "Toplam Saat"
 
 msgid "Total Minutes"
 msgstr "Toplam Dakika"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "Dönemde Yerleştirilen Satın Alma Siparişlerinin Toplamı"
+
+msgid "Total of sales orders placed in the period"
+msgstr "Dönemde Yerleştirilen Satış Siparişlerinin Toplamı"
 
 msgid "Total Price"
 msgstr "Toplam Fiyat"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "Desteklenmeyen kaynak belge türü: {sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "Başlıksız"
 
 msgid "Untitled Diagram"
 msgstr "Başlıksız Diyagram"
@@ -17658,6 +17860,9 @@ msgstr "Kapsanan etki alanlarındaki kullanıcılar yalnızca SAML SSO ile oturu
 msgid "Users to Update"
 msgstr "Güncellenecek Kullanıcılar"
 
+msgid "Utilization"
+msgstr "Kullanım Oranı"
+
 msgid "Valid From"
 msgstr "Geçerli Tarih"
 
@@ -17687,6 +17892,9 @@ msgstr "Değer Özeti"
 
 msgid "Value source by surface"
 msgstr "Yüzeye göre değer kaynağı"
+
+msgid "Value still to ship on open sales orders"
+msgstr "Açık Satış Siparişlerinde Sevk Edilecek Kalan Değer"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "Katma değer vergisi kayıt numarası; AB faturalarında ters ücretlendirme veya sıfır oranlı tedarikler için gereklidir."
@@ -17988,6 +18196,9 @@ msgstr "Bu fişin iptali şunları yapacaktır:"
 
 msgid "Voiding this shipment will:"
 msgstr "Bu sevkiyatı geçersiz kılmak şunları yapacaktır:"
+
+msgid "vs prior period"
+msgstr "Vs. Önceki Dönem"
 
 msgid "Waited"
 msgstr "Beklemede"
@@ -18483,6 +18694,9 @@ msgstr "Bu satırın neden reddedildiği; yazdırılabilir teklifte gösterilir 
 msgid "Why this restore failed"
 msgstr "Bu geri yükleme neden başarısız oldu"
 
+msgid "Widget options"
+msgstr "Widget Seçenekleri"
+
 msgid "Will remain as a comment line"
 msgstr "Yorum satırı olarak kalacak"
 
@@ -18575,6 +18789,9 @@ msgstr "İş akışı adı"
 msgid "Workflow run"
 msgstr "İş akışı çalışması"
 
+msgid "Workflow runs that failed in the period"
+msgstr "Dönemdeki Başarısız İş Akışı Çalıştırmaları"
+
 msgid "Workflows"
 msgstr "İş akışları"
 
@@ -18608,6 +18825,9 @@ msgstr "Bir varlığın değerini yaşamı boyunca azaltma — her ay oluşturdu
 
 msgid "Year"
 msgstr "Yıl"
+
+msgid "Year to date"
+msgstr "Yılı Başından Beri"
 
 msgid "Yearly"
 msgstr "Yıllık"

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -93,6 +93,10 @@ msgstr "{0}个草稿凭证"
 msgid "{0} jobs created"
 msgstr "已创建{0}个工单"
 
+#. placeholder {0}: payload.detail
+msgid "{0} lines past due"
+msgstr "{0} 条已逾期"
+
 #. placeholder {0}: mappings.length
 msgid "{0} lines to map"
 msgstr "{0} 行待映射"
@@ -1095,8 +1099,20 @@ msgstr "激活费 · 我们建议"
 msgid "Active"
 msgstr "启用"
 
+msgid "Active jobs"
+msgstr "活跃的工单"
+
 msgid "Active Jobs"
 msgstr "启用的工单"
+
+msgid "Active jobs due in the next seven days"
+msgstr "活跃的工单即将在未来七天内到期"
+
+msgid "Active jobs grouped by status"
+msgstr "按状态分组的活跃工单"
+
+msgid "Active jobs past their due date"
+msgstr "已过期的活跃工单"
 
 msgid "Active Statuses"
 msgstr "启用的状态"
@@ -1340,6 +1356,9 @@ msgstr "添加到库存以供将来使用"
 
 msgid "Add tools"
 msgstr "添加工具"
+
+msgid "Add widgets"
+msgstr "添加小部件"
 
 #. placeholder {0}: copy.noun
 msgid "Add your first {0}"
@@ -1705,8 +1724,14 @@ msgstr "应付账款账龄"
 msgid "AP Clerk"
 msgstr "应付账款文员"
 
+msgid "AP outstanding"
+msgstr "应付账款未付"
+
 msgid "AP Outstanding"
 msgstr "应付账款未结"
+
+msgid "AP overdue"
+msgstr "应付账款已逾期"
 
 msgid "AP Overdue"
 msgstr "应付账款已逾期"
@@ -1844,8 +1869,14 @@ msgstr "应收账款账龄"
 msgid "AR Clerk"
 msgstr "应收账款文员"
 
+msgid "AR outstanding"
+msgstr "应收账款未收"
+
 msgid "AR Outstanding"
 msgstr "应收账款未结"
+
+msgid "AR overdue"
+msgstr "应收账款已逾期"
 
 msgid "AR Overdue"
 msgstr "应收账款已逾期"
@@ -3263,6 +3294,9 @@ msgstr "选择另一个文件"
 msgid "Choose what appears on the printed job traveler."
 msgstr "选择打印工单流转卡上显示的内容。"
 
+msgid "Choose which widgets appear on your home page."
+msgstr "选择在您的主页上显示哪些小部件。"
+
 msgid "Choose your style"
 msgstr "选择您的风格"
 
@@ -4533,6 +4567,12 @@ msgstr "客户"
 msgid "Customer Accounts"
 msgstr "客户账户"
 
+msgid "Customer balances not yet paid"
+msgstr "客户未支付的余额"
+
+msgid "Customer balances past their due date"
+msgstr "客户已逾期的余额"
+
 msgid "Customer contact"
 msgstr "客户联系人"
 
@@ -4658,6 +4698,9 @@ msgstr "定制、培训和集成"
 
 msgid "Customize"
 msgstr "自定义"
+
+msgid "Customize analytics"
+msgstr "自定义分析"
 
 msgid "Customize the layout of your PDF documents — reorder sections, hide what you don't need, and add your own blocks."
 msgstr "自定义您的 PDF 文档布局 — 重新排列部分、隐藏不需要的内容，并添加您自己的块。"
@@ -7103,6 +7146,9 @@ msgstr "上传 PDF 失败"
 msgid "Failed to upload thumbnail"
 msgstr "上传缩略图失败"
 
+msgid "Failed workflow runs"
+msgstr "失败的工作流运行"
+
 msgid "Failure"
 msgstr "故障"
 
@@ -7252,6 +7298,9 @@ msgstr "名字"
 msgid "First Operation"
 msgstr "首次操作"
 
+msgid "First-pass yield"
+msgstr "首检合格率"
+
 msgid "First-year additional deduction taken before the regular MACRS schedule begins."
 msgstr "在常规MACRS折旧计划开始之前的第一年额外扣除。"
 
@@ -7308,6 +7357,9 @@ msgstr "工装夹具ID"
 
 msgid "Flags"
 msgstr "标志"
+
+msgid "Follow page range"
+msgstr "跟踪页面范围"
 
 msgid "for anything. They'll pull in the right person."
 msgstr "用于任何事项。他们会调配合适的人员。"
@@ -7751,6 +7803,9 @@ msgstr "隐藏原始内容"
 msgid "Hide system quantities until the review step"
 msgstr "在评审步骤前隐藏系统数量"
 
+msgid "Hide widget"
+msgstr "隐藏小部件"
+
 msgid "Hide, pin and reorder columns"
 msgstr "隐藏、固定和重新排序列"
 
@@ -7810,6 +7865,9 @@ msgstr "此工位的小时数"
 
 msgid "Hours not yet assigned"
 msgstr "未分配的小时数"
+
+msgid "Hours of production time per work center in the period"
+msgstr "期间内每个工作中心的生产时间（小时）"
 
 msgid "Hours per Week"
 msgstr "每周小时数"
@@ -8223,6 +8281,9 @@ msgstr "检验文件"
 msgid "Inspection Level"
 msgstr "检验水平"
 
+msgid "Inspection pass rate"
+msgstr "检验合格率"
+
 msgid "Inspection Plan"
 msgstr "检验计划"
 
@@ -8237,6 +8298,9 @@ msgstr "检验状态"
 
 msgid "Inspections"
 msgstr "检验"
+
+msgid "Inspections passed as a share of those dispositioned"
+msgstr "已处置检验中的合格比例"
 
 msgid "Inspections, nonconformance, and CAPA"
 msgstr "检验、不合格和CAPA"
@@ -8369,6 +8433,9 @@ msgstr "库存计量单位"
 
 msgid "Inventory Valuation"
 msgstr "库存估价"
+
+msgid "Inventory value"
+msgstr "库存价值"
 
 msgid "Invite"
 msgstr "邀请"
@@ -8535,6 +8602,12 @@ msgstr "签发日期"
 msgid "Issues"
 msgstr "问题"
 
+msgid "Issues by type"
+msgstr "按类型分类的问题"
+
+msgid "Issues opened"
+msgstr "已打开的问题"
+
 msgid "It will stop running until you publish a version again. Nothing is deleted."
 msgstr "它将停止运行，直到您再次发布版本。不会删除任何内容。"
 
@@ -8673,6 +8746,15 @@ msgstr "工单"
 msgid "Jobs Assigned to Me"
 msgstr "分配给我的工单"
 
+msgid "Jobs by status"
+msgstr "按状态分类的工单"
+
+msgid "Jobs due this week"
+msgstr "本周到期的工单"
+
+msgid "Jobs planned, ready, in progress or paused"
+msgstr "计划中、就绪、进行中或暂停的工单"
+
 msgid "Jobs Required"
 msgstr "所需工单"
 
@@ -8804,8 +8886,20 @@ msgstr "人工单位"
 msgid "Language"
 msgstr "语言"
 
+msgid "Last 12 months"
+msgstr "过去12个月"
+
+msgid "Last 30 days"
+msgstr "过去30天"
+
 msgid "Last 6 Months"
 msgstr "最近6个月"
+
+msgid "Last 7 days"
+msgstr "过去7天"
+
+msgid "Last 90 days"
+msgstr "过去90天"
 
 msgid "Last attempt"
 msgstr "上次尝试"
@@ -8857,6 +8951,9 @@ msgstr "最后使用"
 
 msgid "Late in the evening, {name}."
 msgstr "傍晚晚些时候，{name}。"
+
+msgid "Late jobs"
+msgstr "延迟的工单"
 
 msgid "Latest operation end"
 msgstr "最新操作结束"
@@ -8998,6 +9095,9 @@ msgstr "行需要内部零件号"
 
 msgid "Lines need prices or lead times"
 msgstr "行需要价格或提前期"
+
+msgid "Lines shipped on or before their promised date"
+msgstr "在承诺日期或之前发货的行"
 
 msgid "Lineside"
 msgstr "线边"
@@ -9773,6 +9873,9 @@ msgstr "你欠的钱"
 msgid "Money you owe"
 msgstr "你欠的钱"
 
+msgid "Month to date"
+msgstr "月初至今"
+
 msgid "Monthly"
 msgstr "每月"
 
@@ -9799,6 +9902,9 @@ msgstr "更多加班"
 
 msgid "Morning, {name}."
 msgstr "早上，{name}。"
+
+msgid "Most frequent issue types in the period"
+msgstr "期间内最常见的问题类型"
 
 msgid "Most things get caught and resolved here. Name it plainly."
 msgstr "大多数问题在这里都会被发现和解决。直言不讳地说出来。"
@@ -9858,6 +9964,9 @@ msgstr "MRP 每 3 小时自动运行一次，但您也可以在此手动运行�
 
 msgid "Must be in the same location"
 msgstr "必须在同一位置"
+
+msgid "My active operations"
+msgstr "我的进行中的工序"
 
 msgid "My Documents"
 msgstr "我的文档"
@@ -10044,6 +10153,9 @@ msgstr "新发票"
 
 msgid "New Issue"
 msgstr "新问题"
+
+msgid "New issues over the period"
+msgstr "期间内新建的问题"
 
 msgid "New Item Group"
 msgstr "新建项目组"
@@ -10912,6 +11024,9 @@ msgstr "确定"
 msgid "Oldest first"
 msgstr "最早优先"
 
+msgid "Oldest overdue orders first"
+msgstr "最早逾期的订单优先"
+
 msgid "On cutover day, work the checklist below in order. Acceptance tests come from your in-scope requirements. Support details are at the bottom."
 msgstr "在转换日，按顺序完成下列检查清单。验收测试来自您范围内的要求。支持详情见下方。"
 
@@ -10962,6 +11077,9 @@ msgstr "现有库存数量"
 
 msgid "On-hand floor to maintain for service use at this location"
 msgstr "在此位置维护用于服务的最低库存"
+
+msgid "On-hand inventory at cost"
+msgstr "库存成本"
 
 msgid "On-hand inventory remains"
 msgstr "剩余可用库存"
@@ -11055,6 +11173,9 @@ msgstr "未结应收账款"
 msgid "Open Audit Log"
 msgstr "打开审计日志"
 
+msgid "Open backlog"
+msgstr "未结积压"
+
 msgid "Open date"
 msgstr "打开日期"
 
@@ -11076,6 +11197,9 @@ msgstr "打开于变更通知 {ids}。下达它们来创建新版本或修订版
 msgid "Open in MES"
 msgstr "在 MES 中打开"
 
+msgid "Open issues"
+msgstr "未结问题"
+
 msgid "Open Issues"
 msgstr "未结领料"
 
@@ -11094,6 +11218,9 @@ msgstr "打开菜单"
 msgid "Open navigation"
 msgstr "打开导航"
 
+msgid "Open orders with a line past its promised date"
+msgstr "包含已逾期行的未结订单"
+
 msgid "Open payables by supplier and age"
 msgstr "按供应商和期限打开应付款项"
 
@@ -11105,6 +11232,9 @@ msgstr "未结采购订单"
 
 msgid "Open Purchase Orders"
 msgstr "未结采购订单"
+
+msgid "Open quotes"
+msgstr "未结报价单"
 
 msgid "Open Quotes"
 msgstr "未结报价"
@@ -11208,6 +11338,9 @@ msgstr "工序/步骤"
 
 msgid "Operations Type"
 msgstr "工序类型"
+
+msgid "Operations you currently have running"
+msgstr "你当前运行中的工序"
 
 msgid "Operator"
 msgstr "操作员"
@@ -11318,6 +11451,9 @@ msgstr "订单"
 msgid "Orders submitted"
 msgstr "订单已提交"
 
+msgid "Orders, quotes and RFQs where you are the assignee"
+msgstr "你是经办人的订单、报价单和询价单"
+
 msgid "Origin"
 msgstr "来源"
 
@@ -11371,6 +11507,9 @@ msgstr "总体结果"
 
 msgid "Overdue"
 msgstr "已逾期"
+
+msgid "Overdue purchase orders"
+msgstr "已逾期采购订单"
 
 msgid "Overhead Absorption"
 msgstr "制造费用分配"
@@ -12179,6 +12318,9 @@ msgstr "生产数量"
 msgid "Production Quantity"
 msgstr "生产数量"
 
+msgid "Production quantity without rework or scrap"
+msgstr "无返工或报废的生产数量"
+
 msgid "Production variance"
 msgstr "生产差异"
 
@@ -12382,6 +12524,9 @@ msgstr "采购订单已成功删除"
 msgid "Purchase Order Type"
 msgstr "采购订单类型"
 
+msgid "Purchase order value over the period"
+msgstr "期间采购订单价值"
+
 msgid "Purchase orders"
 msgstr "采购订单"
 
@@ -12390,6 +12535,9 @@ msgstr "采购订单"
 
 msgid "Purchase Orders and Planning"
 msgstr "采购订单和计划"
+
+msgid "Purchase orders not yet received and invoiced"
+msgstr "尚未收货和开票的采购订单"
 
 msgid "Purchase orders required"
 msgstr "采购订单必需"
@@ -12408,6 +12556,9 @@ msgstr "采购价格差异（默认）"
 
 msgid "Purchase Qty"
 msgstr "采购数量"
+
+msgid "Purchase spend"
+msgstr "采购支出"
 
 msgid "Purchase Tax Payable"
 msgstr "应付采购税（默认）"
@@ -12429,6 +12580,9 @@ msgstr "已购买"
 
 msgid "Purchases"
 msgstr "采购"
+
+msgid "Purchases by supplier"
+msgstr "按供应商分类的采购"
 
 msgid "purchasing"
 msgstr "采购和已售商品成本"
@@ -12603,6 +12757,9 @@ msgstr "此覆盖的基于数量的定价层；应用的单价是满足订单行
 msgid "Quantity: {0}"
 msgstr "数量：{0}"
 
+msgid "Quarter to date"
+msgstr "季度至今"
+
 msgid "Quarterly"
 msgstr "每季度"
 
@@ -12665,6 +12822,9 @@ msgstr "报价日期"
 
 msgid "Quotes"
 msgstr "报价"
+
+msgid "Quotes in draft or sent to the customer"
+msgstr "草稿中或已发送给客户的报价单"
 
 msgid "Quoting and sales orders"
 msgstr "报价和销售订单"
@@ -12948,6 +13108,9 @@ msgstr "已注册"
 
 msgid "Registered"
 msgstr "已登记"
+
+msgid "Registered and in-progress issues"
+msgstr "已登记和进行中的问题"
 
 msgid "Registration failed"
 msgstr "注册失败"
@@ -13414,6 +13577,9 @@ msgstr "收入"
 msgid "Revenue and expenses over a period"
 msgstr "期间的收入和费用"
 
+msgid "Revenue trend"
+msgstr "收入趋势"
+
 msgid "Reverse all inventory adjustments"
 msgstr "反转所有库存调整"
 
@@ -13720,6 +13886,9 @@ msgstr "销售折扣"
 msgid "Sales Discounts (default)"
 msgstr "销售折扣 (默认)"
 
+msgid "Sales documents assigned to me"
+msgstr "分配给我的销售文档"
+
 msgid "Sales Funnel"
 msgstr "销售漏斗"
 
@@ -13765,14 +13934,23 @@ msgstr "销售订单位置"
 msgid "Sales Order Number"
 msgstr "销售订单号"
 
+msgid "Sales order value over the period"
+msgstr "期间销售订单价值"
+
 msgid "Sales orders"
 msgstr "销售订单"
 
 msgid "Sales Orders"
 msgstr "销售订单"
 
+msgid "Sales orders not yet shipped and invoiced"
+msgstr "尚未发货和开票的销售订单"
+
 msgid "Sales Person"
 msgstr "销售人员"
+
+msgid "Sales revenue"
+msgstr "销售收入"
 
 msgid "Sales Revenue"
 msgstr "销售收入"
@@ -13954,6 +14132,9 @@ msgstr "报废"
 msgid "Scrap / Cost of Quality"
 msgstr "报废/质量成本"
 
+msgid "Scrap as a share of production plus scrap quantities"
+msgstr "报废占生产加报废数量的比例"
+
 msgid "Scrap Percent"
 msgstr "报废率"
 
@@ -13971,6 +14152,9 @@ msgstr "报废数量"
 
 msgid "Scrap Quantity Per Job"
 msgstr "每个工作的报废数量"
+
+msgid "Scrap rate"
+msgstr "报废率"
 
 msgid "scrap reason"
 msgstr "报废原因"
@@ -14945,6 +15129,9 @@ msgstr "特定物料"
 msgid "Spend by supplier, item, or category — your biggest cost drivers"
 msgstr "按供应商、项目或类别的支出 — 您最大的成本驱动因素"
 
+msgid "Spend trend"
+msgstr "支出趋势"
+
 msgid "Split"
 msgstr "拆分"
 
@@ -15336,6 +15523,12 @@ msgstr "供应商账户"
 
 msgid "Supplier added and selected"
 msgstr "供应商已添加并选中"
+
+msgid "Supplier balances not yet paid"
+msgstr "尚未支付的供应商余额"
+
+msgid "Supplier balances past their due date"
+msgstr "超过到期日的供应商余额"
 
 msgid "Supplier contact"
 msgstr "供应商联系人"
@@ -16977,6 +17170,9 @@ msgstr "工具"
 msgid "Tools"
 msgstr "工具"
 
+msgid "Top suppliers by purchase order value in the period"
+msgstr "期间采购订单价值最高的供应商"
+
 msgid "Top-level classification (asset / liability / equity / revenue / expense); set only on root groups, inherited by children."
 msgstr "顶级分类（资产/负债/所有者权益/收入/费用）；仅在根组上设置，由子项继承。"
 
@@ -17006,6 +17202,12 @@ msgstr "总计小时"
 
 msgid "Total Minutes"
 msgstr "总计分钟"
+
+msgid "Total of purchase orders placed in the period"
+msgstr "期间下达的采购订单总计"
+
+msgid "Total of sales orders placed in the period"
+msgstr "期间下达的销售订单总计"
 
 msgid "Total Price"
 msgstr "总价格"
@@ -17410,7 +17612,7 @@ msgid "Unsupported source document type: {sourceDocument}"
 msgstr "不支持的源单据类型：{sourceDocument}"
 
 msgid "Untitled"
-msgstr ""
+msgstr "未命名"
 
 msgid "Untitled Diagram"
 msgstr "未命名图表"
@@ -17658,6 +17860,9 @@ msgstr "覆盖域上的用户只能使用 SAML SSO 登录；magic link、Google 
 msgid "Users to Update"
 msgstr "要更新的用户"
 
+msgid "Utilization"
+msgstr "利用率"
+
 msgid "Valid From"
 msgstr "有效期开始"
 
@@ -17687,6 +17892,9 @@ msgstr "价值快照"
 
 msgid "Value source by surface"
 msgstr "按表面的值来源"
+
+msgid "Value still to ship on open sales orders"
+msgstr "未结销售订单中待发货的价值"
 
 msgid "Value-added-tax registration number; required on EU invoices for reverse-charge or zero-rated supplies."
 msgstr "增值税注册号;欧盟发票中反向收费或零税率供应所需。"
@@ -17988,6 +18196,9 @@ msgstr "作废此收据将："
 
 msgid "Voiding this shipment will:"
 msgstr "作废此发货将："
+
+msgid "vs prior period"
+msgstr "相对前期"
 
 msgid "Waited"
 msgstr "已等待"
@@ -18483,6 +18694,9 @@ msgstr "该行被拒绝的原因;显示在可打印报价上,并为损益报告�
 msgid "Why this restore failed"
 msgstr "还原失败原因"
 
+msgid "Widget options"
+msgstr "小部件选项"
+
 msgid "Will remain as a comment line"
 msgstr "将保留为注释行"
 
@@ -18575,6 +18789,9 @@ msgstr "工作流名称"
 msgid "Workflow run"
 msgstr "工作流运行"
 
+msgid "Workflow runs that failed in the period"
+msgstr "期间失败的工作流运行"
+
 msgid "Workflows"
 msgstr "工作流"
 
@@ -18608,6 +18825,9 @@ msgstr "在资产的生命周期内减少其价值——你创建的每月批次
 
 msgid "Year"
 msgstr "年份"
+
+msgid "Year to date"
+msgstr "年初迄今"
 
 msgid "Yearly"
 msgstr "年度"

--- a/scripts/restore-database.sh
+++ b/scripts/restore-database.sh
@@ -55,7 +55,7 @@
 set -euo pipefail
 # Private, unpredictable error-log path (a fixed /tmp name is symlink-attackable
 # and can be pre-created by another local user).
-RESTORE_LOG="$(mktemp "${TMPDIR:-/tmp}/restore-errors.XXXXXX.log")"
+RESTORE_LOG="$(mktemp "${TMPDIR:-/tmp}/restore-errors.XXXXXX")"
 RESTORE_INCOMPLETE=""
 ADMIN_EMAIL="${ADMIN_EMAIL:-}"
 ADMIN_PASSWORD="${ADMIN_PASSWORD:-localpass}"


### PR DESCRIPTION
## Summary

Adds a per-user **Analytics** section to the ERP home page.

- **31 registry-defined widgets** across sales, purchasing, production, quality, invoicing, inventory and workflows. Four kinds: stat (with prior-period delta), trend, breakdown, list. Each widget is gated by its module's `view` permission and fetched on the client from `api/dashboard/widget/:key`.
- **Page-wide range** (7d / 30d / 90d / MTD / QTD / YTD / 12m) with per-widget override from the card menu. URL `?range=` wins over the saved preference so links are reproducible.
- **Customize**: "Add widgets" opens a catalog of switches grouped by module; "Hide widget" lives in each card's menu; cards are **dragged by their grip to reorder** (dnd-kit, keyboard accessible). Order saves on drop.
- **Persistence**: `userDashboardWidget` (visible + range override per widget) and `userDashboardPreference` (page range + `widgetOrder TEXT[]`). Absent rows fall back to registry defaults; unknown keys in a saved order are ignored so a saved layout can never error the page.
- **Five new SECURITY INVOKER KPI functions**: `get_on_time_delivery`, `get_production_quantity_summary`, `get_inspection_pass_rate`, `get_open_backlog`, `get_overdue_purchase_orders`. None divides; ratios are computed in the app at the display boundary.
- Work-center utilization moved from the production KPI route into `production.service.ts` so the module page and the widget share one query.
- Also includes a one-line fix to `scripts/restore-database.sh`: BSD `mktemp` only substitutes trailing `X`s, so the error-log template created a literal file and every later run failed with "File exists".

Spec: `.ai/specs/2026-09-05-homepage-analytics-dashboard.md` (Q2 revised from show/hide only to show/hide + reorder).

## Verification

- `pnpm exec turbo run typecheck --filter=erp --filter=@carbon/database` — pass
- `vitest app/modules/dashboard` — 18 tests pass (range resolution, layout + order resolution, validators, percent helpers)
- Biome clean on all changed files; `check:workflow-catalog` ok with no catalog change
- `linguito check` exit 0 — 888 new translations filled across 12 locales via the translate skill with the glossary attached
- Full ERP vitest run: 14 failures, all in files untouched by this branch (`accounting.periods.test.ts`, Kanban `drag-lifecycle.test.tsx`, `$jobId.status.test.ts`, and the two repo-wide i18n audit tests which are red on `main` with 284 pre-existing offenders). The new labels file uses the React `t` macro so it does not add to that list.

## Notes for review

- `swagger-docs-schema.ts` is **not** regenerated in this PR. My local database is a prod restore that differs from `main` in unrelated places, so a regeneration there produced hundreds of spurious deletions. It should be regenerated on a clean local stack (or CI) after merge.
- The glossary consistency check reports 54 non-advisory hits inside the new strings (mostly "Jobs" and "Due Date" rendered with a synonym instead of the approved term, concentrated in fr/pt/zh/es). These are review items per the translation runbook, not fill gaps.
- Perf: each visible widget is one request. Batching the widget fetch into a single loader is a follow-up; see the AGENTS.md in the module.

## Migration

`20260904202730_homepage-dashboard.sql` — two new tables with owner-only RLS, five read-only functions. No changes to existing tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)