### PR TITLE
Harden the generator and utility scripts

### DIFF
--- a/scripts/generate-db-types.ts
+++ b/scripts/generate-db-types.ts
@@ -1,102 +1,22 @@
-import {
-  closeSync,
-  copyFileSync,
-  openSync,
-  readFileSync,
-  writeFileSync
-} from "node:fs";
-import { spawnSync } from "node:child_process";
-import { join } from "node:path";
-import * as dotenv from "dotenv";
+import { existsSync, readFileSync } from "node:fs";
+import { parseEnv } from "node:util";
+import { generateDatabaseTypes } from "./lib/generate-db-types";
 
-dotenv.config({ path: ".env" });
-dotenv.config({ path: ".env.local", override: true });
-
-const dbUrl = process.env.SUPABASE_DB_URL;
-if (!dbUrl) {
-  console.error(
-    "SUPABASE_DB_URL not set (expected in .env or .env.local). Run `pnpm dev:up` first."
-  );
-  process.exit(1);
-}
-
-if (!/(localhost|127\.0\.0\.1)/.test(dbUrl)) {
-  console.error(
-    `Refusing to generate types against non-local DB: ${dbUrl.replace(/:[^:@/]+@/, ":***@")}`
-  );
-  process.exit(1);
-}
-
-const typesPath = join("packages", "database", "src", "types.ts");
-const fnTypesPath = join(
-  "packages",
-  "database",
-  "supabase",
-  "functions",
-  "lib",
-  "types.ts"
-);
-
-// Pipe supabase stdout directly to the types file to avoid spawnSync's 1MB
-// default buffer cap (generated types are ~MBs).
-const out = openSync(typesPath, "w");
-const r = spawnSync(
-  "supabase",
-  [
-    "gen",
-    "types",
-    "typescript",
-    "--db-url",
-    dbUrl,
-    "--schema",
-    "public",
-    "--schema",
-    "storage",
-    "--schema",
-    "graphql_public"
-  ],
-  { stdio: ["ignore", out, "inherit"] }
-);
-closeSync(out);
-
-if (r.status !== 0) {
-  console.error(`supabase gen types failed (exit ${r.status})`);
-  process.exit(r.status ?? 1);
-}
-
-// Strip per-tenant `searchIndex_<companyId>` / `auditLog_<companyId>` tables.
-// They are created at runtime per company (rebuild_search_index and the audit
-// log setup in the migrations), so which ones exist depends on the local DB's
-// seeded companies — committing them makes types.ts machine-dependent and
-// churns on every regen. The static `searchIndexRegistry` / `auditLogArchive`
-// tables (no underscore) are unaffected.
-const stripPerTenantTables = (source: string): string => {
-  const lines = source.split("\n");
-  const result: string[] = [];
-  let skipping = false;
-  let stripped = 0;
-  for (const line of lines) {
-    if (
-      !skipping &&
-      /^      (searchIndex|auditLog)_[A-Za-z0-9]+: \{$/.test(line)
-    ) {
-      skipping = true;
-      stripped++;
-      continue;
+try {
+  for (const file of [".env", ".env.local"]) {
+    if (!existsSync(file)) continue;
+    for (const [key, value] of Object.entries(
+      parseEnv(readFileSync(file, "utf8"))
+    )) {
+      if (file === ".env.local" || process.env[key] === undefined)
+        process.env[key] = value;
     }
-    if (skipping) {
-      if (line === "      }") skipping = false;
-      continue;
-    }
-    result.push(line);
   }
-  if (stripped > 0) {
-    console.log(`stripped ${stripped} per-tenant table(s)`);
-  }
-  return result.join("\n");
-};
-
-writeFileSync(typesPath, stripPerTenantTables(readFileSync(typesPath, "utf8")));
-
-copyFileSync(typesPath, fnTypesPath);
-console.log(`wrote ${typesPath}\nwrote ${fnTypesPath}`);
+  generateDatabaseTypes(process.env.SUPABASE_DB_URL);
+  process.stdout.write("Database types refreshed in both output files.\n");
+} catch (error) {
+  process.stderr.write(
+    `${error instanceof Error ? error.message : "Database type generation failed."}\n`
+  );
+  process.exitCode = 1;
+}

--- a/scripts/generate-mcp.ts
+++ b/scripts/generate-mcp.ts
@@ -14,7 +14,13 @@ import {
   buildManifestDigest,
   serializeManifestDigest
 } from "./lib/manifest-digest";
-import { buildAllToolMetadataWithValidators } from "./lib/service-metadata";
+import {
+  buildAllToolMetadataWithValidators,
+  MODULE_LIST
+} from "./lib/service-metadata";
+
+const log = (message: string) => process.stdout.write(`${message}\n`);
+const warn = (message: string) => process.stderr.write(`${message}\n`);
 
 const ROOT = path.resolve(__dirname, "..");
 const METADATA_FILE = path.join(
@@ -31,18 +37,21 @@ export const DIGEST_FILE = path.join(
 );
 
 export async function generateToolMetadata(): Promise<void> {
-  console.log("Generating tool metadata from service files...");
+  log("Generating tool metadata from service files...");
 
-  const { tools: allTools, registryStats, responseStats, resolutions } =
-    await buildAllToolMetadataWithValidators({
-      onModule: (mod, count) => console.log(`  ✓ ${mod}: ${count} tools`),
-    });
+  const {
+    tools: allTools,
+    registryStats,
+    responseStats,
+    resolutions
+  } = await buildAllToolMetadataWithValidators({
+    onModule: (mod, count) => log(`  ✓ ${mod}: ${count} tools`)
+  });
 
   const metadata = {
-    generated: new Date().toISOString(),
     totalTools: allTools.length,
     modules: [...new Set(allTools.map((t) => t.module))].length,
-    tools: allTools,
+    tools: allTools
   };
 
   // Minified: this file is gitignored build output that only machines read, and
@@ -52,37 +61,37 @@ export async function generateToolMetadata(): Promise<void> {
     DIGEST_FILE,
     serializeManifestDigest(buildManifestDigest(allTools))
   );
-  console.log(`\n✓ Generated metadata for ${allTools.length} tools`);
-  console.log(`  Output: ${path.relative(ROOT, METADATA_FILE)} (gitignored)`);
-  console.log(`  Digest: ${path.relative(ROOT, DIGEST_FILE)} (committed)`);
+  log(`\n✓ Generated metadata for ${allTools.length} tools`);
+  log(`  Output: ${path.relative(ROOT, METADATA_FILE)} (gitignored)`);
+  log(`  Digest: ${path.relative(ROOT, DIGEST_FILE)} (committed)`);
 
   // Schema provenance. A validator that fell back to source-text parsing still
   // produces a manifest entry, so surface it rather than letting the degrade pass
   // silently — that fallback is the only path that can publish a lossy schema.
   const fallbacks = resolutions.filter((r) => r.how !== "native");
-  console.log(
-    `  Schemas: ${registryStats.validatorsConverted} validators converted from ${registryStats.modulesLoaded}/15 modules`
+  log(
+    `  Schemas: ${registryStats.validatorsConverted} validators converted from ${registryStats.modulesLoaded}/${MODULE_LIST.length} modules`
   );
-  console.log(
+  log(
     `  Responses: ${responseStats.derived}/${responseStats.functions} reflected from return types (${responseStats.empty} yielded nothing usable)`
   );
   if (registryStats.moduleErrors.length > 0) {
-    console.warn(`  ⚠ ${registryStats.moduleErrors.length} module(s) failed to load:`);
+    warn(`  ⚠ ${registryStats.moduleErrors.length} module(s) failed to load:`);
     for (const e of registryStats.moduleErrors) {
-      console.warn(`      ${e.module}: ${e.error}`);
+      warn(`      ${e.module}: ${e.error}`);
     }
   }
   if (registryStats.conversionFailures.length > 0) {
-    console.warn(
+    warn(
       `  ⚠ ${registryStats.conversionFailures.length} validator(s) failed to convert:`
     );
     for (const f of registryStats.conversionFailures.slice(0, 10)) {
-      console.warn(`      ${f.module}.${f.name}: ${f.error}`);
+      warn(`      ${f.module}.${f.name}: ${f.error}`);
     }
   }
   if (fallbacks.length > 0) {
     const unique = [...new Set(fallbacks.map((f) => f.validatorName))];
-    console.warn(
+    warn(
       `  ⚠ ${fallbacks.length} param(s) used the source-text fallback: ${unique.slice(0, 12).join(", ")}`
     );
   }
@@ -90,7 +99,7 @@ export async function generateToolMetadata(): Promise<void> {
 
 if (require.main === module) {
   generateToolMetadata().catch((err) => {
-    console.error(err);
+    process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
     process.exit(1);
   });
 }

--- a/scripts/generate-swagger-docs.ts
+++ b/scripts/generate-swagger-docs.ts
@@ -1,26 +1,74 @@
-import { writeFileSync } from "node:fs";
-import * as dotenv from "dotenv";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { parseEnv } from "node:util";
+import {
+  normalizeSwaggerSchema,
+  PARTNER_ALIAS_PROOF_SQL
+} from "./lib/swagger-schema";
 
-dotenv.config({ path: ".env" });
-dotenv.config({ path: ".env.local", override: true });
-
-const studioPort = process.env.PORT_STUDIO;
-if (!studioPort) {
-  console.error(
-    "PORT_STUDIO not set (expected in .env.local). Run `pnpm dev:up` first."
-  );
-  process.exit(1);
+async function responseJson(
+  response: Response,
+  label: string
+): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    throw new Error(`${label} response is not valid JSON`);
+  }
 }
 
-const url = `http://localhost:${studioPort}/api/platform/projects/default/api/rest`;
-
-(async () => {
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+async function main(): Promise<void> {
+  for (const file of [".env", ".env.local"]) {
+    if (!existsSync(file)) continue;
+    for (const [key, value] of Object.entries(
+      parseEnv(readFileSync(file, "utf8"))
+    )) {
+      if (file === ".env.local" || process.env[key] === undefined)
+        process.env[key] = value;
+    }
   }
-
-  const data = await response.json();
+  const studioPort = process.env.PORT_STUDIO;
+  if (
+    !studioPort ||
+    !/^\d+$/.test(studioPort) ||
+    Number(studioPort) < 1 ||
+    Number(studioPort) > 65535
+  )
+    throw new Error(
+      "PORT_STUDIO must identify a local Studio port; start the development stack first"
+    );
+  const studio = `http://127.0.0.1:${studioPort}`;
+  const response = await fetch(
+    `${studio}/api/platform/projects/default/api/rest`,
+    { signal: AbortSignal.timeout(30_000) }
+  );
+  if (!response.ok)
+    throw new Error(`Swagger request failed (HTTP ${response.status})`);
+  const raw = await responseJson(response, "Swagger");
+  const proofResponse = await fetch(
+    `${studio}/api/platform/pg-meta/default/query`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: PARTNER_ALIAS_PROOF_SQL }),
+      signal: AbortSignal.timeout(30_000)
+    }
+  );
+  if (!proofResponse.ok)
+    throw new Error(
+      `Schema proof request failed (HTTP ${proofResponse.status})`
+    );
+  const data = normalizeSwaggerSchema(
+    raw,
+    await responseJson(proofResponse, "Schema proof")
+  );
 
   // Strip per-tenant `searchIndex_<companyId>` / `auditLog_<companyId>` tables
   // (created at runtime per company) — which ones exist depends on the local
@@ -41,8 +89,26 @@ const url = `http://localhost:${studioPort}/api/platform/projects/default/api/re
     return value;
   };
 
-  writeFileSync(
-    "packages/database/src/swagger-docs-schema.ts",
-    `export default ${JSON.stringify(stripPerTenantKeys(data), null, 2)}`
+  const output = "packages/database/src/swagger-docs-schema.ts";
+  const temporary = mkdtempSync(join(dirname(output), ".swagger-generation-"));
+  try {
+    const candidate = join(temporary, "schema.ts");
+    writeFileSync(
+      candidate,
+      `export default ${JSON.stringify(stripPerTenantKeys(data), null, 2)}`
+    );
+    renameSync(candidate, output);
+  } finally {
+    rmSync(temporary, { recursive: true, force: true });
+  }
+  process.stdout.write(
+    "Swagger schema refreshed with verified partner alias metadata.\n"
   );
-})();
+}
+
+main().catch((error) => {
+  process.stderr.write(
+    `Swagger generation failed: ${error instanceof Error ? error.message : "verification did not complete"}\n`
+  );
+  process.exitCode = 1;
+});

--- a/scripts/lib/generate-db-types.test.ts
+++ b/scripts/lib/generate-db-types.test.ts
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { sortRelationships } from "./generate-db-types";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const targets = [
+  "packages/database/src/types.ts",
+  "packages/database/supabase/functions/lib/types.ts"
+] as const;
+const original = "export type Database = { public: { Tables: {} } };\n";
+const generated =
+  "export type Database = { public: { Tables: { example: {} } } };\n";
+
+function runGenerator(
+  output: string,
+  options: {
+    exit?: number;
+    databaseUrl?: string;
+    missingExecutable?: boolean;
+    failSecondReplacement?: boolean;
+    envFiles?: Record<string, string>;
+  } = {}
+) {
+  const directory = realpathSync(
+    mkdtempSync(join(tmpdir(), "carbon-db-generation-"))
+  );
+  try {
+    for (const [file, content] of Object.entries(options.envFiles ?? {})) {
+      writeFileSync(join(directory, file), content);
+    }
+    for (const target of targets) {
+      mkdirSync(dirname(join(directory, target)), { recursive: true });
+      writeFileSync(join(directory, target), original);
+    }
+    mkdirSync(join(directory, "scripts/lib"), { recursive: true });
+    copyFileSync(
+      join(root, "scripts/generate-db-types.ts"),
+      join(directory, "scripts/generate-db-types.ts")
+    );
+    const helper = "scripts/lib/generate-db-types.ts";
+    if (existsSync(join(root, helper)))
+      copyFileSync(join(root, helper), join(directory, helper));
+    symlinkSync(
+      join(root, "node_modules"),
+      join(directory, "node_modules"),
+      "dir"
+    );
+    const bin = join(directory, "bin");
+    mkdirSync(bin);
+    const marker = join(directory, "invoked");
+    writeFileSync(join(directory, "output.txt"), output);
+    if (!options.missingExecutable) {
+      writeFileSync(
+        join(bin, "supabase"),
+        `#!${process.execPath}\nconst fs = require('node:fs');\nfs.writeFileSync(${JSON.stringify(marker)}, 'yes');\nfs.writeSync(1, fs.readFileSync(${JSON.stringify(join(directory, "output.txt"))}));\nprocess.exit(${options.exit ?? 0});\n`,
+        { mode: 0o755 }
+      );
+    }
+    const preload = join(directory, "failure.cjs");
+    // Inject an operating-system failure at the second destination only. Real
+    // subprocess generation, validation, writes and rollback still execute.
+    writeFileSync(
+      preload,
+      `const fs = require('node:fs');\nlet failed = false;\nconst target = ${JSON.stringify(join(directory, targets[1]))};\nfor (const name of ['renameSync', 'copyFileSync', 'writeFileSync']) {\n  const original = fs[name];\n  fs[name] = (...args) => {\n    const destination = name === 'writeFileSync' ? args[0] : args[1];\n    if (${Boolean(options.failSecondReplacement)} && !failed && require('node:path').resolve(String(destination)) === target) {\n      failed = true;\n      throw Object.assign(new Error('Synthetic second replacement failure'), { code: 'EACCES' });\n    }\n    return original(...args);\n  };\n}\nrequire('node:module').syncBuiltinESMExports();\n`
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--require",
+        preload,
+        "--import",
+        require.resolve("tsx"),
+        join(directory, "scripts/generate-db-types.ts")
+      ],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        timeout: 20_000,
+        env: {
+          ...process.env,
+          NODE_PATH: undefined,
+          PATH: bin,
+          SUPABASE_DB_URL:
+            options.databaseUrl ??
+            "postgresql://example:synthetic@127.0.0.1:5432/example"
+        }
+      }
+    );
+    return {
+      ...result,
+      invoked: existsSync(marker),
+      contents: targets.map((target) =>
+        readFileSync(join(directory, target), "utf8")
+      ),
+      remaining: targets.map((target) =>
+        readdirSync(dirname(join(directory, target)))
+      )
+    };
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("default .env preserves the caller's database URL without dotenv or NODE_PATH", () => {
+  const result = runGenerator(generated, {
+    envFiles: {
+      ".env": "SUPABASE_DB_URL=postgresql://external.example.com/database\n"
+    }
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.invoked, true);
+});
+
+test(".env.local overrides the caller's URL before the local-host safety check", () => {
+  const result = runGenerator(generated, {
+    envFiles: {
+      ".env.local":
+        "SUPABASE_DB_URL=postgresql://external.example.com/database\n"
+    }
+  });
+  assert.notEqual(result.status, 0);
+  assert.equal(result.invoked, false);
+  assert.deepEqual(result.contents, [original, original]);
+});
+
+test("failed subprocess preserves both last-good outputs and cleans temporary files", () => {
+  const result = runGenerator("partial output", { exit: 7 });
+  assert.equal(result.invoked, true, result.stderr);
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(result.contents, [original, original]);
+  assert.deepEqual(result.remaining, [["types.ts"], ["types.ts"]]);
+});
+
+test("missing generator executable preserves both last-good outputs", () => {
+  const result = runGenerator(generated, { missingExecutable: true });
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(result.contents, [original, original]);
+  assert.deepEqual(result.remaining, [["types.ts"], ["types.ts"]]);
+});
+
+for (const output of [
+  "",
+  "   \n",
+  "export type Database = {",
+  "export const unrelated = 42;",
+  "type Database = {};"
+]) {
+  test(`rejects unusable successful output (${JSON.stringify(output)})`, () => {
+    const result = runGenerator(output);
+    assert.equal(result.invoked, true, result.stderr);
+    assert.notEqual(result.status, 0);
+    assert.deepEqual(result.contents, [original, original]);
+    assert.deepEqual(result.remaining, [["types.ts"], ["types.ts"]]);
+  });
+}
+
+test("failure replacing the second output rolls back the first output", () => {
+  const result = runGenerator(generated, { failSecondReplacement: true });
+  assert.equal(result.invoked, true, result.stderr);
+  assert.notEqual(result.status, 0);
+  assert.deepEqual(result.contents, [original, original]);
+  assert.deepEqual(result.remaining, [["types.ts"], ["types.ts"]]);
+});
+
+for (const databaseUrl of [
+  "postgresql://localhost:synthetic-secret@example.com/example",
+  "postgresql://example:synthetic-secret@127.0.0.1.example.com/example",
+  "postgresql://example:synthetic-secret@example.com/localhost",
+  "http://example:synthetic-secret@localhost/example",
+  "postgresql://example:synthetic-secret@localhost/example?host=example.com",
+  "postgresql://example:synthetic-secret@localhost/example?hostaddr=192.0.2.1",
+  "not-a-database-url"
+]) {
+  test(`rejects a malformed or non-local database URL (${databaseUrl.split(":")[0]})`, () => {
+    const result = runGenerator(generated, { databaseUrl });
+    assert.notEqual(result.status, 0);
+    assert.equal(result.invoked, false);
+    assert.deepEqual(result.contents, [original, original]);
+    assert.doesNotMatch(
+      result.stdout + result.stderr,
+      /synthetic-secret|example\.com/
+    );
+  });
+}
+
+for (const host of ["localhost", "127.0.0.1", "[::1]"]) {
+  test(`publishes identical validated outputs for local host ${host}`, () => {
+    const result = runGenerator(generated, {
+      databaseUrl: `postgresql://example:synthetic@${host}:5432/example`
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(result.contents, [generated, generated]);
+    assert.deepEqual(result.remaining, [["types.ts"], ["types.ts"]]);
+  });
+}
+
+test("MCP generation does not cache incomplete transitive input coverage", () => {
+  const turbo = JSON.parse(readFileSync(join(root, "turbo.json"), "utf8"));
+  assert.equal(turbo.tasks["//#generate:mcp"].cache, false);
+});
+
+test("sortRelationships orders each Relationships block deterministically", () => {
+  const block = (entries: string[]) =>
+    ["      x: {", "        Relationships: [", ...entries, "        ]", "      }"].join("\n");
+  const entry = (fk: string, col: string, last = false) =>
+    [
+      "          {",
+      `            foreignKeyName: "${fk}"`,
+      `            columns: ["${col}"]`,
+      "            isOneToOne: false",
+      '            referencedRelation: "country"',
+      '            referencedColumns: ["code"]',
+      last ? "          }" : "          },"
+    ].join("\n");
+  const a = block([entry("x_fkey", "supplierCountryCode"), entry("x_fkey", "customerCountryCode", true)]);
+  const b = block([entry("x_fkey", "customerCountryCode"), entry("x_fkey", "supplierCountryCode", true)]);
+  assert.equal(sortRelationships(a), sortRelationships(b));
+  assert.equal(sortRelationships(a), b, "sorted output keeps a trailing comma on every entry but the last");
+  assert.equal(sortRelationships("        Relationships: []\n      }"), "        Relationships: []\n      }");
+});

--- a/scripts/lib/generate-db-types.ts
+++ b/scripts/lib/generate-db-types.ts
@@ -1,0 +1,242 @@
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import ts from "typescript";
+
+function validateDatabaseUrl(value: string | undefined): string {
+  if (!value?.trim()) {
+    throw new Error(
+      "SUPABASE_DB_URL is not set. Configure the local database before generating types."
+    );
+  }
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error("SUPABASE_DB_URL must be a valid local PostgreSQL URL.");
+  }
+  if (
+    !["postgres:", "postgresql:"].includes(url.protocol) ||
+    !["localhost", "127.0.0.1", "[::1]"].includes(url.hostname) ||
+    url.searchParams.has("host") ||
+    url.searchParams.has("hostaddr")
+  ) {
+    // Never include the URL: even a redacted password can leave private hosts,
+    // usernames or query parameters in output copied into public run logs.
+    throw new Error(
+      "Refusing to generate types: SUPABASE_DB_URL must use a local PostgreSQL host."
+    );
+  }
+  return value;
+}
+
+function validateTypes(source: string): void {
+  if (!source.trim())
+    throw new Error("Database type generation produced empty output.");
+  const parsed = ts.createSourceFile(
+    "types.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true
+  );
+  const result = ts.transpileModule(source, { reportDiagnostics: true });
+  const hasDatabase = parsed.statements.some(
+    (statement) =>
+      (ts.isTypeAliasDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement)) &&
+      statement.name.text === "Database" &&
+      statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+      )
+  );
+  if (
+    result.diagnostics?.some(
+      (diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error
+    ) ||
+    !hasDatabase
+  ) {
+    throw new Error(
+      "Database type generation did not produce valid TypeScript with an exported Database type."
+    );
+  }
+}
+
+// Runtime-created per-tenant tables depend on locally seeded companies. Keep
+// the existing filter while validating both the original and normalized output.
+function stripPerTenantTables(source: string): string {
+  const lines: string[] = [];
+  let skipping = false;
+  for (const line of source.split("\n")) {
+    if (
+      !skipping &&
+      /^      (searchIndex|auditLog)_[A-Za-z0-9]+: \{$/.test(line)
+    ) {
+      skipping = true;
+      continue;
+    }
+    if (skipping) {
+      if (line === "      }") skipping = false;
+      continue;
+    }
+    lines.push(line);
+  }
+  return lines.join("\n");
+}
+
+// `supabase gen types` emits a table's `Relationships` entries in catalog order,
+// which is not stable across databases built from the same migrations (two
+// foreign keys to the same table swap places between runs). Sort each block's
+// entries by their text so the output is a pure function of the schema and the
+// generated-files drift check can compare it byte for byte.
+export function sortRelationships(source: string): string {
+  const lines = source.split("\n");
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    out.push(line);
+    if (!/^\s*Relationships: \[$/.test(line)) continue;
+    const indent = line.match(/^\s*/)?.[0] ?? "";
+    const entries: string[][] = [];
+    let j = i + 1;
+    while (j < lines.length && lines[j] !== `${indent}]`) {
+      if (lines[j] === `${indent}  {`) {
+        const entry = [lines[j]];
+        j++;
+        while (j < lines.length && !/^\s*\},?$/.test(lines[j])) entry.push(lines[j++]);
+        entry.push(lines[j]);
+        entries.push(entry);
+      }
+      j++;
+    }
+    if (j >= lines.length) continue;
+    const closing = lines[j];
+    entries.sort((a, b) => {
+      const ka = a.slice(1, -1).join("\n");
+      const kb = b.slice(1, -1).join("\n");
+      return ka < kb ? -1 : ka > kb ? 1 : 0;
+    });
+    entries.forEach((entry, index) => {
+      const last = entry[entry.length - 1].replace(/,$/, "");
+      out.push(...entry.slice(0, -1), index < entries.length - 1 ? `${last},` : last);
+    });
+    out.push(closing);
+    i = j;
+  }
+  return out.join("\n");
+}
+
+type StagedOutput = {
+  target: string;
+  directory: string;
+  candidate: string;
+  backup: string;
+  existed: boolean;
+  replaced: boolean;
+};
+
+export function generateDatabaseTypes(databaseUrl: string | undefined): void {
+  const dbUrl = validateDatabaseUrl(databaseUrl);
+  const targets = [
+    resolve("packages/database/src/types.ts"),
+    resolve("packages/database/supabase/functions/lib/types.ts")
+  ];
+  const staged: StagedOutput[] = [];
+  let preserveBackups = false;
+  try {
+    for (const target of targets) {
+      const directory = mkdtempSync(join(dirname(target), ".db-types-"));
+      const entry = {
+        target,
+        directory,
+        candidate: join(directory, "types.ts"),
+        backup: join(directory, "previous.ts"),
+        existed: existsSync(target),
+        replaced: false
+      };
+      staged.push(entry);
+      if (entry.existed) copyFileSync(target, entry.backup);
+    }
+    const first = staged[0];
+    if (!first)
+      throw new Error("Database type generation has no output destination.");
+    const out = openSync(first.candidate, "wx");
+    try {
+      // File-backed stdout avoids truncating large schemas or a maxBuffer cap.
+      // Do not inherit stderr: CLI failures can echo the credential-bearing URL.
+      const result = spawnSync(
+        "supabase",
+        [
+          "gen",
+          "types",
+          "typescript",
+          "--db-url",
+          dbUrl,
+          "--schema",
+          "public",
+          "--schema",
+          "storage",
+          "--schema",
+          "graphql_public"
+        ],
+        { stdio: ["ignore", out, "pipe"] }
+      );
+      if (result.error || result.status !== 0) {
+        const status =
+          result.status === null
+            ? "could not complete"
+            : `exited ${result.status}`;
+        throw new Error(
+          `Supabase type generation ${status}; existing type files were preserved.`
+        );
+      }
+    } finally {
+      closeSync(out);
+    }
+    const source = readFileSync(first.candidate, "utf8");
+    validateTypes(source);
+    const normalized = sortRelationships(stripPerTenantTables(source));
+    validateTypes(normalized);
+    for (const entry of staged) writeFileSync(entry.candidate, normalized);
+    try {
+      for (const entry of staged) {
+        renameSync(entry.candidate, entry.target);
+        entry.replaced = true;
+      }
+    } catch {
+      const failedRollbacks: string[] = [];
+      for (const entry of staged.toReversed()) {
+        if (!entry.replaced) continue;
+        try {
+          if (entry.existed) renameSync(entry.backup, entry.target);
+          else rmSync(entry.target);
+        } catch {
+          failedRollbacks.push(entry.backup);
+        }
+      }
+      if (failedRollbacks.length) {
+        preserveBackups = true;
+        throw new Error(
+          `Database type replacement and rollback failed. Recover the previous files from: ${failedRollbacks.join(", ")}`
+        );
+      }
+      throw new Error(
+        "Database type replacement failed; both previous output files were preserved."
+      );
+    }
+  } finally {
+    if (!preserveBackups) {
+      for (const entry of staged)
+        rmSync(entry.directory, { recursive: true, force: true });
+    }
+  }
+}

--- a/scripts/lib/local-script-config.test.ts
+++ b/scripts/lib/local-script-config.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { runInNewContext } from "node:vm";
+import ts from "typescript";
+
+const settings = {
+  SUPABASE_URL: "https://database.example.com",
+  SUPABASE_ANON_KEY: "fixture-public-key",
+  CARBON_API_KEY: "fixture-api-key",
+  CARBON_COMPANY_ID: "fixture-company",
+  MODEL_UPLOAD_URL: "https://erp.example.com/api/model/upload",
+  MODEL_FILE_PATH: "/fixture/model.stl",
+  SALES_INVOICE_REPORT_PATH: "/fixture/report.json"
+};
+
+function compile(filename: string) {
+  const source = readFileSync(filename, "utf8").replaceAll(
+    "import.meta.url",
+    JSON.stringify(pathToFileURL(resolve(filename)).href)
+  );
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      esModuleInterop: true
+    }
+  }).outputText;
+}
+
+function execute(script: string, env: Record<string, string>) {
+  const clients: unknown[][] = [];
+  const requests: unknown[][] = [];
+  const reads: unknown[] = [];
+  const writes: unknown[][] = [];
+  const filters: unknown[][] = [];
+  const uploads: unknown[][] = [];
+  const chain = {
+    select: () => chain,
+    limit: () => chain,
+    order: () => chain,
+    eq: (...args: unknown[]) => {
+      filters.push(args);
+      return chain;
+    },
+    then: (resolve: (value: unknown) => void) =>
+      resolve({ data: [{ id: "fixture-result" }], error: null })
+  };
+  const bindings = {
+    exports: {},
+    process: {
+      env,
+      stdout: { write: () => undefined },
+      stderr: { write: () => undefined },
+      exit: () => assert.fail("Unexpected process exit")
+    },
+    console: { log: () => undefined, error: () => undefined },
+    FormData,
+    fetch: async (...args: unknown[]) => {
+      requests.push(args);
+      return new Response(JSON.stringify({ uploaded: true }));
+    },
+    require: (name: string) => {
+      if (name === "node:module") {
+        return { createRequire: () => bindings.require };
+      }
+      if (name === "node:util") return { parseEnv: () => ({}) };
+      if (name === "./lib/local-script-config") {
+        const exports = {};
+        runInNewContext(compile("scripts/lib/local-script-config.ts"), {
+          exports,
+          require: bindings.require,
+          URL
+        });
+        return exports;
+      }
+      if (name === "@supabase/supabase-js") {
+        return {
+          createClient: (...args: unknown[]) => {
+            clients.push(args);
+            return {
+              from: () => chain,
+              storage: {
+                from: () => ({
+                  upload: async (...args: unknown[]) => {
+                    uploads.push(args);
+                    return { error: null };
+                  }
+                })
+              }
+            };
+          }
+        };
+      }
+      if (name === "fs" || name === "node:fs") {
+        return {
+          existsSync: () => false,
+          readFileSync: (path: string) => {
+            reads.push(path);
+            return Buffer.from("fixture");
+          },
+          statSync: () => ({ size: 7 }),
+          writeFileSync: (...args: unknown[]) => writes.push(args)
+        };
+      }
+      if (name === "crypto" || name === "node:crypto") {
+        return { randomUUID: () => "fixture-model" };
+      }
+      if (name === "os" || name === "node:os") {
+        return { homedir: () => "/fixture/home" };
+      }
+      if (name === "path" || name === "node:path") {
+        return {
+          basename: () => "model.stl",
+          extname: () => ".stl",
+          join: (...parts: string[]) => parts.join("/")
+        };
+      }
+      throw new Error(`Unexpected script dependency: ${name}`);
+    }
+  };
+  return {
+    run: Promise.resolve().then(() =>
+      runInNewContext(compile(`scripts/${script}.ts`), bindings)
+    ),
+    clients,
+    requests,
+    reads,
+    writes,
+    filters,
+    uploads
+  };
+}
+
+for (const script of ["sandbox", "model-upload", "sales-invoice-report"]) {
+  test(`${script} CLI reaches its configuration error with NODE_PATH unset`, () => {
+    const directory = mkdtempSync(join(tmpdir(), "carbon-script-config-"));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          createRequire(import.meta.url).resolve("tsx"),
+          resolve(`scripts/${script}.ts`)
+        ],
+        { cwd: directory, env: {}, encoding: "utf8", timeout: 15_000 }
+      );
+      assert(result.status === 1, "Missing configuration must fail the CLI");
+      assert(
+        result.stderr.includes("Missing required local configuration"),
+        "CLI must reach the configuration guard before any dependency or IO error"
+      );
+      assert(!result.stderr.includes("ERR_MODULE_NOT_FOUND"));
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  test(`${script} rejects missing local configuration before any client or IO`, async () => {
+    const result = execute(script, {});
+    await assert.rejects(result.run, /Missing required local configuration/);
+    assert.equal(result.clients.length, 0);
+    assert.equal(result.requests.length, 0);
+    assert.equal(result.reads.length, 0);
+    assert.equal(result.writes.length, 0);
+  });
+
+  test(`${script} rejects blank keys without disclosing other configured values`, async () => {
+    const result = execute(script, {
+      ...settings,
+      SUPABASE_ANON_KEY: "private-value-sentinel",
+      CARBON_API_KEY: "   "
+    });
+    await assert.rejects(result.run, (error: unknown) => {
+      assert(error instanceof Error || typeof error === "object");
+      const message = String((error as Error).message);
+      assert.match(message, /CARBON_API_KEY/);
+      assert.doesNotMatch(message, /private-value-sentinel/);
+      return true;
+    });
+    assert.equal(result.clients.length, 0);
+  });
+}
+
+test("sandbox passes explicitly configured identity to its real client call", async () => {
+  const result = execute("sandbox", settings);
+  await result.run;
+  assert.equal(result.clients.length, 1);
+  const [url, publicKey, options] = result.clients[0]!;
+  assert(url === settings.SUPABASE_URL, "Configured database URL must be used");
+  assert(
+    publicKey === settings.SUPABASE_ANON_KEY,
+    "Configured public key must be used"
+  );
+  assert(
+    (options as { global: { headers: Record<string, string> } }).global.headers[
+      "carbon-key"
+    ] === settings.CARBON_API_KEY,
+    "Configured API key must be used"
+  );
+});
+
+test("model upload uses explicit file, company, and API endpoint configuration", async () => {
+  const result = execute("model-upload", settings);
+  await result.run;
+  assert(
+    result.reads[0] === settings.MODEL_FILE_PATH,
+    "Configured file must be read"
+  );
+  assert(
+    result.uploads[0]?.[0] === "fixture-company/models/fixture-model.stl",
+    "Storage upload must retain configured company scoping"
+  );
+  assert(
+    result.requests[0]?.[0] === settings.MODEL_UPLOAD_URL,
+    "Metadata must be posted to the configured endpoint"
+  );
+});
+
+test("sales report uses configured company scope and explicit local output path", async () => {
+  const result = execute("sales-invoice-report", settings);
+  await result.run;
+  assert(
+    result.filters[0]?.[0] === "companyId" &&
+      result.filters[0]?.[1] === settings.CARBON_COMPANY_ID,
+    "Report query must retain configured company scoping"
+  );
+  assert(
+    result.writes[0]?.[0] === settings.SALES_INVOICE_REPORT_PATH,
+    "Report must be written to the explicitly configured path"
+  );
+});
+
+test("real .env parser and pinned SDK load without root dependency aliases or network", () => {
+  const directory = mkdtempSync(join(tmpdir(), "carbon-script-client-"));
+  try {
+    writeFileSync(
+      join(directory, ".env"),
+      'SUPABASE_URL="https://database.example.com"\nCARBON_API_KEY="fixture-api-key"\n'
+    );
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        createRequire(import.meta.url).resolve("tsx"),
+        "--input-type=module",
+        "--eval",
+        `import assert from "node:assert/strict";
+import helpers from ${JSON.stringify(
+          pathToFileURL(resolve("scripts/lib/local-script-config.ts")).href
+        )};
+const { createScriptClient, readLocalScriptConfig } = helpers;
+const config = readLocalScriptConfig(
+  ["SUPABASE_URL", "SUPABASE_ANON_KEY", "CARBON_API_KEY"],
+  { SUPABASE_ANON_KEY: "fixture-public-key", CARBON_API_KEY: "fixture-override" }
+);
+let calls = 0;
+globalThis.fetch = async (input, init) => {
+  calls += 1;
+  assert(String(input).startsWith("https://database.example.com/rest/v1/fixture"));
+  assert(new Headers(init.headers).get("carbon-key") === "fixture-override");
+  return new Response('[{"id":"fixture"}]', {
+    status: 200,
+    headers: { "content-type": "application/json" }
+  });
+};
+const client = createScriptClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY, config.CARBON_API_KEY);
+const result = await client.from("fixture").select("*");
+assert.equal(result.error, null);
+assert.equal(result.data[0].id, "fixture");
+assert.equal(calls, 1);`
+      ],
+      { cwd: directory, env: {}, encoding: "utf8", timeout: 15_000 }
+    );
+    assert(
+      result.status === 0,
+      "Real environment parsing, pinned SDK resolution, and stubbed request must succeed"
+    );
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});

--- a/scripts/lib/local-script-config.ts
+++ b/scripts/lib/local-script-config.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { parseEnv } from "node:util";
+
+export function readLocalScriptConfig<const Keys extends readonly string[]>(
+  names: Keys,
+  environment: Record<string, string | undefined>
+): { [Key in Keys[number]]: string } {
+  const local = existsSync(".env")
+    ? parseEnv(readFileSync(".env", "utf8"))
+    : {};
+  const values = Object.fromEntries(
+    names.map((name) => [name, environment[name] ?? local[name]])
+  );
+  const missing = names.filter((name) => !values[name]?.trim());
+  if (missing.length) {
+    throw new Error(
+      `Missing required local configuration: ${missing.join(", ")}. Set these values in your local environment or ignored .env file.`
+    );
+  }
+  return values as {
+    [Key in Keys[number]]: string;
+  };
+}
+
+export function createScriptClient(
+  url: string,
+  publicKey: string,
+  apiKey: string
+) {
+  // The database workspace declares and pins this dependency; root scripts do not.
+  const fromDatabase = createRequire(
+    new URL("../../packages/database/package.json", import.meta.url)
+  );
+  const { createClient } = fromDatabase("@supabase/supabase-js");
+  return createClient(url, publicKey, {
+    global: { headers: { "carbon-key": apiKey } }
+  });
+}

--- a/scripts/lib/swagger-partner-alias.sql
+++ b/scripts/lib/swagger-partner-alias.sql
@@ -1,0 +1,22 @@
+-- Read catalog facts from the same database that serves the Swagger document.
+-- The transaction-local search path makes pg_get_viewdef schema-qualified.
+WITH scope AS MATERIALIZED (
+  SELECT pg_catalog.set_config('search_path', '', true)
+)
+SELECT
+  pg_catalog.pg_get_viewdef(view_relation.oid, false) AS view_definition,
+  view_relation.relkind AS relation_kind,
+  ARRAY(
+    SELECT attribute.attname::text
+    FROM pg_catalog.pg_constraint constraint_definition
+    CROSS JOIN LATERAL unnest(constraint_definition.conkey) WITH ORDINALITY AS key_column(number, position)
+    JOIN pg_catalog.pg_attribute attribute
+      ON attribute.attrelid = constraint_definition.conrelid
+      AND attribute.attnum = key_column.number
+    WHERE constraint_definition.conrelid = 'public.partner'::regclass
+      AND constraint_definition.contype = 'p'
+    ORDER BY key_column.position
+  ) AS primary_key
+FROM scope
+CROSS JOIN pg_catalog.pg_class view_relation
+WHERE view_relation.oid = 'public.partners'::regclass;

--- a/scripts/lib/swagger-schema.test.ts
+++ b/scripts/lib/swagger-schema.test.ts
@@ -1,0 +1,358 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeSwaggerSchema,
+  PARTNER_ALIAS_PROOF_SQL
+} from "./swagger-schema";
+
+const view = `SELECT p.id, p."hoursPerWeek", p."abilityId", p.active,
+  p."companyId", p."createdBy", p."createdAt", p."updatedBy", p."updatedAt", p."customFields",
+  p.id AS "supplierLocationId", a2.name AS "abilityName", s.id AS "supplierId",
+  s.name AS "supplierName", a.city, a."stateProvince" AS state
+ FROM ((((public.partner p
+  JOIN public."supplierLocation" sl ON ((sl.id = p.id)))
+  JOIN public.supplier s ON ((s.id = sl."supplierId")))
+  JOIN public.address a ON ((a.id = sl."addressId")))
+  JOIN public.ability a2 ON ((a2.id = p."abilityId"))) WHERE (p.active = true);`;
+const pk = "This is a Primary Key.<pk/>";
+const fk =
+  "This is a Foreign Key to `supplierLocation.id`.<fk table='supplierLocation' column='id'/>";
+const proof = () => [
+  {
+    view_definition: view,
+    primary_key: ["id", "abilityId"],
+    relation_kind: "v"
+  }
+];
+const fixture = (chosen: "id" | "supplierLocationId") => ({
+  swagger: "2.0",
+  definitions: {
+    partners: {
+      properties: {
+        id: {
+          type: "string",
+          format: "text",
+          description: `Original id documentation.\n\nNote:\n${chosen === "id" ? `${pk}\n` : ""}${fk}`
+        },
+        supplierLocationId: {
+          type: "string",
+          format: "text",
+          description: `Alias documentation.\n\nNote:\n${chosen === "supplierLocationId" ? `${pk}\n` : ""}${fk}`
+        },
+        abilityId: {
+          type: "string",
+          format: "text",
+          description: `Note:\n${pk}\nThis is a Foreign Key to \`ability.id\`.<fk table='ability' column='id'/>`
+        }
+      }
+    },
+    unrelated: { properties: { id: { description: `Leave untouched: ${pk}` } } }
+  },
+  paths: { "/partners": { get: { description: "Public API contract" } } }
+});
+
+test("both observed alias choices generate identical metadata with the composite key preserved", () => {
+  assert.deepEqual(
+    normalizeSwaggerSchema(fixture("supplierLocationId"), proof()),
+    fixture("id")
+  );
+  assert.deepEqual(
+    normalizeSwaggerSchema(fixture("id"), proof()),
+    fixture("id")
+  );
+});
+
+test("generation twice is identical and leaves the input object intact", () => {
+  const input = fixture("supplierLocationId");
+  const saved = structuredClone(input);
+  const first = normalizeSwaggerSchema(input, proof());
+  assert.deepEqual(first, normalizeSwaggerSchema(first, proof()));
+  assert.deepEqual(input, saved);
+});
+
+for (const [name, mutate] of [
+  [
+    "key column removed",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.primary_key = ["id"];
+    }
+  ],
+  [
+    "key column added",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.primary_key.push("companyId");
+    }
+  ],
+  [
+    "key order changed",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.primary_key.reverse();
+    }
+  ],
+  [
+    "alias comes from another table",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.view_definition = view.replace(
+        'p.id AS "supplierLocationId"',
+        'sl.id AS "supplierLocationId"'
+      );
+    }
+  ],
+  [
+    "alias is an expression",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.view_definition = view.replace(
+        'p.id AS "supplierLocationId"',
+        "(p.id || '') AS \"supplierLocationId\""
+      );
+    }
+  ],
+  [
+    "source relation changed",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.view_definition = view.replace(
+        "public.partner p",
+        "public.other p"
+      );
+    }
+  ],
+  [
+    "column spelling changed",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.view_definition = view.replace(
+        '"hoursPerWeek"',
+        '"hours Per Week"'
+      );
+    }
+  ],
+  [
+    "view became a table",
+    (rows: ReturnType<typeof proof>) => {
+      rows[0]!.relation_kind = "r";
+    }
+  ],
+  [
+    "proof missing",
+    (rows: ReturnType<typeof proof>) => {
+      rows.length = 0;
+    }
+  ]
+] as const) {
+  test(`rejects actual schema drift: ${name}`, () => {
+    const rows = proof();
+    mutate(rows);
+    assert.throws(
+      () => normalizeSwaggerSchema(fixture("id"), rows),
+      /proof|schema/
+    );
+  });
+}
+
+async function runCli(
+  options: {
+    invalidProof?: boolean;
+    proofStatus?: number;
+    malformedProofJson?: boolean;
+    malformedSchema?: boolean;
+    repeat?: boolean;
+  } = {}
+) {
+  const root = fileURLToPath(new URL("../../", import.meta.url));
+  const directory = mkdtempSync(join(tmpdir(), "carbon-swagger-generation-"));
+  const output = join(
+    directory,
+    "packages/database/src/swagger-docs-schema.ts"
+  );
+  const previous = "export default { previous: true };\n";
+  const requests: {
+    method: string | undefined;
+    url: string | undefined;
+    body: string;
+  }[] = [];
+  let generations = 0;
+  const server = createServer(async (request, response) => {
+    let body = "";
+    for await (const chunk of request) body += chunk;
+    requests.push({ method: request.method, url: request.url, body });
+    response.setHeader("Content-Type", "application/json");
+    if (
+      request.method === "GET" &&
+      request.url === "/api/platform/projects/default/api/rest"
+    ) {
+      response.end(
+        JSON.stringify(
+          options.malformedSchema
+            ? []
+            : fixture(generations++ % 2 === 0 ? "supplierLocationId" : "id")
+        )
+      );
+    } else if (
+      request.method === "POST" &&
+      request.url === "/api/platform/pg-meta/default/query" &&
+      body === JSON.stringify({ query: PARTNER_ALIAS_PROOF_SQL })
+    ) {
+      response.statusCode = options.proofStatus ?? 200;
+      const rows = proof();
+      if (options.invalidProof) rows[0]!.primary_key = ["id"];
+      response.end(
+        options.malformedProofJson
+          ? "synthetic-private-diagnostic"
+          : JSON.stringify(
+              response.statusCode === 200
+                ? rows
+                : { error: "synthetic-private-diagnostic" }
+            )
+      );
+    } else {
+      response.statusCode = 400;
+      response.end("{}");
+    }
+  });
+  try {
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve)
+    );
+    const address = server.address();
+    assert.ok(address && typeof address !== "string");
+    mkdirSync(dirname(output), { recursive: true });
+    writeFileSync(output, previous);
+    mkdirSync(join(directory, "scripts/lib"), { recursive: true });
+    for (const path of [
+      "scripts/generate-swagger-docs.ts",
+      "scripts/lib/swagger-schema.ts",
+      "scripts/lib/swagger-partner-alias.sql"
+    ])
+      copyFileSync(join(root, path), join(directory, path));
+    const results = [];
+    for (let iteration = 0; iteration < (options.repeat ? 2 : 1); iteration++) {
+      const child = spawn(
+        process.execPath,
+        [
+          "--import",
+          join(root, "node_modules/tsx/dist/loader.mjs"),
+          join(directory, "scripts/generate-swagger-docs.ts")
+        ],
+        {
+          cwd: directory,
+          env: {
+            PATH: process.env.PATH,
+            PORT_STUDIO: String(address.port),
+            NODE_PATH: undefined
+          },
+          stdio: ["ignore", "pipe", "pipe"]
+        }
+      );
+      let stderr = "";
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk;
+      });
+      const code = await new Promise<number | null>((resolve, reject) => {
+        child.once("error", reject);
+        child.once("close", resolve);
+      });
+      results.push({ code, stderr, output: readFileSync(output, "utf8") });
+    }
+    return {
+      results,
+      requests,
+      previous,
+      remaining: readdirSync(dirname(output))
+    };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("real CLI requests catalog proof and produces identical files for both observed variants", async () => {
+  const result = await runCli({ repeat: true });
+  for (const run of result.results) assert.equal(run.code, 0, run.stderr);
+  assert.equal(
+    result.requests.filter((request) => request.method === "POST").length,
+    2
+  );
+  assert.equal(result.results[0]!.output, result.results[1]!.output);
+});
+
+for (const options of [
+  { invalidProof: true },
+  { proofStatus: 403 },
+  { malformedSchema: true },
+  { malformedProofJson: true }
+]) {
+  test(`real CLI preserves last-good output when verification fails: ${JSON.stringify(options)}`, async () => {
+    const result = await runCli(options);
+    assert.notEqual(result.results[0]!.code, 0);
+    assert.equal(result.results[0]!.output, result.previous);
+    assert.deepEqual(result.remaining, ["swagger-docs-schema.ts"]);
+    assert.doesNotMatch(result.results[0]!.stderr, /synthetic/);
+  });
+}
+
+for (const [name, mutate] of [
+  [
+    "both aliases marked primary",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.supplierLocationId.description = `Note:\n${pk}\n${fk}`;
+    }
+  ],
+  [
+    "neither alias marked primary",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.id.description = `Note:\n${fk}`;
+    }
+  ],
+  [
+    "foreign key changed",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.id.description =
+        schema.definitions.partners.properties.id.description.replaceAll(
+          "supplierLocation",
+          "otherTable"
+        );
+    }
+  ],
+  [
+    "unknown primary key notation",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.id.description =
+        schema.definitions.partners.properties.id.description.replace(
+          pk,
+          "Primary key: id"
+        );
+    }
+  ],
+  [
+    "composite key member loses its marker",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.abilityId.description =
+        "Changed metadata";
+    }
+  ],
+  [
+    "column type changed",
+    (schema: ReturnType<typeof fixture>) => {
+      schema.definitions.partners.properties.id.type = "number";
+    }
+  ]
+] as const) {
+  test(`rejects unrecognized metadata: ${name}`, () => {
+    const schema = fixture("id");
+    mutate(schema);
+    assert.throws(() => normalizeSwaggerSchema(schema, proof()), /metadata/);
+  });
+}

