### PR TITLE
fix(purchasing,invoicing): correct required-field labels on order and invoice lines

### DIFF
--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceExplorer.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceExplorer.tsx
@@ -69,7 +69,9 @@ export default function PurchaseInvoiceExplorer() {
 
   const purchaseInvoiceLineInitialValues = {
     invoiceId: invoiceId,
-    invoiceLineType: "Item" as ItemType,
+    // "Item" is the picker's generic mode, not a member of the line-type
+    // enum; posting it failed validation with "Type is required".
+    invoiceLineType: "Part" as ItemType,
     purchaseQuantity: 1,
     locationId:
       purchaseInvoiceData?.purchaseInvoice?.locationId ??

--- a/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
+++ b/apps/erp/app/modules/invoicing/ui/PurchaseInvoice/PurchaseInvoiceLineForm.tsx
@@ -568,6 +568,9 @@ const PurchaseInvoiceLineForm = ({
                         validItemTypes={[...itemType]}
                         locationId={locationId}
                         replenishmentSystem="Buy"
+                        // Required by a refine rather than the schema object,
+                        // so the field can't infer this for itself.
+                        isOptional={false}
                         onChange={(value) => {
                           onItemChange(value?.value as string);
                         }}

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceExplorer.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceExplorer.tsx
@@ -66,7 +66,9 @@ export default function SalesInvoiceExplorer() {
 
   const salesInvoiceLineInitialValues = {
     invoiceId: invoiceId,
-    invoiceLineType: "Item" as ItemType,
+    // "Item" is the picker's generic mode, not a member of the line-type
+    // enum; posting it failed validation with "Type is required".
+    invoiceLineType: "Part" as ItemType,
     quantity: 1,
     locationId:
       salesInvoiceData?.salesInvoice?.locationId ?? defaults.locationId ?? "",

--- a/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceLineForm.tsx
+++ b/apps/erp/app/modules/invoicing/ui/SalesInvoice/SalesInvoiceLineForm.tsx
@@ -525,6 +525,9 @@ const SalesInvoiceLineForm = ({
                         type={lineType}
                         validItemTypes={[...itemType]}
                         locationId={locationId}
+                        // Required by a refine rather than the schema object,
+                        // so the field can't infer this for itself.
+                        isOptional={false}
                         onChange={(value) => {
                           onItemChange(value?.value as string);
                         }}

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderExplorer.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderExplorer.tsx
@@ -69,7 +69,11 @@ export default function PurchaseOrderExplorer() {
 
   const purchaseOrderLineInitialValues = {
     purchaseOrderId: orderId,
-    purchaseOrderLineType: "Item" as ItemType,
+    // "Item" is the picker's generic mode, not a member of the line-type enum.
+    // Posting it made the validator fail with "Type is required" — an error
+    // naming a field the modal doesn't show. Start from a real type; the item
+    // picker overwrites it with the selected item's type on change.
+    purchaseOrderLineType: "Part" as ItemType,
     purchaseQuantity: 1,
     supplierUnitPrice: 0,
     locationId:

--- a/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
+++ b/apps/erp/app/modules/purchasing/ui/PurchaseOrder/PurchaseOrderLineForm.tsx
@@ -613,6 +613,10 @@ const PurchaseOrderLineForm = ({
                           replenishmentSystem={
                             isOutsideProcessing ? undefined : "Buy"
                           }
+                          // itemId is optional on the schema object and made
+                          // required by a refine, so the field can't infer its
+                          // own requiredness — every item-typed line needs one.
+                          isOptional={false}
                           onChange={(value) => {
                             onItemChange(value?.value as string);
                           }}
@@ -623,7 +627,6 @@ const PurchaseOrderLineForm = ({
                           label={t`Description`}
                           name="description"
                           value={itemData.description}
-                          isOptional={false}
                         />
 
                         <InputControlled

--- a/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.new.tsx
+++ b/apps/erp/app/routes/x+/purchase-invoice+/$invoiceId.new.tsx
@@ -99,7 +99,9 @@ export default function NewPurchaseInvoiceLineRoute() {
 
   const initialValues = {
     invoiceId: invoiceId,
-    invoiceLineType: "Item" as MethodItemType,
+    // "Item" is the picker's generic mode, not a member of the line-type
+    // enum; posting it failed validation with "Type is required".
+    invoiceLineType: "Part" as MethodItemType,
     purchaseQuantity: 1,
     locationId:
       purchaseInvoiceData?.purchaseInvoice?.locationId ??

--- a/apps/erp/app/routes/x+/purchase-order+/$orderId.new.tsx
+++ b/apps/erp/app/routes/x+/purchase-order+/$orderId.new.tsx
@@ -112,7 +112,9 @@ export default function NewPurchaseOrderLineRoute() {
     inventoryUnitOfMeasureCode: "",
     itemId: "",
     purchaseOrderId: orderId,
-    purchaseOrderLineType: "Item" as MethodItemType,
+    // See PurchaseOrderExplorer — "Item" is the picker's generic mode and is
+    // not a valid line type.
+    purchaseOrderLineType: "Part" as MethodItemType,
     purchaseQuantity: 1,
     purchaseUnitOfMeasureCode: "",
     requiredDate: undefined,

--- a/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.new.tsx
+++ b/apps/erp/app/routes/x+/sales-invoice+/$invoiceId.new.tsx
@@ -104,7 +104,9 @@ export default function NewSalesInvoiceLineRoute() {
 
   const initialValues = {
     invoiceId: invoiceId,
-    invoiceLineType: "Item" as MethodItemType,
+    // "Item" is the picker's generic mode, not a member of the line-type
+    // enum; posting it failed validation with "Type is required".
+    invoiceLineType: "Part" as MethodItemType,
     quantity: 1,
     unitOfMeasureCode: "EA",
     locationId:


### PR DESCRIPTION
The New Purchase Order Line modal labels every field "Optional" except Description — the opposite of what the validator enforces. `itemId` is required for every item-typed line; `description` is only required on G/L Account lines.

Submitting without an item also fails with **"Type is required"**, naming a field the modal doesn't show. The hidden `purchaseOrderLineType` is seeded with `"Item"`, which is the item picker's generic mode and not a member of the line-type enum, so the enum check fails before the refine that would have pointed at the item field.

## Changes

- Seed the line type with `"Part"` instead of `"Item"`. Submitting without an item now fails with "Part is required", against the field the user has to fill.
- Mark the item field required and the description field optional.
- Same two fixes in the purchase invoice and sales invoice line forms, which share the sentinel and the mis-labelled item field.

No behaviour change beyond the messages — the picker already overwrites the line type with the selected item's real type, so the sentinel only ever survived when no item was chosen.

## Verification

Biome clean. `tsgo --noEmit` on `erp` reports no errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYp1UguFfcE28WQUAP541e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - New purchase and sales invoice lines now default to a valid “Part” line type, preventing posting validation errors.
  - New purchase order lines now use a valid default line type.
  - Item selection is correctly enforced as required in purchase and sales invoice forms.
  - Item selection is correctly enforced as required for purchase order lines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->