### PR TITLE
fix(build): restore SSR noExternal on Vercel server bundles after v8_viteEnvironmentApi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,10 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc turbo.json lingui.co
 COPY apps ./apps
 COPY packages ./packages
 COPY patches ./patches
+# scripts/ is needed by the postinstall (pnpm run generate:mcp → tsx
+# scripts/generate-mcp.ts) and by the //#generate:mcp turbo task that build:${APP}
+# depends on; without it `pnpm install` fails with ERR_MODULE_NOT_FOUND.
+COPY scripts ./scripts
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build

--- a/apps/erp/vite.config.ts
+++ b/apps/erp/vite.config.ts
@@ -6,8 +6,59 @@ import path from "node:path";
 import { defineConfig, PluginOption } from "vite";
 import babelMacros from "vite-plugin-babel-macros";
 
-export default defineConfig(({ isSsrBuild, mode }) => {
+export default defineConfig(({ command, isSsrBuild, mode }) => {
   applyDotenvToProcessEnv(mode, __dirname);
+
+  /**
+   * SSR dependencies that must be bundled into the server output rather than
+   * left as bare `import`s. Defined once and applied to BOTH `ssr.noExternal`
+   * (honored by the dev server and the plain `react-router build`) and
+   * `environments.ssr.resolve.noExternal`.
+   *
+   * The second location is not redundant: with `future.v8_viteEnvironmentApi`
+   * enabled, the Vercel preset builds each route group as a named server-bundle
+   * environment (`ssr_bundle_*`), and React Router's server-bundle environment
+   * resolver merges `viteUserConfig.environments.ssr` — NOT the top-level `ssr`
+   * config. Without this, every entry below is externalized in the Vercel
+   * Lambda, and `zustand` (default-imported by @react-three/fiber, see below)
+   * crashes the function on cold start with "does not provide an export named
+   * 'default'".
+   */
+  const ssrNoExternal = [
+    "react-tweet",
+    "react-dropzone",
+    "react-icons",
+    "react-phone-number-input",
+    "tailwind-merge",
+    /**
+     * react-csv@2.2.2 ships a broken manifest: it `require('react')` and
+     * `require('prop-types')` at runtime but declares neither as a
+     * dependency or peer. Externalized, the SSR server bundle keeps the bare
+     * `require('react')`, which resolves locally via pnpm's hoisted store
+     * but is NOT traced into the Vercel serverless function — so the Lambda
+     * crashes on cold start with "Cannot find module 'react'". Bundling it
+     * inline resolves react/prop-types against the app's copies at build
+     * time, the same reason the react-* packages above are inlined.
+     *
+     * Build-only: react-csv also declares `"jsnext:main": "src/index.js"`,
+     * so when inlined in the dev server Vite picks the untranspiled ESM
+     * source, whose `import { func } from "prop-types"` fails under Node's
+     * CJS interop ("Named export 'func' not found"). In dev the CJS entry is
+     * externalized and `require`d directly, which works via pnpm's store.
+     * (Gated on `command` — not `isSsrBuild` — because under the environment
+     * API the config callback runs once for the whole build, so `isSsrBuild`
+     * is unreliable, whereas `command` is always "build" vs "serve".)
+     */
+    ...(command === "build" ? ["react-csv"] : []),
+    /**
+     * @react-three/fiber v8 (inlined via @carbon/viewer) default-imports
+     * its nested zustand v3, while the app uses zustand v5 (no default
+     * export). Externalizing zustand merges both into one bare import that
+     * resolves to v5 at runtime and crashes the server at module load.
+     * Bundling it lets each importer keep its own version.
+     */
+    "zustand",
+  ];
 
   return {
     build: {
@@ -27,39 +78,14 @@ export default defineConfig(({ isSsrBuild, mode }) => {
       global: "globalThis",
     },
     ssr: {
-      noExternal: [
-        "react-tweet",
-        "react-dropzone",
-        "react-icons",
-        "react-phone-number-input",
-        "tailwind-merge",
-        /**
-         * react-csv@2.2.2 ships a broken manifest: it `require('react')` and
-         * `require('prop-types')` at runtime but declares neither as a
-         * dependency or peer. Externalized, the SSR server bundle keeps the bare
-         * `require('react')`, which resolves locally via pnpm's hoisted store
-         * but is NOT traced into the Vercel serverless function — so the Lambda
-         * crashes on cold start with "Cannot find module 'react'". Bundling it
-         * inline resolves react/prop-types against the app's copies at build
-         * time, the same reason the react-* packages above are inlined.
-         *
-         * Build-only: react-csv also declares `"jsnext:main": "src/index.js"`,
-         * so when inlined in the dev server Vite picks the untranspiled ESM
-         * source, whose `import { func } from "prop-types"` fails under Node's
-         * CJS interop ("Named export 'func' not found"). In dev the CJS entry is
-         * externalized and `require`d directly, which works via pnpm's store.
-         */
-
-        ...(isSsrBuild ? ["react-csv"] : []),
-        /**
-         * @react-three/fiber v8 (inlined via @carbon/viewer) default-imports
-         * its nested zustand v3, while the app uses zustand v5 (no default
-         * export). Externalizing zustand merges both into one bare import that
-         * resolves to v5 at runtime and crashes the server at module load.
-         * Bundling it lets each importer keep its own version.
-         */
-        "zustand",
-      ],
+      noExternal: ssrNoExternal,
+    },
+    environments: {
+      ssr: {
+        resolve: {
+          noExternal: ssrNoExternal,
+        },
+      },
     },
     server: {
       port: 3000,

--- a/apps/mes/vite.config.ts
+++ b/apps/mes/vite.config.ts
@@ -9,6 +9,35 @@ import babelMacros from "vite-plugin-babel-macros";
 export default defineConfig(({ mode, isSsrBuild }) => {
   applyDotenvToProcessEnv(mode, __dirname);
 
+  /**
+   * SSR dependencies that must be bundled into the server output rather than
+   * left as bare `import`s. Applied to BOTH `ssr.noExternal` (honored by the
+   * dev server and the plain `react-router build`) and
+   * `environments.ssr.resolve.noExternal`.
+   *
+   * The second location is not redundant: with `future.v8_viteEnvironmentApi`
+   * enabled, the Vercel preset builds each route group as a named server-bundle
+   * environment (`ssr_bundle_*`), and React Router's server-bundle environment
+   * resolver merges `viteUserConfig.environments.ssr` — NOT the top-level `ssr`
+   * config. Without this, `zustand` (default-imported by @react-three/fiber,
+   * see below) is externalized in the Vercel Lambda and crashes the function on
+   * cold start with "does not provide an export named 'default'".
+   */
+  const ssrNoExternal = [
+    "react-dropzone",
+    "react-icons",
+    "react-phone-number-input",
+    "tailwind-merge",
+    /**
+     * @react-three/fiber v8 (inlined via @carbon/viewer) default-imports
+     * its nested zustand v3, while the app uses zustand v5 (no default
+     * export). Externalizing zustand merges both into one bare import that
+     * resolves to v5 at runtime and crashes the server at module load.
+     * Bundling it lets each importer keep its own version.
+     */
+    "zustand",
+  ];
+
   return {
     build: {
       minify: true,
@@ -27,20 +56,14 @@ export default defineConfig(({ mode, isSsrBuild }) => {
       global: "globalThis",
     },
     ssr: {
-      noExternal: [
-        "react-dropzone",
-        "react-icons",
-        "react-phone-number-input",
-        "tailwind-merge",
-        /**
-         * @react-three/fiber v8 (inlined via @carbon/viewer) default-imports
-         * its nested zustand v3, while the app uses zustand v5 (no default
-         * export). Externalizing zustand merges both into one bare import that
-         * resolves to v5 at runtime and crashes the server at module load.
-         * Bundling it lets each importer keep its own version.
-         */
-        "zustand",
-      ],
+      noExternal: ssrNoExternal,
+    },
+    environments: {
+      ssr: {
+        resolve: {
+          noExternal: ssrNoExternal,
+        },
+      },
     },
     server: {
       port: 3001,


### PR DESCRIPTION
## What does this PR do?

The api/mcp/docs merge (#1589) enabled `future.v8_viteEnvironmentApi`, which made the Vercel preset build each route group as a named server-bundle environment whose resolver reads `environments.ssr` instead of the top-level `ssr.noExternal`, so every dependency in that list got externalized in the Lambda and `zustand` (default-imported by `@react-three/fiber`, but v5 with no default export in the app) crashed the function on cold start with `does not provide an export named 'default'`. This routes the SSR `noExternal` list through `environments.ssr.resolve.noExternal` as well (and gates `react-csv` on `command` since `isSsrBuild` is unreliable under the environment API) in both the erp and mes vite configs. It also adds `COPY scripts ./scripts` to the Dockerfile so the `generate:mcp` postinstall/turbo task can find `scripts/generate-mcp.ts` during `pnpm install`.

- Fixes the Vercel cold-start crash introduced by #1589

## How should this be tested?

Build each app with the Vercel preset and confirm the server bundle no longer contains a bare zustand/react-csv import:

```
cd apps/erp && VERCEL=1 pnpm exec react-router build
grep -rl "from\"zustand\"" build/server/   # expect: no matches
```

Verified locally: erp+mes with `VERCEL=1` and plain `react-router build` all exit 0 with `zustand` and `react-csv` inlined (previously externalized under `VERCEL=1`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## Checklist

- N/A — build/config fix, verified by reproducing the failing Vercel build and confirming the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server-rendered application builds and deployments.
  - Prevented certain dependencies from being incorrectly externalized in server bundles, avoiding route failures during serverless cold starts.
  - Updated build configuration to apply dependency resolution consistently across supported server-rendering environments.
  - Improved installation and generation steps during container builds by ensuring required project resources are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->