--- a/scripts/lib/swagger-schema.ts
+++ b/scripts/lib/swagger-schema.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export const PARTNER_ALIAS_PROOF_SQL = readFileSync(
+  join(__dirname, "swagger-partner-alias.sql"),
+  "utf8"
+);
+
+// The complete, reviewed pg_get_viewdef output proves column origins without
+// interpreting arbitrary SQL or trusting PostgREST's inferred descriptions.
+// A changed view requires an explicit review of this compatibility correction.
+const PARTNERS_VIEW = `SELECT p.id, p."hoursPerWeek", p."abilityId", p.active,
+ p."companyId", p."createdBy", p."createdAt", p."updatedBy", p."updatedAt", p."customFields",
+ p.id AS "supplierLocationId", a2.name AS "abilityName", s.id AS "supplierId",
+ s.name AS "supplierName", a.city, a."stateProvince" AS state
+ FROM ((((public.partner p
+ JOIN public."supplierLocation" sl ON ((sl.id = p.id)))
+ JOIN public.supplier s ON ((s.id = sl."supplierId")))
+ JOIN public.address a ON ((a.id = sl."addressId")))
+ JOIN public.ability a2 ON ((a2.id = p."abilityId"))) WHERE (p.active = true);`;
+
+const PRIMARY_KEY_NOTE = "This is a Primary Key.<pk/>";
+const foreignKeyNote = (table: string) =>
+  `This is a Foreign Key to \`${table}.id\`.<fk table='${table}' column='id'/>`;
+
+function object(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    throw new Error("Unexpected Swagger metadata object");
+  return value as Record<string, unknown>;
+}
+
+function sqlTokens(source: string): string {
+  // Preserve quoted identifiers/string contents; only token whitespace varies.
+  return JSON.stringify(
+    source.match(
+      /"(?:[^"]|"")*"|'(?:[^']|'')*'|[A-Za-z_][A-Za-z_0-9]*|[0-9]+|[^\s]/g
+    )
+  );
+}
+
+function verifyProof(value: unknown): void {
+  if (!Array.isArray(value) || value.length !== 1)
+    throw new Error("Partner alias schema proof is unavailable");
+  const row = object(value[0]);
+  if (
+    row.relation_kind !== "v" ||
+    typeof row.view_definition !== "string" ||
+    sqlTokens(row.view_definition) !== sqlTokens(PARTNERS_VIEW) ||
+    JSON.stringify(row.primary_key) !== JSON.stringify(["id", "abilityId"])
+  )
+    throw new Error(
+      "Partner alias schema proof changed; review the compatibility correction"
+    );
+}
+
+function columnNote(value: unknown, table: string) {
+  const column = object(value);
+  const description = column.description;
+  if (
+    column.type !== "string" ||
+    column.format !== "text" ||
+    typeof description !== "string"
+  )
+    throw new Error("Unexpected partner alias column metadata");
+  const fk = foreignKeyNote(table);
+  const withPrimary = `Note:\n${PRIMARY_KEY_NOTE}\n${fk}`;
+  const withoutPrimary = `Note:\n${fk}`;
+  const primary = description.endsWith(withPrimary);
+  const suffix = primary ? withPrimary : withoutPrimary;
+  if (!description.endsWith(suffix))
+    throw new Error("Unexpected partner alias key metadata");
+  const prefix = description.slice(0, -suffix.length);
+  if (
+    (prefix && !prefix.endsWith("\n\n")) ||
+    prefix.includes("<pk/>") ||
+    prefix.includes("<fk ")
+  )
+    throw new Error("Unexpected partner alias description metadata");
+  return { column, prefix, primary, fk };
+}
+
+export function normalizeSwaggerSchema(
+  schema: unknown,
+  proof: unknown
+): unknown {
+  verifyProof(proof);
+  const result = structuredClone(object(schema));
+  if (result.swagger !== "2.0")
+    throw new Error("Unexpected Swagger version metadata");
+  const properties = object(
+    object(object(result.definitions).partners).properties
+  );
+  const id = columnNote(properties.id, "supplierLocation");
+  const alias = columnNote(properties.supplierLocationId, "supplierLocation");
+  const ability = columnNote(properties.abilityId, "ability");
+  if (id.primary === alias.primary || !ability.primary)
+    throw new Error("Unexpected partner composite primary-key metadata");
+  // PostgREST 13 chooses an unordered first alias for a source PK column.
+  // Select the first projected alias while preserving every FK and prose byte.
+  id.column.description = `${id.prefix}Note:\n${PRIMARY_KEY_NOTE}\n${id.fk}`;
+  alias.column.description = `${alias.prefix}Note:\n${alias.fk}`;
+  return result;
+}

