### PR TITLE
fix(ui): truncate long titles in BoM/BoP rows 

### DIFF
--- a/apps/erp/app/components/SortableList.tsx
+++ b/apps/erp/app/components/SortableList.tsx
@@ -144,7 +144,7 @@ function SortableListItem<T>({
                         {typeof item.title === "string" ? (
                           <span
                             className={cn(
-                              "flex font-medium text-sm md:text-base truncate hover:underline cursor-pointer",
+                              "flex min-w-0 font-medium text-sm md:text-base truncate hover:underline cursor-pointer",
                               item.checked ? "text-red-400" : "text-foreground"
                             )}
                             onClick={(e) => {
@@ -162,7 +162,10 @@ function SortableListItem<T>({
                                 onSelectItem(item.id);
                               }
                             }}
-                            className={item.checked ? "text-red-400" : ""}
+                            className={cn(
+                              "min-w-0 flex-1",
+                              item.checked && "text-red-400"
+                            )}
                           >
                             {item.title}
                           </div>

--- a/apps/erp/app/modules/items/ui/Item/BillOfMaterial.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfMaterial.tsx
@@ -1250,8 +1250,8 @@ function makeItem(
     id: material.id!,
     title: (
       <VStack spacing={0} className="py-1 cursor-pointer">
-        <div className="flex items-center gap-2 group">
-          <h3 className="font-semibold truncate">
+        <div className="flex w-full min-w-0 items-center gap-2 group">
+          <h3 className="font-semibold min-w-0 truncate">
             {getItemReadableId(items, material.itemId) ?? ""}
           </h3>
           <ItemLifecycleBadge

--- a/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
+++ b/apps/erp/app/modules/items/ui/Item/BillOfProcess.tsx
@@ -3932,7 +3932,7 @@ function makeItem(
     id: operation.id!,
     title: (
       <VStack spacing={0}>
-        <h3 className="font-semibold truncate cursor-pointer">
+        <h3 className="font-semibold max-w-full truncate cursor-pointer">
           {operation.description}
         </h3>
         {operation.operationType === "Outside Processing" && (

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfMaterial.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfMaterial.tsx
@@ -155,8 +155,10 @@ function makeItem(
     id: material.id!,
     title: (
       <VStack spacing={0} className="py-1 cursor-pointer">
-        <div className="flex items-center gap-2 group">
-          <h3 className="font-semibold truncate">{itemReadableId ?? ""}</h3>
+        <div className="flex w-full min-w-0 items-center gap-2 group">
+          <h3 className="font-semibold min-w-0 truncate">
+            {itemReadableId ?? ""}
+          </h3>
           <ItemLifecycleBadge
             mode={items.find((i) => i.id === material.itemId)?.supersessionMode}
           />

--- a/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
+++ b/apps/erp/app/modules/production/ui/Jobs/JobBillOfProcess.tsx
@@ -265,8 +265,8 @@ function makeItem(
     id: operation.id!,
     title: (
       <VStack spacing={0}>
-        <HStack spacing={2}>
-          <h3 className="font-semibold truncate cursor-pointer">
+        <HStack spacing={2} className="w-full min-w-0">
+          <h3 className="font-semibold min-w-0 truncate cursor-pointer">
             {operation.description}
           </h3>
           {operation.reworkId && <Badge variant="red">Rework</Badge>}

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfMaterial.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfMaterial.tsx
@@ -143,8 +143,8 @@ function makeItem(
     id: material.id!,
     title: (
       <VStack spacing={0} className="py-1 cursor-pointer">
-        <div className="flex items-center gap-2 group">
-          <h3 className="font-semibold truncate">{itemReadableId}</h3>
+        <div className="flex w-full min-w-0 items-center gap-2 group">
+          <h3 className="font-semibold min-w-0 truncate">{itemReadableId}</h3>
           {material.itemId && material.itemType && (
             <Link
               to={getLinkToItemDetails(material.itemType, material.itemId)}

--- a/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
+++ b/apps/erp/app/modules/sales/ui/Quotes/QuoteBillOfProcess.tsx
@@ -184,7 +184,7 @@ function makeItem(
     id: operation.id!,
     title: (
       <VStack spacing={0}>
-        <h3 className="font-semibold truncate cursor-pointer">
+        <h3 className="font-semibold max-w-full truncate cursor-pointer">
           {operation.description}
         </h3>
         {operation.operationType === "Outside Processing" && (


### PR DESCRIPTION
## What does this PR do?

- Fixes long operation/material titles in the Bill of Process and Bill of Materials cards pushing the time badges off the edge of the card, where they were clipped and overlapped the settings icon.
- Long titles now truncate with an ellipsis so the badges and row actions always stay fully visible. Applied to all six places that use these cards: job, quote, and item methods (both BoM and BoP).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved text truncation and responsive layout for item names and operation descriptions across bills of materials, bills of process, production jobs, and quotes.
  - Long titles now fit more reliably within list rows without forcing surrounding content beyond available space.
  - Preserved checked-state styling and existing pointer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->