### PR TITLE
fix(sales): log Paperless Parts webhook errors instead of swallowing them

### DIFF
--- a/apps/erp/app/routes/api+/webhook.paperless-parts.$companyId.ts
+++ b/apps/erp/app/routes/api+/webhook.paperless-parts.$companyId.ts
@@ -157,7 +157,12 @@ export async function action({ request, params }: ActionFunctionArgs) {
     });
 
     return { success: true };
-  } catch (_err) {
+  } catch (err) {
+    logger.error("Paperless Parts webhook failed", {
+      companyId,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined
+    });
     return data({ success: false }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Problem

The Paperless Parts inbound webhook (`/api/webhook/paperless-parts/$companyId`) started returning **500** in production right after the raw-body signature fix (#1618) shipped, having previously returned **401**.

Investigation via the Vercel MCP:
- The fix (`2dd6782`) is the live production deployment.
- Two POSTs to `/api/webhook/paperless-parts/cs868u84gfk07v78v9e0` returned `500` (7s apart = Paperless retrying).
- **The Vercel runtime error table was empty for the route** — because the `action`'s `catch (_err)` swallowed the error and returned 500 with zero diagnostics.

The 401→500 transition is itself the signal: the old code rejected at signature verification and never proceeded. The new code verifies against the raw body, so execution now reaches previously-dead code (the `trigger("paperless-parts", …)` enqueue → `inngest.send()` and surrounding parse/validate). Whatever throws there is invisible because the catch logs nothing.

## Change

Log the error message + stack (with `companyId`) in the catch, matching the existing `logger.warning(...)` rejection-logging style already in the file. No behavior change beyond diagnostics — still returns 500.

```ts
} catch (err) {
  logger.error("Paperless Parts webhook failed", {
    companyId,
    error: err instanceof Error ? err.message : String(err),
    stack: err instanceof Error ? err.stack : undefined
  });
  return data({ success: false }, { status: 500 });
}
```

## Verification

- `biome check` — clean
- `webhook.paperless-parts.$companyId.test.ts` — 3/3 pass
- Once deployed, the next Paperless delivery will surface the actual cause under logger `webhook-paperless-parts-companyid`, so we can pin the exact throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error logging for failed webhook processing, including the company identifier, error message, and available stack trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->