--- a/scripts/model-upload.ts
+++ b/scripts/model-upload.ts
@@ -1,50 +1,58 @@
-import { createClient } from "@supabase/supabase-js";
-import axios from "axios";
-import crypto from "crypto";
-import fs from "fs";
-import path from "path";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import {
+  createScriptClient,
+  readLocalScriptConfig
+} from "./lib/local-script-config";
 
-const companyId = "N4Mk6kWM4ycK5Qj941axi4";
-const apiKey = "crbn_JLN5eYtzfoIzdkncQo3uO";
-const carbonApiUrl = "http://localhost:54321"; // https://api.carbon.ms
-const carbonPublicKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0";
-
-const apiUrl = "http://localhost:3000/api/model/upload"; // https://app.carbon.ms/api/model/upload
-
-const filePath = "~/Downloads/test.stl";
+const {
+  CARBON_COMPANY_ID: companyId,
+  CARBON_API_KEY: apiKey,
+  SUPABASE_URL: carbonApiUrl,
+  SUPABASE_ANON_KEY: carbonPublicKey,
+  MODEL_UPLOAD_URL: apiUrl,
+  MODEL_FILE_PATH: filePath
+} = readLocalScriptConfig(
+  [
+    "CARBON_COMPANY_ID",
+    "CARBON_API_KEY",
+    "SUPABASE_URL",
+    "SUPABASE_ANON_KEY",
+    "MODEL_UPLOAD_URL",
+    "MODEL_FILE_PATH"
+  ],
+  process.env
+);
 
 (async () => {
-  const resolvedPath = filePath.replace("~", process.env.HOME!);
+  const resolvedPath = filePath.startsWith("~/")
+    ? path.join(homedir(), filePath.slice(2))
+    : filePath;
   const fileName = path.basename(resolvedPath);
   const fileExtension = path.extname(resolvedPath).slice(1);
   const fileBuffer = fs.readFileSync(resolvedPath);
   const fileSize = fs.statSync(resolvedPath).size;
 
-  const modelId = crypto.randomUUID();
+  const modelId = randomUUID();
   const modelPath = `${companyId}/models/${modelId}.${fileExtension}`;
 
   // 1. Upload the file to Supabase storage
-  const client = createClient(carbonApiUrl, carbonPublicKey, {
-    global: {
-      headers: {
-        "carbon-key": apiKey,
-      },
-    },
-  });
+  const client = createScriptClient(carbonApiUrl, carbonPublicKey, apiKey);
 
   const { error: uploadError } = await client.storage
     .from("private")
     .upload(modelPath, fileBuffer, {
-      contentType: "application/octet-stream",
+      contentType: "application/octet-stream"
     });
 
   if (uploadError) {
-    console.error("Storage upload failed:", uploadError);
+    process.stderr.write("Storage upload failed.\n");
     process.exit(1);
   }
 
-  console.log("File uploaded to storage:", modelPath);
+  process.stdout.write(`File uploaded to storage: ${modelPath}\n`);
 
   // 2. POST the metadata to the API
   const formData = new FormData();
@@ -53,15 +61,17 @@ const filePath = "~/Downloads/test.stl";
   formData.append("modelPath", modelPath);
   formData.append("size", String(fileSize));
 
-  const response = await axios.post(
-    "http://localhost:3000/api/model/upload",
-    formData,
-    {
-      headers: {
-        "carbon-key": apiKey,
-      },
+  const response = await fetch(apiUrl, {
+    method: "POST",
+    body: formData,
+    headers: {
+      "carbon-key": apiKey
     }
-  );
+  });
 
-  console.log(response.data);
-})();
+  if (!response.ok) throw new Error("Model metadata request failed");
+  process.stdout.write(`${await response.text()}\n`);
+})().catch(() => {
+  process.stderr.write("Model upload failed.\n");
+  process.exitCode = 1;
+});

