### PR TITLE
fix(settings): merge integration secrets in vault to stop partial-save wipes

### DIFF
--- a/apps/erp/app/modules/settings/settings.server.ts
+++ b/apps/erp/app/modules/settings/settings.server.ts
@@ -340,6 +340,10 @@ export async function upsertCompanyIntegration(
   // Split secret material out of the metadata: only the non-secret config is
   // written to the column; the secrets go to Supabase Vault. The row is upserted
   // FIRST (so it exists), then the vault RPC stamps `secretRef` onto it.
+  // `secrets` is a PARTIAL bag — splitSecrets omits untouched masked fields — so
+  // `upsert_integration_secret` MERGES it into the stored bag (an omitted secret
+  // keeps its value). A full replace here silently wiped a multi-secret
+  // integration's other credential on a partial save.
   const { config, secrets } = splitSecrets(update.id, update.metadata);
 
   const result = await client

--- a/packages/database/supabase/migrations/20260911164732_integration-secret-merge.sql
+++ b/packages/database/supabase/migrations/20260911164732_integration-secret-merge.sql
@@ -1,0 +1,60 @@
+-- Fix: partial secret updates silently wiped an integration's OTHER secrets.
+--
+-- The integration settings form loads secret fields MASKED (never sent to the
+-- browser). On save, splitSecrets() (packages/ee/src/integrations/secrets.ts)
+-- deliberately OMITS any secret whose field was left untouched — the documented
+-- "unchanged, don't write" rule (D4a). For a multi-secret integration
+-- (paperless-parts: apiKey + secretKey; xero/quickbooks/jira/onshape/rillet/email:
+-- two each) that means a save which rotates ONE secret submits a bag with only
+-- that secret, e.g. { "secretKey": "..." }.
+--
+-- upsert_integration_secret then called vault.update_secret(), which REPLACES the
+-- whole stored bag. So the untouched secret (apiKey) was dropped from the vault.
+-- resolveIntegrationSecrets() later merged the now-incomplete bag back onto the
+-- metadata, leaving apiKey undefined, and the inbound Paperless Parts webhook
+-- failed with a ZodError ("apiKey: expected string, received undefined") before
+-- it could even verify the signature.
+--
+-- Fix: MERGE the incoming bag into the existing one on update, so an omitted key
+-- keeps its stored value — exactly what splitSecrets' anti-overwrite rule
+-- assumes. The bag is a FLAT { dotPath: value } map (keys like "apiKey" or
+-- "credentials.accessToken"), so a shallow jsonb `||` merge is precisely correct.
+--
+-- CREATE OR REPLACE keeps the existing grants; the REVOKE/GRANT below are
+-- re-stated (idempotent) to keep this migration self-describing. Signature is
+-- unchanged from 20260817122916.
+--
+-- Note: a secret can no longer be REMOVED via this path (only overwritten or
+-- added), which is correct for every current caller — individual secret removal
+-- only happens on uninstall via delete_integration_secret(), which drops the
+-- whole bag. A stale opposite-provider email secret may linger encrypted at rest
+-- after an SMTP<->Resend switch; it is unused (the provider is chosen by a
+-- non-secret field) and far preferable to silently wiping a live credential.
+CREATE OR REPLACE FUNCTION upsert_integration_secret(p_company_id text, p_integration_id text, p_secret jsonb)
+RETURNS text LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, vault AS $$
+DECLARE
+  v_name text := 'integration:' || p_company_id || ':' || p_integration_id;
+  v_id uuid;
+  v_existing jsonb;
+BEGIN
+  SELECT id INTO v_id FROM vault.secrets WHERE name = v_name;
+  IF v_id IS NULL THEN
+    v_id := vault.create_secret(p_secret::text, v_name, 'Carbon integration secret');
+  ELSE
+    -- Merge into the stored bag: an omitted key keeps its existing value.
+    SELECT decrypted_secret::jsonb INTO v_existing
+      FROM vault.decrypted_secrets WHERE id = v_id;
+    -- Vault restricts direct UPDATE on vault.secrets; use the supported function.
+    PERFORM vault.update_secret(v_id, (COALESCE(v_existing, '{}'::jsonb) || p_secret)::text);
+  END IF;
+  UPDATE "companyIntegration" SET "secretRef" = v_id::text
+    WHERE "companyId" = p_company_id AND id = p_integration_id;
+  RETURN v_id::text;
+END;
+$$;
+
+-- Service-role only (re-stated; unchanged from the original definition).
+REVOKE ALL ON FUNCTION upsert_integration_secret(text,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION upsert_integration_secret(text,text,jsonb) TO service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/packages/ee/src/integrations/secrets.ts
+++ b/packages/ee/src/integrations/secrets.ts
@@ -129,6 +129,9 @@ export async function persistIntegrationSecrets(
 ): Promise<Json> {
   const { config, secrets } = splitSecrets(integrationId, metadata);
 
+  // `secrets` is a PARTIAL bag — splitSecrets omits untouched masked fields — so
+  // the RPC MERGES it into the stored bag (an omitted secret keeps its value).
+  // A full replace silently wiped a multi-secret integration's other credential.
   if (Object.keys(secrets).length > 0) {
     const { error } = await serviceClient.rpc("upsert_integration_secret", {
       p_company_id: companyId,


### PR DESCRIPTION
## What does this PR do?

Fixes the Paperless Parts inbound webhook failing with `ZodError: apiKey — expected string, received undefined`. The integration settings form loads secret fields masked, so `splitSecrets` omits untouched fields on save (the "unchanged, don't write" rule), but `upsert_integration_secret` replaced the whole Vault bag — so rotating one secret of a multi-secret integration silently dropped the other credential, wiping the Paperless Parts `apiKey`. This migration makes the Vault upsert **merge** the incoming bag into the stored one so an omitted key keeps its value, fixing every multi-secret integration (paperless-parts, xero, quickbooks, jira, onshape, rillet, email). Note: affected companies must re-enter the lost credential once, since the old value was already overwritten in the Vault before this fix.

## Mandatory Tasks (DO NOT REMOVE)

- [x] I have self-reviewed the code (A decent size PR without self-review might be rejected).
- [ ] I confirm automated tests are in place that prove my fix is effective or that my feature works.

## How should this be tested?

- Apply the migration with `pnpm db:migrate`.
- Install a multi-secret integration (e.g. Paperless Parts) with both `apiKey` and `secretKey`, then re-open Settings and save while re-entering only one secret and leaving the other masked.
- Expected: the untouched secret is preserved in the Vault (previously it was wiped). The inbound Paperless Parts webhook resolves both credentials and no longer 500s with a `ZodError` on `apiKey`.

## Checklist

- My code follows the style guidelines of this project.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated integration secret handling so saving one credential no longer overwrites or removes other credentials that were not changed.
  - Existing credentials are now preserved when integration settings are partially updated.
  - New integration setups continue to create and store secrets as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->