### PR TITLE
fix(security): scope eventSystemSubscription to tenant (RLS + RPC guard)

### DIFF
--- a/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
+++ b/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
@@ -14,7 +14,7 @@
 --      four-policy pattern (below).
 --   2. The SECURITY DEFINER RPCs that maintain this table bypass RLS and are
 --      auto-exposed as PostgREST RPCs — an equivalent cross-tenant vector — so
---      each gains an in-function tenant guard (below).
+--      each gains an in-function authorization guard (below).
 
 -- ---------------------------------------------------------------------------
 -- 1. Tenant-scoped RLS policies
@@ -63,34 +63,72 @@ FOR DELETE USING (
 );
 
 -- ---------------------------------------------------------------------------
--- 2. In-function tenant guard on the SECURITY DEFINER RPCs
+-- 2. In-function authorization guard on the SECURITY DEFINER RPCs
 --
 -- The RLS above scopes DIRECT PostgREST table access, but the three RPCs that
 -- maintain "eventSystemSubscription" bypass RLS and are auto-exposed as
 -- PostgREST RPCs. They took a companyId / row id with NO caller check, so an
--- authenticated user could still create_event_system_subscription(...) for ANY
--- company (plant a WEBHOOK pointing config.url at an attacker server — the
--- disclosure's INSERT PoC), or delete for ANY company (integration DoS).
+-- authenticated user could create_event_system_subscription(...) — even for
+-- their OWN company, without any settings permission — with handlerType WEBHOOK
+-- and an attacker-controlled config.url, forwarding company records externally
+-- (and for ANY company, cross-tenant, as in the disclosure's INSERT PoC).
 --
--- They cannot be revoked from `authenticated`: the audit-log settings UI
--- (enableAuditLog / syncAuditSubscriptions in @carbon/database/src/audit.ts) and
--- the sync_webhook_subscription trigger both call them from an authenticated
--- context. So each gains an in-function tenant guard: allow when the request is
--- the service role, OR the caller is an employee of the target company.
--- auth.role() / the claims read by get_companies_with_employee_role() come from
+-- can_manage_event_subscription() centralizes the rule:
+--   * service role                       -> always allowed
+--   * WEBHOOK (external url + secret)     -> a settings write permission
+--       (create OR update OR delete). The sync_webhook_subscription trigger
+--       recreates the row (delete+create) on every webhook write, and the writer
+--       may hold only ONE of those perms (INSERT=create, UPDATE=update,
+--       DELETE=delete), so any of the three must satisfy it — this mirrors the
+--       "webhook" table's own per-verb policies while never breaking the trigger.
+--   * internal handler types (AUDIT, SYNC, SEARCH, EMBEDDING, WORKFLOW)
+--       -> employee membership, so the audit-sync loader (gated only on
+--       settings_view) keeps working.
+--
+-- auth.role() / the claims read by the get_companies_* helpers come from
 -- request-scoped GUCs that SECURITY DEFINER does not reset, so the guard sees the
 -- ORIGINAL caller even through the (also SECURITY DEFINER) webhook trigger.
--- Membership — not a granular settings_* permission — is used deliberately: it is
--- the minimum that blocks cross-tenant while leaving every legitimate same-company
--- caller (the audit UI's settings_view-only loader included) working as before.
--- get_companies_with_employee_role() returns NULL for a non-employee, and
--- `= ANY(NULL)` is NULL (which an IF treats as false, skipping the RAISE), so the
--- array is COALESCEd to empty to reject non-employees.
+-- get_companies_*() returns NULL for a non-member, and `= ANY(NULL)` is NULL
+-- (which an IF treats as false, skipping the RAISE), so each array is COALESCEd
+-- to empty to reject non-members.
 --
--- Bodies are forked verbatim from 20260204080000_async-search-triggers.sql; only
--- the guard is prepended. Signatures/return types are unchanged, so
--- CREATE OR REPLACE preserves existing grants and dependents.
+-- All four functions pin search_path (public, pg_temp last) — required for a
+-- SECURITY DEFINER function that references unqualified relations, else a
+-- pg_temp relation could shadow "eventSystemSubscription" and bypass the guard.
+--
+-- RPC bodies are forked verbatim from 20260204080000_async-search-triggers.sql;
+-- only the guard + search_path are added. Signatures/return types are unchanged,
+-- so CREATE OR REPLACE preserves existing grants and dependents.
 -- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION can_manage_event_subscription(
+  p_company_id TEXT,
+  p_handler_type TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  IF (SELECT auth.role()) = 'service_role' THEN
+    RETURN TRUE;
+  END IF;
+
+  IF p_handler_type = 'WEBHOOK' THEN
+    RETURN p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_permission('settings_create'))::text[], ARRAY[]::text[]))
+        OR p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_permission('settings_update'))::text[], ARRAY[]::text[]))
+        OR p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_permission('settings_delete'))::text[], ARRAY[]::text[]));
+  END IF;
+
+  RETURN p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]));
+END;
+$$;
+
+-- Internal predicate only — the three SECURITY DEFINER RPCs call it as owner, so
+-- it need not (and should not) be a directly callable PostgREST RPC.
+REVOKE ALL ON FUNCTION can_manage_event_subscription(TEXT, TEXT) FROM PUBLIC;
+
 
 CREATE OR REPLACE FUNCTION create_event_system_subscription(
   p_name TEXT,
@@ -102,11 +140,14 @@ CREATE OR REPLACE FUNCTION create_event_system_subscription(
   p_filter JSONB DEFAULT '{}',
   p_active BOOLEAN DEFAULT TRUE
 )
-RETURNS TABLE (id TEXT, name TEXT, "handlerType" TEXT, "table" TEXT) AS $$
+RETURNS TABLE (id TEXT, name TEXT, "handlerType" TEXT, "table" TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
 BEGIN
-  IF (SELECT auth.role()) <> 'service_role'
-     AND NOT (p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
-    RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', p_company_id
+  IF NOT can_manage_event_subscription(p_company_id, p_handler_type) THEN
+    RAISE EXCEPTION 'Not authorized to manage % event subscriptions for company %', p_handler_type, p_company_id
       USING ERRCODE = '42501';
   END IF;
 
@@ -132,17 +173,22 @@ BEGIN
     "eventSystemSubscription"."handlerType",
     "eventSystemSubscription"."table";
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 
 CREATE OR REPLACE FUNCTION delete_event_system_subscription(
   p_subscription_id TEXT
 )
-RETURNS VOID AS $$
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
 DECLARE
   v_company_id TEXT;
+  v_handler_type TEXT;
 BEGIN
-  SELECT "companyId" INTO v_company_id
+  SELECT "companyId", "handlerType" INTO v_company_id, v_handler_type
   FROM "eventSystemSubscription"
   WHERE "id" = p_subscription_id;
 
@@ -151,25 +197,37 @@ BEGIN
     RETURN;
   END IF;
 
-  IF (SELECT auth.role()) <> 'service_role'
-     AND NOT (v_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
-    RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', v_company_id
+  IF NOT can_manage_event_subscription(v_company_id, v_handler_type) THEN
+    RAISE EXCEPTION 'Not authorized to manage % event subscriptions for company %', v_handler_type, v_company_id
       USING ERRCODE = '42501';
   END IF;
 
   DELETE FROM "eventSystemSubscription" WHERE "id" = p_subscription_id;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 
 CREATE OR REPLACE FUNCTION delete_event_system_subscriptions_by_name(
   p_company_id TEXT,
   p_name TEXT
 )
-RETURNS VOID AS $$
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_handler_type TEXT;
 BEGIN
-  IF (SELECT auth.role()) <> 'service_role'
-     AND NOT (p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
+  -- A (companyId, name) group is one handler type in practice; if any matching
+  -- row is WEBHOOK, require the stricter WEBHOOK gate. NULL (no rows) falls
+  -- through to the membership gate on a delete that affects nothing.
+  SELECT CASE WHEN bool_or("handlerType" = 'WEBHOOK') THEN 'WEBHOOK' ELSE max("handlerType") END
+  INTO v_handler_type
+  FROM "eventSystemSubscription"
+  WHERE "companyId" = p_company_id AND "name" = p_name;
+
+  IF NOT can_manage_event_subscription(p_company_id, COALESCE(v_handler_type, '')) THEN
     RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', p_company_id
       USING ERRCODE = '42501';
   END IF;
@@ -177,4 +235,4 @@ BEGIN
   DELETE FROM "eventSystemSubscription"
   WHERE "companyId" = p_company_id AND "name" = p_name;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;

--- a/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
+++ b/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
@@ -73,7 +73,9 @@ FOR DELETE USING (
 -- and an attacker-controlled config.url, forwarding company records externally
 -- (and for ANY company, cross-tenant, as in the disclosure's INSERT PoC).
 --
--- can_manage_event_subscription() centralizes the rule:
+-- util.can_manage_event_subscription() centralizes the rule (in the internal
+-- `util` schema — like util.wake_event_queue() — so it is never exposed as a
+-- PostgREST RPC; anon/authenticated have no USAGE on util):
 --   * service role                       -> always allowed
 --   * WEBHOOK (external url + secret)     -> a settings write permission
 --       (create OR update OR delete). The sync_webhook_subscription trigger
@@ -101,7 +103,9 @@ FOR DELETE USING (
 -- so CREATE OR REPLACE preserves existing grants and dependents.
 -- ---------------------------------------------------------------------------
 
-CREATE OR REPLACE FUNCTION can_manage_event_subscription(
+CREATE SCHEMA IF NOT EXISTS util;
+
+CREATE OR REPLACE FUNCTION util.can_manage_event_subscription(
   p_company_id TEXT,
   p_handler_type TEXT
 )
@@ -125,9 +129,8 @@ BEGIN
 END;
 $$;
 
--- Internal predicate only — the three SECURITY DEFINER RPCs call it as owner, so
--- it need not (and should not) be a directly callable PostgREST RPC.
-REVOKE ALL ON FUNCTION can_manage_event_subscription(TEXT, TEXT) FROM PUBLIC;
+-- Internal predicate only — the three SECURITY DEFINER RPCs call it as owner.
+REVOKE ALL ON FUNCTION util.can_manage_event_subscription(TEXT, TEXT) FROM PUBLIC;
 
 
 CREATE OR REPLACE FUNCTION create_event_system_subscription(
@@ -146,7 +149,7 @@ SECURITY DEFINER
 SET search_path = public, pg_temp
 AS $$
 BEGIN
-  IF NOT can_manage_event_subscription(p_company_id, p_handler_type) THEN
+  IF NOT util.can_manage_event_subscription(p_company_id, p_handler_type) THEN
     RAISE EXCEPTION 'Not authorized to manage % event subscriptions for company %', p_handler_type, p_company_id
       USING ERRCODE = '42501';
   END IF;
@@ -197,7 +200,7 @@ BEGIN
     RETURN;
   END IF;
 
-  IF NOT can_manage_event_subscription(v_company_id, v_handler_type) THEN
+  IF NOT util.can_manage_event_subscription(v_company_id, v_handler_type) THEN
     RAISE EXCEPTION 'Not authorized to manage % event subscriptions for company %', v_handler_type, v_company_id
       USING ERRCODE = '42501';
   END IF;
@@ -227,7 +230,7 @@ BEGIN
   FROM "eventSystemSubscription"
   WHERE "companyId" = p_company_id AND "name" = p_name;
 
-  IF NOT can_manage_event_subscription(p_company_id, COALESCE(v_handler_type, '')) THEN
+  IF NOT util.can_manage_event_subscription(p_company_id, COALESCE(v_handler_type, '')) THEN
     RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', p_company_id
       USING ERRCODE = '42501';
   END IF;

--- a/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
+++ b/packages/database/supabase/migrations/20260907164512_event-subscription-tenant-rls.sql
@@ -1,0 +1,180 @@
+-- Security fix: cross-tenant authorization flaw on "eventSystemSubscription"
+-- (coordinated disclosure, S9S Security Research; CWE-284 / CWE-639).
+--
+-- The prior policy was `FOR ALL USING (auth.role() = 'authenticated')` — no
+-- companyId predicate and no WITH CHECK — so any authenticated user of any
+-- company could SELECT/INSERT/UPDATE/DELETE every other company's event
+-- subscriptions over PostgREST. WEBHOOK rows carry `config` JSONB holding the
+-- target url + signing secret, so this leaked secrets and allowed planting a
+-- webhook that exfiltrates a victim's records (and deleting a victim's
+-- subscriptions for a DoS).
+--
+-- Two vectors are closed here:
+--   1. The permissive RLS policy is replaced with the standard tenant-scoped
+--      four-policy pattern (below).
+--   2. The SECURITY DEFINER RPCs that maintain this table bypass RLS and are
+--      auto-exposed as PostgREST RPCs — an equivalent cross-tenant vector — so
+--      each gains an in-function tenant guard (below).
+
+-- ---------------------------------------------------------------------------
+-- 1. Tenant-scoped RLS policies
+--
+-- SELECT uses get_companies_with_employee_role() — the Carbon-standard read
+-- gate: any employee of the company can read (pure userToCompany membership, no
+-- permission grant required). Writes are gated on settings_{create,update,delete},
+-- mirroring the "webhook" table (the user-facing source of truth for WEBHOOK
+-- subscriptions).
+--
+-- Safe by construction: the only authenticated-client access to this table is
+-- the audit-log settings read in @carbon/database/src/audit.ts, whose routes
+-- require settings_view / settings_update — so those callers are employees and
+-- pass the employee-role SELECT gate. Every write path is service-role, a
+-- SECURITY DEFINER RPC, or Kysely (workflows sync, dataset seeding) — all of
+-- which bypass RLS — so the new write policies block only the cross-tenant
+-- PostgREST writes from the disclosure, not any real flow.
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "manage_subscriptions" ON "public"."eventSystemSubscription";
+DROP POLICY IF EXISTS "SELECT" ON "public"."eventSystemSubscription";
+DROP POLICY IF EXISTS "INSERT" ON "public"."eventSystemSubscription";
+DROP POLICY IF EXISTS "UPDATE" ON "public"."eventSystemSubscription";
+DROP POLICY IF EXISTS "DELETE" ON "public"."eventSystemSubscription";
+
+CREATE POLICY "SELECT" ON "public"."eventSystemSubscription"
+FOR SELECT USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_role())::text[])
+);
+
+CREATE POLICY "INSERT" ON "public"."eventSystemSubscription"
+FOR INSERT WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_create'))::text[])
+);
+
+CREATE POLICY "UPDATE" ON "public"."eventSystemSubscription"
+FOR UPDATE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_update'))::text[])
+) WITH CHECK (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_update'))::text[])
+);
+
+CREATE POLICY "DELETE" ON "public"."eventSystemSubscription"
+FOR DELETE USING (
+  "companyId" = ANY ((SELECT get_companies_with_employee_permission('settings_delete'))::text[])
+);
+
+-- ---------------------------------------------------------------------------
+-- 2. In-function tenant guard on the SECURITY DEFINER RPCs
+--
+-- The RLS above scopes DIRECT PostgREST table access, but the three RPCs that
+-- maintain "eventSystemSubscription" bypass RLS and are auto-exposed as
+-- PostgREST RPCs. They took a companyId / row id with NO caller check, so an
+-- authenticated user could still create_event_system_subscription(...) for ANY
+-- company (plant a WEBHOOK pointing config.url at an attacker server — the
+-- disclosure's INSERT PoC), or delete for ANY company (integration DoS).
+--
+-- They cannot be revoked from `authenticated`: the audit-log settings UI
+-- (enableAuditLog / syncAuditSubscriptions in @carbon/database/src/audit.ts) and
+-- the sync_webhook_subscription trigger both call them from an authenticated
+-- context. So each gains an in-function tenant guard: allow when the request is
+-- the service role, OR the caller is an employee of the target company.
+-- auth.role() / the claims read by get_companies_with_employee_role() come from
+-- request-scoped GUCs that SECURITY DEFINER does not reset, so the guard sees the
+-- ORIGINAL caller even through the (also SECURITY DEFINER) webhook trigger.
+-- Membership — not a granular settings_* permission — is used deliberately: it is
+-- the minimum that blocks cross-tenant while leaving every legitimate same-company
+-- caller (the audit UI's settings_view-only loader included) working as before.
+-- get_companies_with_employee_role() returns NULL for a non-employee, and
+-- `= ANY(NULL)` is NULL (which an IF treats as false, skipping the RAISE), so the
+-- array is COALESCEd to empty to reject non-employees.
+--
+-- Bodies are forked verbatim from 20260204080000_async-search-triggers.sql; only
+-- the guard is prepended. Signatures/return types are unchanged, so
+-- CREATE OR REPLACE preserves existing grants and dependents.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION create_event_system_subscription(
+  p_name TEXT,
+  p_table TEXT,
+  p_company_id TEXT,
+  p_operations TEXT[],
+  p_handler_type TEXT,
+  p_config JSONB DEFAULT '{}',
+  p_filter JSONB DEFAULT '{}',
+  p_active BOOLEAN DEFAULT TRUE
+)
+RETURNS TABLE (id TEXT, name TEXT, "handlerType" TEXT, "table" TEXT) AS $$
+BEGIN
+  IF (SELECT auth.role()) <> 'service_role'
+     AND NOT (p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
+    RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', p_company_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  INSERT INTO "eventSystemSubscription" (
+    "name", "table", "companyId", "operations",
+    "handlerType", "config", "filter", "active"
+  )
+  VALUES (
+    p_name, p_table, p_company_id, p_operations,
+    p_handler_type, p_config, p_filter, p_active
+  )
+  ON CONFLICT ON CONSTRAINT "unique_subscription_name_per_company"
+  DO UPDATE SET
+    "operations" = EXCLUDED."operations",
+    "filter" = EXCLUDED."filter",
+    "handlerType" = EXCLUDED."handlerType",
+    "config" = EXCLUDED."config",
+    "active" = EXCLUDED."active"
+  RETURNING
+    "eventSystemSubscription"."id",
+    "eventSystemSubscription"."name",
+    "eventSystemSubscription"."handlerType",
+    "eventSystemSubscription"."table";
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+CREATE OR REPLACE FUNCTION delete_event_system_subscription(
+  p_subscription_id TEXT
+)
+RETURNS VOID AS $$
+DECLARE
+  v_company_id TEXT;
+BEGIN
+  SELECT "companyId" INTO v_company_id
+  FROM "eventSystemSubscription"
+  WHERE "id" = p_subscription_id;
+
+  -- Nothing to delete (missing id, or already gone) — no-op, as before.
+  IF v_company_id IS NULL THEN
+    RETURN;
+  END IF;
+
+  IF (SELECT auth.role()) <> 'service_role'
+     AND NOT (v_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
+    RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', v_company_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM "eventSystemSubscription" WHERE "id" = p_subscription_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+
+CREATE OR REPLACE FUNCTION delete_event_system_subscriptions_by_name(
+  p_company_id TEXT,
+  p_name TEXT
+)
+RETURNS VOID AS $$
+BEGIN
+  IF (SELECT auth.role()) <> 'service_role'
+     AND NOT (p_company_id = ANY (COALESCE((SELECT get_companies_with_employee_role())::text[], ARRAY[]::text[]))) THEN
+    RAISE EXCEPTION 'Not authorized to manage event subscriptions for company %', p_company_id
+      USING ERRCODE = '42501';
+  END IF;
+
+  DELETE FROM "eventSystemSubscription"
+  WHERE "companyId" = p_company_id AND "name" = p_name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-tenant authorization flaw on `public."eventSystemSubscription"` (coordinated disclosure, CWE-284 / CWE-639): its only RLS policy was `FOR ALL USING (auth.role() = 'authenticated')` — no `companyId` predicate and no `WITH CHECK` — so any authenticated user of any company could read and write every other company's event subscriptions over PostgREST, including the webhook `config` JSONB that holds target urls and signing secrets. This migration replaces that policy with the standard tenant-scoped four-policy pattern (SELECT via `get_companies_with_employee_role()` employee membership, writes via `settings_{create,update,delete}`), and — because the three `SECURITY DEFINER` RPCs that maintain the table bypass RLS and are auto-exposed over PostgREST as an equivalent vector — adds an in-function tenant guard to each (`create_event_system_subscription`, `delete_event_system_subscription`, `delete_event_system_subscriptions_by_name`) allowing only the service role or an employee of the target company. Every legitimate caller (accounting install hooks, workflow/dataset seeding via Kysely, and the audit-log settings UI) is service-role, Kysely, or a same-company employee, so no real flow is affected.

- Reported via coordinated disclosure (no public issue).

## Visual Demo (For contributors especially)

N/A — database RLS/policy migration, no UI surface.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

Apply with `pnpm db:migrate`. As a non-admin employee of Company A, over PostgREST with a user JWT: `GET /eventSystemSubscription` must no longer return Company B rows, and both a direct `POST /eventSystemSubscription {"companyId":"CMPY_B",...}` and `POST /rpc/create_event_system_subscription`/`/rpc/delete_event_system_subscription` targeting Company B must fail (`42501`), while the same operations for Company A still succeed. Regression-check the legitimate paths: enabling audit logging and creating/deleting a webhook (which drives `sync_webhook_subscription`) must still work.

## Checklist

- (none)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened access controls for event subscriptions with company-scoped permissions.
  - Restricted subscription creation, updates, deletion, and viewing to authorized employees within the relevant company.
  - Added safeguards to prevent unauthorized cross-company subscription management.
  - Applied appropriate permissions based on subscription type and operation.
  - Service-level operations continue to support authorized system access.
  - Unauthorized subscription actions are now rejected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->