### PR TITLE
fix(sales): exclude voided invoices and count partial payments on sales order

### DIFF
--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -1776,7 +1776,7 @@ export async function getSalesOrderInvoicesByIds(
 ) {
   return client
     .from("salesInvoices")
-    .select("id, invoiceTotal, status, currencyCode")
+    .select("id, invoiceTotal, balance, status, currencyCode")
     .in("id", invoiceIds);
 }
 

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-manifest.digest.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-manifest.digest.json
@@ -1283,7 +1283,7 @@
     {"name":"sales_getSalesOrderCustomerDetails","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"141326b70f84","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderCustomers","classification":"READ","paramCount":0,"schema":"efddc7bd8bbc","response":"fc7a0345fc53","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderInvoiceLines","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"1ff852ae9154","injectAuth":"companyId","permission":"sales:view","paginates":false},
-    {"name":"sales_getSalesOrderInvoicesByIds","classification":"READ","paramCount":1,"schema":"d51ae9969843","response":"b06c9fe383e6","injectAuth":"companyId","permission":"sales:view","paginates":false},
+    {"name":"sales_getSalesOrderInvoicesByIds","classification":"READ","paramCount":1,"schema":"d51ae9969843","response":"7b2008a52299","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLine","classification":"READ","paramCount":1,"schema":"58e3c9762923","response":"680c6abfc2c8","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLines","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"12480eaf2ca4","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLinesByItemId","classification":"READ","paramCount":1,"schema":"623ca47a6c74","response":"12480eaf2ca4","injectAuth":"companyId","permission":"sales:view","paginates":false},

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
@@ -133,6 +133,12 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
     const orderCurrency = salesOrder.data?.currencyCode;
 
     for (const invoice of invoices.data ?? []) {
+      // A voided invoice was never billed — it must not inflate the invoiced
+      // total, nor contribute any payments to the paid total.
+      if (invoice.status === "Voided") {
+        continue;
+      }
+
       const invoiceTotal = invoice.invoiceTotal ?? 0;
       const invoiceCurrency = invoice.currencyCode;
 
@@ -147,9 +153,13 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       }
 
       invoicedAmount += invoiceTotal;
-      if (invoice.status === "Paid") {
-        paidAmount += invoiceTotal;
-      }
+
+      // Paid = the settled portion in document currency (invoiceTotal - balance
+      // from the salesInvoices view, which only counts posted payments/memos).
+      // A fully-Paid invoice reports balance 0, a partially-paid one reports its
+      // outstanding remainder — so partial payments are counted, not ignored.
+      const balance = invoice.balance ?? 0;
+      paidAmount += invoiceTotal - balance;
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

The sales order summary computes its **Invoiced Amount** and **Paid Amount** in the route loader (`x+/sales-order+/$orderId.tsx`), and both were wrong: voided invoices still carry an `invoiceTotal` in the `salesInvoices` view, so they inflated the invoiced total, and paid only counted fully-`Paid` invoices (adding their full total), so an invoice with posted-but-partial payments showed **$0** paid. This PR skips `Voided` invoices for both totals and computes paid as `invoiceTotal - balance` — the posted-only settled portion the view already derives — so partial payments are counted and fully-paid invoices still report their full amount. `getSalesOrderInvoicesByIds` now also selects `balance` (which regenerated the committed MCP tool-manifest digest). Only `Voided` is excluded from the invoiced total; `Draft`/`Pending` invoices still count as before.

## How should this be tested?

On a sales order linked to a voided invoice plus at least one invoice with posted (but not fully settled) payments: the Invoiced Amount should no longer include the voided invoice's total, and the Paid Amount should show the settled portion of the posted payments rather than $0. No env vars or migrations required — the change is read-only in the loader.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sales order invoice totals now exclude voided invoices.
  - Paid amounts now accurately include partial payments based on each invoice’s settled balance.
  - Invoice balance information is now available when retrieving sales order invoices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->