--- a/scripts/sales-invoice-report.ts
+++ b/scripts/sales-invoice-report.ts
@@ -1,17 +1,27 @@
-import { createClient } from "@supabase/supabase-js";
-import fs from "fs";
-const companyId = "********************";
-const apiKey = "crbn_******************";
-const publicApiKey =
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InNxb2ppamlpamtuaGJneW9nbWx1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3MjM2MDU0MzksImV4cCI6MjAzOTE4MTQzOX0.JMzLs9Y4Y4kQ-jhQHrSqgNyHSZgrkwzBd1PwPbVPtbQ";
+import fs from "node:fs";
+import {
+  createScriptClient,
+  readLocalScriptConfig
+} from "./lib/local-script-config";
 
-const carbon = createClient("https://api.carbon.ms", publicApiKey, {
-  global: {
-    headers: {
-      "carbon-key": apiKey,
-    },
-  },
-});
+const {
+  CARBON_COMPANY_ID: companyId,
+  CARBON_API_KEY: apiKey,
+  SUPABASE_URL: carbonApiUrl,
+  SUPABASE_ANON_KEY: publicApiKey,
+  SALES_INVOICE_REPORT_PATH: outputPath
+} = readLocalScriptConfig(
+  [
+    "CARBON_COMPANY_ID",
+    "CARBON_API_KEY",
+    "SUPABASE_URL",
+    "SUPABASE_ANON_KEY",
+    "SALES_INVOICE_REPORT_PATH"
+  ],
+  process.env
+);
+
+const carbon = createScriptClient(carbonApiUrl, publicApiKey, apiKey);
 
 (async () => {
   const { data, error } = await carbon
@@ -24,13 +34,14 @@ const carbon = createClient("https://api.carbon.ms", publicApiKey, {
     .order("createdAt", { ascending: false });
 
   if (data) {
-    fs.writeFileSync(
-      "sales-invoice-report.json",
-      JSON.stringify(data, null, 2)
-    );
+    fs.writeFileSync(outputPath, JSON.stringify(data, null, 2));
   }
 
   if (error) {
-    console.error(error);
+    process.stderr.write("Sales invoice query failed.\n");
+    process.exitCode = 1;
   }
-})();
+})().catch(() => {
+  process.stderr.write("Sales invoice report failed.\n");
+  process.exitCode = 1;
+});

