### PR TITLE
fix(users): clear revokedAt when re-inviting a user

### DIFF
--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -888,14 +888,20 @@ export async function insertInvite(
   client: SupabaseClient<Database>,
   invite: InviteInsert
 ) {
-  return client
-    .from("invite")
-    .upsert([{ ...invite, acceptedAt: null }], {
-      onConflict: "email, companyId",
-      ignoreDuplicates: false
-    })
-    .select("*")
-    .single();
+  return (
+    client
+      .from("invite")
+      // Re-inviting an email that already has an invite row reuses it via the
+      // onConflict upsert. Clear both terminal states so a previously revoked or
+      // accepted invite becomes redeemable again — otherwise the acceptance
+      // loader (invite.$code.tsx) rejects the row and it can never be accepted.
+      .upsert([{ ...invite, acceptedAt: null, revokedAt: null }], {
+        onConflict: "email, companyId",
+        ignoreDuplicates: false
+      })
+      .select("*")
+      .single()
+  );
 }
 
 async function insertSupplierAccount(


### PR DESCRIPTION
## What does this PR do?

`insertInvite` (the shared write path for all account-creation/invite flows) upserts on `(email, companyId)` and reset only `acceptedAt`, leaving a stale `revokedAt` when re-inviting a user whose prior invite was revoked or deactivated. Because every redemption reader (`acceptInvite`, the `invite.$code.tsx` loader, the SSO callback, `getUnrevokedInviteEmails`) filters `revokedAt IS NULL`, the reissued invite was created non-redeemable and could never be accepted. This nulls `revokedAt` alongside `acceptedAt` so a re-invite becomes valid again, matching the two dedicated resend paths (`resend-invite.tsx`, `user-admin.ts`).

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

1. Invite a user, then revoke/deactivate them (sets `invite.revokedAt`).
2. Invite the same email again through any account-creation flow.
3. Open the invite link — it should now be accepted successfully (previously it was rejected as "no longer valid" because `revokedAt` was still set).

## Checklist

- My code follows the style guidelines of this project.