### PR TITLE
fix(users): re-invite a deactivated employee instead of dead-ending

### DIFF
--- a/.claude/rules/user-employee-job-relationships.md
+++ b/.claude/rules/user-employee-job-relationships.md
@@ -80,10 +80,19 @@ is the separate `job` table from `20240909194622_jobs.sql`).
   don't conflate "role" the enum with "role" the job title (`employeeJob.title`).
 - Permission company-ID array `"0"` means "all companies" — don't string-match a literal company id only.
 - Deactivating an employee (`deactivateEmployee` in `users.server.ts`) removes the company from
-  `userPermission.permissions`, deletes the `userToCompany` and `employeeJob` rows, sets
-  `employee.active = false`, and invalidates the Redis claims cache. It does **not** clear
-  `user.active` or scrub stored userId references (assignee columns, `workCenterEmployee`,
-  notification-group settings arrays).
+  `userPermission.permissions`, deletes the `userToCompany` row and every `membership` in groups
+  owned by that company, sets `employee.active = false`, and invalidates the Redis claims cache.
+  It does **not** clear `user.active`, delete the `employee` or `employeeJob` rows, or scrub stored
+  userId references (assignee columns, `workCenterEmployee`, notification-group settings arrays).
+  `employeeJob` is kept on purpose — it is org placement, not access — so title, start date,
+  department, shift, manager, location, tags and custom fields survive a deactivate/re-invite
+  round trip.
+- Re-adding a deactivated person through Add Account (`createEmployeeAccount`) reuses the surviving
+  rows rather than failing: it refuses only when the existing `employee` row is `active`, and writes
+  through `upsertEmployee`/`upsertEmployeeJob` on `(id, companyId)`. Re-activation happens on invite
+  acceptance — `activateEmployee` flips `active` back to true and restores the employee-type
+  `membership` the deactivation removed (the `sync_add_employee_to_type_group` trigger fires on
+  INSERT only, so an UPDATE cannot rely on it).
 - Notification fan-out (`notify.ts` `resolve-recipients` in `packages/jobs`) filters resolved
   recipients against `userToCompany` for the notification's company — a missing membership row
   (i.e. a deactivated user) is dropped before any in-app/email/Slack delivery, regardless of how

--- a/.claude/rules/user-employee-job-relationships.md
+++ b/.claude/rules/user-employee-job-relationships.md
@@ -79,20 +79,27 @@ is the separate `job` table from `20240909194622_jobs.sql`).
 - `userToCompany.role` (membership type) is distinct from `employeeType` (which permission set);
   don't conflate "role" the enum with "role" the job title (`employeeJob.title`).
 - Permission company-ID array `"0"` means "all companies" — don't string-match a literal company id only.
-- Deactivating an employee (`deactivateEmployee` in `users.server.ts`) removes the company from
-  `userPermission.permissions`, deletes the `userToCompany` row and every `membership` in groups
-  owned by that company, sets `employee.active = false`, and invalidates the Redis claims cache.
+- Deactivating an employee (`deactivateEmployee` in `packages/auth/src/services/users.server.ts`)
+  removes the company from `userPermission.permissions`, deletes the `userToCompany` row and every
+  `membership` in groups owned by that company, and sets `employee.active = false`.
   It does **not** clear `user.active`, delete the `employee` or `employeeJob` rows, or scrub stored
   userId references (assignee columns, `workCenterEmployee`, notification-group settings arrays).
+- **The claims cache is invalidated by the deactivate\* functions themselves**, not by their
+  callers. `deactivateEmployee`/`Customer`/`Supplier` each `redis.del(getPermissionCacheKey(userId))`
+  on success, and `deactivateUser` deletes it again after delegating. That matters because
+  `requirePermissions` reads the cache (1h TTL) before the database, and the `create*Account`
+  rollback paths in the ERP call the role-specific functions directly rather than going through
+  `deactivateUser` — a caller that skipped the invalidation would leave revoked grants live.
   `employeeJob` is kept on purpose — it is org placement, not access — so title, start date,
   department, shift, manager, location, tags and custom fields survive a deactivate/re-invite
   round trip.
 - Re-adding a deactivated person through Add Account (`createEmployeeAccount`) reuses the surviving
   rows rather than failing: it refuses only when the existing `employee` row is `active`, and writes
   through `upsertEmployee`/`upsertEmployeeJob` on `(id, companyId)`. Re-activation happens on invite