--- a/scripts/sandbox.ts
+++ b/scripts/sandbox.ts
@@ -1,22 +1,22 @@
-import { createClient } from "@supabase/supabase-js";
-import { config } from "dotenv";
+import {
+  createScriptClient,
+  readLocalScriptConfig
+} from "./lib/local-script-config";
 
-config();
+const { SUPABASE_URL, SUPABASE_ANON_KEY, CARBON_API_KEY } =
+  readLocalScriptConfig(
+    ["SUPABASE_URL", "SUPABASE_ANON_KEY", "CARBON_API_KEY"],
+    process.env
+  );
 
-const carbon = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_ANON_KEY!,
-  {
-    global: {
-      headers: {
-        "carbon-key": "crbn_yPkz1hszqh6mVLDf4jiDv",
-      },
-    },
-  }
+const carbon = createScriptClient(
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  CARBON_API_KEY
 );
 
 (async () => {
   const employees = await carbon.from("salesOrder").select("*").limit(1000);
 
-  console.log(employees);
+  process.stdout.write(`${JSON.stringify(employees, null, 2)}\n`);
 })();

--- a/turbo.json
+++ b/turbo.json
@@ -72,6 +72,7 @@
       "outputs": []
     },
     "//#generate:mcp": {
+      "cache": false,
       "inputs": [
         "apps/erp/app/modules/*/*.service.ts",
         "apps/erp/app/modules/*/*.mcp.server.ts",


### PR DESCRIPTION
- generate-db-types: refuse non-local database URLs without echoing them,
  generate into temporary files and validate (parses, exports Database) before
  atomically replacing both output copies, restore the last-good files on
  failure, and sort each table's Relationships block so the output is a pure
  function of the schema (supabase gen types emits catalog order, which differs
  between databases built from the same migrations).
- generate-swagger-docs: verify the partners view definition through Studio's
  catalog query and normalise only PostgREST's known duplicate-alias primary-key
  annotation, so two independently built databases produce identical output.
- generate-mcp: drop the wall-clock timestamp from the metadata (repeatable
  output) and disable turbo caching for //#generate:mcp until its transitive
  inputs are declared.
- sandbox / model-upload / sales-invoice-report: read configuration from
  explicit local environment variables instead of embedded values; error
  messages name the missing variable without printing values.
- Tests for all of the above under scripts/lib (node:test, run with tsx).

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added environment-based configuration for local tools, model uploads, sandbox queries, and sales invoice reports.
  - Added validation and safer handling for database type and Swagger documentation generation.
  - Added support for configurable report output paths and home-directory paths.

- **Bug Fixes**
  - Improved error reporting and exit status handling for script failures.
  - Preserved existing generated files when generation or validation fails.
  - Prevented sensitive configuration values from appearing in error messages.

- **Tests**
  - Added comprehensive coverage for configuration validation, generation failures, schema verification, and output preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->