### PR TITLE
feat(infra): inject Onshape OAuth secrets into SST deploys

### DIFF
--- a/ci/src/deploy.ts
+++ b/ci/src/deploy.ts
@@ -52,6 +52,9 @@ export type Workspace = {
   jira_client_secret: string | null;
   jira_oauth_redirect_url: string | null;
   jira_state_secret: string | null;
+  onshape_client_id: string | null;
+  onshape_client_secret: string | null;
+  onshape_oauth_redirect_url: string | null;
   openai_api_key: string | null;
   posthog_api_host: string | null;
   posthog_project_public_key: string | null;
@@ -134,6 +137,9 @@ async function deploy(): Promise<void> {
         jira_oauth_redirect_url,
         jira_state_secret,
         jwt_secret,
+        onshape_client_id,
+        onshape_client_secret,
+        onshape_oauth_redirect_url,
         openai_api_key,
         posthog_api_host,
         posthog_project_public_key,
@@ -293,6 +299,9 @@ async function deploy(): Promise<void> {
           JIRA_CLIENT_SECRET: jira_client_secret ?? undefined,
           JIRA_OAUTH_REDIRECT_URL: jira_oauth_redirect_url ?? undefined,
           JIRA_STATE_SECRET: jira_state_secret ?? undefined,
+          ONSHAPE_CLIENT_ID: onshape_client_id ?? undefined,
+          ONSHAPE_CLIENT_SECRET: onshape_client_secret ?? undefined,
+          ONSHAPE_OAUTH_REDIRECT_URL: onshape_oauth_redirect_url ?? undefined,
           OPENAI_API_KEY: openai_api_key,
           POSTHOG_API_HOST: posthog_api_host ?? undefined,
           POSTHOG_PROJECT_PUBLIC_KEY: posthog_project_public_key ?? undefined,

--- a/packages/locale/locales/de/erp.po
+++ b/packages/locale/locales/de/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Diese Buchungssätze sind noch Entwurf, sodass ihre Sollposten und Habenposten nicht im Sachkonto für diesen Zeitraum enthalten sind. Buchen Sie jeden einzelnen oder ändern Sie das Datum zu einem späteren offenen Zeitraum."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Diese Zeilen sind mit Daten außerhalb dieses Unternehmens verknüpft, daher kann keine Sicherungskopie Ihrer aktuellen Daten erstellt werden. Das Löschen dieser Zeilen kann nicht rückgängig gemacht werden. Sollten sich diese Zeilen als für andere Unternehmen in dieser Gruppe freigegeben herausstellen, wird nichts gelöscht und die Wiederherstellung wird nicht gestartet."
 msgstr "Diese Zeilen verlinken auf Daten außerhalb dieses Unternehmens. Daher kann keine Sicherheitskopie Ihrer aktuellen Daten erstellt werden. Das Löschen kann nicht rückgängig gemacht werden. Sollten diese sich als gemeinsam mit anderen Unternehmen in dieser Gruppe herausstellen, wird nichts gelöscht und die Wiederherstellung wird nicht gestartet."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/es/erp.po
+++ b/packages/locale/locales/es/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Estos asientos aún están en Borrador, por lo que sus debe y haber no están en el libro mayor para este período. Contabiliza cada uno, o cambia su fecha a un período abierto posterior."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Estas filas están vinculadas a datos fuera de esta empresa, por lo que no se puede hacer una copia de seguridad de sus datos actuales. Su eliminación no se puede deshacer. Si resulta que están compartidas con otras empresas en este grupo, nada se elimina y la restauración no comienza."
 msgstr "Estas filas contienen referencias a datos fuera de esta empresa, por lo que no se puede crear una copia de seguridad de los datos actuales. La eliminación de estas filas no se puede deshacer. Si se encuentran compartidas con otras empresas del grupo, nada se eliminará y la restauración no se iniciará."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/fr/erp.po
+++ b/packages/locale/locales/fr/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Ces écritures de journal sont encore Brouillon, de sorte que leurs débits et crédits ne se trouvent pas dans le grand livre pour cette période. Comptabilisez chacune ou redatez-la à une période ouverte ultérieure."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Ces lignes renvoient à des données en dehors de cette Société, c'est pourquoi une copie de sécurité de vos données actuelles ne peut pas être créée. Leur suppression ne peut pas être annulée. Si ces lignes s'avèrent être partagées avec d'autres Sociétés de ce groupe, rien n'est supprimé et la restauration ne démarre pas."
 msgstr "Ces lignes sont liées à des données en dehors de cette Société, c'est pourquoi une copie de sécurité de vos données actuelles ne peut pas être créée. La suppression de ces lignes ne peut pas être annulée. S'il s'avère qu'elles sont partagées avec d'autres Sociétés de ce groupe, rien n'est supprimé et la restauration ne démarre pas."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/hi/erp.po
+++ b/packages/locale/locales/hi/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "ये जर्नल प्रविष्टियां अभी भी ड्राफ्ट हैं, इसलिए उनके नामे और जमा इस अवधि के लिए खाता बही में नहीं हैं। प्रत्येक को पोस्ट करें, या इसे बाद की खुली अवधि में फिर से दिनांकित करें।"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "ये पंक्तियाँ इस कंपनी के बाहर के डेटा से जुड़ी हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती। इन्हें हटाना पूर्ववत नहीं किया जा सकता। यदि ये इस समूह की अन्य कंपनियों के साथ साझा की गई हैं, तो कुछ भी नहीं हटाया जाएगा और बहाली शुरू नहीं होगी।"
 msgstr "ये पंक्तियां इस कंपनी के बाहर के डेटा से जुड़ी हुई हैं, इसलिए आपके वर्तमान डेटा की सुरक्षा प्रति नहीं बनाई जा सकती। उन्हें हटाना पूर्ववत नहीं किया जा सकता। यदि वे इस समूह की अन्य कंपनियों के साथ साझा की जाती हैं, तो कुछ भी हटाया नहीं जाता है और पुनर्स्थापन शुरू नहीं होता है।"
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/it/erp.po
+++ b/packages/locale/locales/it/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Queste voci di prima nota sono ancora Bozza, quindi i loro dare e avere non sono nel registro per questo periodo. Registra ognuno, o ri-datalo in un periodo aperto successivo."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Queste righe sono collegate a dati al di fuori di questa Azienda, quindi non è possibile creare una copia di sicurezza dei dati attuali. L'eliminazione non può essere annullata. Se risultassero condivise con altre Aziende in questo gruppo, nulla viene eliminato e il ripristino non si avvia."
 msgstr "Queste righe sono collegate a dati esterni a questa azienda, pertanto non è possibile effettuare una copia di sicurezza dei dati attuali. La loro eliminazione non può essere annullata. Se risultano condivise con altre aziende del gruppo, nulla viene eliminato e il ripristino non si avvierà."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/ja/erp.po
+++ b/packages/locale/locales/ja/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "これらの仕訳はまだ下書きであるため、それらの借方と貸方は当期の元帳に含まれていません。各仕訳を転記するか、後の開いている期間に再度日付を付け直してください。"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "これらの行はこの会社外のデータにリンクしているため、現在のデータの安全なコピーを作成できません。これらを削除することは取り消せません。このグループ内の他の会社と共有されていることが判明した場合、何も削除されず、復元は開始されません。"
 msgstr "これらの行はこの会社外のデータにリンクしているため、現在のデータのバックアップを作成できません。削除を元に戻すことはできません。このグループ内の他の会社と共有されていることが判明した場合、何も削除されず、復元は開始されません。"
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/ko/erp.po
+++ b/packages/locale/locales/ko/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "이 전표들은 아직 초안 상태이므로 이 기간에 차변 및 대변이 원장에 없습니다. 각 전표를 전기하거나 이후 미결 기간으로 다시 날짜를 지정하십시오."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "이 행들은 이 회사 외부의 데이터와 연결되어 있어 현재 데이터의 안전한 복사본을 만들 수 없습니다. 이들을 삭제하면 취소할 수 없습니다. 이들이 이 그룹의 다른 회사들과 공유되고 있는 것으로 판명되면 아무것도 삭제되지 않으며 복원도 시작되지 않습니다."
 msgstr "이 행들은 이 회사 외부의 데이터와 연결되어 있으므로 현재 데이터의 안전한 사본을 만들 수 없습니다. 이들을 삭제하면 되돌릴 수 없습니다. 이들이 이 그룹의 다른 회사와 공유되는 경우, 아무것도 삭제되지 않고 복원이 시작되지 않습니다."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/pl/erp.po
+++ b/packages/locale/locales/pl/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Te dowody księgowe są wciąż w wersji roboczej, dlatego ich wpisy Winien i Ma nie znajdują się w księdze dla tego okresu. Zaksięguj każdy z nich lub przesyć go do późniejszego otwartego okresu."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Te wiersze zawierają odniesienia do danych poza tą firmą, dlatego nie można utworzyć kopii zapasowej bieżących danych. Usunięcie ich nie może być cofnięte. Jeśli okaże się, że są udostępnione innym firmom w tej grupie, nic nie zostanie usunięte i przywracanie się nie uruchomi."
 msgstr "Te wiersze łączą się z danymi spoza tej firmy, dlatego nie można wykonać bezpiecznej kopii bieżących danych. Usunięcie ich nie może być cofnięte. Jeśli okaże się, że są współdzielone z innymi firmami w tej grupie, nic nie zostanie usunięte i przywracanie nie zostanie uruchomione."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/pt/erp.po
+++ b/packages/locale/locales/pt/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Estes lançamentos de diário ainda estão em Rascunho, portanto seus débitos e créditos não estão no livro-razão para este período. Lance cada um, ou redatē-o para um período aberto posterior."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Esses registros estão vinculados a dados fora desta empresa, portanto um backup de seus dados atuais não pode ser criado. A exclusão deles não pode ser desfeita. Se eles forem compartilhados com outras empresas deste grupo, nenhum dado será excluído e a restauração não será iniciada."
 msgstr "Essas linhas estão vinculadas a dados fora desta empresa, portanto não é possível criar uma cópia de segurança dos seus dados atuais. A exclusão dessas linhas não pode ser desfeita. Se forem compartilhadas com outras empresas neste grupo, nada será excluído e a restauração não será iniciada."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/ru/erp.po
+++ b/packages/locale/locales/ru/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Эти операции по-прежнему находятся в режиме Черновик, поэтому их дебеты и кредиты не включены в главную книгу для этого периода. Проведите каждый из них или переведите его в более поздний открытый период."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Эти строки связаны с данными вне этой организации, поэтому невозможно создать резервную копию текущих данных. Удаление этих строк нельзя отменить. Если они окажутся общими с другими организациями в этой группе, ничего не будет удалено и восстановление не начнется."
 msgstr "Эти строки связаны с данными вне этой организации, поэтому не удаётся создать резервную копию текущих данных. Удаление их не может быть отменено. Если окажется, что они используются другими организациями в этой группе, ничего не удаляется и восстановление не начинается."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/tr/erp.po
+++ b/packages/locale/locales/tr/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "Bu muhasebe fişleri hala Taslak halinde olduğundan borç ve alacakları bu dönemin defterine girmedi. Her birini muhasebeleştir veya daha sonraki açık bir döneme yeniden tarihle."
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "Bu kayıtlar bu Şirketin dışındaki verilere bağlı olduğundan, mevcut verilerinizin bir güvenlik kopyası oluşturulamaz. Bunları silmek geri alınamaz. Eğer bu Gruptaki diğer Şirketlerle paylaşıldığı ortaya çıkarsa, hiçbir şey silinmez ve geri yükleme işlemi başlamaz."
 msgstr "Bu satırlar bu Şirket dışındaki verilere bağlı olduğundan, mevcut verilerinizin bir güvenlik kopyası oluşturulamaz. Bu satırları silmek geri alınamaz. Bunların bu gruptaki diğer Şirketlerle paylaşıldığı anlaşılırsa, hiçbir şey silinmez ve geri yükleme başlamaz."
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."

--- a/packages/locale/locales/zh/erp.po
+++ b/packages/locale/locales/zh/erp.po
@@ -16534,7 +16534,6 @@ msgid "These journal entries are still Draft, so their debits and credits aren't
 msgstr "这些凭证仍是草稿，所以其借方和贷方不在此期间的账簿中。过账每一个，或将其重新标注日期到更后的未结期间。"
 
 msgid "These rows link to data outside this company, so a safety copy of your current data can't be made. Deleting them cannot be undone. If they turn out to be shared with other companies in this group, nothing is deleted and the restore doesn't start."
-msgstr "这些行链接到本公司以外的数据，因此无法创建您当前数据的安全备份。删除这些行无法撤销。如果发现这些行与此组中的其他公司共享，则不会删除任何内容，且不会启动还原。"
 msgstr "这些行链接到此公司外的数据，因此无法创建当前数据的安全备份。删除它们无法撤销。如果这些行实际上与此集团中的其他公司共享，则不删除任何行，且不启动还原。"
 
 msgid "These rows link to data outside this company, so they could never be restored. Everything else was backed up."


### PR DESCRIPTION
## What does this PR do?

The SST config already read `ONSHAPE_CLIENT_ID` / `ONSHAPE_CLIENT_SECRET` / `ONSHAPE_OAUTH_REDIRECT_URL` into both the ERP and MES service environments, but `ci/src/deploy.ts` never sourced them from the per-workspace `workspaces` row — so they always deployed empty and the Onshape OAuth integration could not be configured in AWS deployments. This wires the three columns through the `Workspace` type, the destructure, and the SST env object (following the existing JIRA `client_id`/`client_secret`/`redirect_url` pattern). The redirect URL is kept as an explicit variable rather than computed from `getAppUrl()` because in dev it must point at a publicly reachable tunnel and OAuth requires the `redirect_uri` to exactly match the value registered in the Onshape dev portal.

- Fixes #XXXX (GitHub issue number)

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- The `workspaces` Supabase table needs the columns `onshape_client_id`, `onshape_client_secret`, and `onshape_oauth_redirect_url` populated for any workspace that uses the Onshape integration.
- Run the deploy fan-out (`pnpm --filter ci ci:deploy`) for a workspace with those values set and confirm the ERP/MES services boot with the three `ONSHAPE_*` env vars present.
- Happy path: with the values set, the Onshape "Connect" OAuth flow completes; without them the routes return the existing "not configured" response.

## Checklist

- My code follows the style guidelines of this project.
- I have checked that my changes generate no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring Onshape OAuth credentials and redirect settings during workspace deployments.

- **Localization**
  - Refined the warning about rows linked to data outside the company across German, Spanish, French, Hindi, Italian, Japanese, Korean, Polish, Portuguese, Russian, Turkish, and Chinese translations.
  - Improved wording and consistency around backups, irreversible deletion, shared data, and restore behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->