-  acceptance — `activateEmployee` flips `active` back to true and restores the employee-type
-  `membership` the deactivation removed (the `sync_add_employee_to_type_group` trigger fires on
-  INSERT only, so an UPDATE cannot rely on it).
+  acceptance — `activateEmployee` restores the employee-type `membership` the deactivation removed
+  (the `sync_add_employee_to_type_group` trigger fires on INSERT only, so an UPDATE cannot rely on
+  it) and only then flips `active` back to true, so a failed restore leaves the invite unaccepted
+  and retryable rather than an active employee outside their type's group.
 - Notification fan-out (`notify.ts` `resolve-recipients` in `packages/jobs`) filters resolved
   recipients against `userToCompany` for the notification's company — a missing membership row
   (i.e. a deactivated user) is dropped before any in-app/email/Slack delivery, regardless of how

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -241,7 +241,7 @@ async function activateEmployee(
     .update({ active: true })
     .eq("id", userId)
     .eq("companyId", companyId)
-    .select("id");
+    .select("id, employeeTypeId");
 
   if (!result.error && (!result.data || result.data.length === 0)) {
     return {
@@ -250,6 +250,41 @@ async function activateEmployee(
         message: `Employee record not found for user ${userId} in company ${companyId}. The record may have been deleted during deactivation.`
       }
     };
+  }
+
+  // Deactivation drops every membership in groups owned by this company,
+  // including the employee-type group. The trigger that seeds that membership
+  // (sync_add_employee_to_type_group) fires on INSERT only, and reactivation is
+  // an UPDATE, so it has to be restored here or the user returns outside their
+  // employee-type group. Best-effort: a missing group membership must not fail
+  // an otherwise valid invite acceptance.
+  const employeeTypeId = result.data?.[0]?.employeeTypeId;
+  if (!result.error && employeeTypeId) {
+    // uq_membership spans (groupId, memberGroupId, memberUserId) and
+    // memberGroupId is null for user rows, so NULLS DISTINCT leaves nothing for
+    // an upsert to conflict against — check before inserting.
+    const existingMembership = await client
+      .from("membership")
+      .select("id")
+      .eq("groupId", employeeTypeId)
+      .eq("memberUserId", userId)
+      .limit(1)
+      .maybeSingle();
+
+    if (!existingMembership.data) {
+      const membershipInsert = await client
+        .from("membership")
+        .insert({ groupId: employeeTypeId, memberUserId: userId });
+
+      if (membershipInsert.error) {
+        logger.error("Failed to restore employee type group membership", {
+          userId,
+          companyId,
+          employeeTypeId,
+          error: membershipInsert.error
+        });
+      }
+    }
   }
 
   return result;
@@ -491,6 +526,7 @@ export async function createEmployeeAccount(
   const user = await getUserByEmail(email);
   let userId = "";
   let isNewUser = false;
+  let isReactivation = false;
 
   if (user.data) {
     userId = user.data.id;
@@ -504,17 +540,25 @@ export async function createEmployeeAccount(
 
     const existingEmployee = await client
       .from("employee")
-      .select("id")
+      .select("id, active")
       .eq("id", userId)
       .eq("companyId", companyId)
       .maybeSingle();
 
-    if (existingEmployee.data) {
+    // Only an *active* employee is genuinely already a member. An inactive row
+    // is the residue of a deactivation or a revoked invite: deactivation keeps
+    // the "employee" row (and now the "employeeJob" row too), so refusing here
+    // dead-ended re-adding someone — the blocking record is also hidden by the
+    // employee list's default Active/Invited filter, leaving no way to act on
+    // the error. The writes below upsert so this path reuses those rows.
+    if (existingEmployee.data?.active) {
       return {
         success: false,
         message: "This user is already an employee in this company"
       };
     }
+
+    isReactivation = Boolean(existingEmployee.data);
   } else {
     isNewUser = true;
     const resolvedId = await resolveAuthUserId(email);
@@ -540,14 +584,22 @@ export async function createEmployeeAccount(
   }
 
   const code = crypto.randomUUID();
+  // Reusing surviving rows is an UPDATE, and the RLS policies on "employee" and
+  // "employeeJob" gate updates behind users_update / people_update while this
+  // route is gated on users_create. Re-adding someone is the same authorization
+  // decision as adding them the first time — the UPDATE is an artifact of
+  // keeping the rows on deactivation, not a wider grant — so the reuse path
+  // writes with the service role the invite already uses, scoped by id +
+  // companyId. A first-time create still writes under the caller's RLS client.
+  const accountWriteClient = isReactivation ? serviceRole : client;
   const [employeeInsert, jobInsert, inviteInsert] = await Promise.all([
-    insertEmployee(client, {
+    upsertEmployee(accountWriteClient, {
       id: userId,
       employeeTypeId: employeeType,
       active: false,
       companyId
     }),
-    insertEmployeeJob(client, {
+    upsertEmployeeJob(accountWriteClient, {
       id: userId,
       companyId,
       locationId
@@ -882,6 +934,47 @@ export async function insertEmployee(
   employee: EmployeeInsert
 ) {
   return client.from("employee").insert([employee]).select("*").single();
+}
+
+/**
+ * Insert, or reuse the row a previous deactivation left behind. Re-adding
+ * someone who was deactivated or had their invite revoked has to write over
+ * that row — it survives deactivation, so a plain insert hits the (id,
+ * companyId) primary key. Re-asserts the employee type chosen on the form;
+ * active stays false until the invite is accepted.
+ */
+async function upsertEmployee(
+  client: SupabaseClient<Database>,
+  employee: EmployeeInsert
+) {
+  return client
+    .from("employee")
+    .upsert([employee], { onConflict: "id, companyId" })
+    .select("*")
+    .single();
+}
+
+/**
+ * The "employeeJob" counterpart. Deactivation keeps this row so org placement
+ * survives, which means re-adding someone hits its (id, companyId) primary key
+ * too. Only the columns passed here are written on conflict, so title, start
+ * date, department, shift, manager, tags and custom fields carry through a
+ * deactivate/re-invite round trip. Kept local rather than added to
+ * people.service.ts — every export there is also published as an MCP tool.
+ */
+async function upsertEmployeeJob(
+  client: SupabaseClient<Database>,
+  job: {
+    id: string;
+    companyId: string;
+    locationId?: string;
+  }
+) {
+  return client
+    .from("employeeJob")
+    .upsert(job, { onConflict: "id, companyId" })
+    .select("*")
+    .single();
 }
 
 export async function insertInvite(

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -236,33 +236,43 @@ async function activateEmployee(
     companyId: string;
   }
 ) {
-  const result = await client
+  const notFound = {
+    data: null,
+    error: {
+      message: `Employee record not found for user ${userId} in company ${companyId}. The record may have been deleted during deactivation.`
+    }
+  };
+
+  // Read the employee type before flipping anything. Deactivation drops every
+  // membership in groups owned by this company, including the employee-type
+  // group, and the trigger that seeds it (sync_add_employee_to_type_group)
+  // fires on INSERT while reactivation is an UPDATE — so it has to be restored
+  // here or the user comes back outside their employee type's group.
+  // Restoring it BEFORE the activation means a failure leaves nothing
+  // half-done: acceptInvite stamps acceptedAt only when this returns cleanly,
+  // so the invite stays redeemable and a retry re-runs the whole step.
+  const employee = await client
     .from("employee")
-    .update({ active: true })
+    .select("id, employeeTypeId")
     .eq("id", userId)
     .eq("companyId", companyId)
-    .select("id, employeeTypeId");
+    .maybeSingle();
 
-  if (!result.error && (!result.data || result.data.length === 0)) {
-    return {
-      data: null,
-      error: {
-        message: `Employee record not found for user ${userId} in company ${companyId}. The record may have been deleted during deactivation.`
-      }
-    };
+  if (employee.error) {
+    return employee;
   }
 
-  // Deactivation drops every membership in groups owned by this company,
-  // including the employee-type group. The trigger that seeds that membership
-  // (sync_add_employee_to_type_group) fires on INSERT only, and reactivation is
-  // an UPDATE, so it has to be restored here or the user returns outside their
-  // employee-type group. Best-effort: a missing group membership must not fail
-  // an otherwise valid invite acceptance.
-  const employeeTypeId = result.data?.[0]?.employeeTypeId;
-  if (!result.error && employeeTypeId) {
+  if (!employee.data) {
+    return notFound;
+  }
+
+  const employeeTypeId = employee.data.employeeTypeId;
+  if (employeeTypeId) {
     // uq_membership spans (groupId, memberGroupId, memberUserId) and
     // memberGroupId is null for user rows, so NULLS DISTINCT leaves nothing for
-    // an upsert to conflict against — check before inserting.
+    // an upsert to conflict against — check before inserting. Two concurrent
+    // acceptances could still both insert; a unique key on
+    // (groupId, memberUserId) is the real fix and needs its own migration.
     const existingMembership = await client
       .from("membership")
       .select("id")
@@ -283,8 +293,20 @@ async function activateEmployee(
           employeeTypeId,
           error: membershipInsert.error
         });
+        return membershipInsert;
       }
     }
+  }
+
+  const result = await client
+    .from("employee")
+    .update({ active: true })
+    .eq("id", userId)
+    .eq("companyId", companyId)
+    .select("id");
+
+  if (!result.error && (!result.data || result.data.length === 0)) {
+    return notFound;
   }
 
   return result;

--- a/apps/erp/app/modules/users/users.server.ts
+++ b/apps/erp/app/modules/users/users.server.ts
@@ -22,10 +22,14 @@ import {
   getSsoConnection,
   getSsoConnectionByDomain,
   isSsoEnabled,
+  // Shared with migrateUserToSso on purpose: both paths merge an invite's
+  // permissions into userPermission, and they must not drift.
+  mergeInvitePermissions,
   seedSsoIdentityForUser,
   uncoveredSsoDomainError
 } from "@carbon/ee/sso.server";
 import { getLogger } from "@carbon/logger";
+import { datetime } from "@carbon/utils";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { redirect } from "react-router";
 import { getSupplierContact } from "~/modules/purchasing";
@@ -125,16 +129,7 @@ export async function acceptInvite(
   const user = await getUserByEmail(invite.data.email);
   if (user.error) return user;
 
-  const activationFunction =
-    invite.data.role === "employee"
-      ? activateEmployee
-      : invite.data.role === "customer"
-        ? activateCustomer
-        : invite.data.role === "supplier"
-          ? activateSupplier
-          : null;
-
-  if (!activationFunction) {
+  if (!["employee", "customer", "supplier"].includes(invite.data.role)) {
     return {
       data: null,
       error: {
@@ -143,202 +138,155 @@ export async function acceptInvite(
     };
   }
 
-  const [activate, addUser, setPermissions] = await Promise.all([
-    activationFunction(serviceRole, {
-      userId: user.data.id,
-      companyId: invite.data.companyId
-    }),
-    addUserToCompany(serviceRole, {
-      userId: user.data.id,
-      companyId: invite.data.companyId,
-      role: invite.data.role
-    }),
-    setUserPermissions(
-      serviceRole,
-      user.data.id,
-      invite.data.permissions as Record<string, string[]>
-    )
-  ]);
+  const userId = user.data.id;
+  const { companyId, role } = invite.data;
 
-  if (activate.error) {
-    logger.error("Failed to activate invite", { error: activate.error });
-    await rollbackInvite(serviceRole, {
-      userId: user.data.id,
-      companyId: invite.data.companyId
+  // Account activation, company membership, the permission merge and the
+  // acceptedAt stamp are one unit of work. They used to run as three
+  // concurrent writes followed by a compensating rollbackInvite, which could
+  // not undo what it had not yet written and silently mismatched the
+  // customer/supplier account keys. A transaction removes the half-states
+  // instead of trying to repair them: nothing is visible unless all of it
+  // commits. Mirrors migrateUserToSso, the SSO path that has to finish the
+  // same work.
+  const db = getDatabaseClient();
+
+  try {
+    const acceptedInvite = await db.transaction().execute(async (trx) => {
+      if (role === "employee") {
+        // Deactivation dropped this membership and the trigger that seeds it
+        // only fires on INSERT, so reactivation has to restore it. Done before
+        // the active flip and inside the transaction: an employee is never
+        // visible as active while outside their employee type's group.
+        const employee = await trx
+          .selectFrom("employee")
+          .select(["id", "employeeTypeId"])
+          .where("id", "=", userId)
+          .where("companyId", "=", companyId)
+          .executeTakeFirst();
+
+        if (!employee) {
+          throw new Error(
+            `Employee record not found for user ${userId} in company ${companyId}. The record may have been deleted during deactivation.`
+          );
+        }
+
+        if (employee.employeeTypeId) {
+          await trx
+            .insertInto("membership")
+            .values({
+              groupId: employee.employeeTypeId,
+              memberUserId: userId
+            })
+            .onConflict((oc) =>
+              oc.columns(["groupId", "memberUserId"]).doNothing()
+            )
+            .execute();
+        }
+
+        await trx
+          .updateTable("employee")
+          .set({ active: true })
+          .where("id", "=", userId)
+          .where("companyId", "=", companyId)
+          .execute();
+      } else if (role === "customer") {
+        const customerAccount = await trx
+          .updateTable("customerAccount")
+          .set({ active: true })
+          .where("id", "=", userId)
+          .where("companyId", "=", companyId)
+          .returning("id")
+          .executeTakeFirst();
+
+        if (!customerAccount) {
+          throw new Error(
+            `Customer account not found for user ${userId} in company ${companyId}. The account may have been deleted during deactivation.`
+          );
+        }
+      } else {
+        const supplierAccount = await trx
+          .updateTable("supplierAccount")
+          .set({ active: true })
+          .where("id", "=", userId)
+          .where("companyId", "=", companyId)
+          .returning("id")
+          .executeTakeFirst();
+
+        if (!supplierAccount) {
+          throw new Error(
+            `Supplier account not found for user ${userId} in company ${companyId}. The account may have been deleted during deactivation.`
+          );
+        }
+      }
+
+      await trx
+        .insertInto("userToCompany")
+        .values({ userId, companyId, role })
+        .onConflict((oc) => oc.columns(["userId", "companyId"]).doNothing())
+        .execute();
+
+      // setUserPermissions semantics, but under a row lock so two concurrent
+      // grants cannot lose one another's writes.
+      const currentPermission = await trx
+        .selectFrom("userPermission")
+        .select("permissions")
+        .where("id", "=", userId)
+        .forUpdate()
+        .executeTakeFirst();
+
+      const mergedPermissions = JSON.stringify(
+        mergeInvitePermissions(
+          (currentPermission?.permissions ?? {}) as Record<string, string[]>,
+          (invite.data.permissions ?? {}) as Record<string, string[]>
+        )
+      );
+
+      await trx
+        .insertInto("userPermission")
+        .values({ id: userId, permissions: mergedPermissions })
+        .onConflict((oc) =>
+          oc.column("id").doUpdateSet({ permissions: mergedPermissions })
+        )
+        .execute();
+
+      // Guarded so a concurrent acceptance can never apply twice.
+      const accepted = await trx
+        .updateTable("invite")
+        .set({ acceptedAt: datetime.timestamp() })
+        .where("code", "=", code)
+        .where("acceptedAt", "is", null)
+        .returningAll()
+        .executeTakeFirst();
+
+      if (!accepted) {
+        throw new Error("This invite has already been accepted.");
+      }
+
+      return accepted;
     });
-    return activate;
-  }
 
-  if (addUser.error) {
-    logger.error("Failed to add user to company", { error: addUser.error });
-    await rollbackInvite(serviceRole, {
-      userId: user.data.id,
-      companyId: invite.data.companyId
-    });
-    return addUser;
-  }
+    // Post-commit and failure-tolerant: the grants just written are cached by
+    // requirePermissions, so a stale entry would outlive the acceptance.
+    try {
+      await redis.del(getPermissionCacheKey(userId));
+    } catch (err) {
+      logger.error(
+        "Failed to invalidate permission cache after invite accept",
+        { error: err, userId }
+      );
+    }
 
-  if (setPermissions.error) {
-    logger.error("Failed to set user permissions", {
-      error: setPermissions.error
-    });
-    await rollbackInvite(serviceRole, {
-      userId: user.data.id,
-      companyId: invite.data.companyId
-    });
-    return setPermissions;
-  }
-
-  return serviceRole
-    .from("invite")
-    .update({ acceptedAt: new Date().toISOString() })
-    .eq("code", code)
-    .select("*")
-    .single();
-}
-
-async function activateCustomer(
-  client: SupabaseClient<Database>,
-  {
-    userId,
-    companyId
-  }: {
-    userId: string;
-    companyId: string;
-  }
-) {
-  const result = await client
-    .from("customerAccount")
-    .update({ active: true })
-    .eq("id", userId)
-    .eq("companyId", companyId)
-    .select("id");
-
-  if (!result.error && (!result.data || result.data.length === 0)) {
+    return { data: acceptedInvite, error: null };
+  } catch (err) {
+    logger.error("Failed to accept invite", { error: err, userId, companyId });
     return {
       data: null,
       error: {
-        message: `Customer account not found for user ${userId} in company ${companyId}. The account may have been deleted during deactivation.`
+        message: err instanceof Error ? err.message : "Failed to accept invite"
       }
     };
   }
-
-  return result;
-}
-
-async function activateEmployee(
-  client: SupabaseClient<Database>,
-  {
-    userId,
-    companyId
-  }: {
-    userId: string;
-    companyId: string;
-  }
-) {
-  const notFound = {
-    data: null,
-    error: {
-      message: `Employee record not found for user ${userId} in company ${companyId}. The record may have been deleted during deactivation.`
-    }
-  };
-
-  // Read the employee type before flipping anything. Deactivation drops every
-  // membership in groups owned by this company, including the employee-type
-  // group, and the trigger that seeds it (sync_add_employee_to_type_group)
-  // fires on INSERT while reactivation is an UPDATE — so it has to be restored
-  // here or the user comes back outside their employee type's group.
-  // Restoring it BEFORE the activation means a failure leaves nothing
-  // half-done: acceptInvite stamps acceptedAt only when this returns cleanly,
-  // so the invite stays redeemable and a retry re-runs the whole step.
-  const employee = await client
-    .from("employee")
-    .select("id, employeeTypeId")
-    .eq("id", userId)
-    .eq("companyId", companyId)
-    .maybeSingle();
-
-  if (employee.error) {
-    return employee;
-  }
-
-  if (!employee.data) {
-    return notFound;
-  }
-
-  const employeeTypeId = employee.data.employeeTypeId;
-  if (employeeTypeId) {
-    // uq_membership spans (groupId, memberGroupId, memberUserId) and
-    // memberGroupId is null for user rows, so NULLS DISTINCT leaves nothing for
-    // an upsert to conflict against — check before inserting. Two concurrent
-    // acceptances could still both insert; a unique key on
-    // (groupId, memberUserId) is the real fix and needs its own migration.
-    const existingMembership = await client
-      .from("membership")
-      .select("id")
-      .eq("groupId", employeeTypeId)
-      .eq("memberUserId", userId)
-      .limit(1)
-      .maybeSingle();
-
-    if (!existingMembership.data) {
-      const membershipInsert = await client
-        .from("membership")
-        .insert({ groupId: employeeTypeId, memberUserId: userId });
-
-      if (membershipInsert.error) {
-        logger.error("Failed to restore employee type group membership", {
-          userId,
-          companyId,
-          employeeTypeId,
-          error: membershipInsert.error
-        });
-        return membershipInsert;
-      }
-    }
-  }
-
-  const result = await client
-    .from("employee")
-    .update({ active: true })
-    .eq("id", userId)
-    .eq("companyId", companyId)
-    .select("id");
-
-  if (!result.error && (!result.data || result.data.length === 0)) {
-    return notFound;
-  }
-
-  return result;
-}
-
-async function activateSupplier(
-  client: SupabaseClient<Database>,
-  {
-    userId,
-    companyId
-  }: {
-    userId: string;
-    companyId: string;
-  }
-) {
-  const result = await client
-    .from("supplierAccount")
-    .update({ active: true })
-    .eq("id", userId)
-    .eq("companyId", companyId)
-    .select("id");
-
-  if (!result.error && (!result.data || result.data.length === 0)) {
-    return {
-      data: null,
-      error: {
-        message: `Supplier account not found for user ${userId} in company ${companyId}. The account may have been deleted during deactivation.`
-      }
-    };
-  }
-
-  return result;
 }
 
 export async function addUserToCompany(
@@ -1531,68 +1479,6 @@ export async function resetPassword(userId: string, password: string) {
   return getCarbonServiceRole().auth.admin.updateUserById(userId, {
     password
   });
-}
-
-async function rollbackInvite(
-  serviceRole: SupabaseClient<Database>,
-  { userId, companyId }: { userId: string; companyId: string }
-) {
-  await Promise.all([
-    serviceRole
-      .from("employee")
-      .update({ active: false })
-      .eq("id", userId)
-      .eq("companyId", companyId),
-    serviceRole
-      .from("userToCompany")
-      .delete()
-      .eq("userId", userId)
-      .eq("companyId", companyId),
-    serviceRole
-      .from("customerAccount")
-      .delete()
-      .eq("userId", userId)
-      .eq("companyId", companyId),
-    serviceRole
-      .from("supplierAccount")
-      .delete()
-      .eq("userId", userId)
-      .eq("companyId", companyId)
-  ]);
-}
-
-async function setUserPermissions(
-  client: SupabaseClient<Database>,
-  userId: string,
-  permissions: Record<string, string[]>
-) {
-  const user = await client
-    .from("userPermission")
-    .select("permissions")
-    .eq("id", userId)
-    .maybeSingle();
-
-  const currentPermissions = (user.data?.permissions ?? {}) as Record<
-    string,
-    string[]
-  >;
-  const newPermissions = { ...currentPermissions };
-
-  Object.entries(permissions).forEach(([key, value]) => {
-    if (key in newPermissions) {
-      newPermissions[key] = [...newPermissions[key], ...value];
-    } else {
-      newPermissions[key] = value;
-    }
-  });
-
-  const result = await client
-    .from("userPermission")
-    .upsert({ id: userId, permissions: newPermissions });
-
-  await redis.del(getPermissionCacheKey(userId));
-
-  return result;
 }
 
 export async function updateEmployee(

--- a/packages/auth/src/services/deactivate-employee.test.ts
+++ b/packages/auth/src/services/deactivate-employee.test.ts
@@ -3,11 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // Same simulation preamble as the sibling auth tests: @carbon/kv is wrapped in
 // withResilience(), and env is validated at import time, so both are stubbed
 // rather than requiring Redis and a full environment in the test run.
+const { redisDel } = vi.hoisted(() => ({
+  redisDel: vi.fn().mockResolvedValue(null)
+}));
+
 vi.mock("@carbon/kv", () => ({
   redis: {
     get: vi.fn().mockResolvedValue(null),
     set: vi.fn().mockResolvedValue(null),
-    del: vi.fn().mockResolvedValue(null),
+    del: redisDel,
     getdel: vi.fn().mockResolvedValue(null)
   }
 }));
@@ -79,6 +83,7 @@ function makeClient(reads: Record<string, unknown>) {
 
 beforeEach(() => {
   ops = [];
+  redisDel.mockClear();
 });
 
 describe("deactivateEmployee", () => {
@@ -117,6 +122,15 @@ describe("deactivateEmployee", () => {
       expect.objectContaining({ table: "membership", op: "delete" })
     );
     expect(result.success).toBe(true);
+  });
+
+  it("invalidates the cached claims itself, for callers that skip deactivateUser", async () => {
+    await deactivateEmployee(client(), USER, COMPANY);
+
+    // requirePermissions reads this cache (1h TTL) before the database, and the
+    // create*Account rollbacks call this function directly rather than through
+    // deactivateUser — so the invalidation has to live here.
+    expect(redisDel).toHaveBeenCalledWith(`permissions:${USER}`);
   });
 
   it("strips only the deactivating company from the permission map", async () => {

--- a/packages/auth/src/services/deactivate-employee.test.ts
+++ b/packages/auth/src/services/deactivate-employee.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same simulation preamble as the sibling auth tests: @carbon/kv is wrapped in
+// withResilience(), and env is validated at import time, so both are stubbed
+// rather than requiring Redis and a full environment in the test run.
+vi.mock("@carbon/kv", () => ({
+  redis: {
+    get: vi.fn().mockResolvedValue(null),
+    set: vi.fn().mockResolvedValue(null),
+    del: vi.fn().mockResolvedValue(null),
+    getdel: vi.fn().mockResolvedValue(null)
+  }
+}));
+
+vi.mock("../config/env", () => ({
+  RESEND_DOMAIN: "test.dev",
+  DOMAIN: "localhost",
+  ERP_URL: "http://localhost:3000",
+  MES_URL: "http://localhost:3001",
+  VERCEL_URL: "",
+  CarbonEdition: "Community",
+  REFRESH_ACCESS_TOKEN_THRESHOLD: 60,
+  SESSION_KEY: "auth",
+  SESSION_MAX_AGE: 60 * 60 * 24 * 7,
+  SESSION_SECRET: "test-session-secret",
+  SUPABASE_URL: "http://localhost:54321",
+  SUPABASE_ANON_KEY: "test-anon-key",
+  SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+  SUPABASE_JWT_SECRET: "test-jwt-secret"
+}));
+
+vi.mock("./auth-events.server", () => ({
+  logRoleChange: vi.fn(),
+  logPermissionChange: vi.fn()
+}));
+
+import { deactivateEmployee } from "./users.server";
+
+const USER = "usr_1";
+const COMPANY = "cmp_1";
+const OTHER_COMPANY = "cmp_2";
+
+type Op = { table: string; op: string; payload?: unknown };
+
+let ops: Op[];
+
+/**
+ * Minimal stand-in for the Supabase client: every builder method returns the
+ * same object so calls chain, and the object is awaitable so `Promise.all` over
+ * a list of builders resolves. Each terminal verb is recorded so a test can
+ * assert on which tables were written and how.
+ */
+function makeClient(reads: Record<string, unknown>) {
+  const builder = (table: string) => {
+    const record = (op: string, payload?: unknown) => {
+      ops.push({ table, op, payload });
+      return chain;
+    };
+
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      in: () => chain,
+      update: (payload: unknown) => record("update", payload),
+      delete: () => record("delete"),
+      insert: (payload: unknown) => record("insert", payload),
+      upsert: (payload: unknown) => record("upsert", payload),
+      maybeSingle: () => Promise.resolve(reads[table] ?? { data: null }),
+      single: () => Promise.resolve(reads[table] ?? { data: null }),
+      then: (resolve: (value: unknown) => unknown) =>
+        resolve(reads[table] ?? { data: null, error: null })
+    };
+
+    return chain;
+  };
+
+  return { from: (table: string) => builder(table) };
+}
+
+beforeEach(() => {
+  ops = [];
+});
+
+describe("deactivateEmployee", () => {
+  const client = () =>
+    makeClient({
+      userPermission: {
+        data: { permissions: { parts_view: [COMPANY, OTHER_COMPANY] } },
+        error: null
+      },
+      group: { data: [{ id: "grp_1" }], error: null }
+    }) as any;
+
+  it("keeps the employeeJob row so org placement survives", async () => {
+    await deactivateEmployee(client(), USER, COMPANY);
+
+    // Regression guard: deleting employeeJob here made deactivation lossy —
+    // title, start date, department, shift, manager, location, tags and custom
+    // fields cannot be reconstructed when the person is re-invited.
+    expect(ops.filter((o) => o.table === "employeeJob")).toEqual([]);
+  });
+
+  it("still removes everything that grants access", async () => {
+    const result = await deactivateEmployee(client(), USER, COMPANY);
+
+    expect(ops).toContainEqual(
+      expect.objectContaining({ table: "userToCompany", op: "delete" })
+    );
+    expect(ops).toContainEqual(
+      expect.objectContaining({
+        table: "employee",
+        op: "update",
+        payload: { active: false }
+      })
+    );
+    expect(ops).toContainEqual(
+      expect.objectContaining({ table: "membership", op: "delete" })
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("strips only the deactivating company from the permission map", async () => {
+    await deactivateEmployee(client(), USER, COMPANY);
+
+    const update = ops.find(
+      (o) => o.table === "userPermission" && o.op === "update"
+    );
+    expect(update?.payload).toEqual({
+      permissions: { parts_view: [OTHER_COMPANY] }
+    });
+  });
+});

--- a/packages/auth/src/services/users.server.ts
+++ b/packages/auth/src/services/users.server.ts
@@ -248,11 +248,13 @@ export async function deactivateEmployee(
         .update({ active: false })
         .eq("id", userId)
         .eq("companyId", companyId),
-      serviceRole
-        .from("employeeJob")
-        .delete()
-        .eq("id", userId)
-        .eq("companyId", companyId),
+      // "employeeJob" is deliberately left in place. It carries org placement —
+      // title, start date, department, shift, manager, location, tags, custom
+      // fields — none of which grants access; membership ("userToCompany"),
+      // permissions, and "employee".active are what gate it, and all three are
+      // cleared here. Deleting the row made deactivation lossy: nothing in the
+      // re-invite path can reconstruct it, so a revoked employee who was later
+      // re-invited came back with their placement silently blanked.
       ...(groupIds.length > 0
         ? [
             serviceRole

--- a/packages/auth/src/services/users.server.ts
+++ b/packages/auth/src/services/users.server.ts
@@ -193,6 +193,11 @@ export async function deactivateCustomer(
     reason: "deactivate"
   });
 
+  // Same ownership as the employee path below: invalidate here so the
+  // create*Account rollbacks, which call this directly, cannot leave revoked
+  // grants readable from cache.
+  await redis.del(getPermissionCacheKey(userId));
+
   return success("Sucessfully deactivated customer");
 }
 
@@ -292,6 +297,13 @@ export async function deactivateEmployee(
     ip,
     reason: "deactivate"
   });
+
+  // The permissions this function just revoked are cached in Redis, and
+  // `requirePermissions` reads that cache before the database. Invalidating
+  // here rather than only in `deactivateUser` covers the callers that reach
+  // this function directly — the create*Account rollback paths — which
+  // otherwise left a deactivated user's grants live until the 1h TTL.
+  await redis.del(getPermissionCacheKey(userId));
 
   return success("Sucessfully deactivated employee");
 }
@@ -510,6 +522,9 @@ export async function deactivateSupplier(
     ip,
     reason: "deactivate"
   });
+
+  // See deactivateEmployee: the direct callers own nothing, this function does.
+  await redis.del(getPermissionCacheKey(userId));
 
   return success("Sucessfully deactivated supplier");
 }

--- a/packages/database/supabase/migrations/20260911083113_membership-user-unique.sql
+++ b/packages/database/supabase/migrations/20260911083113_membership-user-unique.sql
@@ -1,0 +1,25 @@
+-- A user may belong to a group exactly once.
+--
+-- "uq_membership" spans ("groupId", "memberGroupId", "memberUserId"), and
+-- "memberGroupId" is NULL on every user membership. Under the default NULLS
+-- DISTINCT those rows never conflict with each other, so the constraint that
+-- looks like it dedupes user memberships has never done so: two concurrent
+-- writers — the sync_add_employee_to_type_group trigger and the invite
+-- acceptance path that restores the membership on reactivation — can both
+-- insert the same (groupId, memberUserId) pair.
+--
+-- A plain (not partial) unique index is deliberate: it gives ON CONFLICT an
+-- inferrable target, and group memberships keep "memberUserId" NULL, so they
+-- stay mutually distinct and are unaffected.
+
+-- Collapse existing duplicates first, keeping the earliest row of each pair so
+-- any FK or audit reference to the surviving id stays valid.
+DELETE FROM "membership" m
+USING "membership" keeper
+WHERE m."memberUserId" IS NOT NULL
+  AND m."groupId" = keeper."groupId"
+  AND m."memberUserId" = keeper."memberUserId"
+  AND m."id" > keeper."id";
+
+CREATE UNIQUE INDEX "membership_groupId_memberUserId_key"
+  ON "membership" ("groupId", "memberUserId");


### PR DESCRIPTION
Follow-up to #1609, which fixed re-invites for customer/supplier contacts. Employees
were never reached by it: `createEmployeeAccount` returns before `insertInvite` is
called, so clearing `revokedAt` never applied to them.

## The bug

Revoke an employee's invite, then try to add them again. You get **"This user is
already an employee in this company"** — and the record causing that is invisible,
because deactivation leaves the `employee` row behind as inactive and the employee
list defaults to Active + Invited. The error names a state you cannot see or act on,
and there is no way forward from that screen.

Worse, the revoke already destroyed data. `deactivateEmployee` deleted `employeeJob`
— title, start date, department, shift, manager, location, tags, custom fields — and
dropped the employee-type group membership. Neither is access: `userToCompany`, the
permissions map, and `employee.active` are what gate that, and all three are still
cleared. So anyone who found the resend path came back with their org placement
silently blanked and outside their employee type's group, with nothing in the UI
saying so.

## The fix

- `deactivateEmployee` keeps `employeeJob`. Access removal is unchanged.
- `createEmployeeAccount` refuses only an **active** employee. An inactive row is
  reused via upserts on `(id, companyId)`; only the columns passed are written on
  conflict, so preserved placement survives while the form's employee type and
  location are re-asserted. `active` stays false until acceptance, so the person
  reappears as Invited in the default list straight away.
- Invite acceptance restores the employee-type membership, since the trigger that
  seeds it fires on INSERT and reactivation is an UPDATE.

## Risk

**Deactivation semantics change.** A deactivated person now keeps a location and
title on file and shows them in the Inactive list. This is the one behavior change a
reviewer should agree with or reject; the rule doc is updated to match.

**`acceptInvite` is now a transaction.** It previously ran three concurrent writes
plus a compensating `rollbackInvite`; it is now one Kysely transaction (details
below). Same observable behavior and error messages, but it is the path every new
user walks, so it deserves a careful read.

**The reuse path writes with the service role.** RLS update policies on `employee`
and `employeeJob` want `users_update` / `people_update`, but this route is gated on
`users_create` — so a create-only admin would hit an RLS failure on re-add. Re-adding
someone is the same authorization decision as adding them the first time, and the
UPDATE only exists because we keep the rows, so widening the route's gate looked
wrong. First-time creates still write under the caller's RLS client, and both writes
are scoped by `id` + `companyId`.

**Not browser-verified.** Needs a live invite → revoke → re-add → accept round trip
with mail. Worth doing before merge.

## CodeRabbit review — all four findings addressed

**Claims cache ownership.** `deactivateEmployee`/`Customer`/`Supplier` now invalidate
the Redis claims cache themselves instead of relying on `deactivateUser`.
`requirePermissions` reads that cache (1h TTL) before the database, and the
`create*Account` rollback paths call these directly — so a rolled-back account kept
its revoked grants until the TTL expired. Applied to all three siblings because the
hole and the fix are identical. The rule doc now states who owns the invalidation.

**Atomic invite acceptance.** Activation, the membership restore, `userToCompany`,
the permission merge and the `acceptedAt` stamp are one Kysely transaction, with the
permission read under `FOR UPDATE` and the acceptance guarded on `acceptedAt IS NULL`
so a concurrent accept cannot double-apply. This replaces `rollbackInvite`, which
could not undo writes that had not happened yet and tried to delete
`customerAccount`/`supplierAccount` rows by a `userId` column neither table has.
`rollbackInvite` and the four helpers it existed to repair are deleted rather than
left to drift from the transaction. The permission merge reuses
`mergeInvitePermissions` from the SSO path, which already had to reimplement these
semantics; the cache invalidation moved post-commit.

**Duplicate user memberships.** New migration adds a unique index on
`("groupId", "memberUserId")`, collapsing existing duplicates first.
`uq_membership` spans `(groupId, memberGroupId, memberUserId)` and `memberGroupId`
is NULL on every user membership, so under NULLS DISTINCT it never deduped them —
the seeding trigger and the acceptance path could both insert the same pair. The
index is deliberately not partial so `ON CONFLICT` can infer it; group memberships
keep `memberUserId` NULL and stay mutually distinct.

Known sibling, untouched: `migrateUserToSso` activates an employee without restoring
the employee-type membership, so an SSO-covered domain has the same gap this PR
closes for the normal path. Worth its own change.

## Not included

`upsertEmployeeJob` is local to `users.server.ts` rather than added to
`people.service.ts`, because every export there is also published as an MCP tool and
this PR has no reason to widen that contract.

Three other findings from reviewing #1609 are out of scope: `createdAt` not being
reset on re-invite (expires a controlled-environment invite on arrival), the missing
audit entry when an invite is un-revoked, and the rollback paths no longer re-revoking
after a failed account creation.

## Verification

- `turbo run typecheck --filter=erp` and `--filter=@carbon/auth` — clean
- `turbo run test --filter=@carbon/auth` — 41 passed, including four new cases in
  `deactivate-employee.test.ts`: the `employeeJob` regression guard, that everything
  granting access is still removed, that the claims cache is invalidated, and that
  only the deactivating company leaves the permission map
- `biome check` — clean
- MCP tool manifest digest unchanged (1552 tools)
- `db:check:datasets` / `db:check:backups` — both skipped, no local stack running.
  The migration adds an index only, so `generate:types` produces no change and was
  not run against a database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XdYswNKEg13ysyJTz7338c


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deactivating employees now removes company access while preserving job and organizational details.
  * Permission caches are cleared immediately when employees, customers, or suppliers are deactivated.
  * Re-inviting deactivated employees safely restores their account access and job placement without duplicate memberships.
  * Failed re-invites no longer leave partially updated employee records or redeemable invites.
  * Invite acceptance safely restores activation and membership access.
  * Duplicate user memberships are cleaned up and prevented going forward.
* **Documentation**
  * Updated guidance for deactivation, cache invalidation, and employee reactivation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->