### PR TITLE
fix(sales): report actual paid amount on sales orders

### DIFF
--- a/apps/erp/app/modules/sales/sales.service.ts
+++ b/apps/erp/app/modules/sales/sales.service.ts
@@ -1776,8 +1776,33 @@ export async function getSalesOrderInvoicesByIds(
 ) {
   return client
     .from("salesInvoices")
-    .select("id, invoiceTotal, balance, status, currencyCode")
+    .select(
+      "id, invoiceTotal, balance, status, baseStatus, currencyCode, exchangeRate"
+    )
     .in("id", invoiceIds);
+}
+
+export async function getSalesOrderInvoicePaymentsByIds(
+  client: SupabaseClient<Database>,
+  companyId: string,
+  invoiceIds: string[]
+) {
+  return fetchAllFromTable<{
+    targetSalesInvoiceId: string | null;
+    sourceAmount: number | null;
+    payment: { status: string } | null;
+  }>(
+    client,
+    "invoiceSettlement",
+    "targetSalesInvoiceId, sourceAmount, payment:payment!invoiceSettlement_paymentId_fkey!inner(status)",
+    (query) =>
+      query
+        .eq("companyId", companyId)
+        .eq("payment.companyId", companyId)
+        .eq("payment.status", "Posted")
+        .in("targetSalesInvoiceId", invoiceIds)
+        .order("id")
+  );
 }
 
 export async function getSalesOrderLinesByItemId(

--- a/apps/erp/app/routes/api+/mcp+/lib/tool-manifest.digest.json
+++ b/apps/erp/app/routes/api+/mcp+/lib/tool-manifest.digest.json
@@ -1,5 +1,5 @@
 {
-  "totalTools": 1552,
+  "totalTools": 1553,
   "modules": 15,
   "tools": [
     {"name":"account_deleteUserAttributeValue","classification":"DESTRUCTIVE","paramCount":2,"schema":"0d38e12233b4","response":"bcde375ebd4c","injectAuth":"companyId","permission":"none","paginates":false},
@@ -1283,7 +1283,8 @@
     {"name":"sales_getSalesOrderCustomerDetails","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"141326b70f84","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderCustomers","classification":"READ","paramCount":0,"schema":"efddc7bd8bbc","response":"fc7a0345fc53","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderInvoiceLines","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"1ff852ae9154","injectAuth":"companyId","permission":"sales:view","paginates":false},
-    {"name":"sales_getSalesOrderInvoicesByIds","classification":"READ","paramCount":1,"schema":"d51ae9969843","response":"7b2008a52299","injectAuth":"companyId","permission":"sales:view","paginates":false},
+    {"name":"sales_getSalesOrderInvoicePaymentsByIds","classification":"READ","paramCount":1,"schema":"d51ae9969843","response":"8d4d69c4c240","injectAuth":"companyId","permission":"sales:view","paginates":false},
+    {"name":"sales_getSalesOrderInvoicesByIds","classification":"READ","paramCount":1,"schema":"d51ae9969843","response":"59ff21b17d0d","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLine","classification":"READ","paramCount":1,"schema":"58e3c9762923","response":"680c6abfc2c8","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLines","classification":"READ","paramCount":1,"schema":"d160a49d6787","response":"12480eaf2ca4","injectAuth":"companyId","permission":"sales:view","paginates":false},
     {"name":"sales_getSalesOrderLinesByItemId","classification":"READ","paramCount":1,"schema":"623ca47a6c74","response":"12480eaf2ca4","injectAuth":"companyId","permission":"sales:view","paginates":false},

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.invoice-summary.test.ts
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.invoice-summary.test.ts
@@ -1,0 +1,227 @@
+import { requirePermissions } from "@carbon/auth/auth.server";
+import { getCarbonServiceRole } from "@carbon/auth/client.server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as sales from "~/modules/sales";
+import { getCompanySettings } from "~/modules/settings";
+import { loader } from "./$orderId";
+
+vi.mock("@carbon/auth", () => ({
+  error: (cause: unknown, message: string) => ({ cause, message })
+}));
+vi.mock("@carbon/auth/auth.server", () => ({ requirePermissions: vi.fn() }));
+vi.mock("@carbon/auth/client.server", () => ({
+  getCarbonServiceRole: vi.fn()
+}));
+vi.mock("@carbon/auth/session.server", () => ({
+  flash: vi.fn(async () => ({}))
+}));
+vi.mock("@carbon/react", () => ({ VStack: () => null }));
+vi.mock("@lingui/core/macro", () => ({
+  msg: (strings: TemplateStringsArray) => ({ id: strings.join("") })
+}));
+vi.mock("~/components/Layout/Panels", () => ({
+  PanelProvider: () => null,
+  ResizablePanels: () => null
+}));
+vi.mock("~/modules/sales/ui/SalesOrder", () => ({
+  SalesOrderExplorer: () => null,
+  SalesOrderHeader: () => null,
+  SalesOrderProperties: () => null
+}));
+vi.mock("~/modules/settings", () => ({ getCompanySettings: vi.fn() }));
+vi.mock("~/utils/handle", () => ({
+  detailBreadcrumb: () => undefined
+}));
+vi.mock("~/utils/path", () => ({
+  path: {
+    to: {
+      items: "/x/items",
+      salesOrders: "/x/sales-orders",
+      salesOrder: (id: string) => `/x/sales-order/${id}`
+    }
+  }
+}));
+vi.mock("~/modules/sales", () => ({
+  getCustomer: vi.fn(),
+  getOpportunity: vi.fn(),
+  getOpportunityDocuments: vi.fn(),
+  getQuote: vi.fn(),
+  getSalesOrder: vi.fn(),
+  getSalesOrderInvoiceLines: vi.fn(),
+  getSalesOrderInvoicePaymentsByIds: vi.fn(),
+  getSalesOrderInvoicesByIds: vi.fn(),
+  getSalesOrderLines: vi.fn(),
+  getSalesOrderRelatedItems: vi.fn()
+}));
+
+const getSalesOrderInvoicePaymentsByIds = vi.mocked(
+  sales.getSalesOrderInvoicePaymentsByIds
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(requirePermissions).mockResolvedValue({
+    client: {},
+    companyId: "company-1"
+  } as Awaited<ReturnType<typeof requirePermissions>>);
+  vi.mocked(getCarbonServiceRole).mockReturnValue({} as never);
+  vi.mocked(sales.getSalesOrder).mockResolvedValue({
+    data: {
+      id: "order-1",
+      companyId: "company-1",
+      opportunityId: "opportunity-1",
+      customerId: "customer-1",
+      currencyCode: "USD"
+    },
+    error: null
+  } as never);
+  vi.mocked(sales.getSalesOrderLines).mockResolvedValue({
+    data: [],
+    error: null
+  } as never);
+  vi.mocked(sales.getOpportunity).mockResolvedValue({
+    data: { id: "opportunity-1", quotes: [] },
+    error: null
+  } as never);
+  vi.mocked(sales.getCustomer).mockResolvedValue({
+    data: { defaultCc: [] },
+    error: null
+  } as never);
+  vi.mocked(getCompanySettings).mockResolvedValue({
+    data: { defaultCustomerCc: [] },
+    error: null
+  } as never);
+  vi.mocked(sales.getSalesOrderInvoiceLines).mockResolvedValue({
+    data: [{ invoiceId: "invoice-1" }],
+    error: null
+  } as never);
+  vi.mocked(sales.getSalesOrderInvoicesByIds).mockResolvedValue({
+    data: [
+      {
+        id: "invoice-1",
+        invoiceTotal: 100,
+        balance: 0,
+        status: "Paid",
+        baseStatus: "Submitted",
+        currencyCode: "USD",
+        exchangeRate: 1
+      }
+    ],
+    error: null
+  } as never);
+  getSalesOrderInvoicePaymentsByIds.mockResolvedValue({
+    data: [
+      {
+        targetSalesInvoiceId: "invoice-1",
+        sourceAmount: 80,
+        payment: { status: "Posted" }
+      }
+    ],
+    count: 1,
+    error: null
+  });
+  vi.mocked(sales.getOpportunityDocuments).mockResolvedValue({
+    data: [],
+    error: null
+  } as never);
+  vi.mocked(sales.getSalesOrderRelatedItems).mockResolvedValue({
+    data: [],
+    error: null
+  } as never);
+});
+
+describe("sales order invoice summary", () => {
+  it("counts posted cash principal instead of discounts and write-offs", async () => {
+    const result = await loader({
+      request: new Request("http://localhost/x/sales-order/order-1"),
+      params: { orderId: "order-1" },
+      context: {}
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(result.invoiceSummary).toEqual({
+      invoicedAmount: 100,
+      paidAmount: 80,
+      currencyMismatchCount: 0
+    });
+  });
+
+  it("preserves legacy invoices explicitly marked paid", async () => {
+    vi.mocked(sales.getSalesOrderInvoicesByIds).mockResolvedValue({
+      data: [
+        {
+          id: "invoice-1",
+          invoiceTotal: 100,
+          balance: 0,
+          status: "Paid",
+          baseStatus: "Paid",
+          currencyCode: "USD",
+          exchangeRate: 1
+        }
+      ],
+      error: null
+    } as never);
+    getSalesOrderInvoicePaymentsByIds.mockResolvedValue({
+      data: [],
+      count: 0,
+      error: null
+    });
+
+    const result = await loader({
+      request: new Request("http://localhost/x/sales-order/order-1"),
+      params: { orderId: "order-1" },
+      context: {}
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(result.invoiceSummary.paidAmount).toBe(100);
+  });
+
+  it("returns invoice and payment totals in the order currency", async () => {
+    vi.mocked(sales.getSalesOrder).mockResolvedValue({
+      data: {
+        id: "order-1",
+        companyId: "company-1",
+        opportunityId: "opportunity-1",
+        customerId: "customer-1",
+        currencyCode: "EUR"
+      },
+      error: null
+    } as never);
+    vi.mocked(sales.getSalesOrderInvoicesByIds).mockResolvedValue({
+      data: [
+        {
+          id: "invoice-1",
+          invoiceTotal: 100,
+          balance: 50,
+          status: "Partially Paid",
+          baseStatus: "Submitted",
+          currencyCode: "EUR",
+          exchangeRate: 0.8
+        }
+      ],
+      error: null
+    } as never);
+    getSalesOrderInvoicePaymentsByIds.mockResolvedValue({
+      data: [
+        {
+          targetSalesInvoiceId: "invoice-1",
+          sourceAmount: 40,
+          payment: { status: "Posted" }
+        }
+      ],
+      count: 1,
+      error: null
+    });
+
+    const result = await loader({
+      request: new Request("http://localhost/x/sales-order/order-1"),
+      params: { orderId: "order-1" },
+      context: {}
+    } as unknown as Parameters<typeof loader>[0]);
+
+    expect(result.invoiceSummary).toEqual({
+      invoicedAmount: 80,
+      paidAmount: 40,
+      currencyMismatchCount: 0
+    });
+  });
+});

--- a/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
+++ b/apps/erp/app/routes/x+/sales-order+/$orderId.tsx
@@ -14,6 +14,7 @@ import {
   getQuote,
   getSalesOrder,
   getSalesOrderInvoiceLines,
+  getSalesOrderInvoicePaymentsByIds,
   getSalesOrderInvoicesByIds,
   getSalesOrderLines,
   getSalesOrderRelatedItems
@@ -118,7 +119,10 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
   let currencyMismatchCount = 0;
 
   if (invoiceIds.length > 0) {
-    const invoices = await getSalesOrderInvoicesByIds(client, invoiceIds);
+    const [invoices, payments] = await Promise.all([
+      getSalesOrderInvoicesByIds(client, invoiceIds),
+      getSalesOrderInvoicePaymentsByIds(client, companyId, invoiceIds)
+    ]);
 
     if (invoices.error) {
       throw redirect(
@@ -127,6 +131,26 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
           request,
           error(invoices.error, "Failed to load sales invoice totals")
         )
+      );
+    }
+
+    if (payments.error) {
+      throw redirect(
+        path.to.salesOrder(orderId),
+        await flash(
+          request,
+          error(payments.error, "Failed to load sales invoice payments")
+        )
+      );
+    }
+
+    const paidByInvoiceId = new Map<string, number>();
+    for (const payment of payments.data ?? []) {
+      if (!payment.targetSalesInvoiceId) continue;
+      paidByInvoiceId.set(
+        payment.targetSalesInvoiceId,
+        (paidByInvoiceId.get(payment.targetSalesInvoiceId) ?? 0) +
+          (payment.sourceAmount ?? 0)
       );
     }
 
@@ -152,14 +176,14 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
         continue;
       }
 
-      invoicedAmount += invoiceTotal;
-
-      // Paid = the settled portion in document currency (invoiceTotal - balance
-      // from the salesInvoices view, which only counts posted payments/memos).
-      // A fully-Paid invoice reports balance 0, a partially-paid one reports its
-      // outstanding remainder — so partial payments are counted, not ignored.
-      const balance = invoice.balance ?? 0;
-      paidAmount += invoiceTotal - balance;
+      const invoiceTotalInOrderCurrency =
+        invoiceTotal * (invoice.exchangeRate ?? 1);
+      invoicedAmount += invoiceTotalInOrderCurrency;
+      if (invoice.baseStatus === "Paid") {
+        paidAmount += invoiceTotalInOrderCurrency;
+      } else if (invoice.id) {
+        paidAmount += paidByInvoiceId.get(invoice.id) ?? 0;
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

Reports the Sales Order Paid Amount from posted cash payment principal instead of total invoice balance relief, preventing credit memos, discounts, and write-offs from being counted as paid.
Preserves legacy invoices explicitly marked Paid and converts invoice totals into the sales order currency.

## Visual Demo (For contributors especially)

Not included because this changes loader accounting logic without changing the interface.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [x] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- `pnpm --dir apps/erp exec vitest run '$orderId.invoice-summary.test.ts' app/modules/sales` — 26 tests pass.
- `pnpm exec turbo run typecheck --filter=erp` — 2 tasks pass.
- `pnpm check:manifest` — 1,553 operations and a current digest.
- Minimal data: a sales order linked to an invoice with a posted payment plus a discount, write-off, or credit memo; Paid Amount should equal posted cash principal while Invoiced Amount remains the invoice total in order currency.

## Checklist



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Sales order invoice summaries now calculate paid amounts using posted payment records for more accurate totals.
  - Legacy invoices marked as paid continue to display as fully paid, even when payment records are unavailable.
  - Invoice and payment amounts are now converted correctly into the sales order’s currency.
  - Improved error handling when payment details cannot be loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->