### PR TITLE
fix(quality): serialize issue disposition writes with a shared lock

### DIFF
--- a/.claude/rules/inspection-system.md
+++ b/.claude/rules/inspection-system.md
@@ -214,7 +214,8 @@ quality engine stays pure (verdicts only); orchestration lives in
 (`getInspectionOutcomeState` — buckets recomputed fresh from the DB per POST;
 `getSerialCompletionCandidates` / `postSerialCompletions` /
 `postBulkCompletion`; `createInspectionRejectionIssue` — the NCR block lifted
-from the retired reject route).
+from the retired reject route; it passes `inspectionId` to `createQualityIssue` so the
+inspection link is written with the disposition row under the issue lock).
 
 | Decision | Physical postings |
 |---|---|

--- a/.claude/rules/issue-module.md
+++ b/.claude/rules/issue-module.md
@@ -51,13 +51,25 @@ in the migrations — **newest wins**; core tables created in
   `nonConformanceItemTrackedEntity` links. `AssociatedItemsList.tsx` renders these as
   an inline-editable quantity + disposition `Select` (no entity chips; "Move entities"
   stays gated on `links.length > 0`). The quantity saves through `item+/update.tsx`
-  (`field: "quantity"`, user-scoped client so the audit log records the actor), which
-  refuses rows with entity links (their quantity is the link sum) and any NCR with a
-  `nonConformanceInspection` link (the reject already wrote off the lot, and
+  (`field: "quantity"`) → `updateIssueItemQuantity` (`quality-disposition.server.ts`),
+  which refuses rows with entity links (their quantity is the link sum) and any NCR with
+  a `nonConformanceInspection` link (the reject already wrote off the lot, and
   `closeIssue` restores `row.quantity` on Use As Is / Rework). The write is a
   compare-and-set on `expectedQuantity` (the quantity the client last saw), so a stale
-  save, or one racing a tracked-entity link (link writers also change the row
-  quantity), matches no row and is refused. **Split** works for a non-tracked row as a pure quantity split
+  save matches no row and is refused. It is a Kysely write, so the audit actor comes
+  from `updatedBy` (the audit handler's fallback when `auth.uid()` is null).
+- **Issue disposition lock**: `lockIssueDispositions` (`@carbon/database/quality`)
+  takes `FOR NO KEY UPDATE` on the `nonConformance` row. Every writer that inserts
+  `nonConformanceItemTrackedEntity` / `nonConformanceInspection` rows or changes
+  `nonConformanceItem.quantity` takes it first, inside its transaction, before touching
+  any item row: the quantity edit, `assignEntitiesToIssueItem`, `splitIssueItem`, the
+  inspection association (`$id.association.new.tsx`), `new.tsx` job-operation
+  auto-link, the ERP inspection reject, sales-return escalation, and MES
+  `linkIssueDispositionContext` (which also writes the MES reject's inspection link, via
+  `createQualityIssue({ inspectionId })`). `linkEntitiesToIssueItemRow` is the shared
+  find-or-create-row + link + grow-quantity step. A new writer of those tables must take
+  the lock too, or the quantity edit's link / inspection checks can race it.
+- **Split** works for a non-tracked row as a pure quantity split
   (`splitIssueItem` creates a new `Pending` row for the split-off quantity and shrinks
   the original, no entity subdivision), so MRB can e.g. scrap N and use-as-is the
   rest. `closeIssue` still requires every row (tracked or not) to be non-`Pending`.

--- a/apps/erp/app/modules/quality/AGENTS.md
+++ b/apps/erp/app/modules/quality/AGENTS.md
@@ -18,6 +18,7 @@ Non-conformances (issues/NCRs), corrective/preventive actions (CAPAs), gauge man
 - MUST check `isIssueLocked(status)` before allowing edits — Closed issues are locked.
 - MUST use `deleteIssueAssociation` with the `type` parameter for managing NCR links — it handles 10+ association types via `nonConformanceAssociationType`.
 - MUST scope all queries by `companyId`.
+- MUST take `lockIssueDispositions` (`@carbon/database/quality`) first, inside the transaction, before inserting `nonConformanceItemTrackedEntity` / `nonConformanceInspection` rows or changing `nonConformanceItem.quantity` — the inline quantity edit's link and inspection checks rely on every such writer holding it. See `.claude/rules/issue-module.md`.
 - MUST use `saveInspectionDocumentAtomic` RPC for inspection document saves — it handles balloons and features atomically.
 
 ### Ask First

--- a/apps/erp/app/modules/quality/quality-disposition.server.test.ts
+++ b/apps/erp/app/modules/quality/quality-disposition.server.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// @carbon/glossary's terms.ts evaluates Lingui `msg` macros at module load,
+// which vitest doesn't transform; the module graph pulls it in transitively.
+vi.mock("@carbon/glossary", () => ({
+  terms: {},
+  getEntry: vi.fn(),
+  lookupEntry: vi.fn(),
+  hasEntry: vi.fn(),
+  termSlug: vi.fn(),
+  glossaryEntries: () => []
+}));
+
+type Row = Record<string, unknown>;
+type Tables = Record<string, Row[]>;
+
+// An in-memory stand-in for the Kysely transaction: enough of the query
+// builder for these writers, plus an ordered log of reads, writes and locks so
+// the tests can assert the issue lock is taken before anything else.
+let tables: Tables;
+let log: string[];
+
+function matches(row: Row, filters: [string, string, unknown][]) {
+  return filters.every(([column, op, value]) =>
+    op === "in"
+      ? (value as unknown[]).includes(row[column])
+      : String(row[column]) === String(value)
+  );
+}
+
+function query(table: string, kind: "select" | "update" | "insert") {
+  const filters: [string, string, unknown][] = [];
+  let patch: Row = {};
+  let values: Row[] = [];
+  let locked = false;
+
+  const run = (): Row[] => {
+    const rows = (tables[table] ??= []);
+    if (kind === "insert") {
+      log.push(`insert:${table}`);
+      const inserted = values.map((v, i) => ({
+        id: `${table}-${rows.length + i + 1}`,
+        ...v
+      }));
+      rows.push(...inserted);
+      return inserted;
+    }
+    const hit = rows.filter((r) => matches(r, filters));
+    if (kind === "update") {
+      log.push(`update:${table}`);
+      for (const r of hit) Object.assign(r, patch);
+      return hit;
+    }
+    log.push(`${locked ? "lock" : "read"}:${table}`);
+    return hit;
+  };
+
+  const builder: any = {
+    select: () => builder,
+    returning: () => builder,
+    set: (value: Row) => {
+      patch = value;
+      return builder;
+    },
+    values: (value: Row | Row[]) => {
+      values = Array.isArray(value) ? value : [value];
+      return builder;
+    },
+    where: (column: string, op: string, value: unknown) => {
+      filters.push([column, op, value]);
+      return builder;
+    },
+    forNoKeyUpdate: () => {
+      locked = true;
+      return builder;
+    },
+    execute: async () => run(),
+    executeTakeFirst: async () => run()[0],
+    executeTakeFirstOrThrow: async () => {
+      const row = run()[0];
+      if (!row) throw new Error("no result");
+      return row;
+    }
+  };
+  return builder;
+}
+
+const trx = {
+  selectFrom: (table: string) => query(table, "select"),
+  updateTable: (table: string) => query(table, "update"),
+  insertInto: (table: string) => query(table, "insert")
+};
+
+vi.mock("~/services/database.server", () => ({
+  getDatabaseClient: () => ({
+    transaction: () => ({
+      execute: async (fn: (t: typeof trx) => unknown) => fn(trx)
+    })
+  })
+}));
+vi.mock("./quality.server", () => ({
+  errResult: (message: string) => ({ data: null, error: { message } })
+}));
+
+import {
+  linkEntitiesToIssueItemRow,
+  updateIssueItemQuantity
+} from "./quality-disposition.server";
+
+function seed(overrides: Partial<Tables> = {}) {
+  tables = {
+    nonConformance: [{ id: "nc-1", companyId: "c-1", status: "In Progress" }],
+    nonConformanceItem: [
+      {
+        id: "nci-1",
+        nonConformanceId: "nc-1",
+        itemId: "item-1",
+        quantity: 0,
+        companyId: "c-1"
+      }
+    ],
+    nonConformanceItemTrackedEntity: [],
+    nonConformanceInspection: [],
+    ...overrides
+  };
+  log = [];
+}
+
+const edit = (quantity: number, expectedQuantity: number) =>
+  updateIssueItemQuantity({
+    id: "nci-1",
+    companyId: "c-1",
+    userId: "u-1",
+    quantity,
+    expectedQuantity
+  });
+
+const itemRow = () => tables.nonConformanceItem[0];
+
+beforeEach(() => seed());
+
+describe("updateIssueItemQuantity", () => {
+  it("locks the issue before checking links and writing", async () => {
+    const result = await edit(5, 0);
+
+    expect(result.error).toBeNull();
+    expect(itemRow().quantity).toBe(5);
+    const lockAt = log.indexOf("lock:nonConformance");
+    expect(lockAt).toBeGreaterThan(-1);
+    expect(log.indexOf("read:nonConformanceItemTrackedEntity")).toBeGreaterThan(
+      lockAt
+    );
+    expect(log.indexOf("read:nonConformanceInspection")).toBeGreaterThan(
+      lockAt
+    );
+    expect(log.indexOf("update:nonConformanceItem")).toBeGreaterThan(lockAt);
+  });
+
+  it("refuses an older save that completes after a newer one", async () => {
+    const newer = await edit(7, 0);
+    const older = await edit(5, 0);
+
+    expect(newer.error).toBeNull();
+    expect(older.error?.message).toMatch(/changed since the page loaded/);
+    expect(itemRow().quantity).toBe(7);
+  });
+
+  it("refuses a row with linked tracked entities", async () => {
+    seed({
+      nonConformanceItemTrackedEntity: [
+        {
+          id: "l-1",
+          nonConformanceItemId: "nci-1",
+          nonConformanceId: "nc-1",
+          trackedEntityId: "te-1",
+          quantity: 1,
+          companyId: "c-1"
+        }
+      ]
+    });
+    const result = await edit(4, 0);
+
+    expect(result.error?.message).toMatch(/linked tracked entities/);
+    expect(itemRow().quantity).toBe(0);
+  });
+
+  it("refuses an issue with an inspection link", async () => {
+    seed({
+      nonConformanceInspection: [
+        { id: "i-1", nonConformanceId: "nc-1", companyId: "c-1" }
+      ]
+    });
+    const result = await edit(4, 0);
+
+    expect(result.error?.message).toMatch(/inspection lot/);
+    expect(itemRow().quantity).toBe(0);
+  });
+
+  it("refuses a closed issue", async () => {
+    seed({
+      nonConformance: [{ id: "nc-1", companyId: "c-1", status: "Closed" }]
+    });
+    const result = await edit(4, 0);
+
+    expect(result.error?.message).toMatch(/closed issue/);
+    expect(itemRow().quantity).toBe(0);
+  });
+});
+
+describe("linkEntitiesToIssueItemRow", () => {
+  const link = (
+    entities: { id: string; quantity: number }[],
+    fallbackQuantity?: number
+  ) =>
+    linkEntitiesToIssueItemRow(trx as any, {
+      nonConformanceId: "nc-1",
+      companyId: "c-1",
+      userId: "u-1",
+      itemId: "item-1",
+      entities,
+      fallbackQuantity
+    });
+
+  it("grows the row quantity by the linked entities", async () => {
+    await link([
+      { id: "te-1", quantity: 2 },
+      { id: "te-2", quantity: 3 }
+    ]);
+
+    expect(itemRow().quantity).toBe(5);
+    expect(tables.nonConformanceItemTrackedEntity).toHaveLength(2);
+  });
+
+  it("skips entities already linked on the issue", async () => {
+    seed({
+      nonConformanceItemTrackedEntity: [
+        {
+          id: "l-1",
+          nonConformanceItemId: "nci-other",
+          nonConformanceId: "nc-1",
+          trackedEntityId: "te-1",
+          quantity: 2,
+          companyId: "c-1"
+        }
+      ]
+    });
+    await link([
+      { id: "te-1", quantity: 2 },
+      { id: "te-2", quantity: 3 }
+    ]);
+
+    expect(itemRow().quantity).toBe(3);
+    expect(tables.nonConformanceItemTrackedEntity).toHaveLength(2);
+  });
+
+  it("creates the row when the item has none", async () => {
+    seed({ nonConformanceItem: [] });
+    await link([{ id: "te-1", quantity: 4 }]);
+
+    expect(tables.nonConformanceItem).toHaveLength(1);
+    expect(itemRow().quantity).toBe(4);
+  });
+
+  it("uses the fallback quantity for an empty row with no entities", async () => {
+    await link([], 12);
+
+    expect(itemRow().quantity).toBe(12);
+  });
+
+  it("ignores the fallback when every entity is already linked", async () => {
+    seed({
+      nonConformanceItemTrackedEntity: [
+        {
+          id: "l-1",
+          nonConformanceItemId: "nci-other",
+          nonConformanceId: "nc-1",
+          trackedEntityId: "te-1",
+          quantity: 2,
+          companyId: "c-1"
+        }
+      ]
+    });
+    await link([{ id: "te-1", quantity: 2 }], 12);
+
+    expect(itemRow().quantity).toBe(0);
+  });
+});

--- a/apps/erp/app/modules/quality/quality-disposition.server.ts
+++ b/apps/erp/app/modules/quality/quality-disposition.server.ts
@@ -1,6 +1,7 @@
 import type { Database, Json } from "@carbon/database";
 import type { KyselyTx } from "@carbon/database/client";
-import { EPSILON } from "@carbon/utils";
+import { lockIssueDispositions } from "@carbon/database/quality";
+import { datetime, EPSILON, round } from "@carbon/utils";
 import { FunctionRegion, type SupabaseClient } from "@supabase/supabase-js";
 import { nanoid } from "nanoid";
 import { getDatabaseClient } from "~/services/database.server";
@@ -43,6 +44,25 @@ export async function assignEntitiesToIssueItem(args: {
 
   try {
     const result = await db.transaction().execute(async (trx) => {
+      // Lock the issue before reading any quantity, so a concurrent quantity
+      // edit or link writer on the same issue waits for this move.
+      const owner = await trx
+        .selectFrom("nonConformanceItem")
+        .select(["nonConformanceId"])
+        .where("id", "=", nonConformanceItemId)
+        .where("companyId", "=", companyId)
+        .executeTakeFirst();
+      if (!owner) throw new Error("Source item association not found");
+      // Re-check the closed lock inside the transaction: the route check is a
+      // separate read and could race with a concurrent close.
+      const { status } = await lockIssueDispositions(trx, {
+        nonConformanceId: owner.nonConformanceId,
+        companyId
+      });
+      if (isIssueLocked(status)) {
+        throw new Error("Cannot modify a closed issue. Reopen it first.");
+      }
+
       const source = await trx
         .selectFrom("nonConformanceItem")
         .select(["id", "nonConformanceId", "quantity"])
@@ -61,18 +81,6 @@ export async function assignEntitiesToIssueItem(args: {
 
       if (source.nonConformanceId !== target.nonConformanceId) {
         throw new Error("Cannot move entities between different NCRs");
-      }
-
-      // Re-check the lock inside the transaction: the route check is a separate
-      // read and could race with a concurrent close.
-      const parent = await trx
-        .selectFrom("nonConformance")
-        .select(["status"])
-        .where("id", "=", source.nonConformanceId)
-        .where("companyId", "=", companyId)
-        .executeTakeFirst();
-      if (isIssueLocked(parent?.status)) {
-        throw new Error("Cannot modify a closed issue. Reopen it first.");
       }
 
       const existingLinks = await trx
@@ -144,6 +152,204 @@ export async function assignEntitiesToIssueItem(args: {
       err instanceof Error ? err.message : "Failed to move entities"
     );
   }
+}
+
+// -------------------------------------------------------------
+// updateIssueItemQuantity
+// -------------------------------------------------------------
+// Writes:
+//   - nonConformanceItem.quantity (compare-and-set on expectedQuantity)
+//
+// Only link-less rows on issues without an inspection link are editable: a
+// tracked row's quantity is the sum of its links, and an inspection-originated
+// issue already wrote off the lot, which closeIssue restores as row.quantity
+// on Use As Is / Rework. The checks and the update run under the issue lock,
+// which every link and inspection writer also takes, so a link cannot land
+// between the check and the write.
+
+export async function updateIssueItemQuantity(args: {
+  id: string;
+  companyId: string;
+  userId: string;
+  quantity: number;
+  expectedQuantity: number;
+}): Promise<Result<{ id: string }>> {
+  const { id, companyId, userId, quantity, expectedQuantity } = args;
+  const db = getDatabaseClient();
+
+  try {
+    return await db.transaction().execute(async (trx) => {
+      const owner = await trx
+        .selectFrom("nonConformanceItem")
+        .select(["nonConformanceId"])
+        .where("id", "=", id)
+        .where("companyId", "=", companyId)
+        .executeTakeFirst();
+      if (!owner) return errResult("Issue item not found");
+
+      const { status } = await lockIssueDispositions(trx, {
+        nonConformanceId: owner.nonConformanceId,
+        companyId
+      });
+      if (isIssueLocked(status)) {
+        return errResult("Cannot modify a closed issue. Reopen it first.");
+      }
+
+      const link = await trx
+        .selectFrom("nonConformanceItemTrackedEntity")
+        .select(["id"])
+        .where("nonConformanceItemId", "=", id)
+        .where("companyId", "=", companyId)
+        .executeTakeFirst();
+      if (link) {
+        return errResult(
+          "This row's quantity comes from its linked tracked entities. Split or move entities instead."
+        );
+      }
+
+      const inspection = await trx
+        .selectFrom("nonConformanceInspection")
+        .select(["id"])
+        .where("nonConformanceId", "=", owner.nonConformanceId)
+        .where("companyId", "=", companyId)
+        .executeTakeFirst();
+      if (inspection) {
+        return errResult(
+          "Quantity is set by the rejected inspection lot and cannot be edited."
+        );
+      }
+
+      // Compare-and-set: a stale save (an older request finishing after a
+      // newer one) matches no row instead of overwriting it.
+      const updated = await trx
+        .updateTable("nonConformanceItem")
+        .set({
+          quantity: round(quantity),
+          updatedBy: userId,
+          updatedAt: datetime.timestamp()
+        })
+        .where("id", "=", id)
+        .where("companyId", "=", companyId)
+        .where("quantity", "=", expectedQuantity)
+        .returning(["id"])
+        .executeTakeFirst();
+      if (!updated) {
+        return errResult(
+          "This quantity changed since the page loaded. Refresh and try again."
+        );
+      }
+      return { data: { id: updated.id }, error: null };
+    });
+  } catch (err) {
+    return errResult(
+      err instanceof Error ? err.message : "Failed to update quantity"
+    );
+  }
+}
+
+// -------------------------------------------------------------
+// linkEntitiesToIssueItemRow
+// -------------------------------------------------------------
+// Writes:
+//   - nonConformanceItem (find-or-create the item's row, grow its quantity)
+//   - nonConformanceItemTrackedEntity (one link per entity not yet on a row)
+//
+// The caller must hold lockIssueDispositions for the issue. Entities already
+// linked to any row of the issue are skipped (an entity sits on at most one
+// disposition row per issue). The row quantity grows by the linked entities'
+// quantities, so it stays equal to the link sum. With no entities at all, a
+// row still at 0 takes `fallbackQuantity` (e.g. an untracked inspection lot
+// size); entities that are all already linked change nothing.
+
+export async function linkEntitiesToIssueItemRow(
+  trx: KyselyTx,
+  args: {
+    nonConformanceId: string;
+    companyId: string;
+    userId: string;
+    itemId: string;
+    entities: { id: string; quantity: number }[];
+    fallbackQuantity?: number;
+  }
+): Promise<void> {
+  const { nonConformanceId, companyId, userId, itemId, entities } = args;
+  const nowIso = datetime.timestamp();
+
+  let row = await trx
+    .selectFrom("nonConformanceItem")
+    .select(["id", "quantity"])
+    .where("nonConformanceId", "=", nonConformanceId)
+    .where("itemId", "=", itemId)
+    .where("companyId", "=", companyId)
+    .executeTakeFirst();
+  if (!row) {
+    row = await trx
+      .insertInto("nonConformanceItem")
+      .values({
+        nonConformanceId,
+        itemId,
+        quantity: 0,
+        companyId,
+        createdBy: userId
+      })
+      .returning(["id", "quantity"])
+      .executeTakeFirstOrThrow();
+  }
+  const currentQty = Number(row.quantity ?? 0);
+
+  if (entities.length === 0) {
+    const fallback = args.fallbackQuantity ?? 0;
+    if (currentQty === 0 && fallback > 0) {
+      await trx
+        .updateTable("nonConformanceItem")
+        .set({ quantity: fallback, updatedBy: userId, updatedAt: nowIso })
+        .where("id", "=", row.id)
+        .where("companyId", "=", companyId)
+        .execute();
+    }
+    return;
+  }
+
+  const alreadyLinked = await trx
+    .selectFrom("nonConformanceItemTrackedEntity")
+    .select(["trackedEntityId"])
+    .where("nonConformanceId", "=", nonConformanceId)
+    .where(
+      "trackedEntityId",
+      "in",
+      entities.map((e) => e.id)
+    )
+    .where("companyId", "=", companyId)
+    .execute();
+  const alreadyLinkedIds = new Set(alreadyLinked.map((l) => l.trackedEntityId));
+  const toLink = entities.filter((e) => !alreadyLinkedIds.has(e.id));
+  if (toLink.length === 0) return;
+
+  await trx
+    .insertInto("nonConformanceItemTrackedEntity")
+    .values(
+      toLink.map((e) => ({
+        nonConformanceItemId: row.id,
+        nonConformanceId,
+        trackedEntityId: e.id,
+        quantity: e.quantity,
+        companyId,
+        createdBy: userId
+      }))
+    )
+    .execute();
+
+  const addedQty = toLink.reduce((acc, e) => acc + e.quantity, 0);
+  await trx
+    .updateTable("nonConformanceItem")
+    .set({
+      quantity: currentQty + addedQty,
+      updatedBy: userId,
+      updatedAt: nowIso
+    })
+    .where("id", "=", row.id)
+    .where("companyId", "=", companyId)
+    .execute();
 }
 
 // -------------------------------------------------------------
@@ -368,6 +574,25 @@ export async function splitIssueItem(args: {
 
   try {
     const result = await db.transaction().execute(async (trx) => {
+      // Lock the issue before reading the row quantity, so a concurrent
+      // quantity edit or link writer on the same issue waits for this split.
+      const owner = await trx
+        .selectFrom("nonConformanceItem")
+        .select(["nonConformanceId"])
+        .where("id", "=", id)
+        .where("companyId", "=", companyId)
+        .executeTakeFirst();
+      if (!owner) throw new Error("Item association not found");
+      // Re-check inside the transaction: the route lock check is a separate read
+      // and could race with a concurrent close.
+      const { status } = await lockIssueDispositions(trx, {
+        nonConformanceId: owner.nonConformanceId,
+        companyId
+      });
+      if (isIssueLocked(status)) {
+        throw new Error("Cannot modify a closed issue. Reopen it first.");
+      }
+
       const item = await trx
         .selectFrom("nonConformanceItem")
         .select(["id", "nonConformanceId", "itemId", "quantity"])
@@ -378,15 +603,10 @@ export async function splitIssueItem(args: {
 
       const issue = await trx
         .selectFrom("nonConformance")
-        .select(["nonConformanceId", "status", "locationId"])
+        .select(["nonConformanceId", "locationId"])
         .where("id", "=", item.nonConformanceId)
         .where("companyId", "=", companyId)
         .executeTakeFirst();
-      // Re-check inside the transaction: the route lock check is a separate read
-      // and could race with a concurrent close.
-      if (isIssueLocked(issue?.status)) {
-        throw new Error("Cannot modify a closed issue. Reopen it first.");
-      }
       const readableNc = issue?.nonConformanceId ?? item.nonConformanceId;
       const locationId = issue?.locationId ?? null;
 

--- a/apps/erp/app/routes/x+/inspection+/$id.reject.tsx
+++ b/apps/erp/app/routes/x+/inspection+/$id.reject.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, ERP_URL, error, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
+import { lockIssueDispositions } from "@carbon/database/quality";
 import { notifyIssueCreated } from "@carbon/ee/notifications";
 import { getLogger } from "@carbon/logger";
 import { datetime } from "@carbon/utils";
@@ -21,6 +22,7 @@ import { dispositionInspection } from "~/modules/quality/quality.server";
 import { getCompanyIntegrations } from "~/modules/settings/settings.server";
 import { getLocationTimeZone } from "~/modules/shared/timezone.server";
 import { getUserDefaults } from "~/modules/users/users.server";
+import { getDatabaseClient } from "~/services/database.server";
 import { path } from "~/utils/path";
 
 const logger = getLogger("erp", "inspections-id-reject");
@@ -239,41 +241,107 @@ export async function action({ request, params }: ActionFunctionArgs) {
 
   const ncrId = createResult.data.id;
 
+  // Every tracked entity in the lot: the sampled ones plus the un-sampled
+  // ones, which the cascade also Rejected.
+  const trackedEntityIds = ((insp.inspectionSample as any[]) ?? [])
+    .map((s) => s.trackedEntityId as string)
+    .filter(Boolean);
+  const receiptLineEntities = await client
+    .from("trackedEntity")
+    .select("id")
+    .eq("attributes ->> Receipt Line", insp.sourceDocumentLineId ?? "")
+    .eq("companyId", companyId);
+  const allLotEntityIds = Array.from(
+    new Set([
+      ...trackedEntityIds,
+      ...(receiptLineEntities.data ?? []).map((r: any) => r.id as string)
+    ])
+  );
+  const entityQuantities =
+    allLotEntityIds.length > 0
+      ? await serviceRole
+          .from("trackedEntity")
+          .select("id, quantity")
+          .in("id", allLotEntityIds)
+          .eq("companyId", companyId)
+      : { data: [] };
+
   // insertIssue inserted nonConformanceItem rows with default qty 0 and
   // disposition 'Pending'. Now that we know the lot context, overwrite with
   // the actual lot quantity and default the MRB's starting disposition to
   // 'Scrap' (the most conservative outcome — they can downgrade to Rework /
-  // Use As Is / split later).
-  let scrapRowId: string | null = null;
-  if (insp.itemId) {
-    await serviceRole
-      .from("nonConformanceItem")
-      .update({
-        quantity: Number(insp.lotSize ?? 0),
-        disposition: "Scrap",
-        updatedBy: userId,
-        updatedAt: new Date().toISOString()
-      })
-      .eq("nonConformanceId", ncrId)
-      .eq("itemId", insp.itemId);
+  // Use As Is / split later), link the source inspection, and seed the
+  // per-row entity links so the MRB can split / reassign specific entities.
+  // All of it runs under the issue lock shared by every disposition writer,
+  // so a quantity edit cannot land between the lot quantity and the
+  // inspection link.
+  try {
+    await getDatabaseClient()
+      .transaction()
+      .execute(async (trx) => {
+        await lockIssueDispositions(trx, {
+          nonConformanceId: ncrId,
+          companyId
+        });
 
-    const scrapRow = await serviceRole
-      .from("nonConformanceItem")
-      .select("id")
-      .eq("nonConformanceId", ncrId)
-      .eq("itemId", insp.itemId)
-      .single();
-    scrapRowId = scrapRow.data?.id ?? null;
+        let scrapRowId: string | null = null;
+        if (insp.itemId) {
+          const scrapRow = await trx
+            .updateTable("nonConformanceItem")
+            .set({
+              quantity: Number(insp.lotSize ?? 0),
+              disposition: "Scrap",
+              updatedBy: userId,
+              updatedAt: datetime.timestamp()
+            })
+            .where("nonConformanceId", "=", ncrId)
+            .where("itemId", "=", insp.itemId)
+            .where("companyId", "=", companyId)
+            .returning(["id"])
+            .executeTakeFirst();
+          scrapRowId = scrapRow?.id ?? null;
+        }
+
+        await trx
+          .insertInto("nonConformanceInspection")
+          .values({
+            nonConformanceId: ncrId,
+            inspectionId: insp.id,
+            companyId,
+            createdBy: userId
+          })
+          .execute();
+
+        const entityRows = (entityQuantities.data ?? []) as {
+          id: string;
+          quantity: number | null;
+        }[];
+        if (scrapRowId && entityRows.length > 0) {
+          await trx
+            .insertInto("nonConformanceItemTrackedEntity")
+            .values(
+              entityRows.map((e) => ({
+                nonConformanceItemId: scrapRowId!,
+                nonConformanceId: ncrId,
+                trackedEntityId: e.id,
+                quantity: Number(e.quantity ?? 1),
+                companyId,
+                createdBy: userId
+              }))
+            )
+            .execute();
+        }
+      });
+  } catch (err) {
+    await deleteIssue(serviceRole, ncrId);
+    throw redirect(
+      path.to.inspection(id),
+      await flash(
+        request,
+        error(err, "Lot rejected, but failed to link the NCR to the lot")
+      )
+    );
   }
-
-  // Link the source inspection to the NCR so the issue explorer can surface
-  // the origin and deep-link back to the inspection lot.
-  await serviceRole.from("nonConformanceInspection").insert({
-    nonConformanceId: ncrId,
-    inspectionId: insp.id,
-    companyId,
-    createdBy: userId
-  });
 
   // Also link the receipt line — gives the explorer the supplier / receipt
   // context through the existing "Receipt Lines" association branch.
@@ -293,22 +361,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
   }
 
   // Link every tracked entity in the lot to the NCR.
-  const trackedEntityIds = ((insp.inspectionSample as any[]) ?? [])
-    .map((s) => s.trackedEntityId as string)
-    .filter(Boolean);
-  // Include un-sampled entities too (they were also Rejected by the cascade).
-  const receiptLineEntities = await client
-    .from("trackedEntity")
-    .select("id")
-    .eq("attributes ->> Receipt Line", insp.sourceDocumentLineId ?? "")
-    .eq("companyId", companyId);
-  const allLotEntityIds = Array.from(
-    new Set([
-      ...trackedEntityIds,
-      ...(receiptLineEntities.data ?? []).map((r: any) => r.id as string)
-    ])
-  );
-
   if (allLotEntityIds.length > 0) {
     await serviceRole.from("nonConformanceTrackedEntity").insert(
       allLotEntityIds.map((trackedEntityId) => ({
@@ -318,29 +370,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
         createdBy: userId
       }))
     );
-
-    // Seed the per-row entity links on the default Scrap row so the MRB can
-    // split / reassign specific entities to other dispositions. Each entity
-    // contributes its own quantity to the row.
-    if (scrapRowId) {
-      const entityQuantities = await serviceRole
-        .from("trackedEntity")
-        .select("id, quantity")
-        .in("id", allLotEntityIds)
-        .eq("companyId", companyId);
-      const rows = (entityQuantities.data ?? []).map((e: any) => ({
-        nonConformanceItemId: scrapRowId!,
-        trackedEntityId: e.id as string,
-        quantity: Number(e.quantity ?? 1),
-        companyId,
-        createdBy: userId
-      }));
-      if (rows.length > 0) {
-        await (serviceRole as any)
-          .from("nonConformanceItemTrackedEntity")
-          .insert(rows);
-      }
-    }
   }
 
   const tasks = await serviceRole.functions.invoke("create", {

--- a/apps/erp/app/routes/x+/issue+/$id.association.new.tsx
+++ b/apps/erp/app/routes/x+/issue+/$id.association.new.tsx
@@ -1,10 +1,13 @@
 import { assertIsPost } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
+import { lockIssueDispositions } from "@carbon/database/quality";
 import { validator } from "@carbon/form";
 import { getLogger } from "@carbon/logger";
 import type { ActionFunctionArgs } from "react-router";
 import { getIssue, isIssueLocked } from "~/modules/quality";
 import { issueAssociationValidator } from "~/modules/quality/quality.models";
+import { linkEntitiesToIssueItemRow } from "~/modules/quality/quality-disposition.server";
+import { getDatabaseClient } from "~/services/database.server";
 import { requireUnlocked } from "~/utils/lockedGuard.server";
 import { path } from "~/utils/path";
 
@@ -387,31 +390,15 @@ export async function action({ request, params }: ActionFunctionArgs) {
       const inspection = await (client as any)
         .from("inspection")
         .select(
-          "id, itemId, lotSize, receiptLineId, inspectionSample(trackedEntityId)"
+          "id, itemId, lotSize, sourceDocument, sourceDocumentLineId, inspectionSample(trackedEntityId)"
         )
         .eq("id", id)
+        // The link below is written through Kysely (no RLS), so scope here.
+        .eq("companyId", companyId)
         .single();
       if (inspection.error) {
         logger.error("Failed to create association", {
           error: inspection.error
-        });
-        return {
-          success: false,
-          message: "Failed to create issue inbound inspection"
-        };
-      }
-
-      const linkResult = await (client as any)
-        .from("nonConformanceInspection")
-        .insert({
-          nonConformanceId,
-          inspectionId: inspection.data.id,
-          createdBy: userId,
-          companyId: companyId
-        });
-      if (linkResult.error) {
-        logger.error("Failed to create association", {
-          error: linkResult.error
         });
         return {
           success: false,
@@ -429,11 +416,17 @@ export async function action({ request, params }: ActionFunctionArgs) {
       // Pull the rest of the lot too — un-sampled entities are still part of
       // the lot the MRB needs to disposition.
       let lotEntityIds: string[] = sampledIds;
-      if (inspection.data.receiptLineId) {
+      if (
+        inspection.data.sourceDocument === "Receipt" &&
+        inspection.data.sourceDocumentLineId
+      ) {
         const receiptLineEntities = await client
           .from("trackedEntity")
           .select("id")
-          .eq("attributes ->> Receipt Line", inspection.data.receiptLineId)
+          .eq(
+            "attributes ->> Receipt Line",
+            inspection.data.sourceDocumentLineId
+          )
           .eq("companyId", companyId);
         lotEntityIds = Array.from(
           new Set([
@@ -445,14 +438,21 @@ export async function action({ request, params }: ActionFunctionArgs) {
         );
       }
 
-      await autoLinkInspectionContext(client, {
+      const linked = await linkInspection(client, {
         nonConformanceId,
         companyId,
         userId,
+        inspectionId: inspection.data.id,
         itemId: inspection.data.itemId ?? null,
         lotSize: Number(inspection.data.lotSize ?? 0),
         trackedEntityIds: lotEntityIds
       });
+      if (!linked) {
+        return {
+          success: false,
+          message: "Failed to create issue inbound inspection"
+        };
+      }
       break;
     }
   }
@@ -514,21 +514,27 @@ async function autoLinkJobOperationContext(
   });
 }
 
-async function autoLinkInspectionContext(
+// Links an inspection to the issue and seeds the item's disposition row with
+// the lot. The inspection link and the row writes share one transaction under
+// the issue lock, so a concurrent quantity edit either lands before (and the
+// row write overwrites it) or sees the inspection link and is refused.
+async function linkInspection(
   client: Awaited<ReturnType<typeof requirePermissions>>["client"],
   args: {
     nonConformanceId: string;
     companyId: string;
     userId: string;
+    inspectionId: string;
     itemId: string | null;
     lotSize: number;
     trackedEntityIds: string[];
   }
-) {
+): Promise<boolean> {
   const {
     nonConformanceId,
     companyId,
     userId,
+    inspectionId,
     itemId,
     lotSize,
     trackedEntityIds
@@ -541,113 +547,62 @@ async function autoLinkInspectionContext(
     trackedEntityIds
   });
 
-  if (!itemId) return;
-
-  // Find or create the disposition row for this item. New rows start at qty 0;
-  // we'll bump the qty below by the sum of newly-attached entity quantities
-  // so nonConformanceItem.quantity stays in sync with sum(links.quantity) and
-  // the closure validator's link-sum check is satisfied.
-  const existing = await client
-    .from("nonConformanceItem")
-    .select("id, quantity")
-    .eq("nonConformanceId", nonConformanceId)
-    .eq("itemId", itemId)
-    .maybeSingle();
-
-  let itemRowId: string;
-  let currentQty: number;
-  if (existing.data) {
-    itemRowId = existing.data.id as string;
-    currentQty = Number(existing.data.quantity ?? 0);
-  } else {
-    const insert = await (client as any)
-      .from("nonConformanceItem")
-      .insert({
-        itemId,
-        nonConformanceId,
-        createdBy: userId,
-        companyId,
-        quantity: 0
-      })
-      .select("id, quantity")
-      .single();
-    if (insert.error || !insert.data) {
-      logger.error("Failed to create association", { error: insert.error });
-      return;
-    }
-    itemRowId = insert.data.id as string;
-    currentQty = Number(insert.data.quantity ?? 0);
-  }
-
-  if (trackedEntityIds.length === 0) {
-    // No entities to link — leave the row at its current qty (or fall back to
-    // the lot size for a freshly-created empty row, so the user sees something
-    // meaningful in the disposition list).
-    if (currentQty === 0 && lotSize > 0) {
-      await client
-        .from("nonConformanceItem")
-        .update({
-          quantity: lotSize,
-          updatedBy: userId,
-          updatedAt: new Date().toISOString()
-        })
-        .eq("id", itemRowId)
-        .eq("companyId", companyId);
-    }
-    return;
-  }
-
-  // An entity may only appear on one disposition row per NCR (DB ncUnique
-  // constraint) — skip anything that's already linked anywhere on this NCR.
-  const alreadyLinked = await (client as any)
-    .from("nonConformanceItemTrackedEntity")
-    .select("trackedEntityId")
-    .eq("nonConformanceId", nonConformanceId)
-    .in("trackedEntityId", trackedEntityIds);
-  const alreadyLinkedSet = new Set(
-    ((alreadyLinked.data ?? []) as { trackedEntityId: string }[]).map(
-      (r) => r.trackedEntityId
-    )
-  );
-  const toLink = trackedEntityIds.filter((id) => !alreadyLinkedSet.has(id));
-  if (toLink.length === 0) return;
-
-  const entityQuantities = await client
-    .from("trackedEntity")
-    .select("id, quantity")
-    .in("id", toLink)
-    .eq("companyId", companyId);
-  const entityQtyById = new Map(
+  const entityQuantities =
+    trackedEntityIds.length > 0
+      ? await client
+          .from("trackedEntity")
+          .select("id, quantity")
+          .in("id", trackedEntityIds)
+          .eq("companyId", companyId)
+      : { data: [] };
+  const quantityById = new Map(
     (
       (entityQuantities.data ?? []) as { id: string; quantity: number | null }[]
     ).map((e) => [e.id, Number(e.quantity ?? 1)])
   );
-
-  const linkRows = toLink.map((trackedEntityId) => ({
-    nonConformanceItemId: itemRowId,
-    trackedEntityId,
-    quantity: entityQtyById.get(trackedEntityId) ?? 1,
-    companyId,
-    createdBy: userId
+  const entities = trackedEntityIds.map((id) => ({
+    id,
+    quantity: quantityById.get(id) ?? 1
   }));
-  const linkInsert = await (client as any)
-    .from("nonConformanceItemTrackedEntity")
-    .insert(linkRows);
-  if (linkInsert.error) {
-    logger.error("Failed to create association", { error: linkInsert.error });
-    return;
-  }
 
-  const addedQty = linkRows.reduce((acc, r) => acc + r.quantity, 0);
-  await client
-    .from("nonConformanceItem")
-    .update({
-      quantity: currentQty + addedQty,
-      updatedBy: userId,
-      updatedAt: new Date().toISOString()
-    })
-    .eq("id", itemRowId)
-    .eq("companyId", companyId);
+  try {
+    await getDatabaseClient()
+      .transaction()
+      .execute(async (trx) => {
+        const { status } = await lockIssueDispositions(trx, {
+          nonConformanceId,
+          companyId
+        });
+        if (isIssueLocked(status)) {
+          throw new Error("Cannot modify a closed issue. Reopen it first.");
+        }
+
+        await trx
+          .insertInto("nonConformanceInspection")
+          .values({
+            nonConformanceId,
+            inspectionId,
+            companyId,
+            createdBy: userId
+          })
+          .execute();
+
+        if (itemId) {
+          await linkEntitiesToIssueItemRow(trx, {
+            nonConformanceId,
+            companyId,
+            userId,
+            itemId,
+            entities,
+            fallbackQuantity: lotSize
+          });
+        }
+      });
+    return true;
+  } catch (err) {
+    logger.error("Failed to create association", { error: err });
+    return false;
+  }
 }
 
 async function insertMissingItem(

--- a/apps/erp/app/routes/x+/issue+/item+/update.test.ts
+++ b/apps/erp/app/routes/x+/issue+/item+/update.test.ts
@@ -1,6 +1,5 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { action } from "./update";
 
 // @carbon/glossary's terms.ts evaluates Lingui `msg` macros at module load,
 // which vitest doesn't transform; the route graph pulls it in transitively.
@@ -24,84 +23,44 @@ vi.mock("~/modules/quality", () => ({
 vi.mock("~/modules/quality/quality.models", () => ({
   disposition: ["Pending", "Scrap", "Use As Is"]
 }));
+// The locked compare-and-set lives in updateIssueItemQuantity and is covered
+// by quality-disposition.server.test.ts; this file covers the route's parsing.
+vi.mock("~/modules/quality/quality-disposition.server", () => ({
+  updateIssueItemQuantity: vi.fn(async () => ({
+    data: { id: "nci-1" },
+    error: null
+  }))
+}));
 
-type Row = { id: string; quantity: number };
+import { updateIssueItemQuantity } from "~/modules/quality/quality-disposition.server";
+import { action } from "./update";
 
-// A minimal stateful stand-in for the Supabase query builder: the update
-// applies only when every eq() filter matches the stored row, like Postgres.
-function fakeClient(opts: {
-  row: Row;
-  status?: string;
-  linkCount?: number;
-  inspectionCount?: number;
-}) {
-  const from = vi.fn((table: string) => {
-    const filters: Record<string, unknown> = {};
-    let patch: Partial<Row> | null = null;
-
-    const resolve = () => {
-      if (table === "nonConformanceItemTrackedEntity") {
-        return { count: opts.linkCount ?? 0, error: null };
-      }
-      if (table === "nonConformanceInspection") {
-        return { count: opts.inspectionCount ?? 0, error: null };
-      }
-      if (patch) {
-        const matches = Object.entries(filters).every(
-          ([column, value]) =>
-            column === "companyId" ||
-            String(opts.row[column as keyof Row]) === String(value)
-        );
-        if (!matches) return { data: [], error: null };
-        Object.assign(opts.row, { quantity: patch.quantity });
-        return { data: [{ id: opts.row.id }], error: null };
-      }
-      return { data: null, error: null };
-    };
-
-    const builder: any = {
-      select: vi.fn(() => builder),
-      update: vi.fn((value: Partial<Row>) => {
-        patch = value;
-        return builder;
-      }),
-      eq: vi.fn((column: string, value: unknown) => {
-        filters[column] = value;
-        return builder;
-      }),
-      single: vi.fn(async () => ({
-        data: {
-          nonConformanceId: "nc-1",
-          nonConformance: { status: opts.status ?? "In Progress" }
-        },
+const client = {
+  from: () => {
+    const chain: any = {
+      select: () => chain,
+      eq: () => chain,
+      single: async () => ({
+        data: { nonConformance: { status: "In Progress" } },
         error: null
-      })),
-      then: (onFulfilled: (value: unknown) => unknown) =>
-        Promise.resolve(resolve()).then(onFulfilled)
+      })
     };
-    return builder;
-  });
-  return { from };
-}
+    return chain;
+  }
+};
 
-function quantityRequest(value: string, expectedQuantity: string) {
+function quantityRequest(fields: Record<string, string>) {
   const body = new FormData();
   body.set("id", "nci-1");
   body.set("field", "quantity");
-  body.set("value", value);
-  body.set("expectedQuantity", expectedQuantity);
+  for (const [key, value] of Object.entries(fields)) body.set(key, value);
   return new Request("http://localhost/x/issue/item/update", {
     method: "POST",
     body
   });
 }
 
-async function run(client: ReturnType<typeof fakeClient>, request: Request) {
-  vi.mocked(requirePermissions).mockResolvedValue({
-    client,
-    companyId: "company-1",
-    userId: "user-1"
-  } as any);
+async function run(request: Request) {
   return (await action({ request, params: {}, context: {} } as any)) as {
     error: { message: string } | null;
   };
@@ -109,65 +68,40 @@ async function run(client: ReturnType<typeof fakeClient>, request: Request) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(requirePermissions).mockResolvedValue({
+    client,
+    companyId: "company-1",
+    userId: "user-1"
+  } as any);
 });
 
 describe("issue item update — quantity", () => {
-  it("saves when the stored quantity matches the expected quantity", async () => {
-    const row = { id: "nci-1", quantity: 0 };
-    const result = await run(fakeClient({ row }), quantityRequest("5", "0"));
+  it("passes the parsed quantity and expected quantity to the locked update", async () => {
+    const result = await run(
+      quantityRequest({ value: "2.5", expectedQuantity: "0" })
+    );
 
     expect(result.error).toBeNull();
-    expect(row.quantity).toBe(5);
+    expect(updateIssueItemQuantity).toHaveBeenCalledWith({
+      id: "nci-1",
+      companyId: "company-1",
+      userId: "user-1",
+      quantity: 2.5,
+      expectedQuantity: 0
+    });
   });
 
-  it("refuses an older save that completes after a newer one", async () => {
-    const row = { id: "nci-1", quantity: 0 };
-    const client = fakeClient({ row });
+  it.each(["-3", "", "abc"])("refuses the quantity %j", async (value) => {
+    const result = await run(quantityRequest({ value, expectedQuantity: "0" }));
 
-    // Both saves were sent while the row held 0; the newer one lands first.
-    const newer = await run(client, quantityRequest("7", "0"));
-    const older = await run(client, quantityRequest("5", "0"));
-
-    expect(newer.error).toBeNull();
-    expect(older.error?.message).toMatch(/changed since the page loaded/);
-    expect(row.quantity).toBe(7);
-  });
-
-  it("refuses a row with linked tracked entities", async () => {
-    const row = { id: "nci-1", quantity: 1 };
-    const result = await run(
-      fakeClient({ row, linkCount: 1 }),
-      quantityRequest("4", "1")
-    );
-
-    expect(result.error?.message).toMatch(/linked tracked entities/);
-    expect(row.quantity).toBe(1);
-  });
-
-  it("refuses an inspection-originated issue", async () => {
-    const row = { id: "nci-1", quantity: 5 };
-    const result = await run(
-      fakeClient({ row, inspectionCount: 1 }),
-      quantityRequest("7", "5")
-    );
-
-    expect(result.error?.message).toMatch(/inspection lot/);
-    expect(row.quantity).toBe(5);
+    expect(result.error?.message).toBe("Quantity must be zero or more");
+    expect(updateIssueItemQuantity).not.toHaveBeenCalled();
   });
 
   it("refuses a missing expected quantity", async () => {
-    const row = { id: "nci-1", quantity: 0 };
-    const body = new FormData();
-    body.set("id", "nci-1");
-    body.set("field", "quantity");
-    body.set("value", "5");
-    const request = new Request("http://localhost/x/issue/item/update", {
-      method: "POST",
-      body
-    });
-    const result = await run(fakeClient({ row }), request);
+    const result = await run(quantityRequest({ value: "5" }));
 
     expect(result.error?.message).toBe("Invalid expected quantity");
-    expect(row.quantity).toBe(0);
+    expect(updateIssueItemQuantity).not.toHaveBeenCalled();
   });
 });

--- a/apps/erp/app/routes/x+/issue+/item+/update.tsx
+++ b/apps/erp/app/routes/x+/issue+/item+/update.tsx
@@ -1,8 +1,8 @@
 import { requirePermissions } from "@carbon/auth/auth.server";
-import { datetime, round } from "@carbon/utils";
 import type { ActionFunctionArgs } from "react-router";
 import { isIssueLocked } from "~/modules/quality";
 import { disposition } from "~/modules/quality/quality.models";
+import { updateIssueItemQuantity } from "~/modules/quality/quality-disposition.server";
 import { requireUnlockedBulk } from "~/utils/lockedGuard.server";
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -31,7 +31,7 @@ export async function action({ request }: ActionFunctionArgs) {
 
   const parent = await client
     .from("nonConformanceItem")
-    .select("nonConformanceId, nonConformance(status)")
+    .select("nonConformance(status)")
     .eq("id", id)
     .eq("companyId", companyId)
     .single();
@@ -86,83 +86,13 @@ export async function action({ request }: ActionFunctionArgs) {
           data: null
         };
       }
-      if (parent.error || !parent.data) {
-        return {
-          error: { message: "Issue item not found" },
-          data: null
-        };
-      }
-
-      // A tracked row's quantity is the sum of its linked entities — editing
-      // it directly would break the closure link-sum check. An inspection-
-      // originated NCR already wrote off the lot at reject, and closeIssue
-      // restores row.quantity on Use As Is / Rework, so a changed quantity
-      // would restore a different amount than was written off.
-      const [links, inspections] = await Promise.all([
-        client
-          .from("nonConformanceItemTrackedEntity")
-          .select("id", { count: "exact", head: true })
-          .eq("nonConformanceItemId", id)
-          .eq("companyId", companyId),
-        client
-          .from("nonConformanceInspection")
-          .select("id", { count: "exact", head: true })
-          .eq("nonConformanceId", parent.data.nonConformanceId)
-          .eq("companyId", companyId)
-      ]);
-      if (links.error || inspections.error) {
-        return {
-          error: { message: "Failed to load issue item" },
-          data: null
-        };
-      }
-      if ((links.count ?? 0) > 0) {
-        return {
-          error: {
-            message:
-              "This row's quantity comes from its linked tracked entities. Split or move entities instead."
-          },
-          data: null
-        };
-      }
-      if ((inspections.count ?? 0) > 0) {
-        return {
-          error: {
-            message:
-              "Quantity is set by the rejected inspection lot and cannot be edited."
-          },
-          data: null
-        };
-      }
-
-      // Compare-and-set on the quantity the client last saw. An older request
-      // that finishes after a newer one matches no row instead of overwriting
-      // it, and so does an edit that races a tracked-entity link — every link
-      // writer also changes the row quantity.
-      const updated = await client
-        .from("nonConformanceItem")
-        .update({
-          quantity: round(quantity),
-          updatedBy: userId,
-          updatedAt: datetime.timestamp()
-        })
-        .eq("id", id)
-        .eq("companyId", companyId)
-        .eq("quantity", expectedQuantity)
-        .select("id");
-      if (updated.error) {
-        return { error: updated.error, data: null };
-      }
-      if (!updated.data || updated.data.length === 0) {
-        return {
-          error: {
-            message:
-              "This quantity changed since the page loaded. Refresh and try again."
-          },
-          data: null
-        };
-      }
-      return updated;
+      return await updateIssueItemQuantity({
+        id,
+        companyId,
+        userId,
+        quantity,
+        expectedQuantity
+      });
     }
     default:
       return {

--- a/apps/erp/app/routes/x+/issue+/new.tsx
+++ b/apps/erp/app/routes/x+/issue+/new.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, ERP_URL, error } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
+import { lockIssueDispositions } from "@carbon/database/quality";
 import { notifyIssueCreated } from "@carbon/ee/notifications";
 import { validationError, validator } from "@carbon/form";
 import { getLogger } from "@carbon/logger";
@@ -19,8 +20,10 @@ import {
   insertIssue,
   issueValidator
 } from "~/modules/quality";
+import { linkEntitiesToIssueItemRow } from "~/modules/quality/quality-disposition.server";
 import IssueForm from "~/modules/quality/ui/Issue/IssueForm";
 import { getCompanyIntegrations } from "~/modules/settings/settings.server";
+import { getDatabaseClient } from "~/services/database.server";
 import { setCustomFields } from "~/utils/form";
 import type { Handle } from "~/utils/handle";
 import { path } from "~/utils/path";
@@ -323,79 +326,26 @@ async function autoLinkJobOperationDisposition(
     }
   }
 
-  // Disposition row: find or create. insertIssue may have already inserted
-  // one for this item via the form's `items` array.
-  const existingItem = await client
-    .from("nonConformanceItem")
-    .select("id, quantity")
-    .eq("nonConformanceId", nonConformanceId)
-    .eq("itemId", itemId)
-    .maybeSingle();
-
-  let itemRowId: string;
-  let currentQty: number;
-  if (existingItem.data) {
-    itemRowId = existingItem.data.id as string;
-    currentQty = Number(existingItem.data.quantity ?? 0);
-  } else {
-    const insert = await (client as any)
-      .from("nonConformanceItem")
-      .insert({
-        itemId,
-        nonConformanceId,
-        createdBy: userId,
-        companyId,
-        quantity: 0
-      })
-      .select("id, quantity")
-      .single();
-    if (insert.error || !insert.data) {
-      logger.error("Issue creation step failed", { error: insert.error });
-      return;
-    }
-    itemRowId = insert.data.id as string;
-    currentQty = Number(insert.data.quantity ?? 0);
+  // Disposition row: find or create (insertIssue may have already inserted
+  // one for this item via the form's `items` array), link the lot, and grow
+  // the row quantity — under the issue lock shared by every link writer.
+  try {
+    await getDatabaseClient()
+      .transaction()
+      .execute(async (trx) => {
+        await lockIssueDispositions(trx, { nonConformanceId, companyId });
+        await linkEntitiesToIssueItemRow(trx, {
+          nonConformanceId,
+          companyId,
+          userId,
+          itemId,
+          entities: lotEntities.map((e) => ({
+            id: e.id,
+            quantity: Number(e.quantity ?? 1)
+          }))
+        });
+      });
+  } catch (err) {
+    logger.error("Issue creation step failed", { error: err });
   }
-
-  // ncUnique: an entity may sit on at most one disposition row per NCR.
-  const alreadyLinked = await (client as any)
-    .from("nonConformanceItemTrackedEntity")
-    .select("trackedEntityId")
-    .eq("nonConformanceId", nonConformanceId)
-    .in("trackedEntityId", entityIds);
-  const alreadyLinkedSet = new Set(
-    ((alreadyLinked.data ?? []) as { trackedEntityId: string }[]).map(
-      (r) => r.trackedEntityId
-    )
-  );
-
-  const linkRows = lotEntities
-    .filter((e) => !alreadyLinkedSet.has(e.id))
-    .map((e) => ({
-      nonConformanceItemId: itemRowId,
-      trackedEntityId: e.id,
-      quantity: Number(e.quantity ?? 1),
-      companyId,
-      createdBy: userId
-    }));
-  if (linkRows.length === 0) return;
-
-  const linkInsert = await (client as any)
-    .from("nonConformanceItemTrackedEntity")
-    .insert(linkRows);
-  if (linkInsert.error) {
-    logger.error("Issue creation step failed", { error: linkInsert.error });
-    return;
-  }
-
-  const addedQty = linkRows.reduce((acc, r) => acc + r.quantity, 0);
-  await client
-    .from("nonConformanceItem")
-    .update({
-      quantity: currentQty + addedQty,
-      updatedBy: userId,
-      updatedAt: new Date().toISOString()
-    })
-    .eq("id", itemRowId)
-    .eq("companyId", companyId);
 }

--- a/apps/erp/app/routes/x+/sales-return-order+/$id.$lineId.issue.tsx
+++ b/apps/erp/app/routes/x+/sales-return-order+/$id.$lineId.issue.tsx
@@ -2,6 +2,7 @@ import { assertIsPost, error, notFound, success } from "@carbon/auth";
 import { requirePermissions } from "@carbon/auth/auth.server";
 import { getCarbonServiceRole } from "@carbon/auth/client.server";
 import { flash } from "@carbon/auth/session.server";
+import { lockIssueDispositions } from "@carbon/database/quality";
 import { datetime } from "@carbon/utils";
 import { FunctionRegion } from "@supabase/supabase-js";
 import type { ActionFunctionArgs } from "react-router";
@@ -236,34 +237,6 @@ export async function action({ request, params }: ActionFunctionArgs) {
     return failWith(err, message);
   };
 
-  // insertIssue seeded a nonConformanceItem row with default qty and Pending
-  // disposition. Overwrite with the line's received quantity and the requested
-  // disposition so MRB starts from the escalation's context.
-  const itemUpdate = await serviceRole
-    .from("nonConformanceItem")
-    .update({
-      quantity: quantityReceived,
-      disposition,
-      updatedBy: userId,
-      updatedAt: datetime.timestamp()
-    })
-    .eq("nonConformanceId", ncrId)
-    .eq("itemId", line.data.itemId);
-  if (itemUpdate.error) {
-    throw await failWithRollback(
-      itemUpdate.error,
-      "Failed to set the Issue's item"
-    );
-  }
-
-  const itemRow = await serviceRole
-    .from("nonConformanceItem")
-    .select("id")
-    .eq("nonConformanceId", ncrId)
-    .eq("itemId", line.data.itemId)
-    .single();
-  const nonConformanceItemId = itemRow.data?.id ?? null;
-
   // Link the RMA line so the issue explorer can surface the origin and
   // deep-link back to the return order.
   const lineLink = await serviceRole
@@ -283,8 +256,8 @@ export async function action({ request, params }: ActionFunctionArgs) {
     );
   }
 
-  // Link the line's returned entities to the NCR, and seed the per-row entity
-  // links on the item row so MRB can split / reassign specific entities.
+  // Link the line's returned entities to the NCR.
+  let entityRows: { id: string; quantity: number }[] = [];
   if (entityIds.length > 0) {
     const entityLinks = await serviceRole
       .from("nonConformanceTrackedEntity")
@@ -303,32 +276,64 @@ export async function action({ request, params }: ActionFunctionArgs) {
       );
     }
 
-    if (nonConformanceItemId) {
-      const entityQuantities = await serviceRole
-        .from("trackedEntity")
-        .select("id, quantity")
-        .in("id", entityIds)
-        .eq("companyId", companyId);
-      const rows = (entityQuantities.data ?? []).map((entity) => ({
-        nonConformanceItemId,
-        nonConformanceId: ncrId,
-        trackedEntityId: entity.id,
-        quantity: Number(entity.quantity ?? 1),
-        companyId,
-        createdBy: userId
-      }));
-      if (rows.length > 0) {
-        const itemEntityLinks = await serviceRole
-          .from("nonConformanceItemTrackedEntity")
-          .insert(rows);
-        if (itemEntityLinks.error) {
-          throw await failWithRollback(
-            itemEntityLinks.error,
-            "Failed to link the returned entities to the Issue's item"
-          );
+    const entityQuantities = await serviceRole
+      .from("trackedEntity")
+      .select("id, quantity")
+      .in("id", entityIds)
+      .eq("companyId", companyId);
+    entityRows = (entityQuantities.data ?? []).map((entity) => ({
+      id: entity.id,
+      quantity: Number(entity.quantity ?? 1)
+    }));
+  }
+
+  // insertIssue seeded a nonConformanceItem row with default qty and Pending
+  // disposition. Overwrite with the line's received quantity and the requested
+  // disposition so MRB starts from the escalation's context, and seed the
+  // per-row entity links so MRB can split / reassign specific entities. Both
+  // run under the issue lock shared by every disposition writer, so a quantity
+  // edit cannot land between the quantity and the links.
+  try {
+    await getDatabaseClient()
+      .transaction()
+      .execute(async (trx) => {
+        await lockIssueDispositions(trx, {
+          nonConformanceId: ncrId,
+          companyId
+        });
+
+        const itemRow = await trx
+          .updateTable("nonConformanceItem")
+          .set({
+            quantity: quantityReceived,
+            disposition,
+            updatedBy: userId,
+            updatedAt: datetime.timestamp()
+          })
+          .where("nonConformanceId", "=", ncrId)
+          .where("itemId", "=", line.data.itemId)
+          .where("companyId", "=", companyId)
+          .returning(["id"])
+          .executeTakeFirst();
+
+        if (itemRow && entityRows.length > 0) {
+          await trx
+            .insertInto("nonConformanceItemTrackedEntity")
+            .values(
+              entityRows.map((entity) => ({
+                nonConformanceItemId: itemRow.id,
+                nonConformanceId: ncrId,
+                trackedEntityId: entity.id,
+                quantity: entity.quantity,
+                companyId,
+                createdBy: userId
+              }))
+            )
+            .execute();
         }
-      }
-    }
+      });
+  } catch (err) {
+    throw await failWithRollback(err, "Failed to set the Issue's item");
   }
 
   const tasks = await serviceRole.functions.invoke("create", {

--- a/apps/mes/app/services/quality.server.ts
+++ b/apps/mes/app/services/quality.server.ts
@@ -1,8 +1,10 @@
 import type { getCarbonServiceRole } from "@carbon/auth/client.server";
 import type { Database } from "@carbon/database";
 import { getLocationTimeZone } from "@carbon/database";
+import { lockIssueDispositions } from "@carbon/database/quality";
 import { datetime } from "@carbon/utils";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { getDatabaseClient } from "~/services/database.server";
 import {
   getJobMakeMethod,
   getTrackedEntitiesByMakeMethodId,
@@ -54,6 +56,9 @@ export type CreateQualityIssueArgs = {
   nonConformanceTypeId?: string;
   priority?: "Low" | "Medium" | "High" | "Critical";
   quantity?: number;
+  // Links the source inspection in the same locked transaction as the
+  // disposition row, so the row is never visible without its inspection link.
+  inspectionId?: string;
 };
 
 // MES-owned NCR creation for a job operation: sequence, nonConformance insert,
@@ -153,7 +158,8 @@ export async function createQualityIssue(
       itemId: context.itemId,
       jobMakeMethodId: context.jobMakeMethodId,
       trackedEntityId: args.trackedEntityId,
-      quantity
+      quantity,
+      inspectionId: args.inspectionId
     })
   ]);
   const associationError =
@@ -630,28 +636,16 @@ export async function createInspectionRejectionIssue(
     name: issueTitle,
     description: `Auto-created from inspection ${inspectionReadableId}. Lot size ${insp.lotSize}, sample ${insp.sampleSize}, Ac ${insp.acceptanceNumber} / Re ${insp.rejectionNumber}.${failedFeaturesBlock}`,
     priority: "Medium",
-    quantity: Number(insp.lotSize ?? 1)
+    quantity: Number(insp.lotSize ?? 1),
+    // Link the source inspection to the issue so the ERP issue explorer can
+    // surface the origin and deep-link back to the inspection lot.
+    inspectionId
   });
 
   if (issue.error || !issue.data) {
     return {
       error: issue.error,
       message: issue.message ?? "Failed to create quality issue"
-    };
-  }
-
-  // Link the source inspection to the issue so the ERP issue explorer can
-  // surface the origin and deep-link back to the inspection lot.
-  const link = await serviceRole.from("nonConformanceInspection").insert({
-    nonConformanceId: issue.data.id,
-    inspectionId,
-    companyId,
-    createdBy: userId
-  });
-  if (link.error) {
-    return {
-      error: link.error,
-      message: "Quality issue created, but failed to link the inspection"
     };
   }
 
@@ -759,6 +753,10 @@ async function getIssueContext(
   };
 }
 
+// Writes the issue's disposition row, its entity links and (optionally) the
+// source inspection link in one transaction under the issue lock shared by
+// every disposition writer, so a concurrent quantity edit in the ERP can never
+// see the row without its links or inspection.
 async function linkIssueDispositionContext(
   client: ServiceRole,
   args: {
@@ -769,6 +767,7 @@ async function linkIssueDispositionContext(
     jobMakeMethodId: string | null;
     trackedEntityId?: string;
     quantity: number;
+    inspectionId?: string;
   }
 ): Promise<{ error: unknown | null }> {
   const {
@@ -778,16 +777,19 @@ async function linkIssueDispositionContext(
     itemId,
     jobMakeMethodId,
     trackedEntityId,
-    quantity
+    quantity,
+    inspectionId
   } = args;
 
-  if (!itemId) return { error: null };
+  if (!itemId && !inspectionId) return { error: null };
 
-  const trackedEntities = await getTrackedEntitiesForIssue(client, {
-    companyId,
-    jobMakeMethodId,
-    trackedEntityId
-  });
+  const trackedEntities = itemId
+    ? await getTrackedEntitiesForIssue(client, {
+        companyId,
+        jobMakeMethodId,
+        trackedEntityId
+      })
+    : { data: [], error: null };
 
   if (trackedEntities.error) {
     return { error: trackedEntities.error };
@@ -801,56 +803,72 @@ async function linkIssueDispositionContext(
         )
       : quantity;
 
-  const item = await client
-    .from("nonConformanceItem")
-    .insert({
-      nonConformanceId,
-      itemId,
-      quantity: itemQuantity,
-      disposition: "Pending",
-      companyId,
-      createdBy: userId
-    })
-    .select("id")
-    .single();
+  try {
+    await getDatabaseClient()
+      .transaction()
+      .execute(async (trx) => {
+        await lockIssueDispositions(trx, { nonConformanceId, companyId });
 
-  if (item.error || !item.data?.id) {
-    return { error: item.error ?? new Error("Failed to create issue item") };
+        if (inspectionId) {
+          await trx
+            .insertInto("nonConformanceInspection")
+            .values({
+              nonConformanceId,
+              inspectionId,
+              companyId,
+              createdBy: userId
+            })
+            .execute();
+        }
+
+        if (!itemId) return;
+
+        const item = await trx
+          .insertInto("nonConformanceItem")
+          .values({
+            nonConformanceId,
+            itemId,
+            quantity: itemQuantity,
+            disposition: "Pending",
+            companyId,
+            createdBy: userId
+          })
+          .returning(["id"])
+          .executeTakeFirstOrThrow();
+
+        if (trackedEntities.data.length === 0) return;
+
+        await trx
+          .insertInto("nonConformanceTrackedEntity")
+          .values(
+            trackedEntities.data.map((entity) => ({
+              nonConformanceId,
+              trackedEntityId: entity.id,
+              companyId,
+              createdBy: userId
+            }))
+          )
+          .execute();
+
+        await trx
+          .insertInto("nonConformanceItemTrackedEntity")
+          .values(
+            trackedEntities.data.map((entity) => ({
+              nonConformanceItemId: item.id,
+              nonConformanceId,
+              trackedEntityId: entity.id,
+              quantity: Number(entity.quantity ?? quantity),
+              companyId,
+              createdBy: userId
+            }))
+          )
+          .execute();
+      });
+  } catch (err) {
+    return { error: err };
   }
 
-  if (trackedEntities.data.length === 0) {
-    return { error: null };
-  }
-
-  const trackedEntityLinks = await client
-    .from("nonConformanceTrackedEntity")
-    .insert(
-      trackedEntities.data.map((entity) => ({
-        nonConformanceId,
-        trackedEntityId: entity.id,
-        companyId,
-        createdBy: userId
-      }))
-    );
-
-  if (trackedEntityLinks.error) {
-    return { error: trackedEntityLinks.error };
-  }
-
-  const dispositionLinks = await client
-    .from("nonConformanceItemTrackedEntity")
-    .insert(
-      trackedEntities.data.map((entity) => ({
-        nonConformanceItemId: item.data.id,
-        nonConformanceId,
-        trackedEntityId: entity.id,
-        quantity: Number(entity.quantity ?? quantity),
-        companyId,
-        createdBy: userId
-      }))
-    );
-
-  return { error: dispositionLinks.error };
+  return { error: null };
 }
 
 async function getTrackedEntitiesForIssue(

--- a/packages/database/src/quality.ts
+++ b/packages/database/src/quality.ts
@@ -1346,3 +1346,34 @@ export async function getOrCreateJobOperationInspection(
     );
   }
 }
+
+// -------------------------------------------------------------
+// Issue disposition lock
+// -------------------------------------------------------------
+
+/**
+ * Serializes writes to an issue's disposition rows. Every writer that inserts
+ * `nonConformanceItemTrackedEntity` or `nonConformanceInspection` rows, or
+ * changes `nonConformanceItem.quantity`, takes this lock first inside its
+ * transaction — before touching any item row, so the lock order is always
+ * issue → item and writers cannot deadlock each other.
+ *
+ * It holds a `FOR NO KEY UPDATE` lock on the `nonConformance` row, which
+ * conflicts with other holders of the same lock but not with the FK checks of
+ * unrelated child inserts. Returns the issue status for the caller's
+ * locked-issue check; throws when the issue does not exist in the company.
+ */
+export async function lockIssueDispositions(
+  trx: Transaction<KyselyDatabase>,
+  args: { nonConformanceId: string; companyId: string }
+): Promise<{ status: string }> {
+  const issue = await trx
+    .selectFrom("nonConformance")
+    .select(["status"])
+    .where("id", "=", args.nonConformanceId)
+    .where("companyId", "=", args.companyId)
+    .forNoKeyUpdate()
+    .executeTakeFirst();
+  if (!issue) throw new Error("Issue not found");
+  return { status: issue.status };
+}


### PR DESCRIPTION
## What does this PR do?

Stacked on #1612. Every place that links tracked entities or inspections to an issue, or changes a disposition row quantity, now locks the issue row inside one transaction before writing. The inline quantity edit from #1612 takes the same lock, so its checks can't race another writer.

Covered writers: quantity edit, move entities, split, link inspection, new issue from a job operation, inspection reject (ERP and MES), and sales-return escalation.

Also fixes linking an inspection to an existing issue from the issue tree. It read a removed `inspection.receiptLineId` column and always failed.

## How should this be tested?

1. Edit a quantity, split a row, and link an inspection to an issue. Each should work as before.
2. Hold the lock in a SQL session (`SELECT ... FROM "nonConformance" WHERE id = ... FOR NO KEY UPDATE`), then edit a quantity on that issue. The edit should wait until the session commits.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkcw2Ag6sEhoSXCogcBsha
